### PR TITLE
Add durable shell run identity

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -173,7 +173,14 @@ BOOMUX_WORKSPACE_ID
 BOOMUX_WORKSPACE
 BOOMUX_SHELL_ID
 BOOMUX_SHELL_NAME
+BOOMUX_RUN_ID
 ```
+
+`BOOMUX_RUN_ID` identifies the current process incarnation. It remains stable
+across attachment changes and graceful daemon handoff, but changes when the same
+durable shell starts a new process after recovery. A process transferred from a
+legacy daemon may have a daemon-side run identity without this environment
+variable; inspect `environment_has_run_id` before relying on it.
 
 `boomux prompt` prints `workspace/shell` inside Boomux and nothing outside it.
 It is intended for prompt integrations. Use `boomux --help` and

--- a/README.md
+++ b/README.md
@@ -152,10 +152,15 @@ BOOMUX_WORKSPACE_ID
 BOOMUX_WORKSPACE
 BOOMUX_SHELL_ID
 BOOMUX_SHELL_NAME
+BOOMUX_RUN_ID
 ```
 
-IDs remain authoritative after a rename. A dynamic Starship segment can call
-the hidden prompt command:
+Workspace and shell IDs remain authoritative after a rename. `BOOMUX_RUN_ID`
+identifies one process incarnation and changes when a durable shell starts a
+new process after recovery. A live process transferred from a pre-run-identity
+daemon receives a daemon-side run identity, but its existing environment cannot
+be retrofitted; `shell inspect` reports that compatibility case. A dynamic
+Starship segment can call the hidden prompt command:
 
 ```toml
 [custom.boomux]
@@ -201,8 +206,9 @@ See [`docs/live-pty-handoff.md`](docs/live-pty-handoff.md) for the handoff desig
 
 ## POC Limitations
 
-- Live daemon restart preserves pending and running shells. Active attachment
-  clients reconnect cooperatively; exited shells use metadata recovery.
+- Live daemon restart preserves pending and running shells, and active attachment
+  clients reconnect cooperatively. An exited shell currently prevents graceful
+  replacement until final terminal-state transfer is implemented.
 - An unexpected daemon exit cannot hand off live PTYs. Persisted shell metadata
   returns as pending and starts fresh processes when reopened.
 - Mutated process environment and in-memory application state are not persisted.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,12 +32,17 @@ name resolution, and conversion from daemon snapshots into TUI view models.
 with a four-byte big-endian length prefix. Attachment traffic uses small binary
 frames for input, output, resize, and detach events.
 
-The domain has only two durable identities:
+The domain has three durable identities:
 
 - A workspace is a globally named shell container with a UUID. It has no path
   or working directory.
-- A shell owns one PTY, child process, name, explicit working directory, and
-  workspace ID.
+- A shell is a durable process slot with a name, startup command, explicit
+  working directory, and workspace ID.
+- A shell run identifies one process incarnation beneath that durable shell. It
+  owns the PTY and child while live and carries a generation, lifecycle
+  timestamps, exit reason, and output revision.
+  Runs created by Boomux export `BOOMUX_RUN_ID`; a process imported from a
+  legacy daemon is marked when its existing environment lacks that variable.
 
 There are no separate tab, pane, and terminal identity layers.
 
@@ -131,8 +136,8 @@ the PTY master and child. Reopening a window acquires the controller and first
 receives sanitized reconstructed terminal state followed by live output.
 
 Closing a pending shell removes only metadata. Closing a running shell terminates
-its child and disconnects its controller. Closing a
-workspace removes all its shells from the registry before terminating them.
+its child and disconnects its controller. Closing a workspace terminates its
+shells before removing the workspace from the registry.
 On Linux, cleanup signals every process still belonging to the shell's session
 before reaping the session leader. `boomux daemon stop` applies the same cleanup
 to the complete registry and removes the runtime socket.
@@ -141,7 +146,8 @@ The daemon atomically writes reproducible registry metadata to
 `$XDG_STATE_HOME/boomux/state.json`, falling back to
 `~/.local/state/boomux/state.json`. Workspace and shell IDs, names, grouping,
 shell working directories, startup commands, and last terminal profiles survive
-restart. Recovered shells are pending: Boomux does not claim that arbitrary
+restart. The last run record also preserves its identity and outcome. Recovered
+shells are pending: Boomux does not claim that arbitrary
 processes, mutated environments, or PTYs survive daemon restart or crash.
 
 `boomux daemon restart` transfers the existing listener and both ownership locks
@@ -149,10 +155,11 @@ to a replacement process through a private, versioned `SCM_RIGHTS` handshake.
 Prepare/finalize acknowledgement keeps rollback safe before the irreversible
 ownership boundary. Pending shells restore from metadata. Detached running
 shells transfer their PTY master, pidfd-backed process identity, terminal
-profile, and reconstructed VT state without changing the child PID. Attached
-clients receive a reconnect request, acknowledge an input-ordering boundary,
-and reconnect to the replacement while remaining in raw mode. Exited shells use
-metadata recovery.
+profile, run identity, output revision, and reconstructed VT state without
+changing the child PID. Attached clients receive a reconnect request,
+acknowledge an input-ordering boundary, and reconnect to the replacement while
+remaining in raw mode. An exited shell currently prevents graceful replacement;
+persisting its final terminal state is the next handoff milestone.
 
 ## Next Technical Steps
 

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -26,7 +26,8 @@ The private handoff channel will carry a versioned manifest followed by Unix
 - Existing listener socket
 - Runtime and state lock files
 - One PTY master per running shell
-- Shell ID, terminal profile, PID/session identity, and sanitized VT state
+- Shell and run IDs, terminal profile, PID/session identity, output revision,
+  and sanitized VT state
 
 The PTY master is full duplex, so reader and writer duplicates do not need to be
 transferred separately. The replacement cannot inherit Unix parenthood; process

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,10 +71,37 @@ terminal handshake, VT reconstruction, and restart-persistence plan.
 
 ## Agent Workflows
 
-- Record state transitions and show when an agent last changed state.
-- Provide an attention queue for blocked and completed agents.
-- Send common responses or commands to a selected pane.
-- Run hooks, tests, notifications, or focus actions when an agent finishes.
+Build agent orchestration on explicit process identity and observable daemon
+state rather than parsing human CLI tables or treating a durable shell as one
+eternal process.
+
+### Foundation
+
+1. [Complete] Add a `ShellRun` identity beneath each durable shell, including
+   generation, lifecycle timestamps, exit reason, output revision, and
+   `BOOMUX_RUN_ID`.
+2. Preserve final exited-run metadata and terminal state across graceful daemon
+   restart without starting a replacement process implicitly.
+3. Add stable versioned JSON output, typed errors, and capability reporting for
+   integrations.
+4. Add a monotonic daemon event stream with reconnectable cursors and
+   revision-aware output reads.
+5. Route runtime transitions through one coordinator so persistence and events
+   share an ordering boundary.
+
+### Agent Runtime
+
+1. Model agent instances separately from shells and runs, with explicit state
+   authority, evidence, and confidence.
+2. Prefer lifecycle integrations, then process adapters, then conservative
+   terminal-screen heuristics for `working`, `blocked`, `idle`, `done`, and
+   `unknown` states.
+3. Aggregate agent states as workspace counts and provide an explainable,
+   persistent attention queue for blocked and completed work.
+4. Add notifications and revision-aware `agent wait` and `agent read` commands.
+5. Add guarded prompts and common responses only after defining run-scoped
+   leases, user-controller precedence, idempotency, and audit events.
+6. Run hooks, tests, notifications, or focus actions from durable transitions.
 
 ## Distribution And Polish
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10,9 +10,9 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{self, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -23,10 +23,12 @@ use crate::client;
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::protocol::{
-    self, AttachFrame, Envelope, Request, Response, ShellSnapshot, ShellSpec, ShellStatus,
-    Snapshot, TerminalProfile, WorkspaceSnapshot,
+    self, AttachFrame, Envelope, Request, Response, ShellRunExitReason, ShellRunSnapshot,
+    ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalProfile, WorkspaceSnapshot,
 };
-use crate::state_store::{PersistedShell, PersistedState, PersistedWorkspace, StateStore};
+use crate::state_store::{
+    PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace, StateStore,
+};
 use crate::terminal_state::TerminalState;
 
 const CONTROLLER_QUEUE: usize = 64;
@@ -34,6 +36,7 @@ const SHUTDOWN_GRACE: Duration = Duration::from_millis(50);
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 const RESTART_TIMEOUT: Duration = Duration::from_secs(10);
 const IO_RETRY_DELAY: Duration = Duration::from_millis(2);
+const PERSIST_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_TERMINAL_ENV_VALUE: usize = 256;
 const MAX_TERMINAL_ROWS: u16 = 1_000;
 const MAX_TERMINAL_COLS: u16 = 1_000;
@@ -101,7 +104,7 @@ fn run_daemon(
     transferred_runtimes: Vec<handoff::TransferredRuntime>,
     committed: Option<&mut UnixStream>,
 ) -> io::Result<()> {
-    let registry = Arc::new(Registry::restore(store)?);
+    let registry = Arc::new(Registry::restore(store, committed.is_some())?);
     let gated_readers = registry.import_runtimes(transferred_runtimes)?;
     if let Some(channel) = committed {
         channel.write_all(&[handoff::PREPARED])?;
@@ -136,8 +139,15 @@ fn run_daemon(
     let (restart_sender, restart_receiver) = mpsc::channel::<RestartRequest>();
     let mut handlers = Vec::new();
     let mut handed_off = false;
+    let mut last_persistence_retry = Instant::now();
 
     while !shutdown.load(Ordering::Acquire) {
+        if registry.persistence_dirty.load(Ordering::Acquire)
+            && last_persistence_retry.elapsed() >= PERSIST_RETRY_INTERVAL
+        {
+            let _ = registry.persist();
+            last_persistence_retry = Instant::now();
+        }
         match restart_receiver.try_recv() {
             Ok(request) => {
                 let result = launch_replacement(&listener, &daemon_lock, &registry);
@@ -265,6 +275,9 @@ fn launch_replacement(
 ) -> io::Result<()> {
     let _mutation = lock(&registry.mutation_lock)?;
     registry.ensure_running()?;
+    if registry.persistence_dirty.load(Ordering::Acquire) {
+        registry.persist()?;
+    }
     registry.stopping.store(true, Ordering::Release);
     let mut paused = Vec::new();
     let result = (|| {
@@ -272,11 +285,13 @@ fn launch_replacement(
         let state = lock(&registry.state)?;
         let mut transfers = Vec::new();
         for shell in state.shells.values() {
-            let (profile, runtime) = match &*lock(&shell.lifecycle)? {
+            let (profile, run, runtime) = match &*lock(&shell.lifecycle)? {
                 ShellLifecycle::Pending => continue,
-                ShellLifecycle::Running { profile, runtime } => {
-                    (profile.clone(), Arc::clone(runtime))
-                }
+                ShellLifecycle::Running {
+                    profile,
+                    run,
+                    runtime,
+                } => (profile.clone(), Arc::clone(run), Arc::clone(runtime)),
                 ShellLifecycle::Exited { .. } => {
                     return Err(io::Error::new(
                         io::ErrorKind::Unsupported,
@@ -292,6 +307,8 @@ fn launch_replacement(
             transfers.push(OutgoingRuntime {
                 manifest: handoff::RuntimeManifest {
                     shell_id: shell.id.clone(),
+                    run_id: Some(run.id.clone()),
+                    output_revision: Some(run.output_revision.load(Ordering::Acquire)),
                     profile,
                     pid,
                 },
@@ -524,6 +541,7 @@ struct Registry {
     mutation_lock: Mutex<()>,
     persist_lock: Mutex<()>,
     stopping: AtomicBool,
+    persistence_dirty: AtomicBool,
 }
 
 #[derive(Default)]
@@ -538,7 +556,6 @@ struct RegistryBackup {
     workspace_names: HashMap<String, String>,
     workspace_shell_ids: HashMap<String, Vec<String>>,
     shell_names: HashMap<String, String>,
-    last_profiles: HashMap<String, Option<TerminalProfile>>,
 }
 
 impl Default for Registry {
@@ -549,6 +566,7 @@ impl Default for Registry {
             mutation_lock: Mutex::new(()),
             persist_lock: Mutex::new(()),
             stopping: AtomicBool::new(false),
+            persistence_dirty: AtomicBool::new(false),
         }
     }
 }
@@ -565,7 +583,7 @@ struct Shell {
     name: Mutex<String>,
     cwd: PathBuf,
     command: Vec<String>,
-    last_profile: Mutex<Option<TerminalProfile>>,
+    last_run: Mutex<Option<PersistedShellRun>>,
     lifecycle: Mutex<ShellLifecycle>,
 }
 
@@ -573,14 +591,100 @@ enum ShellLifecycle {
     Pending,
     Running {
         profile: TerminalProfile,
+        run: Arc<ShellRun>,
         runtime: Arc<ShellRuntime>,
     },
     Exited {
         code: Option<u32>,
         profile: TerminalProfile,
+        run: Arc<ShellRun>,
         runtime: Arc<ShellRuntime>,
     },
     Closed,
+}
+
+struct ShellRun {
+    id: String,
+    generation: u64,
+    started_at_ms: u64,
+    ended: Mutex<Option<ShellRunEnd>>,
+    output_revision: AtomicU64,
+    environment_has_run_id: bool,
+}
+
+#[derive(Clone)]
+struct ShellRunEnd {
+    ended_at_ms: u64,
+    reason: ShellRunExitReason,
+}
+
+impl ShellRun {
+    fn new(generation: u64) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            generation,
+            started_at_ms: unix_time_ms(),
+            ended: Mutex::new(None),
+            output_revision: AtomicU64::new(0),
+            environment_has_run_id: true,
+        }
+    }
+
+    fn from_persisted(run: &PersistedShellRun) -> Self {
+        let ended = run
+            .ended_at_ms
+            .zip(run.exit_reason.clone())
+            .map(|(ended_at_ms, reason)| ShellRunEnd {
+                ended_at_ms,
+                reason,
+            });
+        Self {
+            id: run.id.clone(),
+            generation: run.generation,
+            started_at_ms: run.started_at_ms,
+            ended: Mutex::new(ended),
+            output_revision: AtomicU64::new(run.output_revision),
+            environment_has_run_id: run.environment_has_run_id,
+        }
+    }
+
+    fn finish(&self, reason: ShellRunExitReason) -> io::Result<()> {
+        let mut ended = lock(&self.ended)?;
+        if ended.is_none() {
+            *ended = Some(ShellRunEnd {
+                ended_at_ms: unix_time_ms().max(self.started_at_ms),
+                reason,
+            });
+        }
+        Ok(())
+    }
+
+    fn snapshot(&self) -> io::Result<ShellRunSnapshot> {
+        let ended = lock(&self.ended)?.clone();
+        Ok(ShellRunSnapshot {
+            id: self.id.clone(),
+            generation: self.generation,
+            started_at_ms: self.started_at_ms,
+            ended_at_ms: ended.as_ref().map(|end| end.ended_at_ms),
+            exit_reason: ended.map(|end| end.reason),
+            output_revision: self.output_revision.load(Ordering::Acquire),
+            environment_has_run_id: self.environment_has_run_id,
+        })
+    }
+
+    fn persisted(&self, profile: TerminalProfile) -> io::Result<PersistedShellRun> {
+        let snapshot = self.snapshot()?;
+        Ok(PersistedShellRun {
+            id: snapshot.id,
+            generation: snapshot.generation,
+            started_at_ms: snapshot.started_at_ms,
+            ended_at_ms: snapshot.ended_at_ms,
+            exit_reason: snapshot.exit_reason,
+            output_revision: snapshot.output_revision,
+            environment_has_run_id: snapshot.environment_has_run_id,
+            profile,
+        })
+    }
 }
 
 struct ShellRuntime {
@@ -989,10 +1093,12 @@ impl Registry {
         }
     }
 
-    fn restore(store: StateStore) -> io::Result<Self> {
+    fn restore(store: StateStore, live_handoff: bool) -> io::Result<Self> {
         let persisted = store.load()?.unwrap_or_default();
         let mut state = RegistryState::default();
         let mut workspace_names = HashSet::new();
+        let mut run_ids = HashSet::new();
+        let mut recovered_interrupted_run = false;
         for saved_workspace in persisted.workspaces {
             validate_id("workspace", &saved_workspace.id)?;
             validate_name(&saved_workspace.name)?;
@@ -1006,12 +1112,30 @@ impl Registry {
             }
             let mut shell_names = HashSet::new();
             let mut shell_ids = Vec::with_capacity(saved_workspace.shells.len());
-            for saved_shell in saved_workspace.shells {
+            for mut saved_shell in saved_workspace.shells {
                 validate_id("shell", &saved_shell.id)?;
                 validate_name(&saved_shell.name)?;
                 validate_persisted_cwd(&saved_shell.cwd)?;
-                if let Some(profile) = &saved_shell.last_profile {
-                    validate_terminal_profile(profile)?;
+                if let Some(run) = &mut saved_shell.last_run {
+                    validate_id("run", &run.id)?;
+                    validate_terminal_profile(&run.profile)?;
+                    if run.generation == 0
+                        || run.ended_at_ms.is_some() != run.exit_reason.is_some()
+                        || run
+                            .ended_at_ms
+                            .is_some_and(|ended_at_ms| ended_at_ms < run.started_at_ms)
+                        || !run_ids.insert(run.id.clone())
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Boomux state contains an invalid shell run",
+                        ));
+                    }
+                    if !live_handoff && run.ended_at_ms.is_none() {
+                        run.ended_at_ms = Some(unix_time_ms().max(run.started_at_ms));
+                        run.exit_reason = Some(ShellRunExitReason::Interrupted);
+                        recovered_interrupted_run = true;
+                    }
                 }
                 if !shell_names.insert(saved_shell.name.clone())
                     || state.shells.contains_key(&saved_shell.id)
@@ -1027,7 +1151,7 @@ impl Registry {
                     name: Mutex::new(saved_shell.name),
                     cwd: saved_shell.cwd,
                     command: saved_shell.command,
-                    last_profile: Mutex::new(saved_shell.last_profile),
+                    last_run: Mutex::new(saved_shell.last_run),
                     lifecycle: Mutex::new(ShellLifecycle::Pending),
                 });
                 shell_ids.push(shell.id.clone());
@@ -1040,21 +1164,27 @@ impl Registry {
             });
             state.workspaces.insert(saved_workspace.id, workspace);
         }
-        Ok(Self {
+        let registry = Self {
             state: Mutex::new(state),
             store: Some(store),
             mutation_lock: Mutex::new(()),
             persist_lock: Mutex::new(()),
             stopping: AtomicBool::new(false),
-        })
+            persistence_dirty: AtomicBool::new(false),
+        };
+        if recovered_interrupted_run {
+            registry.persist()?;
+        }
+        Ok(registry)
     }
 
     fn import_runtimes(
-        &self,
+        self: &Arc<Self>,
         transferred: Vec<handoff::TransferredRuntime>,
     ) -> io::Result<Vec<Arc<ShellRuntime>>> {
         let state = lock(&self.state)?;
         let mut prepared = Vec::with_capacity(transferred.len());
+        let mut imported_shell_ids = HashSet::new();
         for transferred in transferred {
             let manifest = transferred.manifest;
             validate_terminal_profile(&manifest.profile)?;
@@ -1063,12 +1193,35 @@ impl Registry {
                 .get(&manifest.shell_id)
                 .cloned()
                 .ok_or_else(|| not_found("persisted shell", &manifest.shell_id))?;
+            imported_shell_ids.insert(shell.id.clone());
             if !matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending) {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "transferred shell is not pending in restored metadata",
                 ));
             }
+            let mut saved_run = lock(&shell.last_run)?.clone().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "transferred shell has no persisted run",
+                )
+            })?;
+            if saved_run.ended_at_ms.is_some()
+                || manifest
+                    .run_id
+                    .as_ref()
+                    .is_some_and(|run_id| run_id != &saved_run.id)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "transferred runtime does not match its persisted run",
+                ));
+            }
+            saved_run.profile = manifest.profile.clone();
+            if let Some(output_revision) = manifest.output_revision {
+                saved_run.output_revision = output_revision;
+            }
+            let run = Arc::new(ShellRun::from_persisted(&saved_run));
             let stat = fs::read_to_string(format!("/proc/{}/stat", manifest.pid))?;
             if proc_session_id(&stat) != Some(manifest.pid as libc::pid_t) {
                 return Err(io::Error::new(
@@ -1098,29 +1251,56 @@ impl Registry {
                 controller: Mutex::new(None),
                 reader: Mutex::new(None),
             });
-            prepared.push((shell, manifest.profile, runtime, reader));
+            prepared.push((shell, saved_run, run, runtime, reader));
+        }
+        let mut interrupted_untransferred_run = false;
+        for shell in state.shells.values() {
+            if imported_shell_ids.contains(&shell.id) {
+                continue;
+            }
+            let mut last_run = lock(&shell.last_run)?;
+            if let Some(last_run) = last_run.as_mut()
+                && last_run.ended_at_ms.is_none()
+            {
+                last_run.ended_at_ms = Some(unix_time_ms().max(last_run.started_at_ms));
+                last_run.exit_reason = Some(ShellRunExitReason::Interrupted);
+                interrupted_untransferred_run = true;
+            }
         }
         drop(state);
 
         let mut readers = Vec::with_capacity(prepared.len());
-        for (shell, profile, runtime, reader) in prepared {
-            *lock(&shell.last_profile)? = Some(profile.clone());
+        for (shell, saved_run, run, runtime, reader) in prepared {
+            let profile = saved_run.profile.clone();
+            *lock(&shell.last_run)? = Some(saved_run);
             *lock(&shell.lifecycle)? = ShellLifecycle::Running {
                 profile,
+                run: Arc::clone(&run),
                 runtime: Arc::clone(&runtime),
             };
-            start_pty_reader(shell, Arc::clone(&runtime), reader, true)?;
+            start_pty_reader(
+                Arc::downgrade(self),
+                shell,
+                Arc::clone(&run),
+                Arc::clone(&runtime),
+                reader,
+                true,
+            )?;
             readers.push(runtime);
+        }
+        if interrupted_untransferred_run || !readers.is_empty() {
+            self.persist()?;
         }
         Ok(readers)
     }
 
     fn durable_mutation<T>(&self, operation: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
         let _mutation = lock(&self.mutation_lock)?;
+        let _persistence = lock(&self.persist_lock)?;
         self.ensure_running()?;
         let backup = self.backup()?;
         match operation() {
-            Ok(value) => match self.persist() {
+            Ok(value) => match self.persist_unlocked() {
                 Ok(()) => Ok(value),
                 Err(error) => {
                     self.restore_backup(backup)?;
@@ -1232,10 +1412,8 @@ impl Registry {
             workspace_shell_ids.insert(workspace.id.clone(), lock(&workspace.shell_ids)?.clone());
         }
         let mut shell_names = HashMap::new();
-        let mut last_profiles = HashMap::new();
         for shell in state.shells.values() {
             shell_names.insert(shell.id.clone(), lock(&shell.name)?.clone());
-            last_profiles.insert(shell.id.clone(), lock(&shell.last_profile)?.clone());
         }
         Ok(RegistryBackup {
             workspaces: state.workspaces.clone(),
@@ -1243,7 +1421,6 @@ impl Registry {
             workspace_names,
             workspace_shell_ids,
             shell_names,
-            last_profiles,
         })
     }
 
@@ -1261,9 +1438,6 @@ impl Registry {
             if let Some(name) = backup.shell_names.get(&shell.id) {
                 *lock(&shell.name)? = name.clone();
             }
-            if let Some(profile) = backup.last_profiles.get(&shell.id) {
-                *lock(&shell.last_profile)? = profile.clone();
-            }
         }
         state.workspaces = backup.workspaces;
         state.shells = backup.shells;
@@ -1271,10 +1445,14 @@ impl Registry {
     }
 
     fn persist(&self) -> io::Result<()> {
+        let _persist = lock(&self.persist_lock)?;
+        self.persist_unlocked()
+    }
+
+    fn persist_unlocked(&self) -> io::Result<()> {
         let Some(store) = &self.store else {
             return Ok(());
         };
-        let _persist = lock(&self.persist_lock)?;
         let state = lock(&self.state)?;
         let mut workspaces = state.workspaces.values().cloned().collect::<Vec<_>>();
         workspaces.sort_by(|left, right| left.id.cmp(&right.id));
@@ -1291,7 +1469,7 @@ impl Registry {
                     name: lock(&shell.name)?.clone(),
                     cwd: shell.cwd.clone(),
                     command: shell.command.clone(),
-                    last_profile: lock(&shell.last_profile)?.clone(),
+                    last_run: lock(&shell.last_run)?.clone(),
                 });
             }
             saved.workspaces.push(PersistedWorkspace {
@@ -1301,7 +1479,40 @@ impl Registry {
             });
         }
         drop(state);
-        store.save(&saved)
+        let result = store.save(&saved);
+        self.persistence_dirty
+            .store(result.is_err(), Ordering::Release);
+        result
+    }
+
+    fn record_run_exit(
+        &self,
+        shell: &Arc<Shell>,
+        run: &Arc<ShellRun>,
+        runtime: &Arc<ShellRuntime>,
+        code: Option<u32>,
+    ) -> io::Result<()> {
+        let mut lifecycle = lock(&shell.lifecycle)?;
+        let profile = match &*lifecycle {
+            ShellLifecycle::Running {
+                profile,
+                run: current_run,
+                runtime: current_runtime,
+            } if Arc::ptr_eq(current_run, run) && Arc::ptr_eq(current_runtime, runtime) => {
+                profile.clone()
+            }
+            _ => return Ok(()),
+        };
+        run.finish(ShellRunExitReason::Exited { code })?;
+        *lock(&shell.last_run)? = Some(run.persisted(profile.clone())?);
+        *lifecycle = ShellLifecycle::Exited {
+            code,
+            profile,
+            run: Arc::clone(run),
+            runtime: Arc::clone(runtime),
+        };
+        drop(lifecycle);
+        self.persist()
     }
 
     fn snapshot(&self) -> io::Result<Snapshot> {
@@ -1317,7 +1528,9 @@ impl Registry {
 
     fn shutdown(&self) -> io::Result<()> {
         let _mutation = lock(&self.mutation_lock)?;
-        self.stopping.store(true, Ordering::Release);
+        if self.stopping.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
         let shells = {
             let state = lock(&self.state)?;
             state.shells.values().cloned().collect::<Vec<_>>()
@@ -1332,6 +1545,13 @@ impl Registry {
                 return Err(error);
             }
             killed.push(Arc::clone(shell));
+        }
+        if let Err(error) = self.persist() {
+            for shell in killed {
+                shell.reset_pending()?;
+            }
+            self.stopping.store(false, Ordering::Release);
+            return Err(error);
         }
         let mut state = lock(&self.state)?;
         state.workspaces.clear();
@@ -1565,9 +1785,12 @@ impl Registry {
         let backup = self.backup()?;
         let shell = self.shell(shell_id)?;
         shell.kill()?;
+        let killed_run = lock(&shell.last_run)?.clone();
+        let _persistence = lock(&self.persist_lock)?;
         self.remove_shell(shell_id)?;
-        if let Err(error) = self.persist() {
+        if let Err(error) = self.persist_unlocked() {
             self.restore_backup(backup)?;
+            *lock(&shell.last_run)? = killed_run;
             shell.reset_pending()?;
             return Err(error);
         }
@@ -1587,6 +1810,7 @@ impl Registry {
                 .collect::<Vec<_>>()
         };
         let mut killed: Vec<Arc<Shell>> = Vec::new();
+        let mut killed_runs = HashMap::new();
         for shell in &shells {
             if let Err(error) = shell.kill() {
                 for shell in killed {
@@ -1594,12 +1818,17 @@ impl Registry {
                 }
                 return Err(error);
             }
+            killed_runs.insert(shell.id.clone(), lock(&shell.last_run)?.clone());
             killed.push(Arc::clone(shell));
         }
+        let _persistence = lock(&self.persist_lock)?;
         self.remove_workspace(workspace_id)?;
-        if let Err(error) = self.persist() {
+        if let Err(error) = self.persist_unlocked() {
             self.restore_backup(backup)?;
             for shell in shells {
+                if let Some(run) = killed_runs.get(&shell.id) {
+                    *lock(&shell.last_run)? = run.clone();
+                }
                 shell.reset_pending()?;
             }
             return Err(error);
@@ -1631,17 +1860,22 @@ impl Workspace {
 
 impl Shell {
     fn snapshot(&self) -> io::Result<ShellSnapshot> {
+        let lifecycle = lock(&self.lifecycle)?;
+        let (status, run) = match &*lifecycle {
+            ShellLifecycle::Pending => (ShellStatus::Pending, None),
+            ShellLifecycle::Running { run, .. } => (ShellStatus::Running, Some(run.snapshot()?)),
+            ShellLifecycle::Exited { code, run, .. } => {
+                (ShellStatus::Exited { code: *code }, Some(run.snapshot()?))
+            }
+            ShellLifecycle::Closed => return Err(not_found("shell", &self.id)),
+        };
         Ok(ShellSnapshot {
             id: self.id.clone(),
             workspace_id: self.workspace_id.clone(),
             name: lock(&self.name)?.clone(),
             cwd: self.cwd.clone(),
-            status: match &*lock(&self.lifecycle)? {
-                ShellLifecycle::Pending => ShellStatus::Pending,
-                ShellLifecycle::Running { .. } => ShellStatus::Running,
-                ShellLifecycle::Exited { code, .. } => ShellStatus::Exited { code: *code },
-                ShellLifecycle::Closed => return Err(not_found("shell", &self.id)),
-            },
+            status,
+            run,
         })
     }
 
@@ -1696,14 +1930,26 @@ impl Shell {
 
         runtime.stop_reader()?;
         let mut lifecycle = lock(&self.lifecycle)?;
-        let current_runtime = match &*lifecycle {
-            ShellLifecycle::Running { runtime, .. } | ShellLifecycle::Exited { runtime, .. } => {
-                Some(runtime)
+        match &*lifecycle {
+            ShellLifecycle::Running {
+                profile,
+                run,
+                runtime: current,
+            } if Arc::ptr_eq(current, &runtime) => {
+                run.finish(ShellRunExitReason::Terminated)?;
+                *lock(&self.last_run)? = Some(run.persisted(profile.clone())?);
+                *lifecycle = ShellLifecycle::Closed;
             }
-            ShellLifecycle::Pending | ShellLifecycle::Closed => None,
-        };
-        if current_runtime.is_some_and(|current| Arc::ptr_eq(current, &runtime)) {
-            *lifecycle = ShellLifecycle::Closed;
+            ShellLifecycle::Exited {
+                profile,
+                run,
+                runtime: current,
+                ..
+            } if Arc::ptr_eq(current, &runtime) => {
+                *lock(&self.last_run)? = Some(run.persisted(profile.clone())?);
+                *lifecycle = ShellLifecycle::Closed;
+            }
+            _ => {}
         }
         Ok(())
     }
@@ -1761,13 +2007,14 @@ fn create_pending_shell(workspace_id: &str, spec: ShellSpec) -> io::Result<Arc<S
         name: Mutex::new(spec.name),
         cwd: spec.cwd,
         command: spec.command,
-        last_profile: Mutex::new(None),
+        last_run: Mutex::new(None),
         lifecycle: Mutex::new(ShellLifecycle::Pending),
     }))
 }
 
 fn spawn_runtime(
     shell: &Arc<Shell>,
+    run: &ShellRun,
     workspace_name: &str,
     shell_name: &str,
     profile: &TerminalProfile,
@@ -1811,6 +2058,7 @@ fn spawn_runtime(
     command.env("BOOMUX_WORKSPACE", workspace_name);
     command.env("BOOMUX_SHELL_ID", &shell.id);
     command.env("BOOMUX_SHELL_NAME", shell_name);
+    command.env("BOOMUX_RUN_ID", &run.id);
     let child = pty.slave.spawn_command(command).map_err(io::Error::other)?;
     drop(pty.slave);
     drop(pty.master);
@@ -1829,13 +2077,16 @@ fn spawn_runtime(
 }
 
 fn start_pty_reader(
+    registry: Weak<Registry>,
     shell: Arc<Shell>,
+    run: Arc<ShellRun>,
     runtime: Arc<ShellRuntime>,
     mut reader: PtyReader,
     start_paused: bool,
 ) -> io::Result<()> {
     let (commands, command_receiver) = mpsc::channel();
     let reader_runtime = Arc::clone(&runtime);
+    let reader_run = Arc::clone(&run);
     let handle = thread::Builder::new()
         .name(format!("boomux-pty-{}", shell.id))
         .spawn(move || {
@@ -1903,6 +2154,19 @@ fn start_pty_reader(
                         let bytes = &buffer[..count];
                         if let Ok(mut terminal) = reader_runtime.terminal.lock() {
                             terminal.process(bytes);
+                            let revision = reader_run
+                                .output_revision
+                                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |revision| {
+                                    Some(revision.saturating_add(1))
+                                })
+                                .unwrap_or_else(|revision| revision)
+                                .saturating_add(1);
+                            if let Ok(mut last_run) = shell.last_run.lock()
+                                && let Some(last_run) = last_run.as_mut()
+                                && last_run.id == reader_run.id
+                            {
+                                last_run.output_revision = revision;
+                            }
                             if let Ok(mut controller) = reader_runtime.controller.lock() {
                                 let disconnect = controller.as_ref().is_some_and(|current| {
                                     matches!(
@@ -1943,18 +2207,11 @@ fn start_pty_reader(
                 .lock()
                 .ok()
                 .and_then(|mut process| process.try_wait_code().ok().flatten().flatten());
-            if let Ok(mut lifecycle) = shell.lifecycle.lock()
-                && let ShellLifecycle::Running {
-                    profile,
-                    runtime: current,
-                } = &*lifecycle
-                && Arc::ptr_eq(current, &reader_runtime)
+            if let Some(registry) = registry.upgrade()
+                && let Err(error) =
+                    registry.record_run_exit(&shell, &reader_run, &reader_runtime, code)
             {
-                *lifecycle = ShellLifecycle::Exited {
-                    code,
-                    profile: profile.clone(),
-                    runtime: Arc::clone(&reader_runtime),
-                };
+                eprintln!("boomux: could not persist shell run exit: {error}");
             }
             let _ = reader_runtime
                 .controller
@@ -1975,7 +2232,7 @@ fn tail_utf8(text: &str, max_bytes: usize) -> &str {
 
 fn handle_attach(
     mut stream: UnixStream,
-    registry: &Registry,
+    registry: &Arc<Registry>,
     shell_id: &str,
     takeover: bool,
     profile: TerminalProfile,
@@ -2011,7 +2268,7 @@ fn handle_attach(
     let token = Uuid::new_v4().to_string();
     let (output, receiver) = mpsc::sync_channel(CONTROLLER_QUEUE);
     let connection = stream.try_clone()?;
-    let previous_profile = lock(&shell.last_profile)?.clone();
+    let previous_run = lock(&shell.last_run)?.clone();
     let (runtime, startup_profile, running, started) = {
         let mut lifecycle = lock(&shell.lifecycle)?;
         let mut started = false;
@@ -2027,8 +2284,14 @@ fn handle_attach(
             let workspace = registry.workspace(&shell.workspace_id)?;
             let workspace_name = lock(&workspace.name)?.clone();
             let shell_name = lock(&shell.name)?.clone();
+            let generation = previous_run.as_ref().map_or(Ok(1), |run| {
+                run.generation
+                    .checked_add(1)
+                    .ok_or_else(|| io::Error::other("shell run generation exhausted"))
+            })?;
+            let run = Arc::new(ShellRun::new(generation));
             let (runtime, reader) =
-                match spawn_runtime(&shell, &workspace_name, &shell_name, &profile) {
+                match spawn_runtime(&shell, &run, &workspace_name, &shell_name, &profile) {
                     Ok(runtime) => runtime,
                     Err(error) => {
                         return send_response(
@@ -2041,16 +2304,43 @@ fn handle_attach(
                 };
             *lifecycle = ShellLifecycle::Running {
                 profile: profile.clone(),
+                run: Arc::clone(&run),
                 runtime: Arc::clone(&runtime),
             };
-            *lock(&shell.last_profile)? = Some(profile.clone());
+            *lock(&shell.last_run)? = Some(run.persisted(profile.clone())?);
             started = true;
-            start_pty_reader(Arc::clone(&shell), runtime, reader, false)?;
+            if let Err(error) = start_pty_reader(
+                Arc::downgrade(registry),
+                Arc::clone(&shell),
+                run,
+                runtime,
+                reader,
+                true,
+            ) {
+                drop(lifecycle);
+                let cleanup = shell.kill();
+                if cleanup.is_ok() {
+                    shell.reset_pending()?;
+                }
+                return send_response(
+                    &mut stream,
+                    Response::Error {
+                        message: cleanup.map_or_else(
+                            |cleanup| {
+                                format!(
+                                    "could not start shell reader: {error}; process cleanup also failed: {cleanup}"
+                                )
+                            },
+                            |()| format!("could not start shell reader: {error}"),
+                        ),
+                    },
+                );
+            }
         }
         match &*lifecycle {
-            ShellLifecycle::Running { profile, runtime } => {
-                (Arc::clone(runtime), profile.clone(), true, started)
-            }
+            ShellLifecycle::Running {
+                profile, runtime, ..
+            } => (Arc::clone(runtime), profile.clone(), true, started),
             ShellLifecycle::Exited {
                 profile, runtime, ..
             } => (Arc::clone(runtime), profile.clone(), false, started),
@@ -2069,7 +2359,6 @@ fn handle_attach(
         let cleanup = shell.kill();
         if cleanup.is_ok() {
             shell.reset_pending()?;
-            *lock(&shell.last_profile)? = previous_profile;
         }
         return send_response(
             &mut stream,
@@ -2084,6 +2373,9 @@ fn handle_attach(
                 ),
             },
         );
+    }
+    if started {
+        runtime.resume_reader()?;
     }
     drop(mutation);
     let warning = term_mismatch_warning(startup_profile.term.as_deref(), profile.term.as_deref());
@@ -2310,6 +2602,7 @@ fn update_runtime_dimensions(
         ShellLifecycle::Running {
             profile,
             runtime: current,
+            ..
         }
         | ShellLifecycle::Exited {
             profile,
@@ -2322,6 +2615,9 @@ fn update_runtime_dimensions(
     profile.cols = size.cols;
     profile.pixel_width = size.pixel_width;
     profile.pixel_height = size.pixel_height;
+    if let Some(last_run) = lock(&shell.last_run)?.as_mut() {
+        last_run.profile = profile.clone();
+    }
     Ok(())
 }
 
@@ -2383,6 +2679,15 @@ fn validate_name(name: &str) -> io::Result<()> {
     } else {
         Ok(())
     }
+}
+
+fn unix_time_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 fn signal_session(session_id: libc::pid_t, signal: libc::c_int) {
@@ -2586,7 +2891,7 @@ mod tests {
         let directory = env::temp_dir().join(format!("boomux-rollback-{}", Uuid::new_v4()));
         let state_directory = directory.join("state");
         let registry =
-            Registry::restore(StateStore::at(state_directory.join("state.json"))).unwrap();
+            Registry::restore(StateStore::at(state_directory.join("state.json")), false).unwrap();
         fs::remove_dir(&state_directory).unwrap();
         fs::write(&state_directory, b"not a directory").unwrap();
 
@@ -2617,13 +2922,25 @@ mod tests {
         )
         .unwrap();
         let terminal_profile = profile();
+        let run = Arc::new(ShellRun::new(1));
         let (runtime, reader) =
-            spawn_runtime(&shell, "workspace", "pause-test", &terminal_profile).unwrap();
+            spawn_runtime(&shell, &run, "workspace", "pause-test", &terminal_profile).unwrap();
+        *lock(&shell.last_run).unwrap() = Some(run.persisted(terminal_profile.clone()).unwrap());
         *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
             profile: terminal_profile,
+            run: Arc::clone(&run),
             runtime: Arc::clone(&runtime),
         };
-        start_pty_reader(Arc::clone(&shell), Arc::clone(&runtime), reader, false).unwrap();
+        let registry = Arc::new(Registry::default());
+        start_pty_reader(
+            Arc::downgrade(&registry),
+            Arc::clone(&shell),
+            run,
+            Arc::clone(&runtime),
+            reader,
+            false,
+        )
+        .unwrap();
 
         runtime.pause_reader().unwrap();
         lock(&runtime.master).unwrap().write(b"paused\n").unwrap();
@@ -2655,6 +2972,51 @@ mod tests {
     }
 
     #[test]
+    fn close_does_not_deadlock_with_a_naturally_exiting_reader() {
+        let registry = Arc::new(Registry::default());
+        let workspace = registry
+            .create_workspace(
+                "exit-race".into(),
+                vec![ShellSpec {
+                    name: "short-lived".into(),
+                    command: vec!["/bin/sh".into(), "-c".into(), "sleep 0.01".into()],
+                    cwd: env::temp_dir(),
+                }],
+            )
+            .unwrap();
+        let shell = registry.shell(&workspace.shells[0].id).unwrap();
+        let terminal_profile = profile();
+        let run = Arc::new(ShellRun::new(1));
+        let (runtime, reader) =
+            spawn_runtime(&shell, &run, "exit-race", "short-lived", &terminal_profile).unwrap();
+        *lock(&shell.last_run).unwrap() = Some(run.persisted(terminal_profile.clone()).unwrap());
+        *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
+            profile: terminal_profile,
+            run: Arc::clone(&run),
+            runtime: Arc::clone(&runtime),
+        };
+        start_pty_reader(
+            Arc::downgrade(&registry),
+            Arc::clone(&shell),
+            run,
+            runtime,
+            reader,
+            false,
+        )
+        .unwrap();
+        let shell_id = shell.id.clone();
+        let (completed, completion) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let _ = completed.send(registry.close_shell(&shell_id));
+        });
+
+        completion
+            .recv_timeout(Duration::from_secs(3))
+            .expect("shell close deadlocked with the PTY reader")
+            .unwrap();
+    }
+
+    #[test]
     fn timed_out_reader_pause_cancels_queued_command() {
         let (commands, receiver) = mpsc::channel();
         let (observed, observation) = mpsc::sync_channel(1);
@@ -2680,6 +3042,22 @@ mod tests {
         assert_eq!(term_mismatch_warning(Some("xterm"), Some("xterm")), None);
         assert!(term_mismatch_warning(Some("xterm"), Some("alacritty")).is_some());
         assert!(term_mismatch_warning(None, Some("xterm")).is_some());
+    }
+
+    #[test]
+    fn run_completion_never_precedes_its_start_timestamp() {
+        let run = ShellRun {
+            id: Uuid::new_v4().to_string(),
+            generation: 1,
+            started_at_ms: u64::MAX,
+            ended: Mutex::new(None),
+            output_revision: AtomicU64::new(0),
+            environment_has_run_id: true,
+        };
+
+        run.finish(ShellRunExitReason::Interrupted).unwrap();
+
+        assert_eq!(run.snapshot().unwrap().ended_at_ms, Some(u64::MAX));
     }
 
     #[test]

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -36,6 +36,10 @@ pub(crate) struct Manifest {
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct RuntimeManifest {
     pub(crate) shell_id: String,
+    #[serde(default)]
+    pub(crate) run_id: Option<String>,
+    #[serde(default)]
+    pub(crate) output_revision: Option<u64>,
     pub(crate) profile: TerminalProfile,
     pub(crate) pid: u32,
 }
@@ -180,8 +184,13 @@ fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
         ));
     }
     let mut shell_ids = std::collections::HashSet::new();
+    let mut run_ids = std::collections::HashSet::new();
     for runtime in &manifest.runtimes {
-        if runtime.pid == 0 || !shell_ids.insert(&runtime.shell_id) {
+        let valid_run = runtime
+            .run_id
+            .as_ref()
+            .is_none_or(|run_id| uuid::Uuid::parse_str(run_id).is_ok() && run_ids.insert(run_id));
+        if runtime.pid == 0 || !shell_ids.insert(&runtime.shell_id) || !valid_run {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "handoff manifest contains an invalid runtime",

--- a/src/main.rs
+++ b/src/main.rs
@@ -611,14 +611,15 @@ fn unique_shell_name(base_name: &str, shells: &[ShellSnapshot]) -> String {
 
 fn list_shells() -> Result<(), Box<dyn Error>> {
     let snapshot = client::connect_or_start()?.snapshot()?;
-    println!("WORKSPACE\tNAME\tSHELL ID\tSTATUS");
+    println!("WORKSPACE\tNAME\tSHELL ID\tRUN ID\tSTATUS");
     for workspace in snapshot.workspaces {
         for shell in workspace.shells {
             println!(
-                "{}\t{}\t{}\t{}",
+                "{}\t{}\t{}\t{}\t{}",
                 workspace.name,
                 shell.name,
                 shell.id,
+                shell.run.as_ref().map_or("-", |run| run.id.as_str()),
                 shell_status(&shell.status)
             );
         }
@@ -652,12 +653,13 @@ fn workspace_command(command: WorkspaceCommands) -> Result<(), Box<dyn Error>> {
             println!("NAME\t{}", workspace.name);
             println!("SHELLS\t{}", workspace.shells.len());
             if !workspace.shells.is_empty() {
-                println!("\nNAME\tSHELL ID\tSTATUS\tCWD");
+                println!("\nNAME\tSHELL ID\tRUN ID\tSTATUS\tCWD");
                 for shell in &workspace.shells {
                     println!(
-                        "{}\t{}\t{}\t{}",
+                        "{}\t{}\t{}\t{}\t{}",
                         shell.name,
                         shell.id,
+                        shell.run.as_ref().map_or("-", |run| run.id.as_str()),
                         shell_status(&shell.status),
                         shell.cwd.display()
                     );
@@ -722,6 +724,24 @@ fn shell_command(command: ShellCommands) -> Result<(), Box<dyn Error>> {
             println!("WORKSPACE\t{}", workspace.name);
             println!("STATUS\t{}", shell_status(&shell.status));
             println!("CWD\t{}", shell.cwd.display());
+            if let Some(run) = &shell.run {
+                println!("RUN ID\t{}", run.id);
+                println!("GENERATION\t{}", run.generation);
+                println!("STARTED AT MS\t{}", run.started_at_ms);
+                println!(
+                    "ENDED AT MS\t{}",
+                    run.ended_at_ms
+                        .map_or_else(|| "-".into(), |value| value.to_string())
+                );
+                println!(
+                    "EXIT REASON\t{}",
+                    run.exit_reason
+                        .as_ref()
+                        .map_or_else(|| "-".into(), shell_exit_reason)
+                );
+                println!("OUTPUT REVISION\t{}", run.output_revision);
+                println!("ENVIRONMENT HAS RUN ID\t{}", run.environment_has_run_id);
+            }
         }
         ShellCommands::Rename {
             target,
@@ -745,12 +765,13 @@ fn list_workspace_shells() -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let shell = current_shell(&client)?;
     let workspace = client.get_workspace(&shell.workspace_id)?;
-    println!("NAME\tSHELL ID\tSTATUS");
+    println!("NAME\tSHELL ID\tRUN ID\tSTATUS");
     for shell in workspace.shells {
         println!(
-            "{}\t{}\t{}",
+            "{}\t{}\t{}\t{}",
             shell.name,
             shell.id,
+            shell.run.as_ref().map_or("-", |run| run.id.as_str()),
             shell_status(&shell.status)
         );
     }
@@ -891,6 +912,19 @@ fn shell_status(status: &ShellStatus) -> &'static str {
         ShellStatus::Pending => "pending",
         ShellStatus::Running => "running",
         ShellStatus::Exited { .. } => "exited",
+    }
+}
+
+fn shell_exit_reason(reason: &boomux::protocol::ShellRunExitReason) -> String {
+    match reason {
+        boomux::protocol::ShellRunExitReason::Exited { code: Some(code) } => {
+            format!("exited ({code})")
+        }
+        boomux::protocol::ShellRunExitReason::Exited { code: None } => {
+            "exited (code unavailable)".into()
+        }
+        boomux::protocol::ShellRunExitReason::Terminated => "terminated".into(),
+        boomux::protocol::ShellRunExitReason::Interrupted => "interrupted".into(),
     }
 }
 
@@ -1184,6 +1218,7 @@ mod tests {
             name: name.into(),
             cwd: PathBuf::from("/tmp/project"),
             status: ShellStatus::Running,
+            run: None,
         }
     }
 
@@ -1360,6 +1395,18 @@ mod tests {
     fn selects_recent_rendered_lines() {
         assert_eq!(recent_lines("one\ntwo\nthree\n", 2), "two\nthree\n");
         assert_eq!(recent_lines("one\ntwo", 1), "two");
+    }
+
+    #[test]
+    fn formats_shell_run_exit_codes() {
+        assert_eq!(
+            shell_exit_reason(&boomux::protocol::ShellRunExitReason::Exited { code: Some(7) }),
+            "exited (7)"
+        );
+        assert_eq!(
+            shell_exit_reason(&boomux::protocol::ShellRunExitReason::Exited { code: None }),
+            "exited (code unavailable)"
+        );
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -42,6 +42,8 @@ pub struct ShellSnapshot {
     pub name: String,
     pub cwd: PathBuf,
     pub status: ShellStatus,
+    #[serde(default)]
+    pub run: Option<ShellRunSnapshot>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -50,6 +52,25 @@ pub enum ShellStatus {
     Pending,
     Running,
     Exited { code: Option<u32> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShellRunSnapshot {
+    pub id: String,
+    pub generation: u64,
+    pub started_at_ms: u64,
+    pub ended_at_ms: Option<u64>,
+    pub exit_reason: Option<ShellRunExitReason>,
+    pub output_revision: u64,
+    pub environment_has_run_id: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum ShellRunExitReason {
+    Exited { code: Option<u32> },
+    Terminated,
+    Interrupted,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -276,6 +297,12 @@ pub fn read_message<T: DeserializeOwned>(reader: &mut impl Read) -> io::Result<T
 mod tests {
     use super::*;
 
+    #[derive(Deserialize)]
+    struct ProtocolSixShellSnapshot {
+        id: String,
+        status: ShellStatus,
+    }
+
     #[test]
     fn control_frame_round_trips() {
         let value = Envelope::new(Request::Attach {
@@ -305,6 +332,41 @@ mod tests {
         let request = r#"{"request":"create_shell","workspace_id":"w1","shell":{"name":"shell","command":[]}}"#;
 
         assert!(serde_json::from_str::<Request>(request).is_err());
+    }
+
+    #[test]
+    fn shell_snapshot_accepts_protocol_six_payload_without_run_identity() {
+        let snapshot = serde_json::from_str::<ShellSnapshot>(
+            r#"{"id":"s1","workspace_id":"w1","name":"shell","cwd":"/tmp","status":"running"}"#,
+        )
+        .unwrap();
+
+        assert!(snapshot.run.is_none());
+    }
+
+    #[test]
+    fn protocol_six_client_ignores_additive_run_identity() {
+        let snapshot = ShellSnapshot {
+            id: "s1".into(),
+            workspace_id: "w1".into(),
+            name: "shell".into(),
+            cwd: "/tmp".into(),
+            status: ShellStatus::Running,
+            run: Some(ShellRunSnapshot {
+                id: "r1".into(),
+                generation: 1,
+                started_at_ms: 1,
+                ended_at_ms: None,
+                exit_reason: None,
+                output_revision: 2,
+                environment_has_run_id: true,
+            }),
+        };
+
+        let legacy: ProtocolSixShellSnapshot =
+            serde_json::from_value(serde_json::to_value(snapshot).unwrap()).unwrap();
+        assert_eq!(legacy.id, "s1");
+        assert_eq!(legacy.status, ShellStatus::Running);
     }
 
     #[test]

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -9,9 +9,10 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::protocol::TerminalProfile;
+use crate::protocol::{ShellRunExitReason, TerminalProfile};
 
-const STATE_VERSION: u32 = 1;
+const STATE_VERSION: u32 = 2;
+const LEGACY_STATE_VERSION: u32 = 1;
 const MAX_STATE_BYTES: u64 = 8 * 1024 * 1024;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -45,7 +46,50 @@ pub(crate) struct PersistedShell {
     pub(crate) name: String,
     pub(crate) cwd: PathBuf,
     pub(crate) command: Vec<String>,
-    pub(crate) last_profile: Option<TerminalProfile>,
+    pub(crate) last_run: Option<PersistedShellRun>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PersistedShellRun {
+    pub(crate) id: String,
+    pub(crate) generation: u64,
+    pub(crate) started_at_ms: u64,
+    pub(crate) ended_at_ms: Option<u64>,
+    pub(crate) exit_reason: Option<ShellRunExitReason>,
+    pub(crate) output_revision: u64,
+    pub(crate) environment_has_run_id: bool,
+    pub(crate) profile: TerminalProfile,
+}
+
+#[derive(Deserialize)]
+struct StateVersion {
+    version: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyPersistedState {
+    version: u32,
+    workspaces: Vec<LegacyPersistedWorkspace>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyPersistedWorkspace {
+    id: String,
+    name: String,
+    shells: Vec<LegacyPersistedShell>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyPersistedShell {
+    id: String,
+    name: String,
+    cwd: PathBuf,
+    command: Vec<String>,
+    last_profile: Option<TerminalProfile>,
 }
 
 pub(crate) struct StateStore {
@@ -134,21 +178,27 @@ impl StateStore {
         }
         let mut bytes = Vec::with_capacity(metadata.len() as usize);
         File::open(&self.path)?.read_to_end(&mut bytes)?;
-        let state: PersistedState = serde_json::from_slice(&bytes).map_err(|error| {
+        let version: StateVersion = serde_json::from_slice(&bytes).map_err(|error| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("could not parse {}: {error}", self.path.display()),
             )
         })?;
-        if state.version != STATE_VERSION {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "unsupported Boomux state version {}; expected {STATE_VERSION}",
-                    state.version
-                ),
-            ));
-        }
+        let state = match version.version {
+            STATE_VERSION => parse_state(&bytes, &self.path)?,
+            LEGACY_STATE_VERSION => {
+                let legacy: LegacyPersistedState = parse_state(&bytes, &self.path)?;
+                let state = migrate_legacy_state(legacy);
+                self.save(&state)?;
+                state
+            }
+            version => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unsupported Boomux state version {version}; expected {STATE_VERSION}"),
+                ));
+            }
+        };
         Ok(Some(state))
     }
 
@@ -184,6 +234,60 @@ impl StateStore {
         }
         result
     }
+}
+
+fn parse_state<T: for<'de> Deserialize<'de>>(bytes: &[u8], path: &Path) -> io::Result<T> {
+    serde_json::from_slice(bytes).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("could not parse {}: {error}", path.display()),
+        )
+    })
+}
+
+fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
+    debug_assert_eq!(legacy.version, LEGACY_STATE_VERSION);
+    let migrated_at_ms = unix_time_ms();
+    PersistedState {
+        version: STATE_VERSION,
+        workspaces: legacy
+            .workspaces
+            .into_iter()
+            .map(|workspace| PersistedWorkspace {
+                id: workspace.id,
+                name: workspace.name,
+                shells: workspace
+                    .shells
+                    .into_iter()
+                    .map(|shell| PersistedShell {
+                        id: shell.id,
+                        name: shell.name,
+                        cwd: shell.cwd,
+                        command: shell.command,
+                        last_run: shell.last_profile.map(|profile| PersistedShellRun {
+                            id: Uuid::new_v4().to_string(),
+                            generation: 1,
+                            started_at_ms: migrated_at_ms,
+                            ended_at_ms: None,
+                            exit_reason: None,
+                            output_revision: 0,
+                            environment_has_run_id: false,
+                            profile,
+                        }),
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }
+}
+
+fn unix_time_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 pub(crate) fn lock_path_from_environment() -> io::Result<PathBuf> {
@@ -264,6 +368,72 @@ mod tests {
         let error = store.load().unwrap_err();
 
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_one_runs_once_and_preserves_the_generated_identity() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            br#"{
+  "version": 1,
+  "workspaces": [{
+    "id": "5bb1712a-8d4e-4998-bca2-a79aa673ca8f",
+    "name": "legacy",
+    "shells": [{
+      "id": "75dd46b5-6cd3-407a-813a-13e1b10f3614",
+      "name": "agent",
+      "cwd": "/tmp",
+      "command": ["opencode"],
+      "last_profile": {
+        "term": "xterm-256color",
+        "colorterm": null,
+        "term_program": null,
+        "term_program_version": null,
+        "rows": 24,
+        "cols": 80,
+        "pixel_width": 0,
+        "pixel_height": 0
+      }
+    }, {
+      "id": "93ffbd8b-d0e9-444e-a101-c9141abb3848",
+      "name": "pending",
+      "cwd": "/tmp",
+      "command": [],
+      "last_profile": null
+    }]
+  }]
+}"#,
+        )
+        .unwrap();
+        let store = StateStore::at(path.clone());
+
+        let migrated = store.load().unwrap().unwrap();
+        let run = migrated.workspaces[0].shells[0].last_run.as_ref().unwrap();
+        let run_id = run.id.clone();
+        assert!(Uuid::parse_str(&run_id).is_ok());
+        assert_eq!(run.generation, 1);
+        assert!(!run.environment_has_run_id);
+        assert_eq!(run.profile.term.as_deref(), Some("xterm-256color"));
+        assert!(migrated.workspaces[0].shells[1].last_run.is_none());
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("\"version\": 2")
+        );
+
+        let reloaded = store.load().unwrap().unwrap();
+        assert_eq!(
+            reloaded.workspaces[0].shells[0]
+                .last_run
+                .as_ref()
+                .unwrap()
+                .id,
+            run_id
+        );
         fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -10,7 +10,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use boomux::client::{Attachment, Client};
-use boomux::protocol::{self, AttachFrame, ShellSpec, ShellStatus, TerminalProfile};
+use boomux::protocol::{
+    self, AttachFrame, ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile,
+};
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use uuid::Uuid;
 
@@ -99,6 +101,12 @@ impl TestDaemon {
             || !self.client.socket_path().exists(),
             "daemon socket was not removed",
         );
+    }
+
+    fn crash(&mut self) {
+        let mut child = self.child.take().unwrap();
+        child.kill().unwrap();
+        child.wait().unwrap();
     }
 }
 
@@ -241,6 +249,15 @@ fn native_daemon_recovers_reproducible_metadata_after_restart() {
         &read_until(&mut first, b"restored-command"),
         b"restored-command"
     ));
+    let first_run = daemon
+        .client
+        .get_shell(&shell_id)
+        .unwrap()
+        .run
+        .expect("started shell has no run identity");
+    assert_eq!(first_run.generation, 1);
+    assert!(first_run.environment_has_run_id);
+    assert!(first_run.ended_at_ms.is_none());
     drop(first);
     daemon
         .client
@@ -255,8 +272,12 @@ fn native_daemon_recovers_reproducible_metadata_after_restart() {
     )
     .unwrap();
     assert_eq!(
-        persisted["workspaces"][0]["shells"][0]["last_profile"]["term"],
+        persisted["workspaces"][0]["shells"][0]["last_run"]["profile"]["term"],
         "attachment-term"
+    );
+    assert_eq!(
+        persisted["workspaces"][0]["shells"][0]["last_run"]["id"],
+        first_run.id
     );
 
     daemon.stop_with_cli();
@@ -268,6 +289,7 @@ fn native_daemon_recovers_reproducible_metadata_after_restart() {
     assert_eq!(restored.shells[0].id, shell_id);
     assert_eq!(restored.shells[0].name, "restored-renamed");
     assert_eq!(restored.shells[0].status, ShellStatus::Pending);
+    assert!(restored.shells[0].run.is_none());
     let mut second = daemon
         .client
         .attach(&shell_id, false, profile())
@@ -277,7 +299,141 @@ fn native_daemon_recovers_reproducible_metadata_after_restart() {
         &read_until(&mut second, b"restored-command"),
         b"restored-command"
     ));
+    let second_run = daemon
+        .client
+        .get_shell(&shell_id)
+        .unwrap()
+        .run
+        .expect("restarted shell has no run identity");
+    assert_ne!(second_run.id, first_run.id);
+    assert_eq!(second_run.generation, 2);
     drop(second);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn native_daemon_marks_a_crashed_run_interrupted() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "crash-run",
+            vec![ShellSpec::login("agent", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let first_run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+    drop(attachment.stream);
+
+    daemon.crash();
+    daemon.restart();
+
+    let restored = daemon.client.get_shell(&shell_id).unwrap();
+    assert_eq!(restored.status, ShellStatus::Pending);
+    assert!(restored.run.is_none());
+    let persisted: serde_json::Value = serde_json::from_slice(
+        &fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap(),
+    )
+    .unwrap();
+    let last_run = &persisted["workspaces"][0]["shells"][0]["last_run"];
+    assert_eq!(last_run["id"], first_run.id);
+    assert_eq!(last_run["exit_reason"]["reason"], "interrupted");
+    assert!(last_run["ended_at_ms"].as_u64().is_some());
+
+    let second = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let second_run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+    assert_ne!(second_run.id, first_run.id);
+    assert_eq!(second_run.generation, 2);
+    drop(second.stream);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn failed_start_persistence_advances_the_run_generation() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "failed-run-persistence",
+            vec![ShellSpec::login("shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let state_directory = daemon.runtime_dir.join("state/boomux");
+    let saved_directory = daemon.runtime_dir.join("saved-state");
+    fs::rename(&state_directory, &saved_directory).unwrap();
+    fs::write(&state_directory, b"not a directory").unwrap();
+
+    let error = daemon
+        .client
+        .attach(&shell_id, false, profile())
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("could not persist started shell")
+    );
+
+    fs::remove_file(&state_directory).unwrap();
+    fs::rename(&saved_directory, &state_directory).unwrap();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+    assert_eq!(run.generation, 2);
+    drop(attachment.stream);
+    daemon.client.close_workspace(&workspace.id).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn exited_run_persistence_retries_after_storage_recovers() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "exit-persistence-retry",
+            vec![ShellSpec::login("shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let mut attachment = daemon
+        .client
+        .attach(&shell_id, false, profile())
+        .unwrap()
+        .stream;
+    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+    let state_directory = daemon.runtime_dir.join("state/boomux");
+    let saved_directory = daemon.runtime_dir.join("saved-exit-state");
+    fs::rename(&state_directory, &saved_directory).unwrap();
+    fs::write(&state_directory, b"not a directory").unwrap();
+
+    AttachFrame::Input(b"exit\n".to_vec())
+        .write_to(&mut attachment)
+        .unwrap();
+    wait_until(
+        || {
+            matches!(
+                daemon.client.get_shell(&shell_id).unwrap().status,
+                ShellStatus::Exited { .. }
+            )
+        },
+        "shell did not exit while persistence was unavailable",
+    );
+    drop(attachment);
+    fs::remove_file(&state_directory).unwrap();
+    fs::rename(&saved_directory, &state_directory).unwrap();
+    let state_path = state_directory.join("state.json");
+    wait_until(
+        || {
+            let state: serde_json::Value =
+                serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+            let run = &state["workspaces"][0]["shells"][0]["last_run"];
+            run["id"] == run_id && run["ended_at_ms"].as_u64().is_some()
+        },
+        "exited run was not persisted after storage recovered",
+    );
+
+    daemon.client.close_workspace(&workspace.id).unwrap();
     daemon.stop_with_cli();
 }
 
@@ -295,6 +451,8 @@ fn native_daemon_handoffs_multiple_detached_shells() {
         )
         .unwrap();
     let mut pids = Vec::new();
+    let mut run_ids = Vec::new();
+    let mut output_revisions = Vec::new();
     for (index, shell) in workspace.shells.iter().enumerate() {
         let mut attachment = daemon
             .client
@@ -311,6 +469,9 @@ fn native_daemon_handoffs_multiple_detached_shells() {
             .unwrap();
         let output = read_until(&mut attachment, b":end");
         pids.push(parse_pid(&output, &format!("pid{index}=")).unwrap());
+        let run = daemon.client.get_shell(&shell.id).unwrap().run.unwrap();
+        run_ids.push(run.id);
+        output_revisions.push(run.output_revision);
     }
 
     let restart = daemon
@@ -325,6 +486,9 @@ fn native_daemon_handoffs_multiple_detached_shells() {
     );
 
     for (index, shell) in workspace.shells.iter().enumerate() {
+        let transferred_run = daemon.client.get_shell(&shell.id).unwrap().run.unwrap();
+        assert_eq!(transferred_run.id, run_ids[index]);
+        assert_eq!(transferred_run.output_revision, output_revisions[index]);
         let mut attachment = daemon
             .client
             .attach(&shell.id, false, profile())
@@ -631,6 +795,14 @@ fn native_daemon_lifecycle() {
         daemon.client.get_shell(&failed_shell.id).unwrap().status,
         ShellStatus::Pending
     );
+    assert!(
+        daemon
+            .client
+            .get_shell(&failed_shell.id)
+            .unwrap()
+            .run
+            .is_none()
+    );
     daemon
         .client
         .close_workspace(&generated_workspace.id)
@@ -651,6 +823,20 @@ fn native_daemon_lifecycle() {
     assert!(attachment.reconstruction.len() <= 1024 * 1024);
     assert!(attachment.warning.is_none());
     let mut first = attachment.stream;
+    let initial_run = daemon
+        .client
+        .get_shell(&shell_id)
+        .unwrap()
+        .run
+        .expect("running shell has no run identity");
+    let inspected = daemon
+        .command()
+        .args(["shell", "inspect", &shell_id])
+        .output()
+        .unwrap();
+    assert!(inspected.status.success());
+    assert!(contains(&inspected.stdout, b"RUN ID"));
+    assert!(contains(&inspected.stdout, initial_run.id.as_bytes()));
     AttachFrame::Input(b"stty -echo\n".to_vec())
         .write_to(&mut first)
         .unwrap();
@@ -667,6 +853,15 @@ fn native_daemon_lifecycle() {
     .unwrap();
     let expected = b"env=attachment-term|truecolor|integration-terminal|1.0";
     assert!(contains(&read_until(&mut first, expected), expected));
+    let run_command = "printf 'run=%s:end\\n' \"$BOOMUX_RUN_ID\"\n".to_owned();
+    AttachFrame::Input(run_command.into_bytes())
+        .write_to(&mut first)
+        .unwrap();
+    let output = read_until(&mut first, b":end");
+    assert!(contains(
+        &output,
+        format!("run={}", initial_run.id).as_bytes()
+    ));
     AttachFrame::Input(b"printf 'transport-ok\\n'\n".to_vec())
         .write_to(&mut first)
         .unwrap();
@@ -710,6 +905,10 @@ fn native_daemon_lifecycle() {
         restart.status.success(),
         "active-controller restart failed: {}",
         String::from_utf8_lossy(&restart.stderr)
+    );
+    assert_eq!(
+        daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id,
+        initial_run.id
     );
     AttachFrame::Input(b"printf 'still-running\\n'\n".to_vec())
         .write_to(&mut first)
@@ -882,6 +1081,14 @@ fn native_daemon_lifecycle() {
         },
         "imported shell leader exit was not detected",
     );
+    let exited_run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+    assert_eq!(exited_run.id, initial_run.id);
+    assert!(exited_run.ended_at_ms.is_some());
+    assert!(matches!(
+        exited_run.exit_reason,
+        Some(ShellRunExitReason::Exited { .. })
+    ));
+    assert!(exited_run.output_revision > initial_run.output_revision);
     daemon.client.close_workspace(&workspace.id).unwrap();
     wait_until(
         || !process_exists(child_pid),


### PR DESCRIPTION
## Summary
- model each shell process incarnation as a durable ShellRun with stable identity and generation
- persist run lifecycle, output revisions, exit reasons, and migrate state from version 1 to version 2
- preserve run metadata across compatible daemon handoff and expose it through the CLI and environment

## Verification
- cargo test --all-targets
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check