### PR TITLE
Add grouped project launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -351,6 +352,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "indoc"
@@ -754,6 +765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +907,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1022,18 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ crossterm = "0.29"
 ratatui = { version = "0.30", default-features = false, features = ["all-widgets", "crossterm", "layout-cache"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.9"

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ between workspaces and terminals, then `j`/`k` or the arrow keys to navigate.
 
 - `Enter` restores the selected workspace or opens only the selected terminal,
   depending on which table is focused.
-- `a` creates a workspace with one shell from workspace focus, or adds one plain
-  shell from terminal focus. New workspaces use the directory where the
-  dashboard was launched.
+- `a` opens the project launcher from workspace focus, or adds one plain shell
+  from terminal focus. Type to filter configured Git projects, use Up/Down to
+  select one, and press Enter to create a basename-named workspace with
+  `shell-1`.
 - `e` renames the selected terminal when the terminal table is focused.
 - `x`, then `y`, closes the selected workspace and all of its shells.
 - `r` refreshes immediately; `q` or `Esc` quits.
@@ -102,6 +103,27 @@ dashboard follows theme changes in the same way as LazyGit.
 Restored terminals take over stale writable attachments while keeping their
 shell or agent processes running. Closing every Ghostty window leaves the
 Herdr-owned workspace and terminals alive for later restoration.
+
+## Configuration
+
+Boomux reads optional user configuration from
+`$XDG_CONFIG_HOME/boomux/config.toml`, falling back to
+`~/.config/boomux/config.toml`. Set `BOOMUX_CONFIG` to load another file after
+the global file; fields present in the override take precedence.
+
+```toml
+[projects]
+roots = ["~/Projects", "~/Work"]
+max_depth = 3
+```
+
+Project roots must be absolute or start with `~`. Boomux recursively discovers
+Git repositories up to `max_depth`, skips hidden and common generated
+directories, and stops descending after it finds a repository. Launcher results
+are visually grouped by each configured root's directory name while sharing one
+search query. No directories are scanned unless roots are explicitly configured.
+`boomux doctor` validates the configuration and reports how many projects were
+discovered.
 
 Boomux must be launched from a fresh terminal rather than from inside a
 Herdr-managed pane. The picker also hides panes whose foreground process is
@@ -133,7 +155,7 @@ server-owned terminal and its child processes continue running in Herdr.
 - Rust 2024 for a small native executable and alignment with Herdr's ecosystem
 - Clap for the CLI
 - Ratatui with the Crossterm backend for the dashboard
-- Serde for Herdr CLI responses
+- Serde and TOML for Herdr responses and layered user configuration
 - Gum for the interactive session chooser
 - Ghostty and Herdr as external runtime dependencies
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,21 @@ Dashboard colors use semantic ANSI roles and the terminal's default foreground
 and background. This keeps the TUI portable while allowing terminal-level theme
 systems such as Omarchy to supply the concrete palette.
 
+## Project Discovery
+
+The dashboard loads global TOML configuration from the XDG config directory and
+then merges an optional `BOOMUX_CONFIG` file over it. Project discovery walks
+only explicitly configured roots to a bounded depth, recognizes Git worktrees
+as well as ordinary repositories through their `.git` marker, and does not
+descend into repositories after discovering them.
+
+The resulting canonical paths and source-root labels are passed to the dashboard
+as a sorted snapshot. Workspace creation uses a grouped type-to-filter launcher
+over that snapshot; all groups share one query, and the selected project's
+basename becomes the workspace name. Configuration loading and filesystem
+discovery remain outside the TUI so input and rendering do not perform filesystem
+scans.
+
 ### Ghostty Launcher
 
 Creates native windows with stable human-readable titles. Boomux does not rely

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,223 @@
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+const DEFAULT_PROJECT_SEARCH_DEPTH: usize = 3;
+const MAX_PROJECT_SEARCH_DEPTH: usize = 10;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawConfig {
+    projects: Option<RawProjectsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawProjectsConfig {
+    roots: Option<Vec<String>>,
+    max_depth: Option<usize>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Config {
+    pub(crate) projects: ProjectsConfig,
+    pub(crate) path: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ProjectsConfig {
+    pub(crate) roots: Vec<PathBuf>,
+    pub(crate) max_depth: usize,
+}
+
+#[derive(Debug)]
+struct ConfigError(String);
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl Error for ConfigError {}
+
+pub(crate) fn load() -> Result<Config, Box<dyn Error>> {
+    let global_path = global_config_path();
+    let mut raw = RawConfig::default();
+    let mut loaded_path = None;
+
+    if let Some(path) = global_path.as_deref()
+        && path.is_file()
+    {
+        merge(&mut raw, read(path)?);
+        loaded_path = Some(path.to_owned());
+    }
+
+    if let Some(path) = env::var_os("BOOMUX_CONFIG") {
+        let path = PathBuf::from(path);
+        if path.as_os_str().is_empty() {
+            return Err(ConfigError("BOOMUX_CONFIG cannot be empty".into()).into());
+        }
+        merge(&mut raw, read(&path)?);
+        loaded_path = Some(path);
+    }
+
+    resolve(raw, loaded_path)
+}
+
+pub(crate) fn global_config_path() -> Option<PathBuf> {
+    env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| {
+            env::var_os("HOME")
+                .map(PathBuf::from)
+                .filter(|path| path.is_absolute())
+                .map(|home| home.join(".config"))
+        })
+        .map(|directory| directory.join("boomux/config.toml"))
+}
+
+fn read(path: &Path) -> Result<RawConfig, Box<dyn Error>> {
+    let contents = fs::read_to_string(path)
+        .map_err(|error| ConfigError(format!("could not read {}: {error}", path.display())))?;
+    toml::from_str(&contents)
+        .map_err(|error| ConfigError(format!("invalid config {}: {error}", path.display())).into())
+}
+
+fn merge(base: &mut RawConfig, next: RawConfig) {
+    let Some(next_projects) = next.projects else {
+        return;
+    };
+    let projects = base.projects.get_or_insert_default();
+    if next_projects.roots.is_some() {
+        projects.roots = next_projects.roots;
+    }
+    if next_projects.max_depth.is_some() {
+        projects.max_depth = next_projects.max_depth;
+    }
+}
+
+fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Error>> {
+    let projects = raw.projects.unwrap_or_default();
+    let max_depth = projects.max_depth.unwrap_or(DEFAULT_PROJECT_SEARCH_DEPTH);
+    if !(1..=MAX_PROJECT_SEARCH_DEPTH).contains(&max_depth) {
+        return Err(ConfigError(format!(
+            "projects.max_depth must be between 1 and {MAX_PROJECT_SEARCH_DEPTH}"
+        ))
+        .into());
+    }
+
+    let roots = projects
+        .roots
+        .unwrap_or_default()
+        .into_iter()
+        .map(|root| expand_root(&root))
+        .collect::<Result<_, _>>()?;
+
+    Ok(Config {
+        projects: ProjectsConfig { roots, max_depth },
+        path,
+    })
+}
+
+fn expand_root(root: &str) -> Result<PathBuf, Box<dyn Error>> {
+    let path = if root == "~" {
+        home_directory()?
+    } else if let Some(relative) = root.strip_prefix("~/") {
+        home_directory()?.join(relative)
+    } else {
+        PathBuf::from(root)
+    };
+    if !path.is_absolute() {
+        return Err(ConfigError(format!(
+            "project root must be absolute or start with ~: {root}"
+        ))
+        .into());
+    }
+    Ok(path)
+}
+
+fn home_directory() -> Result<PathBuf, Box<dyn Error>> {
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .ok_or_else(|| ConfigError("HOME must be an absolute path to expand ~".into()).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_project_settings() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+                [projects]
+                roots = ["/tmp/projects"]
+                max_depth = 4
+            "#,
+        )
+        .expect("valid config");
+        let config = resolve(raw, None).expect("resolved config");
+
+        assert_eq!(config.projects.roots, [PathBuf::from("/tmp/projects")]);
+        assert_eq!(config.projects.max_depth, 4);
+    }
+
+    #[test]
+    fn override_merges_only_specified_project_fields() {
+        let mut base: RawConfig = toml::from_str(
+            r#"
+                [projects]
+                roots = ["/tmp/projects"]
+                max_depth = 2
+            "#,
+        )
+        .expect("valid base");
+        let next: RawConfig = toml::from_str(
+            r#"
+                [projects]
+                max_depth = 5
+            "#,
+        )
+        .expect("valid override");
+
+        merge(&mut base, next);
+        let config = resolve(base, None).expect("resolved config");
+
+        assert_eq!(config.projects.roots, [PathBuf::from("/tmp/projects")]);
+        assert_eq!(config.projects.max_depth, 5);
+    }
+
+    #[test]
+    fn rejects_unknown_settings_and_relative_roots() {
+        assert!(toml::from_str::<RawConfig>("unknown = true").is_err());
+
+        let raw: RawConfig = toml::from_str(
+            r#"
+                [projects]
+                roots = ["Projects"]
+            "#,
+        )
+        .expect("valid TOML");
+        assert!(resolve(raw, None).is_err());
+    }
+
+    #[test]
+    fn rejects_unbounded_project_depth() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+                [projects]
+                max_depth = 11
+            "#,
+        )
+        .expect("valid TOML");
+
+        assert!(resolve(raw, None).is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ use std::process::{Command, ExitCode, Stdio};
 use clap::{Parser, Subcommand};
 use serde::Deserialize;
 
+mod config;
+mod projects;
 mod tui;
 
 #[derive(Parser)]
@@ -168,8 +170,28 @@ fn picker() -> Result<(), Box<dyn Error>> {
 fn dashboard() -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
     let views = dashboard_snapshot()?;
+    let config = config::load()?;
+    let roots_configured = !config.projects.roots.is_empty();
+    let discovery = projects::discover(&config.projects);
+    let project_views = discovery
+        .projects
+        .into_iter()
+        .map(|project| tui::ProjectView {
+            name: project.name,
+            path: project.path,
+            group: project.group,
+            group_order: project.group_order,
+        })
+        .collect();
+    let project_context = tui::ProjectContext {
+        projects: project_views,
+        config_path: config.path.or_else(config::global_config_path),
+        warning: (!discovery.warnings.is_empty()).then(|| discovery.warnings.join("; ")),
+        roots_configured,
+    };
     tui::run(
         views,
+        project_context,
         tui::Actions {
             on_restore: |workspace_id: &str| {
                 let panes = load_panes().map_err(|error| error.to_string())?;
@@ -200,8 +222,8 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
                 close_workspace(workspace_id).map_err(|error| error.to_string())?;
                 Ok(format!("Closed {label} and all of its shells"))
             },
-            on_create_workspace: |name: &str| {
-                create_dashboard_workspace(name).map_err(|error| error.to_string())
+            on_create_workspace: |directory: &Path| {
+                create_dashboard_workspace(directory).map_err(|error| error.to_string())
             },
             on_create_shell: |workspace_id: &str| {
                 create_dashboard_shell(workspace_id).map_err(|error| error.to_string())
@@ -310,10 +332,9 @@ fn open_directory(
 fn default_workspace_name(directory: &Path) -> String {
     directory
         .file_name()
-        .and_then(|name| name.to_str())
+        .map(|name| name.to_string_lossy().into_owned())
         .filter(|name| !name.is_empty())
-        .unwrap_or("default")
-        .to_owned()
+        .unwrap_or_else(|| "default".into())
 }
 
 fn ensure_host_terminal() -> Result<(), Box<dyn Error>> {
@@ -462,19 +483,16 @@ fn create_tab_terminal(
     Ok(response.result.root_pane)
 }
 
-fn create_dashboard_workspace(name: &str) -> Result<String, Box<dyn Error>> {
-    let name = name.trim();
-    if name.is_empty() {
-        return Err("workspace name cannot be empty".into());
-    }
-    let cwd = env::current_dir()?.canonicalize()?;
+fn create_dashboard_workspace(directory: &Path) -> Result<String, Box<dyn Error>> {
+    let cwd = resolve_directory(directory)?;
+    let name = default_workspace_name(&cwd);
     let panes = load_panes()?;
     let workspaces = load_workspaces()?;
-    if find_workspace(&workspaces, &panes, &cwd, name).is_some() {
+    if find_workspace(&workspaces, &panes, &cwd, &name).is_some() {
         return Err(format!("workspace {name} already exists in {}", cwd.display()).into());
     }
 
-    let pane = create_workspace(&cwd, name)?.root_pane;
+    let pane = create_workspace(&cwd, &name)?.root_pane;
     if let Err(error) = rename_pane(&pane.pane_id, "shell-1") {
         return Err(with_cleanup_error(
             error,
@@ -711,10 +729,33 @@ fn doctor() -> Result<(), Box<dyn Error>> {
         }
     }
 
+    match config::load() {
+        Ok(config) => {
+            let discovery = projects::discover(&config.projects);
+            let count = discovery.projects.len();
+            let source = config
+                .path
+                .map_or_else(|| "defaults".to_owned(), |path| path.display().to_string());
+            if discovery.warnings.is_empty() {
+                println!("ok  config: {source} ({count} projects)");
+            } else {
+                healthy = false;
+                eprintln!("err config: {source} ({count} projects)");
+                for warning in discovery.warnings {
+                    eprintln!("    {warning}");
+                }
+            }
+        }
+        Err(error) => {
+            healthy = false;
+            eprintln!("err config: {error}");
+        }
+    }
+
     if healthy {
         Ok(())
     } else {
-        Err("one or more dependencies are unavailable".into())
+        Err("one or more dependency or configuration checks failed".into())
     }
 }
 
@@ -766,6 +807,19 @@ mod tests {
         assert!(cli.name.is_none());
         assert!(!cli.new_window);
         assert!(cli.command.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn derives_a_visible_name_from_non_utf8_directories() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let directory = PathBuf::from(OsString::from_vec(b"/tmp/project-\x80".to_vec()));
+        let name = default_workspace_name(&directory);
+
+        assert!(name.starts_with("project-"));
+        assert_ne!(name, "default");
     }
 
     #[test]

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -1,0 +1,295 @@
+use std::collections::HashSet;
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::config::ProjectsConfig;
+
+const MAX_PROJECTS: usize = 2_000;
+const MAX_SCANNED_DIRECTORIES: usize = 10_000;
+const MAX_SCANNED_ENTRIES: usize = 50_000;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Project {
+    pub(crate) name: String,
+    pub(crate) path: PathBuf,
+    pub(crate) group: String,
+    pub(crate) group_order: usize,
+}
+
+struct Candidate {
+    path: PathBuf,
+    group: String,
+    group_order: usize,
+}
+
+struct RootContext<'a> {
+    label: &'a str,
+    order: usize,
+    max_depth: usize,
+}
+
+#[derive(Default)]
+struct ScanBudget {
+    directories: usize,
+    entries: usize,
+}
+
+pub(crate) struct Discovery {
+    pub(crate) projects: Vec<Project>,
+    pub(crate) warnings: Vec<String>,
+}
+
+pub(crate) fn discover(config: &ProjectsConfig) -> Discovery {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    let mut warnings = Vec::new();
+    let mut budget = ScanBudget::default();
+    for (group_order, root) in config.roots.iter().enumerate() {
+        if !root.is_dir() {
+            warnings.push(format!(
+                "project root is not a directory: {}",
+                root.display()
+            ));
+            continue;
+        }
+        let label = root_label(root);
+        let context = RootContext {
+            label: &label,
+            order: group_order,
+            max_depth: config.max_depth,
+        };
+        if let Err(error) = scan(root, &context, 0, &mut paths, &mut seen, &mut budget) {
+            warnings.push(format!("could not scan {}: {error}", root.display()));
+        }
+        if paths.len() >= MAX_PROJECTS
+            || budget.directories >= MAX_SCANNED_DIRECTORIES
+            || budget.entries >= MAX_SCANNED_ENTRIES
+        {
+            break;
+        }
+    }
+    if budget.directories >= MAX_SCANNED_DIRECTORIES {
+        warnings.push(format!(
+            "project scan stopped after {MAX_SCANNED_DIRECTORIES} directories"
+        ));
+    }
+    if budget.entries >= MAX_SCANNED_ENTRIES {
+        warnings.push(format!(
+            "project scan stopped after {MAX_SCANNED_ENTRIES} filesystem entries"
+        ));
+    }
+    if paths.len() >= MAX_PROJECTS {
+        warnings.push(format!(
+            "project scan stopped after {MAX_PROJECTS} projects"
+        ));
+    }
+
+    let mut projects: Vec<_> = paths
+        .into_iter()
+        .map(|path| Project {
+            name: path
+                .path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.path.display().to_string()),
+            path: path.path,
+            group: path.group,
+            group_order: path.group_order,
+        })
+        .collect();
+    projects.sort_by_cached_key(|project| {
+        (
+            project.group_order,
+            project.name.to_lowercase(),
+            project.path.to_string_lossy().to_lowercase(),
+        )
+    });
+    Discovery { projects, warnings }
+}
+
+fn scan(
+    directory: &Path,
+    context: &RootContext<'_>,
+    depth: usize,
+    projects: &mut Vec<Candidate>,
+    seen: &mut HashSet<PathBuf>,
+    budget: &mut ScanBudget,
+) -> Result<(), Box<dyn Error>> {
+    if budget.directories >= MAX_SCANNED_DIRECTORIES || budget.entries >= MAX_SCANNED_ENTRIES {
+        return Ok(());
+    }
+    budget.directories += 1;
+    if is_project(directory) {
+        if let Ok(directory) = directory.canonicalize()
+            && seen.insert(directory.clone())
+        {
+            projects.push(Candidate {
+                path: directory,
+                group: context.label.to_owned(),
+                group_order: context.order,
+            });
+        }
+        return Ok(());
+    }
+    if depth >= context.max_depth || projects.len() >= MAX_PROJECTS {
+        return Ok(());
+    }
+
+    let entries = match fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if depth == 0 => return Err(error.into()),
+        Err(_) => return Ok(()),
+    };
+    let mut children = Vec::new();
+    for entry in entries {
+        if budget.entries >= MAX_SCANNED_ENTRIES {
+            break;
+        }
+        budget.entries += 1;
+        let Ok(entry) = entry else {
+            continue;
+        };
+        if entry.file_type().is_ok_and(|kind| kind.is_dir())
+            && !ignored(entry.file_name().to_string_lossy().as_ref())
+        {
+            children.push(entry.path());
+        }
+    }
+    children.sort_by_cached_key(|path| path.to_string_lossy().to_lowercase());
+    for child in children {
+        scan(&child, context, depth + 1, projects, seen, budget)?;
+        if projects.len() >= MAX_PROJECTS
+            || budget.directories >= MAX_SCANNED_DIRECTORIES
+            || budget.entries >= MAX_SCANNED_ENTRIES
+        {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn is_project(directory: &Path) -> bool {
+    directory.join(".git").exists()
+}
+
+fn root_label(root: &Path) -> String {
+    root.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| root.display().to_string())
+}
+
+fn ignored(name: &str) -> bool {
+    name.starts_with('.') || matches!(name, "node_modules" | "target")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("boomux-projects-{nonce}"));
+            fs::create_dir_all(&path).expect("test directory");
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn discovers_git_repositories_and_stops_at_projects() {
+        let root = TestDirectory::new();
+        fs::create_dir_all(root.0.join("team/alpha/.git")).expect("alpha repository");
+        fs::create_dir_all(root.0.join("team/alpha/nested/.git")).expect("nested repository");
+        fs::create_dir_all(root.0.join("beta/.git")).expect("beta repository");
+        fs::create_dir_all(root.0.join("plain")).expect("plain directory");
+        let config = ProjectsConfig {
+            roots: vec![root.0.clone()],
+            max_depth: 3,
+        };
+
+        let projects = discover(&config).projects;
+
+        assert_eq!(projects.len(), 2);
+        assert_eq!(projects[0].name, "alpha");
+        assert_eq!(projects[1].name, "beta");
+    }
+
+    #[test]
+    fn search_depth_limits_discovery() {
+        let root = TestDirectory::new();
+        fs::create_dir_all(root.0.join("group/deep/project/.git")).expect("repository");
+        let config = ProjectsConfig {
+            roots: vec![root.0.clone()],
+            max_depth: 2,
+        };
+
+        assert!(discover(&config).projects.is_empty());
+    }
+
+    #[test]
+    fn recognizes_git_worktree_marker_files() {
+        let root = TestDirectory::new();
+        let project = root.0.join("worktree");
+        fs::create_dir_all(&project).expect("worktree directory");
+        fs::write(project.join(".git"), "gitdir: /tmp/example").expect("worktree marker");
+        let config = ProjectsConfig {
+            roots: vec![root.0.clone()],
+            max_depth: 1,
+        };
+
+        let projects = discover(&config).projects;
+
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].name, "worktree");
+    }
+
+    #[test]
+    fn missing_roots_warn_without_hiding_valid_projects() {
+        let root = TestDirectory::new();
+        fs::create_dir_all(root.0.join("project/.git")).expect("repository");
+        let config = ProjectsConfig {
+            roots: vec![root.0.join("missing"), root.0.clone()],
+            max_depth: 1,
+        };
+
+        let discovery = discover(&config);
+
+        assert_eq!(discovery.projects.len(), 1);
+        assert_eq!(discovery.warnings.len(), 1);
+    }
+
+    #[test]
+    fn assigns_projects_to_configured_root_groups() {
+        let root = TestDirectory::new();
+        let projects_root = root.0.join("Projects");
+        let work_root = root.0.join("Work");
+        fs::create_dir_all(projects_root.join("personal/.git")).expect("personal repository");
+        fs::create_dir_all(work_root.join("service/.git")).expect("work repository");
+        let config = ProjectsConfig {
+            roots: vec![projects_root, work_root],
+            max_depth: 1,
+        };
+
+        let discovery = discover(&config);
+
+        assert_eq!(discovery.projects[0].group, "Projects");
+        assert_eq!(discovery.projects[0].name, "personal");
+        assert_eq!(discovery.projects[1].group, "Work");
+        assert_eq!(discovery.projects[1].name, "service");
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,12 +1,15 @@
 use std::io;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout};
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Cell, Paragraph, Row, Table, TableState};
+use ratatui::widgets::{
+    Block, Cell, Clear, List, ListItem, ListState, Paragraph, Row, Table, TableState,
+};
 
 const BASE: Color = Color::Reset;
 const OVERLAY: Color = Color::DarkGray;
@@ -25,6 +28,21 @@ pub(crate) struct WorkspaceView {
     pub(crate) status: String,
     pub(crate) directory: String,
     pub(crate) terminals: Vec<TerminalView>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ProjectView {
+    pub(crate) name: String,
+    pub(crate) path: PathBuf,
+    pub(crate) group: String,
+    pub(crate) group_order: usize,
+}
+
+pub(crate) struct ProjectContext {
+    pub(crate) projects: Vec<ProjectView>,
+    pub(crate) config_path: Option<PathBuf>,
+    pub(crate) warning: Option<String>,
+    pub(crate) roots_configured: bool,
 }
 
 pub(crate) struct TerminalView {
@@ -54,6 +72,7 @@ struct App {
     mode: Mode,
     message: Option<Message>,
     pending_close: Option<PendingClose>,
+    project_context: ProjectContext,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -64,8 +83,18 @@ enum Focus {
 
 enum Mode {
     Normal,
-    CreateWorkspace(String),
+    PickProject(ProjectPicker),
     Rename { pane_id: String, input: String },
+}
+
+struct ProjectPicker {
+    projects: Vec<ProjectView>,
+    matches: Vec<usize>,
+    state: ListState,
+    query: String,
+    config_path: Option<PathBuf>,
+    warning: Option<String>,
+    roots_configured: bool,
 }
 
 struct Message {
@@ -79,8 +108,106 @@ struct PendingClose {
     shell_count: usize,
 }
 
+impl ProjectPicker {
+    fn new(context: &ProjectContext) -> Self {
+        let mut picker = Self {
+            projects: context.projects.clone(),
+            matches: Vec::new(),
+            state: ListState::default(),
+            query: String::new(),
+            config_path: context.config_path.clone(),
+            warning: context.warning.clone(),
+            roots_configured: context.roots_configured,
+        };
+        picker.update_matches();
+        picker
+    }
+
+    fn update_matches(&mut self) {
+        let query = self.query.to_lowercase();
+        let mut matches: Vec<_> = self
+            .projects
+            .iter()
+            .enumerate()
+            .filter_map(|(index, project)| {
+                project_match_score(project, &query).map(|score| (index, score))
+            })
+            .collect();
+        matches.sort_by_key(|(index, score)| (self.projects[*index].group_order, *score));
+        self.matches = matches.into_iter().map(|(index, _)| index).collect();
+        self.state.select((!self.matches.is_empty()).then_some(0));
+    }
+
+    fn selected(&self) -> Option<&ProjectView> {
+        self.state
+            .selected()
+            .and_then(|index| self.matches.get(index))
+            .and_then(|index| self.projects.get(*index))
+    }
+
+    fn next(&mut self) {
+        if self.matches.is_empty() {
+            return;
+        }
+        let next = self
+            .state
+            .selected()
+            .map_or(0, |index| (index + 1) % self.matches.len());
+        self.state.select(Some(next));
+    }
+
+    fn previous(&mut self) {
+        if self.matches.is_empty() {
+            return;
+        }
+        let previous = self.state.selected().map_or(0, |index| {
+            if index == 0 {
+                self.matches.len() - 1
+            } else {
+                index - 1
+            }
+        });
+        self.state.select(Some(previous));
+    }
+}
+
+fn project_match_score(project: &ProjectView, query: &str) -> Option<(u8, usize)> {
+    if query.is_empty() {
+        return Some((0, 0));
+    }
+    let name = project.name.to_lowercase();
+    let path = project.path.to_string_lossy().to_lowercase();
+    if name.starts_with(query) {
+        Some((0, name.len()))
+    } else if let Some(index) = name.find(query) {
+        Some((1, index))
+    } else if let Some(index) = path.find(query) {
+        Some((2, index))
+    } else if is_subsequence(query, &name) {
+        Some((3, name.len()))
+    } else if is_subsequence(query, &path) {
+        Some((4, path.len()))
+    } else {
+        None
+    }
+}
+
+fn is_subsequence(query: &str, candidate: &str) -> bool {
+    let mut query = query.chars();
+    let mut expected = query.next();
+    for character in candidate.chars() {
+        if expected == Some(character) {
+            expected = query.next();
+            if expected.is_none() {
+                return true;
+            }
+        }
+    }
+    expected.is_none()
+}
+
 impl App {
-    fn new(workspaces: Vec<WorkspaceView>) -> Self {
+    fn new(workspaces: Vec<WorkspaceView>, project_context: ProjectContext) -> Self {
         let mut workspace_state = TableState::default();
         let mut terminal_state = TableState::default();
         if !workspaces.is_empty() {
@@ -97,6 +224,7 @@ impl App {
             mode: Mode::Normal,
             message: None,
             pending_close: None,
+            project_context,
         }
     }
 
@@ -216,7 +344,7 @@ impl App {
     {
         match self.focus {
             Focus::Workspaces => {
-                self.mode = Mode::CreateWorkspace(String::new());
+                self.mode = Mode::PickProject(ProjectPicker::new(&self.project_context));
                 self.message = None;
                 false
             }
@@ -234,12 +362,12 @@ impl App {
         }
     }
 
-    fn create_workspace<F>(&mut self, name: &str, on_create_workspace: &mut F)
+    fn create_workspace<F>(&mut self, directory: &Path, on_create_workspace: &mut F)
     where
-        F: FnMut(&str) -> Result<String, String>,
+        F: FnMut(&Path) -> Result<String, String>,
     {
         self.mode = Mode::Normal;
-        self.message = Some(match on_create_workspace(name) {
+        self.message = Some(match on_create_workspace(directory) {
             Ok(text) => Message { text, error: false },
             Err(text) => Message { text, error: true },
         });
@@ -346,19 +474,24 @@ impl App {
 
 pub(crate) fn run<R, O, C, W, N, E, F>(
     workspaces: Vec<WorkspaceView>,
+    project_context: ProjectContext,
     actions: Actions<R, O, C, W, N, E, F>,
 ) -> io::Result<()>
 where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&Path) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
 {
     let mut terminal = ratatui::init();
-    let result = run_loop(&mut terminal, App::new(workspaces), actions);
+    let result = run_loop(
+        &mut terminal,
+        App::new(workspaces, project_context),
+        actions,
+    );
     ratatui::restore();
     result
 }
@@ -372,7 +505,7 @@ where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&Path) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
@@ -394,8 +527,14 @@ where
         if key.kind != KeyEventKind::Press {
             continue;
         }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            return Ok(());
+        }
 
         if app.pending_close.is_some() {
+            if !key.modifiers.is_empty() {
+                continue;
+            }
             match key.code {
                 KeyCode::Char('y') => {
                     app.confirm_close(&mut actions.on_close);
@@ -412,12 +551,16 @@ where
             if handle_mode_key(
                 &mut app,
                 key.code,
+                key.modifiers,
                 &mut actions.on_create_workspace,
                 &mut actions.on_rename,
             ) {
                 app.refresh(&mut actions.on_refresh);
                 last_refresh = Instant::now();
             }
+            continue;
+        }
+        if !key.modifiers.is_empty() {
             continue;
         }
 
@@ -454,35 +597,52 @@ where
 fn handle_mode_key<W, E>(
     app: &mut App,
     key: KeyCode,
+    modifiers: KeyModifiers,
     on_create_workspace: &mut W,
     on_rename: &mut E,
 ) -> bool
 where
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&Path) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
 {
     let mode = std::mem::replace(&mut app.mode, Mode::Normal);
+    if !modifiers.difference(KeyModifiers::SHIFT).is_empty() {
+        app.mode = mode;
+        return false;
+    }
     match mode {
         Mode::Normal => false,
-        Mode::CreateWorkspace(mut input) => match key {
-            KeyCode::Enter if !input.trim().is_empty() => {
-                let name = input.trim().to_owned();
-                app.create_workspace(&name, on_create_workspace);
+        Mode::PickProject(mut picker) => match key {
+            KeyCode::Enter if picker.selected().is_some() => {
+                let directory = picker.selected().expect("selected project").path.clone();
+                app.create_workspace(&directory, on_create_workspace);
                 true
             }
             KeyCode::Esc => false,
+            KeyCode::Down => {
+                picker.next();
+                app.mode = Mode::PickProject(picker);
+                false
+            }
+            KeyCode::Up => {
+                picker.previous();
+                app.mode = Mode::PickProject(picker);
+                false
+            }
             KeyCode::Backspace => {
-                input.pop();
-                app.mode = Mode::CreateWorkspace(input);
+                picker.query.pop();
+                picker.update_matches();
+                app.mode = Mode::PickProject(picker);
                 false
             }
             KeyCode::Char(character) => {
-                input.push(character);
-                app.mode = Mode::CreateWorkspace(input);
+                picker.query.push(character);
+                picker.update_matches();
+                app.mode = Mode::PickProject(picker);
                 false
             }
             _ => {
-                app.mode = Mode::CreateWorkspace(input);
+                app.mode = Mode::PickProject(picker);
                 false
             }
         },
@@ -535,6 +695,108 @@ fn render(frame: &mut Frame, app: &mut App) {
     render_terminals(frame, terminal_area, app);
     render_metrics(frame, metrics_area, app);
     render_footer(frame, footer_area, app);
+    if let Mode::PickProject(picker) = &mut app.mode {
+        render_project_picker(frame, area, picker);
+    }
+}
+
+fn render_project_picker(frame: &mut Frame, area: Rect, picker: &mut ProjectPicker) {
+    let popup_area = centered_rect(area, 76, 65);
+    frame.render_widget(Clear, popup_area);
+    frame.render_widget(Block::new().style(Style::new().bg(BASE)), popup_area);
+    let [search_area, list_area, help_area] = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Fill(1),
+        Constraint::Length(2),
+    ])
+    .areas(popup_area);
+
+    let search = Paragraph::new(format!("> {}_", picker.query)).block(
+        Block::bordered()
+            .title(" Create workspace from project ")
+            .border_style(Style::new().fg(TEAL)),
+    );
+    frame.render_widget(search, search_area);
+
+    let items: Vec<_> = if picker.matches.is_empty() {
+        let message = if !picker.roots_configured {
+            let path = picker.config_path.as_deref().map_or_else(
+                || "config.toml".to_owned(),
+                |path| path.display().to_string(),
+            );
+            format!("No projects configured. Add [projects] roots to {path}")
+        } else if picker.query.is_empty() {
+            "No Git projects discovered in configured roots".to_owned()
+        } else {
+            "No matching projects".to_owned()
+        };
+        vec![ListItem::new(Span::styled(
+            message,
+            Style::new().fg(SUBTEXT),
+        ))]
+    } else {
+        let mut previous_group = None;
+        picker
+            .matches
+            .iter()
+            .filter_map(|index| picker.projects.get(*index))
+            .map(|project| {
+                let group = if previous_group.as_deref() == Some(project.group.as_str()) {
+                    String::new()
+                } else {
+                    previous_group = Some(project.group.clone());
+                    project.group.clone()
+                };
+                ListItem::new(Line::from(vec![
+                    Span::styled(
+                        format!("{group:<14}"),
+                        Style::new().fg(TEAL).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        format!("{:<24}", project.name),
+                        Style::new().fg(TEXT).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(project.path.display().to_string(), Style::new().fg(SUBTEXT)),
+                ]))
+            })
+            .collect()
+    };
+    let list = List::new(items)
+        .block(
+            Block::bordered()
+                .title(format!(" {} projects ", picker.matches.len()))
+                .border_style(Style::new().fg(OVERLAY)),
+        )
+        .highlight_symbol("> ")
+        .highlight_style(Style::new().fg(TEXT).add_modifier(Modifier::REVERSED));
+    frame.render_stateful_widget(list, list_area, &mut picker.state);
+
+    let help = picker.warning.as_ref().map_or_else(
+        || {
+            Line::from(vec![
+                Span::styled(" type", Style::new().fg(TEAL)),
+                Span::raw(" filter  "),
+                Span::styled("up/down", Style::new().fg(BLUE)),
+                Span::raw(" select  "),
+                Span::styled("enter", Style::new().fg(GREEN)),
+                Span::raw(" create  "),
+                Span::styled("esc", Style::new().fg(RED)),
+                Span::raw(" cancel"),
+            ])
+        },
+        |warning| Line::from(Span::styled(format!(" {warning}"), Style::new().fg(YELLOW))),
+    );
+    frame.render_widget(Paragraph::new(help).style(Style::new().bg(BASE)), help_area);
+}
+
+fn centered_rect(area: Rect, width_percent: u16, height_percent: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Percentage(height_percent)])
+        .flex(ratatui::layout::Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Percentage(width_percent)])
+        .flex(ratatui::layout::Flex::Center)
+        .areas(vertical);
+    horizontal
 }
 
 fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
@@ -740,15 +1002,6 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Span::styled("n/esc", Style::new().fg(GREEN)),
             Span::styled(" cancel", Style::new().fg(SUBTEXT)),
         ])
-    } else if let Mode::CreateWorkspace(input) = &app.mode {
-        Line::from(vec![
-            Span::styled(" Workspace name: ", Style::new().fg(YELLOW)),
-            Span::styled(format!("{input}_"), Style::new().fg(TEXT)),
-            Span::styled("  enter", Style::new().fg(GREEN)),
-            Span::raw(" create  "),
-            Span::styled("esc", Style::new().fg(RED)),
-            Span::raw(" cancel"),
-        ])
     } else if let Mode::Rename { input, .. } = &app.mode {
         Line::from(vec![
             Span::styled(" New shell name: ", Style::new().fg(YELLOW)),
@@ -770,7 +1023,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Span::styled("a", Style::new().fg(GREEN)),
             Span::styled(
                 if app.focus == Focus::Workspaces {
-                    " add workspace  "
+                    " find project  "
                 } else {
                     " add shell  "
                 },
@@ -830,7 +1083,29 @@ mod tests {
     use ratatui::backend::TestBackend;
 
     fn app() -> App {
-        App::new(vec![workspace("w1", "boomux")])
+        App::new(vec![workspace("w1", "boomux")], project_context())
+    }
+
+    fn project_context() -> ProjectContext {
+        ProjectContext {
+            projects: vec![
+                ProjectView {
+                    name: "alpha".into(),
+                    path: "/tmp/alpha".into(),
+                    group: "Projects".into(),
+                    group_order: 0,
+                },
+                ProjectView {
+                    name: "boomux".into(),
+                    path: "/tmp/boomux".into(),
+                    group: "Work".into(),
+                    group_order: 1,
+                },
+            ],
+            config_path: Some("/tmp/config.toml".into()),
+            warning: None,
+            roots_configured: true,
+        }
     }
 
     fn workspace(id: &str, name: &str) -> WorkspaceView {
@@ -882,11 +1157,12 @@ mod tests {
         let mut created = None;
 
         assert!(!app.request_add(&mut |_| Ok(String::new())));
-        assert!(matches!(app.mode, Mode::CreateWorkspace(_)));
-        for character in "feature".chars() {
+        assert!(matches!(app.mode, Mode::PickProject(_)));
+        for character in "alp".chars() {
             handle_mode_key(
                 &mut app,
                 KeyCode::Char(character),
+                KeyModifiers::NONE,
                 &mut |_| Ok(String::new()),
                 &mut |_, _| Ok(String::new()),
             );
@@ -894,16 +1170,82 @@ mod tests {
         let changed = handle_mode_key(
             &mut app,
             KeyCode::Enter,
-            &mut |name| {
-                created = Some(name.to_owned());
+            KeyModifiers::NONE,
+            &mut |directory| {
+                created = Some(directory.to_owned());
                 Ok("Created workspace".into())
             },
             &mut |_, _| Ok(String::new()),
         );
 
         assert!(changed);
-        assert_eq!(created.as_deref(), Some("feature"));
+        assert_eq!(created.as_deref(), Some(Path::new("/tmp/alpha")));
         assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn project_search_matches_subsequences() {
+        let mut picker = ProjectPicker::new(&project_context());
+        picker.query = "bmx".into();
+        picker.update_matches();
+
+        assert_eq!(picker.matches.len(), 1);
+        assert_eq!(
+            picker.selected().map(|project| project.name.as_str()),
+            Some("boomux")
+        );
+    }
+
+    #[test]
+    fn project_search_preserves_root_groups() {
+        let mut picker = ProjectPicker::new(&project_context());
+        picker.query = "tmp".into();
+        picker.update_matches();
+
+        let groups: Vec<_> = picker
+            .matches
+            .iter()
+            .map(|index| picker.projects[*index].group.as_str())
+            .collect();
+        assert_eq!(groups, ["Projects", "Work"]);
+    }
+
+    #[test]
+    fn project_search_ignores_modified_characters() {
+        let mut app = app();
+        app.request_add(&mut |_| Ok(String::new()));
+
+        handle_mode_key(
+            &mut app,
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL,
+            &mut |_| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
+        );
+
+        let Mode::PickProject(picker) = &app.mode else {
+            panic!("expected project picker");
+        };
+        assert!(picker.query.is_empty());
+    }
+
+    #[test]
+    fn project_search_accepts_shifted_characters() {
+        let mut app = app();
+        app.request_add(&mut |_| Ok(String::new()));
+
+        handle_mode_key(
+            &mut app,
+            KeyCode::Char('_'),
+            KeyModifiers::SHIFT,
+            &mut |_| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
+        );
+
+        let Mode::PickProject(picker) = &app.mode else {
+            panic!("expected project picker");
+        };
+        assert_eq!(picker.query, "_");
     }
 
     #[test]
@@ -947,6 +1289,7 @@ mod tests {
             handle_mode_key(
                 &mut app,
                 KeyCode::Char(character),
+                KeyModifiers::NONE,
                 &mut |_| Ok(String::new()),
                 &mut |_, _| Ok(String::new()),
             );
@@ -954,6 +1297,7 @@ mod tests {
         let changed = handle_mode_key(
             &mut app,
             KeyCode::Enter,
+            KeyModifiers::NONE,
             &mut |_| Ok(String::new()),
             &mut |pane_id, name| {
                 renamed = Some((pane_id.to_owned(), name.to_owned()));
@@ -1018,7 +1362,10 @@ mod tests {
 
     #[test]
     fn refresh_preserves_the_selected_workspace() {
-        let mut app = App::new(vec![workspace("w1", "one"), workspace("w2", "two")]);
+        let mut app = App::new(
+            vec![workspace("w1", "one"), workspace("w2", "two")],
+            project_context(),
+        );
         app.next();
 
         app.replace_workspaces(vec![workspace("w2", "two"), workspace("w3", "three")]);
@@ -1031,7 +1378,10 @@ mod tests {
 
     #[test]
     fn refresh_removes_stale_workspaces_and_repairs_selection() {
-        let mut app = App::new(vec![workspace("w1", "one"), workspace("w2", "two")]);
+        let mut app = App::new(
+            vec![workspace("w1", "one"), workspace("w2", "two")],
+            project_context(),
+        );
         app.next();
 
         app.replace_workspaces(vec![workspace("w1", "one")]);
@@ -1049,6 +1399,16 @@ mod tests {
         let backend = TestBackend::new(120, 34);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = app();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn project_launcher_renders_to_test_backend() {
+        let backend = TestBackend::new(120, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+        app.request_add(&mut |_| Ok(String::new()));
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
     }


### PR DESCRIPTION
## Summary
- add layered TOML configuration from the XDG config directory and `BOOMUX_CONFIG`
- discover Git repositories beneath bounded configured project roots
- replace workspace-name input with a grouped type-to-filter project launcher
- preserve visual `Projects` and `Work` groups under one shared search
- validate configuration and project discovery through `boomux doctor`

## Verification
- `cargo test` (37 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- release build installed to `~/.local/bin/boomux`; `boomux doctor` discovers 20 projects