### PR TITLE
Show Git metadata for workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ For a full workspace overview, open the Ratatui dashboard:
 boomux ui
 ```
 
-The dashboard provides workspace and terminal tables, aggregate status cards,
-and live Herdr state refreshed four times per second. Use `Tab` to switch focus
-between workspaces and terminals, then `j`/`k` or the arrow keys to navigate.
+The dashboard provides workspace and terminal tables with live Herdr state
+refreshed four times per second. Workspace rows include the Git repository,
+branch, clean or changed state, and primary or linked worktree. Use `Tab` to
+switch focus between workspaces and terminals, then `j`/`k` or the arrow keys to
+navigate.
 
 - `Enter` restores the selected workspace or opens only the selected terminal,
   depending on which table is focused.
@@ -157,7 +159,7 @@ server-owned terminal and its child processes continue running in Herdr.
 - Ratatui with the Crossterm backend for the dashboard
 - Serde and TOML for Herdr responses and layered user configuration
 - Gum for the interactive session chooser
-- Ghostty and Herdr as external runtime dependencies
+- Git, Ghostty, and Herdr as external runtime dependencies
 
 The MVP uses Gum rather than maintaining its own TUI framework, and the Herdr
 CLI rather than a custom socket client. Dependencies are added only when a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,12 +49,16 @@ launches a Ghostty window for every terminal belonging to that Herdr workspace.
 
 ### Dashboard
 
-Provides a Ratatui overview of workspaces, terminals, directories, and agent
-state. It is a control plane only: restoring a workspace still launches native
-Ghostty windows rather than embedding terminal sessions in the dashboard. The
-dashboard remains open after restoration so it can continue managing other
-workspaces. It refreshes from Herdr four times per second and validates the
-selected workspace against a fresh snapshot before launching Ghostty windows.
+Provides a Ratatui overview of workspaces, terminals, directories, Git state,
+and per-terminal agent state. It is a control plane only: restoring a workspace
+still launches native Ghostty windows rather than embedding terminal sessions in
+the dashboard. The dashboard remains open after restoration so it can continue
+managing other workspaces. It refreshes from Herdr four times per second and
+validates the selected workspace against a fresh snapshot before launching
+Ghostty windows.
+Repository name, branch, dirty state, and primary or linked worktree information
+come from the Git CLI and are cached for two seconds so the faster Herdr refresh
+does not repeatedly spawn Git processes.
 Closing a workspace uses Herdr's atomic workspace close command after explicit
 confirmation, terminating every shell in that workspace. Shell creation uses
 Herdr tabs, and pane labels provide durable shell names for the dashboard,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,27 @@
-# Product Ideas
+# Roadmap
 
-Boomux is under active development. This document collects possible directions
-for exploration; it is not a release commitment.
+Boomux is under active development. This document tracks shipped capabilities
+and possible directions for exploration; future ideas are not release
+commitments.
+
+## Completed
+
+- [x] Manage persistent Herdr workspaces and shells from a live Ratatui
+  dashboard.
+- [x] Restore a whole workspace into native Ghostty windows or open only one
+  selected terminal.
+- [x] Create workspaces from a searchable Git project launcher grouped by
+  configured roots.
+- [x] Load layered TOML configuration from the XDG config directory and an
+  optional `BOOMUX_CONFIG` override.
+- [x] Add plain shells, assign durable shell names, and carry those names into
+  the dashboard, Ghostty titles, and dynamic Starship prompts.
+- [x] Close a workspace and all of its shells through an explicit confirmation.
+- [x] Follow the active terminal theme through semantic ANSI colors.
+- [x] Display repository, branch, dirty state, and primary or linked worktree
+  information for each workspace.
+- [x] Validate runtime dependencies, configuration, and project discovery with
+  `boomux doctor`.
 
 ## Workspace Control
 
@@ -9,10 +29,8 @@ for exploration; it is not a release commitment.
   value.
 - Notify when an agent becomes blocked, finishes, or needs input.
 - Create shells, OpenCode, LazyGit, and custom commands from the dashboard.
-- Name individual shells and carry those names into Ghostty titles and prompts.
 - Show an opt-in, read-only preview of the selected terminal.
 - Search workspaces and actions from a command palette.
-- Display repository, branch, dirty state, and worktree information.
 - Launch workspace templates such as editor, agent, tests, and LazyGit.
 - Duplicate a workspace structure for another branch or worktree.
 - Archive inactive workspaces without terminating their shells.

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,340 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Metadata {
+    pub(crate) repository: String,
+    pub(crate) branch: String,
+    pub(crate) state: String,
+    pub(crate) worktree: String,
+}
+
+impl Default for Metadata {
+    fn default() -> Self {
+        Self {
+            repository: "-".into(),
+            branch: "-".into(),
+            state: "-".into(),
+            worktree: "-".into(),
+        }
+    }
+}
+
+struct CachedMetadata {
+    value: Metadata,
+    inspected_at: Instant,
+}
+
+pub(crate) struct Cache {
+    entries: HashMap<PathBuf, CachedMetadata>,
+    pending: HashSet<PathBuf>,
+    requests: Sender<PathBuf>,
+    results: Receiver<(PathBuf, Metadata)>,
+}
+
+impl Default for Cache {
+    fn default() -> Self {
+        Self::with_inspector(Arc::new(|directory| inspect(directory).unwrap_or_default()))
+    }
+}
+
+impl Cache {
+    fn with_inspector(inspector: Arc<dyn Fn(&Path) -> Metadata + Send + Sync>) -> Self {
+        let (request_sender, request_receiver) = mpsc::channel::<PathBuf>();
+        let (result_sender, result_receiver) = mpsc::channel();
+        thread::spawn(move || {
+            while let Ok(directory) = request_receiver.recv() {
+                let metadata = inspector(&directory);
+                if result_sender.send((directory, metadata)).is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            entries: HashMap::new(),
+            pending: HashSet::new(),
+            requests: request_sender,
+            results: result_receiver,
+        }
+    }
+
+    pub(crate) fn inspect(&mut self, directory: &Path) -> Metadata {
+        for (directory, value) in self.results.try_iter() {
+            self.pending.remove(&directory);
+            self.entries.insert(
+                directory,
+                CachedMetadata {
+                    value,
+                    inspected_at: Instant::now(),
+                },
+            );
+        }
+
+        if let Some(cached) = self.entries.get(directory)
+            && cached.inspected_at.elapsed() < REFRESH_INTERVAL
+        {
+            return cached.value.clone();
+        }
+
+        if !self.pending.contains(directory) {
+            let directory = directory.to_owned();
+            if self.requests.send(directory.clone()).is_ok() {
+                self.pending.insert(directory);
+            }
+        }
+        self.entries
+            .get(directory)
+            .map(|cached| cached.value.clone())
+            .unwrap_or_default()
+    }
+}
+
+fn inspect(directory: &Path) -> Option<Metadata> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(directory)
+        .args([
+            "rev-parse",
+            "--path-format=absolute",
+            "--show-toplevel",
+            "--git-dir",
+            "--git-common-dir",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let output = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<_> = output.lines().map(str::to_owned).collect();
+    let [root, git_directory, common_directory] = lines.as_slice() else {
+        return None;
+    };
+    let root = Path::new(root);
+    let git_directory = Path::new(git_directory);
+    let common_directory = Path::new(common_directory);
+    let worktree = worktree_label(git_directory, common_directory);
+    let branch = inspect_branch(directory);
+    let state = inspect_state(directory).unwrap_or_else(|| "unknown".into());
+
+    Some(Metadata {
+        repository: repository_name(root, git_directory, common_directory),
+        branch,
+        state,
+        worktree,
+    })
+}
+
+fn inspect_branch(directory: &Path) -> String {
+    let symbolic = Command::new("git")
+        .arg("-C")
+        .arg(directory)
+        .args(["symbolic-ref", "--short", "-q", "HEAD"])
+        .output();
+    if let Ok(output) = symbolic
+        && output.status.success()
+    {
+        return String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    }
+    "detached".into()
+}
+
+fn inspect_state(directory: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(directory)
+        .args(["status", "--porcelain=v1", "--untracked-files=normal"])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| summarize_status(&String::from_utf8_lossy(&output.stdout)))
+}
+
+fn summarize_status(status: &str) -> String {
+    let mut changed = 0;
+    let mut conflicts = 0;
+    for line in status.lines().filter(|line| line.len() >= 2) {
+        changed += 1;
+        if matches!(&line[..2], "DD" | "AU" | "UD" | "UA" | "DU" | "AA" | "UU") {
+            conflicts += 1;
+        }
+    }
+
+    if conflicts > 0 {
+        format!(
+            "{conflicts} conflict{}",
+            if conflicts == 1 { "" } else { "s" }
+        )
+    } else if changed > 0 {
+        format!("{changed} changed")
+    } else {
+        "clean".into()
+    }
+}
+
+fn worktree_label(git_directory: &Path, common_directory: &Path) -> String {
+    if git_directory == common_directory {
+        "primary".into()
+    } else {
+        git_directory
+            .file_name()
+            .map(|name| format!("linked:{}", name.to_string_lossy()))
+            .unwrap_or_else(|| "linked".into())
+    }
+}
+
+fn repository_name(root: &Path, git_directory: &Path, common_directory: &Path) -> String {
+    let repository = if git_directory == common_directory {
+        root
+    } else if common_directory
+        .file_name()
+        .is_some_and(|name| name == ".git")
+    {
+        common_directory.parent().unwrap_or(common_directory)
+    } else {
+        common_directory
+    };
+    repository
+        .file_name()
+        .map(|name| {
+            let name = name.to_string_lossy();
+            name.strip_suffix(".git")
+                .unwrap_or(name.as_ref())
+                .to_owned()
+        })
+        .unwrap_or_else(|| repository.display().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    struct TestRepository(PathBuf);
+
+    impl TestRepository {
+        fn unborn() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("boomux-git-{nonce}"));
+            let status = Command::new("git")
+                .args(["init", "-q", "-b", "unborn"])
+                .arg(&path)
+                .status()
+                .expect("git init");
+            assert!(status.success());
+            Self(path)
+        }
+    }
+
+    impl Drop for TestRepository {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn summarizes_clean_changed_and_conflicted_states() {
+        assert_eq!(summarize_status(""), "clean");
+        assert_eq!(
+            summarize_status(" M src/main.rs\n?? notes.md\n"),
+            "2 changed"
+        );
+        assert_eq!(
+            summarize_status("UU src/main.rs\nAA Cargo.toml\n"),
+            "2 conflicts"
+        );
+    }
+
+    #[test]
+    fn identifies_primary_and_linked_worktrees() {
+        assert_eq!(
+            worktree_label(Path::new("/repo/.git"), Path::new("/repo/.git")),
+            "primary"
+        );
+        assert_eq!(
+            worktree_label(
+                Path::new("/repo/.git/worktrees/feature"),
+                Path::new("/repo/.git")
+            ),
+            "linked:feature"
+        );
+    }
+
+    #[test]
+    fn derives_linked_worktree_repository_from_the_common_directory() {
+        assert_eq!(
+            repository_name(
+                Path::new("/worktrees/feature"),
+                Path::new("/repo/boomux/.git/worktrees/feature"),
+                Path::new("/repo/boomux/.git")
+            ),
+            "boomux"
+        );
+        assert_eq!(
+            repository_name(
+                Path::new("/worktrees/feature"),
+                Path::new("/repos/boomux.git/worktrees/feature"),
+                Path::new("/repos/boomux.git")
+            ),
+            "boomux"
+        );
+    }
+
+    #[test]
+    fn cache_returns_stale_values_without_repeating_fresh_inspections() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let worker_calls = Arc::clone(&calls);
+        let (finished_sender, finished_receiver) = mpsc::channel();
+        let mut cache = Cache::with_inspector(Arc::new(move |_| {
+            worker_calls.fetch_add(1, Ordering::SeqCst);
+            let _ = finished_sender.send(());
+            Metadata {
+                repository: "boomux".into(),
+                ..Metadata::default()
+            }
+        }));
+
+        assert_eq!(cache.inspect(Path::new("/tmp")).repository, "-");
+        finished_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("inspection completed");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while cache.inspect(Path::new("/tmp")).repository != "boomux" {
+            assert!(
+                Instant::now() < deadline,
+                "inspection result was not published"
+            );
+            thread::yield_now();
+        }
+
+        assert_eq!(cache.inspect(Path::new("/tmp")).repository, "boomux");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn inspects_repositories_without_an_initial_commit() {
+        let repository = TestRepository::unborn();
+
+        let metadata = inspect(&repository.0).expect("Git metadata");
+
+        assert_eq!(metadata.branch, "unborn");
+        assert_eq!(metadata.state, "clean");
+        assert_eq!(metadata.worktree, "primary");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use clap::{Parser, Subcommand};
 use serde::Deserialize;
 
 mod config;
+mod git;
 mod projects;
 mod tui;
 
@@ -169,7 +170,8 @@ fn picker() -> Result<(), Box<dyn Error>> {
 
 fn dashboard() -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
-    let views = dashboard_snapshot()?;
+    let mut git_cache = git::Cache::default();
+    let views = dashboard_snapshot(&mut git_cache)?;
     let config = config::load()?;
     let roots_configured = !config.projects.roots.is_empty();
     let discovery = projects::discover(&config.projects);
@@ -232,24 +234,31 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
                 rename_pane(pane_id, name).map_err(|error| error.to_string())?;
                 Ok(format!("Renamed shell to {name}"))
             },
-            on_refresh: || dashboard_snapshot().map_err(|error| error.to_string()),
+            on_refresh: || dashboard_snapshot(&mut git_cache).map_err(|error| error.to_string()),
         },
     )?;
     Ok(())
 }
 
-fn dashboard_snapshot() -> Result<Vec<tui::WorkspaceView>, Box<dyn Error>> {
+fn dashboard_snapshot(
+    git_cache: &mut git::Cache,
+) -> Result<Vec<tui::WorkspaceView>, Box<dyn Error>> {
     let panes = load_panes()?;
     let workspaces = load_workspaces()?;
-    Ok(dashboard_views(&workspaces, &panes))
+    Ok(dashboard_views(&workspaces, &panes, git_cache))
 }
 
-fn dashboard_views(workspaces: &[Workspace], panes: &[Pane]) -> Vec<tui::WorkspaceView> {
+fn dashboard_views(
+    workspaces: &[Workspace],
+    panes: &[Pane],
+    git_cache: &mut git::Cache,
+) -> Vec<tui::WorkspaceView> {
     workspaces
         .iter()
         .filter_map(|workspace| {
             let workspace_panes: Vec<_> = workspace_panes(&workspace.workspace_id, panes).collect();
             let directory = workspace_panes.first()?.cwd.clone();
+            let git = git_cache.inspect(Path::new(&directory));
             let terminals = workspace_panes
                 .into_iter()
                 .map(|pane| tui::TerminalView {
@@ -264,8 +273,11 @@ fn dashboard_views(workspaces: &[Workspace], panes: &[Pane]) -> Vec<tui::Workspa
             Some(tui::WorkspaceView {
                 id: workspace.workspace_id.clone(),
                 name: workspace.label.clone(),
-                status: workspace.agent_status.clone(),
                 directory,
+                repository: git.repository,
+                branch: git.branch,
+                git_state: git.state,
+                worktree: git.worktree,
                 terminals,
             })
         })
@@ -712,7 +724,7 @@ fn load_workspaces() -> Result<Vec<Workspace>, Box<dyn Error>> {
 fn doctor() -> Result<(), Box<dyn Error>> {
     let mut healthy = true;
 
-    for command in ["ghostty", "herdr", "gum"] {
+    for command in ["ghostty", "herdr", "gum", "git"] {
         match Command::new(command).arg("--version").output() {
             Ok(output) if output.status.success() => {
                 let version = String::from_utf8_lossy(&output.stdout);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -6,7 +6,7 @@ use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
+use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
     Block, Cell, Clear, List, ListItem, ListState, Paragraph, Row, Table, TableState,
 };
@@ -25,8 +25,11 @@ const REFRESH_INTERVAL: Duration = Duration::from_millis(250);
 pub(crate) struct WorkspaceView {
     pub(crate) id: String,
     pub(crate) name: String,
-    pub(crate) status: String,
     pub(crate) directory: String,
+    pub(crate) repository: String,
+    pub(crate) branch: String,
+    pub(crate) git_state: String,
+    pub(crate) worktree: String,
     pub(crate) terminals: Vec<TerminalView>,
 }
 
@@ -675,17 +678,10 @@ fn render(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
     frame.render_widget(Block::new().style(Style::new().bg(BASE)), area);
 
-    let [
-        header_area,
-        workspace_area,
-        terminal_area,
-        metrics_area,
-        footer_area,
-    ] = Layout::vertical([
+    let [header_area, workspace_area, terminal_area, footer_area] = Layout::vertical([
         Constraint::Length(3),
         Constraint::Percentage(38),
         Constraint::Fill(1),
-        Constraint::Length(5),
         Constraint::Length(1),
     ])
     .areas(area);
@@ -693,7 +689,6 @@ fn render(frame: &mut Frame, app: &mut App) {
     render_header(frame, header_area, app);
     render_workspaces(frame, workspace_area, app);
     render_terminals(frame, terminal_area, app);
-    render_metrics(frame, metrics_area, app);
     render_footer(frame, footer_area, app);
     if let Mode::PickProject(picker) = &mut app.mode {
         render_project_picker(frame, area, picker);
@@ -829,48 +824,163 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
 }
 
 fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
-    let header = Row::new(["#", "NAME", "STATUS", "SHELLS", "DIRECTORY", "ID"])
-        .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD));
-    let rows = app.workspaces.iter().enumerate().map(|(index, workspace)| {
-        Row::new(vec![
-            Cell::from((index + 1).to_string()),
-            Cell::from(workspace.name.as_str()),
-            Cell::from(status_span(&workspace.status)),
-            Cell::from(workspace.terminals.len().to_string()),
-            Cell::from(workspace.directory.as_str()),
-            Cell::from(workspace.id.as_str()),
-        ])
-    });
-    let table = Table::new(
-        rows,
-        [
-            Constraint::Length(4),
-            Constraint::Length(20),
-            Constraint::Length(12),
-            Constraint::Length(8),
-            Constraint::Min(24),
-            Constraint::Length(12),
-        ],
-    )
-    .header(header)
-    .column_spacing(1)
-    .block(
-        Block::bordered()
-            .title(" Workspaces ")
-            .border_style(Style::new().fg(if app.focus == Focus::Workspaces {
-                TEAL
-            } else {
-                OVERLAY
-            })),
-    )
-    .row_highlight_style(
-        Style::new()
-            .fg(TEXT)
-            .add_modifier(Modifier::BOLD | Modifier::REVERSED),
-    )
-    .highlight_symbol("> ");
+    let (header, rows, widths) = if area.width >= 140 {
+        let rows: Vec<_> = app
+            .workspaces
+            .iter()
+            .enumerate()
+            .map(|(index, workspace)| {
+                Row::new(vec![
+                    Cell::from((index + 1).to_string()),
+                    Cell::from(workspace.name.as_str()),
+                    Cell::from(workspace.repository.as_str()),
+                    Cell::from(workspace.branch.as_str()),
+                    git_state_cell(&workspace.git_state),
+                    Cell::from(workspace.worktree.as_str()),
+                    Cell::from(workspace.terminals.len().to_string()),
+                    Cell::from(workspace.directory.as_str()),
+                ])
+            })
+            .collect();
+        (
+            Row::new([
+                "#",
+                "NAME",
+                "REPOSITORY",
+                "BRANCH",
+                "DIRTY",
+                "WORKTREE",
+                "SHELLS",
+                "DIRECTORY",
+            ]),
+            rows,
+            vec![
+                Constraint::Length(4),
+                Constraint::Length(18),
+                Constraint::Length(18),
+                Constraint::Length(22),
+                Constraint::Length(12),
+                Constraint::Length(18),
+                Constraint::Length(8),
+                Constraint::Min(24),
+            ],
+        )
+    } else if area.width >= 100 {
+        let rows: Vec<_> = app
+            .workspaces
+            .iter()
+            .enumerate()
+            .map(|(index, workspace)| {
+                let name = if workspace.repository == "-" || workspace.repository == workspace.name
+                {
+                    workspace.name.clone()
+                } else {
+                    format!("{} / {}", workspace.name, workspace.repository)
+                };
+                Row::new(vec![
+                    Cell::from((index + 1).to_string()),
+                    Cell::from(name),
+                    Cell::from(workspace.branch.as_str()),
+                    git_state_cell(&workspace.git_state),
+                    Cell::from(workspace.worktree.as_str()),
+                    Cell::from(workspace.terminals.len().to_string()),
+                ])
+            })
+            .collect();
+        (
+            Row::new([
+                "#",
+                "WORKSPACE / REPOSITORY",
+                "BRANCH",
+                "DIRTY",
+                "WORKTREE",
+                "SHELLS",
+            ]),
+            rows,
+            vec![
+                Constraint::Length(4),
+                Constraint::Min(20),
+                Constraint::Length(18),
+                Constraint::Length(12),
+                Constraint::Length(18),
+                Constraint::Length(7),
+            ],
+        )
+    } else {
+        let rows: Vec<_> = app
+            .workspaces
+            .iter()
+            .enumerate()
+            .map(|(index, workspace)| {
+                let name = if workspace.repository == "-" || workspace.repository == workspace.name
+                {
+                    workspace.name.clone()
+                } else {
+                    format!("{} / {}", workspace.name, workspace.repository)
+                };
+                Row::new(vec![
+                    Cell::from((index + 1).to_string()),
+                    Cell::from(Text::from(vec![
+                        Line::from(name),
+                        Line::from(format!(
+                            "{} shell{}",
+                            workspace.terminals.len(),
+                            if workspace.terminals.len() == 1 {
+                                ""
+                            } else {
+                                "s"
+                            }
+                        )),
+                    ])),
+                    Cell::from(Text::from(vec![
+                        Line::from(workspace.branch.as_str()),
+                        Line::from(vec![
+                            Span::styled(
+                                workspace.git_state.as_str(),
+                                Style::new().fg(git_state_color(&workspace.git_state)),
+                            ),
+                            Span::raw(" | "),
+                            Span::raw(workspace.worktree.as_str()),
+                        ]),
+                    ])),
+                ])
+                .height(2)
+            })
+            .collect();
+        (
+            Row::new(["#", "WORKSPACE / REPOSITORY", "GIT DETAILS"]),
+            rows,
+            vec![
+                Constraint::Length(4),
+                Constraint::Min(24),
+                Constraint::Length(34),
+            ],
+        )
+    };
+    let table = Table::new(rows, widths)
+        .header(header.style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
+        .column_spacing(1)
+        .block(
+            Block::bordered()
+                .title(" Workspaces ")
+                .border_style(Style::new().fg(if app.focus == Focus::Workspaces {
+                    TEAL
+                } else {
+                    OVERLAY
+                })),
+        )
+        .row_highlight_style(
+            Style::new()
+                .fg(TEXT)
+                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+        )
+        .highlight_symbol("> ");
 
     frame.render_stateful_widget(table, area, &mut app.workspace_state);
+}
+
+fn git_state_cell(state: &str) -> Cell<'_> {
+    Cell::from(Span::styled(state, Style::new().fg(git_state_color(state))))
 }
 
 fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
@@ -926,65 +1036,6 @@ fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut Ap
     )
     .highlight_symbol("> ");
     frame.render_stateful_widget(table, area, &mut app.terminal_state);
-}
-
-fn render_metrics(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
-    let [name_area, id_area, shells_area, status_area] = Layout::horizontal([
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-    ])
-    .areas(area);
-    let selected = app.selected();
-
-    render_metric(
-        frame,
-        name_area,
-        "Workspace",
-        selected.map_or("-", |workspace| workspace.name.as_str()),
-        TEXT,
-    );
-    render_metric(
-        frame,
-        id_area,
-        "Herdr ID",
-        selected.map_or("-", |workspace| workspace.id.as_str()),
-        BLUE,
-    );
-    let shell_count = selected
-        .map(|workspace| workspace.terminals.len().to_string())
-        .unwrap_or_else(|| "0".into());
-    render_metric(frame, shells_area, "Shells", &shell_count, GREEN);
-    let status = selected.map_or("-", |workspace| workspace.status.as_str());
-    render_metric(
-        frame,
-        status_area,
-        "Agent State",
-        status,
-        status_color(status),
-    );
-}
-
-fn render_metric(
-    frame: &mut Frame,
-    area: ratatui::layout::Rect,
-    title: &str,
-    value: &str,
-    color: Color,
-) {
-    frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(
-            format!(" {value}"),
-            Style::new().fg(color).add_modifier(Modifier::BOLD),
-        )))
-        .block(
-            Block::bordered()
-                .title(format!(" {title} "))
-                .border_style(Style::new().fg(OVERLAY)),
-        ),
-        area,
-    );
 }
 
 fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
@@ -1058,10 +1109,6 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
     frame.render_widget(Paragraph::new(line), area);
 }
 
-fn status_span(status: &str) -> Span<'_> {
-    Span::styled(status_label(status), Style::new().fg(status_color(status)))
-}
-
 fn status_label(status: &str) -> &str {
     if status == "unknown" { "-" } else { status }
 }
@@ -1073,6 +1120,18 @@ fn status_color(status: &str) -> Color {
         "idle" => GREEN,
         "unknown" | "-" => SUBTEXT,
         _ => TEAL,
+    }
+}
+
+fn git_state_color(state: &str) -> Color {
+    if state == "clean" {
+        GREEN
+    } else if state.contains("conflict") {
+        RED
+    } else if state == "-" || state == "unknown" {
+        SUBTEXT
+    } else {
+        YELLOW
     }
 }
 
@@ -1112,8 +1171,11 @@ mod tests {
         WorkspaceView {
             id: id.into(),
             name: name.into(),
-            status: "working".into(),
             directory: "/tmp/boomux".into(),
+            repository: "boomux".into(),
+            branch: "main".into(),
+            git_state: "clean".into(),
+            worktree: "primary".into(),
             terminals: vec![TerminalView {
                 id: "term_1".into(),
                 pane_id: "w1:p1".into(),
@@ -1133,6 +1195,14 @@ mod tests {
         assert_eq!(app.selected_index(), Some(0));
         app.previous();
         assert_eq!(app.selected_index(), Some(0));
+    }
+
+    #[test]
+    fn git_states_use_semantic_colors() {
+        assert_eq!(git_state_color("clean"), GREEN);
+        assert_eq!(git_state_color("3 changed"), YELLOW);
+        assert_eq!(git_state_color("1 conflict"), RED);
+        assert_eq!(git_state_color("-"), SUBTEXT);
     }
 
     #[test]
@@ -1401,6 +1471,58 @@ mod tests {
         let mut app = app();
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("BRANCH"));
+        assert!(text.contains("DIRTY"));
+        assert!(text.contains("WORKTREE"));
+        assert!(text.contains("SHELLS"));
+        assert!(text.contains("primary"));
+    }
+
+    #[test]
+    fn wide_dashboard_renders_repository_and_directory_columns() {
+        let backend = TestBackend::new(180, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("REPOSITORY"));
+        assert!(text.contains("DIRECTORY"));
+    }
+
+    #[test]
+    fn narrow_dashboard_keeps_workspace_and_git_details_visible() {
+        let backend = TestBackend::new(80, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("WORKSPACE / REPOSITORY"));
+        assert!(text.contains("GIT DETAILS"));
+        assert!(text.contains("main"));
+        assert!(text.contains("clean"));
+        assert!(text.contains("primary"));
+        assert!(text.contains("1 shell"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- display repository, branch, dirty state, and primary or linked worktree in workspace rows
- inspect Git metadata through a non-blocking background worker with a two-second cache
- adapt workspace columns across wide, compact, and 80-column terminal layouts
- remove the unused metrics section and give its space to the terminal table
- update the roadmap with shipped Boomux capabilities

## Verification
- `cargo test` (45 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- release build installed to `~/.local/bin/boomux`; `boomux doctor` passes