### PR TITLE
Add TUI workspace and shell management

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ The dashboard provides workspace and terminal tables, aggregate status cards,
 and live Herdr state refreshed four times per second. Use `Tab` to switch focus
 between workspaces and terminals, then `j`/`k` or the arrow keys to navigate.
 
-- `Enter` restores every shell in the selected workspace.
-- `a` creates a shell, OpenCode, LazyGit, or a custom command.
+- `Enter` restores the selected workspace or opens only the selected terminal,
+  depending on which table is focused.
+- `a` creates a workspace with one shell from workspace focus, or adds one plain
+  shell from terminal focus. New workspaces use the directory where the
+  dashboard was launched.
 - `e` renames the selected terminal when the terminal table is focused.
 - `x`, then `y`, closes the selected workspace and all of its shells.
 - `r` refreshes immediately; `q` or `Esc` quits.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ format = """...${custom.boomux}..."""
 [custom.boomux]
 command = "boomux prompt"
 when = 'test -n "$HERDR_PANE_ID"'
-format = '[ 󰊠 $output](bg:blue fg:yellow)'
+format = '[ 󰊠](bg:blue fg:yellow)[ $output](bg:blue fg:crust)'
 ```
 
 The dashboard uses the terminal's ANSI palette rather than a hardcoded color

--- a/README.md
+++ b/README.md
@@ -66,13 +66,31 @@ For a full workspace overview, open the Ratatui dashboard:
 boomux ui
 ```
 
-The first dashboard pass provides workspace and terminal tables, aggregate
-status cards, `j`/`k` and arrow-key navigation, `Enter` to restore the selected
-workspace without closing the dashboard, `r` to refresh immediately, and `q` or
-`Esc` to quit. Press `x` and then `y` to close the selected workspace and
-terminate all of its shells; `n` or `Esc` cancels the confirmation. The
-dashboard automatically refreshes its Herdr workspace and terminal snapshot
-four times per second.
+The dashboard provides workspace and terminal tables, aggregate status cards,
+and live Herdr state refreshed four times per second. Use `Tab` to switch focus
+between workspaces and terminals, then `j`/`k` or the arrow keys to navigate.
+
+- `Enter` restores every shell in the selected workspace.
+- `a` creates a shell, OpenCode, LazyGit, or a custom command.
+- `e` renames the selected terminal when the terminal table is focused.
+- `x`, then `y`, closes the selected workspace and all of its shells.
+- `r` refreshes immediately; `q` or `Esc` quits.
+
+Shell names are stored as Herdr pane labels and appear in the dashboard and
+restored Ghostty window titles. New shells receive `BOOMUX_WORKSPACE` and
+`BOOMUX_SHELL_NAME` environment variables.
+
+For a dynamic Starship segment that follows later renames, add the hidden prompt
+command to your Starship format and configuration:
+
+```toml
+format = """...${custom.boomux}..."""
+
+[custom.boomux]
+command = "boomux prompt"
+when = 'test -n "$HERDR_PANE_ID"'
+format = '[ 󰊠 $output](bg:blue fg:yellow)'
+```
 
 The dashboard uses the terminal's ANSI palette rather than a hardcoded color
 scheme. On Omarchy, Ghostty maps those colors through the active theme, so the
@@ -147,9 +165,11 @@ this machine's `PATH`. Run `boomux` from any directory.
 
 ## Roadmap
 
-1. Add workspace and terminal creation controls to the dashboard.
-2. Add workspace and terminal rename/close operations.
-3. Add live agent-state refresh and notifications.
+See [`docs/roadmap.md`](docs/roadmap.md) for the broader product idea backlog.
+
+1. Aggregate multiple agent states and add attention notifications.
+2. Add terminal close and workspace rename operations.
+3. Add configurable shell and agent recipes.
 4. Use the public socket API only when the CLI stops meeting an actual need.
 5. After explicit user approval, add optional desktop keybinding and launcher
    integration outside the core.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,8 +57,8 @@ workspaces. It refreshes from Herdr four times per second and validates the
 selected workspace against a fresh snapshot before launching Ghostty windows.
 Closing a workspace uses Herdr's atomic workspace close command after explicit
 confirmation, terminating every shell in that workspace. Shell creation uses
-Herdr tabs, `pane run` starts selected recipes, and pane labels provide durable
-shell names for the dashboard, Ghostty titles, and prompt integrations.
+Herdr tabs, and pane labels provide durable shell names for the dashboard,
+Ghostty titles, and prompt integrations.
 
 Dashboard colors use semantic ANSI roles and the terminal's default foreground
 and background. This keeps the TUI portable while allowing terminal-level theme

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,9 @@ dashboard remains open after restoration so it can continue managing other
 workspaces. It refreshes from Herdr four times per second and validates the
 selected workspace against a fresh snapshot before launching Ghostty windows.
 Closing a workspace uses Herdr's atomic workspace close command after explicit
-confirmation, terminating every shell in that workspace.
+confirmation, terminating every shell in that workspace. Shell creation uses
+Herdr tabs, `pane run` starts selected recipes, and pane labels provide durable
+shell names for the dashboard, Ghostty titles, and prompt integrations.
 
 Dashboard colors use semantic ANSI roles and the terminal's default foreground
 and background. This keeps the TUI portable while allowing terminal-level theme

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,42 @@
+# Product Ideas
+
+Boomux is under active development. This document collects possible directions
+for exploration; it is not a release commitment.
+
+## Workspace Control
+
+- Aggregate multiple agent states as counts instead of one workspace-level
+  value.
+- Notify when an agent becomes blocked, finishes, or needs input.
+- Create shells, OpenCode, LazyGit, and custom commands from the dashboard.
+- Name individual shells and carry those names into Ghostty titles and prompts.
+- Show an opt-in, read-only preview of the selected terminal.
+- Search workspaces and actions from a command palette.
+- Display repository, branch, dirty state, and worktree information.
+- Launch workspace templates such as editor, agent, tests, and LazyGit.
+- Duplicate a workspace structure for another branch or worktree.
+- Archive inactive workspaces without terminating their shells.
+
+## Desktop Integration
+
+- Restore shells into optional Hyprland layout presets.
+- Place workspace groups on selected Hyprland workspaces or monitors.
+- Give each Boomux workspace a consistent border color.
+- Focus an existing Ghostty attachment instead of opening another window.
+- Offer the dashboard as an optional Hyprland special workspace.
+
+## Agent Workflows
+
+- Record state transitions and show when an agent last changed state.
+- Provide an attention queue for blocked and completed agents.
+- Send common responses or commands to a selected pane.
+- Define recipes for OpenCode, Claude, Codex, and custom agents.
+- Run hooks, tests, notifications, or focus actions when an agent finishes.
+
+## Distribution And Polish
+
+- Make the Ratatui interface the default and remove the Gum dependency.
+- Add a LazyGit-style interactive keybinding panel.
+- Support configuration for recipes, refresh rate, and notifications.
+- Package Herdr and Boomux for Arch and Omarchy users.
+- Validate compatible Herdr and Ghostty versions in `boomux doctor`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,41 +170,48 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
     let views = dashboard_snapshot()?;
     tui::run(
         views,
-        |workspace_id| {
-            let panes = available_panes().map_err(|error| error.to_string())?;
-            let workspaces = load_workspaces().map_err(|error| error.to_string())?;
-            let workspace = workspaces
-                .iter()
-                .find(|workspace| workspace.workspace_id == workspace_id)
-                .ok_or_else(|| "selected workspace no longer exists".to_owned())?;
-            let shell_count = workspace_panes(&workspace.workspace_id, &panes).count();
-            open_workspace(workspace, &panes).map_err(|error| error.to_string())?;
-            Ok(format!(
-                "Restored {shell_count} shell(s) for {}",
-                workspace.label
-            ))
+        tui::Actions {
+            on_restore: |workspace_id: &str| {
+                let panes = load_panes().map_err(|error| error.to_string())?;
+                let workspaces = load_workspaces().map_err(|error| error.to_string())?;
+                let workspace = workspaces
+                    .iter()
+                    .find(|workspace| workspace.workspace_id == workspace_id)
+                    .ok_or_else(|| "selected workspace no longer exists".to_owned())?;
+                let shell_count = workspace_panes(&workspace.workspace_id, &panes).count();
+                open_workspace(workspace, &panes).map_err(|error| error.to_string())?;
+                Ok(format!(
+                    "Restored {shell_count} shell(s) for {}",
+                    workspace.label
+                ))
+            },
+            on_open: |terminal_id: &str| {
+                open_dashboard_terminal(terminal_id).map_err(|error| error.to_string())
+            },
+            on_close: |workspace_id: &str| {
+                let workspaces = load_workspaces().map_err(|error| error.to_string())?;
+                let Some(workspace) = workspaces
+                    .iter()
+                    .find(|workspace| workspace.workspace_id == workspace_id)
+                else {
+                    return Ok("Workspace was already closed".to_owned());
+                };
+                let label = workspace.label.clone();
+                close_workspace(workspace_id).map_err(|error| error.to_string())?;
+                Ok(format!("Closed {label} and all of its shells"))
+            },
+            on_create_workspace: |name: &str| {
+                create_dashboard_workspace(name).map_err(|error| error.to_string())
+            },
+            on_create_shell: |workspace_id: &str| {
+                create_dashboard_shell(workspace_id).map_err(|error| error.to_string())
+            },
+            on_rename: |pane_id: &str, name: &str| {
+                rename_pane(pane_id, name).map_err(|error| error.to_string())?;
+                Ok(format!("Renamed shell to {name}"))
+            },
+            on_refresh: || dashboard_snapshot().map_err(|error| error.to_string()),
         },
-        |workspace_id| {
-            let workspaces = load_workspaces().map_err(|error| error.to_string())?;
-            let Some(workspace) = workspaces
-                .iter()
-                .find(|workspace| workspace.workspace_id == workspace_id)
-            else {
-                return Ok("Workspace was already closed".to_owned());
-            };
-            let label = workspace.label.clone();
-            close_workspace(workspace_id).map_err(|error| error.to_string())?;
-            Ok(format!("Closed {label} and all of its shells"))
-        },
-        |workspace_id, base_name, command| {
-            create_dashboard_shell(workspace_id, base_name, command)
-                .map_err(|error| error.to_string())
-        },
-        |pane_id, name| {
-            rename_pane(pane_id, name).map_err(|error| error.to_string())?;
-            Ok(format!("Renamed shell to {name}"))
-        },
-        || dashboard_snapshot().map_err(|error| error.to_string()),
     )?;
     Ok(())
 }
@@ -280,12 +287,12 @@ fn open_directory(
         )
     };
     if let Err(error) = rename_pane(&pane.pane_id, &shell_name) {
-        if created_workspace {
-            let _ = close_workspace(&pane.workspace_id);
+        let cleanup = if created_workspace {
+            close_workspace(&pane.workspace_id)
         } else {
-            let _ = close_tab(&pane.tab_id);
-        }
-        return Err(error);
+            close_tab(&pane.tab_id)
+        };
+        return Err(with_cleanup_error(error, cleanup));
     }
 
     if open_in_new_window {
@@ -415,8 +422,6 @@ fn choose_workspace(
 }
 
 fn create_workspace(cwd: &Path, name: &str) -> Result<WorkspaceCreateResult, Box<dyn Error>> {
-    println!("Creating workspace {name} in {}", cwd.display());
-
     let output = Command::new("herdr")
         .args(["workspace", "create", "--cwd"])
         .arg(cwd)
@@ -457,11 +462,29 @@ fn create_tab_terminal(
     Ok(response.result.root_pane)
 }
 
-fn create_dashboard_shell(
-    workspace_id: &str,
-    base_name: &str,
-    command: Option<&str>,
-) -> Result<String, Box<dyn Error>> {
+fn create_dashboard_workspace(name: &str) -> Result<String, Box<dyn Error>> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err("workspace name cannot be empty".into());
+    }
+    let cwd = env::current_dir()?.canonicalize()?;
+    let panes = load_panes()?;
+    let workspaces = load_workspaces()?;
+    if find_workspace(&workspaces, &panes, &cwd, name).is_some() {
+        return Err(format!("workspace {name} already exists in {}", cwd.display()).into());
+    }
+
+    let pane = create_workspace(&cwd, name)?.root_pane;
+    if let Err(error) = rename_pane(&pane.pane_id, "shell-1") {
+        return Err(with_cleanup_error(
+            error,
+            close_workspace(&pane.workspace_id),
+        ));
+    }
+    Ok(format!("Created workspace {name} with shell-1"))
+}
+
+fn create_dashboard_shell(workspace_id: &str) -> Result<String, Box<dyn Error>> {
     let panes = load_panes()?;
     let workspaces = load_workspaces()?;
     let workspace = workspaces
@@ -474,17 +497,10 @@ fn create_dashboard_shell(
         .ok_or("selected workspace has no terminals")?
         .cwd
         .as_str();
-    let shell_name = unique_shell_name(base_name, &workspace_panes);
+    let shell_name = unique_shell_name("shell", &workspace_panes);
     let pane = create_tab_terminal(workspace_id, Path::new(cwd), &workspace.label, &shell_name)?;
     if let Err(error) = rename_pane(&pane.pane_id, &shell_name) {
-        let _ = close_tab(&pane.tab_id);
-        return Err(error);
-    }
-    if let Some(command) = command
-        && let Err(error) = run_pane_command(&pane.pane_id, command)
-    {
-        let _ = close_tab(&pane.tab_id);
-        return Err(error);
+        return Err(with_cleanup_error(error, close_tab(&pane.tab_id)));
     }
 
     Ok(format!("Created {shell_name} in {}", workspace.label))
@@ -524,23 +540,40 @@ fn rename_pane(pane_id: &str, name: &str) -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn run_pane_command(pane_id: &str, command: &str) -> Result<(), Box<dyn Error>> {
-    let output = Command::new("herdr")
-        .args(["pane", "run", pane_id, command])
-        .output()?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        let message = String::from_utf8_lossy(&output.stderr);
-        Err(format!("could not run command in Herdr pane: {}", message.trim()).into())
-    }
-}
-
 fn pane_name(pane: &Pane) -> &str {
     pane.label
         .as_deref()
         .or(pane.agent.as_deref())
         .unwrap_or("shell")
+}
+
+fn with_cleanup_error(
+    error: Box<dyn Error>,
+    cleanup: Result<(), Box<dyn Error>>,
+) -> Box<dyn Error> {
+    match cleanup {
+        Ok(()) => error,
+        Err(cleanup_error) => format!("{error}; cleanup also failed: {cleanup_error}").into(),
+    }
+}
+
+fn open_dashboard_terminal(terminal_id: &str) -> Result<String, Box<dyn Error>> {
+    let panes = load_panes()?;
+    let pane = panes
+        .iter()
+        .find(|pane| pane.terminal_id == terminal_id)
+        .ok_or("selected terminal no longer exists")?;
+    let workspace = load_workspaces()?
+        .into_iter()
+        .find(|workspace| workspace.workspace_id == pane.workspace_id)
+        .ok_or("selected workspace no longer exists")?;
+    let shell_name = pane_name(pane);
+    open_terminal(
+        terminal_id,
+        Some(&format!("{} - {shell_name}", workspace.label)),
+        true,
+    )?;
+    Ok(format!("Opened {shell_name} from {}", workspace.label))
 }
 
 fn open_workspace(workspace: &Workspace, panes: &[Pane]) -> Result<(), Box<dyn Error>> {
@@ -838,8 +871,8 @@ mod tests {
                 terminal_id: "term_2".into(),
                 workspace_id: "w1".into(),
                 cwd: "/tmp".into(),
-                label: Some("opencode".into()),
-                agent: Some("opencode".into()),
+                label: Some("api".into()),
+                agent: None,
                 agent_status: "idle".into(),
             },
         ];
@@ -849,12 +882,12 @@ mod tests {
             "shell-2"
         );
         assert_eq!(
-            unique_shell_name("opencode", &panes.iter().collect::<Vec<_>>()),
-            "opencode-2"
+            unique_shell_name("api", &panes.iter().collect::<Vec<_>>()),
+            "api-2"
         );
         assert_eq!(
-            unique_shell_name("lazygit", &panes.iter().collect::<Vec<_>>()),
-            "lazygit"
+            unique_shell_name("logs", &panes.iter().collect::<Vec<_>>()),
+            "logs"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,9 @@ enum Commands {
         #[arg(long)]
         takeover: bool,
     },
+    /// Print the current Boomux workspace and shell name for prompt integrations
+    #[command(hide = true)]
+    Prompt,
 }
 
 fn main() -> ExitCode {
@@ -76,6 +79,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             title,
             takeover,
         }) => open_terminal(&terminal_id, title.as_deref(), takeover),
+        Some(Commands::Prompt) => print_prompt_label(),
         None => picker(),
     }
 }
@@ -130,9 +134,12 @@ struct Workspace {
 #[derive(Deserialize)]
 struct Pane {
     pane_id: String,
+    tab_id: String,
     terminal_id: String,
     workspace_id: String,
     cwd: String,
+    #[serde(default)]
+    label: Option<String>,
     #[serde(default)]
     agent: Option<String>,
     agent_status: String,
@@ -189,6 +196,14 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
             close_workspace(workspace_id).map_err(|error| error.to_string())?;
             Ok(format!("Closed {label} and all of its shells"))
         },
+        |workspace_id, base_name, command| {
+            create_dashboard_shell(workspace_id, base_name, command)
+                .map_err(|error| error.to_string())
+        },
+        |pane_id, name| {
+            rename_pane(pane_id, name).map_err(|error| error.to_string())?;
+            Ok(format!("Renamed shell to {name}"))
+        },
         || dashboard_snapshot().map_err(|error| error.to_string()),
     )?;
     Ok(())
@@ -210,6 +225,8 @@ fn dashboard_views(workspaces: &[Workspace], panes: &[Pane]) -> Vec<tui::Workspa
                 .into_iter()
                 .map(|pane| tui::TerminalView {
                     id: pane.terminal_id.clone(),
+                    pane_id: pane.pane_id.clone(),
+                    name: pane_name(pane).to_owned(),
                     kind: pane.agent.clone().unwrap_or_else(|| "shell".into()),
                     status: pane.agent_status.clone(),
                     directory: pane.cwd.clone(),
@@ -240,28 +257,45 @@ fn open_directory(
         .filter(|name| !name.is_empty())
         .map(str::to_owned)
         .unwrap_or_else(|| default_workspace_name(&directory));
-    let (terminal_id, shell_number) =
-        if let Some(workspace) = find_workspace(&workspaces, &panes, &directory, &name) {
-            let shell_number = workspace_panes(&workspace.workspace_id, &panes).count() + 1;
-            (
-                create_tab_terminal(&workspace.workspace_id, &directory)?.terminal_id,
-                shell_number,
-            )
+    let (pane, shell_name, created_workspace) = if let Some(workspace) =
+        find_workspace(&workspaces, &panes, &directory, &name)
+    {
+        let workspace_panes: Vec<_> = workspace_panes(&workspace.workspace_id, &panes).collect();
+        let shell_name = unique_shell_name("shell", &workspace_panes);
+        (
+            create_tab_terminal(
+                &workspace.workspace_id,
+                &directory,
+                &workspace.label,
+                &shell_name,
+            )?,
+            shell_name,
+            false,
+        )
+    } else {
+        (
+            create_workspace(&directory, &name)?.root_pane,
+            "shell-1".into(),
+            true,
+        )
+    };
+    if let Err(error) = rename_pane(&pane.pane_id, &shell_name) {
+        if created_workspace {
+            let _ = close_workspace(&pane.workspace_id);
         } else {
-            (
-                create_workspace(&directory, &name)?.root_pane.terminal_id,
-                1,
-            )
-        };
+            let _ = close_tab(&pane.tab_id);
+        }
+        return Err(error);
+    }
 
     if open_in_new_window {
         open_terminal(
-            &terminal_id,
-            Some(&format!("{name} [{shell_number}]")),
+            &pane.terminal_id,
+            Some(&format!("{name} - {shell_name}")),
             true,
         )?;
-    } else if !attach_terminal(&terminal_id)? {
-        return Err(format!("could not attach to Herdr terminal {terminal_id}").into());
+    } else if !attach_terminal(&pane.terminal_id)? {
+        return Err(format!("could not attach to Herdr terminal {}", pane.terminal_id).into());
     }
     Ok(())
 }
@@ -387,6 +421,8 @@ fn create_workspace(cwd: &Path, name: &str) -> Result<WorkspaceCreateResult, Box
         .args(["workspace", "create", "--cwd"])
         .arg(cwd)
         .args(["--label", name])
+        .args(["--env", &format!("BOOMUX_WORKSPACE={name}")])
+        .args(["--env", "BOOMUX_SHELL_NAME=shell-1"])
         .arg("--focus")
         .output()?;
     if !output.status.success() {
@@ -398,10 +434,18 @@ fn create_workspace(cwd: &Path, name: &str) -> Result<WorkspaceCreateResult, Box
     Ok(response.result)
 }
 
-fn create_tab_terminal(workspace_id: &str, cwd: &Path) -> Result<Pane, Box<dyn Error>> {
+fn create_tab_terminal(
+    workspace_id: &str,
+    cwd: &Path,
+    workspace_name: &str,
+    shell_name: &str,
+) -> Result<Pane, Box<dyn Error>> {
     let output = Command::new("herdr")
         .args(["tab", "create", "--workspace", workspace_id, "--cwd"])
         .arg(cwd)
+        .args(["--label", shell_name])
+        .args(["--env", &format!("BOOMUX_WORKSPACE={workspace_name}")])
+        .args(["--env", &format!("BOOMUX_SHELL_NAME={shell_name}")])
         .arg("--focus")
         .output()?;
     if !output.status.success() {
@@ -413,6 +457,92 @@ fn create_tab_terminal(workspace_id: &str, cwd: &Path) -> Result<Pane, Box<dyn E
     Ok(response.result.root_pane)
 }
 
+fn create_dashboard_shell(
+    workspace_id: &str,
+    base_name: &str,
+    command: Option<&str>,
+) -> Result<String, Box<dyn Error>> {
+    let panes = load_panes()?;
+    let workspaces = load_workspaces()?;
+    let workspace = workspaces
+        .iter()
+        .find(|workspace| workspace.workspace_id == workspace_id)
+        .ok_or("selected workspace no longer exists")?;
+    let workspace_panes: Vec<_> = workspace_panes(workspace_id, &panes).collect();
+    let cwd = workspace_panes
+        .first()
+        .ok_or("selected workspace has no terminals")?
+        .cwd
+        .as_str();
+    let shell_name = unique_shell_name(base_name, &workspace_panes);
+    let pane = create_tab_terminal(workspace_id, Path::new(cwd), &workspace.label, &shell_name)?;
+    if let Err(error) = rename_pane(&pane.pane_id, &shell_name) {
+        let _ = close_tab(&pane.tab_id);
+        return Err(error);
+    }
+    if let Some(command) = command
+        && let Err(error) = run_pane_command(&pane.pane_id, command)
+    {
+        let _ = close_tab(&pane.tab_id);
+        return Err(error);
+    }
+
+    Ok(format!("Created {shell_name} in {}", workspace.label))
+}
+
+fn unique_shell_name(base_name: &str, panes: &[&Pane]) -> String {
+    let highest_suffix = panes
+        .iter()
+        .filter_map(|pane| pane.label.as_deref())
+        .filter_map(|label| {
+            if label == base_name {
+                Some(1)
+            } else {
+                label
+                    .strip_prefix(base_name)
+                    .and_then(|suffix| suffix.strip_prefix('-'))
+                    .and_then(|suffix| suffix.parse::<usize>().ok())
+            }
+        })
+        .max();
+
+    highest_suffix.map_or_else(
+        || base_name.to_owned(),
+        |suffix| format!("{base_name}-{}", suffix + 1),
+    )
+}
+
+fn rename_pane(pane_id: &str, name: &str) -> Result<(), Box<dyn Error>> {
+    let output = Command::new("herdr")
+        .args(["pane", "rename", pane_id, name])
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let message = String::from_utf8_lossy(&output.stderr);
+        Err(format!("could not rename Herdr pane: {}", message.trim()).into())
+    }
+}
+
+fn run_pane_command(pane_id: &str, command: &str) -> Result<(), Box<dyn Error>> {
+    let output = Command::new("herdr")
+        .args(["pane", "run", pane_id, command])
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let message = String::from_utf8_lossy(&output.stderr);
+        Err(format!("could not run command in Herdr pane: {}", message.trim()).into())
+    }
+}
+
+fn pane_name(pane: &Pane) -> &str {
+    pane.label
+        .as_deref()
+        .or(pane.agent.as_deref())
+        .unwrap_or("shell")
+}
+
 fn open_workspace(workspace: &Workspace, panes: &[Pane]) -> Result<(), Box<dyn Error>> {
     let workspace_panes: Vec<_> = workspace_panes(&workspace.workspace_id, panes).collect();
     if workspace_panes.is_empty() {
@@ -420,13 +550,40 @@ fn open_workspace(workspace: &Workspace, panes: &[Pane]) -> Result<(), Box<dyn E
     }
 
     for (index, pane) in workspace_panes.iter().enumerate() {
+        let shell_name = pane
+            .label
+            .as_deref()
+            .map(str::to_owned)
+            .unwrap_or_else(|| format!("shell-{}", index + 1));
         open_terminal(
             &pane.terminal_id,
-            Some(&format!("{} [{}]", workspace.label, index + 1)),
+            Some(&format!("{} - {shell_name}", workspace.label)),
             true,
         )?;
     }
 
+    Ok(())
+}
+
+fn print_prompt_label() -> Result<(), Box<dyn Error>> {
+    let Some(pane_id) = env::var_os("HERDR_PANE_ID").and_then(|value| value.into_string().ok())
+    else {
+        return Ok(());
+    };
+    let panes = load_panes()?;
+    let Some(pane) = panes.iter().find(|pane| pane.pane_id == pane_id) else {
+        return Ok(());
+    };
+    let workspace_name = load_workspaces()?
+        .into_iter()
+        .find(|workspace| workspace.workspace_id == pane.workspace_id)
+        .map(|workspace| workspace.label);
+    let shell_name = pane_name(pane);
+    if let Some(workspace_name) = workspace_name {
+        println!("{workspace_name}/{shell_name}");
+    } else {
+        println!("{shell_name}");
+    }
     Ok(())
 }
 
@@ -439,6 +596,18 @@ fn close_workspace(workspace_id: &str) -> Result<(), Box<dyn Error>> {
     } else {
         let message = String::from_utf8_lossy(&output.stderr);
         Err(format!("could not close Herdr workspace: {}", message.trim()).into())
+    }
+}
+
+fn close_tab(tab_id: &str) -> Result<(), Box<dyn Error>> {
+    let output = Command::new("herdr")
+        .args(["tab", "close", tab_id])
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let message = String::from_utf8_lossy(&output.stderr);
+        Err(format!("could not close Herdr tab: {}", message.trim()).into())
     }
 }
 
@@ -528,6 +697,7 @@ fn open_terminal(
     command
         .arg("+new-window")
         .arg(format!("--title={title}"))
+        .arg("--shell-integration-features=no-title")
         .args(["-e", "herdr", "terminal", "attach", terminal_id]);
 
     if takeover {
@@ -588,6 +758,9 @@ mod tests {
 
         assert!(cli.path.is_none());
         assert!(matches!(cli.command, Some(Commands::Doctor)));
+
+        let cli = Cli::try_parse_from(["boomux", "prompt"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Prompt)));
     }
 
     #[test]
@@ -608,9 +781,11 @@ mod tests {
         }];
         let panes = vec![Pane {
             pane_id: "w1:p1".into(),
+            tab_id: "w1:t1".into(),
             terminal_id: "term_123".into(),
             workspace_id: "w1".into(),
             cwd: directory.display().to_string(),
+            label: Some("shell-1".into()),
             agent: None,
             agent_status: "unknown".into(),
         }];
@@ -626,9 +801,11 @@ mod tests {
                 "result": {
                     "panes": [{
                         "pane_id": "w1:p1",
+                        "tab_id": "w1:t1",
                         "terminal_id": "term_123",
                         "workspace_id": "w1",
                         "cwd": "/tmp/project",
+                        "label": "api",
                         "agent_status": "working"
                     }]
                 }
@@ -639,6 +816,46 @@ mod tests {
         assert_eq!(response.result.panes.len(), 1);
         assert_eq!(response.result.panes[0].pane_id, "w1:p1");
         assert_eq!(response.result.panes[0].terminal_id, "term_123");
+        assert_eq!(response.result.panes[0].label.as_deref(), Some("api"));
+    }
+
+    #[test]
+    fn generates_unique_shell_names() {
+        let panes = [
+            Pane {
+                pane_id: "w1:p1".into(),
+                tab_id: "w1:t1".into(),
+                terminal_id: "term_1".into(),
+                workspace_id: "w1".into(),
+                cwd: "/tmp".into(),
+                label: Some("shell-1".into()),
+                agent: None,
+                agent_status: "unknown".into(),
+            },
+            Pane {
+                pane_id: "w1:p2".into(),
+                tab_id: "w1:t2".into(),
+                terminal_id: "term_2".into(),
+                workspace_id: "w1".into(),
+                cwd: "/tmp".into(),
+                label: Some("opencode".into()),
+                agent: Some("opencode".into()),
+                agent_status: "idle".into(),
+            },
+        ];
+
+        assert_eq!(
+            unique_shell_name("shell", &panes.iter().collect::<Vec<_>>()),
+            "shell-2"
+        );
+        assert_eq!(
+            unique_shell_name("opencode", &panes.iter().collect::<Vec<_>>()),
+            "opencode-2"
+        );
+        assert_eq!(
+            unique_shell_name("lazygit", &panes.iter().collect::<Vec<_>>()),
+            "lazygit"
+        );
     }
 
     #[test]
@@ -654,6 +871,7 @@ mod tests {
                 "result": {
                     "root_pane": {
                         "pane_id": "w1:p1",
+                        "tab_id": "w1:t1",
                         "terminal_id": "term_456",
                         "workspace_id": "w1",
                         "cwd": "/tmp/project",

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -36,6 +36,16 @@ pub(crate) struct TerminalView {
     pub(crate) directory: String,
 }
 
+pub(crate) struct Actions<R, O, C, W, N, E, F> {
+    pub(crate) on_restore: R,
+    pub(crate) on_open: O,
+    pub(crate) on_close: C,
+    pub(crate) on_create_workspace: W,
+    pub(crate) on_create_shell: N,
+    pub(crate) on_rename: E,
+    pub(crate) on_refresh: F,
+}
+
 struct App {
     workspaces: Vec<WorkspaceView>,
     workspace_state: TableState,
@@ -54,8 +64,7 @@ enum Focus {
 
 enum Mode {
     Normal,
-    Create,
-    CustomCommand(String),
+    CreateWorkspace(String),
     Rename { pane_id: String, input: String },
 }
 
@@ -189,13 +198,6 @@ impl App {
         );
     }
 
-    fn request_create(&mut self) {
-        if self.selected().is_some() {
-            self.mode = Mode::Create;
-            self.message = None;
-        }
-    }
-
     fn request_rename(&mut self) {
         if self.focus == Focus::Terminals
             && let Some(terminal) = self.selected_terminal()
@@ -208,15 +210,36 @@ impl App {
         }
     }
 
-    fn create_shell<F>(&mut self, base_name: &str, command: Option<&str>, on_create: &mut F)
+    fn request_add<F>(&mut self, on_create_shell: &mut F) -> bool
     where
-        F: FnMut(&str, &str, Option<&str>) -> Result<String, String>,
+        F: FnMut(&str) -> Result<String, String>,
     {
-        let Some(workspace_id) = self.selected().map(|workspace| workspace.id.clone()) else {
-            return;
-        };
+        match self.focus {
+            Focus::Workspaces => {
+                self.mode = Mode::CreateWorkspace(String::new());
+                self.message = None;
+                false
+            }
+            Focus::Terminals => {
+                let Some(workspace_id) = self.selected().map(|workspace| workspace.id.clone())
+                else {
+                    return false;
+                };
+                self.message = Some(match on_create_shell(&workspace_id) {
+                    Ok(text) => Message { text, error: false },
+                    Err(text) => Message { text, error: true },
+                });
+                true
+            }
+        }
+    }
+
+    fn create_workspace<F>(&mut self, name: &str, on_create_workspace: &mut F)
+    where
+        F: FnMut(&str) -> Result<String, String>,
+    {
         self.mode = Mode::Normal;
-        self.message = Some(match on_create(&workspace_id, base_name, command) {
+        self.message = Some(match on_create_workspace(name) {
             Ok(text) => Message { text, error: false },
             Err(text) => Message { text, error: true },
         });
@@ -241,6 +264,19 @@ impl App {
             return;
         };
         self.message = Some(match on_restore(&workspace_id) {
+            Ok(text) => Message { text, error: false },
+            Err(text) => Message { text, error: true },
+        });
+    }
+
+    fn open_selected_terminal<F>(&mut self, on_open: &mut F)
+    where
+        F: FnMut(&str) -> Result<String, String>,
+    {
+        let Some(terminal_id) = self.selected_terminal().map(|terminal| terminal.id.clone()) else {
+            return;
+        };
+        self.message = Some(match on_open(&terminal_id) {
             Ok(text) => Message { text, error: false },
             Err(text) => Message { text, error: true },
         });
@@ -308,55 +344,43 @@ impl App {
     }
 }
 
-pub(crate) fn run<R, C, N, E, F>(
+pub(crate) fn run<R, O, C, W, N, E, F>(
     workspaces: Vec<WorkspaceView>,
-    on_restore: R,
-    on_close: C,
-    on_create: N,
-    on_rename: E,
-    on_refresh: F,
+    actions: Actions<R, O, C, W, N, E, F>,
 ) -> io::Result<()>
 where
     R: FnMut(&str) -> Result<String, String>,
+    O: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
-    N: FnMut(&str, &str, Option<&str>) -> Result<String, String>,
+    W: FnMut(&str) -> Result<String, String>,
+    N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
 {
     let mut terminal = ratatui::init();
-    let result = run_loop(
-        &mut terminal,
-        App::new(workspaces),
-        on_restore,
-        on_close,
-        on_create,
-        on_rename,
-        on_refresh,
-    );
+    let result = run_loop(&mut terminal, App::new(workspaces), actions);
     ratatui::restore();
     result
 }
 
-fn run_loop<R, C, N, E, F>(
+fn run_loop<R, O, C, W, N, E, F>(
     terminal: &mut ratatui::DefaultTerminal,
     mut app: App,
-    mut on_restore: R,
-    mut on_close: C,
-    mut on_create: N,
-    mut on_rename: E,
-    mut on_refresh: F,
+    mut actions: Actions<R, O, C, W, N, E, F>,
 ) -> io::Result<()>
 where
     R: FnMut(&str) -> Result<String, String>,
+    O: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
-    N: FnMut(&str, &str, Option<&str>) -> Result<String, String>,
+    W: FnMut(&str) -> Result<String, String>,
+    N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
 {
     let mut last_refresh = Instant::now();
     loop {
         if last_refresh.elapsed() >= REFRESH_INTERVAL {
-            app.refresh(&mut on_refresh);
+            app.refresh(&mut actions.on_refresh);
             last_refresh = Instant::now();
         }
         terminal.draw(|frame| render(frame, &mut app))?;
@@ -374,8 +398,8 @@ where
         if app.pending_close.is_some() {
             match key.code {
                 KeyCode::Char('y') => {
-                    app.confirm_close(&mut on_close);
-                    app.refresh(&mut on_refresh);
+                    app.confirm_close(&mut actions.on_close);
+                    app.refresh(&mut actions.on_refresh);
                     last_refresh = Instant::now();
                 }
                 KeyCode::Char('n') | KeyCode::Esc => app.cancel_close(),
@@ -385,8 +409,13 @@ where
         }
 
         if !matches!(app.mode, Mode::Normal) {
-            if handle_mode_key(&mut app, key.code, &mut on_create, &mut on_rename) {
-                app.refresh(&mut on_refresh);
+            if handle_mode_key(
+                &mut app,
+                key.code,
+                &mut actions.on_create_workspace,
+                &mut actions.on_rename,
+            ) {
+                app.refresh(&mut actions.on_refresh);
                 last_refresh = Instant::now();
             }
             continue;
@@ -397,16 +426,24 @@ where
             KeyCode::Down | KeyCode::Char('j') => app.next(),
             KeyCode::Up | KeyCode::Char('k') => app.previous(),
             KeyCode::Enter => {
-                app.restore_selected(&mut on_restore);
-                app.refresh(&mut on_refresh);
+                match app.focus {
+                    Focus::Workspaces => app.restore_selected(&mut actions.on_restore),
+                    Focus::Terminals => app.open_selected_terminal(&mut actions.on_open),
+                }
+                app.refresh(&mut actions.on_refresh);
                 last_refresh = Instant::now();
             }
             KeyCode::Char('r') => {
-                app.refresh(&mut on_refresh);
+                app.refresh(&mut actions.on_refresh);
                 last_refresh = Instant::now();
             }
             KeyCode::Char('x') => app.request_close(),
-            KeyCode::Char('a') => app.request_create(),
+            KeyCode::Char('a') => {
+                if app.request_add(&mut actions.on_create_shell) {
+                    app.refresh(&mut actions.on_refresh);
+                    last_refresh = Instant::now();
+                }
+            }
             KeyCode::Char('e') => app.request_rename(),
             KeyCode::Tab => app.toggle_focus(),
             _ => {}
@@ -414,62 +451,38 @@ where
     }
 }
 
-fn handle_mode_key<N, E>(app: &mut App, key: KeyCode, on_create: &mut N, on_rename: &mut E) -> bool
+fn handle_mode_key<W, E>(
+    app: &mut App,
+    key: KeyCode,
+    on_create_workspace: &mut W,
+    on_rename: &mut E,
+) -> bool
 where
-    N: FnMut(&str, &str, Option<&str>) -> Result<String, String>,
+    W: FnMut(&str) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
 {
     let mode = std::mem::replace(&mut app.mode, Mode::Normal);
     match mode {
         Mode::Normal => false,
-        Mode::Create => match key {
-            KeyCode::Char('s') => {
-                app.create_shell("shell", None, on_create);
-                true
-            }
-            KeyCode::Char('o') => {
-                app.create_shell("opencode", Some("opencode"), on_create);
-                true
-            }
-            KeyCode::Char('l') => {
-                app.create_shell("lazygit", Some("lazygit"), on_create);
-                true
-            }
-            KeyCode::Char('c') => {
-                app.mode = Mode::CustomCommand(String::new());
-                false
-            }
-            KeyCode::Esc => false,
-            _ => {
-                app.mode = Mode::Create;
-                false
-            }
-        },
-        Mode::CustomCommand(mut input) => match key {
+        Mode::CreateWorkspace(mut input) => match key {
             KeyCode::Enter if !input.trim().is_empty() => {
-                let command = input.trim().to_owned();
-                let base_name = command
-                    .split_whitespace()
-                    .next()
-                    .and_then(|program| program.rsplit('/').next())
-                    .unwrap_or("custom")
-                    .to_owned();
-                app.create_shell(&base_name, Some(&command), on_create);
+                let name = input.trim().to_owned();
+                app.create_workspace(&name, on_create_workspace);
                 true
             }
             KeyCode::Esc => false,
             KeyCode::Backspace => {
                 input.pop();
-                app.mode = Mode::CustomCommand(input);
+                app.mode = Mode::CreateWorkspace(input);
                 false
             }
             KeyCode::Char(character) => {
                 input.push(character);
-                app.mode = Mode::CustomCommand(input);
+                app.mode = Mode::CreateWorkspace(input);
                 false
             }
             _ => {
-                app.mode = Mode::CustomCommand(input);
+                app.mode = Mode::CreateWorkspace(input);
                 false
             }
         },
@@ -727,23 +740,9 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Span::styled("n/esc", Style::new().fg(GREEN)),
             Span::styled(" cancel", Style::new().fg(SUBTEXT)),
         ])
-    } else if matches!(app.mode, Mode::Create) {
+    } else if let Mode::CreateWorkspace(input) = &app.mode {
         Line::from(vec![
-            Span::styled(" Add shell:  ", Style::new().fg(TEXT)),
-            Span::styled("s", Style::new().fg(GREEN)),
-            Span::raw(" shell  "),
-            Span::styled("o", Style::new().fg(GREEN)),
-            Span::raw(" opencode  "),
-            Span::styled("l", Style::new().fg(GREEN)),
-            Span::raw(" lazygit  "),
-            Span::styled("c", Style::new().fg(GREEN)),
-            Span::raw(" custom  "),
-            Span::styled("esc", Style::new().fg(RED)),
-            Span::raw(" cancel"),
-        ])
-    } else if let Mode::CustomCommand(input) = &app.mode {
-        Line::from(vec![
-            Span::styled(" Custom command: ", Style::new().fg(YELLOW)),
+            Span::styled(" Workspace name: ", Style::new().fg(YELLOW)),
             Span::styled(format!("{input}_"), Style::new().fg(TEXT)),
             Span::styled("  enter", Style::new().fg(GREEN)),
             Span::raw(" create  "),
@@ -765,22 +764,43 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Style::new().fg(if message.error { RED } else { GREEN }),
         ))
     } else {
-        Line::from(vec![
+        let mut spans = vec![
             Span::styled(" j/k", Style::new().fg(TEAL)),
             Span::styled(" navigate  tab focus  ", Style::new().fg(SUBTEXT)),
             Span::styled("a", Style::new().fg(GREEN)),
-            Span::styled(" add  ", Style::new().fg(SUBTEXT)),
-            Span::styled("e", Style::new().fg(YELLOW)),
-            Span::styled(" rename  ", Style::new().fg(SUBTEXT)),
+            Span::styled(
+                if app.focus == Focus::Workspaces {
+                    " add workspace  "
+                } else {
+                    " add shell  "
+                },
+                Style::new().fg(SUBTEXT),
+            ),
+        ];
+        if app.focus == Focus::Terminals {
+            spans.extend([
+                Span::styled("e", Style::new().fg(YELLOW)),
+                Span::styled(" rename  ", Style::new().fg(SUBTEXT)),
+            ]);
+        }
+        spans.extend([
             Span::styled("enter", Style::new().fg(GREEN)),
-            Span::styled(" restore workspace  ", Style::new().fg(SUBTEXT)),
+            Span::styled(
+                if app.focus == Focus::Workspaces {
+                    " restore workspace  "
+                } else {
+                    " open shell  "
+                },
+                Style::new().fg(SUBTEXT),
+            ),
             Span::styled("r", Style::new().fg(BLUE)),
             Span::styled(" refresh  ", Style::new().fg(SUBTEXT)),
             Span::styled("x", Style::new().fg(RED)),
-            Span::styled(" close  ", Style::new().fg(SUBTEXT)),
+            Span::styled(" close workspace  ", Style::new().fg(SUBTEXT)),
             Span::styled("q", Style::new().fg(RED)),
             Span::styled(" quit", Style::new().fg(SUBTEXT)),
-        ])
+        ]);
+        Line::from(spans)
     };
     frame.render_widget(Paragraph::new(line), area);
 }
@@ -857,31 +877,63 @@ mod tests {
     }
 
     #[test]
-    fn create_menu_dispatches_builtin_recipes() {
+    fn add_creates_a_workspace_from_workspace_focus() {
         let mut app = app();
         let mut created = None;
 
-        app.request_create();
+        assert!(!app.request_add(&mut |_| Ok(String::new())));
+        assert!(matches!(app.mode, Mode::CreateWorkspace(_)));
+        for character in "feature".chars() {
+            handle_mode_key(
+                &mut app,
+                KeyCode::Char(character),
+                &mut |_| Ok(String::new()),
+                &mut |_, _| Ok(String::new()),
+            );
+        }
         let changed = handle_mode_key(
             &mut app,
-            KeyCode::Char('o'),
-            &mut |workspace_id, name, command| {
-                created = Some((
-                    workspace_id.to_owned(),
-                    name.to_owned(),
-                    command.map(str::to_owned),
-                ));
-                Ok("Created shell".into())
+            KeyCode::Enter,
+            &mut |name| {
+                created = Some(name.to_owned());
+                Ok("Created workspace".into())
             },
             &mut |_, _| Ok(String::new()),
         );
 
         assert!(changed);
-        assert_eq!(
-            created,
-            Some(("w1".into(), "opencode".into(), Some("opencode".into())))
-        );
+        assert_eq!(created.as_deref(), Some("feature"));
         assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn add_creates_a_shell_from_terminal_focus() {
+        let mut app = app();
+        let mut workspace_id = None;
+        app.toggle_focus();
+
+        let changed = app.request_add(&mut |selected_workspace_id| {
+            workspace_id = Some(selected_workspace_id.to_owned());
+            Ok("Created shell".into())
+        });
+
+        assert!(changed);
+        assert_eq!(workspace_id.as_deref(), Some("w1"));
+        assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn enter_on_terminal_opens_only_the_selected_shell() {
+        let mut app = app();
+        let mut opened = None;
+        app.toggle_focus();
+
+        app.open_selected_terminal(&mut |terminal_id| {
+            opened = Some(terminal_id.to_owned());
+            Ok("Opened shell".into())
+        });
+
+        assert_eq!(opened.as_deref(), Some("term_1"));
     }
 
     #[test]
@@ -895,14 +947,14 @@ mod tests {
             handle_mode_key(
                 &mut app,
                 KeyCode::Char(character),
-                &mut |_, _, _| Ok(String::new()),
+                &mut |_| Ok(String::new()),
                 &mut |_, _| Ok(String::new()),
             );
         }
         let changed = handle_mode_key(
             &mut app,
             KeyCode::Enter,
-            &mut |_, _, _| Ok(String::new()),
+            &mut |_| Ok(String::new()),
             &mut |pane_id, name| {
                 renamed = Some((pane_id.to_owned(), name.to_owned()));
                 Ok("Renamed shell".into())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -29,6 +29,8 @@ pub(crate) struct WorkspaceView {
 
 pub(crate) struct TerminalView {
     pub(crate) id: String,
+    pub(crate) pane_id: String,
+    pub(crate) name: String,
     pub(crate) kind: String,
     pub(crate) status: String,
     pub(crate) directory: String,
@@ -37,8 +39,24 @@ pub(crate) struct TerminalView {
 struct App {
     workspaces: Vec<WorkspaceView>,
     workspace_state: TableState,
+    terminal_state: TableState,
+    focus: Focus,
+    mode: Mode,
     message: Option<Message>,
     pending_close: Option<PendingClose>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Focus {
+    Workspaces,
+    Terminals,
+}
+
+enum Mode {
+    Normal,
+    Create,
+    CustomCommand(String),
+    Rename { pane_id: String, input: String },
 }
 
 struct Message {
@@ -55,12 +73,19 @@ struct PendingClose {
 impl App {
     fn new(workspaces: Vec<WorkspaceView>) -> Self {
         let mut workspace_state = TableState::default();
+        let mut terminal_state = TableState::default();
         if !workspaces.is_empty() {
             workspace_state.select(Some(0));
+            if !workspaces[0].terminals.is_empty() {
+                terminal_state.select(Some(0));
+            }
         }
         Self {
             workspaces,
             workspace_state,
+            terminal_state,
+            focus: Focus::Workspaces,
+            mode: Mode::Normal,
             message: None,
             pending_close: None,
         }
@@ -75,28 +100,137 @@ impl App {
             .and_then(|index| self.workspaces.get(index))
     }
 
+    fn selected_terminal(&self) -> Option<&TerminalView> {
+        self.selected().and_then(|workspace| {
+            self.terminal_state
+                .selected()
+                .and_then(|index| workspace.terminals.get(index))
+        })
+    }
+
     fn next(&mut self) {
-        if self.workspaces.is_empty() {
-            return;
+        match self.focus {
+            Focus::Workspaces => {
+                if self.workspaces.is_empty() {
+                    return;
+                }
+                let next = self
+                    .selected_index()
+                    .map_or(0, |index| (index + 1) % self.workspaces.len());
+                self.workspace_state.select(Some(next));
+                self.select_first_terminal();
+            }
+            Focus::Terminals => {
+                let terminal_count = self
+                    .selected()
+                    .map_or(0, |workspace| workspace.terminals.len());
+                if terminal_count == 0 {
+                    return;
+                }
+                let next = self
+                    .terminal_state
+                    .selected()
+                    .map_or(0, |index| (index + 1) % terminal_count);
+                self.terminal_state.select(Some(next));
+            }
         }
-        let next = self
-            .selected_index()
-            .map_or(0, |index| (index + 1) % self.workspaces.len());
-        self.workspace_state.select(Some(next));
+        self.message = None;
     }
 
     fn previous(&mut self) {
-        if self.workspaces.is_empty() {
-            return;
-        }
-        let previous = self.selected_index().map_or(0, |index| {
-            if index == 0 {
-                self.workspaces.len() - 1
-            } else {
-                index - 1
+        match self.focus {
+            Focus::Workspaces => {
+                if self.workspaces.is_empty() {
+                    return;
+                }
+                let previous = self.selected_index().map_or(0, |index| {
+                    if index == 0 {
+                        self.workspaces.len() - 1
+                    } else {
+                        index - 1
+                    }
+                });
+                self.workspace_state.select(Some(previous));
+                self.select_first_terminal();
             }
+            Focus::Terminals => {
+                let terminal_count = self
+                    .selected()
+                    .map_or(0, |workspace| workspace.terminals.len());
+                if terminal_count == 0 {
+                    return;
+                }
+                let previous = self.terminal_state.selected().map_or(0, |index| {
+                    if index == 0 {
+                        terminal_count - 1
+                    } else {
+                        index - 1
+                    }
+                });
+                self.terminal_state.select(Some(previous));
+            }
+        }
+        self.message = None;
+    }
+
+    fn toggle_focus(&mut self) {
+        self.focus = match self.focus {
+            Focus::Workspaces => Focus::Terminals,
+            Focus::Terminals => Focus::Workspaces,
+        };
+        self.message = None;
+    }
+
+    fn select_first_terminal(&mut self) {
+        self.terminal_state.select(
+            self.selected()
+                .is_some_and(|workspace| !workspace.terminals.is_empty())
+                .then_some(0),
+        );
+    }
+
+    fn request_create(&mut self) {
+        if self.selected().is_some() {
+            self.mode = Mode::Create;
+            self.message = None;
+        }
+    }
+
+    fn request_rename(&mut self) {
+        if self.focus == Focus::Terminals
+            && let Some(terminal) = self.selected_terminal()
+        {
+            self.mode = Mode::Rename {
+                pane_id: terminal.pane_id.clone(),
+                input: String::new(),
+            };
+            self.message = None;
+        }
+    }
+
+    fn create_shell<F>(&mut self, base_name: &str, command: Option<&str>, on_create: &mut F)
+    where
+        F: FnMut(&str, &str, Option<&str>) -> Result<String, String>,
+    {
+        let Some(workspace_id) = self.selected().map(|workspace| workspace.id.clone()) else {
+            return;
+        };
+        self.mode = Mode::Normal;
+        self.message = Some(match on_create(&workspace_id, base_name, command) {
+            Ok(text) => Message { text, error: false },
+            Err(text) => Message { text, error: true },
         });
-        self.workspace_state.select(Some(previous));
+    }
+
+    fn rename_shell<F>(&mut self, pane_id: &str, name: &str, on_rename: &mut F)
+    where
+        F: FnMut(&str, &str) -> Result<String, String>,
+    {
+        self.mode = Mode::Normal;
+        self.message = Some(match on_rename(pane_id, name) {
+            Ok(text) => Message { text, error: false },
+            Err(text) => Message { text, error: true },
+        });
     }
 
     fn restore_selected<F>(&mut self, on_restore: &mut F)
@@ -149,6 +283,7 @@ impl App {
 
     fn replace_workspaces(&mut self, workspaces: Vec<WorkspaceView>) {
         let selected_id = self.selected().map(|workspace| workspace.id.clone());
+        let selected_terminal_id = self.selected_terminal().map(|terminal| terminal.id.clone());
         let previous_index = self.selected_index().unwrap_or(0);
         let selected_index = selected_id
             .and_then(|id| workspaces.iter().position(|workspace| workspace.id == id))
@@ -156,18 +291,36 @@ impl App {
 
         self.workspaces = workspaces;
         self.workspace_state.select(selected_index);
+        let terminal_index = self.selected().and_then(|workspace| {
+            selected_terminal_id
+                .and_then(|id| {
+                    workspace
+                        .terminals
+                        .iter()
+                        .position(|terminal| terminal.id == id)
+                })
+                .or_else(|| (!workspace.terminals.is_empty()).then_some(0))
+        });
+        self.terminal_state.select(terminal_index);
+        if self.focus == Focus::Terminals && terminal_index.is_none() {
+            self.focus = Focus::Workspaces;
+        }
     }
 }
 
-pub(crate) fn run<R, C, F>(
+pub(crate) fn run<R, C, N, E, F>(
     workspaces: Vec<WorkspaceView>,
     on_restore: R,
     on_close: C,
+    on_create: N,
+    on_rename: E,
     on_refresh: F,
 ) -> io::Result<()>
 where
     R: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
+    N: FnMut(&str, &str, Option<&str>) -> Result<String, String>,
+    E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
 {
     let mut terminal = ratatui::init();
@@ -176,22 +329,28 @@ where
         App::new(workspaces),
         on_restore,
         on_close,
+        on_create,
+        on_rename,
         on_refresh,
     );
     ratatui::restore();
     result
 }
 
-fn run_loop<R, C, F>(
+fn run_loop<R, C, N, E, F>(
     terminal: &mut ratatui::DefaultTerminal,
     mut app: App,
     mut on_restore: R,
     mut on_close: C,
+    mut on_create: N,
+    mut on_rename: E,
     mut on_refresh: F,
 ) -> io::Result<()>
 where
     R: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
+    N: FnMut(&str, &str, Option<&str>) -> Result<String, String>,
+    E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
 {
     let mut last_refresh = Instant::now();
@@ -225,6 +384,14 @@ where
             continue;
         }
 
+        if !matches!(app.mode, Mode::Normal) {
+            if handle_mode_key(&mut app, key.code, &mut on_create, &mut on_rename) {
+                app.refresh(&mut on_refresh);
+                last_refresh = Instant::now();
+            }
+            continue;
+        }
+
         match key.code {
             KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
             KeyCode::Down | KeyCode::Char('j') => app.next(),
@@ -239,8 +406,95 @@ where
                 last_refresh = Instant::now();
             }
             KeyCode::Char('x') => app.request_close(),
+            KeyCode::Char('a') => app.request_create(),
+            KeyCode::Char('e') => app.request_rename(),
+            KeyCode::Tab => app.toggle_focus(),
             _ => {}
         }
+    }
+}
+
+fn handle_mode_key<N, E>(app: &mut App, key: KeyCode, on_create: &mut N, on_rename: &mut E) -> bool
+where
+    N: FnMut(&str, &str, Option<&str>) -> Result<String, String>,
+    E: FnMut(&str, &str) -> Result<String, String>,
+{
+    let mode = std::mem::replace(&mut app.mode, Mode::Normal);
+    match mode {
+        Mode::Normal => false,
+        Mode::Create => match key {
+            KeyCode::Char('s') => {
+                app.create_shell("shell", None, on_create);
+                true
+            }
+            KeyCode::Char('o') => {
+                app.create_shell("opencode", Some("opencode"), on_create);
+                true
+            }
+            KeyCode::Char('l') => {
+                app.create_shell("lazygit", Some("lazygit"), on_create);
+                true
+            }
+            KeyCode::Char('c') => {
+                app.mode = Mode::CustomCommand(String::new());
+                false
+            }
+            KeyCode::Esc => false,
+            _ => {
+                app.mode = Mode::Create;
+                false
+            }
+        },
+        Mode::CustomCommand(mut input) => match key {
+            KeyCode::Enter if !input.trim().is_empty() => {
+                let command = input.trim().to_owned();
+                let base_name = command
+                    .split_whitespace()
+                    .next()
+                    .and_then(|program| program.rsplit('/').next())
+                    .unwrap_or("custom")
+                    .to_owned();
+                app.create_shell(&base_name, Some(&command), on_create);
+                true
+            }
+            KeyCode::Esc => false,
+            KeyCode::Backspace => {
+                input.pop();
+                app.mode = Mode::CustomCommand(input);
+                false
+            }
+            KeyCode::Char(character) => {
+                input.push(character);
+                app.mode = Mode::CustomCommand(input);
+                false
+            }
+            _ => {
+                app.mode = Mode::CustomCommand(input);
+                false
+            }
+        },
+        Mode::Rename { pane_id, mut input } => match key {
+            KeyCode::Enter if !input.trim().is_empty() => {
+                let name = input.trim().to_owned();
+                app.rename_shell(&pane_id, &name, on_rename);
+                true
+            }
+            KeyCode::Esc => false,
+            KeyCode::Backspace => {
+                input.pop();
+                app.mode = Mode::Rename { pane_id, input };
+                false
+            }
+            KeyCode::Char(character) => {
+                input.push(character);
+                app.mode = Mode::Rename { pane_id, input };
+                false
+            }
+            _ => {
+                app.mode = Mode::Rename { pane_id, input };
+                false
+            }
+        },
     }
 }
 
@@ -287,10 +541,7 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         ),
         Span::styled("  |  ", Style::new().fg(OVERLAY)),
         Span::styled(format!("{shell_count} shells"), Style::new().fg(BLUE)),
-        Span::styled(
-            "    Enter restores selected workspace",
-            Style::new().fg(SUBTEXT),
-        ),
+        Span::styled("    Tab switches tables", Style::new().fg(SUBTEXT)),
     ]);
     frame.render_widget(
         Paragraph::new(line).block(
@@ -331,7 +582,11 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
     .block(
         Block::bordered()
             .title(" Workspaces ")
-            .border_style(Style::new().fg(OVERLAY)),
+            .border_style(Style::new().fg(if app.focus == Focus::Workspaces {
+                TEAL
+            } else {
+                OVERLAY
+            })),
     )
     .row_highlight_style(
         Style::new()
@@ -343,10 +598,10 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
     frame.render_stateful_widget(table, area, &mut app.workspace_state);
 }
 
-fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
-    let header = Row::new(["#", "TYPE", "STATUS", "DIRECTORY", "TERMINAL ID"])
+fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
+    let header = Row::new(["#", "NAME", "TYPE", "STATUS", "DIRECTORY", "TERMINAL ID"])
         .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD));
-    let rows = app
+    let rows: Vec<_> = app
         .selected()
         .into_iter()
         .flat_map(|workspace| workspace.terminals.iter())
@@ -354,12 +609,17 @@ fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         .map(|(index, terminal)| {
             Row::new(vec![
                 Cell::from((index + 1).to_string()),
-                Cell::from(terminal.kind.as_str()),
-                Cell::from(status_span(&terminal.status)),
-                Cell::from(terminal.directory.as_str()),
-                Cell::from(terminal.id.as_str()),
+                Cell::from(terminal.name.clone()),
+                Cell::from(terminal.kind.clone()),
+                Cell::from(Span::styled(
+                    status_label(&terminal.status).to_owned(),
+                    Style::new().fg(status_color(&terminal.status)),
+                )),
+                Cell::from(terminal.directory.clone()),
+                Cell::from(terminal.id.clone()),
             ])
-        });
+        })
+        .collect();
     let title = app.selected().map_or_else(
         || " Terminals ".to_owned(),
         |workspace| format!(" Terminals: {} ", workspace.name),
@@ -369,6 +629,7 @@ fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         [
             Constraint::Length(4),
             Constraint::Length(18),
+            Constraint::Length(18),
             Constraint::Length(12),
             Constraint::Min(24),
             Constraint::Length(24),
@@ -376,12 +637,20 @@ fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
     )
     .header(header)
     .column_spacing(1)
-    .block(
-        Block::bordered()
-            .title(title)
-            .border_style(Style::new().fg(OVERLAY)),
-    );
-    frame.render_widget(table, area);
+    .block(Block::bordered().title(title).border_style(Style::new().fg(
+        if app.focus == Focus::Terminals {
+            TEAL
+        } else {
+            OVERLAY
+        },
+    )))
+    .row_highlight_style(
+        Style::new()
+            .fg(TEXT)
+            .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+    )
+    .highlight_symbol("> ");
+    frame.render_stateful_widget(table, area, &mut app.terminal_state);
 }
 
 fn render_metrics(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
@@ -458,6 +727,38 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Span::styled("n/esc", Style::new().fg(GREEN)),
             Span::styled(" cancel", Style::new().fg(SUBTEXT)),
         ])
+    } else if matches!(app.mode, Mode::Create) {
+        Line::from(vec![
+            Span::styled(" Add shell:  ", Style::new().fg(TEXT)),
+            Span::styled("s", Style::new().fg(GREEN)),
+            Span::raw(" shell  "),
+            Span::styled("o", Style::new().fg(GREEN)),
+            Span::raw(" opencode  "),
+            Span::styled("l", Style::new().fg(GREEN)),
+            Span::raw(" lazygit  "),
+            Span::styled("c", Style::new().fg(GREEN)),
+            Span::raw(" custom  "),
+            Span::styled("esc", Style::new().fg(RED)),
+            Span::raw(" cancel"),
+        ])
+    } else if let Mode::CustomCommand(input) = &app.mode {
+        Line::from(vec![
+            Span::styled(" Custom command: ", Style::new().fg(YELLOW)),
+            Span::styled(format!("{input}_"), Style::new().fg(TEXT)),
+            Span::styled("  enter", Style::new().fg(GREEN)),
+            Span::raw(" create  "),
+            Span::styled("esc", Style::new().fg(RED)),
+            Span::raw(" cancel"),
+        ])
+    } else if let Mode::Rename { input, .. } = &app.mode {
+        Line::from(vec![
+            Span::styled(" New shell name: ", Style::new().fg(YELLOW)),
+            Span::styled(format!("{input}_"), Style::new().fg(TEXT)),
+            Span::styled("  enter", Style::new().fg(GREEN)),
+            Span::raw(" rename  "),
+            Span::styled("esc", Style::new().fg(RED)),
+            Span::raw(" cancel"),
+        ])
     } else if let Some(message) = &app.message {
         Line::from(Span::styled(
             format!(" {}", message.text),
@@ -466,7 +767,11 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
     } else {
         Line::from(vec![
             Span::styled(" j/k", Style::new().fg(TEAL)),
-            Span::styled(" or arrows navigate  ", Style::new().fg(SUBTEXT)),
+            Span::styled(" navigate  tab focus  ", Style::new().fg(SUBTEXT)),
+            Span::styled("a", Style::new().fg(GREEN)),
+            Span::styled(" add  ", Style::new().fg(SUBTEXT)),
+            Span::styled("e", Style::new().fg(YELLOW)),
+            Span::styled(" rename  ", Style::new().fg(SUBTEXT)),
             Span::styled("enter", Style::new().fg(GREEN)),
             Span::styled(" restore workspace  ", Style::new().fg(SUBTEXT)),
             Span::styled("r", Style::new().fg(BLUE)),
@@ -516,6 +821,8 @@ mod tests {
             directory: "/tmp/boomux".into(),
             terminals: vec![TerminalView {
                 id: "term_1".into(),
+                pane_id: "w1:p1".into(),
+                name: "agent".into(),
                 kind: "opencode".into(),
                 status: "working".into(),
                 directory: "/tmp/boomux".into(),
@@ -531,6 +838,89 @@ mod tests {
         assert_eq!(app.selected_index(), Some(0));
         app.previous();
         assert_eq!(app.selected_index(), Some(0));
+    }
+
+    #[test]
+    fn terminal_navigation_uses_the_focused_table() {
+        let mut app = app();
+
+        app.toggle_focus();
+        assert_eq!(app.focus, Focus::Terminals);
+        app.next();
+
+        assert_eq!(app.terminal_state.selected(), Some(0));
+        assert_eq!(
+            app.selected_terminal()
+                .map(|terminal| terminal.name.as_str()),
+            Some("agent")
+        );
+    }
+
+    #[test]
+    fn create_menu_dispatches_builtin_recipes() {
+        let mut app = app();
+        let mut created = None;
+
+        app.request_create();
+        let changed = handle_mode_key(
+            &mut app,
+            KeyCode::Char('o'),
+            &mut |workspace_id, name, command| {
+                created = Some((
+                    workspace_id.to_owned(),
+                    name.to_owned(),
+                    command.map(str::to_owned),
+                ));
+                Ok("Created shell".into())
+            },
+            &mut |_, _| Ok(String::new()),
+        );
+
+        assert!(changed);
+        assert_eq!(
+            created,
+            Some(("w1".into(), "opencode".into(), Some("opencode".into())))
+        );
+        assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn rename_mode_dispatches_the_selected_pane_and_name() {
+        let mut app = app();
+        let mut renamed = None;
+        app.toggle_focus();
+        app.request_rename();
+
+        for character in ['a', 'p', 'i'] {
+            handle_mode_key(
+                &mut app,
+                KeyCode::Char(character),
+                &mut |_, _, _| Ok(String::new()),
+                &mut |_, _| Ok(String::new()),
+            );
+        }
+        let changed = handle_mode_key(
+            &mut app,
+            KeyCode::Enter,
+            &mut |_, _, _| Ok(String::new()),
+            &mut |pane_id, name| {
+                renamed = Some((pane_id.to_owned(), name.to_owned()));
+                Ok("Renamed shell".into())
+            },
+        );
+
+        assert!(changed);
+        assert_eq!(renamed, Some(("w1:p1".into(), "api".into())));
+        assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn rename_requires_terminal_focus() {
+        let mut app = app();
+
+        app.request_rename();
+
+        assert!(matches!(app.mode, Mode::Normal));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add focus-aware workspace and terminal navigation to the dashboard
- create named workspaces with one shell from workspace focus and add plain shells from terminal focus
- open only the selected shell from terminal focus while preserving restore-all behavior for workspace focus
- persist individual shell names in Herdr pane labels and reuse them in the TUI, Ghostty titles, and Starship prompt output
- add the product ideas roadmap and document the new controls

## Testing
- cargo fmt --check
- cargo test (22 passing)
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check