### PR TITLE
Negotiate terminal profile on first attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ Ghostty, Alacritty, or another XDG terminal
 Live PTY bytes pass through unchanged. The attachment client only enables raw
 mode, forwards input and resize events, writes output, and restores terminal
 mode on exit. See [`docs/architecture.md`](docs/architecture.md) for details.
-The remaining terminal handshake and reconnect work is tracked in
+Shells remain pending until their first attachment reports terminal environment
+and dimensions; that profile initializes the PTY and child process. The
+remaining reconnect and persistence work is tracked in
 [`docs/native-terminal-follow-up.md`](docs/native-terminal-follow-up.md).
 
 ## POC Limitations
@@ -186,8 +188,8 @@ The remaining terminal handshake and reconnect work is tracked in
   imperfectly.
 - One writable controller is supported per shell; takeover replaces it.
 - Slow controllers can lose live output chunks rather than block the child.
-- Terminal capabilities are inherited when the daemon starts rather than
-  negotiated independently for every attachment.
+- A running shell keeps its first attachment's terminal environment. A later
+  attachment with a different `TERM` receives a compatibility warning.
 - The native backend currently targets Unix/Linux and Omarchy.
 
 ## Development

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,13 +66,18 @@ The daemon supports:
 - Bounded output replay
 - One writable attachment with explicit takeover
 - PTY input and resize forwarding
+- Pending shell metadata and first-attachment terminal negotiation
 
 An empty shell specification list remains empty. When an explicit populated
 creation is requested, the daemon stages every child before publishing any of
 them; a failed spawn kills the staged children. Workspace names are checked for
 global uniqueness at publication while the registry is locked.
 
-Shell creation may omit a workspace ID. The daemon then selects the lowest
+Shell creation records metadata without immediately starting a process. The
+first attachment supplies `TERM`, `COLORTERM`, terminal program identity, and
+cell/pixel dimensions; the daemon then creates the PTY and child. Failed startup
+leaves the shell pending and retryable. Shell creation may omit a workspace ID.
+The daemon then selects the lowest
 available `workspace-N` name and publishes the generated workspace and shell as
 one operation. Concurrent requests retry name allocation rather than exposing
 an ungrouped shell.
@@ -119,7 +124,8 @@ Closing a terminal window closes only its socket attachment. The daemon retains
 the PTY master and child. Reopening a window acquires the controller and first
 receives retained raw output followed by live output.
 
-Closing a shell terminates its child and disconnects its controller. Closing a
+Closing a pending shell removes only metadata. Closing a running shell terminates
+its child and disconnects its controller. Closing a
 workspace removes all its shells from the registry before terminating them.
 On Linux, cleanup signals every process still belonging to the shell's session
 before reaping the session leader. `boomux daemon stop` applies the same cleanup
@@ -134,10 +140,8 @@ restart or crash.
 The detailed design, acceptance criteria, and manual test matrix are tracked in
 [`native-terminal-follow-up.md`](native-terminal-follow-up.md).
 
-1. Negotiate terminal capabilities when the first native attachment creates a
-   shell.
-2. Track terminal state with a VT parser and emit a sanitized reconnect snapshot.
-3. Persist reproducible workspace and shell metadata atomically under
+1. Track terminal state with a VT parser and emit a sanitized reconnect snapshot.
+2. Persist reproducible workspace and shell metadata atomically under
    `$XDG_STATE_HOME`, keeping working directories on shells only.
-4. Add graceful daemon restart or live PTY handoff only after the base lifecycle
+3. Add graceful daemon restart or live PTY handoff only after the base lifecycle
    is reliable.

--- a/docs/native-terminal-follow-up.md
+++ b/docs/native-terminal-follow-up.md
@@ -23,9 +23,9 @@ consistently in Ghostty, Alacritty, Kitty, and other XDG terminal emulators.
 | Single-controller takeover | Working |
 | Workspace and shell lifecycle | Working |
 | Graceful daemon stop and process cleanup | Working |
-| First-attachment terminal negotiation | Missing |
-| Correct terminal environment at child startup | Missing |
-| Initial pixel dimensions | Missing |
+| First-attachment terminal negotiation | Working |
+| Correct terminal environment at child startup | Working |
+| Initial pixel dimensions | Working when reported by the terminal |
 | Reconstructed terminal state on reconnect | Missing |
 | ANSI-aware logical output for `boomux read` | Missing |
 | Metadata recovery after daemon restart | Missing |
@@ -40,19 +40,18 @@ atomically creates the next available `workspace-N` container.
 
 ## Current Creation Sequence
 
-Workspace creation itself is empty. The daemon currently starts a process when
-an explicit shell is created, before a native terminal attaches:
+Workspace creation itself is empty. Explicit shell creation records pending
+metadata and waits for a native terminal attachment:
 
 ```text
-create shell with explicit working directory
-  -> daemon allocates PTY
-  -> daemon starts child
+create pending shell with explicit working directory
   -> native terminal opens
-  -> attachment sends rows and columns
+  -> attachment sends terminal profile and dimensions
+  -> daemon allocates the correctly sized PTY
+  -> daemon starts the child with the reported environment
 ```
 
-The child inherits these variables from the process that originally started the
-daemon:
+The attachment explicitly supplies these variables:
 
 ```text
 TERM
@@ -61,18 +60,17 @@ TERM_PROGRAM
 TERM_PROGRAM_VERSION
 ```
 
-Those values may not describe the terminal that eventually renders the shell.
-For example, an Alacritty window may start the daemon and a later Ghostty window
-may attach to a child that still identifies its terminal as Alacritty.
+Missing values remain unset rather than inheriting the daemon's terminal
+environment. A later attachment does not mutate a running child and receives a
+warning when its `TERM` differs from the startup profile.
 
 This can affect terminfo selection, true-color detection, keyboard protocols,
 shell integration, terminal-specific workarounds, and whether an application
 attempts graphics protocols. Direct byte pass-through preserves an extension
 only after the application decides to emit it.
 
-The PTY also begins with a default size. The attachment corrects rows and
-columns afterward, but startup output may already have rendered at the wrong
-dimensions. Pixel width and height are currently sent as zero.
+The PTY begins with the first attachment's rows, columns, pixel width, and pixel
+height. Pixel dimensions may remain zero when the terminal does not report them.
 
 ## Phase 1: Terminal Handshake
 
@@ -159,13 +157,13 @@ testing shows that warnings are insufficient.
 - Reattaching through a mismatched emulator follows the documented warning
   policy.
 
-### Open Product Decision
+### Product Decision
 
 Workspace creation must remain empty. A future explicit shell creation or first
 attachment can create pending shell metadata and delay the command until a
 terminal profile is available.
 
-Choose one behavior before implementation:
+Boomux uses option 2:
 
 1. Open the explicitly requested shell window immediately so it receives a real
    profile.
@@ -173,8 +171,8 @@ Choose one behavior before implementation:
 3. Permit explicit headless shell startup with a documented conservative
    profile.
 
-Option 1 best matches the native-terminal goal. Option 2 is the smallest model.
-Option 3 should be added only for a concrete headless workflow.
+Pending shells remain visible and retryable until opened. Headless startup is
+not supported without a concrete terminal profile.
 
 ## Phase 2: VT Reconnection State
 
@@ -306,14 +304,10 @@ stty size
 
 ## Implementation Order
 
-1. Create `feat/terminal-handshake`.
-2. Add `TerminalProfile` and `Pending` to the shell protocol and domain model.
-3. Move PTY spawn from shell metadata creation to first attachment.
-4. Add emulator mismatch diagnostics and acceptance tests.
-5. Dogfood Alacritty and Ghostty with the manual matrix.
-6. Create a separate VT reconstruction branch.
-7. Replace raw `boomux read` extraction with parser-backed logical lines.
-8. Add metadata persistence only after terminal behavior is stable.
+1. Dogfood Alacritty and Ghostty with the manual matrix.
+2. Create a separate VT reconstruction branch.
+3. Replace raw `boomux read` extraction with parser-backed logical lines.
+4. Add metadata persistence only after terminal behavior is stable.
 
 ## Definition Of Done
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,13 +36,14 @@ commitments.
 - [x] Make the Ratatui dashboard the default interface and remove the external
   picker dependency.
 - [x] Run an explicit one-off command when creating a shell from a path.
+- [x] Start pending shells on first attachment using its terminal environment,
+  cell dimensions, and pixel dimensions.
 
 ## Workspace Control
 
 See [`native-terminal-follow-up.md`](native-terminal-follow-up.md) for the
 terminal handshake, VT reconstruction, and restart-persistence plan.
 
-- Negotiate terminal capabilities when a shell receives its first attachment.
 - Reconstruct reconnect state with a VT parser instead of replaying raw bytes.
 - Persist reproducible workspace and shell metadata under `$XDG_STATE_HOME`,
   keeping working directories on shells only.

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -1,10 +1,11 @@
+use std::env;
 use std::io::{self, Read, Write};
 use std::os::fd::AsRawFd;
 
 use crossterm::terminal;
 
 use crate::client;
-use crate::protocol::AttachFrame;
+use crate::protocol::{AttachFrame, TerminalProfile};
 
 const POLL_INTERVAL_MS: i32 = 100;
 
@@ -24,16 +25,25 @@ impl Drop for RawMode {
 }
 
 pub fn run(shell_id: &str, takeover: bool) -> io::Result<()> {
+    let profile = terminal_profile()?;
+    let mut size = (
+        profile.rows,
+        profile.cols,
+        profile.pixel_width,
+        profile.pixel_height,
+    );
     let client = client::connect_or_start()?;
-    let (mut stream, _token, replay) = client.attach(shell_id, takeover)?;
+    let attachment = client.attach(shell_id, takeover, profile)?;
+    if let Some(warning) = attachment.warning {
+        eprintln!("boomux: warning: {warning}");
+    }
+    let mut stream = attachment.stream;
     let _raw_mode = RawMode::enter()?;
     let mut stdin = io::stdin().lock();
     let mut stdout = io::stdout().lock();
-    stdout.write_all(&replay)?;
+    stdout.write_all(&attachment.replay)?;
     stdout.flush()?;
 
-    let (mut cols, mut rows) = terminal::size()?;
-    AttachFrame::Resize { rows, cols }.write_to(&mut stream)?;
     let mut input = [0; 16 * 1024];
 
     loop {
@@ -90,12 +100,55 @@ pub fn run(shell_id: &str, takeover: bool) -> io::Result<()> {
             }
         }
 
-        if let Ok((new_cols, new_rows)) = terminal::size()
-            && (new_cols, new_rows) != (cols, rows)
+        if let Ok(new_size) = dimensions()
+            && new_size != size
         {
-            cols = new_cols;
-            rows = new_rows;
-            AttachFrame::Resize { rows, cols }.write_to(&mut stream)?;
+            size = new_size;
+            AttachFrame::Resize {
+                rows: size.0,
+                cols: size.1,
+                pixel_width: size.2,
+                pixel_height: size.3,
+            }
+            .write_to(&mut stream)?;
         }
     }
+}
+
+fn terminal_profile() -> io::Result<TerminalProfile> {
+    let (rows, cols, pixel_width, pixel_height) = dimensions()?;
+    Ok(TerminalProfile {
+        term: terminal_variable("TERM"),
+        colorterm: terminal_variable("COLORTERM"),
+        term_program: terminal_variable("TERM_PROGRAM"),
+        term_program_version: terminal_variable("TERM_PROGRAM_VERSION"),
+        rows,
+        cols,
+        pixel_width,
+        pixel_height,
+    })
+}
+
+fn terminal_variable(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn dimensions() -> io::Result<(u16, u16, u16, u16)> {
+    let mut size = libc::winsize {
+        ws_row: 0,
+        ws_col: 0,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    // stdout remains open while the attachment is active and ioctl only writes `size`.
+    if unsafe { libc::ioctl(io::stdout().as_raw_fd(), libc::TIOCGWINSZ, &mut size) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    if size.ws_row == 0 || size.ws_col == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "terminal reported zero rows or columns",
+        ));
+    }
+    Ok((size.ws_row, size.ws_col, size.ws_xpixel, size.ws_ypixel))
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,8 @@ use std::thread;
 use std::time::Duration;
 
 use crate::protocol::{
-    self, Envelope, Request, Response, ShellSnapshot, ShellSpec, Snapshot, WorkspaceSnapshot,
+    self, Envelope, Request, Response, ShellSnapshot, ShellSpec, Snapshot, TerminalProfile,
+    WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -17,6 +18,14 @@ const CONNECT_DELAY: Duration = Duration::from_millis(25);
 #[derive(Debug, Clone)]
 pub struct Client {
     socket_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct Attachment {
+    pub stream: UnixStream,
+    pub token: String,
+    pub replay: Vec<u8>,
+    pub warning: Option<String>,
 }
 
 pub fn socket_path() -> io::Result<PathBuf> {
@@ -240,13 +249,24 @@ impl Client {
         &self,
         shell_id: impl Into<String>,
         takeover: bool,
-    ) -> io::Result<(UnixStream, String, Vec<u8>)> {
+        profile: TerminalProfile,
+    ) -> io::Result<Attachment> {
         let (stream, response) = self.send(Request::Attach {
             shell_id: shell_id.into(),
             takeover,
+            profile,
         })?;
         match response {
-            Response::Attached { token, replay } => Ok((stream, token, replay)),
+            Response::Attached {
+                token,
+                replay,
+                warning,
+            } => Ok(Attachment {
+                stream,
+                token,
+                replay,
+                warning,
+            }),
             other => unexpected(other),
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -20,12 +20,15 @@ use uuid::Uuid;
 use crate::client;
 use crate::protocol::{
     self, AttachFrame, Envelope, Request, Response, ShellSnapshot, ShellSpec, ShellStatus,
-    Snapshot, WorkspaceSnapshot,
+    Snapshot, TerminalProfile, WorkspaceSnapshot,
 };
 
 const REPLAY_LIMIT: usize = 1024 * 1024;
 const CONTROLLER_QUEUE: usize = 64;
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(50);
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+const IO_RETRY_DELAY: Duration = Duration::from_millis(2);
+const MAX_TERMINAL_ENV_VALUE: usize = 256;
 
 pub fn run() -> io::Result<()> {
     let socket_path = client::socket_path()?;
@@ -126,8 +129,13 @@ fn handle_connection(
         );
     }
 
-    if let Request::Attach { shell_id, takeover } = request.message {
-        return handle_attach(stream, &registry, &shell_id, takeover);
+    if let Request::Attach {
+        shell_id,
+        takeover,
+        profile,
+    } = request.message
+    {
+        return handle_attach(stream, &registry, &shell_id, takeover, profile);
     }
     if matches!(request.message, Request::Shutdown) {
         send_response(&mut stream, Response::Ok)?;
@@ -169,7 +177,26 @@ struct Shell {
     workspace_id: String,
     name: Mutex<String>,
     cwd: PathBuf,
-    status: Mutex<ShellStatus>,
+    command: Vec<String>,
+    lifecycle: Mutex<ShellLifecycle>,
+}
+
+enum ShellLifecycle {
+    Pending,
+    Running {
+        profile: TerminalProfile,
+        runtime: Arc<ShellRuntime>,
+    },
+    Exited {
+        code: Option<u32>,
+        profile: TerminalProfile,
+        runtime: Arc<ShellRuntime>,
+    },
+    Closed,
+}
+
+struct ShellRuntime {
+    control: Mutex<()>,
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
     child: Mutex<Box<dyn Child + Send + Sync>>,
@@ -294,6 +321,13 @@ impl Registry {
             .ok_or_else(|| not_found("shell", id))
     }
 
+    fn contains_shell(&self, shell: &Arc<Shell>) -> io::Result<bool> {
+        Ok(lock(&self.state)?
+            .shells
+            .get(&shell.id)
+            .is_some_and(|current| Arc::ptr_eq(current, shell)))
+    }
+
     fn create_workspace(
         &self,
         name: String,
@@ -305,7 +339,7 @@ impl Registry {
 
         let mut shells = Vec::with_capacity(specs.len());
         for spec in specs {
-            match spawn_shell(&workspace_id, &name, spec) {
+            match create_pending_shell(&workspace_id, spec) {
                 Ok(shell) => shells.push(shell),
                 Err(error) => {
                     for shell in shells {
@@ -348,7 +382,7 @@ impl Registry {
 
     fn create_shell(&self, workspace_id: &str, spec: ShellSpec) -> io::Result<ShellSnapshot> {
         let workspace = self.workspace(workspace_id)?;
-        let shell = spawn_shell(workspace_id, &lock(&workspace.name)?.clone(), spec)?;
+        let shell = create_pending_shell(workspace_id, spec)?;
         let snapshot = shell.snapshot()?;
         let mut state = lock(&self.state)?;
         let Some(current) = state.workspaces.get(workspace_id) else {
@@ -445,7 +479,16 @@ impl Registry {
 
     fn read_shell(&self, shell_id: &str, max_bytes: usize) -> io::Result<Vec<u8>> {
         let shell = self.shell(shell_id)?;
-        let replay = lock(&shell.replay)?;
+        let lifecycle = lock(&shell.lifecycle)?;
+        let runtime = match &*lifecycle {
+            ShellLifecycle::Pending => return Ok(Vec::new()),
+            ShellLifecycle::Running { runtime, .. } | ShellLifecycle::Exited { runtime, .. } => {
+                Arc::clone(runtime)
+            }
+            ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
+        };
+        drop(lifecycle);
+        let replay = lock(&runtime.replay)?;
         let count = max_bytes.min(replay.len());
         Ok(replay.iter().skip(replay.len() - count).copied().collect())
     }
@@ -487,11 +530,15 @@ impl Registry {
 
 impl Workspace {
     fn snapshot(&self, registry: &Registry) -> io::Result<WorkspaceSnapshot> {
-        let state = lock(&registry.state)?;
         let ids = lock(&self.shell_ids)?.clone();
-        let shells = ids
+        let shells = {
+            let state = lock(&registry.state)?;
+            ids.iter()
+                .filter_map(|id| state.shells.get(id).cloned())
+                .collect::<Vec<_>>()
+        };
+        let shells = shells
             .iter()
-            .filter_map(|id| state.shells.get(id))
             .map(|shell| shell.snapshot())
             .collect::<io::Result<_>>()?;
         Ok(WorkspaceSnapshot {
@@ -509,16 +556,27 @@ impl Shell {
             workspace_id: self.workspace_id.clone(),
             name: lock(&self.name)?.clone(),
             cwd: self.cwd.clone(),
-            status: lock(&self.status)?.clone(),
+            status: match &*lock(&self.lifecycle)? {
+                ShellLifecycle::Pending => ShellStatus::Pending,
+                ShellLifecycle::Running { .. } => ShellStatus::Running,
+                ShellLifecycle::Exited { code, .. } => ShellStatus::Exited { code: *code },
+                ShellLifecycle::Closed => return Err(not_found("shell", &self.id)),
+            },
         })
     }
 
     fn kill(&self) -> io::Result<()> {
-        if let Some(controller) = lock(&self.controller)?.take() {
+        let runtime =
+            match std::mem::replace(&mut *lock(&self.lifecycle)?, ShellLifecycle::Closed) {
+                ShellLifecycle::Pending | ShellLifecycle::Closed => return Ok(()),
+                ShellLifecycle::Running { runtime, .. }
+                | ShellLifecycle::Exited { runtime, .. } => runtime,
+            };
+        if let Some(controller) = lock(&runtime.controller)?.take() {
             let _ = controller.connection.shutdown(std::net::Shutdown::Both);
         }
-        let foreground_group = lock(&self.master)?.process_group_leader();
-        let mut child = lock(&self.child)?;
+        let foreground_group = lock(&runtime.master)?.process_group_leader();
+        let mut child = lock(&runtime.child)?;
         if child.try_wait()?.is_some() {
             return Ok(());
         }
@@ -547,13 +605,9 @@ impl Shell {
             (Ok(()), Err(error)) => Err(error),
         }
     }
+}
 
-    fn is_controller(&self, token: &str) -> io::Result<bool> {
-        Ok(lock(&self.controller)?
-            .as_ref()
-            .is_some_and(|controller| controller.token == token))
-    }
-
+impl ShellRuntime {
     fn release_controller(&self, token: &str) -> io::Result<()> {
         let mut controller = lock(&self.controller)?;
         if controller
@@ -566,53 +620,86 @@ impl Shell {
     }
 }
 
-fn spawn_shell(
-    workspace_id: &str,
-    workspace_name: &str,
-    spec: ShellSpec,
-) -> io::Result<Arc<Shell>> {
+fn create_pending_shell(workspace_id: &str, spec: ShellSpec) -> io::Result<Arc<Shell>> {
     validate_name(&spec.name)?;
-    let cwd = spec.cwd;
-    validate_cwd(&cwd)?;
-    let shell_id = Uuid::new_v4().to_string();
+    validate_cwd(&spec.cwd)?;
+    Ok(Arc::new(Shell {
+        id: Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.to_owned(),
+        name: Mutex::new(spec.name),
+        cwd: spec.cwd,
+        command: spec.command,
+        lifecycle: Mutex::new(ShellLifecycle::Pending),
+    }))
+}
+
+fn spawn_runtime(
+    shell: &Arc<Shell>,
+    workspace_name: &str,
+    shell_name: &str,
+    profile: &TerminalProfile,
+) -> io::Result<(Arc<ShellRuntime>, Box<dyn Read + Send>)> {
     let pty = native_pty_system()
-        .openpty(PtySize::default())
+        .openpty(PtySize {
+            rows: profile.rows,
+            cols: profile.cols,
+            pixel_width: profile.pixel_width,
+            pixel_height: profile.pixel_height,
+        })
         .map_err(io::Error::other)?;
+    set_nonblocking(pty.master.as_ref())?;
     let writer = pty.master.take_writer().map_err(io::Error::other)?;
     let reader = pty.master.try_clone_reader().map_err(io::Error::other)?;
 
-    let mut command = if spec.command.is_empty() {
+    let mut command = if shell.command.is_empty() {
         CommandBuilder::new(env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into()))
     } else {
-        let mut command = CommandBuilder::new(&spec.command[0]);
-        command.args(&spec.command[1..]);
+        let mut command = CommandBuilder::new(&shell.command[0]);
+        command.args(&shell.command[1..]);
         command
     };
-    command.cwd(&cwd);
-    command.env("BOOMUX_WORKSPACE_ID", workspace_id);
+    command.cwd(&shell.cwd);
+    for name in ["TERM", "COLORTERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION"] {
+        command.env_remove(name);
+    }
+    for (name, value) in [
+        ("TERM", profile.term.as_deref()),
+        ("COLORTERM", profile.colorterm.as_deref()),
+        ("TERM_PROGRAM", profile.term_program.as_deref()),
+        (
+            "TERM_PROGRAM_VERSION",
+            profile.term_program_version.as_deref(),
+        ),
+    ] {
+        if let Some(value) = value {
+            command.env(name, value);
+        }
+    }
+    command.env("BOOMUX_WORKSPACE_ID", &shell.workspace_id);
     command.env("BOOMUX_WORKSPACE", workspace_name);
-    command.env("BOOMUX_SHELL_ID", &shell_id);
-    command.env("BOOMUX_SHELL_NAME", &spec.name);
+    command.env("BOOMUX_SHELL_ID", &shell.id);
+    command.env("BOOMUX_SHELL_NAME", shell_name);
     let child = pty.slave.spawn_command(command).map_err(io::Error::other)?;
     drop(pty.slave);
 
-    let shell = Arc::new(Shell {
-        id: shell_id,
-        workspace_id: workspace_id.to_owned(),
-        name: Mutex::new(spec.name),
-        cwd,
-        status: Mutex::new(ShellStatus::Running),
-        master: Mutex::new(pty.master),
-        writer: Mutex::new(writer),
-        child: Mutex::new(child),
-        replay: Mutex::new(VecDeque::with_capacity(REPLAY_LIMIT)),
-        controller: Mutex::new(None),
-    });
-    start_pty_reader(Arc::clone(&shell), reader);
-    Ok(shell)
+    Ok((
+        Arc::new(ShellRuntime {
+            control: Mutex::new(()),
+            master: Mutex::new(pty.master),
+            writer: Mutex::new(writer),
+            child: Mutex::new(child),
+            replay: Mutex::new(VecDeque::with_capacity(REPLAY_LIMIT)),
+            controller: Mutex::new(None),
+        }),
+        reader,
+    ))
 }
 
-fn start_pty_reader(shell: Arc<Shell>, mut reader: Box<dyn Read + Send>) {
+fn start_pty_reader(
+    shell: Arc<Shell>,
+    runtime: Arc<ShellRuntime>,
+    mut reader: Box<dyn Read + Send>,
+) {
     thread::spawn(move || {
         let mut buffer = [0; 16 * 1024];
         loop {
@@ -620,9 +707,9 @@ fn start_pty_reader(shell: Arc<Shell>, mut reader: Box<dyn Read + Send>) {
                 Ok(0) => break,
                 Ok(count) => {
                     let bytes = &buffer[..count];
-                    if let Ok(mut replay) = shell.replay.lock() {
+                    if let Ok(mut replay) = runtime.replay.lock() {
                         append_replay(&mut replay, bytes);
-                        if let Ok(mut controller) = shell.controller.lock() {
+                        if let Ok(mut controller) = runtime.controller.lock() {
                             let disconnect = controller.as_ref().is_some_and(|current| {
                                 matches!(
                                     current.output.try_send(bytes.to_vec()),
@@ -635,20 +722,40 @@ fn start_pty_reader(shell: Arc<Shell>, mut reader: Box<dyn Read + Send>) {
                         }
                     }
                 }
-                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
+                    ) =>
+                {
+                    if error.kind() == io::ErrorKind::WouldBlock {
+                        thread::sleep(IO_RETRY_DELAY);
+                    }
+                    continue;
+                }
                 Err(_) => break,
             }
         }
-        let code = shell
+        let code = runtime
             .child
             .lock()
             .ok()
             .and_then(|mut child| child.try_wait().ok().flatten())
             .map(|status| status.exit_code());
-        if let Ok(mut status) = shell.status.lock() {
-            *status = ShellStatus::Exited { code };
+        if let Ok(mut lifecycle) = shell.lifecycle.lock()
+            && let ShellLifecycle::Running {
+                profile,
+                runtime: current,
+            } = &*lifecycle
+            && Arc::ptr_eq(current, &runtime)
+        {
+            *lifecycle = ShellLifecycle::Exited {
+                code,
+                profile: profile.clone(),
+                runtime: Arc::clone(&runtime),
+            };
         }
-        let _ = shell
+        let _ = runtime
             .controller
             .lock()
             .map(|mut controller| controller.take());
@@ -674,7 +781,16 @@ fn handle_attach(
     registry: &Registry,
     shell_id: &str,
     takeover: bool,
+    profile: TerminalProfile,
 ) -> io::Result<()> {
+    if let Err(error) = validate_terminal_profile(&profile) {
+        return send_response(
+            &mut stream,
+            Response::Error {
+                message: error.to_string(),
+            },
+        );
+    }
     let shell = match registry.shell(shell_id) {
         Ok(shell) => shell,
         Err(error) => {
@@ -688,14 +804,70 @@ fn handle_attach(
     };
     let token = Uuid::new_v4().to_string();
     let (output, receiver) = mpsc::sync_channel(CONTROLLER_QUEUE);
-    let replay = {
-        // Match the reader's replay-then-controller lock order so replay ends
-        // exactly where delivery to this controller begins.
-        let replay = lock(&shell.replay)?;
-        let mut controller = lock(&shell.controller)?;
+    let connection = stream.try_clone()?;
+    let (runtime, startup_profile, running) = {
+        let mut lifecycle = lock(&shell.lifecycle)?;
+        if !registry.contains_shell(&shell)? {
+            return send_response(
+                &mut stream,
+                Response::Error {
+                    message: format!("shell not found: {shell_id}"),
+                },
+            );
+        }
+        if matches!(*lifecycle, ShellLifecycle::Pending) {
+            let workspace = registry.workspace(&shell.workspace_id)?;
+            let workspace_name = lock(&workspace.name)?.clone();
+            let shell_name = lock(&shell.name)?.clone();
+            let (runtime, reader) =
+                match spawn_runtime(&shell, &workspace_name, &shell_name, &profile) {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        return send_response(
+                            &mut stream,
+                            Response::Error {
+                                message: format!("could not start shell: {error}"),
+                            },
+                        );
+                    }
+                };
+            *lifecycle = ShellLifecycle::Running {
+                profile: profile.clone(),
+                runtime: Arc::clone(&runtime),
+            };
+            start_pty_reader(Arc::clone(&shell), runtime, reader);
+        }
+        match &*lifecycle {
+            ShellLifecycle::Running { profile, runtime } => {
+                (Arc::clone(runtime), profile.clone(), true)
+            }
+            ShellLifecycle::Exited {
+                profile, runtime, ..
+            } => (Arc::clone(runtime), profile.clone(), false),
+            ShellLifecycle::Pending => unreachable!(),
+            ShellLifecycle::Closed => {
+                return send_response(
+                    &mut stream,
+                    Response::Error {
+                        message: format!("shell not found: {shell_id}"),
+                    },
+                );
+            }
+        }
+    };
+    let warning = term_mismatch_warning(startup_profile.term.as_deref(), profile.term.as_deref());
+    let control = lock(&runtime.control)?;
+    if !registry.contains_shell(&shell)? {
+        return send_response(
+            &mut stream,
+            Response::Error {
+                message: format!("shell not found: {shell_id}"),
+            },
+        );
+    }
+    {
+        let controller = lock(&runtime.controller)?;
         if controller.is_some() && !takeover {
-            drop(controller);
-            drop(replay);
             return send_response(
                 &mut stream,
                 Response::Error {
@@ -703,30 +875,53 @@ fn handle_attach(
                 },
             );
         }
+    }
+    if running {
+        lock(&runtime.master)?
+            .resize(profile_size(&profile))
+            .map_err(io::Error::other)?;
+    }
+    // Keep replay locked until the controller is installed so retained output
+    // ends exactly where live delivery begins.
+    let replay = lock(&runtime.replay)?;
+    stream.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    send_response(
+        &mut stream,
+        Response::Attached {
+            token: token.clone(),
+            replay: replay.iter().copied().collect(),
+            warning,
+        },
+    )?;
+    stream.set_write_timeout(None)?;
+    if !running {
+        return AttachFrame::Detached.write_to(&mut stream);
+    }
+    let lifecycle = lock(&shell.lifecycle)?;
+    let still_running = registry.contains_shell(&shell)?
+        && matches!(
+            &*lifecycle,
+            ShellLifecycle::Running {
+                runtime: current,
+                ..
+            } if Arc::ptr_eq(current, &runtime)
+        );
+    if !still_running {
+        return AttachFrame::Detached.write_to(&mut stream);
+    }
+    {
+        let mut controller = lock(&runtime.controller)?;
         if let Some(previous) = controller.take() {
             let _ = previous.connection.shutdown(std::net::Shutdown::Both);
         }
         *controller = Some(Controller {
             token: token.clone(),
             output,
-            connection: stream.try_clone()?,
+            connection,
         });
-        replay.iter().copied().collect()
-    };
-
-    if let Err(error) = send_response(
-        &mut stream,
-        Response::Attached {
-            token: token.clone(),
-            replay,
-        },
-    ) {
-        shell.release_controller(&token)?;
-        return Err(error);
     }
-
     let mut output_stream = stream.try_clone()?;
-    let output_shell = Arc::clone(&shell);
+    let output_runtime = Arc::clone(&runtime);
     let output_token = token.clone();
     thread::spawn(move || {
         for bytes in receiver {
@@ -738,41 +933,147 @@ fn handle_attach(
             }
         }
         let _ = AttachFrame::Detached.write_to(&mut output_stream);
-        let _ = output_shell.release_controller(&output_token);
+        let _ = output_runtime.release_controller(&output_token);
     });
+    drop(lifecycle);
+    drop(replay);
+    drop(control);
 
     loop {
         let frame = match AttachFrame::read_from(&mut stream) {
             Ok(frame) => frame,
             Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => break,
             Err(error) => {
-                shell.release_controller(&token)?;
+                runtime.release_controller(&token)?;
                 return Err(error);
             }
         };
-        if !shell.is_controller(&token)? {
+        if let AttachFrame::Input(bytes) = frame {
+            if !write_controller_input(&runtime, &token, &bytes)? {
+                break;
+            }
+            continue;
+        }
+        let control = lock(&runtime.control)?;
+        let authorized = lock(&runtime.controller)?
+            .as_ref()
+            .is_some_and(|controller| controller.token == token);
+        if !authorized {
             break;
         }
-        match frame {
-            AttachFrame::Input(bytes) => lock(&shell.writer)?.write_all(&bytes)?,
-            AttachFrame::Resize { rows, cols } => lock(&shell.master)?
+        let result = match frame {
+            AttachFrame::Input(_) => unreachable!(),
+            AttachFrame::Resize {
+                rows,
+                cols,
+                pixel_width,
+                pixel_height,
+            } => lock(&runtime.master)?
                 .resize(PtySize {
                     rows,
                     cols,
-                    pixel_width: 0,
-                    pixel_height: 0,
+                    pixel_width,
+                    pixel_height,
                 })
-                .map_err(io::Error::other)?,
-            AttachFrame::Detached => break,
-            AttachFrame::Output(_) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "client sent output frame",
-                ));
+                .map_err(io::Error::other),
+            AttachFrame::Detached => {
+                drop(control);
+                break;
             }
+            AttachFrame::Output(_) => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "client sent output frame",
+            )),
+        };
+        if let Err(error) = result {
+            runtime.release_controller(&token)?;
+            return Err(error);
         }
     }
-    shell.release_controller(&token)
+    runtime.release_controller(&token)
+}
+
+fn set_nonblocking(master: &dyn MasterPty) -> io::Result<()> {
+    let fd = master
+        .as_raw_fd()
+        .ok_or_else(|| io::Error::other("PTY master does not expose a file descriptor"))?;
+    // `fd` belongs to the live PTY master and fcntl only reads/updates its status flags.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn write_controller_input(runtime: &ShellRuntime, token: &str, bytes: &[u8]) -> io::Result<bool> {
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let control = lock(&runtime.control)?;
+        let authorized = lock(&runtime.controller)?
+            .as_ref()
+            .is_some_and(|controller| controller.token == token);
+        if !authorized {
+            return Ok(false);
+        }
+        let result = lock(&runtime.writer)?.write(&bytes[offset..]);
+        drop(control);
+        match result {
+            Ok(0) => return Err(io::Error::new(io::ErrorKind::WriteZero, "PTY input closed")),
+            Ok(count) => offset += count,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(IO_RETRY_DELAY);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(true)
+}
+
+fn profile_size(profile: &TerminalProfile) -> PtySize {
+    PtySize {
+        rows: profile.rows,
+        cols: profile.cols,
+        pixel_width: profile.pixel_width,
+        pixel_height: profile.pixel_height,
+    }
+}
+
+fn validate_terminal_profile(profile: &TerminalProfile) -> io::Result<()> {
+    if profile.rows == 0 || profile.cols == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "terminal profile rows and columns must be nonzero",
+        ));
+    }
+    for value in [
+        &profile.term,
+        &profile.colorterm,
+        &profile.term_program,
+        &profile.term_program_version,
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if value.is_empty()
+            || value.len() > MAX_TERMINAL_ENV_VALUE
+            || value.chars().any(char::is_control)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "terminal profile contains an invalid environment value",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn term_mismatch_warning(started: Option<&str>, attached: Option<&str>) -> Option<String> {
+    (started != attached).then(|| {
+        format!(
+            "shell started with TERM={started:?}; attachment reports TERM={attached:?}; process environment is unchanged"
+        )
+    })
 }
 
 fn validate_name(name: &str) -> io::Result<()> {
@@ -860,6 +1161,19 @@ mod tests {
     use super::*;
     use std::sync::Barrier;
 
+    fn profile() -> TerminalProfile {
+        TerminalProfile {
+            term: Some("xterm-256color".into()),
+            colorterm: Some("truecolor".into()),
+            term_program: Some("test".into()),
+            term_program_version: Some("1".into()),
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
+
     #[test]
     fn empty_registry_has_empty_snapshot() {
         assert!(
@@ -892,6 +1206,30 @@ mod tests {
         let error = validate_shell_specs(&specs).unwrap_err();
 
         assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn validates_terminal_profile_bounds() {
+        assert!(validate_terminal_profile(&profile()).is_ok());
+
+        let mut invalid = profile();
+        invalid.rows = 0;
+        assert!(validate_terminal_profile(&invalid).is_err());
+
+        let mut invalid = profile();
+        invalid.term = Some("bad\nterm".into());
+        assert!(validate_terminal_profile(&invalid).is_err());
+
+        let mut invalid = profile();
+        invalid.term = Some("x".repeat(MAX_TERMINAL_ENV_VALUE + 1));
+        assert!(validate_terminal_profile(&invalid).is_err());
+    }
+
+    #[test]
+    fn reports_only_term_mismatches() {
+        assert_eq!(term_mismatch_warning(Some("xterm"), Some("xterm")), None);
+        assert!(term_mismatch_warning(Some("xterm"), Some("alacritty")).is_some());
+        assert!(term_mismatch_warning(None, Some("xterm")).is_some());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -625,6 +625,7 @@ fn current_shell(client: &client::Client) -> Result<ShellSnapshot, Box<dyn Error
 
 fn shell_status(status: &ShellStatus) -> &'static str {
     match status {
+        ShellStatus::Pending => "pending",
         ShellStatus::Running => "running",
         ShellStatus::Exited { .. } => "exited",
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
 
@@ -47,8 +47,21 @@ pub struct ShellSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ShellStatus {
+    Pending,
     Running,
     Exited { code: Option<u32> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalProfile {
+    pub term: Option<String>,
+    pub colorterm: Option<String>,
+    pub term_program: Option<String>,
+    pub term_program_version: Option<String>,
+    pub rows: u16,
+    pub cols: u16,
+    pub pixel_width: u16,
+    pub pixel_height: u16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -111,6 +124,7 @@ pub enum Request {
     Attach {
         shell_id: String,
         takeover: bool,
+        profile: TerminalProfile,
     },
 }
 
@@ -118,20 +132,39 @@ pub enum Request {
 #[serde(tag = "response", rename_all = "snake_case")]
 pub enum Response {
     Pong,
-    Snapshot { snapshot: Snapshot },
-    Workspace { workspace: WorkspaceSnapshot },
-    Shell { shell: ShellSnapshot },
-    Output { bytes: Vec<u8> },
-    Attached { token: String, replay: Vec<u8> },
+    Snapshot {
+        snapshot: Snapshot,
+    },
+    Workspace {
+        workspace: WorkspaceSnapshot,
+    },
+    Shell {
+        shell: ShellSnapshot,
+    },
+    Output {
+        bytes: Vec<u8>,
+    },
+    Attached {
+        token: String,
+        replay: Vec<u8>,
+        warning: Option<String>,
+    },
     Ok,
-    Error { message: String },
+    Error {
+        message: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AttachFrame {
     Input(Vec<u8>),
     Output(Vec<u8>),
-    Resize { rows: u16, cols: u16 },
+    Resize {
+        rows: u16,
+        cols: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+    },
     Detached,
 }
 
@@ -145,11 +178,18 @@ impl AttachFrame {
         let (kind, payload): (u8, &[u8]) = match self {
             Self::Input(bytes) => (Self::INPUT, bytes),
             Self::Output(bytes) => (Self::OUTPUT, bytes),
-            Self::Resize { rows, cols } => {
+            Self::Resize {
+                rows,
+                cols,
+                pixel_width,
+                pixel_height,
+            } => {
                 writer.write_all(&[Self::RESIZE])?;
-                writer.write_all(&4_u32.to_be_bytes())?;
+                writer.write_all(&8_u32.to_be_bytes())?;
                 writer.write_all(&rows.to_be_bytes())?;
-                return writer.write_all(&cols.to_be_bytes());
+                writer.write_all(&cols.to_be_bytes())?;
+                writer.write_all(&pixel_width.to_be_bytes())?;
+                return writer.write_all(&pixel_height.to_be_bytes());
             }
             Self::Detached => (Self::DETACHED, &[]),
         };
@@ -181,9 +221,11 @@ impl AttachFrame {
         match kind[0] {
             Self::INPUT => Ok(Self::Input(payload)),
             Self::OUTPUT => Ok(Self::Output(payload)),
-            Self::RESIZE if payload.len() == 4 => Ok(Self::Resize {
+            Self::RESIZE if payload.len() == 8 => Ok(Self::Resize {
                 rows: u16::from_be_bytes([payload[0], payload[1]]),
                 cols: u16::from_be_bytes([payload[2], payload[3]]),
+                pixel_width: u16::from_be_bytes([payload[4], payload[5]]),
+                pixel_height: u16::from_be_bytes([payload[6], payload[7]]),
             }),
             Self::DETACHED if payload.is_empty() => Ok(Self::Detached),
             _ => Err(io::Error::new(
@@ -227,8 +269,19 @@ mod tests {
 
     #[test]
     fn control_frame_round_trips() {
-        let value = Envelope::new(Request::GetShell {
+        let value = Envelope::new(Request::Attach {
             shell_id: "s1".into(),
+            takeover: false,
+            profile: TerminalProfile {
+                term: Some("xterm-256color".into()),
+                colorterm: Some("truecolor".into()),
+                term_program: Some("test".into()),
+                term_program_version: Some("1".into()),
+                rows: 24,
+                cols: 80,
+                pixel_width: 800,
+                pixel_height: 600,
+            },
         });
         let mut bytes = Vec::new();
         write_message(&mut bytes, &value).unwrap();
@@ -249,7 +302,12 @@ mod tests {
     fn attach_frames_round_trip() {
         let frames = [
             AttachFrame::Input(vec![0, 1, 255]),
-            AttachFrame::Resize { rows: 24, cols: 80 },
+            AttachFrame::Resize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 1920,
+                pixel_height: 1080,
+            },
             AttachFrame::Detached,
         ];
         for frame in frames {
@@ -260,5 +318,12 @@ mod tests {
                 frame
             );
         }
+    }
+
+    #[test]
+    fn rejects_protocol_two_resize_frame() {
+        let bytes = [AttachFrame::RESIZE, 0, 0, 0, 4, 0, 24, 0, 80];
+
+        assert!(AttachFrame::read_from(&mut bytes.as_slice()).is_err());
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1165,6 +1165,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
 
 fn status_color(status: &str) -> Color {
     match status {
+        "pending" => YELLOW,
         "exited" => SUBTEXT,
         _ => TEAL,
     }
@@ -1248,6 +1249,13 @@ mod tests {
         assert_eq!(git_state_color("3 changed"), YELLOW);
         assert_eq!(git_state_color("1 conflict"), RED);
         assert_eq!(git_state_color("-"), SUBTEXT);
+    }
+
+    #[test]
+    fn pending_shells_use_attention_color() {
+        assert_eq!(status_color("pending"), YELLOW);
+        assert_eq!(status_color("running"), TEAL);
+        assert_eq!(status_color("exited"), SUBTEXT);
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -6,8 +6,8 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use boomux::client::Client;
-use boomux::protocol::{AttachFrame, ShellSpec, ShellStatus};
+use boomux::client::{Attachment, Client};
+use boomux::protocol::{AttachFrame, ShellSpec, ShellStatus, TerminalProfile};
 use uuid::Uuid;
 
 const TIMEOUT: Duration = Duration::from_secs(5);
@@ -32,6 +32,10 @@ impl TestDaemon {
             .args(["daemon", "run"])
             .env("XDG_RUNTIME_DIR", &runtime_dir)
             .env("SHELL", "/bin/sh")
+            .env("TERM", "daemon-term")
+            .env("COLORTERM", "daemon-color")
+            .env("TERM_PROGRAM", "daemon-program")
+            .env("TERM_PROGRAM_VERSION", "daemon-version")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -93,7 +97,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 2"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 3"));
 
     let mut duplicate = daemon
         .command()
@@ -122,6 +126,34 @@ fn native_daemon_lifecycle() {
         .get_workspace(&generated_shell.workspace_id)
         .unwrap();
     assert_eq!(generated_workspace.name, "workspace-1");
+    assert_eq!(generated_shell.status, ShellStatus::Pending);
+    assert!(
+        daemon
+            .client
+            .read_shell(&generated_shell.id, 1024)
+            .unwrap()
+            .is_empty()
+    );
+    let failed_shell = daemon
+        .client
+        .create_shell(
+            &generated_workspace.id,
+            ShellSpec {
+                name: "failed".into(),
+                command: vec!["/definitely/missing/boomux-command".into()],
+                cwd: std::env::temp_dir(),
+            },
+        )
+        .unwrap();
+    let error = daemon
+        .client
+        .attach(&failed_shell.id, false, profile())
+        .unwrap_err();
+    assert!(error.to_string().contains("could not start shell"));
+    assert_eq!(
+        daemon.client.get_shell(&failed_shell.id).unwrap().status,
+        ShellStatus::Pending
+    );
     daemon
         .client
         .close_workspace(&generated_workspace.id)
@@ -137,15 +169,27 @@ fn native_daemon_lifecycle() {
     let shell = workspace.shells.first().unwrap();
     let shell_id = shell.id.clone();
 
-    let (mut first, _, replay) = daemon.client.attach(&shell_id, false).unwrap();
-    assert!(replay.len() <= 1024 * 1024);
-    AttachFrame::Resize { rows: 24, cols: 80 }
-        .write_to(&mut first)
-        .unwrap();
+    assert_eq!(shell.status, ShellStatus::Pending);
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    assert!(attachment.replay.len() <= 1024 * 1024);
+    assert!(attachment.warning.is_none());
+    let mut first = attachment.stream;
     AttachFrame::Input(b"stty -echo\n".to_vec())
         .write_to(&mut first)
         .unwrap();
     thread::sleep(Duration::from_millis(100));
+    AttachFrame::Input(b"stty size\n".to_vec())
+        .write_to(&mut first)
+        .unwrap();
+    assert!(contains(&read_until(&mut first, b"24 80"), b"24 80"));
+    AttachFrame::Input(
+        b"printf 'env=%s|%s|%s|%s\n' \"$TERM\" \"$COLORTERM\" \"$TERM_PROGRAM\" \"$TERM_PROGRAM_VERSION\"\n"
+            .to_vec(),
+    )
+    .write_to(&mut first)
+    .unwrap();
+    let expected = b"env=attachment-term|truecolor|integration-terminal|1.0";
+    assert!(contains(&read_until(&mut first, expected), expected));
     AttachFrame::Input(b"printf 'transport-ok\\n'\n".to_vec())
         .write_to(&mut first)
         .unwrap();
@@ -163,10 +207,19 @@ fn native_daemon_lifecycle() {
         "shell stopped after its attachment disconnected",
     );
 
-    let (mut second, _, _) = wait_for_attach(&daemon.client, &shell_id);
-    let error = daemon.client.attach(&shell_id, false).unwrap_err();
+    let mut second = wait_for_attach(&daemon.client, &shell_id).stream;
+    let error = daemon
+        .client
+        .attach(&shell_id, false, profile())
+        .unwrap_err();
     assert!(error.to_string().contains("active controller"));
-    let (mut takeover, _, _) = daemon.client.attach(&shell_id, true).unwrap();
+    let mut mismatched = profile();
+    mismatched.term = Some("alacritty".into());
+    let takeover = daemon.client.attach(&shell_id, true, mismatched).unwrap();
+    assert!(takeover.warning.as_deref().is_some_and(|warning| {
+        warning.contains("attachment-term") && warning.contains("alacritty")
+    }));
+    let mut takeover = takeover.stream;
     second
         .set_read_timeout(Some(Duration::from_secs(1)))
         .unwrap();
@@ -175,6 +228,8 @@ fn native_daemon_lifecycle() {
     AttachFrame::Resize {
         rows: 40,
         cols: 100,
+        pixel_width: 1200,
+        pixel_height: 800,
     }
     .write_to(&mut takeover)
     .unwrap();
@@ -205,10 +260,10 @@ fn native_daemon_lifecycle() {
     daemon.stop_with_cli();
 }
 
-fn wait_for_attach(client: &Client, shell_id: &str) -> (UnixStream, String, Vec<u8>) {
+fn wait_for_attach(client: &Client, shell_id: &str) -> Attachment {
     let deadline = Instant::now() + TIMEOUT;
     loop {
-        match client.attach(shell_id, false) {
+        match client.attach(shell_id, false, profile()) {
             Ok(attachment) => return attachment,
             Err(error) if error.to_string().contains("active controller") => {
                 assert!(Instant::now() < deadline, "old attachment was not released");
@@ -216,6 +271,19 @@ fn wait_for_attach(client: &Client, shell_id: &str) -> (UnixStream, String, Vec<
             }
             Err(error) => panic!("could not attach: {error}"),
         }
+    }
+}
+
+fn profile() -> TerminalProfile {
+    TerminalProfile {
+        term: Some("attachment-term".into()),
+        colorterm: Some("truecolor".into()),
+        term_program: Some("integration-terminal".into()),
+        term_program_version: Some("1.0".into()),
+        rows: 24,
+        cols: 80,
+        pixel_width: 800,
+        pixel_height: 600,
     }
 }
 


### PR DESCRIPTION
## Summary
- add protocol 3 terminal profiles and pending shell lifecycle
- create PTYs and child processes from first-attachment environment and dimensions
- make takeover, replay handoff, resize, and close races safe
- document terminal mismatch and pending-shell behavior

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- independent concurrency review
- boomux doctor