### PR TITLE
Reconstruct terminals and persist metadata

### DIFF
--- a/.agents/skills/boomux-shells/SKILL.md
+++ b/.agents/skills/boomux-shells/SKILL.md
@@ -21,9 +21,9 @@ boomux read "<name-or-shell-id>" --lines 200
 ```
 
 Use the returned text to answer the user's question. Increase `--lines` when
-the relevant output is older. This reads Boomux's bounded raw output replay,
-which may not contain a process's complete historical log and may include ANSI
-control sequences.
+the relevant output is older. This reads Boomux's bounded, plain rendered VT
+scrollback. It does not include ANSI sequences or a process's complete
+historical log.
 
 ## Discover Shells
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +110,7 @@ dependencies = [
  "serde_json",
  "toml",
  "uuid",
+ "vt100",
 ]
 
 [[package]]
@@ -1189,6 +1196,27 @@ dependencies = [
  "getrandom",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.9"
 uuid = { version = "1", features = ["v4"] }
+vt100 = "=0.16.2"

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ for scripts and integrations. `shell create` records a pending shell; its PTY
 and process start when the shell is first opened. Shell names require current
 workspace context or `--workspace`; IDs remain globally addressable.
 
-`boomux read` reads from the daemon's bounded raw output replay. The current
-proof of concept decodes bytes lossily and selects recent newline-delimited
-lines. It does not yet interpret ANSI state or terminal soft wrapping.
+`boomux read` reads plain rendered text from the daemon's shadow VT state. It
+understands cursor rewrites and terminal soft wrapping, retains up to 2,000
+scrollback rows per shell, and never returns ANSI control sequences.
 
 ## Configuration
 
@@ -189,17 +189,20 @@ Live PTY bytes pass through unchanged. The attachment client only enables raw
 mode, forwards input and resize events, writes output, and restores terminal
 mode on exit. See [`docs/architecture.md`](docs/architecture.md) for details.
 Shells remain pending until their first attachment reports terminal environment
-and dimensions; that profile initializes the PTY and child process. The
-remaining reconnect and persistence work is tracked in
+and dimensions; that profile initializes the PTY and child process. Reproducible
+workspace and shell metadata is restored after daemon restart. Remaining live
+PTY handoff work is tracked in
 [`docs/native-terminal-follow-up.md`](docs/native-terminal-follow-up.md).
 
 ## POC Limitations
 
-- State and PTYs exist only for the daemon's lifetime.
-- Restarting or crashing the daemon loses all running shells.
-- Reconnection replays at most 1 MiB of raw output, not a reconstructed screen.
-- Alternate-screen applications and truncated escape sequences may replay
-  imperfectly.
+- PTYs and processes exist only for the daemon's lifetime. After restart,
+  persisted shells return as pending and start fresh processes when reopened.
+- Mutated process environment and in-memory application state are not persisted.
+- Reconnection emits at most 1 MiB of sanitized VT reconstruction rather than
+  replaying historical PTY bytes. Graphics are omitted from reconstruction.
+- Alternate-screen applications restore their current screen, but not their
+  alternate-screen history.
 - One writable controller is supported per shell; takeover replaces it.
 - Slow controllers can lose live output chunks rather than block the child.
 - A running shell keeps its first attachment's terminal environment. A later

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ The daemon supports:
 - Workspace and shell snapshots
 - Shell and workspace rename operations
 - Shell and workspace closure
-- Bounded output replay
+- Bounded VT state and sanitized reconnect reconstruction
 - One writable attachment with explicit takeover
 - PTY input and resize forwarding
 - Pending shell metadata and first-attachment terminal negotiation
@@ -91,6 +91,9 @@ the attachment exits.
 
 The daemon keeps a bounded output queue per active controller. A slow client
 drops output rather than blocking the PTY reader and child process.
+It also feeds a shadow `vt100` parser while forwarding the original PTY bytes
+unchanged. Reattachment receives a bounded reconstruction of rendered state,
+not historical OSC or graphics commands.
 
 ### Terminal Launcher
 
@@ -122,7 +125,7 @@ context while exact shell IDs remain globally addressable within the daemon.
 
 Closing a terminal window closes only its socket attachment. The daemon retains
 the PTY master and child. Reopening a window acquires the controller and first
-receives retained raw output followed by live output.
+receives sanitized reconstructed terminal state followed by live output.
 
 Closing a pending shell removes only metadata. Closing a running shell terminates
 its child and disconnects its controller. Closing a
@@ -131,17 +134,17 @@ On Linux, cleanup signals every process still belonging to the shell's session
 before reaping the session leader. `boomux daemon stop` applies the same cleanup
 to the complete registry and removes the runtime socket.
 
-Current persistence is deliberately limited to daemon lifetime. Boomux does not
-yet write registry metadata or claim that arbitrary processes survive daemon
-restart or crash.
+The daemon atomically writes reproducible registry metadata to
+`$XDG_STATE_HOME/boomux/state.json`, falling back to
+`~/.local/state/boomux/state.json`. Workspace and shell IDs, names, grouping,
+shell working directories, startup commands, and last terminal profiles survive
+restart. Recovered shells are pending: Boomux does not claim that arbitrary
+processes, mutated environments, or PTYs survive daemon restart or crash.
 
 ## Next Technical Steps
 
 The detailed design, acceptance criteria, and manual test matrix are tracked in
 [`native-terminal-follow-up.md`](native-terminal-follow-up.md).
 
-1. Track terminal state with a VT parser and emit a sanitized reconnect snapshot.
-2. Persist reproducible workspace and shell metadata atomically under
-   `$XDG_STATE_HOME`, keeping working directories on shells only.
-3. Add graceful daemon restart or live PTY handoff only after the base lifecycle
+1. Add graceful daemon restart or live PTY handoff only after the base lifecycle
    is reliable.

--- a/docs/native-terminal-follow-up.md
+++ b/docs/native-terminal-follow-up.md
@@ -26,13 +26,14 @@ consistently in Ghostty, Alacritty, Kitty, and other XDG terminal emulators.
 | First-attachment terminal negotiation | Working |
 | Correct terminal environment at child startup | Working |
 | Initial pixel dimensions | Working when reported by the terminal |
-| Reconstructed terminal state on reconnect | Missing |
-| ANSI-aware logical output for `boomux read` | Missing |
-| Metadata recovery after daemon restart | Missing |
+| Reconstructed terminal state on reconnect | Working |
+| ANSI-aware logical output for `boomux read` | Working |
+| Metadata recovery after daemon restart | Working |
 | Live PTY handoff to a replacement daemon | Missing |
 
-The current backend is suitable for proof-of-concept testing. It must not yet
-claim exact screen restoration or process survival across daemon restart.
+The current backend is suitable for proof-of-concept testing. It reconstructs
+text VT state but does not claim graphics restoration or process survival across
+daemon restart.
 Workspace metadata contains only a UUID and name; working directories belong
 exclusively to shells. Dashboard project discovery supplies name suggestions
 and does not persist project paths. A shell request without a selected workspace
@@ -176,24 +177,21 @@ not supported without a concrete terminal profile.
 
 ## Phase 2: VT Reconnection State
 
-### Current Limitation
+### Implementation
 
-The daemon retains up to 1 MiB of raw PTY output and replays it into a new
-attachment. Raw output is not terminal state.
+The daemon feeds a shadow `vt100` parser with PTY output while forwarding the
+original bytes unchanged. It retains 2,000 primary-screen scrollback rows and
+emits at most 1 MiB of safe reconstruction into a new attachment.
 
-Reconnection can be incorrect after:
+Reconnection reconstructs cursor movement, in-place rewrites, screen clearing,
+styles, modes, and the current alternate screen. Known limits remain for:
 
-- Cursor movement or in-place line rewrites
-- Screen clearing
-- Alternate-screen applications such as editors and TUIs
-- Progress indicators
-- Replay truncation inside an escape sequence
-- OSC title, notification, hyperlink, or clipboard commands
 - Terminal graphics
-- Soft-wrapped lines
+- Alternate-screen history
+- Emulator-specific state outside the parser's VT model
 
-A newly attached terminal may look correct, partially correct, or remain blank
-until the application redraws.
+Historical OSC title, notification, hyperlink, and clipboard commands are
+intentionally omitted so reconnection cannot repeat their side effects.
 
 ### Target Data Flow
 
@@ -202,7 +200,7 @@ Keep the native live path unchanged and parse a shadow copy:
 ```text
 PTY output
   -> attachment output unchanged
-  -> bounded VT parser input in parallel
+  -> bounded shadow VT state alongside live delivery
 ```
 
 The parser should retain:
@@ -226,17 +224,13 @@ effects merely to reconstruct presentation.
 
 ### `boomux read`
 
-`boomux read` currently decodes raw replay bytes lossily and selects recent
-newline-delimited fragments. It does not understand cursor rewrites, ANSI state,
-or terminal wrapping.
-
-After the VT parser exists, `boomux read` should return logical rendered lines:
+`boomux read` returns parser-backed logical rendered lines:
 
 - Strip control sequences.
 - Preserve intentional hard newlines.
 - Join terminal soft wraps for the unwrapped output mode.
-- Define whether alternate-screen content is included.
-- Retain a bounded history and report truncation when useful.
+- Include the current alternate screen but not alternate-screen history.
+- Retain 2,000 primary-screen scrollback rows.
 
 ### Acceptance Criteria
 
@@ -251,17 +245,15 @@ After the VT parser exists, `boomux read` should return logical rendered lines:
 
 ### Open Engineering Decisions
 
-- Select an existing Rust VT parser rather than implementing ANSI parsing.
-- Decide how much primary-screen scrollback to retain per shell.
-- Decide whether alternate-screen history is readable or only reconstructable.
-- Decide whether graphics payloads are retained, omitted, or restored by asking
-  applications to redraw.
-- Define the safe reset and reconstruction sequence across supported emulators.
+- Decide whether graphics should remain omitted or trigger application redraw.
+- Evaluate moving shadow parsing off the PTY reader if profiling shows meaningful
+  backpressure.
 
 ## Phase 3: Restart Persistence
 
-Terminal negotiation and VT reconstruction should be reliable before adding
-disk persistence.
+The daemon atomically persists versioned JSON state at
+`$XDG_STATE_HOME/boomux/state.json`, with the XDG default
+`~/.local/state/boomux/state.json` when the environment variable is unset.
 
 Persist only reproducible metadata under `$XDG_STATE_HOME/boomux`:
 
@@ -271,9 +263,13 @@ Persist only reproducible metadata under `$XDG_STATE_HOME/boomux`:
 - Explicit shell startup commands
 - Last terminal profile when useful for diagnostics
 
+State directories are owner-only, state files are bounded and owner-validated,
+and updates use a synced temporary file followed by atomic rename. Invalid or
+unsupported state fails startup rather than silently discarding metadata.
+
 Do not claim that arbitrary process state can be serialized. After an ordinary
-daemon restart, Boomux can recreate shells from metadata but cannot recover the
-original processes or their mutated environment.
+daemon restart, Boomux restores every shell as pending and recreates it on first
+attachment, but cannot recover the original process or its mutated environment.
 
 Live process survival during an upgrade requires a separate Unix PTY handoff
 mechanism. Treat that as a later feature, not part of metadata restoration.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,15 +40,16 @@ commitments.
   cell dimensions, and pixel dimensions.
 - [x] Expose workspace and shell create, inspect, rename, and close operations
   through explicit CLI command groups.
+- [x] Reconstruct reconnect state with a shadow VT parser and expose plain
+  rendered scrollback through `boomux read`.
+- [x] Persist reproducible workspace and shell metadata atomically under
+  `$XDG_STATE_HOME`; restore shells as pending after daemon restart.
 
 ## Workspace Control
 
 See [`native-terminal-follow-up.md`](native-terminal-follow-up.md) for the
 terminal handshake, VT reconstruction, and restart-persistence plan.
 
-- Reconstruct reconnect state with a VT parser instead of replaying raw bytes.
-- Persist reproducible workspace and shell metadata under `$XDG_STATE_HOME`,
-  keeping working directories on shells only.
 - Add graceful daemon restart or live PTY handoff.
 - Aggregate multiple agent states as counts instead of one workspace-level
   value.

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -41,7 +41,7 @@ pub fn run(shell_id: &str, takeover: bool) -> io::Result<()> {
     let _raw_mode = RawMode::enter()?;
     let mut stdin = io::stdin().lock();
     let mut stdout = io::stdout().lock();
-    stdout.write_all(&attachment.replay)?;
+    stdout.write_all(&attachment.reconstruction)?;
     stdout.flush()?;
 
     let mut input = [0; 16 * 1024];

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,6 +14,7 @@ use crate::protocol::{
 
 const CONNECT_ATTEMPTS: usize = 40;
 const CONNECT_DELAY: Duration = Duration::from_millis(25);
+const SHUTDOWN_ATTEMPTS: usize = 200;
 
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -24,7 +25,7 @@ pub struct Client {
 pub struct Attachment {
     pub stream: UnixStream,
     pub token: String,
-    pub replay: Vec<u8>,
+    pub reconstruction: Vec<u8>,
     pub warning: Option<String>,
 }
 
@@ -123,7 +124,17 @@ impl Client {
     }
 
     pub fn shutdown(&self) -> io::Result<()> {
-        expect_ok(self.request(Request::Shutdown)?, Response::Ok)
+        expect_ok(self.request(Request::Shutdown)?, Response::Ok)?;
+        for _ in 0..SHUTDOWN_ATTEMPTS {
+            if !self.socket_path.exists() {
+                return Ok(());
+            }
+            thread::sleep(CONNECT_DELAY);
+        }
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "Boomux daemon did not finish shutting down",
+        ))
     }
 
     pub fn snapshot(&self) -> io::Result<Snapshot> {
@@ -259,12 +270,12 @@ impl Client {
         match response {
             Response::Attached {
                 token,
-                replay,
+                reconstruction,
                 warning,
             } => Ok(Attachment {
                 stream,
                 token,
-                replay,
+                reconstruction,
                 warning,
             }),
             other => unexpected(other),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
@@ -22,13 +22,18 @@ use crate::protocol::{
     self, AttachFrame, Envelope, Request, Response, ShellSnapshot, ShellSpec, ShellStatus,
     Snapshot, TerminalProfile, WorkspaceSnapshot,
 };
+use crate::state_store::{PersistedShell, PersistedState, PersistedWorkspace, StateStore};
+use crate::terminal_state::TerminalState;
 
-const REPLAY_LIMIT: usize = 1024 * 1024;
 const CONTROLLER_QUEUE: usize = 64;
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(50);
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 const IO_RETRY_DELAY: Duration = Duration::from_millis(2);
 const MAX_TERMINAL_ENV_VALUE: usize = 256;
+const MAX_TERMINAL_ROWS: u16 = 1_000;
+const MAX_TERMINAL_COLS: u16 = 1_000;
+const MAX_TERMINAL_CELLS: usize = 1_000_000;
+const MAX_SHELL_READ_BYTES: usize = 1024 * 1024;
 
 pub fn run() -> io::Result<()> {
     let socket_path = client::socket_path()?;
@@ -46,17 +51,18 @@ pub fn run() -> io::Result<()> {
     let _socket_cleanup = SocketCleanup(socket_path.clone());
     fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o600))?;
     listener.set_nonblocking(true)?;
-    let registry = Arc::new(Registry::default());
+    let registry = Arc::new(Registry::restore(StateStore::from_environment()?)?);
     let shutdown = Arc::new(AtomicBool::new(false));
+    let mut handlers = Vec::new();
 
     while !shutdown.load(Ordering::Acquire) {
         match listener.accept() {
             Ok((stream, _)) => {
                 let registry = Arc::clone(&registry);
                 let shutdown = Arc::clone(&shutdown);
-                thread::spawn(move || {
+                handlers.push(thread::spawn(move || {
                     let _ = handle_connection(stream, registry, shutdown);
-                });
+                }));
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
                 thread::sleep(Duration::from_millis(25));
@@ -65,7 +71,15 @@ pub fn run() -> io::Result<()> {
             Err(error) => return Err(error),
         }
     }
-    registry.shutdown()
+    for handler in handlers {
+        let _ = handler.join();
+    }
+    let result = registry.shutdown();
+    drop(registry);
+    drop(listener);
+    drop(_daemon_lock);
+    drop(_socket_cleanup);
+    result
 }
 
 struct SocketCleanup(PathBuf);
@@ -115,7 +129,9 @@ fn handle_connection(
     registry: Arc<Registry>,
     shutdown: Arc<AtomicBool>,
 ) -> io::Result<()> {
+    stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
     let request: Envelope<Request> = protocol::read_message(&mut stream)?;
+    stream.set_read_timeout(None)?;
     if request.version != protocol::PROTOCOL_VERSION {
         return send_response(
             &mut stream,
@@ -138,9 +154,18 @@ fn handle_connection(
         return handle_attach(stream, &registry, &shell_id, takeover, profile);
     }
     if matches!(request.message, Request::Shutdown) {
-        send_response(&mut stream, Response::Ok)?;
-        shutdown.store(true, Ordering::Release);
-        return Ok(());
+        return match registry.shutdown() {
+            Ok(()) => {
+                shutdown.store(true, Ordering::Release);
+                send_response(&mut stream, Response::Ok)
+            }
+            Err(error) => send_response(
+                &mut stream,
+                Response::Error {
+                    message: format!("could not stop Boomux daemon: {error}"),
+                },
+            ),
+        };
     }
 
     let response = registry
@@ -155,15 +180,39 @@ fn send_response(stream: &mut UnixStream, response: Response) -> io::Result<()> 
     protocol::write_message(stream, &Envelope::new(response))
 }
 
-#[derive(Default)]
 struct Registry {
     state: Mutex<RegistryState>,
+    store: Option<StateStore>,
+    mutation_lock: Mutex<()>,
+    persist_lock: Mutex<()>,
+    stopping: AtomicBool,
 }
 
 #[derive(Default)]
 struct RegistryState {
     workspaces: HashMap<String, Arc<Workspace>>,
     shells: HashMap<String, Arc<Shell>>,
+}
+
+struct RegistryBackup {
+    workspaces: HashMap<String, Arc<Workspace>>,
+    shells: HashMap<String, Arc<Shell>>,
+    workspace_names: HashMap<String, String>,
+    workspace_shell_ids: HashMap<String, Vec<String>>,
+    shell_names: HashMap<String, String>,
+    last_profiles: HashMap<String, Option<TerminalProfile>>,
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(RegistryState::default()),
+            store: None,
+            mutation_lock: Mutex::new(()),
+            persist_lock: Mutex::new(()),
+            stopping: AtomicBool::new(false),
+        }
+    }
 }
 
 struct Workspace {
@@ -178,6 +227,7 @@ struct Shell {
     name: Mutex<String>,
     cwd: PathBuf,
     command: Vec<String>,
+    last_profile: Mutex<Option<TerminalProfile>>,
     lifecycle: Mutex<ShellLifecycle>,
 }
 
@@ -200,7 +250,7 @@ struct ShellRuntime {
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
     child: Mutex<Box<dyn Child + Send + Sync>>,
-    replay: Mutex<VecDeque<u8>>,
+    terminal: Mutex<TerminalState>,
     controller: Mutex<Option<Controller>>,
 }
 
@@ -224,17 +274,21 @@ impl Registry {
             Request::GetShell { shell_id } => Ok(Response::Shell {
                 shell: self.shell(&shell_id)?.snapshot()?,
             }),
-            Request::CreateWorkspace { name, shells } => Ok(Response::Workspace {
-                workspace: self.create_workspace(name, shells)?,
+            Request::CreateWorkspace { name, shells } => self.durable_mutation(|| {
+                Ok(Response::Workspace {
+                    workspace: self.create_workspace(name, shells)?,
+                })
             }),
             Request::CreateShell {
                 workspace_id,
                 shell,
-            } => Ok(Response::Shell {
-                shell: match workspace_id {
-                    Some(workspace_id) => self.create_shell(&workspace_id, shell)?,
-                    None => self.create_shell_with_workspace(shell)?,
-                },
+            } => self.durable_mutation(|| {
+                Ok(Response::Shell {
+                    shell: match workspace_id {
+                        Some(workspace_id) => self.create_shell(&workspace_id, shell)?,
+                        None => self.create_shell_with_workspace(shell)?,
+                    },
+                })
             }),
             Request::ReadShell {
                 shell_id,
@@ -242,7 +296,7 @@ impl Registry {
             } => Ok(Response::Output {
                 bytes: self.read_shell(&shell_id, max_bytes)?,
             }),
-            Request::RenameWorkspace { workspace_id, name } => {
+            Request::RenameWorkspace { workspace_id, name } => self.durable_mutation(|| {
                 validate_name(&name)?;
                 let workspace = self.workspace(&workspace_id)?;
                 let state = lock(&self.state)?;
@@ -256,11 +310,11 @@ impl Registry {
                 }
                 *lock(&workspace.name)? = name;
                 Ok(Response::Ok)
-            }
-            Request::RenameShell { shell_id, name } => {
+            }),
+            Request::RenameShell { shell_id, name } => self.durable_mutation(|| {
                 self.rename_shell(&shell_id, name)?;
                 Ok(Response::Ok)
-            }
+            }),
             Request::CloseWorkspace { workspace_id } => {
                 self.close_workspace(&workspace_id)?;
                 Ok(Response::Ok)
@@ -271,6 +325,177 @@ impl Registry {
             }
             Request::Attach { .. } => unreachable!("attach is handled before dispatch"),
         }
+    }
+
+    fn restore(store: StateStore) -> io::Result<Self> {
+        let persisted = store.load()?.unwrap_or_default();
+        let mut state = RegistryState::default();
+        let mut workspace_names = HashSet::new();
+        for saved_workspace in persisted.workspaces {
+            validate_id("workspace", &saved_workspace.id)?;
+            validate_name(&saved_workspace.name)?;
+            if !workspace_names.insert(saved_workspace.name.clone())
+                || state.workspaces.contains_key(&saved_workspace.id)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Boomux state contains a duplicate workspace",
+                ));
+            }
+            let mut shell_names = HashSet::new();
+            let mut shell_ids = Vec::with_capacity(saved_workspace.shells.len());
+            for saved_shell in saved_workspace.shells {
+                validate_id("shell", &saved_shell.id)?;
+                validate_name(&saved_shell.name)?;
+                validate_persisted_cwd(&saved_shell.cwd)?;
+                if let Some(profile) = &saved_shell.last_profile {
+                    validate_terminal_profile(profile)?;
+                }
+                if !shell_names.insert(saved_shell.name.clone())
+                    || state.shells.contains_key(&saved_shell.id)
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Boomux state contains a duplicate shell",
+                    ));
+                }
+                let shell = Arc::new(Shell {
+                    id: saved_shell.id,
+                    workspace_id: saved_workspace.id.clone(),
+                    name: Mutex::new(saved_shell.name),
+                    cwd: saved_shell.cwd,
+                    command: saved_shell.command,
+                    last_profile: Mutex::new(saved_shell.last_profile),
+                    lifecycle: Mutex::new(ShellLifecycle::Pending),
+                });
+                shell_ids.push(shell.id.clone());
+                state.shells.insert(shell.id.clone(), shell);
+            }
+            let workspace = Arc::new(Workspace {
+                id: saved_workspace.id.clone(),
+                name: Mutex::new(saved_workspace.name),
+                shell_ids: Mutex::new(shell_ids),
+            });
+            state.workspaces.insert(saved_workspace.id, workspace);
+        }
+        Ok(Self {
+            state: Mutex::new(state),
+            store: Some(store),
+            mutation_lock: Mutex::new(()),
+            persist_lock: Mutex::new(()),
+            stopping: AtomicBool::new(false),
+        })
+    }
+
+    fn durable_mutation<T>(&self, operation: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
+        let _mutation = lock(&self.mutation_lock)?;
+        self.ensure_running()?;
+        let backup = self.backup()?;
+        match operation() {
+            Ok(value) => match self.persist() {
+                Ok(()) => Ok(value),
+                Err(error) => {
+                    self.restore_backup(backup)?;
+                    Err(error)
+                }
+            },
+            Err(error) => {
+                self.restore_backup(backup)?;
+                Err(error)
+            }
+        }
+    }
+
+    fn ensure_running(&self) -> io::Result<()> {
+        if self.stopping.load(Ordering::Acquire) {
+            Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "Boomux daemon is stopping",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn backup(&self) -> io::Result<RegistryBackup> {
+        let state = lock(&self.state)?;
+        let mut workspace_names = HashMap::new();
+        let mut workspace_shell_ids = HashMap::new();
+        for workspace in state.workspaces.values() {
+            workspace_names.insert(workspace.id.clone(), lock(&workspace.name)?.clone());
+            workspace_shell_ids.insert(workspace.id.clone(), lock(&workspace.shell_ids)?.clone());
+        }
+        let mut shell_names = HashMap::new();
+        let mut last_profiles = HashMap::new();
+        for shell in state.shells.values() {
+            shell_names.insert(shell.id.clone(), lock(&shell.name)?.clone());
+            last_profiles.insert(shell.id.clone(), lock(&shell.last_profile)?.clone());
+        }
+        Ok(RegistryBackup {
+            workspaces: state.workspaces.clone(),
+            shells: state.shells.clone(),
+            workspace_names,
+            workspace_shell_ids,
+            shell_names,
+            last_profiles,
+        })
+    }
+
+    fn restore_backup(&self, backup: RegistryBackup) -> io::Result<()> {
+        let mut state = lock(&self.state)?;
+        for workspace in backup.workspaces.values() {
+            if let Some(name) = backup.workspace_names.get(&workspace.id) {
+                *lock(&workspace.name)? = name.clone();
+            }
+            if let Some(ids) = backup.workspace_shell_ids.get(&workspace.id) {
+                *lock(&workspace.shell_ids)? = ids.clone();
+            }
+        }
+        for shell in backup.shells.values() {
+            if let Some(name) = backup.shell_names.get(&shell.id) {
+                *lock(&shell.name)? = name.clone();
+            }
+            if let Some(profile) = backup.last_profiles.get(&shell.id) {
+                *lock(&shell.last_profile)? = profile.clone();
+            }
+        }
+        state.workspaces = backup.workspaces;
+        state.shells = backup.shells;
+        Ok(())
+    }
+
+    fn persist(&self) -> io::Result<()> {
+        let Some(store) = &self.store else {
+            return Ok(());
+        };
+        let _persist = lock(&self.persist_lock)?;
+        let state = lock(&self.state)?;
+        let mut workspaces = state.workspaces.values().cloned().collect::<Vec<_>>();
+        workspaces.sort_by(|left, right| left.id.cmp(&right.id));
+        let mut saved = PersistedState::default();
+        for workspace in workspaces {
+            let ids = lock(&workspace.shell_ids)?.clone();
+            let mut shells = Vec::with_capacity(ids.len());
+            for id in ids {
+                let Some(shell) = state.shells.get(&id) else {
+                    continue;
+                };
+                shells.push(PersistedShell {
+                    id: shell.id.clone(),
+                    name: lock(&shell.name)?.clone(),
+                    cwd: shell.cwd.clone(),
+                    command: shell.command.clone(),
+                    last_profile: lock(&shell.last_profile)?.clone(),
+                });
+            }
+            saved.workspaces.push(PersistedWorkspace {
+                id: workspace.id.clone(),
+                name: lock(&workspace.name)?.clone(),
+                shells,
+            });
+        }
+        drop(state);
+        store.save(&saved)
     }
 
     fn snapshot(&self) -> io::Result<Snapshot> {
@@ -285,24 +510,27 @@ impl Registry {
     }
 
     fn shutdown(&self) -> io::Result<()> {
+        let _mutation = lock(&self.mutation_lock)?;
+        self.stopping.store(true, Ordering::Release);
         let shells = {
-            let mut state = lock(&self.state)?;
-            state.workspaces.clear();
-            state
-                .shells
-                .drain()
-                .map(|(_, shell)| shell)
-                .collect::<Vec<_>>()
+            let state = lock(&self.state)?;
+            state.shells.values().cloned().collect::<Vec<_>>()
         };
-        let mut first_error = None;
-        for shell in shells {
-            if let Err(error) = shell.kill()
-                && first_error.is_none()
-            {
-                first_error = Some(error);
+        let mut killed: Vec<Arc<Shell>> = Vec::new();
+        for shell in &shells {
+            if let Err(error) = shell.kill() {
+                for shell in killed {
+                    shell.reset_pending()?;
+                }
+                self.stopping.store(false, Ordering::Release);
+                return Err(error);
             }
+            killed.push(Arc::clone(shell));
         }
-        first_error.map_or(Ok(()), Err)
+        let mut state = lock(&self.state)?;
+        state.workspaces.clear();
+        state.shells.clear();
+        Ok(())
     }
 
     fn workspace(&self, id: &str) -> io::Result<Arc<Workspace>> {
@@ -488,12 +716,13 @@ impl Registry {
             ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
         };
         drop(lifecycle);
-        let replay = lock(&runtime.replay)?;
-        let count = max_bytes.min(replay.len());
-        Ok(replay.iter().skip(replay.len() - count).copied().collect())
+        let text = lock(&runtime.terminal)?.plain_text();
+        Ok(tail_utf8(&text, max_bytes.min(MAX_SHELL_READ_BYTES))
+            .as_bytes()
+            .to_vec())
     }
 
-    fn close_shell(&self, shell_id: &str) -> io::Result<()> {
+    fn remove_shell(&self, shell_id: &str) -> io::Result<Arc<Shell>> {
         let (shell, workspace) = {
             let mut state = lock(&self.state)?;
             let shell = state
@@ -506,10 +735,10 @@ impl Registry {
         if let Some(workspace) = workspace {
             lock(&workspace.shell_ids)?.retain(|id| id != shell_id);
         }
-        shell.kill()
+        Ok(shell)
     }
 
-    fn close_workspace(&self, workspace_id: &str) -> io::Result<()> {
+    fn remove_workspace(&self, workspace_id: &str) -> io::Result<Vec<Arc<Shell>>> {
         let shells = {
             let mut state = lock(&self.state)?;
             let workspace = state
@@ -521,8 +750,53 @@ impl Registry {
                 .filter_map(|id| state.shells.remove(&id))
                 .collect::<Vec<_>>()
         };
-        for shell in shells {
-            let _ = shell.kill();
+        Ok(shells)
+    }
+
+    fn close_shell(&self, shell_id: &str) -> io::Result<()> {
+        let _mutation = lock(&self.mutation_lock)?;
+        self.ensure_running()?;
+        let backup = self.backup()?;
+        let shell = self.shell(shell_id)?;
+        shell.kill()?;
+        self.remove_shell(shell_id)?;
+        if let Err(error) = self.persist() {
+            self.restore_backup(backup)?;
+            shell.reset_pending()?;
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn close_workspace(&self, workspace_id: &str) -> io::Result<()> {
+        let _mutation = lock(&self.mutation_lock)?;
+        self.ensure_running()?;
+        let backup = self.backup()?;
+        let workspace = self.workspace(workspace_id)?;
+        let shells = {
+            let state = lock(&self.state)?;
+            let ids = lock(&workspace.shell_ids)?;
+            ids.iter()
+                .filter_map(|id| state.shells.get(id).cloned())
+                .collect::<Vec<_>>()
+        };
+        let mut killed: Vec<Arc<Shell>> = Vec::new();
+        for shell in &shells {
+            if let Err(error) = shell.kill() {
+                for shell in killed {
+                    shell.reset_pending()?;
+                }
+                return Err(error);
+            }
+            killed.push(Arc::clone(shell));
+        }
+        self.remove_workspace(workspace_id)?;
+        if let Err(error) = self.persist() {
+            self.restore_backup(backup)?;
+            for shell in shells {
+                shell.reset_pending()?;
+            }
+            return Err(error);
         }
         Ok(())
     }
@@ -530,9 +804,9 @@ impl Registry {
 
 impl Workspace {
     fn snapshot(&self, registry: &Registry) -> io::Result<WorkspaceSnapshot> {
-        let ids = lock(&self.shell_ids)?.clone();
         let shells = {
             let state = lock(&registry.state)?;
+            let ids = lock(&self.shell_ids)?;
             ids.iter()
                 .filter_map(|id| state.shells.get(id).cloned())
                 .collect::<Vec<_>>()
@@ -566,44 +840,72 @@ impl Shell {
     }
 
     fn kill(&self) -> io::Result<()> {
-        let runtime =
-            match std::mem::replace(&mut *lock(&self.lifecycle)?, ShellLifecycle::Closed) {
-                ShellLifecycle::Pending | ShellLifecycle::Closed => return Ok(()),
+        let runtime = {
+            let mut lifecycle = lock(&self.lifecycle)?;
+            match &*lifecycle {
+                ShellLifecycle::Pending => {
+                    *lifecycle = ShellLifecycle::Closed;
+                    return Ok(());
+                }
                 ShellLifecycle::Running { runtime, .. }
-                | ShellLifecycle::Exited { runtime, .. } => runtime,
-            };
+                | ShellLifecycle::Exited { runtime, .. } => Arc::clone(runtime),
+                ShellLifecycle::Closed => return Ok(()),
+            }
+        };
         if let Some(controller) = lock(&runtime.controller)?.take() {
             let _ = controller.connection.shutdown(std::net::Shutdown::Both);
         }
         let foreground_group = lock(&runtime.master)?.process_group_leader();
         let mut child = lock(&runtime.child)?;
-        if child.try_wait()?.is_some() {
-            return Ok(());
+        let result = if child.try_wait()?.is_some() {
+            Ok(())
+        } else {
+            let child_pid = child.process_id().map(|pid| pid as libc::pid_t);
+            if let Some(session_id) = child_pid {
+                signal_session(session_id, libc::SIGHUP);
+            }
+            for process_group in [foreground_group, child_pid].into_iter().flatten() {
+                // Negative PIDs address a process group. portable-pty starts the
+                // child as a session and process-group leader on Unix.
+                let _ = unsafe { libc::kill(-process_group, libc::SIGHUP) };
+            }
+            thread::sleep(SHUTDOWN_GRACE);
+            if let Some(session_id) = child_pid {
+                signal_session(session_id, libc::SIGTERM);
+            }
+            let kill_result = child.kill();
+            thread::sleep(SHUTDOWN_GRACE);
+            if let Some(session_id) = child_pid {
+                signal_session(session_id, libc::SIGKILL);
+            }
+            let wait_result = child.wait();
+            match (kill_result, wait_result) {
+                (_, Ok(_)) => Ok(()),
+                (Err(error), Err(_)) => Err(error),
+                (Ok(()), Err(error)) => Err(error),
+            }
+        };
+        drop(child);
+        if result.is_ok() {
+            let mut lifecycle = lock(&self.lifecycle)?;
+            let current_runtime = match &*lifecycle {
+                ShellLifecycle::Running { runtime, .. }
+                | ShellLifecycle::Exited { runtime, .. } => Some(runtime),
+                ShellLifecycle::Pending | ShellLifecycle::Closed => None,
+            };
+            if current_runtime.is_some_and(|current| Arc::ptr_eq(current, &runtime)) {
+                *lifecycle = ShellLifecycle::Closed;
+            }
         }
-        let child_pid = child.process_id().map(|pid| pid as libc::pid_t);
-        if let Some(session_id) = child_pid {
-            signal_session(session_id, libc::SIGHUP);
+        result
+    }
+
+    fn reset_pending(&self) -> io::Result<()> {
+        let mut lifecycle = lock(&self.lifecycle)?;
+        if matches!(*lifecycle, ShellLifecycle::Closed) {
+            *lifecycle = ShellLifecycle::Pending;
         }
-        for process_group in [foreground_group, child_pid].into_iter().flatten() {
-            // Negative PIDs address a process group. portable-pty starts the
-            // child as a session and process-group leader on Unix.
-            let _ = unsafe { libc::kill(-process_group, libc::SIGHUP) };
-        }
-        thread::sleep(SHUTDOWN_GRACE);
-        if let Some(session_id) = child_pid {
-            signal_session(session_id, libc::SIGTERM);
-        }
-        let kill_result = child.kill();
-        thread::sleep(SHUTDOWN_GRACE);
-        if let Some(session_id) = child_pid {
-            signal_session(session_id, libc::SIGKILL);
-        }
-        let wait_result = child.wait();
-        match (kill_result, wait_result) {
-            (_, Ok(_)) => Ok(()),
-            (Err(error), Err(_)) => Err(error),
-            (Ok(()), Err(error)) => Err(error),
-        }
+        Ok(())
     }
 }
 
@@ -629,6 +931,7 @@ fn create_pending_shell(workspace_id: &str, spec: ShellSpec) -> io::Result<Arc<S
         name: Mutex::new(spec.name),
         cwd: spec.cwd,
         command: spec.command,
+        last_profile: Mutex::new(None),
         lifecycle: Mutex::new(ShellLifecycle::Pending),
     }))
 }
@@ -688,7 +991,7 @@ fn spawn_runtime(
             master: Mutex::new(pty.master),
             writer: Mutex::new(writer),
             child: Mutex::new(child),
-            replay: Mutex::new(VecDeque::with_capacity(REPLAY_LIMIT)),
+            terminal: Mutex::new(TerminalState::new(profile.rows, profile.cols)),
             controller: Mutex::new(None),
         }),
         reader,
@@ -707,8 +1010,8 @@ fn start_pty_reader(
                 Ok(0) => break,
                 Ok(count) => {
                     let bytes = &buffer[..count];
-                    if let Ok(mut replay) = runtime.replay.lock() {
-                        append_replay(&mut replay, bytes);
+                    if let Ok(mut terminal) = runtime.terminal.lock() {
+                        terminal.process(bytes);
                         if let Ok(mut controller) = runtime.controller.lock() {
                             let disconnect = controller.as_ref().is_some_and(|current| {
                                 matches!(
@@ -762,18 +1065,12 @@ fn start_pty_reader(
     });
 }
 
-fn append_replay(replay: &mut VecDeque<u8>, bytes: &[u8]) {
-    if bytes.len() >= REPLAY_LIMIT {
-        replay.clear();
-        replay.extend(&bytes[bytes.len() - REPLAY_LIMIT..]);
-        return;
+fn tail_utf8(text: &str, max_bytes: usize) -> &str {
+    let mut start = text.len().saturating_sub(max_bytes);
+    while !text.is_char_boundary(start) {
+        start += 1;
     }
-    let excess = replay
-        .len()
-        .saturating_add(bytes.len())
-        .saturating_sub(REPLAY_LIMIT);
-    replay.drain(..excess);
-    replay.extend(bytes);
+    &text[start..]
 }
 
 fn handle_attach(
@@ -802,11 +1099,22 @@ fn handle_attach(
             );
         }
     };
+    let mutation = lock(&registry.mutation_lock)?;
+    if registry.stopping.load(Ordering::Acquire) {
+        return send_response(
+            &mut stream,
+            Response::Error {
+                message: "Boomux daemon is stopping".into(),
+            },
+        );
+    }
     let token = Uuid::new_v4().to_string();
     let (output, receiver) = mpsc::sync_channel(CONTROLLER_QUEUE);
     let connection = stream.try_clone()?;
-    let (runtime, startup_profile, running) = {
+    let previous_profile = lock(&shell.last_profile)?.clone();
+    let (runtime, startup_profile, running, started) = {
         let mut lifecycle = lock(&shell.lifecycle)?;
+        let mut started = false;
         if !registry.contains_shell(&shell)? {
             return send_response(
                 &mut stream,
@@ -835,15 +1143,17 @@ fn handle_attach(
                 profile: profile.clone(),
                 runtime: Arc::clone(&runtime),
             };
+            *lock(&shell.last_profile)? = Some(profile.clone());
+            started = true;
             start_pty_reader(Arc::clone(&shell), runtime, reader);
         }
         match &*lifecycle {
             ShellLifecycle::Running { profile, runtime } => {
-                (Arc::clone(runtime), profile.clone(), true)
+                (Arc::clone(runtime), profile.clone(), true, started)
             }
             ShellLifecycle::Exited {
                 profile, runtime, ..
-            } => (Arc::clone(runtime), profile.clone(), false),
+            } => (Arc::clone(runtime), profile.clone(), false, started),
             ShellLifecycle::Pending => unreachable!(),
             ShellLifecycle::Closed => {
                 return send_response(
@@ -855,6 +1165,27 @@ fn handle_attach(
             }
         }
     };
+    if started && let Err(error) = registry.persist() {
+        let cleanup = shell.kill();
+        if cleanup.is_ok() {
+            shell.reset_pending()?;
+            *lock(&shell.last_profile)? = previous_profile;
+        }
+        return send_response(
+            &mut stream,
+            Response::Error {
+                message: cleanup.map_or_else(
+                    |cleanup| {
+                        format!(
+                            "could not persist started shell: {error}; process cleanup also failed: {cleanup}"
+                        )
+                    },
+                    |()| format!("could not persist started shell: {error}"),
+                ),
+            },
+        );
+    }
+    drop(mutation);
     let warning = term_mismatch_warning(startup_profile.term.as_deref(), profile.term.as_deref());
     let control = lock(&runtime.control)?;
     if !registry.contains_shell(&shell)? {
@@ -881,15 +1212,16 @@ fn handle_attach(
             .resize(profile_size(&profile))
             .map_err(io::Error::other)?;
     }
-    // Keep replay locked until the controller is installed so retained output
-    // ends exactly where live delivery begins.
-    let replay = lock(&runtime.replay)?;
+    lock(&runtime.terminal)?.resize(profile.rows, profile.cols);
+    // Keep terminal state locked until the controller is installed so the
+    // reconstruction ends exactly where live delivery begins.
+    let terminal = lock(&runtime.terminal)?;
     stream.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
     send_response(
         &mut stream,
         Response::Attached {
             token: token.clone(),
-            replay: replay.iter().copied().collect(),
+            reconstruction: terminal.reconstruction(),
             warning,
         },
     )?;
@@ -936,7 +1268,7 @@ fn handle_attach(
         let _ = output_runtime.release_controller(&output_token);
     });
     drop(lifecycle);
-    drop(replay);
+    drop(terminal);
     drop(control);
 
     loop {
@@ -968,14 +1300,22 @@ fn handle_attach(
                 cols,
                 pixel_width,
                 pixel_height,
-            } => lock(&runtime.master)?
-                .resize(PtySize {
-                    rows,
-                    cols,
-                    pixel_width,
-                    pixel_height,
-                })
-                .map_err(io::Error::other),
+            } => {
+                if let Err(error) = validate_terminal_dimensions(rows, cols) {
+                    Err(error)
+                } else {
+                    lock(&runtime.master)?
+                        .resize(PtySize {
+                            rows,
+                            cols,
+                            pixel_width,
+                            pixel_height,
+                        })
+                        .map_err(io::Error::other)?;
+                    lock(&runtime.terminal)?.resize(rows, cols);
+                    Ok(())
+                }
+            }
             AttachFrame::Detached => {
                 drop(control);
                 break;
@@ -1040,12 +1380,7 @@ fn profile_size(profile: &TerminalProfile) -> PtySize {
 }
 
 fn validate_terminal_profile(profile: &TerminalProfile) -> io::Result<()> {
-    if profile.rows == 0 || profile.cols == 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "terminal profile rows and columns must be nonzero",
-        ));
-    }
+    validate_terminal_dimensions(profile.rows, profile.cols)?;
     for value in [
         &profile.term,
         &profile.colorterm,
@@ -1064,6 +1399,23 @@ fn validate_terminal_profile(profile: &TerminalProfile) -> io::Result<()> {
                 "terminal profile contains an invalid environment value",
             ));
         }
+    }
+    Ok(())
+}
+
+fn validate_terminal_dimensions(rows: u16, cols: u16) -> io::Result<()> {
+    if rows == 0
+        || cols == 0
+        || rows > MAX_TERMINAL_ROWS
+        || cols > MAX_TERMINAL_COLS
+        || usize::from(rows) * usize::from(cols) > MAX_TERMINAL_CELLS
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "terminal rows and columns must be nonzero and at most {MAX_TERMINAL_ROWS}x{MAX_TERMINAL_COLS}"
+            ),
+        ));
     }
     Ok(())
 }
@@ -1146,6 +1498,29 @@ fn validate_cwd(cwd: &Path) -> io::Result<()> {
     }
 }
 
+fn validate_persisted_cwd(cwd: &Path) -> io::Result<()> {
+    if cwd.is_absolute() {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "persisted working directory must be absolute: {}",
+                cwd.display()
+            ),
+        ))
+    }
+}
+
+fn validate_id(kind: &str, id: &str) -> io::Result<()> {
+    Uuid::parse_str(id).map(|_| ()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("persisted {kind} ID is invalid: {id}"),
+        )
+    })
+}
+
 fn not_found(kind: &str, id: &str) -> io::Error {
     io::Error::new(io::ErrorKind::NotFound, format!("{kind} not found: {id}"))
 }
@@ -1186,13 +1561,9 @@ mod tests {
     }
 
     #[test]
-    fn replay_keeps_only_the_tail() {
-        let mut replay = VecDeque::new();
-        append_replay(&mut replay, &vec![1; REPLAY_LIMIT]);
-        append_replay(&mut replay, &[2, 3]);
-        assert_eq!(replay.len(), REPLAY_LIMIT);
-        assert_eq!(replay[REPLAY_LIMIT - 2], 2);
-        assert_eq!(replay[REPLAY_LIMIT - 1], 3);
+    fn rendered_output_tail_preserves_utf8_boundaries() {
+        assert_eq!(tail_utf8("one-λ", 2), "λ");
+        assert_eq!(tail_utf8("one-λ", 3), "-λ");
     }
 
     #[test]
@@ -1217,12 +1588,35 @@ mod tests {
         assert!(validate_terminal_profile(&invalid).is_err());
 
         let mut invalid = profile();
+        invalid.cols = MAX_TERMINAL_COLS + 1;
+        assert!(validate_terminal_profile(&invalid).is_err());
+
+        let mut invalid = profile();
         invalid.term = Some("bad\nterm".into());
         assert!(validate_terminal_profile(&invalid).is_err());
 
         let mut invalid = profile();
         invalid.term = Some("x".repeat(MAX_TERMINAL_ENV_VALUE + 1));
         assert!(validate_terminal_profile(&invalid).is_err());
+    }
+
+    #[test]
+    fn failed_persistence_rolls_back_registry_mutation() {
+        let directory = env::temp_dir().join(format!("boomux-rollback-{}", Uuid::new_v4()));
+        let state_directory = directory.join("state");
+        let registry =
+            Registry::restore(StateStore::at(state_directory.join("state.json"))).unwrap();
+        fs::remove_dir(&state_directory).unwrap();
+        fs::write(&state_directory, b"not a directory").unwrap();
+
+        let result = registry.dispatch(Request::CreateWorkspace {
+            name: "rolled-back".into(),
+            shells: Vec::new(),
+        });
+
+        assert!(result.is_err());
+        assert!(registry.snapshot().unwrap().workspaces.is_empty());
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,5 @@ pub mod attach;
 pub mod client;
 pub mod daemon;
 pub mod protocol;
+mod state_store;
+mod terminal_state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod terminal;
 mod tui;
 
 const BOOMUX_SHELLS_SKILL: &str = include_str!("../.agents/skills/boomux-shells/SKILL.md");
-const REPLAY_BYTES: usize = 1024 * 1024;
+const READ_BYTES: usize = 1024 * 1024;
 
 #[derive(Parser)]
 #[command(
@@ -721,7 +721,7 @@ fn read_shell(target: &str, lines: u32) -> Result<(), Box<dyn Error>> {
         .ok()
         .and_then(|id| find_shell(&snapshot, &id).map(|shell| shell.workspace_id.clone()));
     let shell = resolve_shell_target(&snapshot, current_workspace_id.as_deref(), target)?;
-    let bytes = client.read_shell(&shell.id, REPLAY_BYTES)?;
+    let bytes = client.read_shell(&shell.id, READ_BYTES)?;
     let output = recent_lines(&String::from_utf8_lossy(&bytes), lines as usize);
     print!("{output}");
     if !output.is_empty() && !output.ends_with('\n') {
@@ -1215,7 +1215,7 @@ mod tests {
     }
 
     #[test]
-    fn selects_recent_lossy_replay_lines() {
+    fn selects_recent_rendered_lines() {
         assert_eq!(recent_lines("one\ntwo\nthree\n", 2), "two\nthree\n");
         assert_eq!(recent_lines("one\ntwo", 1), "two");
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 4;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
 
@@ -146,7 +146,7 @@ pub enum Response {
     },
     Attached {
         token: String,
-        replay: Vec<u8>,
+        reconstruction: Vec<u8>,
         warning: Option<String>,
     },
     Ok,

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -1,0 +1,242 @@
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::protocol::TerminalProfile;
+
+const STATE_VERSION: u32 = 1;
+const MAX_STATE_BYTES: u64 = 8 * 1024 * 1024;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PersistedState {
+    version: u32,
+    pub(crate) workspaces: Vec<PersistedWorkspace>,
+}
+
+impl Default for PersistedState {
+    fn default() -> Self {
+        Self {
+            version: STATE_VERSION,
+            workspaces: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PersistedWorkspace {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) shells: Vec<PersistedShell>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PersistedShell {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) cwd: PathBuf,
+    pub(crate) command: Vec<String>,
+    pub(crate) last_profile: Option<TerminalProfile>,
+}
+
+pub(crate) struct StateStore {
+    path: PathBuf,
+    _lock: Option<File>,
+}
+
+impl StateStore {
+    pub(crate) fn from_environment() -> io::Result<Self> {
+        let root = match env::var_os("XDG_STATE_HOME").filter(|path| !path.is_empty()) {
+            Some(path) => PathBuf::from(path),
+            None => PathBuf::from(
+                env::var_os("HOME")
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is not set"))?,
+            )
+            .join(".local/state"),
+        };
+        if !root.is_absolute() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "XDG_STATE_HOME must be an absolute path",
+            ));
+        }
+        let directory = root.join("boomux");
+        secure_state_dir(&directory)?;
+        let lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(directory.join("daemon.lock"))?;
+        // The descriptor remains open for the store lifetime and `flock` takes
+        // only pointer-free integer arguments.
+        if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == -1 {
+            let error = io::Error::last_os_error();
+            return Err(if matches!(error.raw_os_error(), Some(libc::EWOULDBLOCK)) {
+                io::Error::new(
+                    io::ErrorKind::AddrInUse,
+                    "another Boomux daemon is using this state directory",
+                )
+            } else {
+                error
+            });
+        }
+        Ok(Self {
+            path: directory.join("state.json"),
+            _lock: Some(lock),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn at(path: PathBuf) -> Self {
+        Self { path, _lock: None }
+    }
+
+    pub(crate) fn load(&self) -> io::Result<Option<PersistedState>> {
+        let Some(parent) = self.path.parent() else {
+            return Err(io::Error::other("state path has no parent"));
+        };
+        secure_state_dir(parent)?;
+        let metadata = match fs::symlink_metadata(&self.path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        if !metadata.is_file() || metadata.uid() != effective_uid() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "boomux state path is not an owned regular file",
+            ));
+        }
+        if metadata.len() > MAX_STATE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "boomux state file exceeds the size limit",
+            ));
+        }
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        File::open(&self.path)?.read_to_end(&mut bytes)?;
+        let state: PersistedState = serde_json::from_slice(&bytes).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("could not parse {}: {error}", self.path.display()),
+            )
+        })?;
+        if state.version != STATE_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unsupported Boomux state version {}; expected {STATE_VERSION}",
+                    state.version
+                ),
+            ));
+        }
+        Ok(Some(state))
+    }
+
+    pub(crate) fn save(&self, state: &PersistedState) -> io::Result<()> {
+        let Some(parent) = self.path.parent() else {
+            return Err(io::Error::other("state path has no parent"));
+        };
+        secure_state_dir(parent)?;
+        let bytes = serde_json::to_vec_pretty(state).map_err(io::Error::other)?;
+        if bytes.len() as u64 > MAX_STATE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "boomux state exceeds the size limit",
+            ));
+        }
+        let temporary = parent.join(format!(".state-{}.tmp", Uuid::new_v4()));
+        let result = (|| {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&temporary)?;
+            file.write_all(&bytes)?;
+            file.sync_all()?;
+            fs::rename(&temporary, &self.path)?;
+            // Rename is the commit point. Directory fsync improves crash
+            // durability but cannot be rolled back if a filesystem rejects it.
+            let _ = File::open(parent).and_then(|directory| directory.sync_all());
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temporary);
+        }
+        result
+    }
+}
+
+fn secure_state_dir(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_dir() || metadata.uid() != effective_uid() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "boomux state path is not an owned directory",
+        ));
+    }
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+}
+
+fn effective_uid() -> u32 {
+    // `geteuid` has no arguments, pointers, or caller safety requirements.
+    unsafe { libc::geteuid() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomically_round_trips_state() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let store = StateStore::at(directory.join("boomux/state.json"));
+        let state = PersistedState {
+            version: STATE_VERSION,
+            workspaces: vec![PersistedWorkspace {
+                id: Uuid::new_v4().to_string(),
+                name: "saved".into(),
+                shells: Vec::new(),
+            }],
+        };
+
+        store.save(&state).unwrap();
+        let restored = store.load().unwrap().unwrap();
+
+        assert_eq!(restored.workspaces[0].name, "saved");
+        assert_eq!(
+            fs::metadata(directory.join("boomux/state.json"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn rejects_unsupported_state_versions() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, br#"{"version":99,"workspaces":[]}"#).unwrap();
+        let store = StateStore::at(path);
+
+        let error = store.load().unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -1,0 +1,207 @@
+const SCROLLBACK_ROWS: usize = 2_000;
+const MAX_RECONSTRUCTION_BYTES: usize = 1024 * 1024;
+
+pub(crate) struct TerminalState {
+    parser: vt100::Parser,
+    primary: vt100::Screen,
+}
+
+impl TerminalState {
+    pub(crate) fn new(rows: u16, cols: u16) -> Self {
+        let parser = vt100::Parser::new(rows, cols, SCROLLBACK_ROWS);
+        Self {
+            primary: parser.screen().clone(),
+            parser,
+        }
+    }
+
+    pub(crate) fn process(&mut self, bytes: &[u8]) {
+        if !self.parser.screen().alternate_screen()
+            && let Some(offset) = alternate_screen_start(bytes)
+        {
+            self.parser.process(&bytes[..offset]);
+            self.primary = self.parser.screen().clone();
+            self.parser.process(&bytes[offset..]);
+            return;
+        }
+        self.parser.process(bytes);
+        if !self.parser.screen().alternate_screen() {
+            self.primary = self.parser.screen().clone();
+        }
+    }
+
+    pub(crate) fn resize(&mut self, rows: u16, cols: u16) {
+        self.parser.screen_mut().set_size(rows, cols);
+        if self.parser.screen().alternate_screen() {
+            self.primary.set_size(rows, cols);
+        } else {
+            self.primary = self.parser.screen().clone();
+        }
+    }
+
+    pub(crate) fn reconstruction(&self) -> Vec<u8> {
+        let screen = self.parser.screen();
+        let mut output = b"\x1b[?1049l\x1b[0m\x1b[?25h\x1b[H\x1b[2J".to_vec();
+        append_scrollback(&mut output, &self.primary);
+        output.extend_from_slice(b"\x1b[H\x1b[2J");
+        output.extend(self.primary.contents_formatted());
+        if screen.alternate_screen() {
+            output.extend_from_slice(b"\x1b[?1049h\x1b[H\x1b[2J");
+            output.extend(screen.contents_formatted());
+        }
+        output.extend(screen.input_mode_formatted());
+        if output.len() <= MAX_RECONSTRUCTION_BYTES {
+            return output;
+        }
+
+        let mut fallback = b"\x1b[?1049l\x1b[0m\x1b[?25h\x1b[H\x1b[2J".to_vec();
+        if screen.alternate_screen() {
+            fallback.extend_from_slice(b"\x1b[?1049h\x1b[H\x1b[2J");
+        }
+        let suffix = state_suffix(screen);
+        let text_limit = MAX_RECONSTRUCTION_BYTES.saturating_sub(suffix.len());
+        append_terminal_text_bounded(&mut fallback, &screen.contents(), text_limit);
+        fallback.extend(suffix);
+        fallback
+    }
+
+    pub(crate) fn plain_text(&self) -> String {
+        let screen = self.parser.screen();
+        let mut text = scrollback_text(screen);
+        text.push_str(&screen.contents());
+        text.chars()
+            .filter(|character| !character.is_control() || matches!(character, '\n' | '\t'))
+            .collect()
+    }
+}
+
+fn alternate_screen_start(bytes: &[u8]) -> Option<usize> {
+    [b"\x1b[?1049h".as_slice(), b"\x1b[?1047h", b"\x1b[?47h"]
+        .into_iter()
+        .filter_map(|sequence| {
+            bytes
+                .windows(sequence.len())
+                .position(|window| window == sequence)
+        })
+        .min()
+}
+
+fn scrollback_text(screen: &vt100::Screen) -> String {
+    let mut screen = screen.clone();
+    screen.set_scrollback(usize::MAX);
+    let rows = screen.scrollback();
+    let (_, cols) = screen.size();
+    let mut contents = String::new();
+
+    for offset in (1..=rows).rev() {
+        screen.set_scrollback(offset);
+        if let Some(row) = screen.rows(0, cols).next() {
+            contents.push_str(&row);
+            if !screen.row_wrapped(0) {
+                contents.push('\n');
+            }
+        }
+    }
+    contents
+}
+
+fn append_scrollback(output: &mut Vec<u8>, screen: &vt100::Screen) {
+    let scrollback = scrollback_text(screen);
+    if scrollback.is_empty() {
+        return;
+    }
+    append_terminal_text_bounded(output, &scrollback, MAX_RECONSTRUCTION_BYTES);
+    for _ in 0..screen.size().0.saturating_sub(1) {
+        output.extend_from_slice(b"\r\n");
+    }
+}
+
+fn append_terminal_text_bounded(output: &mut Vec<u8>, text: &str, limit: usize) {
+    for character in text
+        .chars()
+        .filter(|character| !character.is_control() || matches!(character, '\n' | '\t'))
+    {
+        if character == '\n' {
+            if output.len() + 2 > limit {
+                break;
+            }
+            output.extend_from_slice(b"\r\n");
+            continue;
+        }
+        let mut bytes = [0; 4];
+        let encoded = character.encode_utf8(&mut bytes).as_bytes();
+        if output.len() + encoded.len() > limit {
+            break;
+        }
+        output.extend_from_slice(encoded);
+    }
+}
+
+fn state_suffix(screen: &vt100::Screen) -> Vec<u8> {
+    let (row, col) = screen.cursor_position();
+    let mut suffix = format!("\x1b[{};{}H", row + 1, col + 1).into_bytes();
+    suffix.extend_from_slice(if screen.hide_cursor() {
+        b"\x1b[?25l"
+    } else {
+        b"\x1b[?25h"
+    });
+    suffix.extend(screen.input_mode_formatted());
+    suffix
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn carriage_return_rewrites_rendered_line() {
+        let mut state = TerminalState::new(4, 20);
+        state.process(b"abc\rXY");
+
+        assert_eq!(state.plain_text(), "XYc");
+    }
+
+    #[test]
+    fn reconstruction_omits_osc_side_effects() {
+        let mut state = TerminalState::new(4, 40);
+        state.process(b"before\x1b]52;c;Y2xpcGJvYXJk\x07after");
+
+        let reconstruction = state.reconstruction();
+        assert!(!reconstruction.windows(2).any(|bytes| bytes == b"\x1b]"));
+        assert!(!String::from_utf8_lossy(&reconstruction).contains("Y2xpcGJvYXJk"));
+        assert_eq!(state.plain_text(), "beforeafter");
+    }
+
+    #[test]
+    fn alternate_screen_is_reconstructed() {
+        let mut source = TerminalState::new(4, 20);
+        source.process(b"primary\x1b[?1049halt");
+        let reconstruction = source.reconstruction();
+        let mut restored = TerminalState::new(4, 20);
+        restored.process(&reconstruction);
+
+        assert!(restored.parser.screen().alternate_screen());
+        assert_eq!(restored.plain_text(), "alt");
+        restored.process(b"\x1b[?1049l");
+        assert_eq!(restored.plain_text(), "primary");
+    }
+
+    #[test]
+    fn resize_changes_shadow_dimensions() {
+        let mut state = TerminalState::new(4, 20);
+        state.resize(10, 30);
+
+        assert_eq!(state.parser.screen().size(), (10, 30));
+    }
+
+    #[test]
+    fn plain_text_includes_bounded_scrollback() {
+        let mut state = TerminalState::new(2, 20);
+        state.process(b"one\r\ntwo\r\nthree");
+
+        assert_eq!(state.plain_text(), "one\ntwo\nthree");
+        let mut restored = TerminalState::new(2, 20);
+        restored.process(&state.reconstruction());
+        assert_eq!(restored.plain_text(), "one\ntwo\nthree");
+    }
+}

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -31,6 +31,7 @@ impl TestDaemon {
         let child = Command::new(&executable)
             .args(["daemon", "run"])
             .env("XDG_RUNTIME_DIR", &runtime_dir)
+            .env("XDG_STATE_HOME", runtime_dir.join("state"))
             .env("SHELL", "/bin/sh")
             .env("TERM", "daemon-term")
             .env("COLORTERM", "daemon-color")
@@ -54,7 +55,26 @@ impl TestDaemon {
     fn command(&self) -> Command {
         let mut command = Command::new(&self.executable);
         command.env("XDG_RUNTIME_DIR", &self.runtime_dir);
+        command.env("XDG_STATE_HOME", self.runtime_dir.join("state"));
         command
+    }
+
+    fn restart(&mut self) {
+        assert!(self.child.is_none());
+        let child = self
+            .command()
+            .args(["daemon", "run"])
+            .env("SHELL", "/bin/sh")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        self.child = Some(child);
+        wait_until(
+            || self.client.ping().is_ok(),
+            "restarted daemon did not accept requests",
+        );
     }
 
     fn stop_with_cli(&mut self) {
@@ -88,6 +108,76 @@ impl Drop for TestDaemon {
 }
 
 #[test]
+fn native_daemon_recovers_reproducible_metadata_after_restart() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "persistent",
+            vec![ShellSpec {
+                name: "restored".into(),
+                command: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    "printf 'restored-command\\n'; sleep 30".into(),
+                ],
+                cwd: std::env::temp_dir(),
+            }],
+        )
+        .unwrap();
+    let shell = workspace.shells.first().unwrap();
+    let workspace_id = workspace.id.clone();
+    let shell_id = shell.id.clone();
+    let mut first = daemon
+        .client
+        .attach(&shell_id, false, profile())
+        .unwrap()
+        .stream;
+    assert!(contains(
+        &read_until(&mut first, b"restored-command"),
+        b"restored-command"
+    ));
+    drop(first);
+    daemon
+        .client
+        .rename_workspace(&workspace_id, "persistent-renamed")
+        .unwrap();
+    daemon
+        .client
+        .rename_shell(&shell_id, "restored-renamed")
+        .unwrap();
+    let persisted: serde_json::Value = serde_json::from_slice(
+        &fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        persisted["workspaces"][0]["shells"][0]["last_profile"]["term"],
+        "attachment-term"
+    );
+
+    daemon.stop_with_cli();
+    daemon.restart();
+
+    let restored = daemon.client.get_workspace(&workspace_id).unwrap();
+    assert_eq!(restored.name, "persistent-renamed");
+    assert_eq!(restored.shells.len(), 1);
+    assert_eq!(restored.shells[0].id, shell_id);
+    assert_eq!(restored.shells[0].name, "restored-renamed");
+    assert_eq!(restored.shells[0].status, ShellStatus::Pending);
+    let mut second = daemon
+        .client
+        .attach(&shell_id, false, profile())
+        .unwrap()
+        .stream;
+    assert!(contains(
+        &read_until(&mut second, b"restored-command"),
+        b"restored-command"
+    ));
+    drop(second);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn native_daemon_lifecycle() {
     let mut daemon = TestDaemon::start();
 
@@ -97,7 +187,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 3"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 4"));
 
     let mut duplicate = daemon
         .command()
@@ -112,6 +202,23 @@ fn native_daemon_lifecycle() {
         "second daemon did not reject the held startup lock",
     );
     assert!(!duplicate.wait().unwrap().success());
+
+    let second_runtime = daemon.runtime_dir.join("second-runtime");
+    fs::create_dir(&second_runtime).unwrap();
+    let mut duplicate_state = Command::new(&daemon.executable)
+        .args(["daemon", "run"])
+        .env("XDG_RUNTIME_DIR", &second_runtime)
+        .env("XDG_STATE_HOME", daemon.runtime_dir.join("state"))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_until(
+        || duplicate_state.try_wait().unwrap().is_some(),
+        "second daemon did not reject the held state lock",
+    );
+    assert!(!duplicate_state.wait().unwrap().success());
 
     let output = daemon
         .command()
@@ -251,7 +358,7 @@ fn native_daemon_lifecycle() {
 
     assert_eq!(shell.status, ShellStatus::Pending);
     let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    assert!(attachment.replay.len() <= 1024 * 1024);
+    assert!(attachment.reconstruction.len() <= 1024 * 1024);
     assert!(attachment.warning.is_none());
     let mut first = attachment.stream;
     AttachFrame::Input(b"stty -echo\n".to_vec())
@@ -275,6 +382,21 @@ fn native_daemon_lifecycle() {
         .unwrap();
     let output = read_until(&mut first, b"transport-ok");
     assert!(contains(&output, b"transport-ok"));
+    AttachFrame::Input(
+        b"printf 'G101MjtjO1kyeHBjR0p2WVhKawc=' | base64 -d; printf 'progress\rsettled\n'\n"
+            .to_vec(),
+    )
+    .write_to(&mut first)
+    .unwrap();
+    let output = read_until(&mut first, b"settled");
+    assert!(
+        contains(&output, b"\x1b]52;c;Y2xpcGJvYXJk\x07"),
+        "{output:?}"
+    );
+    let rendered = daemon.client.read_shell(&shell_id, 1024).unwrap();
+    assert!(contains(&rendered, b"settled"));
+    assert!(!rendered.contains(&b'\x1b'));
+    assert!(!contains(&rendered, b"Y2xpcGJvYXJk"));
 
     drop(first);
     wait_until(
@@ -287,7 +409,17 @@ fn native_daemon_lifecycle() {
         "shell stopped after its attachment disconnected",
     );
 
-    let mut second = wait_for_attach(&daemon.client, &shell_id).stream;
+    let second_attachment = wait_for_attach(&daemon.client, &shell_id);
+    assert!(!contains(
+        &second_attachment.reconstruction,
+        b"\x1b]52;c;Y2xpcGJvYXJk\x07"
+    ));
+    assert!(!contains(
+        &second_attachment.reconstruction,
+        b"Y2xpcGJvYXJk"
+    ));
+    assert!(contains(&second_attachment.reconstruction, b"settled"));
+    let mut second = second_attachment.stream;
     let error = daemon
         .client
         .attach(&shell_id, false, profile())


### PR DESCRIPTION
## Summary
- replace raw reconnect replay with bounded, sanitized VT reconstruction
- make shell reads return ANSI-free rendered text with scrollback
- atomically persist reproducible workspace and shell metadata across daemon restarts
- harden shutdown, rollback, ownership, and protocol boundaries

## Verification
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- installed-binary restart persistence smoke test