### PR TITLE
Make dashboard the default interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,13 @@ boomux . --terminal Alacritty.desktop
 `--terminal` implies `--new`. Selection precedence is the CLI override, Boomux
 configuration, then Omarchy's default terminal.
 
-Run Boomux without a path to select a workspace with Gum and open every shell
-in its own native terminal window:
+Run Boomux without a path to open the Ratatui dashboard:
 
 ```console
 boomux
 ```
 
-Open the full Ratatui dashboard with:
+The explicit dashboard command remains available as an alias:
 
 ```console
 boomux ui
@@ -62,7 +61,7 @@ Dashboard controls:
 - `j`, `k`, and the arrow keys navigate.
 - `Enter` restores a workspace or opens the selected shell.
 - `a` creates an empty workspace or adds a shell, depending on the focused
-  table. New dashboard shells start in the directory where `boomux ui` was
+  table. New dashboard shells start in the directory where the dashboard was
   launched.
 - `e` renames the selected workspace or shell, depending on focus.
 - `x`, then `y`, closes a workspace and all of its processes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,6 +33,8 @@ commitments.
   socket protocol, PTY lifecycle, and transparent attachment client.
 - [x] Exercise native PTY transport, detach, takeover, resize, process cleanup,
   startup locking, and graceful shutdown through an isolated binary-level test.
+- [x] Make the Ratatui dashboard the default interface and remove the external
+  picker dependency.
 
 ## Workspace Control
 
@@ -71,7 +73,6 @@ terminal handshake, VT reconstruction, and restart-persistence plan.
 
 ## Distribution And Polish
 
-- Make the Ratatui interface the default and remove the Gum dependency.
 - Add a LazyGit-style interactive keybinding panel.
 - Support configuration for refresh rate and notifications.
 - Package Boomux and its daemon lifecycle for Arch and Omarchy users.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitCode, Stdio};
+use std::process::{Command, ExitCode};
 
 use clap::{Parser, Subcommand};
 
@@ -159,10 +159,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         Some(Commands::Prompt) => print_prompt_label(),
         Some(Commands::Daemon { command }) => daemon_control(command),
         Some(Commands::Attach { .. }) => unreachable!(),
-        None => {
-            let terminal = effective_terminal(cli.terminal.as_deref())?;
-            picker(terminal.as_deref())
-        }
+        None => dashboard(cli.terminal.as_deref()),
     }
 }
 
@@ -192,21 +189,6 @@ fn effective_terminal(override_entry: Option<&str>) -> Result<Option<String>, Bo
         return Ok(Some(entry.to_owned()));
     }
     Ok(config::load()?.terminal)
-}
-
-fn picker(terminal: Option<&str>) -> Result<(), Box<dyn Error>> {
-    ensure_host_terminal()?;
-    let client = client::connect_or_start()?;
-    let snapshot = client.snapshot()?;
-    let Some(workspace_id) = choose_workspace(&snapshot.workspaces)? else {
-        return Ok(());
-    };
-    let workspace = snapshot
-        .workspaces
-        .iter()
-        .find(|workspace| workspace.id == workspace_id)
-        .ok_or("selected workspace no longer exists")?;
-    open_workspace(workspace, terminal)
 }
 
 fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
@@ -415,44 +397,6 @@ fn find_workspace<'a>(
     name: &str,
 ) -> Option<&'a WorkspaceSnapshot> {
     workspaces.iter().find(|workspace| workspace.name == name)
-}
-
-fn choose_workspace(workspaces: &[WorkspaceSnapshot]) -> Result<Option<String>, Box<dyn Error>> {
-    if workspaces.is_empty() {
-        return Err("no saved workspaces; run `boomux PATH` to create one".into());
-    }
-    let choices = workspaces
-        .iter()
-        .map(|workspace| {
-            let shell_word = if workspace.shells.len() == 1 {
-                "shell"
-            } else {
-                "shells"
-            };
-            let label = format!(
-                "{:<18} {:>2} {:<6} ({})",
-                workspace.name,
-                workspace.shells.len(),
-                shell_word,
-                workspace.id
-            );
-            (label, workspace.id.clone())
-        })
-        .collect::<Vec<_>>();
-    let output = Command::new("gum")
-        .args(["choose", "--header", "Restore a Boomux workspace"])
-        .args(choices.iter().map(|(label, _)| label))
-        .stdin(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .output()?;
-    if !output.status.success() {
-        return Ok(None);
-    }
-    let selected = String::from_utf8(output.stdout)?;
-    Ok(choices
-        .into_iter()
-        .find(|(label, _)| label == selected.trim_end())
-        .map(|(_, id)| id))
 }
 
 fn create_dashboard_workspace(
@@ -744,7 +688,7 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             eprintln!("err daemon: {error}");
         }
     }
-    for command in ["gum", "git"] {
+    for command in ["git"] {
         match Command::new(command).arg("--version").output() {
             Ok(output) if output.status.success() => {
                 println!(


### PR DESCRIPTION
## Summary
- launch the Ratatui dashboard when Boomux runs without arguments
- remove the external Gum picker and dependency check
- update usage documentation and roadmap status

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- boomux doctor