### PR TITLE
Remove recipe configuration

### DIFF
--- a/docs/native-terminal-follow-up.md
+++ b/docs/native-terminal-follow-up.md
@@ -270,7 +270,7 @@ Persist only reproducible metadata under `$XDG_STATE_HOME/boomux`:
 - Workspace and shell IDs
 - Workspace and shell names and grouping
 - Shell working directories; workspaces have no path
-- Explicit shell startup commands and recipes
+- Explicit shell startup commands
 - Last terminal profile when useful for diagnostics
 
 Do not claim that arbitrary process state can be serialized. After an ordinary

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -52,7 +52,6 @@ terminal handshake, VT reconstruction, and restart-persistence plan.
 - Show an opt-in, read-only preview of the selected terminal.
 - Search workspaces and actions from a command palette.
 - Launch workspace templates such as editor, agent, tests, and LazyGit.
-- Apply configurable shell recipes through an explicit shell-creation flow.
 - Duplicate a workspace structure for another branch or worktree.
 - Archive inactive workspaces without terminating their shells.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use std::collections::{BTreeMap, HashSet};
 use std::env;
 use std::error::Error;
 use std::fmt;
@@ -9,15 +8,12 @@ use serde::Deserialize;
 
 const DEFAULT_PROJECT_SEARCH_DEPTH: usize = 3;
 const MAX_PROJECT_SEARCH_DEPTH: usize = 10;
-const MAX_RECIPE_TERMINALS: usize = 12;
-const MAX_RECIPE_NAME_LENGTH: usize = 64;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 struct RawConfig {
     terminal: Option<String>,
     projects: Option<RawProjectsConfig>,
-    recipes: Option<BTreeMap<String, RawRecipeConfig>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -27,26 +23,10 @@ struct RawProjectsConfig {
     max_depth: Option<usize>,
 }
 
-#[derive(Debug, Default, Deserialize)]
-#[serde(default, deny_unknown_fields)]
-struct RawRecipeConfig {
-    label: Option<String>,
-    terminals: Vec<RawRecipeTerminal>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawRecipeTerminal {
-    name: String,
-    command: Option<String>,
-}
-
 #[derive(Debug)]
 pub(crate) struct Config {
     pub(crate) terminal: Option<String>,
     pub(crate) projects: ProjectsConfig,
-    #[allow(dead_code)] // Reserved for a future explicit shell-creation flow.
-    pub(crate) recipes: Vec<RecipeConfig>,
     pub(crate) path: Option<PathBuf>,
 }
 
@@ -54,19 +34,6 @@ pub(crate) struct Config {
 pub(crate) struct ProjectsConfig {
     pub(crate) roots: Vec<PathBuf>,
     pub(crate) max_depth: usize,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct RecipeConfig {
-    pub(crate) id: String,
-    pub(crate) label: String,
-    pub(crate) terminals: Vec<RecipeTerminalConfig>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct RecipeTerminalConfig {
-    pub(crate) name: String,
-    pub(crate) command: Option<String>,
 }
 
 #[derive(Debug)]
@@ -137,9 +104,6 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
             projects.max_depth = next_projects.max_depth;
         }
     }
-    if let Some(next_recipes) = next.recipes {
-        base.recipes.get_or_insert_default().extend(next_recipes);
-    }
 }
 
 fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Error>> {
@@ -166,92 +130,11 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
         .into_iter()
         .map(|root| expand_root(&root))
         .collect::<Result<_, _>>()?;
-    let recipes = resolve_recipes(raw.recipes.unwrap_or_default())?;
-
     Ok(Config {
         terminal,
         projects: ProjectsConfig { roots, max_depth },
-        recipes,
         path,
     })
-}
-
-fn resolve_recipes(
-    recipes: BTreeMap<String, RawRecipeConfig>,
-) -> Result<Vec<RecipeConfig>, Box<dyn Error>> {
-    let mut ids = HashSet::new();
-    let mut labels = HashSet::new();
-    let mut recipes = recipes
-        .into_iter()
-        .map(|(id, recipe)| {
-            let id = id.trim().to_lowercase();
-            if id.is_empty() || id == "default" || id.chars().any(char::is_control) {
-                return Err(ConfigError(
-                    "recipe IDs cannot be empty or use the reserved name 'default'".into(),
-                )
-                .into());
-            }
-            if !ids.insert(id.clone()) {
-                return Err(ConfigError(format!("duplicate normalized recipe ID {id}")).into());
-            }
-            if recipe.terminals.is_empty() || recipe.terminals.len() > MAX_RECIPE_TERMINALS {
-                return Err(ConfigError(format!(
-                    "recipe {id} must define between 1 and {MAX_RECIPE_TERMINALS} terminals"
-                ))
-                .into());
-            }
-
-            let mut names = HashSet::new();
-            let terminals = recipe
-                .terminals
-                .into_iter()
-                .map(|terminal| {
-                    let name = terminal.name.trim().to_owned();
-                    if name.is_empty()
-                        || name.len() > MAX_RECIPE_NAME_LENGTH
-                        || name.starts_with('-')
-                        || name.chars().any(char::is_control)
-                    {
-                        return Err(ConfigError(format!(
-                            "recipe {id} contains invalid terminal name {name:?}"
-                        )));
-                    }
-                    if !names.insert(name.clone()) {
-                        return Err(ConfigError(format!(
-                            "recipe {id} contains duplicate terminal name {name}"
-                        )));
-                    }
-                    let command = terminal
-                        .command
-                        .map(|command| command.trim().to_owned())
-                        .filter(|command| !command.is_empty());
-                    Ok(RecipeTerminalConfig { name, command })
-                })
-                .collect::<Result<Vec<_>, ConfigError>>()?;
-            let label = recipe
-                .label
-                .map(|label| label.trim().to_owned())
-                .filter(|label| !label.is_empty())
-                .unwrap_or_else(|| id.clone());
-            if label.len() > MAX_RECIPE_NAME_LENGTH || label.chars().any(char::is_control) {
-                return Err(ConfigError(format!("recipe {id} contains an invalid label")).into());
-            }
-            let normalized_label = label.to_lowercase();
-            if normalized_label == "default" || !labels.insert(normalized_label) {
-                return Err(ConfigError(format!(
-                    "recipe {id} uses a reserved or duplicate label {label:?}"
-                ))
-                .into());
-            }
-            Ok(RecipeConfig {
-                id,
-                label,
-                terminals,
-            })
-        })
-        .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
-    recipes.sort_by_cached_key(|recipe| (recipe.terminals.len() > 1, recipe.label.to_lowercase()));
-    Ok(recipes)
 }
 
 fn expand_root(root: &str) -> Result<PathBuf, Box<dyn Error>> {
@@ -384,97 +267,5 @@ mod tests {
         .expect("valid TOML");
 
         assert!(resolve(raw, None).is_err());
-    }
-
-    #[test]
-    fn parses_and_normalizes_recipes() {
-        let raw: RawConfig = toml::from_str(
-            r#"
-                [recipes.full-dev]
-                label = "Full Dev"
-                terminals = [
-                    { name = "opencode", command = "opencode" },
-                    { name = "shell", command = "" },
-                ]
-            "#,
-        )
-        .expect("valid config");
-
-        let config = resolve(raw, None).expect("resolved config");
-
-        assert_eq!(config.recipes[0].id, "full-dev");
-        assert_eq!(config.recipes[0].label, "Full Dev");
-        assert_eq!(
-            config.recipes[0].terminals[0].command.as_deref(),
-            Some("opencode")
-        );
-        assert_eq!(config.recipes[0].terminals[1].command, None);
-    }
-
-    #[test]
-    fn recipe_overrides_replace_matching_recipe_definitions() {
-        let mut base: RawConfig = toml::from_str(
-            r#"
-                [recipes.dev]
-                terminals = [{ name = "shell" }]
-            "#,
-        )
-        .expect("valid base");
-        let next: RawConfig = toml::from_str(
-            r#"
-                [recipes.dev]
-                label = "Development"
-                terminals = [{ name = "agent", command = "opencode" }]
-            "#,
-        )
-        .expect("valid override");
-
-        merge(&mut base, next);
-        let config = resolve(base, None).expect("resolved config");
-
-        assert_eq!(config.recipes[0].label, "Development");
-        assert_eq!(config.recipes[0].terminals[0].name, "agent");
-    }
-
-    #[test]
-    fn rejects_invalid_recipe_definitions() {
-        for contents in [
-            "[recipes.default]\nterminals = [{ name = 'shell' }]",
-            "[recipes.Default]\nterminals = [{ name = 'shell' }]",
-            "[recipes.empty]\nterminals = []",
-            "[recipes.duplicate]\nterminals = [{ name = 'shell' }, { name = 'shell' }]",
-            "[recipes.blank]\nterminals = [{ name = ' ' }]",
-            "[recipes.option]\nterminals = [{ name = '--clear' }]",
-            "[recipes.control]\nterminals = [{ name = \"bad\\nname\" }]",
-        ] {
-            let raw: RawConfig = toml::from_str(contents).expect("valid TOML");
-            assert!(resolve(raw, None).is_err());
-        }
-    }
-
-    #[test]
-    fn rejects_recipe_ids_that_collide_after_layered_normalization() {
-        let mut base: RawConfig =
-            toml::from_str("[recipes.dev]\nterminals = [{ name = 'shell' }]").expect("valid base");
-        let next: RawConfig = toml::from_str(
-            "[recipes.\" Dev \"]\nterminals = [{ name = 'agent', command = 'opencode' }]",
-        )
-        .expect("valid override");
-
-        merge(&mut base, next);
-
-        assert!(resolve(base, None).is_err());
-    }
-
-    #[test]
-    fn rejects_reserved_and_duplicate_recipe_labels() {
-        for contents in [
-            "[recipes.shell]\nlabel = 'Default'\nterminals = [{ name = 'shell' }]",
-            "[recipes.one]\nlabel = 'Dev'\nterminals = [{ name = 'one' }]\n\
-             [recipes.two]\nlabel = 'dev'\nterminals = [{ name = 'two' }]",
-        ] {
-            let raw: RawConfig = toml::from_str(contents).expect("valid TOML");
-            assert!(resolve(raw, None).is_err());
-        }
     }
 }


### PR DESCRIPTION
## Summary
- remove the unused recipe configuration schema and resolved models
- delete recipe validation and its stale tests
- remove recipes from roadmap and persistence documentation

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check