### PR TITLE
Use Omarchy default terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 > **Boomux is under active development.** It is usable today, but installation,
 > commands, and workspace behavior may change as the project takes shape.
 
-Boomux presents persistent Herdr terminals as ordinary Ghostty windows. Herdr
-owns processes and agent state, Ghostty renders terminals, and the desktop's
-existing window manager remains responsible for layout.
+Boomux presents persistent Herdr terminals as ordinary native terminal windows.
+Herdr owns processes and agent state, Omarchy's selected terminal renders them,
+and the desktop's existing window manager remains responsible for layout.
 
 ## Status
 
-Boomux is an early integration spike. It deliberately composes the public
-interfaces of Ghostty and Herdr instead of forking either project.
+Boomux is an early integration spike. It deliberately composes Omarchy's
+`xdg-terminal-exec` integration with Herdr instead of embedding either concern.
 
 During development, launch Boomux manually. It will not install or modify any
 desktop keybindings; `Super+Enter` remains unchanged unless the user explicitly
@@ -40,11 +40,12 @@ boomux ~/Projects/another-project
 
 By default, Boomux attaches the new persistent shell in the invoking terminal.
 Use `--new` to leave the invoking shell available and open the persistent shell
-in a new native Ghostty window instead:
+in a new native terminal window instead:
 
 ```console
 boomux . --new
 boomux . --name feature-x --new
+boomux . --terminal Alacritty.desktop
 ```
 
 Paths must exist and refer to directories. The default workspace name is the
@@ -58,7 +59,7 @@ boomux
 
 The Gum picker lists workspace names, Herdr IDs, directories, agent status,
 and terminal counts. Selecting a workspace opens every terminal in its own
-native Ghostty window.
+native terminal window.
 
 For a full workspace overview, open the Ratatui dashboard:
 
@@ -83,8 +84,8 @@ navigate.
 - `r` refreshes immediately; `q` or `Esc` quits.
 
 Shell names are stored as Herdr pane labels and appear in the dashboard and
-restored Ghostty window titles. New shells receive `BOOMUX_WORKSPACE` and
-`BOOMUX_SHELL_NAME` environment variables.
+restored terminal window titles when supported. New shells receive
+`BOOMUX_WORKSPACE` and `BOOMUX_SHELL_NAME` environment variables.
 
 For a dynamic Starship segment that follows later renames, add the hidden prompt
 command to your Starship format and configuration:
@@ -99,11 +100,10 @@ format = '[ 󰊠](bg:blue fg:yellow)[ $output](bg:blue fg:crust)'
 ```
 
 The dashboard uses the terminal's ANSI palette rather than a hardcoded color
-scheme. On Omarchy, Ghostty maps those colors through the active theme, so the
-dashboard follows theme changes in the same way as LazyGit.
+scheme, so it follows the active terminal theme in the same way as LazyGit.
 
 Restored terminals take over stale writable attachments while keeping their
-shell or agent processes running. Closing every Ghostty window leaves the
+shell or agent processes running. Closing every terminal window leaves the
 Herdr-owned workspace and terminals alive for later restoration.
 
 ## Configuration
@@ -114,6 +114,8 @@ Boomux reads optional user configuration from
 the global file; fields present in the override take precedence.
 
 ```toml
+terminal = "Alacritty.desktop"
+
 [projects]
 roots = ["~/Projects", "~/Work"]
 max_depth = 3
@@ -126,6 +128,11 @@ terminals = [
   { name = "lazyvim", command = "nvim" },
 ]
 ```
+
+New windows use Omarchy's default terminal unless `terminal` names an installed
+XDG desktop entry. `--terminal <desktop-entry>` overrides both for one
+invocation; when used with a path it implies `--new`. Selection precedence is
+the CLI override, Boomux configuration, then Omarchy's default.
 
 Project roots must be absolute or start with `~`. Boomux recursively discovers
 Git repositories up to `max_depth`, skips hidden and common generated
@@ -163,10 +170,10 @@ boomux open <terminal-id> [--title <title>] [--takeover]
 Boomux workspace
 ├── Herdr workspace: durable group identity
 ├── Herdr tabs/panes: independent persistent terminals
-└── Ghostty windows: temporary native clients
+└── Terminal windows: temporary native clients selected through Omarchy
 ```
 
-Closing a Ghostty window ends only its `herdr terminal attach` process. The
+Closing a terminal window ends only its `herdr terminal attach` process. The
 server-owned terminal and its child processes continue running in Herdr.
 
 ## Technology
@@ -176,11 +183,13 @@ server-owned terminal and its child processes continue running in Herdr.
 - Ratatui with the Crossterm backend for the dashboard
 - Serde and TOML for Herdr responses and layered user configuration
 - Gum for the interactive session chooser
-- Git, Ghostty, and Herdr as external runtime dependencies
+- Git, `xdg-terminal-exec`, an XDG-compatible terminal, and Herdr as external
+  runtime dependencies
 
-The MVP uses Gum rather than maintaining its own TUI framework, and the Herdr
-CLI rather than a custom socket client. Dependencies are added only when a
-tested interaction requires them.
+The MVP uses Gum rather than maintaining its own TUI framework, the Herdr CLI
+rather than a custom socket client, and Omarchy's default-terminal metadata
+rather than per-emulator adapters. Dependencies are added only when a tested
+interaction requires them.
 
 ## Development
 
@@ -218,10 +227,9 @@ See [`docs/roadmap.md`](docs/roadmap.md) for the broader product idea backlog.
 5. After explicit user approval, add optional desktop keybinding and launcher
    integration outside the core.
 
-## Fork Policy
+## Integration Policy
 
-Do not fork Ghostty or Herdr unless the prototype identifies a missing
-capability that cannot be supported through their public interfaces. Boomux
-already has the required one-terminal attachment and native-window launch
-boundaries. Keeping both projects upstream makes updates and distribution much
-simpler.
+Do not fork Herdr or maintain terminal-specific adapters unless the prototype
+identifies a missing capability that cannot be supported through their public
+interfaces. Boomux already has the required one-terminal attachment and
+XDG-native-window launch boundaries.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,14 +4,14 @@
 
 Boomux is a session experience, not a terminal emulator or process
 multiplexer. It maps one Herdr workspace to a named Boomux workspace and each
-durable Herdr terminal to one native Ghostty window.
+durable Herdr terminal to one native terminal window.
 
 ```text
 Herdr server
 └── workspace: project/feature
-    ├── terminal A <-> herdr terminal attach <-> Ghostty window A
-    ├── terminal B <-> herdr terminal attach <-> Ghostty window B
-    └── terminal C <-> herdr terminal attach <-> Ghostty window C
+    ├── terminal A <-> herdr terminal attach <-> terminal window A
+    ├── terminal B <-> herdr terminal attach <-> terminal window B
+    └── terminal C <-> herdr terminal attach <-> terminal window C
 ```
 
 ## Why Compose First
@@ -21,10 +21,11 @@ the current rendered state and live ANSI frames, accepts terminal input, and
 propagates terminal resize events. Disconnecting removes the controller without
 terminating the server-owned process.
 
-Ghostty's Linux `+new-window` action creates an independent top-level GTK
-window and can execute `herdr terminal attach <terminal-id>` as that surface's
-command. Closing the surface terminates the attachment command while leaving
-the Herdr server and terminal alive.
+Omarchy's `xdg-terminal-exec` integration resolves the default or explicitly
+selected terminal desktop entry and translates common capabilities such as
+command execution and titles into that emulator's arguments. Closing the
+surface terminates the attachment command while leaving the Herdr server and
+terminal alive.
 
 These contracts provide the MVP without source-level integration.
 
@@ -45,24 +46,24 @@ private and versioned.
 ### Picker
 
 Runs in a normal terminal surface and lists named workspaces. Selecting one
-launches a Ghostty window for every terminal belonging to that Herdr workspace.
+launches a native window for every terminal belonging to that Herdr workspace.
 
 ### Dashboard
 
 Provides a Ratatui overview of workspaces, terminals, directories, Git state,
 and per-terminal agent state. It is a control plane only: restoring a workspace
-still launches native Ghostty windows rather than embedding terminal sessions in
+still launches native terminal windows rather than embedding terminal sessions in
 the dashboard. The dashboard remains open after restoration so it can continue
 managing other workspaces. It refreshes from Herdr four times per second and
 validates the selected workspace against a fresh snapshot before launching
-Ghostty windows.
+terminal windows.
 Repository name, branch, dirty state, and primary or linked worktree information
 come from the Git CLI and are cached for two seconds so the faster Herdr refresh
 does not repeatedly spawn Git processes.
 Closing a workspace uses Herdr's atomic workspace close command after explicit
 confirmation, terminating every shell in that workspace. Shell creation uses
 Herdr tabs, and pane labels provide durable shell names for the dashboard,
-Ghostty titles, and prompt integrations.
+window titles, and prompt integrations.
 
 Dashboard colors use semantic ANSI roles and the terminal's default foreground
 and background. This keeps the TUI portable while allowing terminal-level theme
@@ -100,18 +101,19 @@ failures close the new Herdr workspace rather than leaving a partial recipe. A
 successful mutation followed by an undecodable root response cannot be safely
 rolled back because Boomux has no reliable workspace identity.
 
-### Ghostty Launcher
+### Terminal Launcher
 
-Creates native windows with stable human-readable titles. Boomux does not rely
-on compositor-specific window IDs or control APIs.
+Resolves Omarchy's default terminal or a Boomux-specific XDG desktop entry and
+creates native windows with human-readable titles when supported. Boomux does
+not rely on compositor-specific window IDs or control APIs.
 
 ## Known Constraints
 
 - Herdr permits one writable controller per terminal; `--takeover` is explicit.
 - Direct interactive attachment is currently Unix-only.
-- Ghostty `+new-window` requires its Linux GTK build and session D-Bus.
-- Ghostty windows commonly share one application process, although each is an
-  independent top-level window.
+- Window launching requires Omarchy's `xdg-terminal-exec` and an installed
+  terminal with compatible XDG desktop-entry metadata.
+- Terminal capabilities such as stable titles vary by emulator.
 - Window titles identify sessions for humans but are not durable machine IDs.
 - Herdr sends rendered ANSI frames, not the original raw PTY output stream.
 

--- a/docs/brainstorms/2026-08-01-omarchy-terminal-selection-requirements.md
+++ b/docs/brainstorms/2026-08-01-omarchy-terminal-selection-requirements.md
@@ -1,0 +1,109 @@
+---
+date: 2026-08-01
+topic: omarchy-terminal-selection
+---
+
+# Omarchy Terminal Selection
+
+## Summary
+
+Boomux will open new windows through Omarchy's default-terminal mechanism while
+allowing a persistent configured terminal or a one-invocation CLI override.
+
+---
+
+## Problem Frame
+
+Boomux currently requires Ghostty for every window it opens even though Herdr
+owns the persistent terminal process independently. On an Omarchy installation
+whose default terminal is Alacritty, this makes `boomux doctor` fail and forces
+the user to install a second terminal emulator solely for Boomux.
+
+---
+
+## Key Flows
+
+- F1. Open with the Omarchy default
+  - **Trigger:** The user asks Boomux to open one or more new windows without selecting a terminal.
+  - **Steps:** Boomux resolves Omarchy's current default and launches each Herdr attachment through it.
+  - **Outcome:** The workspace opens in the same terminal emulator Omarchy would normally launch.
+  - **Covered by:** R1, R4, R7
+- F2. Open with an explicit terminal
+  - **Trigger:** The user configures a terminal or supplies a terminal override for one invocation.
+  - **Steps:** Boomux resolves the effective desktop entry, validates it, and launches new windows with it.
+  - **Outcome:** The requested terminal is used without changing Omarchy's system-wide preference.
+  - **Covered by:** R2, R3, R5, R6
+
+---
+
+## Requirements
+
+**Terminal selection**
+
+- R1. Boomux must use Omarchy's default terminal when no Boomux-specific terminal is selected.
+- R2. Users must be able to persist a preferred terminal in Boomux configuration using an XDG desktop-entry ID.
+- R3. Users must be able to select a terminal for one invocation using `--terminal <desktop-entry>`.
+- R4. Selection precedence must be CLI override, Boomux configuration, then Omarchy's default.
+- R5. Selecting a terminal while creating a workspace must imply opening it in a new window, even when `--new` is omitted.
+- R6. An invalid or unavailable explicit terminal must fail with an actionable error rather than silently falling back.
+
+**Launching and diagnostics**
+
+- R7. Every flow that opens a new terminal window must use the effective terminal selection, including workspace restoration, dashboard actions, and `boomux open`.
+- R8. Window titles and other optional terminal capabilities must be applied when supported without making unsupported capabilities a launch failure.
+- R9. `boomux doctor` must validate Omarchy's terminal launcher and the configured or default terminal instead of requiring Ghostty.
+- R10. Direct attachment in the invoking terminal must remain unchanged when neither `--new` nor `--terminal` is supplied.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R4, R7.** Given Omarchy defaults to Alacritty and Boomux has no terminal preference, when a workspace is restored, its windows open in Alacritty.
+- AE2. **Covers R2, R4.** Given Omarchy defaults to Alacritty and Boomux is configured for a valid Ghostty desktop entry, when a workspace is restored, its windows open in Ghostty.
+- AE3. **Covers R3, R4.** Given Boomux is configured for Ghostty, when the user restores a workspace with an Alacritty desktop-entry override, that invocation opens in Alacritty and the saved preference remains Ghostty.
+- AE4. **Covers R5.** Given the user runs `boomux . --terminal Alacritty.desktop`, Boomux opens a new Alacritty window rather than attaching in the invoking terminal.
+- AE5. **Covers R6.** Given an override names a missing desktop entry, Boomux reports that the selection cannot be launched and does not use another terminal.
+- AE6. **Covers R9.** Given Ghostty is absent but Omarchy's default terminal is valid, `boomux doctor` reports the terminal check as healthy.
+- AE7. **Covers R10.** Given the user runs `boomux .` without terminal-related options, Boomux attaches in the current terminal as it does today.
+
+---
+
+## Success Criteria
+
+- An Omarchy user can install and use Boomux without installing Ghostty when another valid default terminal is configured.
+- Users can temporarily or persistently choose a different installed terminal without changing Omarchy's global default.
+- Planning can implement every launch and diagnostic path without inventing selection precedence, fallback behavior, or capability guarantees.
+
+---
+
+## Scope Boundaries
+
+- Support is targeted at Omarchy and its `xdg-terminal-exec` integration; other Linux environments are best-effort only.
+- Boomux will not change the system-wide terminal preference.
+- macOS and Windows support are excluded.
+- Per-emulator adapters, arbitrary command templates, and terminal-specific profiles are excluded.
+- Optional capabilities such as titles do not carry cross-terminal guarantees.
+
+---
+
+## Key Decisions
+
+- Use XDG desktop-entry IDs for explicit selection so Boomux relies on Omarchy's terminal metadata rather than emulator-specific command syntax.
+- Keep both configuration and CLI selection; the CLI value is temporary and takes precedence.
+- Treat an explicit CLI selection as a request for a new window because it cannot alter the terminal already running Boomux.
+- Prefer a single Omarchy terminal-launching contract over maintaining dedicated Ghostty, Alacritty, or Kitty integrations.
+
+---
+
+## Dependencies / Assumptions
+
+- The supported Omarchy environment provides `xdg-terminal-exec` and valid desktop-entry metadata for installed terminals.
+- Herdr terminal attachment remains independent of the terminal emulator used to display it.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R2, R3, R6][Needs research] Determine the safest way to ask `xdg-terminal-exec` to resolve a specific desktop entry without changing the user's global preference or leaking a temporary XDG configuration into the attached shell.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,14 +8,14 @@ commitments.
 
 - [x] Manage persistent Herdr workspaces and shells from a live Ratatui
   dashboard.
-- [x] Restore a whole workspace into native Ghostty windows or open only one
+- [x] Restore a whole workspace into native terminal windows or open only one
   selected terminal.
 - [x] Create workspaces from a searchable Git project launcher grouped by
   configured roots.
 - [x] Load layered TOML configuration from the XDG config directory and an
   optional `BOOMUX_CONFIG` override.
 - [x] Add plain shells, assign durable shell names, and carry those names into
-  the dashboard, Ghostty titles, and dynamic Starship prompts.
+  the dashboard, window titles, and dynamic Starship prompts.
 - [x] Close a workspace and all of its shells through an explicit confirmation.
 - [x] Follow the active terminal theme through semantic ANSI colors.
 - [x] Display repository, branch, dirty state, and primary or linked worktree
@@ -24,6 +24,8 @@ commitments.
   single-shell default.
 - [x] Validate runtime dependencies, configuration, and project discovery with
   `boomux doctor`.
+- [x] Follow Omarchy's default terminal with persistent and per-invocation XDG
+  desktop-entry overrides.
 
 ## Workspace Control
 
@@ -41,7 +43,7 @@ commitments.
 - Restore shells into optional Hyprland layout presets.
 - Place workspace groups on selected Hyprland workspaces or monitors.
 - Give each Boomux workspace a consistent border color.
-- Focus an existing Ghostty attachment instead of opening another window.
+- Focus an existing terminal attachment instead of opening another window.
 - Offer the dashboard as an optional Hyprland special workspace.
 
 ## Agent Workflows
@@ -57,4 +59,4 @@ commitments.
 - Add a LazyGit-style interactive keybinding panel.
 - Support configuration for refresh rate and notifications.
 - Package Herdr and Boomux for Arch and Omarchy users.
-- Validate compatible Herdr and Ghostty versions in `boomux doctor`.
+- Validate compatible Herdr and `xdg-terminal-exec` versions in `boomux doctor`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ const MAX_RECIPE_NAME_LENGTH: usize = 64;
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 struct RawConfig {
+    terminal: Option<String>,
     projects: Option<RawProjectsConfig>,
     recipes: Option<BTreeMap<String, RawRecipeConfig>>,
 }
@@ -42,6 +43,7 @@ struct RawRecipeTerminal {
 
 #[derive(Debug)]
 pub(crate) struct Config {
+    pub(crate) terminal: Option<String>,
     pub(crate) projects: ProjectsConfig,
     pub(crate) recipes: Vec<RecipeConfig>,
     pub(crate) path: Option<PathBuf>,
@@ -122,6 +124,9 @@ fn read(path: &Path) -> Result<RawConfig, Box<dyn Error>> {
 }
 
 fn merge(base: &mut RawConfig, next: RawConfig) {
+    if next.terminal.is_some() {
+        base.terminal = next.terminal;
+    }
     if let Some(next_projects) = next.projects {
         let projects = base.projects.get_or_insert_default();
         if next_projects.roots.is_some() {
@@ -137,6 +142,14 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
 }
 
 fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Error>> {
+    let terminal = raw
+        .terminal
+        .map(|terminal| terminal.trim().to_owned())
+        .map(|terminal| {
+            crate::terminal::validate_desktop_entry(&terminal)?;
+            Ok::<_, Box<dyn Error>>(terminal)
+        })
+        .transpose()?;
     let projects = raw.projects.unwrap_or_default();
     let max_depth = projects.max_depth.unwrap_or(DEFAULT_PROJECT_SEARCH_DEPTH);
     if !(1..=MAX_PROJECT_SEARCH_DEPTH).contains(&max_depth) {
@@ -155,6 +168,7 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
     let recipes = resolve_recipes(raw.recipes.unwrap_or_default())?;
 
     Ok(Config {
+        terminal,
         projects: ProjectsConfig { roots, max_depth },
         recipes,
         path,
@@ -281,6 +295,42 @@ mod tests {
 
         assert_eq!(config.projects.roots, [PathBuf::from("/tmp/projects")]);
         assert_eq!(config.projects.max_depth, 4);
+    }
+
+    #[test]
+    fn parses_terminal_preference() {
+        let raw: RawConfig =
+            toml::from_str(r#"terminal = "Alacritty.desktop""#).expect("valid config");
+
+        let config = resolve(raw, None).expect("resolved config");
+
+        assert_eq!(config.terminal.as_deref(), Some("Alacritty.desktop"));
+    }
+
+    #[test]
+    fn terminal_preference_can_be_overridden() {
+        let mut base: RawConfig =
+            toml::from_str(r#"terminal = "Alacritty.desktop""#).expect("valid base");
+        let next: RawConfig = toml::from_str(r#"terminal = "com.mitchellh.ghostty.desktop""#)
+            .expect("valid override");
+
+        merge(&mut base, next);
+        let config = resolve(base, None).expect("resolved config");
+
+        assert_eq!(
+            config.terminal.as_deref(),
+            Some("com.mitchellh.ghostty.desktop")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_terminal_desktop_entries() {
+        for terminal in ["", "Alacritty", "-Alacritty.desktop", "bad\n.desktop"] {
+            let raw: RawConfig =
+                toml::from_str(&format!("terminal = {terminal:?}")).expect("valid TOML");
+
+            assert!(resolve(raw, None).is_err());
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,13 @@ use serde::Deserialize;
 mod config;
 mod git;
 mod projects;
+mod terminal;
 mod tui;
 
 #[derive(Parser)]
 #[command(
     version,
-    about = "Native Ghostty windows for persistent Herdr terminals",
-    args_conflicts_with_subcommands = true
+    about = "Native terminal windows for persistent Herdr terminals"
 )]
 struct Cli {
     /// Open or create a persistent terminal in this directory
@@ -26,9 +26,13 @@ struct Cli {
     #[arg(short, long, requires = "path")]
     name: Option<String>,
 
-    /// Open the terminal in a new Ghostty window instead of attaching here
+    /// Open the terminal in a new window instead of attaching here
     #[arg(long = "new", requires = "path")]
     new_window: bool,
+
+    /// XDG desktop entry to use for windows opened by this invocation
+    #[arg(long, global = true, value_name = "DESKTOP_ENTRY")]
+    terminal: Option<String>,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -42,11 +46,11 @@ enum Commands {
     Doctor,
     /// List panes managed by Herdr
     List,
-    /// Open a Herdr terminal in a new Ghostty window
+    /// Open a Herdr terminal in a new terminal window
     Open {
         /// Herdr terminal ID, available from `boomux list`
         terminal_id: String,
-        /// Stable title shown on the Ghostty window
+        /// Stable title shown on the terminal window when supported
         #[arg(long)]
         title: Option<String>,
         /// Replace another client currently controlling this terminal
@@ -69,22 +73,57 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
+    if let Some(desktop_entry) = cli.terminal.as_deref() {
+        terminal::validate_desktop_entry(desktop_entry)?;
+    }
     if let Some(path) = cli.path {
-        return open_directory(&path, cli.name.as_deref(), cli.new_window);
+        let open_in_new_window = should_open_new_window(cli.new_window, cli.terminal.as_deref());
+        let terminal = open_in_new_window
+            .then(|| effective_terminal(cli.terminal.as_deref()))
+            .transpose()?
+            .flatten();
+        return open_directory(
+            &path,
+            cli.name.as_deref(),
+            open_in_new_window,
+            terminal.as_deref(),
+        );
     }
 
     match cli.command {
-        Some(Commands::Ui) => dashboard(),
-        Some(Commands::Doctor) => doctor(),
+        Some(Commands::Ui) => dashboard(cli.terminal.as_deref()),
+        Some(Commands::Doctor) => doctor(cli.terminal.as_deref()),
         Some(Commands::List) => run_foreground("herdr", &["pane", "list"]),
         Some(Commands::Open {
             terminal_id,
             title,
             takeover,
-        }) => open_terminal(&terminal_id, title.as_deref(), takeover),
+        }) => {
+            let terminal = effective_terminal(cli.terminal.as_deref())?;
+            open_terminal(
+                &terminal_id,
+                title.as_deref(),
+                takeover,
+                terminal.as_deref(),
+            )
+        }
         Some(Commands::Prompt) => print_prompt_label(),
-        None => picker(),
+        None => {
+            let terminal = effective_terminal(cli.terminal.as_deref())?;
+            picker(terminal.as_deref())
+        }
     }
+}
+
+fn should_open_new_window(new_window: bool, terminal: Option<&str>) -> bool {
+    new_window || terminal.is_some()
+}
+
+fn effective_terminal(override_entry: Option<&str>) -> Result<Option<String>, Box<dyn Error>> {
+    if let Some(entry) = override_entry {
+        return Ok(Some(entry.to_owned()));
+    }
+    Ok(config::load()?.terminal)
 }
 
 #[derive(Deserialize)]
@@ -153,7 +192,7 @@ struct Choice {
     workspace_id: String,
 }
 
-fn picker() -> Result<(), Box<dyn Error>> {
+fn picker(terminal: Option<&str>) -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
     let panes = available_panes()?;
     let workspaces = load_workspaces()?;
@@ -165,14 +204,17 @@ fn picker() -> Result<(), Box<dyn Error>> {
         .find(|workspace| workspace.workspace_id == workspace_id)
         .ok_or("selected workspace no longer exists")?;
 
-    open_workspace(workspace, &panes)
+    open_workspace(workspace, &panes, terminal)
 }
 
-fn dashboard() -> Result<(), Box<dyn Error>> {
+fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
     let mut git_cache = git::Cache::default();
     let views = dashboard_snapshot(&mut git_cache)?;
     let config = config::load()?;
+    let terminal = terminal_override
+        .map(str::to_owned)
+        .or_else(|| config.terminal.clone());
     let recipes = config.recipes.clone();
     let roots_configured = !config.projects.roots.is_empty();
     let discovery = projects::discover(&config.projects);
@@ -216,14 +258,16 @@ fn dashboard() -> Result<(), Box<dyn Error>> {
                     .find(|workspace| workspace.workspace_id == workspace_id)
                     .ok_or_else(|| "selected workspace no longer exists".to_owned())?;
                 let shell_count = workspace_panes(&workspace.workspace_id, &panes).count();
-                open_workspace(workspace, &panes).map_err(|error| error.to_string())?;
+                open_workspace(workspace, &panes, terminal.as_deref())
+                    .map_err(|error| error.to_string())?;
                 Ok(format!(
                     "Restored {shell_count} shell(s) for {}",
                     workspace.label
                 ))
             },
             on_open: |terminal_id: &str| {
-                open_dashboard_terminal(terminal_id).map_err(|error| error.to_string())
+                open_dashboard_terminal(terminal_id, terminal.as_deref())
+                    .map_err(|error| error.to_string())
             },
             on_close: |workspace_id: &str| {
                 let workspaces = load_workspaces().map_err(|error| error.to_string())?;
@@ -302,6 +346,7 @@ fn open_directory(
     path: &Path,
     requested_name: Option<&str>,
     open_in_new_window: bool,
+    terminal: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
     let directory = resolve_directory(path)?;
@@ -348,6 +393,7 @@ fn open_directory(
             &pane.terminal_id,
             Some(&format!("{name} - {shell_name}")),
             true,
+            terminal,
         )?;
     } else if !attach_terminal(&pane.terminal_id)? {
         return Err(format!("could not attach to Herdr terminal {}", pane.terminal_id).into());
@@ -712,7 +758,10 @@ fn with_cleanup_error(
     }
 }
 
-fn open_dashboard_terminal(terminal_id: &str) -> Result<String, Box<dyn Error>> {
+fn open_dashboard_terminal(
+    terminal_id: &str,
+    terminal: Option<&str>,
+) -> Result<String, Box<dyn Error>> {
     let panes = load_panes()?;
     let pane = panes
         .iter()
@@ -727,11 +776,16 @@ fn open_dashboard_terminal(terminal_id: &str) -> Result<String, Box<dyn Error>> 
         terminal_id,
         Some(&format!("{} - {shell_name}", workspace.label)),
         true,
+        terminal,
     )?;
     Ok(format!("Opened {shell_name} from {}", workspace.label))
 }
 
-fn open_workspace(workspace: &Workspace, panes: &[Pane]) -> Result<(), Box<dyn Error>> {
+fn open_workspace(
+    workspace: &Workspace,
+    panes: &[Pane],
+    terminal: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
     let workspace_panes: Vec<_> = workspace_panes(&workspace.workspace_id, panes).collect();
     if workspace_panes.is_empty() {
         return Err(format!("workspace {} has no terminals", workspace.label).into());
@@ -747,6 +801,7 @@ fn open_workspace(workspace: &Workspace, panes: &[Pane]) -> Result<(), Box<dyn E
             &pane.terminal_id,
             Some(&format!("{} - {shell_name}", workspace.label)),
             true,
+            terminal,
         )?;
     }
 
@@ -846,10 +901,10 @@ fn load_workspaces() -> Result<Vec<Workspace>, Box<dyn Error>> {
     Ok(response.result.workspaces)
 }
 
-fn doctor() -> Result<(), Box<dyn Error>> {
+fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     let mut healthy = true;
 
-    for command in ["ghostty", "herdr", "gum", "git"] {
+    for command in ["herdr", "gum", "git"] {
         match Command::new(command).arg("--version").output() {
             Ok(output) if output.status.success() => {
                 let version = String::from_utf8_lossy(&output.stdout);
@@ -882,6 +937,14 @@ fn doctor() -> Result<(), Box<dyn Error>> {
                     eprintln!("    {warning}");
                 }
             }
+            let terminal = terminal_override.or(config.terminal.as_deref());
+            match terminal::selected(terminal) {
+                Ok(selected) => println!("ok  terminal: {selected}"),
+                Err(error) => {
+                    healthy = false;
+                    eprintln!("err terminal: {error}");
+                }
+            }
         }
         Err(error) => {
             healthy = false;
@@ -900,27 +963,12 @@ fn open_terminal(
     terminal_id: &str,
     title: Option<&str>,
     takeover: bool,
+    terminal: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
     let title = title
         .map(str::to_owned)
         .unwrap_or_else(|| format!("Boomux: {terminal_id}"));
-    let mut command = Command::new("ghostty");
-    command
-        .arg("+new-window")
-        .arg(format!("--title={title}"))
-        .arg("--shell-integration-features=no-title")
-        .args(["-e", "herdr", "terminal", "attach", terminal_id]);
-
-    if takeover {
-        command.arg("--takeover");
-    }
-
-    let status = command.status()?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!("Ghostty failed with {status}").into())
-    }
+    terminal::open(terminal, terminal_id, &title, takeover)
 }
 
 fn run_foreground(program: &str, args: &[&str]) -> Result<(), Box<dyn Error>> {
@@ -996,6 +1044,32 @@ mod tests {
         assert!(cli.new_window);
         assert!(Cli::try_parse_from(["boomux", "--new"]).is_err());
         assert!(Cli::try_parse_from(["boomux", ".", "--current"]).is_err());
+    }
+
+    #[test]
+    fn accepts_a_terminal_override_for_window_launches() {
+        let cli = Cli::try_parse_from(["boomux", ".", "--terminal", "Alacritty.desktop"]).unwrap();
+
+        assert_eq!(cli.terminal.as_deref(), Some("Alacritty.desktop"));
+        assert!(should_open_new_window(
+            cli.new_window,
+            cli.terminal.as_deref()
+        ));
+
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "open",
+            "term_123",
+            "--terminal",
+            "Alacritty.desktop",
+        ])
+        .unwrap();
+        assert_eq!(cli.terminal.as_deref(), Some("Alacritty.desktop"));
+
+        let cli =
+            Cli::try_parse_from(["boomux", "--terminal", "Alacritty.desktop", "doctor"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Doctor)));
+        assert_eq!(cli.terminal.as_deref(), Some("Alacritty.desktop"));
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,190 @@
+use std::env;
+use std::error::Error;
+use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{self, Command};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEMPORARY_DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn validate_desktop_entry(entry: &str) -> Result<(), Box<dyn Error>> {
+    let (desktop_entry, action) = entry
+        .split_once(':')
+        .map_or((entry, None), |(entry, action)| (entry, Some(action)));
+    let invalid = entry.trim() != entry
+        || desktop_entry.is_empty()
+        || !desktop_entry.ends_with(".desktop")
+        || desktop_entry.starts_with('-')
+        || desktop_entry.contains(['/', '\\'])
+        || entry.chars().any(char::is_whitespace)
+        || action.is_some_and(|action| action.is_empty() || action.contains(':'));
+    if invalid {
+        Err(format!("invalid terminal desktop entry {entry:?}").into())
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn selected(desktop_entry: Option<&str>) -> Result<String, Box<dyn Error>> {
+    let preference = desktop_entry.map(TemporaryPreference::new).transpose()?;
+    selected_with_preference(desktop_entry, preference.as_ref())
+}
+
+pub(crate) fn open(
+    desktop_entry: Option<&str>,
+    terminal_id: &str,
+    title: &str,
+    takeover: bool,
+) -> Result<(), Box<dyn Error>> {
+    let preference = desktop_entry.map(TemporaryPreference::new).transpose()?;
+    let selected = selected_with_preference(desktop_entry, preference.as_ref())?;
+    let mut resolver = configured_command(preference.as_ref());
+    resolver
+        .arg(r"--print-cmd=\0")
+        .arg(format!("--title={title}"))
+        .arg("--")
+        .args(["herdr", "terminal", "attach", terminal_id]);
+    if takeover {
+        resolver.arg("--takeover");
+    }
+    let output = resolver.output()?;
+    if !output.status.success() {
+        let message = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("could not prepare {selected}: {}", message.trim()).into());
+    }
+    let arguments = parse_nul_arguments(&output.stdout)?;
+    let (program, arguments) = arguments
+        .split_first()
+        .ok_or("xdg-terminal-exec returned an empty terminal command")?;
+    Command::new(program)
+        .args(arguments)
+        .spawn()
+        .map_err(|error| format!("could not launch {selected}: {error}"))?;
+    Ok(())
+}
+
+fn selected_with_preference(
+    requested: Option<&str>,
+    preference: Option<&TemporaryPreference>,
+) -> Result<String, Box<dyn Error>> {
+    if let Some(entry) = requested {
+        validate_desktop_entry(entry)?;
+    }
+    let output = configured_command(preference)
+        .arg("--print-id")
+        .output()
+        .map_err(|error| format!("could not run xdg-terminal-exec: {error}"))?;
+    if !output.status.success() {
+        let message = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("could not resolve an Omarchy terminal: {}", message.trim()).into());
+    }
+    let selected = String::from_utf8(output.stdout)?.trim().to_owned();
+    if selected.is_empty() {
+        return Err("xdg-terminal-exec did not select a terminal".into());
+    }
+    if let Some(requested) = requested
+        && selected != requested
+    {
+        return Err(format!(
+            "terminal desktop entry {requested:?} is unavailable (xdg-terminal-exec selected {selected:?} instead)"
+        )
+        .into());
+    }
+    Ok(selected)
+}
+
+fn configured_command(preference: Option<&TemporaryPreference>) -> Command {
+    let mut command = Command::new("xdg-terminal-exec");
+    if let Some(preference) = preference {
+        command
+            .env("XDG_CONFIG_HOME", &preference.directory)
+            .env("XTE_CACHE_ENABLED", "false");
+    }
+    command
+}
+
+fn parse_nul_arguments(output: &[u8]) -> Result<Vec<OsString>, Box<dyn Error>> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+
+        let arguments = output
+            .split(|byte| *byte == 0)
+            .filter(|argument| !argument.is_empty())
+            .map(|argument| OsString::from_vec(argument.to_vec()))
+            .collect::<Vec<_>>();
+        if arguments.is_empty() {
+            Err("xdg-terminal-exec returned an empty terminal command".into())
+        } else {
+            Ok(arguments)
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = output;
+        Err("terminal launching is supported only on Unix".into())
+    }
+}
+
+struct TemporaryPreference {
+    directory: PathBuf,
+}
+
+impl TemporaryPreference {
+    fn new(entry: &str) -> Result<Self, Box<dyn Error>> {
+        validate_desktop_entry(entry)?;
+        let parent = env::var_os("XDG_RUNTIME_DIR")
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .unwrap_or_else(env::temp_dir);
+        let id = TEMPORARY_DIRECTORY_ID.fetch_add(1, Ordering::Relaxed);
+        let directory = parent.join(format!("boomux-{}-{id}", process::id()));
+        fs::create_dir(&directory)?;
+        if let Err(error) = fs::write(directory.join("xdg-terminals.list"), format!("{entry}\n")) {
+            let _ = fs::remove_dir(&directory);
+            return Err(error.into());
+        }
+        Ok(Self { directory })
+    }
+}
+
+impl Drop for TemporaryPreference {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.directory);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn validates_desktop_entry_ids_and_actions() {
+        assert!(validate_desktop_entry("Alacritty.desktop").is_ok());
+        assert!(validate_desktop_entry("terminal.desktop:new-window").is_ok());
+
+        for invalid in [
+            "",
+            "Alacritty",
+            "-bad.desktop",
+            "bad/name.desktop",
+            "bad.desktop:",
+        ] {
+            assert!(validate_desktop_entry(invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn parses_nul_delimited_commands() {
+        let arguments = parse_nul_arguments(b"alacritty\0-e\0herdr\0terminal\0").unwrap();
+
+        assert_eq!(
+            arguments,
+            ["alacritty", "-e", "herdr", "terminal"]
+                .map(OsStr::new)
+                .map(OsStr::to_owned)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- open Herdr attachments through Omarchy's XDG-selected terminal instead of requiring Ghostty
- add persistent config and per-invocation desktop-entry overrides
- update doctor, tests, and documentation for terminal selection

## Testing
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo fmt --check
- boomux doctor