### PR TITLE
Add individual shell close controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Dashboard controls:
   table. New dashboard shells start in the directory where the dashboard was
   launched.
 - `e` renames the selected workspace or shell, depending on focus.
-- `x`, then `y`, closes a workspace and all of its processes.
+- `x`, then `y`, closes the selected workspace or shell, depending on focus.
 - `r` refreshes immediately.
 - `q` or `Esc` quits.
 
@@ -80,14 +80,16 @@ boomux doctor
 boomux list
 boomux shells
 boomux read <shell-name-or-shell-id> [--lines <count>]
+boomux close <shell-name-or-shell-id>
 boomux open <shell-id> [--title <title>] [--takeover]
 boomux daemon status
 boomux daemon stop
 boomux skill install
 ```
 
-`boomux shells` lists shells in the current workspace. Shell names are resolved
-within that workspace; exact shell IDs work from anywhere.
+`boomux shells` lists shells in the current workspace. `boomux read` and
+`boomux close` resolve shell names within that workspace; exact shell IDs work
+from anywhere. A shell cannot close itself through the CLI.
 
 `boomux read` reads from the daemon's bounded raw output replay. The current
 proof of concept decodes bytes lossily and selects recent newline-delimited

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -970,7 +970,7 @@ mod tests {
     }
 
     #[test]
-    fn registry_creates_and_closes_workspace_shells() {
+    fn registry_closes_shell_without_removing_workspace() {
         let registry = Registry::default();
         let workspace = registry
             .create_workspace(
@@ -984,6 +984,11 @@ mod tests {
             .unwrap();
         assert_eq!(workspace.shells.len(), 1);
         assert_eq!(registry.snapshot().unwrap().workspaces.len(), 1);
+
+        registry.close_shell(&workspace.shells[0].id).unwrap();
+        let snapshot = registry.snapshot().unwrap();
+        assert_eq!(snapshot.workspaces.len(), 1);
+        assert!(snapshot.workspaces[0].shells.is_empty());
 
         registry.close_workspace(&workspace.id).unwrap();
         assert!(registry.snapshot().unwrap().workspaces.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,8 @@ enum Commands {
         #[arg(long, default_value_t = 200, value_parser = clap::value_parser!(u32).range(1..))]
         lines: u32,
     },
+    /// Close a shell by name or shell ID
+    Close { target: String },
     /// Manage the vendor-neutral Boomux Agent Skill
     Skill {
         #[command(subcommand)]
@@ -145,6 +147,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         Some(Commands::List) => list_shells(),
         Some(Commands::Shells) => list_workspace_shells(),
         Some(Commands::Read { target, lines }) => read_shell(&target, lines),
+        Some(Commands::Close { target }) => close_shell(&target),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
         }) => install_skill(force),
@@ -236,15 +239,27 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 open_dashboard_shell(&client, shell_id, terminal.as_deref())
                     .map_err(|error| error.to_string())
             },
-            on_close: |workspace_id: &str| {
-                let name = client
-                    .get_workspace(workspace_id)
-                    .map(|workspace| workspace.name)
-                    .unwrap_or_else(|_| "workspace".into());
-                client
-                    .close_workspace(workspace_id)
-                    .map_err(|error| error.to_string())?;
-                Ok(format!("Closed {name} and all of its shells"))
+            on_close: |target: &tui::CloseTarget| match target {
+                tui::CloseTarget::Workspace(workspace_id) => {
+                    let name = client
+                        .get_workspace(workspace_id)
+                        .map(|workspace| workspace.name)
+                        .unwrap_or_else(|_| "workspace".into());
+                    client
+                        .close_workspace(workspace_id)
+                        .map_err(|error| error.to_string())?;
+                    Ok(format!("Closed {name} and all of its shells"))
+                }
+                tui::CloseTarget::Shell(shell_id) => {
+                    let name = client
+                        .get_shell(shell_id)
+                        .map(|shell| shell.name)
+                        .unwrap_or_else(|_| "shell".into());
+                    client
+                        .close_shell(shell_id)
+                        .map_err(|error| error.to_string())?;
+                    Ok(format!("Closed shell {name}"))
+                }
             },
             on_create_workspace: |name: &str| {
                 create_dashboard_workspace(&client, name).map_err(|error| error.to_string())
@@ -487,6 +502,31 @@ fn read_shell(target: &str, lines: u32) -> Result<(), Box<dyn Error>> {
     if !output.is_empty() && !output.ends_with('\n') {
         println!();
     }
+    Ok(())
+}
+
+fn close_shell(target: &str) -> Result<(), Box<dyn Error>> {
+    let client = client::connect_or_start()?;
+    let snapshot = client.snapshot()?;
+    let current_shell_id = env::var("BOOMUX_SHELL_ID").ok();
+    let current_workspace_id = current_shell_id
+        .as_deref()
+        .and_then(|id| find_shell(&snapshot, id).map(|shell| shell.workspace_id.as_str()));
+    let shell = resolve_shell_target(&snapshot, current_workspace_id, target)?;
+    if current_shell_id.as_deref() == Some(shell.id.as_str()) {
+        return Err(
+            "cannot close the current shell from inside it; use the dashboard or another shell"
+                .into(),
+        );
+    }
+    let workspace_name = snapshot
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == shell.workspace_id)
+        .map(|workspace| workspace.name.as_str())
+        .unwrap_or("workspace");
+    client.close_shell(&shell.id)?;
+    println!("Closed shell {} from {workspace_name}", shell.name);
     Ok(())
 }
 
@@ -778,6 +818,12 @@ mod tests {
         assert!(matches!(
             Cli::try_parse_from(["boomux", "doctor"]).unwrap().command,
             Some(Commands::Doctor)
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "close", "tests"])
+                .unwrap()
+                .command,
+            Some(Commands::Close { target }) if target == "tests"
         ));
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -88,6 +88,12 @@ pub(crate) enum RenameTarget {
     Shell(String),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CloseTarget {
+    Workspace(String),
+    Shell(String),
+}
+
 impl RenameTarget {
     fn label(&self) -> &'static str {
         match self {
@@ -128,7 +134,7 @@ impl Message {
 }
 
 struct PendingClose {
-    id: String,
+    target: CloseTarget,
     name: String,
     shell_count: usize,
 }
@@ -427,11 +433,18 @@ impl App {
     }
 
     fn request_close(&mut self) {
-        self.pending_close = self.selected().map(|workspace| PendingClose {
-            id: workspace.id.clone(),
-            name: workspace.name.clone(),
-            shell_count: workspace.terminals.len(),
-        });
+        self.pending_close = match self.focus {
+            Focus::Workspaces => self.selected().map(|workspace| PendingClose {
+                target: CloseTarget::Workspace(workspace.id.clone()),
+                name: workspace.name.clone(),
+                shell_count: workspace.terminals.len(),
+            }),
+            Focus::Terminals => self.selected_terminal().map(|terminal| PendingClose {
+                target: CloseTarget::Shell(terminal.id.clone()),
+                name: terminal.name.clone(),
+                shell_count: 1,
+            }),
+        };
     }
 
     fn cancel_close(&mut self) {
@@ -440,12 +453,12 @@ impl App {
 
     fn confirm_close<F>(&mut self, on_close: &mut F)
     where
-        F: FnMut(&str) -> Result<String, String>,
+        F: FnMut(&CloseTarget) -> Result<String, String>,
     {
         let Some(pending) = self.pending_close.take() else {
             return;
         };
-        self.message = Some(Message::from_result(on_close(&pending.id)));
+        self.message = Some(Message::from_result(on_close(&pending.target)));
     }
 
     fn refresh<F>(&mut self, on_refresh: &mut F)
@@ -493,7 +506,7 @@ pub(crate) fn run<R, O, C, W, N, E, F>(
 where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&str) -> Result<String, String>,
-    C: FnMut(&str) -> Result<String, String>,
+    C: FnMut(&CloseTarget) -> Result<String, String>,
     W: FnMut(&str) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
@@ -517,7 +530,7 @@ fn run_loop<R, O, C, W, N, E, F>(
 where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&str) -> Result<String, String>,
-    C: FnMut(&str) -> Result<String, String>,
+    C: FnMut(&CloseTarget) -> Result<String, String>,
     W: FnMut(&str) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
@@ -1060,14 +1073,20 @@ fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut Ap
 
 fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
     let line = if let Some(pending) = &app.pending_close {
-        Line::from(vec![
-            Span::styled(
-                format!(
-                    " Close '{}' and terminate {} shell(s)?  ",
-                    pending.name, pending.shell_count
-                ),
-                Style::new().fg(YELLOW).add_modifier(Modifier::BOLD),
+        let prompt = match pending.target {
+            CloseTarget::Workspace(_) => format!(
+                " Close workspace '{}' and terminate {} shell(s)?  ",
+                pending.name, pending.shell_count
             ),
+            CloseTarget::Shell(_) => {
+                format!(
+                    " Close shell '{}' and terminate its process?  ",
+                    pending.name
+                )
+            }
+        };
+        Line::from(vec![
+            Span::styled(prompt, Style::new().fg(YELLOW).add_modifier(Modifier::BOLD)),
             Span::styled("y", Style::new().fg(RED)),
             Span::styled(" confirm  ", Style::new().fg(SUBTEXT)),
             Span::styled("n/esc", Style::new().fg(GREEN)),
@@ -1128,7 +1147,14 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Span::styled("r", Style::new().fg(BLUE)),
             Span::styled(" refresh  ", Style::new().fg(SUBTEXT)),
             Span::styled("x", Style::new().fg(RED)),
-            Span::styled(" close workspace  ", Style::new().fg(SUBTEXT)),
+            Span::styled(
+                if app.focus == Focus::Workspaces {
+                    " close workspace  "
+                } else {
+                    " close shell  "
+                },
+                Style::new().fg(SUBTEXT),
+            ),
             Span::styled("q", Style::new().fg(RED)),
             Span::styled(" quit", Style::new().fg(SUBTEXT)),
         ]);
@@ -1521,22 +1547,42 @@ mod tests {
 
         app.request_close();
         let pending = app.pending_close.as_ref().expect("pending close");
-        assert_eq!(pending.id, "w1");
+        assert_eq!(pending.target, CloseTarget::Workspace("w1".into()));
         assert_eq!(pending.shell_count, 1);
 
         app.cancel_close();
         assert!(app.pending_close.is_none());
         app.request_close();
-        app.confirm_close(&mut |workspace_id| {
-            closed = Some(workspace_id.to_owned());
+        app.confirm_close(&mut |target| {
+            closed = Some(target.clone());
             Ok("Closed workspace".into())
         });
 
-        assert_eq!(closed.as_deref(), Some("w1"));
+        assert_eq!(closed, Some(CloseTarget::Workspace("w1".into())));
         assert!(app.pending_close.is_none());
         let message = app.message.expect("close message");
         assert_eq!(message.text, "Closed workspace");
         assert!(!message.error);
+    }
+
+    #[test]
+    fn closing_a_shell_uses_terminal_focus() {
+        let mut app = app();
+        let mut closed = None;
+        app.toggle_focus();
+
+        app.request_close();
+        let pending = app.pending_close.as_ref().expect("pending close");
+        assert_eq!(pending.target, CloseTarget::Shell("term_1".into()));
+        assert_eq!(pending.name, "agent");
+
+        app.confirm_close(&mut |target| {
+            closed = Some(target.clone());
+            Ok("Closed shell".into())
+        });
+
+        assert_eq!(closed, Some(CloseTarget::Shell("term_1".into())));
+        assert!(app.pending_close.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add contextual shell closure through the CLI
- close the focused workspace or shell from the dashboard
- preserve empty workspaces after their last shell closes

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- boomux doctor