### PR TITLE
Add workspace terminal recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ navigate.
   depending on which table is focused.
 - `a` opens the project launcher from workspace focus, or adds one plain shell
   from terminal focus. Type to filter configured Git projects, use Up/Down to
-  select one, and press Enter to create a basename-named workspace with
-  `shell-1`.
+  select one, and press Enter to choose a terminal recipe. The preselected
+  `Default` recipe creates a basename-named workspace with `shell-1`.
 - `e` renames the selected terminal when the terminal table is focused.
 - `x`, then `y`, closes the selected workspace and all of its shells.
 - `r` refreshes immediately; `q` or `Esc` quits.
@@ -117,6 +117,14 @@ the global file; fields present in the override take precedence.
 [projects]
 roots = ["~/Projects", "~/Work"]
 max_depth = 3
+
+[recipes.full-dev]
+label = "Full Dev"
+terminals = [
+  { name = "opencode", command = "opencode" },
+  { name = "lazygit", command = "lazygit" },
+  { name = "lazyvim", command = "nvim" },
+]
 ```
 
 Project roots must be absolute or start with `~`. Boomux recursively discovers
@@ -126,6 +134,15 @@ are visually grouped by each configured root's directory name while sharing one
 search query. No directories are scanned unless roots are explicitly configured.
 `boomux doctor` validates the configuration and reports how many projects were
 discovered.
+
+Recipe terminals become independently persistent Herdr tabs in the selected
+project directory. `name` becomes the durable tab and shell label; an omitted or
+empty `command` creates a plain shell. Recipe provisioning is all-or-nothing:
+after Herdr returns the root workspace identity, Boomux closes the new workspace
+if a later terminal cannot be created, labeled, or sent its startup command.
+Herdr confirms command delivery but does not confirm that the invoked process
+remains running. The built-in `Default` recipe is always available and cannot be
+overridden.
 
 Boomux must be launched from a fresh terminal rather than from inside a
 Herdr-managed pane. The picker also hides panes whose foreground process is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,23 @@ basename becomes the workspace name. Configuration loading and filesystem
 discovery remain outside the TUI so input and rendering do not perform filesystem
 scans.
 
+## Workspace Recipes
+
+After project selection, the dashboard presents the built-in single-shell
+default followed by validated recipes from Boomux's layered TOML configuration.
+Each recipe defines one or more durable terminal names and optional startup
+commands.
+
+The first recipe terminal reuses the workspace root pane; later terminals use
+Herdr tabs. Boomux labels every tab and pane, applies the existing workspace and
+shell environment variables, and delivers configured startup commands through
+`herdr pane run`. Herdr acknowledges command delivery rather than process
+liveness. After Herdr returns the root workspace identity, provisioning is
+transactional at the workspace boundary: later creation, labeling, or delivery
+failures close the new Herdr workspace rather than leaving a partial recipe. A
+successful mutation followed by an undecodable root response cannot be safely
+rolled back because Boomux has no reliable workspace identity.
+
 ### Ghostty Launcher
 
 Creates native windows with stable human-readable titles. Boomux does not rely

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,6 +20,8 @@ commitments.
 - [x] Follow the active terminal theme through semantic ANSI colors.
 - [x] Display repository, branch, dirty state, and primary or linked worktree
   information for each workspace.
+- [x] Create workspaces from configurable multi-terminal recipes with a built-in
+  single-shell default.
 - [x] Validate runtime dependencies, configuration, and project discovery with
   `boomux doctor`.
 
@@ -28,7 +30,6 @@ commitments.
 - Aggregate multiple agent states as counts instead of one workspace-level
   value.
 - Notify when an agent becomes blocked, finishes, or needs input.
-- Create shells, OpenCode, LazyGit, and custom commands from the dashboard.
 - Show an opt-in, read-only preview of the selected terminal.
 - Search workspaces and actions from a command palette.
 - Launch workspace templates such as editor, agent, tests, and LazyGit.
@@ -48,13 +49,12 @@ commitments.
 - Record state transitions and show when an agent last changed state.
 - Provide an attention queue for blocked and completed agents.
 - Send common responses or commands to a selected pane.
-- Define recipes for OpenCode, Claude, Codex, and custom agents.
 - Run hooks, tests, notifications, or focus actions when an agent finishes.
 
 ## Distribution And Polish
 
 - Make the Ratatui interface the default and remove the Gum dependency.
 - Add a LazyGit-style interactive keybinding panel.
-- Support configuration for recipes, refresh rate, and notifications.
+- Support configuration for refresh rate and notifications.
 - Package Herdr and Boomux for Arch and Omarchy users.
 - Validate compatible Herdr and Ghostty versions in `boomux doctor`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, HashSet};
 use std::env;
 use std::error::Error;
 use std::fmt;
@@ -8,11 +9,14 @@ use serde::Deserialize;
 
 const DEFAULT_PROJECT_SEARCH_DEPTH: usize = 3;
 const MAX_PROJECT_SEARCH_DEPTH: usize = 10;
+const MAX_RECIPE_TERMINALS: usize = 12;
+const MAX_RECIPE_NAME_LENGTH: usize = 64;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 struct RawConfig {
     projects: Option<RawProjectsConfig>,
+    recipes: Option<BTreeMap<String, RawRecipeConfig>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -22,9 +26,24 @@ struct RawProjectsConfig {
     max_depth: Option<usize>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawRecipeConfig {
+    label: Option<String>,
+    terminals: Vec<RawRecipeTerminal>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRecipeTerminal {
+    name: String,
+    command: Option<String>,
+}
+
 #[derive(Debug)]
 pub(crate) struct Config {
     pub(crate) projects: ProjectsConfig,
+    pub(crate) recipes: Vec<RecipeConfig>,
     pub(crate) path: Option<PathBuf>,
 }
 
@@ -32,6 +51,19 @@ pub(crate) struct Config {
 pub(crate) struct ProjectsConfig {
     pub(crate) roots: Vec<PathBuf>,
     pub(crate) max_depth: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RecipeConfig {
+    pub(crate) id: String,
+    pub(crate) label: String,
+    pub(crate) terminals: Vec<RecipeTerminalConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RecipeTerminalConfig {
+    pub(crate) name: String,
+    pub(crate) command: Option<String>,
 }
 
 #[derive(Debug)]
@@ -90,15 +122,17 @@ fn read(path: &Path) -> Result<RawConfig, Box<dyn Error>> {
 }
 
 fn merge(base: &mut RawConfig, next: RawConfig) {
-    let Some(next_projects) = next.projects else {
-        return;
-    };
-    let projects = base.projects.get_or_insert_default();
-    if next_projects.roots.is_some() {
-        projects.roots = next_projects.roots;
+    if let Some(next_projects) = next.projects {
+        let projects = base.projects.get_or_insert_default();
+        if next_projects.roots.is_some() {
+            projects.roots = next_projects.roots;
+        }
+        if next_projects.max_depth.is_some() {
+            projects.max_depth = next_projects.max_depth;
+        }
     }
-    if next_projects.max_depth.is_some() {
-        projects.max_depth = next_projects.max_depth;
+    if let Some(next_recipes) = next.recipes {
+        base.recipes.get_or_insert_default().extend(next_recipes);
     }
 }
 
@@ -118,11 +152,91 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
         .into_iter()
         .map(|root| expand_root(&root))
         .collect::<Result<_, _>>()?;
+    let recipes = resolve_recipes(raw.recipes.unwrap_or_default())?;
 
     Ok(Config {
         projects: ProjectsConfig { roots, max_depth },
+        recipes,
         path,
     })
+}
+
+fn resolve_recipes(
+    recipes: BTreeMap<String, RawRecipeConfig>,
+) -> Result<Vec<RecipeConfig>, Box<dyn Error>> {
+    let mut ids = HashSet::new();
+    let mut labels = HashSet::new();
+    let mut recipes = recipes
+        .into_iter()
+        .map(|(id, recipe)| {
+            let id = id.trim().to_lowercase();
+            if id.is_empty() || id == "default" || id.chars().any(char::is_control) {
+                return Err(ConfigError(
+                    "recipe IDs cannot be empty or use the reserved name 'default'".into(),
+                )
+                .into());
+            }
+            if !ids.insert(id.clone()) {
+                return Err(ConfigError(format!("duplicate normalized recipe ID {id}")).into());
+            }
+            if recipe.terminals.is_empty() || recipe.terminals.len() > MAX_RECIPE_TERMINALS {
+                return Err(ConfigError(format!(
+                    "recipe {id} must define between 1 and {MAX_RECIPE_TERMINALS} terminals"
+                ))
+                .into());
+            }
+
+            let mut names = HashSet::new();
+            let terminals = recipe
+                .terminals
+                .into_iter()
+                .map(|terminal| {
+                    let name = terminal.name.trim().to_owned();
+                    if name.is_empty()
+                        || name.len() > MAX_RECIPE_NAME_LENGTH
+                        || name.starts_with('-')
+                        || name.chars().any(char::is_control)
+                    {
+                        return Err(ConfigError(format!(
+                            "recipe {id} contains invalid terminal name {name:?}"
+                        )));
+                    }
+                    if !names.insert(name.clone()) {
+                        return Err(ConfigError(format!(
+                            "recipe {id} contains duplicate terminal name {name}"
+                        )));
+                    }
+                    let command = terminal
+                        .command
+                        .map(|command| command.trim().to_owned())
+                        .filter(|command| !command.is_empty());
+                    Ok(RecipeTerminalConfig { name, command })
+                })
+                .collect::<Result<Vec<_>, ConfigError>>()?;
+            let label = recipe
+                .label
+                .map(|label| label.trim().to_owned())
+                .filter(|label| !label.is_empty())
+                .unwrap_or_else(|| id.clone());
+            if label.len() > MAX_RECIPE_NAME_LENGTH || label.chars().any(char::is_control) {
+                return Err(ConfigError(format!("recipe {id} contains an invalid label")).into());
+            }
+            let normalized_label = label.to_lowercase();
+            if normalized_label == "default" || !labels.insert(normalized_label) {
+                return Err(ConfigError(format!(
+                    "recipe {id} uses a reserved or duplicate label {label:?}"
+                ))
+                .into());
+            }
+            Ok(RecipeConfig {
+                id,
+                label,
+                terminals,
+            })
+        })
+        .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
+    recipes.sort_by_cached_key(|recipe| (recipe.terminals.len() > 1, recipe.label.to_lowercase()));
+    Ok(recipes)
 }
 
 fn expand_root(root: &str) -> Result<PathBuf, Box<dyn Error>> {
@@ -219,5 +333,97 @@ mod tests {
         .expect("valid TOML");
 
         assert!(resolve(raw, None).is_err());
+    }
+
+    #[test]
+    fn parses_and_normalizes_recipes() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+                [recipes.full-dev]
+                label = "Full Dev"
+                terminals = [
+                    { name = "opencode", command = "opencode" },
+                    { name = "shell", command = "" },
+                ]
+            "#,
+        )
+        .expect("valid config");
+
+        let config = resolve(raw, None).expect("resolved config");
+
+        assert_eq!(config.recipes[0].id, "full-dev");
+        assert_eq!(config.recipes[0].label, "Full Dev");
+        assert_eq!(
+            config.recipes[0].terminals[0].command.as_deref(),
+            Some("opencode")
+        );
+        assert_eq!(config.recipes[0].terminals[1].command, None);
+    }
+
+    #[test]
+    fn recipe_overrides_replace_matching_recipe_definitions() {
+        let mut base: RawConfig = toml::from_str(
+            r#"
+                [recipes.dev]
+                terminals = [{ name = "shell" }]
+            "#,
+        )
+        .expect("valid base");
+        let next: RawConfig = toml::from_str(
+            r#"
+                [recipes.dev]
+                label = "Development"
+                terminals = [{ name = "agent", command = "opencode" }]
+            "#,
+        )
+        .expect("valid override");
+
+        merge(&mut base, next);
+        let config = resolve(base, None).expect("resolved config");
+
+        assert_eq!(config.recipes[0].label, "Development");
+        assert_eq!(config.recipes[0].terminals[0].name, "agent");
+    }
+
+    #[test]
+    fn rejects_invalid_recipe_definitions() {
+        for contents in [
+            "[recipes.default]\nterminals = [{ name = 'shell' }]",
+            "[recipes.Default]\nterminals = [{ name = 'shell' }]",
+            "[recipes.empty]\nterminals = []",
+            "[recipes.duplicate]\nterminals = [{ name = 'shell' }, { name = 'shell' }]",
+            "[recipes.blank]\nterminals = [{ name = ' ' }]",
+            "[recipes.option]\nterminals = [{ name = '--clear' }]",
+            "[recipes.control]\nterminals = [{ name = \"bad\\nname\" }]",
+        ] {
+            let raw: RawConfig = toml::from_str(contents).expect("valid TOML");
+            assert!(resolve(raw, None).is_err());
+        }
+    }
+
+    #[test]
+    fn rejects_recipe_ids_that_collide_after_layered_normalization() {
+        let mut base: RawConfig =
+            toml::from_str("[recipes.dev]\nterminals = [{ name = 'shell' }]").expect("valid base");
+        let next: RawConfig = toml::from_str(
+            "[recipes.\" Dev \"]\nterminals = [{ name = 'agent', command = 'opencode' }]",
+        )
+        .expect("valid override");
+
+        merge(&mut base, next);
+
+        assert!(resolve(base, None).is_err());
+    }
+
+    #[test]
+    fn rejects_reserved_and_duplicate_recipe_labels() {
+        for contents in [
+            "[recipes.shell]\nlabel = 'Default'\nterminals = [{ name = 'shell' }]",
+            "[recipes.one]\nlabel = 'Dev'\nterminals = [{ name = 'one' }]\n\
+             [recipes.two]\nlabel = 'dev'\nterminals = [{ name = 'two' }]",
+        ] {
+            let raw: RawConfig = toml::from_str(contents).expect("valid TOML");
+            assert!(resolve(raw, None).is_err());
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,7 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
     let mut git_cache = git::Cache::default();
     let views = dashboard_snapshot(&mut git_cache)?;
     let config = config::load()?;
+    let recipes = config.recipes.clone();
     let roots_configured = !config.projects.roots.is_empty();
     let discovery = projects::discover(&config.projects);
     let project_views = discovery
@@ -187,6 +188,18 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
         .collect();
     let project_context = tui::ProjectContext {
         projects: project_views,
+        recipes: recipes
+            .iter()
+            .map(|recipe| tui::RecipeView {
+                id: recipe.id.clone(),
+                label: recipe.label.clone(),
+                terminals: recipe
+                    .terminals
+                    .iter()
+                    .map(|terminal| terminal.name.clone())
+                    .collect(),
+            })
+            .collect(),
         config_path: config.path.or_else(config::global_config_path),
         warning: (!discovery.warnings.is_empty()).then(|| discovery.warnings.join("; ")),
         roots_configured,
@@ -224,8 +237,9 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
                 close_workspace(workspace_id).map_err(|error| error.to_string())?;
                 Ok(format!("Closed {label} and all of its shells"))
             },
-            on_create_workspace: |directory: &Path| {
-                create_dashboard_workspace(directory).map_err(|error| error.to_string())
+            on_create_workspace: |directory: &Path, recipe_id: Option<&str>| {
+                create_dashboard_workspace(directory, recipe_id, &recipes)
+                    .map_err(|error| error.to_string())
             },
             on_create_shell: |workspace_id: &str| {
                 create_dashboard_shell(workspace_id).map_err(|error| error.to_string())
@@ -315,7 +329,7 @@ fn open_directory(
         )
     } else {
         (
-            create_workspace(&directory, &name)?.root_pane,
+            create_workspace(&directory, &name, "shell-1")?.root_pane,
             "shell-1".into(),
             true,
         )
@@ -454,15 +468,12 @@ fn choose_workspace(
         .map(|choice| choice.workspace_id))
 }
 
-fn create_workspace(cwd: &Path, name: &str) -> Result<WorkspaceCreateResult, Box<dyn Error>> {
-    let output = Command::new("herdr")
-        .args(["workspace", "create", "--cwd"])
-        .arg(cwd)
-        .args(["--label", name])
-        .args(["--env", &format!("BOOMUX_WORKSPACE={name}")])
-        .args(["--env", "BOOMUX_SHELL_NAME=shell-1"])
-        .arg("--focus")
-        .output()?;
+fn create_workspace(
+    cwd: &Path,
+    name: &str,
+    shell_name: &str,
+) -> Result<WorkspaceCreateResult, Box<dyn Error>> {
+    let output = workspace_create_command(cwd, name, shell_name).output()?;
     if !output.status.success() {
         let message = String::from_utf8_lossy(&output.stderr);
         return Err(format!("could not create Herdr terminal: {}", message.trim()).into());
@@ -472,20 +483,25 @@ fn create_workspace(cwd: &Path, name: &str) -> Result<WorkspaceCreateResult, Box
     Ok(response.result)
 }
 
+fn workspace_create_command(cwd: &Path, name: &str, shell_name: &str) -> Command {
+    let mut command = Command::new("herdr");
+    command
+        .args(["workspace", "create", "--cwd"])
+        .arg(cwd)
+        .args(["--label", name])
+        .args(["--env", &format!("BOOMUX_WORKSPACE={name}")])
+        .args(["--env", &format!("BOOMUX_SHELL_NAME={shell_name}")])
+        .arg("--focus");
+    command
+}
+
 fn create_tab_terminal(
     workspace_id: &str,
     cwd: &Path,
     workspace_name: &str,
     shell_name: &str,
 ) -> Result<Pane, Box<dyn Error>> {
-    let output = Command::new("herdr")
-        .args(["tab", "create", "--workspace", workspace_id, "--cwd"])
-        .arg(cwd)
-        .args(["--label", shell_name])
-        .args(["--env", &format!("BOOMUX_WORKSPACE={workspace_name}")])
-        .args(["--env", &format!("BOOMUX_SHELL_NAME={shell_name}")])
-        .arg("--focus")
-        .output()?;
+    let output = tab_create_command(workspace_id, cwd, workspace_name, shell_name).output()?;
     if !output.status.success() {
         let message = String::from_utf8_lossy(&output.stderr);
         return Err(format!("could not create Herdr terminal: {}", message.trim()).into());
@@ -495,7 +511,28 @@ fn create_tab_terminal(
     Ok(response.result.root_pane)
 }
 
-fn create_dashboard_workspace(directory: &Path) -> Result<String, Box<dyn Error>> {
+fn tab_create_command(
+    workspace_id: &str,
+    cwd: &Path,
+    workspace_name: &str,
+    shell_name: &str,
+) -> Command {
+    let mut command = Command::new("herdr");
+    command
+        .args(["tab", "create", "--workspace", workspace_id, "--cwd"])
+        .arg(cwd)
+        .args(["--label", shell_name])
+        .args(["--env", &format!("BOOMUX_WORKSPACE={workspace_name}")])
+        .args(["--env", &format!("BOOMUX_SHELL_NAME={shell_name}")])
+        .arg("--focus");
+    command
+}
+
+fn create_dashboard_workspace(
+    directory: &Path,
+    recipe_id: Option<&str>,
+    recipes: &[config::RecipeConfig],
+) -> Result<String, Box<dyn Error>> {
     let cwd = resolve_directory(directory)?;
     let name = default_workspace_name(&cwd);
     let panes = load_panes()?;
@@ -504,14 +541,102 @@ fn create_dashboard_workspace(directory: &Path) -> Result<String, Box<dyn Error>
         return Err(format!("workspace {name} already exists in {}", cwd.display()).into());
     }
 
-    let pane = create_workspace(&cwd, &name)?.root_pane;
-    if let Err(error) = rename_pane(&pane.pane_id, "shell-1") {
-        return Err(with_cleanup_error(
-            error,
-            close_workspace(&pane.workspace_id),
-        ));
+    let (recipe_label, terminals) = if let Some(recipe_id) = recipe_id {
+        let recipe = recipes
+            .iter()
+            .find(|recipe| recipe.id == recipe_id)
+            .ok_or_else(|| format!("recipe {recipe_id} no longer exists"))?;
+        (recipe.label.clone(), recipe.terminals.clone())
+    } else {
+        (
+            "Default".into(),
+            vec![config::RecipeTerminalConfig {
+                name: "shell-1".into(),
+                command: None,
+            }],
+        )
+    };
+
+    provision_recipe(
+        &terminals,
+        |terminal| Ok(create_workspace(&cwd, &name, &terminal.name)?.root_pane),
+        |workspace_id, terminal| create_tab_terminal(workspace_id, &cwd, &name, &terminal.name),
+        |pane, terminal| {
+            configure_recipe_terminal(pane, &terminal.name, terminal.command.as_deref())
+        },
+        close_workspace,
+    )?;
+    Ok(format!(
+        "Created workspace {name} with {recipe_label} ({} terminal{})",
+        terminals.len(),
+        if terminals.len() == 1 { "" } else { "s" }
+    ))
+}
+
+fn provision_recipe<R, T, C, X>(
+    terminals: &[config::RecipeTerminalConfig],
+    mut create_root: R,
+    mut create_tab: T,
+    mut configure: C,
+    mut cleanup: X,
+) -> Result<(), Box<dyn Error>>
+where
+    R: FnMut(&config::RecipeTerminalConfig) -> Result<Pane, Box<dyn Error>>,
+    T: FnMut(&str, &config::RecipeTerminalConfig) -> Result<Pane, Box<dyn Error>>,
+    C: FnMut(&Pane, &config::RecipeTerminalConfig) -> Result<(), Box<dyn Error>>,
+    X: FnMut(&str) -> Result<(), Box<dyn Error>>,
+{
+    let first = terminals.first().ok_or("recipe has no terminals")?;
+    let root = create_root(first)?;
+    let result = (|| {
+        configure(&root, first)?;
+        for terminal in terminals.iter().skip(1) {
+            let pane = create_tab(&root.workspace_id, terminal)?;
+            configure(&pane, terminal)?;
+        }
+        Ok(())
+    })();
+    if let Err(error) = result {
+        return Err(with_cleanup_error(error, cleanup(&root.workspace_id)));
     }
-    Ok(format!("Created workspace {name} with shell-1"))
+    Ok(())
+}
+
+fn configure_recipe_terminal(
+    pane: &Pane,
+    name: &str,
+    command: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    rename_tab(&pane.tab_id, name)?;
+    rename_pane(&pane.pane_id, name)?;
+    let Some(command) = command else {
+        return Ok(());
+    };
+    let output = Command::new("herdr")
+        .args(["pane", "run", &pane.pane_id, command])
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let message = String::from_utf8_lossy(&output.stderr);
+        Err(format!(
+            "could not deliver startup command to {name}: {}",
+            message.trim()
+        )
+        .into())
+    }
+}
+
+fn rename_tab(tab_id: &str, name: &str) -> Result<(), Box<dyn Error>> {
+    let output = Command::new("herdr")
+        .args(["tab", "rename", tab_id, name])
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let message = String::from_utf8_lossy(&output.stderr);
+        Err(format!("could not rename Herdr tab: {}", message.trim()).into())
+    }
 }
 
 fn create_dashboard_shell(workspace_id: &str) -> Result<String, Box<dyn Error>> {
@@ -809,7 +934,29 @@ fn run_foreground(program: &str, args: &[&str]) -> Result<(), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
     use super::*;
+
+    fn test_pane(pane_id: &str, tab_id: &str) -> Pane {
+        Pane {
+            pane_id: pane_id.into(),
+            tab_id: tab_id.into(),
+            terminal_id: format!("term-{pane_id}"),
+            workspace_id: "w1".into(),
+            cwd: "/tmp/project".into(),
+            label: None,
+            agent: None,
+            agent_status: "unknown".into(),
+        }
+    }
+
+    fn command_args(command: &Command) -> Vec<String> {
+        command
+            .get_args()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect()
+    }
 
     #[test]
     fn parses_path_like_familiar_project_launchers() {
@@ -982,5 +1129,160 @@ mod tests {
         .unwrap();
 
         assert_eq!(response.result.root_pane.terminal_id, "term_456");
+    }
+
+    #[test]
+    fn recipe_provisioning_creates_and_configures_terminals_in_order() {
+        let terminals = vec![
+            config::RecipeTerminalConfig {
+                name: "opencode".into(),
+                command: Some("opencode".into()),
+            },
+            config::RecipeTerminalConfig {
+                name: "lazygit".into(),
+                command: Some("lazygit".into()),
+            },
+        ];
+        let events = RefCell::new(Vec::new());
+
+        provision_recipe(
+            &terminals,
+            |terminal| {
+                events.borrow_mut().push(format!("root:{}", terminal.name));
+                Ok(test_pane("p1", "t1"))
+            },
+            |workspace_id, terminal| {
+                events
+                    .borrow_mut()
+                    .push(format!("tab:{workspace_id}:{}", terminal.name));
+                Ok(test_pane("p2", "t2"))
+            },
+            |pane, terminal| {
+                events
+                    .borrow_mut()
+                    .push(format!("configure:{}:{}", pane.pane_id, terminal.name));
+                Ok(())
+            },
+            |workspace_id| {
+                events.borrow_mut().push(format!("cleanup:{workspace_id}"));
+                Ok(())
+            },
+        )
+        .expect("provisioned recipe");
+
+        assert_eq!(
+            events.into_inner(),
+            [
+                "root:opencode",
+                "configure:p1:opencode",
+                "tab:w1:lazygit",
+                "configure:p2:lazygit",
+            ]
+        );
+    }
+
+    #[test]
+    fn recipe_provisioning_closes_partial_workspace_after_failure() {
+        let terminals = vec![
+            config::RecipeTerminalConfig {
+                name: "shell".into(),
+                command: None,
+            },
+            config::RecipeTerminalConfig {
+                name: "agent".into(),
+                command: Some("missing-agent".into()),
+            },
+        ];
+        let cleaned = RefCell::new(Vec::new());
+
+        let error = provision_recipe(
+            &terminals,
+            |_| Ok(test_pane("p1", "t1")),
+            |_, _| Ok(test_pane("p2", "t2")),
+            |_, terminal| {
+                if terminal.name == "agent" {
+                    Err("command delivery failed".into())
+                } else {
+                    Ok(())
+                }
+            },
+            |workspace_id| {
+                cleaned.borrow_mut().push(workspace_id.to_owned());
+                Ok(())
+            },
+        )
+        .expect_err("provisioning should fail");
+
+        assert!(error.to_string().contains("command delivery failed"));
+        assert_eq!(cleaned.into_inner(), ["w1"]);
+    }
+
+    #[test]
+    fn recipe_creation_commands_include_labels_and_environment() {
+        assert_eq!(
+            command_args(&workspace_create_command(
+                Path::new("/tmp/project"),
+                "project",
+                "opencode",
+            )),
+            [
+                "workspace",
+                "create",
+                "--cwd",
+                "/tmp/project",
+                "--label",
+                "project",
+                "--env",
+                "BOOMUX_WORKSPACE=project",
+                "--env",
+                "BOOMUX_SHELL_NAME=opencode",
+                "--focus",
+            ]
+        );
+        assert_eq!(
+            command_args(&tab_create_command(
+                "w1",
+                Path::new("/tmp/project"),
+                "project",
+                "lazygit",
+            )),
+            [
+                "tab",
+                "create",
+                "--workspace",
+                "w1",
+                "--cwd",
+                "/tmp/project",
+                "--label",
+                "lazygit",
+                "--env",
+                "BOOMUX_WORKSPACE=project",
+                "--env",
+                "BOOMUX_SHELL_NAME=lazygit",
+                "--focus",
+            ]
+        );
+    }
+
+    #[test]
+    fn recipe_provisioning_reports_cleanup_failures() {
+        let terminals = vec![config::RecipeTerminalConfig {
+            name: "agent".into(),
+            command: Some("opencode".into()),
+        }];
+
+        let error = provision_recipe(
+            &terminals,
+            |_| Ok(test_pane("p1", "t1")),
+            |_, _| unreachable!("no additional terminal"),
+            |_, _| Err("command delivery failed".into()),
+            |_| Err("workspace close failed".into()),
+        )
+        .expect_err("provisioning should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "command delivery failed; cleanup also failed: workspace close failed"
+        );
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -43,9 +43,17 @@ pub(crate) struct ProjectView {
 
 pub(crate) struct ProjectContext {
     pub(crate) projects: Vec<ProjectView>,
+    pub(crate) recipes: Vec<RecipeView>,
     pub(crate) config_path: Option<PathBuf>,
     pub(crate) warning: Option<String>,
     pub(crate) roots_configured: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct RecipeView {
+    pub(crate) id: String,
+    pub(crate) label: String,
+    pub(crate) terminals: Vec<String>,
 }
 
 pub(crate) struct TerminalView {
@@ -87,7 +95,15 @@ enum Focus {
 enum Mode {
     Normal,
     PickProject(ProjectPicker),
-    Rename { pane_id: String, input: String },
+    PickRecipe {
+        directory: PathBuf,
+        project_name: String,
+        picker: RecipePicker,
+    },
+    Rename {
+        pane_id: String,
+        input: String,
+    },
 }
 
 struct ProjectPicker {
@@ -98,6 +114,17 @@ struct ProjectPicker {
     config_path: Option<PathBuf>,
     warning: Option<String>,
     roots_configured: bool,
+}
+
+struct RecipePicker {
+    choices: Vec<RecipeChoice>,
+    state: ListState,
+}
+
+struct RecipeChoice {
+    id: Option<String>,
+    label: String,
+    terminals: Vec<String>,
 }
 
 struct Message {
@@ -166,6 +193,49 @@ impl ProjectPicker {
         let previous = self.state.selected().map_or(0, |index| {
             if index == 0 {
                 self.matches.len() - 1
+            } else {
+                index - 1
+            }
+        });
+        self.state.select(Some(previous));
+    }
+}
+
+impl RecipePicker {
+    fn new(recipes: &[RecipeView]) -> Self {
+        let mut choices = vec![RecipeChoice {
+            id: None,
+            label: "Default".into(),
+            terminals: vec!["shell-1".into()],
+        }];
+        choices.extend(recipes.iter().map(|recipe| RecipeChoice {
+            id: Some(recipe.id.clone()),
+            label: recipe.label.clone(),
+            terminals: recipe.terminals.clone(),
+        }));
+        let mut state = ListState::default();
+        state.select(Some(0));
+        Self { choices, state }
+    }
+
+    fn selected(&self) -> Option<&RecipeChoice> {
+        self.state
+            .selected()
+            .and_then(|index| self.choices.get(index))
+    }
+
+    fn next(&mut self) {
+        let next = self
+            .state
+            .selected()
+            .map_or(0, |index| (index + 1) % self.choices.len());
+        self.state.select(Some(next));
+    }
+
+    fn previous(&mut self) {
+        let previous = self.state.selected().map_or(0, |index| {
+            if index == 0 {
+                self.choices.len() - 1
             } else {
                 index - 1
             }
@@ -365,12 +435,16 @@ impl App {
         }
     }
 
-    fn create_workspace<F>(&mut self, directory: &Path, on_create_workspace: &mut F)
-    where
-        F: FnMut(&Path) -> Result<String, String>,
+    fn create_workspace<F>(
+        &mut self,
+        directory: &Path,
+        recipe_id: Option<&str>,
+        on_create_workspace: &mut F,
+    ) where
+        F: FnMut(&Path, Option<&str>) -> Result<String, String>,
     {
         self.mode = Mode::Normal;
-        self.message = Some(match on_create_workspace(directory) {
+        self.message = Some(match on_create_workspace(directory, recipe_id) {
             Ok(text) => Message { text, error: false },
             Err(text) => Message { text, error: true },
         });
@@ -484,7 +558,7 @@ where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
-    W: FnMut(&Path) -> Result<String, String>,
+    W: FnMut(&Path, Option<&str>) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
@@ -508,7 +582,7 @@ where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&str) -> Result<String, String>,
     C: FnMut(&str) -> Result<String, String>,
-    W: FnMut(&Path) -> Result<String, String>,
+    W: FnMut(&Path, Option<&str>) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
@@ -605,7 +679,7 @@ fn handle_mode_key<W, E>(
     on_rename: &mut E,
 ) -> bool
 where
-    W: FnMut(&Path) -> Result<String, String>,
+    W: FnMut(&Path, Option<&str>) -> Result<String, String>,
     E: FnMut(&str, &str) -> Result<String, String>,
 {
     let mode = std::mem::replace(&mut app.mode, Mode::Normal);
@@ -617,9 +691,13 @@ where
         Mode::Normal => false,
         Mode::PickProject(mut picker) => match key {
             KeyCode::Enter if picker.selected().is_some() => {
-                let directory = picker.selected().expect("selected project").path.clone();
-                app.create_workspace(&directory, on_create_workspace);
-                true
+                let project = picker.selected().expect("selected project");
+                app.mode = Mode::PickRecipe {
+                    directory: project.path.clone(),
+                    project_name: project.name.clone(),
+                    picker: RecipePicker::new(&app.project_context.recipes),
+                };
+                false
             }
             KeyCode::Esc => false,
             KeyCode::Down => {
@@ -646,6 +724,44 @@ where
             }
             _ => {
                 app.mode = Mode::PickProject(picker);
+                false
+            }
+        },
+        Mode::PickRecipe {
+            directory,
+            project_name,
+            mut picker,
+        } => match key {
+            KeyCode::Enter => {
+                let recipe_id = picker.selected().expect("selected recipe").id.as_deref();
+                app.create_workspace(&directory, recipe_id, on_create_workspace);
+                true
+            }
+            KeyCode::Esc => false,
+            KeyCode::Down | KeyCode::Char('j') => {
+                picker.next();
+                app.mode = Mode::PickRecipe {
+                    directory,
+                    project_name,
+                    picker,
+                };
+                false
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                picker.previous();
+                app.mode = Mode::PickRecipe {
+                    directory,
+                    project_name,
+                    picker,
+                };
+                false
+            }
+            _ => {
+                app.mode = Mode::PickRecipe {
+                    directory,
+                    project_name,
+                    picker,
+                };
                 false
             }
         },
@@ -690,9 +806,55 @@ fn render(frame: &mut Frame, app: &mut App) {
     render_workspaces(frame, workspace_area, app);
     render_terminals(frame, terminal_area, app);
     render_footer(frame, footer_area, app);
-    if let Mode::PickProject(picker) = &mut app.mode {
-        render_project_picker(frame, area, picker);
+    match &mut app.mode {
+        Mode::PickProject(picker) => render_project_picker(frame, area, picker),
+        Mode::PickRecipe {
+            project_name,
+            picker,
+            ..
+        } => render_recipe_picker(frame, area, project_name, picker),
+        _ => {}
     }
+}
+
+fn render_recipe_picker(
+    frame: &mut Frame,
+    area: Rect,
+    project_name: &str,
+    picker: &mut RecipePicker,
+) {
+    let popup_area = centered_rect(area, 64, 52);
+    frame.render_widget(Clear, popup_area);
+    frame.render_widget(Block::new().style(Style::new().bg(BASE)), popup_area);
+    let [list_area, help_area] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(2)]).areas(popup_area);
+    let items = picker.choices.iter().map(|choice| {
+        ListItem::new(Line::from(vec![
+            Span::styled(
+                format!("{:<22}", choice.label),
+                Style::new().fg(TEXT).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(choice.terminals.join(" · "), Style::new().fg(SUBTEXT)),
+        ]))
+    });
+    let list = List::new(items)
+        .block(
+            Block::bordered()
+                .title(format!(" Recipe for {project_name} "))
+                .border_style(Style::new().fg(TEAL)),
+        )
+        .highlight_symbol("> ")
+        .highlight_style(Style::new().fg(TEXT).add_modifier(Modifier::REVERSED));
+    frame.render_stateful_widget(list, list_area, &mut picker.state);
+    let help = Line::from(vec![
+        Span::styled(" j/k", Style::new().fg(BLUE)),
+        Span::raw(" select  "),
+        Span::styled("enter", Style::new().fg(GREEN)),
+        Span::raw(" create  "),
+        Span::styled("esc", Style::new().fg(RED)),
+        Span::raw(" cancel"),
+    ]);
+    frame.render_widget(Paragraph::new(help).style(Style::new().bg(BASE)), help_area);
 }
 
 fn render_project_picker(frame: &mut Frame, area: Rect, picker: &mut ProjectPicker) {
@@ -1161,6 +1323,11 @@ mod tests {
                     group_order: 1,
                 },
             ],
+            recipes: vec![RecipeView {
+                id: "full-dev".into(),
+                label: "Full Dev".into(),
+                terminals: vec!["opencode".into(), "lazygit".into(), "lazyvim".into()],
+            }],
             config_path: Some("/tmp/config.toml".into()),
             warning: None,
             roots_configured: true,
@@ -1233,7 +1400,7 @@ mod tests {
                 &mut app,
                 KeyCode::Char(character),
                 KeyModifiers::NONE,
-                &mut |_| Ok(String::new()),
+                &mut |_, _| Ok(String::new()),
                 &mut |_, _| Ok(String::new()),
             );
         }
@@ -1241,8 +1408,19 @@ mod tests {
             &mut app,
             KeyCode::Enter,
             KeyModifiers::NONE,
-            &mut |directory| {
+            &mut |_, _| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
+        );
+        assert!(!changed);
+        assert!(matches!(app.mode, Mode::PickRecipe { .. }));
+
+        let changed = handle_mode_key(
+            &mut app,
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+            &mut |directory, recipe_id| {
                 created = Some(directory.to_owned());
+                assert_eq!(recipe_id, None);
                 Ok("Created workspace".into())
             },
             &mut |_, _| Ok(String::new()),
@@ -1251,6 +1429,41 @@ mod tests {
         assert!(changed);
         assert_eq!(created.as_deref(), Some(Path::new("/tmp/alpha")));
         assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn recipe_picker_dispatches_the_selected_recipe() {
+        let mut app = app();
+        let mut selected_recipe = None;
+        app.request_add(&mut |_| Ok(String::new()));
+
+        handle_mode_key(
+            &mut app,
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+            &mut |_, _| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
+        );
+        handle_mode_key(
+            &mut app,
+            KeyCode::Down,
+            KeyModifiers::NONE,
+            &mut |_, _| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
+        );
+        let changed = handle_mode_key(
+            &mut app,
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+            &mut |_, recipe_id| {
+                selected_recipe = recipe_id.map(str::to_owned);
+                Ok("Created workspace".into())
+            },
+            &mut |_, _| Ok(String::new()),
+        );
+
+        assert!(changed);
+        assert_eq!(selected_recipe.as_deref(), Some("full-dev"));
     }
 
     #[test]
@@ -1289,7 +1502,7 @@ mod tests {
             &mut app,
             KeyCode::Char('c'),
             KeyModifiers::CONTROL,
-            &mut |_| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
             &mut |_, _| Ok(String::new()),
         );
 
@@ -1308,7 +1521,7 @@ mod tests {
             &mut app,
             KeyCode::Char('_'),
             KeyModifiers::SHIFT,
-            &mut |_| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
             &mut |_, _| Ok(String::new()),
         );
 
@@ -1360,7 +1573,7 @@ mod tests {
                 &mut app,
                 KeyCode::Char(character),
                 KeyModifiers::NONE,
-                &mut |_| Ok(String::new()),
+                &mut |_, _| Ok(String::new()),
                 &mut |_, _| Ok(String::new()),
             );
         }
@@ -1368,7 +1581,7 @@ mod tests {
             &mut app,
             KeyCode::Enter,
             KeyModifiers::NONE,
-            &mut |_| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
             &mut |pane_id, name| {
                 renamed = Some((pane_id.to_owned(), name.to_owned()));
                 Ok("Renamed shell".into())
@@ -1533,5 +1746,33 @@ mod tests {
         app.request_add(&mut |_| Ok(String::new()));
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn recipe_launcher_renders_default_and_configured_recipes() {
+        let backend = TestBackend::new(120, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+        app.request_add(&mut |_| Ok(String::new()));
+        handle_mode_key(
+            &mut app,
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+            &mut |_, _| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
+        );
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("Recipe for alpha"));
+        assert!(text.contains("Default"));
+        assert!(text.contains("Full Dev"));
+        assert!(text.contains("opencode · lazygit · lazyvim"));
     }
 }


### PR DESCRIPTION
## Summary
- add validated, layered TOML recipes with named terminals and optional startup commands
- add a second creation picker with the built-in single-shell Default preselected
- provision multi-terminal recipes through Herdr tabs and `pane run` command delivery
- label tabs and panes consistently and roll back partial workspaces after acknowledged-root failures
- document recipe behavior and mark the roadmap item complete

## Verification
- `cargo test` (56 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- final code review found no remaining issues
- release build installed to `~/.local/bin/boomux`; `boomux doctor` passes