### PR TITLE
Add workspace directory picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,22 @@ between workspaces and terminals, then `j`/`k` or the arrow keys to navigate.
 
 - `Enter` restores the selected workspace or opens only the selected terminal,
   depending on which table is focused.
-- `a` creates a workspace with one shell from workspace focus, or adds one plain
-  shell from terminal focus. New workspaces use the directory where the
-  dashboard was launched.
+- `a` opens a directory picker from workspace focus, or adds one plain shell
+  from terminal focus.
 - `e` renames the selected terminal when the terminal table is focused.
 - `x`, then `y`, closes the selected workspace and all of its shells.
 - `r` refreshes immediately; `q` or `Esc` quits.
+
+The workspace directory picker starts with the dashboard launch directory, the
+selected workspace directory, and recently used Boomux directories. Press
+`l`/Right to browse the selected location's immediate children, `h`/Left to
+move to its parent, and `Enter` to create the workspace. Its name defaults to
+the selected directory's basename and it starts with `shell-1`. Recent paths
+are stored under `$XDG_STATE_HOME/boomux` (or `~/.local/state/boomux`).
+
+The picker only reads the filesystem on the host where Boomux is running, so it
+also works in a remote terminal when Boomux and Herdr run there. Restoring native
+Ghostty windows still requires a local graphical Ghostty session.
 
 Shell names are stored as Herdr pane labels and appear in the dashboard and
 restored Ghostty window titles. New shells receive `BOOMUX_WORKSPACE` and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,12 @@ confirmation, terminating every shell in that workspace. Shell creation uses
 Herdr tabs, and pane labels provide durable shell names for the dashboard,
 Ghostty titles, and prompt integrations.
 
+Workspace creation uses a terminal-native directory picker. Quick locations
+come from the launch directory, selected workspace, and a bounded recent-path
+list in the user's XDG state directory. Filesystem browsing is lazy and reads
+only one directory level at a time; the selected directory basename becomes
+the default workspace name.
+
 Dashboard colors use semantic ANSI roles and the terminal's default foreground
 and background. This keeps the TUI portable while allowing terminal-level theme
 systems such as Omarchy to supply the concrete palette.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 use std::env;
 use std::error::Error;
+use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
 
 use clap::{Parser, Subcommand};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 mod tui;
 
@@ -150,6 +151,13 @@ struct Choice {
     workspace_id: String,
 }
 
+#[derive(Default, Deserialize, Serialize)]
+struct BoomuxState {
+    recent_directories: Vec<PathBuf>,
+}
+
+const MAX_RECENT_DIRECTORIES: usize = 10;
+
 fn picker() -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
     let panes = available_panes()?;
@@ -162,14 +170,23 @@ fn picker() -> Result<(), Box<dyn Error>> {
         .find(|workspace| workspace.workspace_id == workspace_id)
         .ok_or("selected workspace no longer exists")?;
 
-    open_workspace(workspace, &panes)
+    open_workspace(workspace, &panes)?;
+    if let Some(pane) = workspace_panes(&workspace.workspace_id, &panes).next() {
+        remember_directory(Path::new(&pane.cwd));
+    }
+    Ok(())
 }
 
 fn dashboard() -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
     let views = dashboard_snapshot()?;
+    let directory_context = tui::DirectoryContext {
+        launch_directory: env::current_dir()?.canonicalize()?,
+        recent_directories: load_recent_directories(),
+    };
     tui::run(
         views,
+        directory_context,
         tui::Actions {
             on_restore: |workspace_id: &str| {
                 let panes = load_panes().map_err(|error| error.to_string())?;
@@ -180,6 +197,9 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
                     .ok_or_else(|| "selected workspace no longer exists".to_owned())?;
                 let shell_count = workspace_panes(&workspace.workspace_id, &panes).count();
                 open_workspace(workspace, &panes).map_err(|error| error.to_string())?;
+                if let Some(pane) = workspace_panes(&workspace.workspace_id, &panes).next() {
+                    remember_directory(Path::new(&pane.cwd));
+                }
                 Ok(format!(
                     "Restored {shell_count} shell(s) for {}",
                     workspace.label
@@ -200,8 +220,8 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
                 close_workspace(workspace_id).map_err(|error| error.to_string())?;
                 Ok(format!("Closed {label} and all of its shells"))
             },
-            on_create_workspace: |name: &str| {
-                create_dashboard_workspace(name).map_err(|error| error.to_string())
+            on_create_workspace: |directory: &Path| {
+                create_dashboard_workspace(directory).map_err(|error| error.to_string())
             },
             on_create_shell: |workspace_id: &str| {
                 create_dashboard_shell(workspace_id).map_err(|error| error.to_string())
@@ -294,6 +314,7 @@ fn open_directory(
         };
         return Err(with_cleanup_error(error, cleanup));
     }
+    remember_directory(&directory);
 
     if open_in_new_window {
         open_terminal(
@@ -314,6 +335,78 @@ fn default_workspace_name(directory: &Path) -> String {
         .filter(|name| !name.is_empty())
         .unwrap_or("default")
         .to_owned()
+}
+
+fn load_recent_directories() -> Vec<PathBuf> {
+    let Some(path) = state_file_path() else {
+        return Vec::new();
+    };
+    fs::read(path)
+        .ok()
+        .and_then(|contents| serde_json::from_slice::<BoomuxState>(&contents).ok())
+        .map(|state| {
+            state
+                .recent_directories
+                .into_iter()
+                .filter(|directory| directory.is_dir())
+                .take(MAX_RECENT_DIRECTORIES)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn remember_directory(directory: &Path) {
+    let Some(path) = state_file_path() else {
+        return;
+    };
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(lock) = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path.with_extension("lock"))
+    else {
+        return;
+    };
+    if lock.lock().is_err() {
+        return;
+    }
+
+    let mut recent_directories = load_recent_directories();
+    update_recent_directories(&mut recent_directories, directory);
+    let state = BoomuxState { recent_directories };
+    let Ok(contents) = serde_json::to_vec_pretty(&state) else {
+        return;
+    };
+    let temporary_path = path.with_extension(format!("tmp-{}", std::process::id()));
+    if fs::write(&temporary_path, contents).is_ok() && fs::rename(&temporary_path, path).is_err() {
+        let _ = fs::remove_file(temporary_path);
+    }
+}
+
+fn update_recent_directories(recent_directories: &mut Vec<PathBuf>, directory: &Path) {
+    recent_directories.retain(|recent| recent != directory);
+    recent_directories.insert(0, directory.to_owned());
+    recent_directories.truncate(MAX_RECENT_DIRECTORIES);
+}
+
+fn state_file_path() -> Option<PathBuf> {
+    env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| {
+            env::var_os("HOME")
+                .map(PathBuf::from)
+                .filter(|path| path.is_absolute())
+                .map(|home| home.join(".local/state"))
+        })
+        .map(|state_home| state_home.join("boomux/state.json"))
 }
 
 fn ensure_host_terminal() -> Result<(), Box<dyn Error>> {
@@ -462,25 +555,23 @@ fn create_tab_terminal(
     Ok(response.result.root_pane)
 }
 
-fn create_dashboard_workspace(name: &str) -> Result<String, Box<dyn Error>> {
-    let name = name.trim();
-    if name.is_empty() {
-        return Err("workspace name cannot be empty".into());
-    }
-    let cwd = env::current_dir()?.canonicalize()?;
+fn create_dashboard_workspace(directory: &Path) -> Result<String, Box<dyn Error>> {
+    let name = default_workspace_name(directory);
+    let cwd = resolve_directory(directory)?;
     let panes = load_panes()?;
     let workspaces = load_workspaces()?;
-    if find_workspace(&workspaces, &panes, &cwd, name).is_some() {
+    if find_workspace(&workspaces, &panes, &cwd, &name).is_some() {
         return Err(format!("workspace {name} already exists in {}", cwd.display()).into());
     }
 
-    let pane = create_workspace(&cwd, name)?.root_pane;
+    let pane = create_workspace(&cwd, &name)?.root_pane;
     if let Err(error) = rename_pane(&pane.pane_id, "shell-1") {
         return Err(with_cleanup_error(
             error,
             close_workspace(&pane.workspace_id),
         ));
     }
+    remember_directory(&cwd);
     Ok(format!("Created workspace {name} with shell-1"))
 }
 
@@ -568,6 +659,7 @@ fn open_dashboard_terminal(terminal_id: &str) -> Result<String, Box<dyn Error>> 
         .find(|workspace| workspace.workspace_id == pane.workspace_id)
         .ok_or("selected workspace no longer exists")?;
     let shell_name = pane_name(pane);
+    remember_directory(Path::new(&pane.cwd));
     open_terminal(
         terminal_id,
         Some(&format!("{} - {shell_name}", workspace.label)),
@@ -802,6 +894,21 @@ mod tests {
 
         assert_eq!(resolve_directory(manifest_dir).unwrap(), manifest_dir);
         assert!(resolve_directory(&manifest_dir.join("Cargo.toml")).is_err());
+    }
+
+    #[test]
+    fn recent_directories_are_deduplicated_and_bounded() {
+        let mut recent: Vec<_> = (0..MAX_RECENT_DIRECTORIES)
+            .map(|index| PathBuf::from(format!("/tmp/project-{index}")))
+            .collect();
+
+        update_recent_directories(&mut recent, Path::new("/tmp/project-4"));
+        assert_eq!(recent[0], PathBuf::from("/tmp/project-4"));
+        assert_eq!(recent.len(), MAX_RECENT_DIRECTORIES);
+
+        update_recent_directories(&mut recent, Path::new("/tmp/new-project"));
+        assert_eq!(recent[0], PathBuf::from("/tmp/new-project"));
+        assert_eq!(recent.len(), MAX_RECENT_DIRECTORIES);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,12 +1,17 @@
+use std::env;
+use std::fs;
 use std::io;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout};
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Cell, Paragraph, Row, Table, TableState};
+use ratatui::widgets::{
+    Block, Cell, Clear, List, ListItem, ListState, Paragraph, Row, Table, TableState,
+};
 
 const BASE: Color = Color::Reset;
 const OVERLAY: Color = Color::DarkGray;
@@ -18,6 +23,8 @@ const GREEN: Color = Color::Green;
 const YELLOW: Color = Color::Yellow;
 const RED: Color = Color::Red;
 const REFRESH_INTERVAL: Duration = Duration::from_millis(250);
+const MAX_DIRECTORY_ENTRIES: usize = 500;
+const MAX_RECENT_DIRECTORIES: usize = 10;
 
 pub(crate) struct WorkspaceView {
     pub(crate) id: String,
@@ -25,6 +32,11 @@ pub(crate) struct WorkspaceView {
     pub(crate) status: String,
     pub(crate) directory: String,
     pub(crate) terminals: Vec<TerminalView>,
+}
+
+pub(crate) struct DirectoryContext {
+    pub(crate) launch_directory: PathBuf,
+    pub(crate) recent_directories: Vec<PathBuf>,
 }
 
 pub(crate) struct TerminalView {
@@ -54,6 +66,7 @@ struct App {
     mode: Mode,
     message: Option<Message>,
     pending_close: Option<PendingClose>,
+    directory_context: DirectoryContext,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -64,8 +77,20 @@ enum Focus {
 
 enum Mode {
     Normal,
-    CreateWorkspace(String),
+    PickDirectory(DirectoryPicker),
     Rename { pane_id: String, input: String },
+}
+
+struct DirectoryPicker {
+    entries: Vec<DirectoryEntry>,
+    state: ListState,
+    browsing: Option<PathBuf>,
+    error: Option<String>,
+}
+
+struct DirectoryEntry {
+    label: String,
+    path: PathBuf,
 }
 
 struct Message {
@@ -79,8 +104,134 @@ struct PendingClose {
     shell_count: usize,
 }
 
+impl DirectoryPicker {
+    fn new(context: &DirectoryContext, selected_directory: Option<&str>) -> Self {
+        let mut entries = Vec::new();
+        push_directory_entry(&mut entries, "current", context.launch_directory.clone());
+        if let Some(directory) = selected_directory {
+            push_directory_entry(&mut entries, "selected workspace", PathBuf::from(directory));
+        }
+        for directory in &context.recent_directories {
+            push_directory_entry(&mut entries, "recent", directory.clone());
+        }
+        let mut state = ListState::default();
+        if !entries.is_empty() {
+            state.select(Some(0));
+        }
+        Self {
+            entries,
+            state,
+            browsing: None,
+            error: None,
+        }
+    }
+
+    fn selected_path(&self) -> Option<&Path> {
+        self.state
+            .selected()
+            .and_then(|index| self.entries.get(index))
+            .map(|entry| entry.path.as_path())
+    }
+
+    fn next(&mut self) {
+        if self.entries.is_empty() {
+            return;
+        }
+        let next = self
+            .state
+            .selected()
+            .map_or(0, |index| (index + 1) % self.entries.len());
+        self.state.select(Some(next));
+    }
+
+    fn previous(&mut self) {
+        if self.entries.is_empty() {
+            return;
+        }
+        let previous = self.state.selected().map_or(0, |index| {
+            if index == 0 {
+                self.entries.len() - 1
+            } else {
+                index - 1
+            }
+        });
+        self.state.select(Some(previous));
+    }
+
+    fn browse_selected(&mut self) {
+        let Some(directory) = self.selected_path().map(Path::to_owned) else {
+            return;
+        };
+        self.show_directory(directory);
+    }
+
+    fn browse_parent(&mut self) {
+        let Some(parent) = self
+            .browsing
+            .as_deref()
+            .or_else(|| self.selected_path())
+            .and_then(Path::parent)
+            .map(Path::to_owned)
+        else {
+            return;
+        };
+        self.show_directory(parent);
+    }
+
+    fn show_directory(&mut self, directory: PathBuf) {
+        match child_directories(&directory) {
+            Ok(children) => {
+                let mut entries = vec![DirectoryEntry {
+                    label: "use this directory".into(),
+                    path: directory.clone(),
+                }];
+                entries.extend(children.into_iter().map(|path| {
+                    DirectoryEntry {
+                        label: path
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .unwrap_or("directory")
+                            .to_owned(),
+                        path,
+                    }
+                }));
+                self.entries = entries;
+                self.state.select(Some(0));
+                self.browsing = Some(directory);
+                self.error = None;
+            }
+            Err(error) => self.error = Some(error.to_string()),
+        }
+    }
+}
+
+fn child_directories(directory: &Path) -> io::Result<Vec<PathBuf>> {
+    let mut children: Vec<_> = fs::read_dir(directory)?
+        .take(MAX_DIRECTORY_ENTRIES)
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect();
+    children.sort_by_cached_key(|path| {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_lowercase()
+    });
+    Ok(children)
+}
+
+fn push_directory_entry(entries: &mut Vec<DirectoryEntry>, label: &str, path: PathBuf) {
+    if path.is_dir() && !entries.iter().any(|entry| entry.path == path) {
+        entries.push(DirectoryEntry {
+            label: label.to_owned(),
+            path,
+        });
+    }
+}
+
 impl App {
-    fn new(workspaces: Vec<WorkspaceView>) -> Self {
+    fn new(workspaces: Vec<WorkspaceView>, directory_context: DirectoryContext) -> Self {
         let mut workspace_state = TableState::default();
         let mut terminal_state = TableState::default();
         if !workspaces.is_empty() {
@@ -97,6 +248,7 @@ impl App {
             mode: Mode::Normal,
             message: None,
             pending_close: None,
+            directory_context,
         }
     }
 
@@ -115,6 +267,18 @@ impl App {
                 .selected()
                 .and_then(|index| workspace.terminals.get(index))
         })
+    }
+
+    fn remember_directory(&mut self, directory: &Path) {
+        self.directory_context
+            .recent_directories
+            .retain(|recent| recent != directory);
+        self.directory_context
+            .recent_directories
+            .insert(0, directory.to_owned());
+        self.directory_context
+            .recent_directories
+            .truncate(MAX_RECENT_DIRECTORIES);
     }
 
     fn next(&mut self) {
@@ -216,7 +380,12 @@ impl App {
     {
         match self.focus {
             Focus::Workspaces => {
-                self.mode = Mode::CreateWorkspace(String::new());
+                let selected_directory =
+                    self.selected().map(|workspace| workspace.directory.clone());
+                self.mode = Mode::PickDirectory(DirectoryPicker::new(
+                    &self.directory_context,
+                    selected_directory.as_deref(),
+                ));
                 self.message = None;
                 false
             }
@@ -234,13 +403,16 @@ impl App {
         }
     }
 
-    fn create_workspace<F>(&mut self, name: &str, on_create_workspace: &mut F)
+    fn create_workspace<F>(&mut self, directory: &Path, on_create_workspace: &mut F)
     where
-        F: FnMut(&str) -> Result<String, String>,
+        F: FnMut(&Path) -> Result<String, String>,
     {
         self.mode = Mode::Normal;
-        self.message = Some(match on_create_workspace(name) {
-            Ok(text) => Message { text, error: false },
+        self.message = Some(match on_create_workspace(directory) {
+            Ok(text) => {
+                self.remember_directory(directory);
+                Message { text, error: false }
+            }
             Err(text) => Message { text, error: true },
         });
     }
@@ -260,11 +432,17 @@ impl App {
     where
         F: FnMut(&str) -> Result<String, String>,
     {
-        let Some(workspace_id) = self.selected().map(|workspace| workspace.id.clone()) else {
+        let Some((workspace_id, directory)) = self
+            .selected()
+            .map(|workspace| (workspace.id.clone(), workspace.directory.clone()))
+        else {
             return;
         };
         self.message = Some(match on_restore(&workspace_id) {
-            Ok(text) => Message { text, error: false },
+            Ok(text) => {
+                self.remember_directory(Path::new(&directory));
+                Message { text, error: false }
+            }
             Err(text) => Message { text, error: true },
         });
     }
@@ -273,11 +451,17 @@ impl App {
     where
         F: FnMut(&str) -> Result<String, String>,
     {
-        let Some(terminal_id) = self.selected_terminal().map(|terminal| terminal.id.clone()) else {
+        let Some((terminal_id, directory)) = self
+            .selected_terminal()
+            .map(|terminal| (terminal.id.clone(), terminal.directory.clone()))
+        else {
             return;
         };
         self.message = Some(match on_open(&terminal_id) {
-            Ok(text) => Message { text, error: false },
+            Ok(text) => {
+                self.remember_directory(Path::new(&directory));
+                Message { text, error: false }
+            }
             Err(text) => Message { text, error: true },
         });
     }
@@ -346,19 +530,24 @@ impl App {
 
 pub(crate) fn run<R, O, C, W, N, E, F>(
     workspaces: Vec<WorkspaceView>,
+    directory_context: DirectoryContext,
     actions: Actions<R, O, C, W, N, E, F>,
 ) -> io::Result<()>
 where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&Path) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
 {
     let mut terminal = ratatui::init();
-    let result = run_loop(&mut terminal, App::new(workspaces), actions);
+    let result = run_loop(
+        &mut terminal,
+        App::new(workspaces, directory_context),
+        actions,
+    );
     ratatui::restore();
     result
 }
@@ -372,7 +561,7 @@ where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&Path) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
@@ -458,31 +647,44 @@ fn handle_mode_key<W, E>(
     on_rename: &mut E,
 ) -> bool
 where
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&Path) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
 {
     let mode = std::mem::replace(&mut app.mode, Mode::Normal);
     match mode {
         Mode::Normal => false,
-        Mode::CreateWorkspace(mut input) => match key {
-            KeyCode::Enter if !input.trim().is_empty() => {
-                let name = input.trim().to_owned();
-                app.create_workspace(&name, on_create_workspace);
+        Mode::PickDirectory(mut picker) => match key {
+            KeyCode::Enter if picker.selected_path().is_some() => {
+                let directory = picker
+                    .selected_path()
+                    .expect("selected directory")
+                    .to_owned();
+                app.create_workspace(&directory, on_create_workspace);
                 true
             }
             KeyCode::Esc => false,
-            KeyCode::Backspace => {
-                input.pop();
-                app.mode = Mode::CreateWorkspace(input);
+            KeyCode::Down | KeyCode::Char('j') => {
+                picker.next();
+                app.mode = Mode::PickDirectory(picker);
                 false
             }
-            KeyCode::Char(character) => {
-                input.push(character);
-                app.mode = Mode::CreateWorkspace(input);
+            KeyCode::Up | KeyCode::Char('k') => {
+                picker.previous();
+                app.mode = Mode::PickDirectory(picker);
+                false
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                picker.browse_selected();
+                app.mode = Mode::PickDirectory(picker);
+                false
+            }
+            KeyCode::Left | KeyCode::Char('h') | KeyCode::Backspace => {
+                picker.browse_parent();
+                app.mode = Mode::PickDirectory(picker);
                 false
             }
             _ => {
-                app.mode = Mode::CreateWorkspace(input);
+                app.mode = Mode::PickDirectory(picker);
                 false
             }
         },
@@ -535,6 +737,79 @@ fn render(frame: &mut Frame, app: &mut App) {
     render_terminals(frame, terminal_area, app);
     render_metrics(frame, metrics_area, app);
     render_footer(frame, footer_area, app);
+    if let Mode::PickDirectory(picker) = &mut app.mode {
+        render_directory_picker(frame, area, picker);
+    }
+}
+
+fn render_directory_picker(frame: &mut Frame, area: Rect, picker: &mut DirectoryPicker) {
+    let popup_area = centered_rect(area, 80, 72);
+    frame.render_widget(Clear, popup_area);
+    frame.render_widget(Block::new().style(Style::new().bg(BASE)), popup_area);
+    let [list_area, help_area] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(2)]).areas(popup_area);
+    let items = picker.entries.iter().map(|entry| {
+        ListItem::new(Line::from(vec![
+            Span::styled(format!("{:<20}", entry.label), Style::new().fg(TEAL)),
+            Span::styled(display_path(&entry.path), Style::new().fg(TEXT)),
+        ]))
+    });
+    let title = picker.browsing.as_ref().map_or_else(
+        || " Create workspace: quick locations ".to_owned(),
+        |directory| format!(" Browse: {} ", display_path(directory)),
+    );
+    let list = List::new(items)
+        .block(
+            Block::bordered()
+                .title(title)
+                .border_style(Style::new().fg(TEAL)),
+        )
+        .highlight_symbol("> ")
+        .highlight_style(
+            Style::new()
+                .fg(TEXT)
+                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+        );
+    frame.render_stateful_widget(list, list_area, &mut picker.state);
+
+    let help = if let Some(error) = &picker.error {
+        Line::from(Span::styled(format!(" {error}"), Style::new().fg(RED)))
+    } else {
+        Line::from(vec![
+            Span::styled(" enter", Style::new().fg(GREEN)),
+            Span::raw(" create  "),
+            Span::styled("l/right", Style::new().fg(BLUE)),
+            Span::raw(" browse  "),
+            Span::styled("h/left", Style::new().fg(YELLOW)),
+            Span::raw(" parent  "),
+            Span::styled("esc", Style::new().fg(RED)),
+            Span::raw(" cancel"),
+        ])
+    };
+    frame.render_widget(Paragraph::new(help).style(Style::new().bg(BASE)), help_area);
+}
+
+fn centered_rect(area: Rect, width_percent: u16, height_percent: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Percentage(height_percent)])
+        .flex(ratatui::layout::Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Percentage(width_percent)])
+        .flex(ratatui::layout::Flex::Center)
+        .areas(vertical);
+    horizontal
+}
+
+fn display_path(path: &Path) -> String {
+    let Some(home) = env::var_os("HOME").map(PathBuf::from) else {
+        return path.display().to_string();
+    };
+    if path == home {
+        "~".into()
+    } else if let Ok(relative) = path.strip_prefix(&home) {
+        format!("~/{}", relative.display())
+    } else {
+        path.display().to_string()
+    }
 }
 
 fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
@@ -740,15 +1015,6 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Span::styled("n/esc", Style::new().fg(GREEN)),
             Span::styled(" cancel", Style::new().fg(SUBTEXT)),
         ])
-    } else if let Mode::CreateWorkspace(input) = &app.mode {
-        Line::from(vec![
-            Span::styled(" Workspace name: ", Style::new().fg(YELLOW)),
-            Span::styled(format!("{input}_"), Style::new().fg(TEXT)),
-            Span::styled("  enter", Style::new().fg(GREEN)),
-            Span::raw(" create  "),
-            Span::styled("esc", Style::new().fg(RED)),
-            Span::raw(" cancel"),
-        ])
     } else if let Mode::Rename { input, .. } = &app.mode {
         Line::from(vec![
             Span::styled(" New shell name: ", Style::new().fg(YELLOW)),
@@ -830,7 +1096,14 @@ mod tests {
     use ratatui::backend::TestBackend;
 
     fn app() -> App {
-        App::new(vec![workspace("w1", "boomux")])
+        App::new(vec![workspace("w1", "boomux")], directory_context())
+    }
+
+    fn directory_context() -> DirectoryContext {
+        DirectoryContext {
+            launch_directory: "/tmp".into(),
+            recent_directories: Vec::new(),
+        }
     }
 
     fn workspace(id: &str, name: &str) -> WorkspaceView {
@@ -882,28 +1155,54 @@ mod tests {
         let mut created = None;
 
         assert!(!app.request_add(&mut |_| Ok(String::new())));
-        assert!(matches!(app.mode, Mode::CreateWorkspace(_)));
-        for character in "feature".chars() {
-            handle_mode_key(
-                &mut app,
-                KeyCode::Char(character),
-                &mut |_| Ok(String::new()),
-                &mut |_, _| Ok(String::new()),
-            );
-        }
+        assert!(matches!(app.mode, Mode::PickDirectory(_)));
         let changed = handle_mode_key(
             &mut app,
             KeyCode::Enter,
-            &mut |name| {
-                created = Some(name.to_owned());
+            &mut |directory| {
+                created = Some(directory.to_owned());
                 Ok("Created workspace".into())
             },
             &mut |_, _| Ok(String::new()),
         );
 
         assert!(changed);
-        assert_eq!(created.as_deref(), Some("feature"));
+        assert_eq!(created.as_deref(), Some(Path::new("/tmp")));
         assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn created_workspace_is_available_as_a_recent_directory() {
+        let mut app = app();
+
+        app.create_workspace(Path::new("/"), &mut |_| Ok("Created workspace".into()));
+        assert!(!app.request_add(&mut |_| Ok(String::new())));
+
+        let Mode::PickDirectory(picker) = &app.mode else {
+            panic!("expected directory picker");
+        };
+        assert!(
+            picker
+                .entries
+                .iter()
+                .any(|entry| entry.label == "recent" && entry.path == Path::new("/"))
+        );
+    }
+
+    #[test]
+    fn directory_picker_browses_children_and_parent_lazily() {
+        let mut picker = DirectoryPicker::new(&directory_context(), None);
+
+        picker.browse_parent();
+        assert_eq!(picker.browsing.as_deref(), Some(Path::new("/")));
+
+        let mut picker = DirectoryPicker::new(&directory_context(), None);
+        picker.browse_selected();
+        assert_eq!(picker.browsing.as_deref(), Some(Path::new("/tmp")));
+        assert_eq!(picker.selected_path(), Some(Path::new("/tmp")));
+
+        picker.browse_parent();
+        assert_eq!(picker.browsing.as_deref(), Some(Path::new("/")));
     }
 
     #[test]
@@ -934,6 +1233,10 @@ mod tests {
         });
 
         assert_eq!(opened.as_deref(), Some("term_1"));
+        assert_eq!(
+            app.directory_context.recent_directories.first(),
+            Some(&PathBuf::from("/tmp/boomux"))
+        );
     }
 
     #[test]
@@ -986,6 +1289,10 @@ mod tests {
         });
 
         assert_eq!(restored.as_deref(), Some("w1"));
+        assert_eq!(
+            app.directory_context.recent_directories.first(),
+            Some(&PathBuf::from("/tmp/boomux"))
+        );
         let message = app.message.expect("restore message");
         assert_eq!(message.text, "Restored workspace");
         assert!(!message.error);
@@ -1018,7 +1325,10 @@ mod tests {
 
     #[test]
     fn refresh_preserves_the_selected_workspace() {
-        let mut app = App::new(vec![workspace("w1", "one"), workspace("w2", "two")]);
+        let mut app = App::new(
+            vec![workspace("w1", "one"), workspace("w2", "two")],
+            directory_context(),
+        );
         app.next();
 
         app.replace_workspaces(vec![workspace("w2", "two"), workspace("w3", "three")]);
@@ -1031,7 +1341,10 @@ mod tests {
 
     #[test]
     fn refresh_removes_stale_workspaces_and_repairs_selection() {
-        let mut app = App::new(vec![workspace("w1", "one"), workspace("w2", "two")]);
+        let mut app = App::new(
+            vec![workspace("w1", "one"), workspace("w2", "two")],
+            directory_context(),
+        );
         app.next();
 
         app.replace_workspaces(vec![workspace("w1", "one")]);


### PR DESCRIPTION
## Summary
- replace workspace-name input with a terminal-native directory picker
- add quick locations, lazy parent/child browsing, and basename-derived workspace names
- persist bounded recent directories with locked atomic state updates
- document local and remote picker behavior

## Verification
- `cargo test` (25 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- release build installed to `~/.local/bin/boomux`; `boomux doctor` passes