### PR TITLE
Preserve live shells across daemon restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "clap",
  "crossterm",
  "libc",
+ "nix",
  "portable-pty",
  "ratatui",
  "serde",
@@ -584,6 +585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +615,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
 libc = "0.2"
+nix = { version = "0.28", default-features = false, features = ["socket", "uio"] }
 portable-pty = "0.9"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm", "layout-cache"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ boomux shell inspect <shell-name-or-id> [--workspace <name-or-id>]
 boomux shell rename <shell-name-or-id> <new-name> [--workspace <name-or-id>]
 boomux shell close <shell-name-or-id> [--workspace <name-or-id>]
 boomux daemon status
+boomux daemon restart
 boomux daemon stop
 boomux skill install
 ```
@@ -198,6 +199,8 @@ PTY handoff work is tracked in
 
 - PTYs and processes exist only for the daemon's lifetime. After restart,
   persisted shells return as pending and start fresh processes when reopened.
+- Live daemon restart currently requires every shell to be pending; started
+  shell runtime transfer is the next handoff phase.
 - Mutated process environment and in-memory application state are not persisted.
 - Reconnection emits at most 1 MiB of sanitized VT reconstruction rather than
   replaying historical PTY bytes. Graphics are omitted from reconstruction.

--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ PTY handoff work is tracked in
 
 - PTYs and processes exist only for the daemon's lifetime. After restart,
   persisted shells return as pending and start fresh processes when reopened.
-- Live daemon restart currently requires every shell to be pending; started
-  shell runtime transfer is the next handoff phase.
+- Live daemon restart preserves pending and running shells. Active attachment
+  clients reconnect cooperatively; exited shells use metadata recovery.
 - Mutated process environment and in-memory application state are not persisted.
 - Reconnection emits at most 1 MiB of sanitized VT reconstruction rather than
   replaying historical PTY bytes. Graphics are omitted from reconstruction.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,10 +141,15 @@ shell working directories, startup commands, and last terminal profiles survive
 restart. Recovered shells are pending: Boomux does not claim that arbitrary
 processes, mutated environments, or PTYs survive daemon restart or crash.
 
+`boomux daemon restart` transfers the existing listener and both ownership locks
+to a replacement process through a private, versioned `SCM_RIGHTS` handshake.
+Prepare/finalize acknowledgement keeps rollback safe before the irreversible
+ownership boundary. This path currently rejects restart unless every shell is
+pending; live PTY runtime transfer is tracked separately.
+
 ## Next Technical Steps
 
 The detailed design, acceptance criteria, and manual test matrix are tracked in
 [`native-terminal-follow-up.md`](native-terminal-follow-up.md).
 
-1. Add graceful daemon restart or live PTY handoff only after the base lifecycle
-   is reliable.
+1. Transfer detached live PTYs and process identity during graceful restart.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,12 +144,17 @@ processes, mutated environments, or PTYs survive daemon restart or crash.
 `boomux daemon restart` transfers the existing listener and both ownership locks
 to a replacement process through a private, versioned `SCM_RIGHTS` handshake.
 Prepare/finalize acknowledgement keeps rollback safe before the irreversible
-ownership boundary. This path currently rejects restart unless every shell is
-pending; live PTY runtime transfer is tracked separately.
+ownership boundary. Pending shells restore from metadata. Detached running
+shells transfer their PTY master, pidfd-backed process identity, terminal
+profile, and reconstructed VT state without changing the child PID. Attached
+clients receive a reconnect request, acknowledge an input-ordering boundary,
+and reconnect to the replacement while remaining in raw mode. Exited shells use
+metadata recovery.
 
 ## Next Technical Steps
 
 The detailed design, acceptance criteria, and manual test matrix are tracked in
 [`native-terminal-follow-up.md`](native-terminal-follow-up.md).
 
-1. Transfer detached live PTYs and process identity during graceful restart.
+1. Evaluate explicit exited-shell terminal-state transfer separately from live
+   process handoff.

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -1,0 +1,62 @@
+# Live PTY Handoff
+
+## Goal
+
+Replace the Boomux daemon without terminating detached shell processes. A
+metadata-only restart remains the crash fallback; handoff is an explicit,
+acknowledged upgrade path.
+
+## Invariants
+
+- Exactly one daemon reads each PTY at a time.
+- The old daemon remains authoritative until the replacement acknowledges every
+  imported runtime.
+- The listener socket and both daemon lock file descriptions keep their existing
+  ownership across the transition.
+- A failed replacement resumes the old daemon without killing shells.
+- The first implementation rejects active controllers rather than disconnecting
+  an attached terminal without consent.
+- Received descriptors are close-on-exec, strictly typed by marker, and closed
+  on every malformed transfer.
+
+## Transfer Manifest
+
+The private handoff channel will carry a versioned manifest followed by Unix
+`SCM_RIGHTS` descriptors:
+
+- Existing listener socket
+- Runtime and state lock files
+- One PTY master per running shell
+- Shell ID, terminal profile, PID/session identity, and sanitized VT state
+
+The PTY master is full duplex, so reader and writer duplicates do not need to be
+transferred separately. The replacement cannot inherit Unix parenthood; process
+monitoring and cleanup therefore need an imported-process representation, with
+a Linux pidfd where available.
+
+Bootstrap starts with the `BOOMUXH1` version header and has bounded read/write
+deadlines. The receiver validates the listener path/type, forces nonblocking
+mode, matches both lock-file inodes, and establishes exclusive flock ownership
+before acknowledging readiness. Explicit abort closes every received duplicate
+without affecting descriptors retained by the old daemon.
+
+## Delivery Slices
+
+1. [Complete] Implement and test strict single-descriptor `SCM_RIGHTS` transport.
+2. [Complete] Replace erased PTY reader/writer ownership with a Boomux-owned Unix
+   runtime and a pauseable, joinable reader task.
+3. [Complete for pending shells] Add replacement-daemon bootstrap over a private
+   socketpair and transfer the listener and lock descriptors with readiness
+   acknowledgement.
+   `boomux daemon restart` now uses prepare/finalize commit semantics, preserves
+   the socket pathname, and rolls back to the old daemon before finalization.
+4. Transfer detached shell runtimes and prove PID, input, output, resize, and
+   later cleanup survive replacement.
+5. Add cooperative attachment reconnection before allowing handoff with active
+   controllers.
+
+## First Acceptance Test
+
+Start a detached shell, record its PID, replace the daemon, reconnect, and prove
+the PID is unchanged. Input, output, resize, lock exclusivity, metadata mutation,
+and a later destructive `daemon stop` must still work.

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -14,8 +14,7 @@ acknowledged upgrade path.
 - The listener socket and both daemon lock file descriptions keep their existing
   ownership across the transition.
 - A failed replacement resumes the old daemon without killing shells.
-- The first implementation rejects active controllers rather than disconnecting
-  an attached terminal without consent.
+- Active controllers acknowledge a reconnect boundary before PTY transfer.
 - Received descriptors are close-on-exec, strictly typed by marker, and closed
   on every malformed transfer.
 
@@ -34,26 +33,36 @@ transferred separately. The replacement cannot inherit Unix parenthood; process
 monitoring and cleanup therefore need an imported-process representation, with
 a Linux pidfd where available.
 
-Bootstrap starts with the `BOOMUXH1` version header and has bounded read/write
+Bootstrap starts with the `BOOMUXH2` version header and has bounded read/write
 deadlines. The receiver validates the listener path/type, forces nonblocking
 mode, matches both lock-file inodes, and establishes exclusive flock ownership
 before acknowledging readiness. Explicit abort closes every received duplicate
 without affecting descriptors retained by the old daemon.
+
+For each detached running shell, the old reader pauses before the manifest is
+captured. The replacement validates the session leader and pidfd, reconstructs
+terminal state, and waits at `PREPARED`; it does not begin reading the PTY until
+`FINALIZE`, so rollback cannot consume output belonging to the old daemon.
+PTY/session identity is cross-checked with `TIOCGSID`, terminal reconstructions
+use separate bounded frames, and imported process/session cleanup uses pidfds to
+avoid signaling a reused numeric PID.
 
 ## Delivery Slices
 
 1. [Complete] Implement and test strict single-descriptor `SCM_RIGHTS` transport.
 2. [Complete] Replace erased PTY reader/writer ownership with a Boomux-owned Unix
    runtime and a pauseable, joinable reader task.
-3. [Complete for pending shells] Add replacement-daemon bootstrap over a private
+3. [Complete] Add replacement-daemon bootstrap over a private
    socketpair and transfer the listener and lock descriptors with readiness
    acknowledgement.
    `boomux daemon restart` now uses prepare/finalize commit semantics, preserves
    the socket pathname, and rolls back to the old daemon before finalization.
-4. Transfer detached shell runtimes and prove PID, input, output, resize, and
-   later cleanup survive replacement.
-5. Add cooperative attachment reconnection before allowing handoff with active
-   controllers.
+4. [Complete] Transfer detached shell runtimes and prove PID, input, output,
+   resize, repeated replacement, rollback, and later cleanup survive.
+5. [Complete] Add cooperative attachment reconnection with ordered
+   `Reconnect`/`ReconnectAck` framing. Input sent before the ACK is processed by
+   the old daemon; later terminal input remains queued while the client retries
+   the replacement in raw mode.
 
 ## First Acceptance Test
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,7 +50,8 @@ commitments.
 See [`native-terminal-follow-up.md`](native-terminal-follow-up.md) for the
 terminal handshake, VT reconstruction, and restart-persistence plan.
 
-- Add graceful daemon restart or live PTY handoff.
+- Add graceful daemon restart through the staged
+  [live PTY handoff design](live-pty-handoff.md).
 - Aggregate multiple agent states as counts instead of one workspace-level
   value.
 - Notify when an agent becomes blocked, finishes, or needs input.

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::io::{self, Read, Write};
 use std::os::fd::AsRawFd;
+use std::thread;
+use std::time::Duration;
 
 use crossterm::terminal;
 
@@ -8,6 +10,8 @@ use crate::client;
 use crate::protocol::{AttachFrame, TerminalProfile};
 
 const POLL_INTERVAL_MS: i32 = 100;
+const RECONNECT_ATTEMPTS: usize = 600;
+const RECONNECT_DELAY: Duration = Duration::from_millis(25);
 
 struct RawMode;
 
@@ -25,7 +29,7 @@ impl Drop for RawMode {
 }
 
 pub fn run(shell_id: &str, takeover: bool) -> io::Result<()> {
-    let profile = terminal_profile()?;
+    let mut profile = terminal_profile()?;
     let mut size = (
         profile.rows,
         profile.cols,
@@ -33,19 +37,58 @@ pub fn run(shell_id: &str, takeover: bool) -> io::Result<()> {
         profile.pixel_height,
     );
     let client = client::connect_or_start()?;
-    let attachment = client.attach(shell_id, takeover, profile)?;
-    if let Some(warning) = attachment.warning {
-        eprintln!("boomux: warning: {warning}");
-    }
-    let mut stream = attachment.stream;
+    let mut attachment = client.attach(shell_id, takeover, profile.clone())?;
     let _raw_mode = RawMode::enter()?;
     let mut stdin = io::stdin().lock();
     let mut stdout = io::stdout().lock();
-    stdout.write_all(&attachment.reconstruction)?;
-    stdout.flush()?;
-
     let mut input = [0; 16 * 1024];
 
+    loop {
+        if let Some(warning) = attachment.warning.take() {
+            eprintln!("boomux: warning: {warning}");
+        }
+        stdout.write_all(&attachment.reconstruction)?;
+        stdout.flush()?;
+        let mut stream = attachment.stream;
+
+        if !pump_attachment(&mut stream, &mut stdin, &mut stdout, &mut input, &mut size)? {
+            return Ok(());
+        }
+        if let Ok((rows, cols, pixel_width, pixel_height)) = dimensions() {
+            size = (rows, cols, pixel_width, pixel_height);
+            profile.rows = rows;
+            profile.cols = cols;
+            profile.pixel_width = pixel_width;
+            profile.pixel_height = pixel_height;
+        }
+        attachment = reconnect(&client, shell_id, takeover, &profile)?;
+    }
+}
+
+fn reconnect(
+    client: &client::Client,
+    shell_id: &str,
+    takeover: bool,
+    profile: &TerminalProfile,
+) -> io::Result<client::Attachment> {
+    let mut last_error = None;
+    for _ in 0..RECONNECT_ATTEMPTS {
+        match client.attach(shell_id, takeover, profile.clone()) {
+            Ok(attachment) => return Ok(attachment),
+            Err(error) => last_error = Some(error),
+        }
+        thread::sleep(RECONNECT_DELAY);
+    }
+    Err(last_error.unwrap_or_else(|| io::Error::other("daemon attachment did not reconnect")))
+}
+
+fn pump_attachment(
+    stream: &mut std::os::unix::net::UnixStream,
+    stdin: &mut (impl Read + AsRawFd),
+    stdout: &mut impl Write,
+    input: &mut [u8],
+    size: &mut (u16, u16, u16, u16),
+) -> io::Result<bool> {
     loop {
         let mut descriptors = [
             libc::pollfd {
@@ -74,43 +117,47 @@ pub fn run(shell_id: &str, takeover: bool) -> io::Result<()> {
             }
         }
 
-        if descriptors[0].revents & libc::POLLIN != 0 {
-            let count = stdin.read(&mut input)?;
-            if count == 0 {
-                AttachFrame::Detached.write_to(&mut stream)?;
-                return Ok(());
-            }
-            AttachFrame::Input(input[..count].to_vec()).write_to(&mut stream)?;
-        }
         if descriptors[1].revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR) != 0 {
-            match AttachFrame::read_from(&mut stream) {
+            match AttachFrame::read_from(stream) {
                 Ok(AttachFrame::Output(bytes)) => {
                     stdout.write_all(&bytes)?;
                     stdout.flush()?;
                 }
-                Ok(AttachFrame::Detached) => return Ok(()),
+                Ok(AttachFrame::Detached) => return Ok(false),
+                Ok(AttachFrame::Reconnect) => {
+                    let _ = AttachFrame::ReconnectAck.write_to(stream);
+                    return Ok(true);
+                }
                 Ok(_) => {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "daemon sent an invalid attach frame",
                     ));
                 }
-                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(false),
                 Err(error) => return Err(error),
             }
         }
+        if descriptors[0].revents & libc::POLLIN != 0 {
+            let count = stdin.read(input)?;
+            if count == 0 {
+                AttachFrame::Detached.write_to(stream)?;
+                return Ok(false);
+            }
+            AttachFrame::Input(input[..count].to_vec()).write_to(stream)?;
+        }
 
         if let Ok(new_size) = dimensions()
-            && new_size != size
+            && new_size != *size
         {
-            size = new_size;
+            *size = new_size;
             AttachFrame::Resize {
                 rows: size.0,
                 cols: size.1,
                 pixel_width: size.2,
                 pixel_height: size.3,
             }
-            .write_to(&mut stream)?;
+            .write_to(stream)?;
         }
     }
 }
@@ -151,4 +198,48 @@ fn dimensions() -> io::Result<(u16, u16, u16, u16)> {
         ));
     }
     Ok((size.ws_row, size.ws_col, size.ws_xpixel, size.ws_ypixel))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::net::UnixStream;
+
+    use super::*;
+
+    #[test]
+    fn reconnect_frame_finishes_current_pump_after_flushing_output() {
+        let (mut daemon, mut attachment) = UnixStream::pair().unwrap();
+        let (mut fake_stdin, mut stdin_writer) = UnixStream::pair().unwrap();
+        let sender = thread::spawn(move || {
+            AttachFrame::Output(b"before-reconnect".to_vec())
+                .write_to(&mut daemon)
+                .unwrap();
+            AttachFrame::Reconnect.write_to(&mut daemon).unwrap();
+            assert_eq!(
+                AttachFrame::read_from(&mut daemon).unwrap(),
+                AttachFrame::Input(b"queued-input".to_vec())
+            );
+            assert_eq!(
+                AttachFrame::read_from(&mut daemon).unwrap(),
+                AttachFrame::ReconnectAck
+            );
+        });
+        stdin_writer.write_all(b"queued-input").unwrap();
+        let mut stdout = Vec::new();
+        let mut input = [0; 128];
+        let mut size = (24, 80, 0, 0);
+
+        let reconnect = pump_attachment(
+            &mut attachment,
+            &mut fake_stdin,
+            &mut stdout,
+            &mut input,
+            &mut size,
+        )
+        .unwrap();
+
+        sender.join().unwrap();
+        assert!(reconnect);
+        assert_eq!(stdout, b"before-reconnect");
+    }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,7 @@
 use std::env;
+use std::fs::OpenOptions;
 use std::io;
+use std::os::fd::AsRawFd;
 use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -126,7 +128,7 @@ impl Client {
     pub fn shutdown(&self) -> io::Result<()> {
         expect_ok(self.request(Request::Shutdown)?, Response::Ok)?;
         for _ in 0..SHUTDOWN_ATTEMPTS {
-            if !self.socket_path.exists() {
+            if !self.socket_path.exists() && daemon_lock_available(&self.socket_path)? {
                 return Ok(());
             }
             thread::sleep(CONNECT_DELAY);
@@ -135,6 +137,19 @@ impl Client {
             io::ErrorKind::TimedOut,
             "Boomux daemon did not finish shutting down",
         ))
+    }
+
+    pub fn restart(&self) -> io::Result<()> {
+        expect_ok(self.request(Request::Restart)?, Response::Ok)?;
+        let mut last_error = None;
+        for _ in 0..CONNECT_ATTEMPTS {
+            match self.ping() {
+                Ok(()) => return Ok(()),
+                Err(error) => last_error = Some(error),
+            }
+            thread::sleep(CONNECT_DELAY);
+        }
+        Err(last_error.unwrap_or_else(|| io::Error::other("replacement daemon did not start")))
     }
 
     pub fn snapshot(&self) -> io::Result<Snapshot> {
@@ -280,6 +295,29 @@ impl Client {
             }),
             other => unexpected(other),
         }
+    }
+}
+
+fn daemon_lock_available(socket_path: &Path) -> io::Result<bool> {
+    let lock_path = socket_path
+        .parent()
+        .ok_or_else(|| io::Error::other("daemon socket has no parent"))?
+        .join("daemon.lock");
+    let lock = match OpenOptions::new().read(true).write(true).open(lock_path) {
+        Ok(lock) => lock,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(true),
+        Err(error) => return Err(error),
+    };
+    // The descriptor remains live for both flock operations.
+    if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        let _ = unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_UN) };
+        return Ok(true);
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::EWOULDBLOCK) {
+        Ok(false)
+    } else {
+        Err(error)
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
@@ -51,6 +51,7 @@ pub fn receive_handoff(channel: i32) -> io::Result<()> {
             listener,
             runtime_lock,
             state_lock,
+            runtimes,
         } => {
             let store = StateStore::from_transferred_lock(state_lock)?;
             let socket_path = client::socket_path()?;
@@ -59,6 +60,7 @@ pub fn receive_handoff(channel: i32) -> io::Result<()> {
                 File::from(runtime_lock),
                 SocketCleanup::disarmed(socket_path),
                 store,
+                runtimes,
                 Some(&mut channel),
             )
         }
@@ -86,6 +88,7 @@ pub fn run() -> io::Result<()> {
         daemon_lock,
         socket_cleanup,
         StateStore::from_environment()?,
+        Vec::new(),
         None,
     )
 }
@@ -95,9 +98,11 @@ fn run_daemon(
     daemon_lock: File,
     mut socket_cleanup: SocketCleanup,
     store: StateStore,
+    transferred_runtimes: Vec<handoff::TransferredRuntime>,
     committed: Option<&mut UnixStream>,
 ) -> io::Result<()> {
     let registry = Arc::new(Registry::restore(store)?);
+    let gated_readers = registry.import_runtimes(transferred_runtimes)?;
     if let Some(channel) = committed {
         channel.write_all(&[handoff::PREPARED])?;
         let mut decision = [0];
@@ -106,6 +111,9 @@ fn run_daemon(
             handoff::ABORT => return Ok(()),
             handoff::FINALIZE => {
                 socket_cleanup.arm();
+                for runtime in gated_readers {
+                    runtime.resume_reader()?;
+                }
                 // FINALIZE is the irreversible ownership boundary. Failure to
                 // report COMMITTED must not make the old daemon resume.
                 let _ = channel.write_all(&[handoff::COMMITTED]);
@@ -117,6 +125,11 @@ fn run_daemon(
                 ));
             }
         }
+    } else if !gated_readers.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "transferred runtimes require a handoff commit channel",
+        ));
     }
     let shutdown = Arc::new(AtomicBool::new(false));
     let transition = Arc::new(AtomicU8::new(TRANSITION_IDLE));
@@ -252,25 +265,55 @@ fn launch_replacement(
 ) -> io::Result<()> {
     let _mutation = lock(&registry.mutation_lock)?;
     registry.ensure_running()?;
-    {
-        let state = lock(&registry.state)?;
-        for shell in state.shells.values() {
-            if !matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending) {
-                return Err(io::Error::new(
-                    io::ErrorKind::Unsupported,
-                    "live daemon restart currently requires every shell to be pending",
-                ));
-            }
-        }
-    }
     registry.stopping.store(true, Ordering::Release);
-    let result = launch_replacement_process(
-        listener.as_fd(),
-        daemon_lock.as_fd(),
-        registry.state_lock_descriptor()?,
-    );
+    let mut paused = Vec::new();
+    let result = (|| {
+        registry.quiesce_controllers()?;
+        let state = lock(&registry.state)?;
+        let mut transfers = Vec::new();
+        for shell in state.shells.values() {
+            let (profile, runtime) = match &*lock(&shell.lifecycle)? {
+                ShellLifecycle::Pending => continue,
+                ShellLifecycle::Running { profile, runtime } => {
+                    (profile.clone(), Arc::clone(runtime))
+                }
+                ShellLifecycle::Exited { .. } => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "exited shell runtime transfer is not supported",
+                    ));
+                }
+                ShellLifecycle::Closed => return Err(not_found("shell", &shell.id)),
+            };
+            runtime.pause_reader()?;
+            paused.push(Arc::clone(&runtime));
+            let (pid, pidfd) = lock(&runtime.process)?.transfer_identity()?;
+            let reconstruction = lock(&runtime.terminal)?.reconstruction();
+            transfers.push(OutgoingRuntime {
+                manifest: handoff::RuntimeManifest {
+                    shell_id: shell.id.clone(),
+                    profile,
+                    pid,
+                },
+                runtime,
+                pidfd,
+                reconstruction,
+            });
+        }
+        drop(state);
+        let state_lock = registry.state_lock_descriptor()?;
+        launch_replacement_process(
+            listener.as_fd(),
+            daemon_lock.as_fd(),
+            state_lock,
+            &transfers,
+        )
+    })();
     if result.is_err() {
         registry.stopping.store(false, Ordering::Release);
+        for runtime in paused {
+            let _ = runtime.resume_reader();
+        }
     }
     result
 }
@@ -279,6 +322,7 @@ fn launch_replacement_process(
     listener: BorrowedFd<'_>,
     runtime_lock: BorrowedFd<'_>,
     state_lock: BorrowedFd<'_>,
+    runtimes: &[OutgoingRuntime],
 ) -> io::Result<()> {
     let (mut channel, child_channel) = UnixStream::pair()?;
     let child_channel_fd = child_channel.as_raw_fd();
@@ -311,9 +355,24 @@ fn launch_replacement_process(
 
     let result = (|| {
         channel.write_all(handoff::HEADER)?;
+        protocol::write_message(
+            &mut channel,
+            &handoff::Manifest {
+                runtimes: runtimes
+                    .iter()
+                    .map(|runtime| runtime.manifest.clone())
+                    .collect(),
+            },
+        )?;
         send_descriptor(&channel, listener, handoff::LISTENER_MARKER)?;
         send_descriptor(&channel, runtime_lock, handoff::RUNTIME_LOCK_MARKER)?;
         send_descriptor(&channel, state_lock, handoff::STATE_LOCK_MARKER)?;
+        for runtime in runtimes {
+            let master = lock(&runtime.runtime.master)?;
+            send_descriptor(&channel, master.descriptor.as_fd(), handoff::PTY_MARKER)?;
+            send_descriptor(&channel, runtime.pidfd.as_fd(), handoff::PIDFD_MARKER)?;
+            protocol::write_message(&mut channel, &runtime.reconstruction)?;
+        }
         let mut acknowledgement = [0];
         channel.read_exact(&mut acknowledgement)?;
         if acknowledgement[0] != handoff::READY {
@@ -527,16 +586,39 @@ enum ShellLifecycle {
 struct ShellRuntime {
     control: Mutex<()>,
     master: Mutex<PtyMaster>,
-    child: Mutex<Box<dyn Child + Send + Sync>>,
+    process: Mutex<ManagedProcess>,
     terminal: Mutex<TerminalState>,
     controller: Mutex<Option<Controller>>,
     reader: Mutex<Option<ReaderTask>>,
 }
 
+enum ManagedProcess {
+    Owned(Box<dyn Child + Send + Sync>),
+    Imported(ImportedProcess),
+}
+
+struct ImportedProcess {
+    pid: u32,
+    pidfd: OwnedFd,
+}
+
+struct OutgoingRuntime {
+    manifest: handoff::RuntimeManifest,
+    runtime: Arc<ShellRuntime>,
+    pidfd: OwnedFd,
+    reconstruction: Vec<u8>,
+}
+
 struct Controller {
     token: String,
-    output: SyncSender<Vec<u8>>,
+    output: SyncSender<ControllerOutput>,
     connection: UnixStream,
+    reconnect_ack: Option<SyncSender<()>>,
+}
+
+enum ControllerOutput {
+    Data(Vec<u8>),
+    Reconnect(SyncSender<bool>),
 }
 
 struct PtyMaster {
@@ -559,6 +641,122 @@ enum ReaderCommand {
     },
     Resume,
     Stop,
+}
+
+impl ManagedProcess {
+    fn try_wait_code(&mut self) -> io::Result<Option<Option<u32>>> {
+        match self {
+            Self::Owned(child) => Ok(child.try_wait()?.map(|status| Some(status.exit_code()))),
+            Self::Imported(process) => process.has_exited().map(|exited| exited.then_some(None)),
+        }
+    }
+
+    fn process_id(&self) -> Option<u32> {
+        match self {
+            Self::Owned(child) => child.process_id(),
+            Self::Imported(process) => Some(process.pid),
+        }
+    }
+
+    fn kill(&mut self) -> io::Result<()> {
+        match self {
+            Self::Owned(child) => child.kill(),
+            Self::Imported(process) => process.send_signal(libc::SIGKILL),
+        }
+    }
+
+    fn wait(&mut self) -> io::Result<()> {
+        match self {
+            Self::Owned(child) => child.wait().map(|_| ()),
+            Self::Imported(process) => process.wait(),
+        }
+    }
+
+    fn transfer_identity(&mut self) -> io::Result<(u32, OwnedFd)> {
+        if self.try_wait_code()?.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "exited shell cannot be transferred as a live runtime",
+            ));
+        }
+        match self {
+            Self::Owned(child) => {
+                let pid = child
+                    .process_id()
+                    .ok_or_else(|| io::Error::other("shell process has no PID"))?;
+                Ok((pid, open_pidfd(pid)?))
+            }
+            Self::Imported(process) => Ok((process.pid, process.pidfd.try_clone()?)),
+        }
+    }
+}
+
+fn open_pidfd(pid: u32) -> io::Result<OwnedFd> {
+    // pidfd_open creates a stable kernel reference to the live process.
+    let descriptor = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+    if descriptor == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    // pidfd_open returned a new descriptor with ownership transferred here.
+    Ok(unsafe { OwnedFd::from_raw_fd(descriptor as RawFd) })
+}
+
+impl ImportedProcess {
+    fn has_exited(&self) -> io::Result<bool> {
+        let mut descriptor = libc::pollfd {
+            fd: self.pidfd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // The pollfd points to initialized writable memory for one descriptor.
+        let result = unsafe { libc::poll(&mut descriptor, 1, 0) };
+        if result == -1 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(result > 0 && descriptor.revents & libc::POLLIN != 0)
+        }
+    }
+
+    fn send_signal(&self, signal: libc::c_int) -> io::Result<()> {
+        send_pidfd_signal(self.pidfd.as_fd(), signal)
+    }
+
+    fn wait(&self) -> io::Result<()> {
+        let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+        while Instant::now() < deadline {
+            if self.has_exited()? {
+                return Ok(());
+            }
+            thread::sleep(IO_RETRY_DELAY);
+        }
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("process {} did not exit", self.pid),
+        ))
+    }
+}
+
+fn send_pidfd_signal(pidfd: BorrowedFd<'_>, signal: libc::c_int) -> io::Result<()> {
+    // pidfd_send_signal uses the stable process reference held by pidfd.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_pidfd_send_signal,
+            pidfd.as_raw_fd(),
+            signal,
+            std::ptr::null::<libc::siginfo_t>(),
+            0,
+        )
+    };
+    if result == -1 {
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            Ok(())
+        } else {
+            Err(error)
+        }
+    } else {
+        Ok(())
+    }
 }
 
 impl PtyMaster {
@@ -601,14 +799,6 @@ impl PtyMaster {
             return Err(io::Error::last_os_error());
         }
         Ok(())
-    }
-
-    fn process_group_leader(&self) -> Option<libc::pid_t> {
-        // The descriptor is a live Unix PTY master.
-        match unsafe { libc::tcgetpgrp(self.descriptor.as_raw_fd()) } {
-            pid if pid > 0 => Some(pid),
-            _ => None,
-        }
     }
 
     fn write(&self, bytes: &[u8]) -> io::Result<usize> {
@@ -859,6 +1049,72 @@ impl Registry {
         })
     }
 
+    fn import_runtimes(
+        &self,
+        transferred: Vec<handoff::TransferredRuntime>,
+    ) -> io::Result<Vec<Arc<ShellRuntime>>> {
+        let state = lock(&self.state)?;
+        let mut prepared = Vec::with_capacity(transferred.len());
+        for transferred in transferred {
+            let manifest = transferred.manifest;
+            validate_terminal_profile(&manifest.profile)?;
+            let shell = state
+                .shells
+                .get(&manifest.shell_id)
+                .cloned()
+                .ok_or_else(|| not_found("persisted shell", &manifest.shell_id))?;
+            if !matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "transferred shell is not pending in restored metadata",
+                ));
+            }
+            let stat = fs::read_to_string(format!("/proc/{}/stat", manifest.pid))?;
+            if proc_session_id(&stat) != Some(manifest.pid as libc::pid_t) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "transferred process is not its session leader",
+                ));
+            }
+            let process = ImportedProcess {
+                pid: manifest.pid,
+                pidfd: transferred.pidfd,
+            };
+            if process.has_exited()? {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "transferred process exited before import",
+                ));
+            }
+            let master = PtyMaster::from_descriptor(transferred.pty)?;
+            let reader = master.try_clone_reader()?;
+            let mut terminal = TerminalState::new(manifest.profile.rows, manifest.profile.cols);
+            terminal.process(&transferred.reconstruction);
+            let runtime = Arc::new(ShellRuntime {
+                control: Mutex::new(()),
+                master: Mutex::new(master),
+                process: Mutex::new(ManagedProcess::Imported(process)),
+                terminal: Mutex::new(terminal),
+                controller: Mutex::new(None),
+                reader: Mutex::new(None),
+            });
+            prepared.push((shell, manifest.profile, runtime, reader));
+        }
+        drop(state);
+
+        let mut readers = Vec::with_capacity(prepared.len());
+        for (shell, profile, runtime, reader) in prepared {
+            *lock(&shell.last_profile)? = Some(profile.clone());
+            *lock(&shell.lifecycle)? = ShellLifecycle::Running {
+                profile,
+                runtime: Arc::clone(&runtime),
+            };
+            start_pty_reader(shell, Arc::clone(&runtime), reader, true)?;
+            readers.push(runtime);
+        }
+        Ok(readers)
+    }
+
     fn durable_mutation<T>(&self, operation: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
         let _mutation = lock(&self.mutation_lock)?;
         self.ensure_running()?;
@@ -887,6 +1143,77 @@ impl Registry {
         } else {
             Ok(())
         }
+    }
+
+    fn quiesce_controllers(&self) -> io::Result<()> {
+        let runtimes = {
+            let state = lock(&self.state)?;
+            let mut runtimes = Vec::new();
+            for shell in state.shells.values() {
+                if let ShellLifecycle::Running { runtime, .. } = &*lock(&shell.lifecycle)? {
+                    runtimes.push(Arc::clone(runtime));
+                }
+            }
+            runtimes
+        };
+        let mut acknowledgements = Vec::new();
+        for runtime in &runtimes {
+            let mut controller = lock(&runtime.controller)?;
+            let Some(current) = controller.as_mut() else {
+                continue;
+            };
+            let (written, write_acknowledged) = mpsc::sync_channel(1);
+            let (client_acknowledge, client_acknowledged) = mpsc::sync_channel(1);
+            current.reconnect_ack = Some(client_acknowledge);
+            match current
+                .output
+                .try_send(ControllerOutput::Reconnect(written))
+            {
+                Ok(()) => acknowledgements.push((write_acknowledged, client_acknowledged)),
+                Err(TrySendError::Disconnected(_)) => {
+                    if let Some(current) = controller.take() {
+                        let _ = current.connection.shutdown(std::net::Shutdown::Both);
+                    }
+                }
+                Err(TrySendError::Full(_)) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "active controller output queue is full",
+                    ));
+                }
+            }
+        }
+
+        for (written, client_acknowledged) in acknowledgements {
+            if !written.recv_timeout(HANDSHAKE_TIMEOUT).unwrap_or(false) {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "active controller did not receive reconnect request",
+                ));
+            }
+            if client_acknowledged.recv_timeout(HANDSHAKE_TIMEOUT).is_err() {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "active controller did not acknowledge reconnect request",
+                ));
+            }
+        }
+
+        let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+        while Instant::now() < deadline {
+            let mut active = false;
+            for runtime in &runtimes {
+                active |= lock(&runtime.controller)?.is_some();
+            }
+            if !active {
+                return Ok(());
+            }
+            thread::sleep(IO_RETRY_DELAY);
+        }
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "active controllers did not reconnect",
+        ))
     }
 
     fn state_lock_descriptor(&self) -> io::Result<BorrowedFd<'_>> {
@@ -1336,35 +1663,31 @@ impl Shell {
         }
         runtime.pause_reader()?;
         let result = (|| {
-            let foreground_group = lock(&runtime.master)?.process_group_leader();
-            let mut child = lock(&runtime.child)?;
-            if child.try_wait()?.is_some() {
-                return Ok(());
-            }
-            let child_pid = child.process_id().map(|pid| pid as libc::pid_t);
+            let mut process = lock(&runtime.process)?;
+            let exited = process.try_wait_code()?.is_some();
+            let child_pid = process.process_id().map(|pid| pid as libc::pid_t);
             if let Some(session_id) = child_pid {
                 signal_session(session_id, libc::SIGHUP);
-            }
-            for process_group in [foreground_group, child_pid].into_iter().flatten() {
-                // Negative PIDs address a process group. portable-pty starts the
-                // child as a session and process-group leader on Unix.
-                let _ = unsafe { libc::kill(-process_group, libc::SIGHUP) };
             }
             thread::sleep(SHUTDOWN_GRACE);
             if let Some(session_id) = child_pid {
                 signal_session(session_id, libc::SIGTERM);
             }
-            let kill_result = child.kill();
+            let kill_result = if exited { Ok(()) } else { process.kill() };
             thread::sleep(SHUTDOWN_GRACE);
             if let Some(session_id) = child_pid {
                 signal_session(session_id, libc::SIGKILL);
             }
-            let wait_result = child.wait();
-            match (kill_result, wait_result) {
-                (_, Ok(_)) => Ok(()),
+            let wait_result = if exited { Ok(()) } else { process.wait() };
+            let result = match (kill_result, wait_result) {
+                (_, Ok(())) => Ok(()),
                 (Err(error), Err(_)) => Err(error),
                 (Ok(()), Err(error)) => Err(error),
+            };
+            if let Some(session_id) = child_pid {
+                wait_for_session_descendants(session_id)?;
             }
+            result
         })();
         if let Err(error) = result {
             runtime.resume_reader()?;
@@ -1496,7 +1819,7 @@ fn spawn_runtime(
         Arc::new(ShellRuntime {
             control: Mutex::new(()),
             master: Mutex::new(master),
-            child: Mutex::new(child),
+            process: Mutex::new(ManagedProcess::Owned(child)),
             terminal: Mutex::new(TerminalState::new(profile.rows, profile.cols)),
             controller: Mutex::new(None),
             reader: Mutex::new(None),
@@ -1509,128 +1832,135 @@ fn start_pty_reader(
     shell: Arc<Shell>,
     runtime: Arc<ShellRuntime>,
     mut reader: PtyReader,
+    start_paused: bool,
 ) -> io::Result<()> {
     let (commands, command_receiver) = mpsc::channel();
     let reader_runtime = Arc::clone(&runtime);
-    let handle = thread::spawn(move || {
-        let mut buffer = [0; 16 * 1024];
-        let mut stopped = false;
-        let mut paused = false;
-        let mut pause_cancellation: Option<Arc<AtomicBool>> = None;
-        loop {
-            if paused {
-                if pause_cancellation
-                    .as_ref()
-                    .is_some_and(|cancelled| cancelled.load(Ordering::Acquire))
-                {
-                    paused = false;
-                    pause_cancellation = None;
+    let handle = thread::Builder::new()
+        .name(format!("boomux-pty-{}", shell.id))
+        .spawn(move || {
+            let mut buffer = [0; 16 * 1024];
+            let mut stopped = false;
+            let mut paused = start_paused;
+            let mut pause_cancellation: Option<Arc<AtomicBool>> = None;
+            loop {
+                if paused {
+                    if pause_cancellation
+                        .as_ref()
+                        .is_some_and(|cancelled| cancelled.load(Ordering::Acquire))
+                    {
+                        paused = false;
+                        pause_cancellation = None;
+                        continue;
+                    }
+                    match command_receiver.recv_timeout(IO_RETRY_DELAY) {
+                        Ok(ReaderCommand::Pause {
+                            acknowledge,
+                            cancelled,
+                        }) => {
+                            if !cancelled.load(Ordering::Acquire) {
+                                let _ = acknowledge.send(());
+                            }
+                        }
+                        Ok(ReaderCommand::Resume) => {
+                            paused = false;
+                            pause_cancellation = None;
+                        }
+                        Ok(ReaderCommand::Stop) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                            stopped = true;
+                            break;
+                        }
+                        Err(mpsc::RecvTimeoutError::Timeout) => {}
+                    }
                     continue;
                 }
-                match command_receiver.recv_timeout(IO_RETRY_DELAY) {
+                match command_receiver.try_recv() {
                     Ok(ReaderCommand::Pause {
                         acknowledge,
                         cancelled,
                     }) => {
-                        if !cancelled.load(Ordering::Acquire) {
-                            let _ = acknowledge.send(());
+                        if cancelled.load(Ordering::Acquire) {
+                            continue;
                         }
+                        paused = true;
+                        pause_cancellation = Some(Arc::clone(&cancelled));
+                        if acknowledge.send(()).is_err() || cancelled.load(Ordering::Acquire) {
+                            paused = false;
+                            pause_cancellation = None;
+                        }
+                        continue;
                     }
-                    Ok(ReaderCommand::Resume) => {
-                        paused = false;
-                        pause_cancellation = None;
-                    }
-                    Ok(ReaderCommand::Stop) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    Ok(ReaderCommand::Resume) => continue,
+                    Ok(ReaderCommand::Stop) | Err(mpsc::TryRecvError::Disconnected) => {
                         stopped = true;
                         break;
                     }
-                    Err(mpsc::RecvTimeoutError::Timeout) => {}
+                    Err(mpsc::TryRecvError::Empty) => {}
                 }
-                continue;
-            }
-            match command_receiver.try_recv() {
-                Ok(ReaderCommand::Pause {
-                    acknowledge,
-                    cancelled,
-                }) => {
-                    if cancelled.load(Ordering::Acquire) {
-                        continue;
-                    }
-                    paused = true;
-                    pause_cancellation = Some(Arc::clone(&cancelled));
-                    if acknowledge.send(()).is_err() || cancelled.load(Ordering::Acquire) {
-                        paused = false;
-                        pause_cancellation = None;
-                    }
-                    continue;
-                }
-                Ok(ReaderCommand::Resume) => continue,
-                Ok(ReaderCommand::Stop) | Err(mpsc::TryRecvError::Disconnected) => {
-                    stopped = true;
-                    break;
-                }
-                Err(mpsc::TryRecvError::Empty) => {}
-            }
-            match reader.read(&mut buffer) {
-                Ok(0) => break,
-                Ok(count) => {
-                    let bytes = &buffer[..count];
-                    if let Ok(mut terminal) = reader_runtime.terminal.lock() {
-                        terminal.process(bytes);
-                        if let Ok(mut controller) = reader_runtime.controller.lock() {
-                            let disconnect = controller.as_ref().is_some_and(|current| {
-                                matches!(
-                                    current.output.try_send(bytes.to_vec()),
-                                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_))
-                                )
-                            });
-                            if disconnect && let Some(current) = controller.take() {
-                                let _ = current.connection.shutdown(std::net::Shutdown::Both);
+                match reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(count) => {
+                        let bytes = &buffer[..count];
+                        if let Ok(mut terminal) = reader_runtime.terminal.lock() {
+                            terminal.process(bytes);
+                            if let Ok(mut controller) = reader_runtime.controller.lock() {
+                                let disconnect = controller.as_ref().is_some_and(|current| {
+                                    matches!(
+                                        current
+                                            .output
+                                            .try_send(ControllerOutput::Data(bytes.to_vec())),
+                                        Err(TrySendError::Full(_) | TrySendError::Disconnected(_))
+                                    )
+                                });
+                                if disconnect && let Some(current) = controller.take() {
+                                    let _ = current.connection.shutdown(std::net::Shutdown::Both);
+                                }
                             }
                         }
                     }
-                }
-                Err(error)
-                    if matches!(
-                        error.kind(),
-                        io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
-                    ) =>
-                {
-                    if error.kind() == io::ErrorKind::WouldBlock {
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        let process_exited = reader_runtime
+                            .process
+                            .lock()
+                            .ok()
+                            .and_then(|mut process| process.try_wait_code().ok())
+                            .flatten()
+                            .is_some();
+                        if process_exited {
+                            break;
+                        }
                         thread::sleep(IO_RETRY_DELAY);
                     }
-                    continue;
+                    Err(_) => break,
                 }
-                Err(_) => break,
             }
-        }
-        if stopped {
-            return;
-        }
-        let code = reader_runtime
-            .child
-            .lock()
-            .ok()
-            .and_then(|mut child| child.try_wait().ok().flatten())
-            .map(|status| status.exit_code());
-        if let Ok(mut lifecycle) = shell.lifecycle.lock()
-            && let ShellLifecycle::Running {
-                profile,
-                runtime: current,
-            } = &*lifecycle
-            && Arc::ptr_eq(current, &reader_runtime)
-        {
-            *lifecycle = ShellLifecycle::Exited {
-                code,
-                profile: profile.clone(),
-                runtime: Arc::clone(&reader_runtime),
-            };
-        }
-        let _ = reader_runtime
-            .controller
-            .lock()
-            .map(|mut controller| controller.take());
-    });
+            if stopped {
+                return;
+            }
+            let code = reader_runtime
+                .process
+                .lock()
+                .ok()
+                .and_then(|mut process| process.try_wait_code().ok().flatten().flatten());
+            if let Ok(mut lifecycle) = shell.lifecycle.lock()
+                && let ShellLifecycle::Running {
+                    profile,
+                    runtime: current,
+                } = &*lifecycle
+                && Arc::ptr_eq(current, &reader_runtime)
+            {
+                *lifecycle = ShellLifecycle::Exited {
+                    code,
+                    profile: profile.clone(),
+                    runtime: Arc::clone(&reader_runtime),
+                };
+            }
+            let _ = reader_runtime
+                .controller
+                .lock()
+                .map(|mut controller| controller.take());
+        })?;
     *lock(&runtime.reader)? = Some(ReaderTask { commands, handle });
     Ok(())
 }
@@ -1715,7 +2045,7 @@ fn handle_attach(
             };
             *lock(&shell.last_profile)? = Some(profile.clone());
             started = true;
-            start_pty_reader(Arc::clone(&shell), runtime, reader)?;
+            start_pty_reader(Arc::clone(&shell), runtime, reader, false)?;
         }
         match &*lifecycle {
             ShellLifecycle::Running { profile, runtime } => {
@@ -1779,6 +2109,7 @@ fn handle_attach(
     }
     if running {
         lock(&runtime.master)?.resize(profile_size(&profile))?;
+        update_runtime_dimensions(&shell, &runtime, profile_size(&profile))?;
     }
     lock(&runtime.terminal)?.resize(profile.rows, profile.cols);
     // Keep terminal state locked until the controller is installed so the
@@ -1818,21 +2149,40 @@ fn handle_attach(
             token: token.clone(),
             output,
             connection,
+            reconnect_ack: None,
         });
     }
     let mut output_stream = stream.try_clone()?;
     let output_runtime = Arc::clone(&runtime);
     let output_token = token.clone();
     thread::spawn(move || {
-        for bytes in receiver {
-            if AttachFrame::Output(bytes)
-                .write_to(&mut output_stream)
-                .is_err()
-            {
-                break;
+        let mut reconnect = false;
+        while let Ok(output) = receiver.recv() {
+            match output {
+                ControllerOutput::Data(bytes) => {
+                    if AttachFrame::Output(bytes)
+                        .write_to(&mut output_stream)
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                ControllerOutput::Reconnect(acknowledge) => {
+                    reconnect = true;
+                    let result = AttachFrame::Reconnect.write_to(&mut output_stream);
+                    let _ = acknowledge.send(result.is_ok());
+                    if result.is_ok() {
+                        while receiver.recv().is_ok() {}
+                    }
+                    break;
+                }
             }
         }
-        let _ = AttachFrame::Detached.write_to(&mut output_stream);
+        if reconnect {
+            let _ = output_stream.shutdown(std::net::Shutdown::Both);
+        } else {
+            let _ = AttachFrame::Detached.write_to(&mut output_stream);
+        }
         let _ = output_runtime.release_controller(&output_token);
     });
     drop(lifecycle);
@@ -1848,6 +2198,19 @@ fn handle_attach(
                 return Err(error);
             }
         };
+        if matches!(frame, AttachFrame::ReconnectAck) {
+            let acknowledge = {
+                let mut controller = lock(&runtime.controller)?;
+                controller
+                    .as_mut()
+                    .filter(|controller| controller.token == token)
+                    .and_then(|controller| controller.reconnect_ack.take())
+            };
+            if let Some(acknowledge) = acknowledge {
+                let _ = acknowledge.send(());
+            }
+            break;
+        }
         if let AttachFrame::Input(bytes) = frame {
             if !write_controller_input(&runtime, &token, &bytes)? {
                 break;
@@ -1872,13 +2235,15 @@ fn handle_attach(
                 if let Err(error) = validate_terminal_dimensions(rows, cols) {
                     Err(error)
                 } else {
-                    lock(&runtime.master)?.resize(PtySize {
+                    let size = PtySize {
                         rows,
                         cols,
                         pixel_width,
                         pixel_height,
-                    })?;
+                    };
+                    lock(&runtime.master)?.resize(size)?;
                     lock(&runtime.terminal)?.resize(rows, cols);
+                    update_runtime_dimensions(&shell, &runtime, size)?;
                     Ok(())
                 }
             }
@@ -1886,10 +2251,12 @@ fn handle_attach(
                 drop(control);
                 break;
             }
-            AttachFrame::Output(_) => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "client sent output frame",
-            )),
+            AttachFrame::Output(_) | AttachFrame::Reconnect | AttachFrame::ReconnectAck => {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "client sent a daemon-only attach frame",
+                ))
+            }
         };
         if let Err(error) = result {
             runtime.release_controller(&token)?;
@@ -1931,6 +2298,31 @@ fn profile_size(profile: &TerminalProfile) -> PtySize {
         pixel_width: profile.pixel_width,
         pixel_height: profile.pixel_height,
     }
+}
+
+fn update_runtime_dimensions(
+    shell: &Shell,
+    runtime: &Arc<ShellRuntime>,
+    size: PtySize,
+) -> io::Result<()> {
+    let mut lifecycle = lock(&shell.lifecycle)?;
+    let profile = match &mut *lifecycle {
+        ShellLifecycle::Running {
+            profile,
+            runtime: current,
+        }
+        | ShellLifecycle::Exited {
+            profile,
+            runtime: current,
+            ..
+        } if Arc::ptr_eq(current, runtime) => profile,
+        _ => return Ok(()),
+    };
+    profile.rows = size.rows;
+    profile.cols = size.cols;
+    profile.pixel_width = size.pixel_width;
+    profile.pixel_height = size.pixel_height;
+    Ok(())
 }
 
 fn validate_terminal_profile(profile: &TerminalProfile) -> io::Result<()> {
@@ -1994,9 +2386,24 @@ fn validate_name(name: &str) -> io::Result<()> {
 }
 
 fn signal_session(session_id: libc::pid_t, signal: libc::c_int) {
+    for pid in session_processes(session_id) {
+        let Ok(pidfd) = open_pidfd(pid as u32) else {
+            continue;
+        };
+        let Ok(stat) = fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            continue;
+        };
+        if proc_session_id(&stat) == Some(session_id) {
+            let _ = send_pidfd_signal(pidfd.as_fd(), signal);
+        }
+    }
+}
+
+fn session_processes(session_id: libc::pid_t) -> Vec<libc::pid_t> {
     let Ok(entries) = fs::read_dir("/proc") else {
-        return;
+        return Vec::new();
     };
+    let mut processes = Vec::new();
     for entry in entries.flatten() {
         let Some(pid) = entry
             .file_name()
@@ -2009,10 +2416,30 @@ fn signal_session(session_id: libc::pid_t, signal: libc::c_int) {
             continue;
         };
         if proc_session_id(&stat) == Some(session_id) {
-            // PIDs came from procfs and the signal carries no pointer data.
-            let _ = unsafe { libc::kill(pid, signal) };
+            processes.push(pid);
         }
     }
+    processes
+}
+
+fn wait_for_session_descendants(session_id: libc::pid_t) -> io::Result<()> {
+    let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+    while Instant::now() < deadline {
+        let has_descendants = session_processes(session_id)
+            .into_iter()
+            .any(|pid| pid != session_id);
+        if !has_descendants {
+            return Ok(());
+        }
+        // Repeat the final pass so descendants forked during an earlier scan
+        // cannot escape session cleanup.
+        signal_session(session_id, libc::SIGKILL);
+        thread::sleep(IO_RETRY_DELAY);
+    }
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("session {session_id} still has descendant processes"),
+    ))
 }
 
 fn proc_session_id(stat: &str) -> Option<libc::pid_t> {
@@ -2196,7 +2623,7 @@ mod tests {
             profile: terminal_profile,
             runtime: Arc::clone(&runtime),
         };
-        start_pty_reader(Arc::clone(&shell), Arc::clone(&runtime), reader).unwrap();
+        start_pty_reader(Arc::clone(&shell), Arc::clone(&runtime), reader, false).unwrap();
 
         runtime.pause_reader().unwrap();
         lock(&runtime.master).unwrap().write(b"paused\n").unwrap();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,22 +2,26 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::mpsc::{self, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 use uuid::Uuid;
 
 use crate::client;
+use crate::fd_transfer::send_descriptor;
+use crate::handoff;
 use crate::protocol::{
     self, AttachFrame, Envelope, Request, Response, ShellSnapshot, ShellSpec, ShellStatus,
     Snapshot, TerminalProfile, WorkspaceSnapshot,
@@ -28,12 +32,38 @@ use crate::terminal_state::TerminalState;
 const CONTROLLER_QUEUE: usize = 64;
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(50);
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+const RESTART_TIMEOUT: Duration = Duration::from_secs(10);
 const IO_RETRY_DELAY: Duration = Duration::from_millis(2);
 const MAX_TERMINAL_ENV_VALUE: usize = 256;
 const MAX_TERMINAL_ROWS: u16 = 1_000;
 const MAX_TERMINAL_COLS: u16 = 1_000;
 const MAX_TERMINAL_CELLS: usize = 1_000_000;
 const MAX_SHELL_READ_BYTES: usize = 1024 * 1024;
+const TRANSITION_IDLE: u8 = 0;
+const TRANSITION_RESTART: u8 = 1;
+const TRANSITION_SHUTDOWN: u8 = 2;
+
+pub fn receive_handoff(channel: i32) -> io::Result<()> {
+    match handoff::receive_bootstrap(channel)? {
+        handoff::Bootstrap::Aborted => Ok(()),
+        handoff::Bootstrap::Committed {
+            mut channel,
+            listener,
+            runtime_lock,
+            state_lock,
+        } => {
+            let store = StateStore::from_transferred_lock(state_lock)?;
+            let socket_path = client::socket_path()?;
+            run_daemon(
+                listener,
+                File::from(runtime_lock),
+                SocketCleanup::disarmed(socket_path),
+                store,
+                Some(&mut channel),
+            )
+        }
+    }
+}
 
 pub fn run() -> io::Result<()> {
     let socket_path = client::socket_path()?;
@@ -41,27 +71,86 @@ pub fn run() -> io::Result<()> {
         .parent()
         .ok_or_else(|| io::Error::other("socket path has no parent"))?;
     secure_runtime_dir(runtime_dir)?;
-    let _daemon_lock = acquire_daemon_lock(runtime_dir)?;
+    let daemon_lock = acquire_daemon_lock(runtime_dir)?;
 
     if socket_path.exists() {
         fs::remove_file(&socket_path)?;
     }
 
     let listener = UnixListener::bind(&socket_path)?;
-    let _socket_cleanup = SocketCleanup(socket_path.clone());
+    let socket_cleanup = SocketCleanup::new(socket_path.clone());
     fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o600))?;
     listener.set_nonblocking(true)?;
-    let registry = Arc::new(Registry::restore(StateStore::from_environment()?)?);
+    run_daemon(
+        listener,
+        daemon_lock,
+        socket_cleanup,
+        StateStore::from_environment()?,
+        None,
+    )
+}
+
+fn run_daemon(
+    listener: UnixListener,
+    daemon_lock: File,
+    mut socket_cleanup: SocketCleanup,
+    store: StateStore,
+    committed: Option<&mut UnixStream>,
+) -> io::Result<()> {
+    let registry = Arc::new(Registry::restore(store)?);
+    if let Some(channel) = committed {
+        channel.write_all(&[handoff::PREPARED])?;
+        let mut decision = [0];
+        channel.read_exact(&mut decision)?;
+        match decision[0] {
+            handoff::ABORT => return Ok(()),
+            handoff::FINALIZE => {
+                socket_cleanup.arm();
+                // FINALIZE is the irreversible ownership boundary. Failure to
+                // report COMMITTED must not make the old daemon resume.
+                let _ = channel.write_all(&[handoff::COMMITTED]);
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "replacement daemon received an invalid final decision",
+                ));
+            }
+        }
+    }
     let shutdown = Arc::new(AtomicBool::new(false));
+    let transition = Arc::new(AtomicU8::new(TRANSITION_IDLE));
+    let (restart_sender, restart_receiver) = mpsc::channel::<RestartRequest>();
     let mut handlers = Vec::new();
+    let mut handed_off = false;
 
     while !shutdown.load(Ordering::Acquire) {
+        match restart_receiver.try_recv() {
+            Ok(request) => {
+                let result = launch_replacement(&listener, &daemon_lock, &registry);
+                if result.is_ok() {
+                    handed_off = true;
+                    shutdown.store(true, Ordering::Release);
+                } else {
+                    transition.store(TRANSITION_IDLE, Ordering::Release);
+                }
+                let _ = request.reply.send(result);
+                continue;
+            }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                return Err(io::Error::other("restart control channel closed"));
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
+        }
         match listener.accept() {
             Ok((stream, _)) => {
                 let registry = Arc::clone(&registry);
                 let shutdown = Arc::clone(&shutdown);
+                let transition = Arc::clone(&transition);
+                let restart_sender = restart_sender.clone();
                 handlers.push(thread::spawn(move || {
-                    let _ = handle_connection(stream, registry, shutdown);
+                    let _ =
+                        handle_connection(stream, registry, shutdown, transition, restart_sender);
                 }));
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
@@ -74,19 +163,51 @@ pub fn run() -> io::Result<()> {
     for handler in handlers {
         let _ = handler.join();
     }
-    let result = registry.shutdown();
+    let result = if handed_off {
+        socket_cleanup.disarm();
+        Ok(())
+    } else {
+        registry.shutdown()
+    };
     drop(registry);
     drop(listener);
-    drop(_daemon_lock);
-    drop(_socket_cleanup);
+    drop(socket_cleanup);
+    drop(daemon_lock);
     result
 }
 
-struct SocketCleanup(PathBuf);
+struct RestartRequest {
+    reply: SyncSender<io::Result<()>>,
+}
+
+struct SocketCleanup {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl SocketCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn disarmed(path: PathBuf) -> Self {
+        Self { path, armed: false }
+    }
+
+    fn arm(&mut self) {
+        self.armed = true;
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
 
 impl Drop for SocketCleanup {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.0);
+        if self.armed {
+            let _ = fs::remove_file(&self.path);
+        }
     }
 }
 
@@ -124,10 +245,111 @@ fn acquire_daemon_lock(runtime_dir: &Path) -> io::Result<File> {
     Ok(lock_file)
 }
 
+fn launch_replacement(
+    listener: &UnixListener,
+    daemon_lock: &File,
+    registry: &Registry,
+) -> io::Result<()> {
+    let _mutation = lock(&registry.mutation_lock)?;
+    registry.ensure_running()?;
+    {
+        let state = lock(&registry.state)?;
+        for shell in state.shells.values() {
+            if !matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending) {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "live daemon restart currently requires every shell to be pending",
+                ));
+            }
+        }
+    }
+    registry.stopping.store(true, Ordering::Release);
+    let result = launch_replacement_process(
+        listener.as_fd(),
+        daemon_lock.as_fd(),
+        registry.state_lock_descriptor()?,
+    );
+    if result.is_err() {
+        registry.stopping.store(false, Ordering::Release);
+    }
+    result
+}
+
+fn launch_replacement_process(
+    listener: BorrowedFd<'_>,
+    runtime_lock: BorrowedFd<'_>,
+    state_lock: BorrowedFd<'_>,
+) -> io::Result<()> {
+    let (mut channel, child_channel) = UnixStream::pair()?;
+    let child_channel_fd = child_channel.as_raw_fd();
+    let mut command = Command::new(env::current_exe()?);
+    command
+        .args([
+            "daemon",
+            "receive-handoff",
+            "--channel",
+            &handoff::CHANNEL_FD.to_string(),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // Only async-signal-safe descriptor operations run between fork and exec.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::dup2(child_channel_fd, handoff::CHANNEL_FD) == -1
+                || libc::fcntl(handoff::CHANNEL_FD, libc::F_SETFD, 0) == -1
+            {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut replacement = command.spawn()?;
+    drop(child_channel);
+    channel.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    channel.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
+
+    let result = (|| {
+        channel.write_all(handoff::HEADER)?;
+        send_descriptor(&channel, listener, handoff::LISTENER_MARKER)?;
+        send_descriptor(&channel, runtime_lock, handoff::RUNTIME_LOCK_MARKER)?;
+        send_descriptor(&channel, state_lock, handoff::STATE_LOCK_MARKER)?;
+        let mut acknowledgement = [0];
+        channel.read_exact(&mut acknowledgement)?;
+        if acknowledgement[0] != handoff::READY {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "replacement daemon did not acknowledge bootstrap readiness",
+            ));
+        }
+        channel.write_all(&[handoff::COMMIT])?;
+        channel.read_exact(&mut acknowledgement)?;
+        if acknowledgement[0] != handoff::PREPARED {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "replacement daemon did not prepare ownership",
+            ));
+        }
+        // A successful one-byte FINALIZE write is the irreversible boundary.
+        // From this point the old daemon must exit even if the final ACK is lost.
+        channel.write_all(&[handoff::FINALIZE])?;
+        let _ = channel.read_exact(&mut acknowledgement);
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = channel.write_all(&[handoff::ABORT]);
+        let _ = replacement.kill();
+        let _ = replacement.wait();
+    }
+    result
+}
+
 fn handle_connection(
     mut stream: UnixStream,
     registry: Arc<Registry>,
     shutdown: Arc<AtomicBool>,
+    transition: Arc<AtomicU8>,
+    restart_sender: mpsc::Sender<RestartRequest>,
 ) -> io::Result<()> {
     stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
     let request: Envelope<Request> = protocol::read_message(&mut stream)?;
@@ -154,15 +376,72 @@ fn handle_connection(
         return handle_attach(stream, &registry, &shell_id, takeover, profile);
     }
     if matches!(request.message, Request::Shutdown) {
+        if transition
+            .compare_exchange(
+                TRANSITION_IDLE,
+                TRANSITION_SHUTDOWN,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return send_response(
+                &mut stream,
+                Response::Error {
+                    message: "another daemon transition is already in progress".into(),
+                },
+            );
+        }
         return match registry.shutdown() {
             Ok(()) => {
                 shutdown.store(true, Ordering::Release);
                 send_response(&mut stream, Response::Ok)
             }
+            Err(error) => {
+                transition.store(TRANSITION_IDLE, Ordering::Release);
+                send_response(
+                    &mut stream,
+                    Response::Error {
+                        message: format!("could not stop Boomux daemon: {error}"),
+                    },
+                )
+            }
+        };
+    }
+    if matches!(request.message, Request::Restart) {
+        if transition
+            .compare_exchange(
+                TRANSITION_IDLE,
+                TRANSITION_RESTART,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return send_response(
+                &mut stream,
+                Response::Error {
+                    message: "daemon restart is already in progress".into(),
+                },
+            );
+        }
+        let (reply, response) = mpsc::sync_channel(1);
+        if restart_sender.send(RestartRequest { reply }).is_err() {
+            transition.store(TRANSITION_IDLE, Ordering::Release);
+            return Err(io::Error::other("daemon restart coordinator stopped"));
+        }
+        return match response.recv_timeout(RESTART_TIMEOUT) {
+            Ok(Ok(())) => send_response(&mut stream, Response::Ok),
+            Ok(Err(error)) => send_response(
+                &mut stream,
+                Response::Error {
+                    message: error.to_string(),
+                },
+            ),
             Err(error) => send_response(
                 &mut stream,
                 Response::Error {
-                    message: format!("could not stop Boomux daemon: {error}"),
+                    message: format!("daemon restart timed out: {error}"),
                 },
             ),
         };
@@ -247,11 +526,11 @@ enum ShellLifecycle {
 
 struct ShellRuntime {
     control: Mutex<()>,
-    master: Mutex<Box<dyn MasterPty + Send>>,
-    writer: Mutex<Box<dyn Write + Send>>,
+    master: Mutex<PtyMaster>,
     child: Mutex<Box<dyn Child + Send + Sync>>,
     terminal: Mutex<TerminalState>,
     controller: Mutex<Option<Controller>>,
+    reader: Mutex<Option<ReaderTask>>,
 }
 
 struct Controller {
@@ -260,10 +539,203 @@ struct Controller {
     connection: UnixStream,
 }
 
+struct PtyMaster {
+    descriptor: OwnedFd,
+}
+
+struct PtyReader {
+    descriptor: OwnedFd,
+}
+
+struct ReaderTask {
+    commands: mpsc::Sender<ReaderCommand>,
+    handle: thread::JoinHandle<()>,
+}
+
+enum ReaderCommand {
+    Pause {
+        acknowledge: SyncSender<()>,
+        cancelled: Arc<AtomicBool>,
+    },
+    Resume,
+    Stop,
+}
+
+impl PtyMaster {
+    fn duplicate(master: &dyn MasterPty) -> io::Result<Self> {
+        let descriptor = master
+            .as_raw_fd()
+            .ok_or_else(|| io::Error::other("PTY master does not expose a file descriptor"))?;
+        // F_DUPFD_CLOEXEC creates an independently owned descriptor for the
+        // same PTY open file description.
+        let duplicated = unsafe { libc::fcntl(descriptor, libc::F_DUPFD_CLOEXEC, 0) };
+        if duplicated == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        // fcntl returned a new descriptor whose ownership transfers here.
+        let descriptor = unsafe { OwnedFd::from_raw_fd(duplicated) };
+        Self::from_descriptor(descriptor)
+    }
+
+    fn from_descriptor(descriptor: OwnedFd) -> io::Result<Self> {
+        let master = Self { descriptor };
+        master.set_nonblocking()?;
+        Ok(master)
+    }
+
+    fn try_clone_reader(&self) -> io::Result<PtyReader> {
+        Ok(PtyReader {
+            descriptor: self.descriptor.try_clone()?,
+        })
+    }
+
+    fn resize(&self, size: PtySize) -> io::Result<()> {
+        let size = libc::winsize {
+            ws_row: size.rows,
+            ws_col: size.cols,
+            ws_xpixel: size.pixel_width,
+            ws_ypixel: size.pixel_height,
+        };
+        // The descriptor is a live Unix PTY master and `size` is initialized.
+        if unsafe { libc::ioctl(self.descriptor.as_raw_fd(), libc::TIOCSWINSZ, &size) } == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    fn process_group_leader(&self) -> Option<libc::pid_t> {
+        // The descriptor is a live Unix PTY master.
+        match unsafe { libc::tcgetpgrp(self.descriptor.as_raw_fd()) } {
+            pid if pid > 0 => Some(pid),
+            _ => None,
+        }
+    }
+
+    fn write(&self, bytes: &[u8]) -> io::Result<usize> {
+        // The byte slice is valid for the duration of this write.
+        let result = unsafe {
+            libc::write(
+                self.descriptor.as_raw_fd(),
+                bytes.as_ptr().cast(),
+                bytes.len(),
+            )
+        };
+        if result == -1 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(result as usize)
+        }
+    }
+
+    fn set_nonblocking(&self) -> io::Result<()> {
+        let descriptor = self.descriptor.as_raw_fd();
+        // fcntl only reads and updates status flags for this live descriptor.
+        let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+        if flags == -1
+            || unsafe { libc::fcntl(descriptor, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+impl Read for PtyReader {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        // The mutable slice is valid for the duration of this read.
+        let result = unsafe {
+            libc::read(
+                self.descriptor.as_raw_fd(),
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+            )
+        };
+        if result == -1 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::EIO) {
+                Ok(0)
+            } else {
+                Err(error)
+            }
+        } else {
+            Ok(result as usize)
+        }
+    }
+}
+
+impl ReaderTask {
+    fn pause(&self) -> io::Result<()> {
+        self.pause_with_timeout(HANDSHAKE_TIMEOUT)
+    }
+
+    fn pause_with_timeout(&self, timeout: Duration) -> io::Result<()> {
+        if self.handle.is_finished() {
+            return Ok(());
+        }
+        let (acknowledge, acknowledged) = mpsc::sync_channel(1);
+        let cancelled = Arc::new(AtomicBool::new(false));
+        if self
+            .commands
+            .send(ReaderCommand::Pause {
+                acknowledge,
+                cancelled: Arc::clone(&cancelled),
+            })
+            .is_err()
+        {
+            return self.handle.is_finished().then_some(()).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "PTY reader control closed")
+            });
+        }
+        let deadline = Instant::now() + timeout;
+        loop {
+            match acknowledged.try_recv() {
+                Ok(()) => return Ok(()),
+                Err(mpsc::TryRecvError::Disconnected) if self.handle.is_finished() => return Ok(()),
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "PTY reader stopped before acknowledging pause",
+                    ));
+                }
+                Err(mpsc::TryRecvError::Empty) if self.handle.is_finished() => return Ok(()),
+                Err(mpsc::TryRecvError::Empty) if Instant::now() >= deadline => {
+                    cancelled.store(true, Ordering::Release);
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "PTY reader did not pause",
+                    ));
+                }
+                Err(mpsc::TryRecvError::Empty) => thread::sleep(IO_RETRY_DELAY),
+            }
+        }
+    }
+
+    fn resume(&self) -> io::Result<()> {
+        if self.handle.is_finished() || self.commands.send(ReaderCommand::Resume).is_ok() {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "PTY reader control closed",
+            ))
+        }
+    }
+
+    fn stop(self) -> io::Result<()> {
+        if !self.handle.is_finished() {
+            let _ = self.commands.send(ReaderCommand::Stop);
+        }
+        self.handle
+            .join()
+            .map_err(|_| io::Error::other("PTY reader thread panicked"))
+    }
+}
+
 impl Registry {
     fn dispatch(&self, request: Request) -> io::Result<Response> {
         match request {
             Request::Ping => Ok(Response::Pong),
+            Request::Restart => unreachable!("restart is handled before dispatch"),
             Request::Shutdown => unreachable!("shutdown is handled before dispatch"),
             Request::Snapshot => Ok(Response::Snapshot {
                 snapshot: self.snapshot()?,
@@ -415,6 +887,13 @@ impl Registry {
         } else {
             Ok(())
         }
+    }
+
+    fn state_lock_descriptor(&self) -> io::Result<BorrowedFd<'_>> {
+        self.store
+            .as_ref()
+            .ok_or_else(|| io::Error::other("registry has no persistent state store"))?
+            .lock_descriptor()
     }
 
     fn backup(&self) -> io::Result<RegistryBackup> {
@@ -855,11 +1334,13 @@ impl Shell {
         if let Some(controller) = lock(&runtime.controller)?.take() {
             let _ = controller.connection.shutdown(std::net::Shutdown::Both);
         }
-        let foreground_group = lock(&runtime.master)?.process_group_leader();
-        let mut child = lock(&runtime.child)?;
-        let result = if child.try_wait()?.is_some() {
-            Ok(())
-        } else {
+        runtime.pause_reader()?;
+        let result = (|| {
+            let foreground_group = lock(&runtime.master)?.process_group_leader();
+            let mut child = lock(&runtime.child)?;
+            if child.try_wait()?.is_some() {
+                return Ok(());
+            }
             let child_pid = child.process_id().map(|pid| pid as libc::pid_t);
             if let Some(session_id) = child_pid {
                 signal_session(session_id, libc::SIGHUP);
@@ -884,20 +1365,24 @@ impl Shell {
                 (Err(error), Err(_)) => Err(error),
                 (Ok(()), Err(error)) => Err(error),
             }
-        };
-        drop(child);
-        if result.is_ok() {
-            let mut lifecycle = lock(&self.lifecycle)?;
-            let current_runtime = match &*lifecycle {
-                ShellLifecycle::Running { runtime, .. }
-                | ShellLifecycle::Exited { runtime, .. } => Some(runtime),
-                ShellLifecycle::Pending | ShellLifecycle::Closed => None,
-            };
-            if current_runtime.is_some_and(|current| Arc::ptr_eq(current, &runtime)) {
-                *lifecycle = ShellLifecycle::Closed;
-            }
+        })();
+        if let Err(error) = result {
+            runtime.resume_reader()?;
+            return Err(error);
         }
-        result
+
+        runtime.stop_reader()?;
+        let mut lifecycle = lock(&self.lifecycle)?;
+        let current_runtime = match &*lifecycle {
+            ShellLifecycle::Running { runtime, .. } | ShellLifecycle::Exited { runtime, .. } => {
+                Some(runtime)
+            }
+            ShellLifecycle::Pending | ShellLifecycle::Closed => None,
+        };
+        if current_runtime.is_some_and(|current| Arc::ptr_eq(current, &runtime)) {
+            *lifecycle = ShellLifecycle::Closed;
+        }
+        Ok(())
     }
 
     fn reset_pending(&self) -> io::Result<()> {
@@ -917,6 +1402,28 @@ impl ShellRuntime {
             .is_some_and(|current| current.token == token)
         {
             controller.take();
+        }
+        Ok(())
+    }
+
+    fn pause_reader(&self) -> io::Result<()> {
+        if let Some(reader) = lock(&self.reader)?.as_ref() {
+            reader.pause()?;
+        }
+        Ok(())
+    }
+
+    fn resume_reader(&self) -> io::Result<()> {
+        if let Some(reader) = lock(&self.reader)?.as_ref() {
+            reader.resume()?;
+        }
+        Ok(())
+    }
+
+    fn stop_reader(&self) -> io::Result<()> {
+        let reader = lock(&self.reader)?.take();
+        if let Some(reader) = reader {
+            reader.stop()?;
         }
         Ok(())
     }
@@ -941,7 +1448,7 @@ fn spawn_runtime(
     workspace_name: &str,
     shell_name: &str,
     profile: &TerminalProfile,
-) -> io::Result<(Arc<ShellRuntime>, Box<dyn Read + Send>)> {
+) -> io::Result<(Arc<ShellRuntime>, PtyReader)> {
     let pty = native_pty_system()
         .openpty(PtySize {
             rows: profile.rows,
@@ -950,9 +1457,8 @@ fn spawn_runtime(
             pixel_height: profile.pixel_height,
         })
         .map_err(io::Error::other)?;
-    set_nonblocking(pty.master.as_ref())?;
-    let writer = pty.master.take_writer().map_err(io::Error::other)?;
-    let reader = pty.master.try_clone_reader().map_err(io::Error::other)?;
+    let master = PtyMaster::duplicate(pty.master.as_ref())?;
+    let reader = master.try_clone_reader()?;
 
     let mut command = if shell.command.is_empty() {
         CommandBuilder::new(env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into()))
@@ -984,15 +1490,16 @@ fn spawn_runtime(
     command.env("BOOMUX_SHELL_NAME", shell_name);
     let child = pty.slave.spawn_command(command).map_err(io::Error::other)?;
     drop(pty.slave);
+    drop(pty.master);
 
     Ok((
         Arc::new(ShellRuntime {
             control: Mutex::new(()),
-            master: Mutex::new(pty.master),
-            writer: Mutex::new(writer),
+            master: Mutex::new(master),
             child: Mutex::new(child),
             terminal: Mutex::new(TerminalState::new(profile.rows, profile.cols)),
             controller: Mutex::new(None),
+            reader: Mutex::new(None),
         }),
         reader,
     ))
@@ -1001,18 +1508,76 @@ fn spawn_runtime(
 fn start_pty_reader(
     shell: Arc<Shell>,
     runtime: Arc<ShellRuntime>,
-    mut reader: Box<dyn Read + Send>,
-) {
-    thread::spawn(move || {
+    mut reader: PtyReader,
+) -> io::Result<()> {
+    let (commands, command_receiver) = mpsc::channel();
+    let reader_runtime = Arc::clone(&runtime);
+    let handle = thread::spawn(move || {
         let mut buffer = [0; 16 * 1024];
+        let mut stopped = false;
+        let mut paused = false;
+        let mut pause_cancellation: Option<Arc<AtomicBool>> = None;
         loop {
+            if paused {
+                if pause_cancellation
+                    .as_ref()
+                    .is_some_and(|cancelled| cancelled.load(Ordering::Acquire))
+                {
+                    paused = false;
+                    pause_cancellation = None;
+                    continue;
+                }
+                match command_receiver.recv_timeout(IO_RETRY_DELAY) {
+                    Ok(ReaderCommand::Pause {
+                        acknowledge,
+                        cancelled,
+                    }) => {
+                        if !cancelled.load(Ordering::Acquire) {
+                            let _ = acknowledge.send(());
+                        }
+                    }
+                    Ok(ReaderCommand::Resume) => {
+                        paused = false;
+                        pause_cancellation = None;
+                    }
+                    Ok(ReaderCommand::Stop) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                        stopped = true;
+                        break;
+                    }
+                    Err(mpsc::RecvTimeoutError::Timeout) => {}
+                }
+                continue;
+            }
+            match command_receiver.try_recv() {
+                Ok(ReaderCommand::Pause {
+                    acknowledge,
+                    cancelled,
+                }) => {
+                    if cancelled.load(Ordering::Acquire) {
+                        continue;
+                    }
+                    paused = true;
+                    pause_cancellation = Some(Arc::clone(&cancelled));
+                    if acknowledge.send(()).is_err() || cancelled.load(Ordering::Acquire) {
+                        paused = false;
+                        pause_cancellation = None;
+                    }
+                    continue;
+                }
+                Ok(ReaderCommand::Resume) => continue,
+                Ok(ReaderCommand::Stop) | Err(mpsc::TryRecvError::Disconnected) => {
+                    stopped = true;
+                    break;
+                }
+                Err(mpsc::TryRecvError::Empty) => {}
+            }
             match reader.read(&mut buffer) {
                 Ok(0) => break,
                 Ok(count) => {
                     let bytes = &buffer[..count];
-                    if let Ok(mut terminal) = runtime.terminal.lock() {
+                    if let Ok(mut terminal) = reader_runtime.terminal.lock() {
                         terminal.process(bytes);
-                        if let Ok(mut controller) = runtime.controller.lock() {
+                        if let Ok(mut controller) = reader_runtime.controller.lock() {
                             let disconnect = controller.as_ref().is_some_and(|current| {
                                 matches!(
                                     current.output.try_send(bytes.to_vec()),
@@ -1039,7 +1604,10 @@ fn start_pty_reader(
                 Err(_) => break,
             }
         }
-        let code = runtime
+        if stopped {
+            return;
+        }
+        let code = reader_runtime
             .child
             .lock()
             .ok()
@@ -1050,19 +1618,21 @@ fn start_pty_reader(
                 profile,
                 runtime: current,
             } = &*lifecycle
-            && Arc::ptr_eq(current, &runtime)
+            && Arc::ptr_eq(current, &reader_runtime)
         {
             *lifecycle = ShellLifecycle::Exited {
                 code,
                 profile: profile.clone(),
-                runtime: Arc::clone(&runtime),
+                runtime: Arc::clone(&reader_runtime),
             };
         }
-        let _ = runtime
+        let _ = reader_runtime
             .controller
             .lock()
             .map(|mut controller| controller.take());
     });
+    *lock(&runtime.reader)? = Some(ReaderTask { commands, handle });
+    Ok(())
 }
 
 fn tail_utf8(text: &str, max_bytes: usize) -> &str {
@@ -1145,7 +1715,7 @@ fn handle_attach(
             };
             *lock(&shell.last_profile)? = Some(profile.clone());
             started = true;
-            start_pty_reader(Arc::clone(&shell), runtime, reader);
+            start_pty_reader(Arc::clone(&shell), runtime, reader)?;
         }
         match &*lifecycle {
             ShellLifecycle::Running { profile, runtime } => {
@@ -1208,9 +1778,7 @@ fn handle_attach(
         }
     }
     if running {
-        lock(&runtime.master)?
-            .resize(profile_size(&profile))
-            .map_err(io::Error::other)?;
+        lock(&runtime.master)?.resize(profile_size(&profile))?;
     }
     lock(&runtime.terminal)?.resize(profile.rows, profile.cols);
     // Keep terminal state locked until the controller is installed so the
@@ -1304,14 +1872,12 @@ fn handle_attach(
                 if let Err(error) = validate_terminal_dimensions(rows, cols) {
                     Err(error)
                 } else {
-                    lock(&runtime.master)?
-                        .resize(PtySize {
-                            rows,
-                            cols,
-                            pixel_width,
-                            pixel_height,
-                        })
-                        .map_err(io::Error::other)?;
+                    lock(&runtime.master)?.resize(PtySize {
+                        rows,
+                        cols,
+                        pixel_width,
+                        pixel_height,
+                    })?;
                     lock(&runtime.terminal)?.resize(rows, cols);
                     Ok(())
                 }
@@ -1333,18 +1899,6 @@ fn handle_attach(
     runtime.release_controller(&token)
 }
 
-fn set_nonblocking(master: &dyn MasterPty) -> io::Result<()> {
-    let fd = master
-        .as_raw_fd()
-        .ok_or_else(|| io::Error::other("PTY master does not expose a file descriptor"))?;
-    // `fd` belongs to the live PTY master and fcntl only reads/updates its status flags.
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-    if flags == -1 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(())
-}
-
 fn write_controller_input(runtime: &ShellRuntime, token: &str, bytes: &[u8]) -> io::Result<bool> {
     let mut offset = 0;
     while offset < bytes.len() {
@@ -1355,7 +1909,7 @@ fn write_controller_input(runtime: &ShellRuntime, token: &str, bytes: &[u8]) -> 
         if !authorized {
             return Ok(false);
         }
-        let result = lock(&runtime.writer)?.write(&bytes[offset..]);
+        let result = lock(&runtime.master)?.write(&bytes[offset..]);
         drop(control);
         match result {
             Ok(0) => return Err(io::Error::new(io::ErrorKind::WriteZero, "PTY input closed")),
@@ -1617,6 +2171,81 @@ mod tests {
         assert!(result.is_err());
         assert!(registry.snapshot().unwrap().workspaces.is_empty());
         fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn pty_reader_pause_forms_an_acknowledged_output_barrier() {
+        let shell = create_pending_shell(
+            "workspace-id",
+            ShellSpec {
+                name: "pause-test".into(),
+                command: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    "stty -echo; while IFS= read -r line; do printf 'observed:%s\\n' \"$line\"; done"
+                        .into(),
+                ],
+                cwd: env::temp_dir(),
+            },
+        )
+        .unwrap();
+        let terminal_profile = profile();
+        let (runtime, reader) =
+            spawn_runtime(&shell, "workspace", "pause-test", &terminal_profile).unwrap();
+        *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
+            profile: terminal_profile,
+            runtime: Arc::clone(&runtime),
+        };
+        start_pty_reader(Arc::clone(&shell), Arc::clone(&runtime), reader).unwrap();
+
+        runtime.pause_reader().unwrap();
+        lock(&runtime.master).unwrap().write(b"paused\n").unwrap();
+        thread::sleep(Duration::from_millis(50));
+        assert!(
+            !lock(&runtime.terminal)
+                .unwrap()
+                .plain_text()
+                .contains("observed:paused")
+        );
+
+        runtime.resume_reader().unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline
+            && !lock(&runtime.terminal)
+                .unwrap()
+                .plain_text()
+                .contains("observed:paused")
+        {
+            thread::sleep(IO_RETRY_DELAY);
+        }
+        assert!(
+            lock(&runtime.terminal)
+                .unwrap()
+                .plain_text()
+                .contains("observed:paused")
+        );
+        shell.kill().unwrap();
+    }
+
+    #[test]
+    fn timed_out_reader_pause_cancels_queued_command() {
+        let (commands, receiver) = mpsc::channel();
+        let (observed, observation) = mpsc::sync_channel(1);
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(30));
+            if let ReaderCommand::Pause { cancelled, .. } = receiver.recv().unwrap() {
+                observed.send(cancelled.load(Ordering::Acquire)).unwrap();
+            }
+        });
+        let task = ReaderTask { commands, handle };
+
+        let error = task
+            .pause_with_timeout(Duration::from_millis(5))
+            .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(observation.recv().unwrap());
+        task.stop().unwrap();
     }
 
     #[test]

--- a/src/fd_transfer.rs
+++ b/src/fd_transfer.rs
@@ -1,0 +1,172 @@
+use std::io::{self, IoSlice, IoSliceMut};
+use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixStream;
+
+use nix::errno::Errno;
+use nix::sys::socket::{ControlMessage, ControlMessageOwned, MsgFlags, recvmsg, sendmsg};
+
+pub(crate) fn send_descriptor(
+    stream: &UnixStream,
+    descriptor: BorrowedFd<'_>,
+    marker: u8,
+) -> io::Result<()> {
+    let marker = [marker];
+    let data = [IoSlice::new(&marker)];
+    let descriptors = [descriptor.as_raw_fd()];
+    let control = [ControlMessage::ScmRights(&descriptors)];
+    loop {
+        match sendmsg::<()>(
+            stream.as_raw_fd(),
+            &data,
+            &control,
+            MsgFlags::MSG_NOSIGNAL,
+            None,
+        ) {
+            Ok(1) => return Ok(()),
+            Ok(count) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    format!("descriptor marker write returned {count} bytes"),
+                ));
+            }
+            Err(Errno::EINTR) => continue,
+            Err(error) => return Err(errno(error)),
+        }
+    }
+}
+
+pub(crate) fn receive_descriptor(stream: &UnixStream, expected_marker: u8) -> io::Result<OwnedFd> {
+    let mut marker = [0_u8];
+    let mut data = [IoSliceMut::new(&mut marker)];
+    let mut control = nix::cmsg_space!([RawFd; 1]);
+    let (bytes, flags, descriptors) = loop {
+        match recvmsg::<()>(
+            stream.as_raw_fd(),
+            &mut data,
+            Some(&mut control),
+            MsgFlags::MSG_CMSG_CLOEXEC,
+        ) {
+            Ok(message) => {
+                let mut descriptors = Vec::new();
+                for control in message.cmsgs() {
+                    match control {
+                        ControlMessageOwned::ScmRights(received) => {
+                            descriptors.extend(received.into_iter().map(|descriptor| {
+                                // SCM_RIGHTS returned a new descriptor owned by this process.
+                                unsafe { OwnedFd::from_raw_fd(descriptor) }
+                            }));
+                        }
+                        _ => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "descriptor transfer contained unexpected control data",
+                            ));
+                        }
+                    }
+                }
+                break (message.bytes, message.flags, descriptors);
+            }
+            Err(Errno::EINTR) => continue,
+            Err(error) => return Err(errno(error)),
+        }
+    };
+
+    if bytes == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "descriptor transfer closed before its marker",
+        ));
+    }
+    if bytes != 1
+        || marker[0] != expected_marker
+        || flags.intersects(MsgFlags::MSG_TRUNC | MsgFlags::MSG_CTRUNC)
+        || descriptors.len() != 1
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid descriptor transfer",
+        ));
+    }
+    descriptors
+        .into_iter()
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "descriptor was not received"))
+}
+
+fn errno(error: Errno) -> io::Error {
+    io::Error::from_raw_os_error(error as i32)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::os::fd::AsFd;
+
+    use super::*;
+    use nix::sys::socket::{ControlMessage, MsgFlags, sendmsg};
+
+    const MARKER: u8 = 0x42;
+
+    #[test]
+    fn transfers_owned_cloexec_descriptor() {
+        let (sender, receiver) = UnixStream::pair().unwrap();
+        let (payload, mut peer) = UnixStream::pair().unwrap();
+
+        send_descriptor(&sender, payload.as_fd(), MARKER).unwrap();
+        let descriptor = receive_descriptor(&receiver, MARKER).unwrap();
+        drop(payload);
+
+        let flags = unsafe { libc::fcntl(descriptor.as_raw_fd(), libc::F_GETFD) };
+        assert_ne!(flags, -1);
+        assert_ne!(flags & libc::FD_CLOEXEC, 0);
+        let mut payload = UnixStream::from(descriptor);
+        peer.write_all(b"handoff").unwrap();
+        let mut received = [0; 7];
+        payload.read_exact(&mut received).unwrap();
+        assert_eq!(&received, b"handoff");
+    }
+
+    #[test]
+    fn rejects_missing_descriptor() {
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        sender.write_all(&[MARKER]).unwrap();
+
+        let error = receive_descriptor(&receiver, MARKER).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn rejects_wrong_marker() {
+        let (sender, receiver) = UnixStream::pair().unwrap();
+        let (payload, _peer) = UnixStream::pair().unwrap();
+        send_descriptor(&sender, payload.as_fd(), MARKER).unwrap();
+
+        let error = receive_descriptor(&receiver, MARKER + 1).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn rejects_multiple_descriptors() {
+        let (sender, receiver) = UnixStream::pair().unwrap();
+        let (first, _first_peer) = UnixStream::pair().unwrap();
+        let (second, _second_peer) = UnixStream::pair().unwrap();
+        let marker = [MARKER];
+        let data = [IoSlice::new(&marker)];
+        let descriptors = [first.as_raw_fd(), second.as_raw_fd()];
+        let control = [ControlMessage::ScmRights(&descriptors)];
+        sendmsg::<()>(
+            sender.as_raw_fd(),
+            &data,
+            &control,
+            MsgFlags::MSG_NOSIGNAL,
+            None,
+        )
+        .unwrap();
+
+        let error = receive_descriptor(&receiver, MARKER).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -1,0 +1,191 @@
+use std::fs;
+use std::io::{self, Read, Write};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+
+use crate::client;
+use crate::fd_transfer::receive_descriptor;
+use crate::state_store;
+
+const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+pub(crate) const CHANNEL_FD: RawFd = 198;
+pub(crate) const HEADER: &[u8; 8] = b"BOOMUXH1";
+pub(crate) const LISTENER_MARKER: u8 = 1;
+pub(crate) const RUNTIME_LOCK_MARKER: u8 = 2;
+pub(crate) const STATE_LOCK_MARKER: u8 = 3;
+pub(crate) const READY: u8 = 4;
+pub(crate) const ABORT: u8 = 5;
+pub(crate) const COMMIT: u8 = 6;
+pub(crate) const PREPARED: u8 = 7;
+pub(crate) const FINALIZE: u8 = 8;
+pub(crate) const COMMITTED: u8 = 9;
+
+pub(crate) enum Bootstrap {
+    Aborted,
+    Committed {
+        channel: UnixStream,
+        listener: UnixListener,
+        runtime_lock: OwnedFd,
+        state_lock: OwnedFd,
+    },
+}
+
+pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
+    let mut channel = adopt_channel(channel)?;
+    channel.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    channel.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    let mut header = [0; HEADER.len()];
+    channel.read_exact(&mut header)?;
+    if &header != HEADER {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "replacement bootstrap version is unsupported",
+        ));
+    }
+    let listener = receive_descriptor(&channel, LISTENER_MARKER)?;
+    let runtime_lock = receive_descriptor(&channel, RUNTIME_LOCK_MARKER)?;
+    let state_lock = receive_descriptor(&channel, STATE_LOCK_MARKER)?;
+
+    let expected_socket = client::socket_path()?;
+    let listener = UnixListener::from(listener);
+    if listener.local_addr()?.as_pathname() != Some(expected_socket.as_path()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "transferred listener does not match the Boomux socket",
+        ));
+    }
+    validate_listener(&listener)?;
+    let runtime_lock_path = expected_socket
+        .parent()
+        .ok_or_else(|| io::Error::other("socket path has no parent"))?
+        .join("daemon.lock");
+    validate_lock(&runtime_lock, &runtime_lock_path)?;
+    validate_lock(&state_lock, &state_store::lock_path_from_environment()?)?;
+
+    channel.write_all(&[READY])?;
+    let mut decision = [0];
+    channel.read_exact(&mut decision)?;
+    match decision[0] {
+        ABORT => Ok(Bootstrap::Aborted),
+        COMMIT => Ok(Bootstrap::Committed {
+            channel,
+            listener,
+            runtime_lock,
+            state_lock,
+        }),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "replacement bootstrap received an unsupported decision",
+        )),
+    }
+}
+
+fn adopt_channel(channel: RawFd) -> io::Result<UnixStream> {
+    if channel < 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "handoff channel descriptor must be nonnegative",
+        ));
+    }
+    // Duplication validates the inherited descriptor before Rust adopts it.
+    let duplicated = unsafe { libc::fcntl(channel, libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicated == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    // fcntl returned a fresh descriptor with unique ownership.
+    let descriptor = unsafe { OwnedFd::from_raw_fd(duplicated) };
+    // The hidden command contract transfers the inherited endpoint; the
+    // validated duplicate is now its sole owner in this process.
+    let _ = unsafe { libc::close(channel) };
+    let stream = UnixStream::from(descriptor);
+    let mut socket_type = 0_i32;
+    let mut length = std::mem::size_of_val(&socket_type) as libc::socklen_t;
+    // The output pointer and length describe a writable integer.
+    if unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_TYPE,
+            (&mut socket_type as *mut i32).cast(),
+            &mut length,
+        )
+    } == -1
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if socket_type != libc::SOCK_STREAM {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "handoff channel is not a stream socket",
+        ));
+    }
+    Ok(stream)
+}
+
+fn validate_listener(listener: &UnixListener) -> io::Result<()> {
+    let mut accepting = 0_i32;
+    let mut length = std::mem::size_of_val(&accepting) as libc::socklen_t;
+    // The output pointer and length describe a writable integer.
+    if unsafe {
+        libc::getsockopt(
+            listener.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_ACCEPTCONN,
+            (&mut accepting as *mut i32).cast(),
+            &mut length,
+        )
+    } == -1
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if accepting != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "transferred descriptor is not a listening socket",
+        ));
+    }
+    let flags = unsafe { libc::fcntl(listener.as_raw_fd(), libc::F_GETFL) };
+    if flags == -1
+        || unsafe {
+            libc::fcntl(
+                listener.as_raw_fd(),
+                libc::F_SETFL,
+                flags | libc::O_NONBLOCK,
+            )
+        } == -1
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn validate_lock(descriptor: &OwnedFd, path: &Path) -> io::Result<()> {
+    let path_metadata = fs::symlink_metadata(path)?;
+    let mut descriptor_metadata = MaybeUninit::<libc::stat>::uninit();
+    // fstat initializes the supplied stat structure for this owned descriptor.
+    if unsafe { libc::fstat(descriptor.as_raw_fd(), descriptor_metadata.as_mut_ptr()) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    // fstat succeeded, so the structure is initialized.
+    let descriptor_metadata = unsafe { descriptor_metadata.assume_init() };
+    if !path_metadata.file_type().is_file()
+        || path_metadata.uid() != unsafe { libc::geteuid() }
+        || path_metadata.dev() != descriptor_metadata.st_dev
+        || path_metadata.ino() != descriptor_metadata.st_ino
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("transferred lock does not match {}", path.display()),
+        ));
+    }
+    // Inherited flock ownership is tied to the transferred open file
+    // description. Reacquiring is idempotent for a valid inherited lock and
+    // establishes exclusivity if the sender omitted it.
+    if unsafe { libc::flock(descriptor.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -6,13 +6,16 @@ use std::os::unix::fs::MetadataExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 
+use serde::{Deserialize, Serialize};
+
 use crate::client;
 use crate::fd_transfer::receive_descriptor;
+use crate::protocol::{self, TerminalProfile};
 use crate::state_store;
 
 const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 pub(crate) const CHANNEL_FD: RawFd = 198;
-pub(crate) const HEADER: &[u8; 8] = b"BOOMUXH1";
+pub(crate) const HEADER: &[u8; 8] = b"BOOMUXH2";
 pub(crate) const LISTENER_MARKER: u8 = 1;
 pub(crate) const RUNTIME_LOCK_MARKER: u8 = 2;
 pub(crate) const STATE_LOCK_MARKER: u8 = 3;
@@ -22,6 +25,27 @@ pub(crate) const COMMIT: u8 = 6;
 pub(crate) const PREPARED: u8 = 7;
 pub(crate) const FINALIZE: u8 = 8;
 pub(crate) const COMMITTED: u8 = 9;
+pub(crate) const PTY_MARKER: u8 = 10;
+pub(crate) const PIDFD_MARKER: u8 = 11;
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct Manifest {
+    pub(crate) runtimes: Vec<RuntimeManifest>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct RuntimeManifest {
+    pub(crate) shell_id: String,
+    pub(crate) profile: TerminalProfile,
+    pub(crate) pid: u32,
+}
+
+pub(crate) struct TransferredRuntime {
+    pub(crate) manifest: RuntimeManifest,
+    pub(crate) pty: OwnedFd,
+    pub(crate) pidfd: OwnedFd,
+    pub(crate) reconstruction: Vec<u8>,
+}
 
 pub(crate) enum Bootstrap {
     Aborted,
@@ -30,6 +54,7 @@ pub(crate) enum Bootstrap {
         listener: UnixListener,
         runtime_lock: OwnedFd,
         state_lock: OwnedFd,
+        runtimes: Vec<TransferredRuntime>,
     },
 }
 
@@ -45,9 +70,31 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             "replacement bootstrap version is unsupported",
         ));
     }
+    let manifest: Manifest = protocol::read_message(&mut channel)?;
+    validate_manifest(&manifest)?;
     let listener = receive_descriptor(&channel, LISTENER_MARKER)?;
     let runtime_lock = receive_descriptor(&channel, RUNTIME_LOCK_MARKER)?;
     let state_lock = receive_descriptor(&channel, STATE_LOCK_MARKER)?;
+    let mut runtimes = Vec::with_capacity(manifest.runtimes.len());
+    for manifest in manifest.runtimes {
+        let pty = receive_descriptor(&channel, PTY_MARKER)?;
+        validate_pty(&pty, manifest.pid)?;
+        let pidfd = receive_descriptor(&channel, PIDFD_MARKER)?;
+        validate_pidfd(&pidfd, manifest.pid)?;
+        let reconstruction: Vec<u8> = protocol::read_message(&mut channel)?;
+        if reconstruction.len() > protocol::MAX_ATTACH_FRAME {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "transferred terminal reconstruction exceeds the size limit",
+            ));
+        }
+        runtimes.push(TransferredRuntime {
+            manifest,
+            pty,
+            pidfd,
+            reconstruction,
+        });
+    }
 
     let expected_socket = client::socket_path()?;
     let listener = UnixListener::from(listener);
@@ -75,12 +122,73 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             listener,
             runtime_lock,
             state_lock,
+            runtimes,
         }),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "replacement bootstrap received an unsupported decision",
         )),
     }
+}
+
+fn validate_pty(descriptor: &OwnedFd, expected_session: u32) -> io::Result<()> {
+    let mut pty_number = 0_u32;
+    // TIOCGPTN succeeds only for a Unix PTY master and initializes the number.
+    if unsafe { libc::ioctl(descriptor.as_raw_fd(), libc::TIOCGPTN, &mut pty_number) } == -1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "transferred PTY descriptor is invalid: {}",
+                io::Error::last_os_error()
+            ),
+        ));
+    }
+    let mut session_id = 0 as libc::pid_t;
+    // TIOCGSID returns the controlling session associated with this PTY.
+    if unsafe { libc::ioctl(descriptor.as_raw_fd(), libc::TIOCGSID, &mut session_id) } == -1
+        || session_id != expected_session as libc::pid_t
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "transferred PTY does not match its process session",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_pidfd(descriptor: &OwnedFd, expected_pid: u32) -> io::Result<()> {
+    let contents = fs::read_to_string(format!("/proc/self/fdinfo/{}", descriptor.as_raw_fd()))?;
+    let actual_pid = contents.lines().find_map(|line| {
+        line.strip_prefix("Pid:")
+            .and_then(|value| value.trim().parse::<u32>().ok())
+    });
+    if actual_pid == Some(expected_pid) {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "transferred pidfd does not match its process",
+        ))
+    }
+}
+
+fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
+    if manifest.runtimes.len() > 1_024 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "handoff manifest contains too many runtimes",
+        ));
+    }
+    let mut shell_ids = std::collections::HashSet::new();
+    for runtime in &manifest.runtimes {
+        if runtime.pid == 0 || !shell_ids.insert(&runtime.shell_id) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "handoff manifest contains an invalid runtime",
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn adopt_channel(channel: RawFd) -> io::Result<UnixStream> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 pub mod attach;
 pub mod client;
 pub mod daemon;
+// The replacement-daemon protocol will activate this transport in the next
+// handoff slice; keeping it compiled now prevents the unsafe boundary drifting.
+#[allow(dead_code)]
+mod fd_transfer;
+mod handoff;
 pub mod protocol;
 mod state_store;
 mod terminal_state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,8 +167,16 @@ enum DaemonCommands {
     /// Start the daemon in the foreground
     #[command(hide = true)]
     Run,
+    /// Receive daemon ownership from a running Boomux process
+    #[command(hide = true)]
+    ReceiveHandoff {
+        #[arg(long)]
+        channel: i32,
+    },
     /// Report whether the daemon is accepting requests
     Status,
+    /// Replace the daemon without changing pending workspace state
+    Restart,
     /// Stop the daemon and its managed shells
     Stop,
 }
@@ -188,6 +196,9 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         Some(Commands::Daemon {
             command: DaemonCommands::Run,
         }) => return Ok(daemon::run()?),
+        Some(Commands::Daemon {
+            command: DaemonCommands::ReceiveHandoff { channel },
+        }) => return Ok(daemon::receive_handoff(*channel)?),
         Some(Commands::Attach { shell_id, takeover }) => {
             return Ok(attach::run(shell_id, *takeover)?);
         }
@@ -247,11 +258,15 @@ fn daemon_control(command: DaemonCommands) -> Result<(), Box<dyn Error>> {
             protocol::PROTOCOL_VERSION,
             client.socket_path().display()
         ),
+        DaemonCommands::Restart => {
+            client.restart()?;
+            println!("Restarted Boomux daemon");
+        }
         DaemonCommands::Stop => {
             client.shutdown()?;
             println!("Stopped Boomux daemon");
         }
-        DaemonCommands::Run => unreachable!(),
+        DaemonCommands::Run | DaemonCommands::ReceiveHandoff { .. } => unreachable!(),
     }
     Ok(())
 }
@@ -1055,6 +1070,7 @@ mod tests {
         let cli = Cli::try_parse_from(["boomux", "."]).unwrap();
         assert_eq!(cli.path, Some(PathBuf::from(".")));
         assert!(Cli::try_parse_from(["boomux", "daemon", "run"]).is_ok());
+        assert!(Cli::try_parse_from(["boomux", "daemon", "restart"]).is_ok());
         assert!(Cli::try_parse_from(["boomux", "daemon", "stop"]).is_ok());
         let cli = Cli::try_parse_from(["boomux", "__attach", "s1", "--takeover"]).unwrap();
         assert!(matches!(

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
 
@@ -167,6 +167,8 @@ pub enum AttachFrame {
         pixel_height: u16,
     },
     Detached,
+    Reconnect,
+    ReconnectAck,
 }
 
 impl AttachFrame {
@@ -174,6 +176,8 @@ impl AttachFrame {
     const OUTPUT: u8 = 2;
     const RESIZE: u8 = 3;
     const DETACHED: u8 = 4;
+    const RECONNECT: u8 = 5;
+    const RECONNECT_ACK: u8 = 6;
 
     pub fn write_to(&self, writer: &mut impl Write) -> io::Result<()> {
         let (kind, payload): (u8, &[u8]) = match self {
@@ -193,6 +197,8 @@ impl AttachFrame {
                 return writer.write_all(&pixel_height.to_be_bytes());
             }
             Self::Detached => (Self::DETACHED, &[]),
+            Self::Reconnect => (Self::RECONNECT, &[]),
+            Self::ReconnectAck => (Self::RECONNECT_ACK, &[]),
         };
         if payload.len() > MAX_ATTACH_FRAME {
             return Err(io::Error::new(
@@ -229,6 +235,8 @@ impl AttachFrame {
                 pixel_height: u16::from_be_bytes([payload[6], payload[7]]),
             }),
             Self::DETACHED if payload.is_empty() => Ok(Self::Detached),
+            Self::RECONNECT if payload.is_empty() => Ok(Self::Reconnect),
+            Self::RECONNECT_ACK if payload.is_empty() => Ok(Self::ReconnectAck),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "invalid attach frame",
@@ -310,6 +318,8 @@ mod tests {
                 pixel_height: 1080,
             },
             AttachFrame::Detached,
+            AttachFrame::Reconnect,
+            AttachFrame::ReconnectAck,
         ];
         for frame in frames {
             let mut bytes = Vec::new();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
 
@@ -86,6 +86,7 @@ impl ShellSpec {
 #[serde(tag = "request", rename_all = "snake_case")]
 pub enum Request {
     Ping,
+    Restart,
     Shutdown,
     Snapshot,
     GetWorkspace {

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -54,29 +55,18 @@ pub(crate) struct StateStore {
 
 impl StateStore {
     pub(crate) fn from_environment() -> io::Result<Self> {
-        let root = match env::var_os("XDG_STATE_HOME").filter(|path| !path.is_empty()) {
-            Some(path) => PathBuf::from(path),
-            None => PathBuf::from(
-                env::var_os("HOME")
-                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is not set"))?,
-            )
-            .join(".local/state"),
-        };
-        if !root.is_absolute() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "XDG_STATE_HOME must be an absolute path",
-            ));
-        }
-        let directory = root.join("boomux");
-        secure_state_dir(&directory)?;
+        let lock_path = lock_path_from_environment()?;
+        let directory = lock_path
+            .parent()
+            .ok_or_else(|| io::Error::other("state lock path has no parent"))?;
+        secure_state_dir(directory)?;
         let lock = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
             .mode(0o600)
-            .open(directory.join("daemon.lock"))?;
+            .open(&lock_path)?;
         // The descriptor remains open for the store lifetime and `flock` takes
         // only pointer-free integer arguments.
         if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == -1 {
@@ -94,6 +84,25 @@ impl StateStore {
             path: directory.join("state.json"),
             _lock: Some(lock),
         })
+    }
+
+    pub(crate) fn from_transferred_lock(lock: OwnedFd) -> io::Result<Self> {
+        let lock_path = lock_path_from_environment()?;
+        let directory = lock_path
+            .parent()
+            .ok_or_else(|| io::Error::other("state lock path has no parent"))?;
+        secure_state_dir(directory)?;
+        Ok(Self {
+            path: directory.join("state.json"),
+            _lock: Some(File::from(lock)),
+        })
+    }
+
+    pub(crate) fn lock_descriptor(&self) -> io::Result<BorrowedFd<'_>> {
+        self._lock
+            .as_ref()
+            .map(AsFd::as_fd)
+            .ok_or_else(|| io::Error::other("state store has no ownership lock"))
     }
 
     #[cfg(test)]
@@ -175,6 +184,24 @@ impl StateStore {
         }
         result
     }
+}
+
+pub(crate) fn lock_path_from_environment() -> io::Result<PathBuf> {
+    let root = match env::var_os("XDG_STATE_HOME").filter(|path| !path.is_empty()) {
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from(
+            env::var_os("HOME")
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is not set"))?,
+        )
+        .join(".local/state"),
+    };
+    if !root.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "XDG_STATE_HOME must be an absolute path",
+        ));
+    }
+    Ok(root.join("boomux/daemon.lock"))
 }
 
 fn secure_state_dir(path: &Path) -> io::Result<()> {

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1,6 +1,9 @@
-use std::fs;
-use std::io;
+use std::fs::{self, OpenOptions};
+use std::io::{self, IoSlice, Read, Write};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::thread;
@@ -11,6 +14,7 @@ use boomux::protocol::{AttachFrame, ShellSpec, ShellStatus, TerminalProfile};
 use uuid::Uuid;
 
 const TIMEOUT: Duration = Duration::from_secs(5);
+const HANDOFF_CHANNEL_FD: RawFd = 198;
 
 struct TestDaemon {
     executable: PathBuf,
@@ -99,12 +103,110 @@ impl TestDaemon {
 
 impl Drop for TestDaemon {
     fn drop(&mut self) {
+        if self.client.socket_path().exists() {
+            let _ = self.client.shutdown();
+        }
         if let Some(child) = self.child.as_mut() {
             let _ = child.kill();
             let _ = child.wait();
         }
         let _ = fs::remove_dir_all(&self.runtime_dir);
     }
+}
+
+#[test]
+fn replacement_bootstrap_rejects_invalid_inherited_descriptor() {
+    let output = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["daemon", "receive-handoff", "--channel", "999999"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Bad file descriptor"));
+}
+
+#[test]
+fn replacement_bootstrap_receives_listener_and_lock_ownership() {
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_boomux"));
+    let root = std::env::temp_dir().join(format!(
+        "boomux-handoff-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let runtime_home = root.join("runtime");
+    let state_home = root.join("state");
+    let runtime_directory = runtime_home.join("boomux");
+    let state_directory = state_home.join("boomux");
+    fs::create_dir_all(&runtime_directory).unwrap();
+    fs::create_dir_all(&state_directory).unwrap();
+    let socket_path = runtime_directory.join("daemon.sock");
+    let listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
+    let runtime_lock = locked_file(&runtime_directory.join("daemon.lock"));
+    let state_lock = locked_file(&state_directory.join("daemon.lock"));
+    let (mut parent_channel, child_channel) = UnixStream::pair().unwrap();
+    let child_channel_fd = child_channel.as_raw_fd();
+    let mut command = Command::new(executable);
+    command
+        .args([
+            "daemon",
+            "receive-handoff",
+            "--channel",
+            &HANDOFF_CHANNEL_FD.to_string(),
+        ])
+        .env("XDG_RUNTIME_DIR", &runtime_home)
+        .env("XDG_STATE_HOME", &state_home)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // The child duplicates its socketpair endpoint to the explicit bootstrap fd
+    // immediately before exec and clears close-on-exec on that duplicate.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::dup2(child_channel_fd, HANDOFF_CHANNEL_FD) == -1
+                || libc::fcntl(HANDOFF_CHANNEL_FD, libc::F_SETFD, 0) == -1
+            {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut replacement = command.spawn().unwrap();
+    drop(child_channel);
+
+    parent_channel.set_read_timeout(Some(TIMEOUT)).unwrap();
+    parent_channel.set_write_timeout(Some(TIMEOUT)).unwrap();
+    parent_channel.write_all(b"BOOMUXH1").unwrap();
+    send_descriptor(&parent_channel, listener.as_raw_fd(), 1);
+    send_descriptor(&parent_channel, runtime_lock.as_raw_fd(), 2);
+    send_descriptor(&parent_channel, state_lock.as_raw_fd(), 3);
+    let mut ready = [0];
+    parent_channel.read_exact(&mut ready).unwrap();
+    assert_eq!(ready, [4]);
+
+    drop(listener);
+    drop(runtime_lock);
+    drop(state_lock);
+    let runtime_contender = open_lock(&runtime_directory.join("daemon.lock"));
+    let state_contender = open_lock(&state_directory.join("daemon.lock"));
+    assert_lock_is_held(&runtime_contender);
+    assert_lock_is_held(&state_contender);
+    UnixStream::connect(&socket_path).unwrap();
+
+    parent_channel.write_all(&[5]).unwrap();
+    wait_until(
+        || replacement.try_wait().unwrap().is_some(),
+        "replacement did not abort",
+    );
+    assert!(replacement.wait().unwrap().success());
+    assert_eq!(
+        unsafe { libc::flock(runtime_contender.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        0
+    );
+    assert_eq!(
+        unsafe { libc::flock(state_contender.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        0
+    );
+    fs::remove_dir_all(root).unwrap();
 }
 
 #[test]
@@ -187,7 +289,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 4"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 5"));
 
     let mut duplicate = daemon
         .command()
@@ -219,6 +321,54 @@ fn native_daemon_lifecycle() {
         "second daemon did not reject the held state lock",
     );
     assert!(!duplicate_state.wait().unwrap().success());
+
+    let pending_workspace = daemon
+        .client
+        .create_workspace(
+            "handoff-pending",
+            vec![ShellSpec::login("pending", std::env::temp_dir())],
+        )
+        .unwrap();
+    let state_path = daemon.runtime_dir.join("state/boomux/state.json");
+    let valid_state = fs::read(&state_path).unwrap();
+    fs::write(&state_path, b"invalid replacement state").unwrap();
+    let failed_restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(!failed_restart.status.success());
+    assert!(daemon.client.ping().is_ok());
+    assert!(daemon.client.socket_path().exists());
+    fs::write(&state_path, valid_state).unwrap();
+
+    let old_daemon_pid = daemon.child.as_ref().unwrap().id();
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "daemon restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    assert!(String::from_utf8_lossy(&restart.stdout).contains("Restarted Boomux daemon"));
+    wait_until(
+        || daemon.child.as_mut().unwrap().try_wait().unwrap().is_some(),
+        "old daemon did not exit after handoff",
+    );
+    assert!(!process_exists(old_daemon_pid as libc::pid_t));
+    let restored_pending = daemon.client.get_workspace(&pending_workspace.id).unwrap();
+    assert_eq!(
+        restored_pending.shells[0].id,
+        pending_workspace.shells[0].id
+    );
+    assert_eq!(restored_pending.shells[0].status, ShellStatus::Pending);
+    daemon
+        .client
+        .close_workspace(&pending_workspace.id)
+        .unwrap();
 
     let output = daemon
         .command()
@@ -382,6 +532,23 @@ fn native_daemon_lifecycle() {
         .unwrap();
     let output = read_until(&mut first, b"transport-ok");
     assert!(contains(&output, b"transport-ok"));
+    let rejected_restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(!rejected_restart.status.success());
+    assert!(
+        String::from_utf8_lossy(&rejected_restart.stderr)
+            .contains("requires every shell to be pending")
+    );
+    AttachFrame::Input(b"printf 'still-running\\n'\n".to_vec())
+        .write_to(&mut first)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut first, b"still-running"),
+        b"still-running"
+    ));
     AttachFrame::Input(
         b"printf 'G101MjtjO1kyeHBjR0p2WVhKawc=' | base64 -d; printf 'progress\rsettled\n'\n"
             .to_vec(),
@@ -497,6 +664,57 @@ fn profile() -> TerminalProfile {
         pixel_width: 800,
         pixel_height: 600,
     }
+}
+
+fn open_lock(path: &std::path::Path) -> std::fs::File {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(path)
+        .unwrap()
+}
+
+fn locked_file(path: &std::path::Path) -> std::fs::File {
+    let file = open_lock(path);
+    assert_eq!(
+        unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        0
+    );
+    file
+}
+
+fn assert_lock_is_held(file: &std::fs::File) {
+    assert_eq!(
+        unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        -1
+    );
+    assert_eq!(
+        io::Error::last_os_error().raw_os_error(),
+        Some(libc::EWOULDBLOCK)
+    );
+}
+
+fn send_descriptor(stream: &UnixStream, descriptor: RawFd, marker: u8) {
+    use nix::sys::socket::{ControlMessage, MsgFlags, sendmsg};
+
+    let marker = [marker];
+    let data = [IoSlice::new(&marker)];
+    let descriptors = [descriptor];
+    let control = [ControlMessage::ScmRights(&descriptors)];
+    assert_eq!(
+        sendmsg::<()>(
+            stream.as_raw_fd(),
+            &data,
+            &control,
+            MsgFlags::MSG_NOSIGNAL,
+            None,
+        )
+        .unwrap(),
+        1
+    );
 }
 
 fn read_until(stream: &mut UnixStream, needle: &[u8]) -> Vec<u8> {

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -10,7 +10,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use boomux::client::{Attachment, Client};
-use boomux::protocol::{AttachFrame, ShellSpec, ShellStatus, TerminalProfile};
+use boomux::protocol::{self, AttachFrame, ShellSpec, ShellStatus, TerminalProfile};
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use uuid::Uuid;
 
 const TIMEOUT: Duration = Duration::from_secs(5);
@@ -175,7 +176,8 @@ fn replacement_bootstrap_receives_listener_and_lock_ownership() {
 
     parent_channel.set_read_timeout(Some(TIMEOUT)).unwrap();
     parent_channel.set_write_timeout(Some(TIMEOUT)).unwrap();
-    parent_channel.write_all(b"BOOMUXH1").unwrap();
+    parent_channel.write_all(b"BOOMUXH2").unwrap();
+    protocol::write_message(&mut parent_channel, &serde_json::json!({ "runtimes": [] })).unwrap();
     send_descriptor(&parent_channel, listener.as_raw_fd(), 1);
     send_descriptor(&parent_channel, runtime_lock.as_raw_fd(), 2);
     send_descriptor(&parent_channel, state_lock.as_raw_fd(), 3);
@@ -280,6 +282,144 @@ fn native_daemon_recovers_reproducible_metadata_after_restart() {
 }
 
 #[test]
+fn native_daemon_handoffs_multiple_detached_shells() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "multiple-live",
+            vec![
+                ShellSpec::login("first", std::env::temp_dir()),
+                ShellSpec::login("second", std::env::temp_dir()),
+            ],
+        )
+        .unwrap();
+    let mut pids = Vec::new();
+    for (index, shell) in workspace.shells.iter().enumerate() {
+        let mut attachment = daemon
+            .client
+            .attach(&shell.id, false, profile())
+            .unwrap()
+            .stream;
+        AttachFrame::Input(b"stty -echo\n".to_vec())
+            .write_to(&mut attachment)
+            .unwrap();
+        thread::sleep(Duration::from_millis(50));
+        let command = format!("printf 'pid{index}=%s:end\\n' \"$$\"\n");
+        AttachFrame::Input(command.into_bytes())
+            .write_to(&mut attachment)
+            .unwrap();
+        let output = read_until(&mut attachment, b":end");
+        pids.push(parse_pid(&output, &format!("pid{index}=")).unwrap());
+    }
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "multi-runtime restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+
+    for (index, shell) in workspace.shells.iter().enumerate() {
+        let mut attachment = daemon
+            .client
+            .attach(&shell.id, false, profile())
+            .unwrap()
+            .stream;
+        let command = format!("printf 'after{index}=%s:end\\n' \"$$\"\n");
+        AttachFrame::Input(command.into_bytes())
+            .write_to(&mut attachment)
+            .unwrap();
+        let output = read_until(&mut attachment, b":end");
+        assert_eq!(
+            parse_pid(&output, &format!("after{index}=")),
+            Some(pids[index])
+        );
+    }
+    daemon.client.close_workspace(&workspace.id).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn attachment_client_reconnects_across_daemon_restart() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "attached-live",
+            vec![ShellSpec::login("attached", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 600,
+        })
+        .unwrap();
+    let descriptor = pty.master.as_raw_fd().unwrap();
+    let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    assert_ne!(flags, -1);
+    assert_ne!(
+        unsafe { libc::fcntl(descriptor, libc::F_SETFL, flags | libc::O_NONBLOCK) },
+        -1
+    );
+    let mut command = CommandBuilder::new(&daemon.executable);
+    command.args(["__attach", &shell_id]);
+    command.env("XDG_RUNTIME_DIR", &daemon.runtime_dir);
+    command.env("XDG_STATE_HOME", daemon.runtime_dir.join("state"));
+    command.env("TERM", "attachment-term");
+    command.env("COLORTERM", "truecolor");
+    command.env("TERM_PROGRAM", "integration-terminal");
+    command.env("TERM_PROGRAM_VERSION", "1.0");
+    let mut attachment_process = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut reader = pty.master.try_clone_reader().unwrap();
+    let mut writer = pty.master.take_writer().unwrap();
+    read_raw_until(reader.as_mut(), b"$ ");
+    writer.write_all(b"stty -echo\n").unwrap();
+    thread::sleep(Duration::from_millis(50));
+    writer
+        .write_all(b"printf 'before-live-restart\\n'\n")
+        .unwrap();
+    assert!(contains(
+        &read_raw_until(reader.as_mut(), b"before-live-restart"),
+        b"before-live-restart"
+    ));
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "attached client restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    writer
+        .write_all(b"printf 'after-live-restart\\n'\n")
+        .unwrap();
+    assert!(contains(
+        &read_raw_until(reader.as_mut(), b"after-live-restart"),
+        b"after-live-restart"
+    ));
+
+    daemon.client.close_workspace(&workspace.id).unwrap();
+    wait_until(
+        || attachment_process.try_wait().unwrap().is_some(),
+        "attachment client did not exit after shell close",
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn native_daemon_lifecycle() {
     let mut daemon = TestDaemon::start();
 
@@ -289,7 +429,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 5"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 6"));
 
     let mut duplicate = daemon
         .command()
@@ -532,15 +672,44 @@ fn native_daemon_lifecycle() {
         .unwrap();
     let output = read_until(&mut first, b"transport-ok");
     assert!(contains(&output, b"transport-ok"));
-    let rejected_restart = daemon
-        .command()
+    let state_path = daemon.runtime_dir.join("state/boomux/state.json");
+    let valid_state = fs::read(&state_path).unwrap();
+    fs::write(&state_path, b"invalid active replacement state").unwrap();
+    let mut failed_restart_command = daemon.command();
+    let failed_restart = failed_restart_command
         .args(["daemon", "restart"])
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .unwrap();
-    assert!(!rejected_restart.status.success());
+    acknowledge_reconnect(&mut first);
+    let failed_restart = failed_restart.wait_with_output().unwrap();
+    assert!(!failed_restart.status.success());
+    fs::write(&state_path, valid_state).unwrap();
+    let mut first = wait_for_attach_with_profile(&daemon.client, &shell_id, profile()).stream;
+    AttachFrame::Input(b"printf 'active-rollback-ok\\n'\n".to_vec())
+        .write_to(&mut first)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut first, b"active-rollback-ok"),
+        b"active-rollback-ok"
+    ));
+
+    let mut restart_command = daemon.command();
+    let restart = restart_command
+        .args(["daemon", "restart"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    acknowledge_reconnect(&mut first);
+    let reconnected = wait_for_attach_with_profile(&daemon.client, &shell_id, profile());
+    let mut first = reconnected.stream;
+    let restart = restart.wait_with_output().unwrap();
     assert!(
-        String::from_utf8_lossy(&rejected_restart.stderr)
-            .contains("requires every shell to be pending")
+        restart.status.success(),
+        "active-controller restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
     );
     AttachFrame::Input(b"printf 'still-running\\n'\n".to_vec())
         .write_to(&mut first)
@@ -564,6 +733,24 @@ fn native_daemon_lifecycle() {
     assert!(contains(&rendered, b"settled"));
     assert!(!rendered.contains(&b'\x1b'));
     assert!(!contains(&rendered, b"Y2xpcGJvYXJk"));
+    let mut resized_profile = profile();
+    resized_profile.rows = 40;
+    resized_profile.cols = 100;
+    resized_profile.pixel_width = 1200;
+    resized_profile.pixel_height = 800;
+    AttachFrame::Resize {
+        rows: resized_profile.rows,
+        cols: resized_profile.cols,
+        pixel_width: resized_profile.pixel_width,
+        pixel_height: resized_profile.pixel_height,
+    }
+    .write_to(&mut first)
+    .unwrap();
+    AttachFrame::Input(b"printf 'shellpid=%s:end\\n' \"$$\"\n".to_vec())
+        .write_to(&mut first)
+        .unwrap();
+    let output = read_until(&mut first, b":end");
+    let shell_pid = parse_pid(&output, "shellpid=").expect("shell did not report its PID");
 
     drop(first);
     wait_until(
@@ -575,8 +762,54 @@ fn native_daemon_lifecycle() {
         },
         "shell stopped after its attachment disconnected",
     );
+    let state_path = daemon.runtime_dir.join("state/boomux/state.json");
+    let valid_state = fs::read(&state_path).unwrap();
+    fs::write(&state_path, b"invalid live replacement state").unwrap();
+    let failed_live_restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(!failed_live_restart.status.success());
+    fs::write(&state_path, valid_state).unwrap();
+    let mut rollback_attachment =
+        wait_for_attach_with_profile(&daemon.client, &shell_id, resized_profile.clone()).stream;
+    AttachFrame::Input(b"printf 'rollback-ok\\n'\n".to_vec())
+        .write_to(&mut rollback_attachment)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut rollback_attachment, b"rollback-ok"),
+        b"rollback-ok"
+    ));
+    drop(rollback_attachment);
 
-    let second_attachment = wait_for_attach(&daemon.client, &shell_id);
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "live daemon restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    assert_eq!(
+        daemon.client.get_shell(&shell_id).unwrap().status,
+        ShellStatus::Running
+    );
+    let repeated_restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        repeated_restart.status.success(),
+        "repeated live daemon restart failed: {}",
+        String::from_utf8_lossy(&repeated_restart.stderr)
+    );
+
+    let second_attachment =
+        wait_for_attach_with_profile(&daemon.client, &shell_id, resized_profile);
     assert!(!contains(
         &second_attachment.reconstruction,
         b"\x1b]52;c;Y2xpcGJvYXJk\x07"
@@ -587,6 +820,15 @@ fn native_daemon_lifecycle() {
     ));
     assert!(contains(&second_attachment.reconstruction, b"settled"));
     let mut second = second_attachment.stream;
+    AttachFrame::Input(b"stty size\n".to_vec())
+        .write_to(&mut second)
+        .unwrap();
+    assert!(contains(&read_until(&mut second, b"40 100"), b"40 100"));
+    AttachFrame::Input(b"printf 'shellpid2=%s:end\\n' \"$$\"\n".to_vec())
+        .write_to(&mut second)
+        .unwrap();
+    let output = read_until(&mut second, b":end");
+    assert_eq!(parse_pid(&output, "shellpid2="), Some(shell_pid));
     let error = daemon
         .client
         .attach(&shell_id, false, profile())
@@ -622,13 +864,24 @@ fn native_daemon_lifecycle() {
         String::from_utf8_lossy(&output)
     );
 
-    AttachFrame::Input(b"sleep 30 & printf 'child=%s\\n' \"$!\"\n".to_vec())
-        .write_to(&mut takeover)
-        .unwrap();
+    AttachFrame::Input(
+        b"/bin/sh -c 'trap \"\" HUP TERM; sleep 30' & printf 'child=%s\\n' \"$!\"; exit\n".to_vec(),
+    )
+    .write_to(&mut takeover)
+    .unwrap();
     let output = read_until(&mut takeover, b"child=");
     let child_pid = parse_child_pid(&output).expect("shell did not report background child PID");
 
     drop(takeover);
+    wait_until(
+        || {
+            matches!(
+                daemon.client.get_shell(&shell_id).unwrap().status,
+                ShellStatus::Exited { .. }
+            )
+        },
+        "imported shell leader exit was not detected",
+    );
     daemon.client.close_workspace(&workspace.id).unwrap();
     wait_until(
         || !process_exists(child_pid),
@@ -639,16 +892,36 @@ fn native_daemon_lifecycle() {
     daemon.stop_with_cli();
 }
 
-fn wait_for_attach(client: &Client, shell_id: &str) -> Attachment {
+fn wait_for_attach_with_profile(
+    client: &Client,
+    shell_id: &str,
+    profile: TerminalProfile,
+) -> Attachment {
     let deadline = Instant::now() + TIMEOUT;
     loop {
-        match client.attach(shell_id, false, profile()) {
+        match client.attach(shell_id, false, profile.clone()) {
             Ok(attachment) => return attachment,
-            Err(error) if error.to_string().contains("active controller") => {
-                assert!(Instant::now() < deadline, "old attachment was not released");
+            Err(error) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "attachment did not reconnect: {error}"
+                );
                 thread::sleep(Duration::from_millis(20));
             }
-            Err(error) => panic!("could not attach: {error}"),
+        }
+    }
+}
+
+fn acknowledge_reconnect(stream: &mut UnixStream) {
+    stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+    loop {
+        match AttachFrame::read_from(stream).unwrap() {
+            AttachFrame::Reconnect => {
+                AttachFrame::ReconnectAck.write_to(stream).unwrap();
+                return;
+            }
+            AttachFrame::Output(_) => {}
+            frame => panic!("expected reconnect frame, got {frame:?}"),
         }
     }
 }
@@ -748,6 +1021,37 @@ fn read_until(stream: &mut UnixStream, needle: &[u8]) -> Vec<u8> {
     );
 }
 
+fn read_raw_until(reader: &mut dyn Read, needle: &[u8]) -> Vec<u8> {
+    let deadline = Instant::now() + TIMEOUT;
+    let mut output = Vec::new();
+    let mut buffer = [0; 16 * 1024];
+    while Instant::now() < deadline {
+        match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(count) => {
+                output.extend_from_slice(&buffer[..count]);
+                if contains(&output, needle) {
+                    return output;
+                }
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
+                ) =>
+            {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => panic!("PTY read failed: {error}"),
+        }
+    }
+    panic!(
+        "did not receive {:?}; PTY output was {:?}",
+        String::from_utf8_lossy(needle),
+        String::from_utf8_lossy(&output)
+    );
+}
+
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
     haystack
         .windows(needle.len())
@@ -755,8 +1059,12 @@ fn contains(haystack: &[u8], needle: &[u8]) -> bool {
 }
 
 fn parse_child_pid(output: &[u8]) -> Option<libc::pid_t> {
+    parse_pid(output, "child=")
+}
+
+fn parse_pid(output: &[u8], label: &str) -> Option<libc::pid_t> {
     let output = String::from_utf8_lossy(output);
-    let value = output.rsplit_once("child=")?.1;
+    let value = output.rsplit_once(label)?.1;
     let digits = value
         .trim_start_matches(|character: char| !character.is_ascii_digit())
         .chars()


### PR DESCRIPTION
## Summary
- add a transactional daemon replacement handshake with rollback before finalization
- transfer live PTY masters, pidfd-backed process identity, terminal state, dimensions, listener, and lock ownership
- reconnect active attachment clients cooperatively with an acknowledged input-ordering boundary
- cover detached, active, repeated, multi-runtime, rollback, resize, PID preservation, and cleanup behavior

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check