### PR TITLE
Redesign dashboard as master-detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,16 +191,16 @@ mode, forwards input and resize events, writes output, and restores terminal
 mode on exit. See [`docs/architecture.md`](docs/architecture.md) for details.
 Shells remain pending until their first attachment reports terminal environment
 and dimensions; that profile initializes the PTY and child process. Reproducible
-workspace and shell metadata is restored after daemon restart. Remaining live
-PTY handoff work is tracked in
-[`docs/native-terminal-follow-up.md`](docs/native-terminal-follow-up.md).
+workspace and shell metadata provides crash recovery, while a graceful
+`boomux daemon restart` transfers running shells and reconnects active clients.
+See [`docs/live-pty-handoff.md`](docs/live-pty-handoff.md) for the handoff design.
 
 ## POC Limitations
 
-- PTYs and processes exist only for the daemon's lifetime. After restart,
-  persisted shells return as pending and start fresh processes when reopened.
 - Live daemon restart preserves pending and running shells. Active attachment
   clients reconnect cooperatively; exited shells use metadata recovery.
+- An unexpected daemon exit cannot hand off live PTYs. Persisted shell metadata
+  returns as pending and starts fresh processes when reopened.
 - Mutated process environment and in-memory application state are not persisted.
 - Reconnection emits at most 1 MiB of sanitized VT reconstruction rather than
   replaying historical PTY bytes. Graphics are omitted from reconstruction.

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -2,9 +2,9 @@
 
 ## Goal
 
-Replace the Boomux daemon without terminating detached shell processes. A
-metadata-only restart remains the crash fallback; handoff is an explicit,
-acknowledged upgrade path.
+Replace the Boomux daemon without terminating running shell processes or ending
+active terminal sessions. Metadata-only recovery remains the crash fallback;
+handoff is an explicit, acknowledged upgrade path.
 
 ## Invariants
 
@@ -39,10 +39,11 @@ mode, matches both lock-file inodes, and establishes exclusive flock ownership
 before acknowledging readiness. Explicit abort closes every received duplicate
 without affecting descriptors retained by the old daemon.
 
-For each detached running shell, the old reader pauses before the manifest is
-captured. The replacement validates the session leader and pidfd, reconstructs
-terminal state, and waits at `PREPARED`; it does not begin reading the PTY until
-`FINALIZE`, so rollback cannot consume output belonging to the old daemon.
+For each running shell, any active controller first acknowledges its reconnect
+boundary and the old reader pauses before the manifest is captured. The
+replacement validates the session leader and pidfd, reconstructs terminal state,
+and waits at `PREPARED`; it does not begin reading the PTY until `FINALIZE`, so
+rollback cannot consume output belonging to the old daemon.
 PTY/session identity is cross-checked with `TIOCGSID`, terminal reconstructions
 use separate bounded frames, and imported process/session cleanup uses pidfds to
 avoid signaling a reused numeric PID.

--- a/docs/native-terminal-follow-up.md
+++ b/docs/native-terminal-follow-up.md
@@ -4,9 +4,9 @@ Date: 2026-08-03
 
 ## Purpose
 
-Boomux now owns its PTYs and shell processes, but the native terminal backend is
-not complete. Live attachment is transparent; terminal initialization and
-reconnection are still approximations.
+Boomux owns its PTYs and shell processes. Live attachment is transparent, and
+the terminal initialization, reconstruction, persistence, and graceful handoff
+phases described here are implemented.
 
 This document records the remaining work needed to make Boomux shells behave
 consistently in Ghostty, Alacritty, Kitty, and other XDG terminal emulators.
@@ -29,11 +29,11 @@ consistently in Ghostty, Alacritty, Kitty, and other XDG terminal emulators.
 | Reconstructed terminal state on reconnect | Working |
 | ANSI-aware logical output for `boomux read` | Working |
 | Metadata recovery after daemon restart | Working |
-| Live PTY handoff to a replacement daemon | Missing |
+| Live PTY handoff to a replacement daemon | Working |
 
-The current backend is suitable for proof-of-concept testing. It reconstructs
-text VT state but does not claim graphics restoration or process survival across
-daemon restart.
+The current backend reconstructs text VT state but does not claim graphics
+restoration. Running processes survive acknowledged graceful daemon restart;
+an unexpected daemon exit falls back to reproducible metadata recovery.
 Workspace metadata contains only a UUID and name; working directories belong
 exclusively to shells. Dashboard project discovery supplies name suggestions
 and does not persist project paths. A shell request without a selected workspace
@@ -267,12 +267,15 @@ State directories are owner-only, state files are bounded and owner-validated,
 and updates use a synced temporary file followed by atomic rename. Invalid or
 unsupported state fails startup rather than silently discarding metadata.
 
-Do not claim that arbitrary process state can be serialized. After an ordinary
-daemon restart, Boomux restores every shell as pending and recreates it on first
-attachment, but cannot recover the original process or its mutated environment.
+Do not claim that arbitrary process state can be serialized. After startup
+without a handoff, such as crash recovery, Boomux restores shells as pending and
+recreates them on first attachment, but cannot recover the original process or
+its mutated environment.
 
-Live process survival during an upgrade requires a separate Unix PTY handoff
-mechanism. Treat that as a later feature, not part of metadata restoration.
+An explicit `boomux daemon restart` instead uses the separate transactional Unix
+PTY handoff documented in [`live-pty-handoff.md`](live-pty-handoff.md). It
+transfers running processes and reconnects active attachment clients; this does
+not change the guarantees of metadata-only recovery.
 
 ## Manual Test Matrix
 
@@ -288,6 +291,8 @@ Run each scenario in Alacritty and Ghostty first, then Kitty if available:
 | Hyperlink and OSC title | Live behavior reaches the emulator unchanged |
 | Controller takeover | Old window disconnects; new window controls the shell |
 | Cross-emulator reattach | Compatibility warning and behavior match policy |
+| Graceful restart while detached | Process PID and subsequent input/output survive |
+| Graceful restart while attached | Client reconnects without leaving raw mode |
 | Daemon stop | All owned process sessions terminate and socket is removed |
 
 Record the terminal environment visible inside each child:
@@ -301,9 +306,11 @@ stty size
 ## Implementation Order
 
 1. Dogfood Alacritty and Ghostty with the manual matrix.
-2. Create a separate VT reconstruction branch.
-3. Replace raw `boomux read` extraction with parser-backed logical lines.
-4. Add metadata persistence only after terminal behavior is stable.
+2. [Complete] Implement VT reconstruction.
+3. [Complete] Replace raw `boomux read` extraction with parser-backed logical
+   lines.
+4. [Complete] Add atomic metadata persistence.
+5. [Complete] Add transactional live PTY handoff and active-client reconnection.
 
 ## Definition Of Done
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,14 +44,14 @@ commitments.
   rendered scrollback through `boomux read`.
 - [x] Persist reproducible workspace and shell metadata atomically under
   `$XDG_STATE_HOME`; restore shells as pending after daemon restart.
+- [x] Preserve running shells and reconnect active terminal clients across a
+  transactional graceful daemon restart.
 
 ## Workspace Control
 
 See [`native-terminal-follow-up.md`](native-terminal-follow-up.md) for the
 terminal handshake, VT reconstruction, and restart-persistence plan.
 
-- Add graceful daemon restart through the staged
-  [live PTY handoff design](live-pty-handoff.md).
 - Aggregate multiple agent states as counts instead of one workspace-level
   value.
 - Notify when an agent becomes blocked, finishes, or needs input.

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,43 +386,27 @@ fn dashboard_views(
     workspaces
         .iter()
         .map(|workspace| {
-            let directory = common_shell_cwd(workspace);
-            let git = directory
-                .map(|directory| git_cache.inspect(directory))
-                .unwrap_or_default();
             let terminals = workspace
                 .shells
                 .iter()
-                .map(|shell| tui::TerminalView {
-                    id: shell.id.clone(),
-                    name: shell.name.clone(),
-                    status: shell_status(&shell.status).into(),
-                    directory: shell.cwd.display().to_string(),
+                .map(|shell| {
+                    let git = git_cache.inspect(&shell.cwd);
+                    tui::TerminalView {
+                        id: shell.id.clone(),
+                        name: shell.name.clone(),
+                        status: shell_status(&shell.status).into(),
+                        directory: shell.cwd.display().to_string(),
+                        branch: git.branch,
+                    }
                 })
                 .collect();
             tui::WorkspaceView {
                 id: workspace.id.clone(),
                 name: workspace.name.clone(),
-                directory: directory
-                    .map(|directory| directory.display().to_string())
-                    .unwrap_or_else(|| "-".into()),
-                repository: git.repository,
-                branch: git.branch,
-                git_state: git.state,
-                worktree: git.worktree,
                 terminals,
             }
         })
         .collect()
-}
-
-fn common_shell_cwd(workspace: &WorkspaceSnapshot) -> Option<&Path> {
-    let first = workspace.shells.first()?.cwd.as_path();
-    workspace
-        .shells
-        .iter()
-        .all(|shell| shell.cwd == first)
-        .then_some(first)
 }
 
 fn open_directory(
@@ -1210,17 +1194,13 @@ mod tests {
     }
 
     #[test]
-    fn empty_workspace_view_has_no_directory_or_git_values() {
+    fn empty_workspace_view_has_no_shells() {
         let views = dashboard_views(
             &[workspace("w1", "empty", Vec::new())],
             &mut git::Cache::default(),
         );
 
-        assert_eq!(views[0].directory, "-");
-        assert_eq!(views[0].repository, "-");
-        assert_eq!(views[0].branch, "-");
-        assert_eq!(views[0].git_state, "-");
-        assert_eq!(views[0].worktree, "-");
+        assert!(views[0].terminals.is_empty());
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -6,7 +6,7 @@ use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span, Text};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{
     Block, Cell, Clear, List, ListItem, ListState, Paragraph, Row, Table, TableState,
 };
@@ -25,11 +25,6 @@ const REFRESH_INTERVAL: Duration = Duration::from_millis(250);
 pub(crate) struct WorkspaceView {
     pub(crate) id: String,
     pub(crate) name: String,
-    pub(crate) directory: String,
-    pub(crate) repository: String,
-    pub(crate) branch: String,
-    pub(crate) git_state: String,
-    pub(crate) worktree: String,
     pub(crate) terminals: Vec<TerminalView>,
 }
 
@@ -53,6 +48,7 @@ pub(crate) struct TerminalView {
     pub(crate) name: String,
     pub(crate) status: String,
     pub(crate) directory: String,
+    pub(crate) branch: String,
 }
 
 pub(crate) struct Actions<R, O, C, W, N, E, F> {
@@ -349,6 +345,21 @@ impl App {
         self.message = None;
     }
 
+    fn set_focus(&mut self, focus: Focus) {
+        self.focus = focus;
+        self.message = None;
+    }
+
+    fn handle_focus_key(&mut self, key: KeyCode) -> bool {
+        let focus = match key {
+            KeyCode::Left | KeyCode::Char('h') => Focus::Workspaces,
+            KeyCode::Right | KeyCode::Char('l') => Focus::Terminals,
+            _ => return false,
+        };
+        self.set_focus(focus);
+        true
+    }
+
     fn select_first_terminal(&mut self) {
         self.terminal_state.select(
             self.selected()
@@ -615,6 +626,7 @@ where
             }
             KeyCode::Char('e') => app.request_rename(),
             KeyCode::Tab => app.toggle_focus(),
+            key if app.handle_focus_key(key) => {}
             _ => {}
         }
     }
@@ -710,17 +722,26 @@ fn render(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
     frame.render_widget(Block::new().style(Style::new().bg(BASE)), area);
 
-    let [header_area, workspace_area, terminal_area, footer_area] = Layout::vertical([
-        Constraint::Length(3),
-        Constraint::Percentage(38),
+    let [header_area, dashboard_area, footer_area] = Layout::vertical([
+        Constraint::Length(1),
         Constraint::Fill(1),
         Constraint::Length(1),
     ])
     .areas(area);
 
     render_header(frame, header_area, app);
-    render_workspaces(frame, workspace_area, app);
-    render_terminals(frame, terminal_area, app);
+    if dashboard_area.width >= 108 {
+        let [workspace_area, terminal_area] =
+            Layout::horizontal([Constraint::Length(28), Constraint::Fill(1)]).areas(dashboard_area);
+        render_workspaces(frame, workspace_area, app);
+        render_terminals(frame, terminal_area, app);
+    } else {
+        let [workspace_area, terminal_area] =
+            Layout::vertical([Constraint::Percentage(32), Constraint::Fill(1)])
+                .areas(dashboard_area);
+        render_workspaces(frame, workspace_area, app);
+        render_terminals(frame, terminal_area, app);
+    }
     render_footer(frame, footer_area, app);
     if let Mode::PickProject(picker) = &mut app.mode {
         render_project_picker(frame, area, picker);
@@ -834,7 +855,7 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         .sum();
     let line = Line::from(vec![
         Span::styled(
-            " BOOMUX DASHBOARD ",
+            " BOOMUX ",
             Style::new().fg(TEAL).add_modifier(Modifier::BOLD),
         ),
         Span::styled(
@@ -843,158 +864,29 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         ),
         Span::styled("  |  ", Style::new().fg(OVERLAY)),
         Span::styled(format!("{shell_count} shells"), Style::new().fg(BLUE)),
-        Span::styled("    Tab switches tables", Style::new().fg(SUBTEXT)),
-    ]);
-    frame.render_widget(
-        Paragraph::new(line).block(
-            Block::bordered()
-                .border_style(Style::new().fg(TEAL))
-                .style(Style::new().bg(BASE)),
+        Span::styled(
+            "    tab/h/l/arrows switches panes",
+            Style::new().fg(SUBTEXT),
         ),
-        area,
-    );
+    ]);
+    frame.render_widget(Paragraph::new(line).style(Style::new().bg(BASE)), area);
 }
 
 fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
-    let (header, rows, widths) = if area.width >= 140 {
-        let rows: Vec<_> = app
-            .workspaces
-            .iter()
-            .enumerate()
-            .map(|(index, workspace)| {
-                Row::new(vec![
-                    Cell::from((index + 1).to_string()),
-                    Cell::from(workspace.name.as_str()),
-                    Cell::from(workspace.repository.as_str()),
-                    Cell::from(workspace.branch.as_str()),
-                    git_state_cell(&workspace.git_state),
-                    Cell::from(workspace.worktree.as_str()),
-                    Cell::from(workspace.terminals.len().to_string()),
-                    Cell::from(workspace.directory.as_str()),
-                ])
-            })
-            .collect();
-        (
-            Row::new([
-                "#",
-                "NAME",
-                "REPOSITORY",
-                "BRANCH",
-                "DIRTY",
-                "WORKTREE",
-                "SHELLS",
-                "DIRECTORY",
-            ]),
-            rows,
-            vec![
-                Constraint::Length(4),
-                Constraint::Length(18),
-                Constraint::Length(18),
-                Constraint::Length(22),
-                Constraint::Length(12),
-                Constraint::Length(18),
-                Constraint::Length(8),
-                Constraint::Min(24),
-            ],
+    let rows = app.workspaces.iter().map(|workspace| {
+        Row::new([
+            Cell::from(workspace.name.as_str()),
+            Cell::from(workspace.terminals.len().to_string()),
+        ])
+    });
+    let table = Table::new(rows, [Constraint::Min(12), Constraint::Length(6)])
+        .header(
+            Row::new(["NAME", "SHELLS"]).style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)),
         )
-    } else if area.width >= 100 {
-        let rows: Vec<_> = app
-            .workspaces
-            .iter()
-            .enumerate()
-            .map(|(index, workspace)| {
-                let name = if workspace.repository == "-" || workspace.repository == workspace.name
-                {
-                    workspace.name.clone()
-                } else {
-                    format!("{} / {}", workspace.name, workspace.repository)
-                };
-                Row::new(vec![
-                    Cell::from((index + 1).to_string()),
-                    Cell::from(name),
-                    Cell::from(workspace.branch.as_str()),
-                    git_state_cell(&workspace.git_state),
-                    Cell::from(workspace.worktree.as_str()),
-                    Cell::from(workspace.terminals.len().to_string()),
-                ])
-            })
-            .collect();
-        (
-            Row::new([
-                "#",
-                "WORKSPACE / REPOSITORY",
-                "BRANCH",
-                "DIRTY",
-                "WORKTREE",
-                "SHELLS",
-            ]),
-            rows,
-            vec![
-                Constraint::Length(4),
-                Constraint::Min(20),
-                Constraint::Length(18),
-                Constraint::Length(12),
-                Constraint::Length(18),
-                Constraint::Length(7),
-            ],
-        )
-    } else {
-        let rows: Vec<_> = app
-            .workspaces
-            .iter()
-            .enumerate()
-            .map(|(index, workspace)| {
-                let name = if workspace.repository == "-" || workspace.repository == workspace.name
-                {
-                    workspace.name.clone()
-                } else {
-                    format!("{} / {}", workspace.name, workspace.repository)
-                };
-                Row::new(vec![
-                    Cell::from((index + 1).to_string()),
-                    Cell::from(Text::from(vec![
-                        Line::from(name),
-                        Line::from(format!(
-                            "{} shell{}",
-                            workspace.terminals.len(),
-                            if workspace.terminals.len() == 1 {
-                                ""
-                            } else {
-                                "s"
-                            }
-                        )),
-                    ])),
-                    Cell::from(Text::from(vec![
-                        Line::from(workspace.branch.as_str()),
-                        Line::from(vec![
-                            Span::styled(
-                                workspace.git_state.as_str(),
-                                Style::new().fg(git_state_color(&workspace.git_state)),
-                            ),
-                            Span::raw(" | "),
-                            Span::raw(workspace.worktree.as_str()),
-                        ]),
-                    ])),
-                ])
-                .height(2)
-            })
-            .collect();
-        (
-            Row::new(["#", "WORKSPACE / REPOSITORY", "GIT DETAILS"]),
-            rows,
-            vec![
-                Constraint::Length(4),
-                Constraint::Min(24),
-                Constraint::Length(34),
-            ],
-        )
-    };
-    let table = Table::new(rows, widths)
-        .header(header.style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
         .column_spacing(1)
         .block(
             Block::bordered()
-                .title(" Workspaces ")
+                .title(format!(" Workspaces ({}) ", app.workspaces.len()))
                 .border_style(Style::new().fg(if app.focus == Focus::Workspaces {
                     TEAL
                 } else {
@@ -1011,64 +903,105 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
     frame.render_stateful_widget(table, area, &mut app.workspace_state);
 }
 
-fn git_state_cell(state: &str) -> Cell<'_> {
-    Cell::from(Span::styled(state, Style::new().fg(git_state_color(state))))
-}
-
 fn render_terminals(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
-    let header = Row::new(["#", "NAME", "STATUS", "DIRECTORY", "SHELL ID"])
+    let header = Row::new(["NAME", "STATUS", "DIRECTORY", "BRANCH", "SHELL ID"])
         .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD));
     let selected = app
         .workspace_state
         .selected()
         .and_then(|index| app.workspaces.get(index));
+    let title = selected.map_or_else(
+        || " Shells ".to_owned(),
+        |workspace| {
+            format!(
+                " Shells: {} ({}) ",
+                workspace.name,
+                workspace.terminals.len()
+            )
+        },
+    );
+    let block = Block::bordered().title(title).border_style(Style::new().fg(
+        if app.focus == Focus::Terminals {
+            TEAL
+        } else {
+            OVERLAY
+        },
+    ));
+    let inner = block.inner(area);
+    let show_full_ids = inner.width >= 150;
     let rows: Vec<_> = selected
         .into_iter()
         .flat_map(|workspace| workspace.terminals.iter())
-        .enumerate()
-        .map(|(index, terminal)| {
+        .map(|terminal| {
             Row::new(vec![
-                Cell::from((index + 1).to_string()),
                 Cell::from(terminal.name.as_str()),
                 Cell::from(Span::styled(
                     terminal.status.as_str(),
                     Style::new().fg(status_color(&terminal.status)),
                 )),
                 Cell::from(terminal.directory.as_str()),
-                Cell::from(terminal.id.as_str()),
+                Cell::from(terminal.branch.as_str()),
+                Cell::from(if show_full_ids {
+                    terminal.id.clone()
+                } else {
+                    short_id(&terminal.id)
+                }),
             ])
         })
         .collect();
-    let title = selected.map_or_else(
-        || " Terminals ".to_owned(),
-        |workspace| format!(" Terminals: {} ", workspace.name),
-    );
-    let table = Table::new(
-        rows,
-        [
-            Constraint::Length(4),
-            Constraint::Length(18),
-            Constraint::Length(12),
-            Constraint::Min(24),
-            Constraint::Length(24),
-        ],
-    )
-    .header(header)
-    .column_spacing(1)
-    .block(Block::bordered().title(title).border_style(Style::new().fg(
-        if app.focus == Focus::Terminals {
-            TEAL
-        } else {
-            OVERLAY
-        },
-    )))
-    .row_highlight_style(
-        Style::new()
-            .fg(TEXT)
-            .add_modifier(Modifier::BOLD | Modifier::REVERSED),
-    )
-    .highlight_symbol("> ");
-    frame.render_stateful_widget(table, area, &mut app.terminal_state);
+    let widths = shell_column_widths(inner.width, show_full_ids);
+    frame.render_widget(block, area);
+    let table_area = if show_full_ids {
+        inner
+    } else {
+        let [detail_area, table_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(inner);
+        let detail = app.selected_terminal().map_or_else(
+            || Line::from(Span::styled(" No shell selected", Style::new().fg(SUBTEXT))),
+            |terminal| {
+                Line::from(vec![
+                    Span::styled(" ID ", Style::new().fg(SUBTEXT)),
+                    Span::styled(terminal.id.as_str(), Style::new().fg(TEXT)),
+                ])
+            },
+        );
+        frame.render_widget(Paragraph::new(detail), detail_area);
+        table_area
+    };
+    let table = Table::new(rows, widths)
+        .header(header)
+        .column_spacing(1)
+        .row_highlight_style(
+            Style::new()
+                .fg(TEXT)
+                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+        )
+        .highlight_symbol("> ");
+    frame.render_stateful_widget(table, table_area, &mut app.terminal_state);
+}
+
+fn shell_column_widths(width: u16, show_full_ids: bool) -> Vec<Constraint> {
+    let (name, status, branch, id, directory_min, directory_max) = if show_full_ids {
+        (18, 10, 30, 36, 24, 42)
+    } else {
+        (16, 10, 18, 8, 16, 36)
+    };
+    // Four column gaps and the highlight marker also consume table width.
+    let fixed = name + status + branch + id + 6;
+    let directory = width
+        .saturating_sub(fixed)
+        .clamp(directory_min, directory_max);
+    vec![
+        Constraint::Length(name),
+        Constraint::Length(status),
+        Constraint::Length(directory),
+        Constraint::Length(branch),
+        Constraint::Length(id),
+    ]
+}
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
 }
 
 fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
@@ -1112,7 +1045,10 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
     } else {
         let mut spans = vec![
             Span::styled(" j/k", Style::new().fg(TEAL)),
-            Span::styled(" navigate  tab focus  ", Style::new().fg(SUBTEXT)),
+            Span::styled(
+                " navigate  tab/h/l/arrows focus  ",
+                Style::new().fg(SUBTEXT),
+            ),
             Span::styled("a", Style::new().fg(GREEN)),
             Span::styled(
                 if app.focus == Focus::Workspaces {
@@ -1171,18 +1107,6 @@ fn status_color(status: &str) -> Color {
     }
 }
 
-fn git_state_color(state: &str) -> Color {
-    if state == "clean" {
-        GREEN
-    } else if state.contains("conflict") {
-        RED
-    } else if state == "-" || state == "unknown" {
-        SUBTEXT
-    } else {
-        YELLOW
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1219,16 +1143,12 @@ mod tests {
         WorkspaceView {
             id: id.into(),
             name: name.into(),
-            directory: "/tmp/boomux".into(),
-            repository: "boomux".into(),
-            branch: "main".into(),
-            git_state: "clean".into(),
-            worktree: "primary".into(),
             terminals: vec![TerminalView {
                 id: "term_1".into(),
                 name: "agent".into(),
                 status: "running".into(),
                 directory: "/tmp/boomux".into(),
+                branch: "main".into(),
             }],
         }
     }
@@ -1244,11 +1164,23 @@ mod tests {
     }
 
     #[test]
-    fn git_states_use_semantic_colors() {
-        assert_eq!(git_state_color("clean"), GREEN);
-        assert_eq!(git_state_color("3 changed"), YELLOW);
-        assert_eq!(git_state_color("1 conflict"), RED);
-        assert_eq!(git_state_color("-"), SUBTEXT);
+    fn shell_ids_are_shortened_to_eight_characters() {
+        assert_eq!(short_id("12345678-1234-1234-1234-123456789abc"), "12345678");
+        assert_eq!(short_id("short"), "short");
+    }
+
+    #[test]
+    fn wide_shell_columns_are_bounded_instead_of_absorbing_extra_space() {
+        assert_eq!(
+            shell_column_widths(180, true),
+            vec![
+                Constraint::Length(18),
+                Constraint::Length(10),
+                Constraint::Length(42),
+                Constraint::Length(30),
+                Constraint::Length(36),
+            ]
+        );
     }
 
     #[test]
@@ -1272,6 +1204,21 @@ mod tests {
                 .map(|terminal| terminal.name.as_str()),
             Some("agent")
         );
+    }
+
+    #[test]
+    fn directional_keys_can_select_each_pane() {
+        let mut app = app();
+
+        assert!(app.handle_focus_key(KeyCode::Char('l')));
+        assert_eq!(app.focus, Focus::Terminals);
+        assert!(app.handle_focus_key(KeyCode::Left));
+        assert_eq!(app.focus, Focus::Workspaces);
+        assert!(app.handle_focus_key(KeyCode::Right));
+        assert_eq!(app.focus, Focus::Terminals);
+        assert!(app.handle_focus_key(KeyCode::Char('h')));
+        assert_eq!(app.focus, Focus::Workspaces);
+        assert!(!app.handle_focus_key(KeyCode::Char('x')));
     }
 
     #[test]
@@ -1642,14 +1589,17 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect();
         assert!(text.contains("BRANCH"));
-        assert!(text.contains("DIRTY"));
-        assert!(text.contains("WORKTREE"));
+        assert!(text.contains("DIRECTORY"));
+        assert!(text.contains("SHELL ID"));
+        assert!(text.contains("ID term_1"));
         assert!(text.contains("SHELLS"));
-        assert!(text.contains("primary"));
+        assert!(text.contains("Shells: boomux (1)"));
+        assert!(!text.contains("DIRTY"));
+        assert!(!text.contains("WORKTREE"));
     }
 
     #[test]
-    fn wide_dashboard_renders_repository_and_directory_columns() {
+    fn wide_dashboard_keeps_workspace_summary_and_shell_details() {
         let backend = TestBackend::new(180, 34);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = app();
@@ -1662,12 +1612,15 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        assert!(text.contains("REPOSITORY"));
+        assert!(text.contains("Workspaces (1)"));
+        assert!(text.contains("agent"));
         assert!(text.contains("DIRECTORY"));
+        assert!(text.contains("main"));
+        assert!(!text.contains("REPOSITORY"));
     }
 
     #[test]
-    fn narrow_dashboard_keeps_workspace_and_git_details_visible() {
+    fn narrow_dashboard_stacks_workspace_and_shell_details() {
         let backend = TestBackend::new(80, 34);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = app();
@@ -1680,12 +1633,36 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        assert!(text.contains("WORKSPACE / REPOSITORY"));
-        assert!(text.contains("GIT DETAILS"));
+        assert!(text.contains("Workspaces (1)"));
+        assert!(text.contains("Shells: boomux (1)"));
+        assert!(text.contains("DIRECTORY"));
+        assert!(text.contains("BRANCH"));
+        assert!(text.contains("SHELL ID"));
         assert!(text.contains("main"));
-        assert!(text.contains("clean"));
-        assert!(text.contains("primary"));
-        assert!(text.contains("1 shell"));
+        assert!(!text.contains("DIRTY"));
+        assert!(!text.contains("WORKTREE"));
+    }
+
+    #[test]
+    fn horizontal_breakpoint_keeps_every_shell_column_visible() {
+        let backend = TestBackend::new(108, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("NAME"));
+        assert!(text.contains("STATUS"));
+        assert!(text.contains("DIRECTORY"));
+        assert!(text.contains("BRANCH"));
+        assert!(text.contains("SHELL ID"));
+        assert!(text.contains("ID term_1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the stacked dashboard tables with a minimal workspace sidebar and detailed shell pane
- show per-shell status, directory, Git branch, and responsive shell IDs without dirty or worktree columns
- support horizontal pane navigation and a stacked narrow-terminal fallback
- bound wide-table columns for balanced spacing and update live-handoff documentation to match shipped behavior

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check
- manually reviewed the installed release UI with populated workspaces