### PR TITLE
Clean up iterative development residue

### DIFF
--- a/.agents/skills/boomux-shells/SKILL.md
+++ b/.agents/skills/boomux-shells/SKILL.md
@@ -17,7 +17,7 @@ user to copy terminal contents.
 When the user provides a shell name or shell ID, run:
 
 ```console
-boomux read "<name-or-terminal-id>" --lines 200
+boomux read "<name-or-shell-id>" --lines 200
 ```
 
 Use the returned text to answer the user's question. Increase `--lines` when

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
 libc = "0.2"
 portable-pty = "0.9"
-ratatui = { version = "0.30", default-features = false, features = ["all-widgets", "crossterm", "layout-cache"] }
+ratatui = { version = "0.30", default-features = false, features = ["crossterm", "layout-cache"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.9"

--- a/docs/native-terminal-follow-up.md
+++ b/docs/native-terminal-follow-up.md
@@ -306,15 +306,14 @@ stty size
 
 ## Implementation Order
 
-1. Review and merge `feat/native-pty-backend`.
-2. Create `feat/terminal-handshake`.
-3. Add `TerminalProfile` and `Pending` to the shell protocol and domain model.
-4. Move PTY spawn from shell metadata creation to first attachment.
-5. Add emulator mismatch diagnostics and acceptance tests.
-6. Dogfood Alacritty and Ghostty with the manual matrix.
-7. Create a separate VT reconstruction branch.
-8. Replace raw `boomux read` extraction with parser-backed logical lines.
-9. Add metadata persistence only after terminal behavior is stable.
+1. Create `feat/terminal-handshake`.
+2. Add `TerminalProfile` and `Pending` to the shell protocol and domain model.
+3. Move PTY spawn from shell metadata creation to first attachment.
+4. Add emulator mismatch diagnostics and acceptance tests.
+5. Dogfood Alacritty and Ghostty with the manual matrix.
+6. Create a separate VT reconstruction branch.
+7. Replace raw `boomux read` extraction with parser-backed logical lines.
+8. Add metadata persistence only after terminal behavior is stable.
 
 ## Definition Of Done
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -90,6 +90,10 @@ impl Client {
     }
 
     pub fn request(&self, request: Request) -> io::Result<Response> {
+        self.send(request).map(|(_, response)| response)
+    }
+
+    fn send(&self, request: Request) -> io::Result<(UnixStream, Response)> {
         let mut stream = UnixStream::connect(&self.socket_path)?;
         protocol::write_message(&mut stream, &Envelope::new(request))?;
         let response: Envelope<Response> = protocol::read_message(&mut stream)?;
@@ -101,7 +105,7 @@ impl Client {
         }
         match response.message {
             Response::Error { message } => Err(io::Error::other(message)),
-            response => Ok(response),
+            response => Ok((stream, response)),
         }
     }
 
@@ -186,7 +190,6 @@ impl Client {
         }
     }
 
-    #[allow(dead_code)]
     pub fn rename_workspace(
         &self,
         workspace_id: impl Into<String>,
@@ -224,7 +227,6 @@ impl Client {
         )
     }
 
-    #[allow(dead_code)]
     pub fn close_shell(&self, shell_id: impl Into<String>) -> io::Result<()> {
         expect_ok(
             self.request(Request::CloseShell {
@@ -239,24 +241,12 @@ impl Client {
         shell_id: impl Into<String>,
         takeover: bool,
     ) -> io::Result<(UnixStream, String, Vec<u8>)> {
-        let mut stream = UnixStream::connect(&self.socket_path)?;
-        protocol::write_message(
-            &mut stream,
-            &Envelope::new(Request::Attach {
-                shell_id: shell_id.into(),
-                takeover,
-            }),
-        )?;
-        let response: Envelope<Response> = protocol::read_message(&mut stream)?;
-        if response.version != protocol::PROTOCOL_VERSION {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "protocol version mismatch",
-            ));
-        }
-        match response.message {
+        let (stream, response) = self.send(Request::Attach {
+            shell_id: shell_id.into(),
+            takeover,
+        })?;
+        match response {
             Response::Attached { token, replay } => Ok((stream, token, replay)),
-            Response::Error { message } => Err(io::Error::other(message)),
             other => unexpected(other),
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -614,7 +614,7 @@ fn spawn_shell(
 
 fn start_pty_reader(shell: Arc<Shell>, mut reader: Box<dyn Read + Send>) {
     thread::spawn(move || {
-        let mut buffer = vec![0; 16 * 1024];
+        let mut buffer = [0; 16 * 1024];
         loop {
             match reader.read(&mut buffer) {
                 Ok(0) => break,
@@ -809,12 +809,12 @@ fn signal_session(session_id: libc::pid_t, signal: libc::c_int) {
 }
 
 fn proc_session_id(stat: &str) -> Option<libc::pid_t> {
-    let fields = stat
-        .rsplit_once(')')?
+    stat.rsplit_once(')')?
         .1
         .split_whitespace()
-        .collect::<Vec<_>>();
-    fields.get(3)?.parse().ok()
+        .nth(3)?
+        .parse()
+        .ok()
 }
 
 fn validate_shell_specs(specs: &[ShellSpec]) -> io::Result<()> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -114,8 +114,10 @@ fn inspect(directory: &Path) -> Option<Metadata> {
     }
 
     let output = String::from_utf8_lossy(&output.stdout);
-    let lines: Vec<_> = output.lines().map(str::to_owned).collect();
-    let [root, git_directory, common_directory] = lines.as_slice() else {
+    let mut lines = output.lines();
+    let (Some(root), Some(git_directory), Some(common_directory), None) =
+        (lines.next(), lines.next(), lines.next(), lines.next())
+    else {
         return None;
     };
     let root = Path::new(root);

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,9 +292,7 @@ fn dashboard_views(
                 .iter()
                 .map(|shell| tui::TerminalView {
                     id: shell.id.clone(),
-                    pane_id: shell.id.clone(),
                     name: shell.name.clone(),
-                    kind: "shell".into(),
                     status: shell_status(&shell.status).into(),
                     directory: shell.cwd.display().to_string(),
                 })
@@ -360,7 +358,7 @@ fn open_directory(
     if open_in_new_window {
         open_terminal(
             &shell.id,
-            Some(&format!("{workspace_name} - {}", shell.name)),
+            &format!("{workspace_name} - {}", shell.name),
             true,
             terminal,
         )
@@ -418,12 +416,8 @@ fn create_dashboard_shell(
 ) -> Result<String, Box<dyn Error>> {
     let workspace = client.get_workspace(workspace_id)?;
     let name = unique_shell_name("shell", &workspace.shells);
-    client.create_shell(workspace_id, dashboard_shell_spec(&name, launch_cwd))?;
+    client.create_shell(workspace_id, ShellSpec::login(&name, launch_cwd))?;
     Ok(format!("Created {name} in {}", workspace.name))
-}
-
-fn dashboard_shell_spec(name: &str, launch_cwd: &Path) -> ShellSpec {
-    ShellSpec::login(name, launch_cwd)
 }
 
 fn unique_shell_name(base_name: &str, shells: &[ShellSnapshot]) -> String {
@@ -572,7 +566,7 @@ fn open_dashboard_shell(
     let workspace = client.get_workspace(&shell.workspace_id)?;
     open_terminal(
         shell_id,
-        Some(&format!("{} - {}", workspace.name, shell.name)),
+        &format!("{} - {}", workspace.name, shell.name),
         true,
         terminal,
     )?;
@@ -589,7 +583,7 @@ fn open_workspace(
     for shell in &workspace.shells {
         open_terminal(
             &shell.id,
-            Some(&format!("{} - {}", workspace.name, shell.name)),
+            &format!("{} - {}", workspace.name, shell.name),
             true,
             terminal,
         )?;
@@ -611,19 +605,16 @@ fn open_shell(
             .map(|workspace| format!("{} - {}", workspace.name, shell.name))
             .unwrap_or_else(|_| format!("Boomux: {}", shell.name))
     });
-    open_terminal(shell_id, Some(&title), takeover, terminal)
+    open_terminal(shell_id, &title, takeover, terminal)
 }
 
 fn open_terminal(
     shell_id: &str,
-    title: Option<&str>,
+    title: &str,
     takeover: bool,
     terminal: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
-    let title = title
-        .map(str::to_owned)
-        .unwrap_or_else(|| format!("Boomux: {shell_id}"));
-    terminal::open(terminal, shell_id, &title, takeover)
+    terminal::open(terminal, shell_id, title, takeover)
 }
 
 fn print_prompt_label() -> Result<(), Box<dyn Error>> {
@@ -823,13 +814,6 @@ mod tests {
         assert_eq!(unique_shell_name("shell", &shells), "shell-2");
         assert_eq!(unique_shell_name("api", &shells), "api-2");
         assert_eq!(unique_shell_name("logs", &shells), "logs");
-    }
-
-    #[test]
-    fn dashboard_shell_uses_launch_cwd() {
-        let spec = dashboard_shell_spec("shell", Path::new("/tmp/dashboard-launch"));
-
-        assert_eq!(spec.cwd, Path::new("/tmp/dashboard-launch"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -50,9 +50,7 @@ pub(crate) struct ProjectContext {
 
 pub(crate) struct TerminalView {
     pub(crate) id: String,
-    pub(crate) pane_id: String,
     pub(crate) name: String,
-    pub(crate) kind: String,
     pub(crate) status: String,
     pub(crate) directory: String,
 }
@@ -118,6 +116,15 @@ struct ProjectPicker {
 struct Message {
     text: String,
     error: bool,
+}
+
+impl Message {
+    fn from_result(result: Result<String, String>) -> Self {
+        match result {
+            Ok(text) => Self { text, error: false },
+            Err(text) => Self { text, error: true },
+        }
+    }
 }
 
 struct PendingClose {
@@ -351,7 +358,7 @@ impl App {
                 .map(|workspace| RenameTarget::Workspace(workspace.id.clone())),
             Focus::Terminals => self
                 .selected_terminal()
-                .map(|terminal| RenameTarget::Shell(terminal.pane_id.clone())),
+                .map(|terminal| RenameTarget::Shell(terminal.id.clone())),
         };
         if let Some(target) = target {
             self.mode = Mode::Rename {
@@ -377,10 +384,7 @@ impl App {
                 else {
                     return false;
                 };
-                self.message = Some(match on_create_shell(&workspace_id) {
-                    Ok(text) => Message { text, error: false },
-                    Err(text) => Message { text, error: true },
-                });
+                self.message = Some(Message::from_result(on_create_shell(&workspace_id)));
                 true
             }
         }
@@ -391,10 +395,7 @@ impl App {
         F: FnMut(&str) -> Result<String, String>,
     {
         self.mode = Mode::Normal;
-        self.message = Some(match on_create_workspace(name) {
-            Ok(text) => Message { text, error: false },
-            Err(text) => Message { text, error: true },
-        });
+        self.message = Some(Message::from_result(on_create_workspace(name)));
     }
 
     fn rename<F>(&mut self, target: &RenameTarget, name: &str, on_rename: &mut F)
@@ -402,10 +403,7 @@ impl App {
         F: FnMut(&RenameTarget, &str) -> Result<String, String>,
     {
         self.mode = Mode::Normal;
-        self.message = Some(match on_rename(target, name) {
-            Ok(text) => Message { text, error: false },
-            Err(text) => Message { text, error: true },
-        });
+        self.message = Some(Message::from_result(on_rename(target, name)));
     }
 
     fn restore_selected<F>(&mut self, on_restore: &mut F)
@@ -415,10 +413,7 @@ impl App {
         let Some(workspace_id) = self.selected().map(|workspace| workspace.id.clone()) else {
             return;
         };
-        self.message = Some(match on_restore(&workspace_id) {
-            Ok(text) => Message { text, error: false },
-            Err(text) => Message { text, error: true },
-        });
+        self.message = Some(Message::from_result(on_restore(&workspace_id)));
     }
 
     fn open_selected_terminal<F>(&mut self, on_open: &mut F)
@@ -428,10 +423,7 @@ impl App {
         let Some(terminal_id) = self.selected_terminal().map(|terminal| terminal.id.clone()) else {
             return;
         };
-        self.message = Some(match on_open(&terminal_id) {
-            Ok(text) => Message { text, error: false },
-            Err(text) => Message { text, error: true },
-        });
+        self.message = Some(Message::from_result(on_open(&terminal_id)));
     }
 
     fn request_close(&mut self) {
@@ -453,10 +445,7 @@ impl App {
         let Some(pending) = self.pending_close.take() else {
             return;
         };
-        self.message = Some(match on_close(&pending.id) {
-            Ok(text) => Message { text, error: false },
-            Err(text) => Message { text, error: true },
-        });
+        self.message = Some(Message::from_result(on_close(&pending.id)));
     }
 
     fn refresh<F>(&mut self, on_refresh: &mut F)
@@ -1014,28 +1003,30 @@ fn git_state_cell(state: &str) -> Cell<'_> {
 }
 
 fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
-    let header = Row::new(["#", "NAME", "TYPE", "STATUS", "DIRECTORY", "TERMINAL ID"])
+    let header = Row::new(["#", "NAME", "STATUS", "DIRECTORY", "SHELL ID"])
         .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD));
-    let rows: Vec<_> = app
+    let selected = app
+        .workspace_state
         .selected()
+        .and_then(|index| app.workspaces.get(index));
+    let rows: Vec<_> = selected
         .into_iter()
         .flat_map(|workspace| workspace.terminals.iter())
         .enumerate()
         .map(|(index, terminal)| {
             Row::new(vec![
                 Cell::from((index + 1).to_string()),
-                Cell::from(terminal.name.clone()),
-                Cell::from(terminal.kind.clone()),
+                Cell::from(terminal.name.as_str()),
                 Cell::from(Span::styled(
-                    status_label(&terminal.status).to_owned(),
+                    terminal.status.as_str(),
                     Style::new().fg(status_color(&terminal.status)),
                 )),
-                Cell::from(terminal.directory.clone()),
-                Cell::from(terminal.id.clone()),
+                Cell::from(terminal.directory.as_str()),
+                Cell::from(terminal.id.as_str()),
             ])
         })
         .collect();
-    let title = app.selected().map_or_else(
+    let title = selected.map_or_else(
         || " Terminals ".to_owned(),
         |workspace| format!(" Terminals: {} ", workspace.name),
     );
@@ -1043,7 +1034,6 @@ fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut Ap
         rows,
         [
             Constraint::Length(4),
-            Constraint::Length(18),
             Constraint::Length(18),
             Constraint::Length(12),
             Constraint::Min(24),
@@ -1147,16 +1137,9 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
     frame.render_widget(Paragraph::new(line), area);
 }
 
-fn status_label(status: &str) -> &str {
-    if status == "unknown" { "-" } else { status }
-}
-
 fn status_color(status: &str) -> Color {
     match status {
-        "working" => YELLOW,
-        "blocked" => RED,
-        "idle" => GREEN,
-        "unknown" | "-" => SUBTEXT,
+        "exited" => SUBTEXT,
         _ => TEAL,
     }
 }
@@ -1216,10 +1199,8 @@ mod tests {
             worktree: "primary".into(),
             terminals: vec![TerminalView {
                 id: "term_1".into(),
-                pane_id: "w1:p1".into(),
                 name: "agent".into(),
-                kind: "opencode".into(),
-                status: "working".into(),
+                status: "running".into(),
                 directory: "/tmp/boomux".into(),
             }],
         }
@@ -1472,7 +1453,7 @@ mod tests {
         assert!(changed);
         assert_eq!(
             renamed,
-            Some((RenameTarget::Shell("w1:p1".into()), "api".into()))
+            Some((RenameTarget::Shell("term_1".into()), "api".into()))
         );
         assert!(matches!(app.mode, Mode::Normal));
     }


### PR DESCRIPTION
## Summary
- remove stale pane, terminal type, and agent-status UI remnants
- reduce render, protocol, and process-inspection allocations and duplication
- trim unused Ratatui features and correct stale documentation

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check