### PR TITLE
Preserve exited shells across daemon restart

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -148,10 +148,11 @@ boomux daemon restart
 boomux daemon stop
 ```
 
-`restart` performs a transactional graceful handoff that preserves pending and
-running shells and reconnects active clients. `stop` terminates every managed
-process session. Confirm before either operation when the user did not request
-it explicitly.
+`restart` performs a transactional graceful handoff that preserves pending,
+running, and exited shells, including final exited terminal state, and reconnects
+active clients. It does not start a new process for an exited shell. `stop`
+terminates every managed process session. Confirm before either operation when
+the user did not request it explicitly.
 
 ## Install Or Update This Skill
 

--- a/README.md
+++ b/README.md
@@ -201,14 +201,15 @@ mode on exit. See [`docs/architecture.md`](docs/architecture.md) for details.
 Shells remain pending until their first attachment reports terminal environment
 and dimensions; that profile initializes the PTY and child process. Reproducible
 workspace and shell metadata provides crash recovery, while a graceful
-`boomux daemon restart` transfers running shells and reconnects active clients.
+`boomux daemon restart` transfers running shells, preserves exited shells and
+their final terminal state, and reconnects active clients.
 See [`docs/live-pty-handoff.md`](docs/live-pty-handoff.md) for the handoff design.
 
 ## POC Limitations
 
-- Live daemon restart preserves pending and running shells, and active attachment
-  clients reconnect cooperatively. An exited shell currently prevents graceful
-  replacement until final terminal-state transfer is implemented.
+- Live daemon restart preserves pending, running, and exited shells. Active
+  attachment clients reconnect cooperatively, while exited shells retain their
+  run metadata and bounded final terminal state without starting a new process.
 - An unexpected daemon exit cannot hand off live PTYs. Persisted shell metadata
   returns as pending and starts fresh processes when reopened.
 - Mutated process environment and in-memory application state are not persisted.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,13 +158,15 @@ shells transfer their PTY master, pidfd-backed process identity, terminal
 profile, run identity, output revision, and reconstructed VT state without
 changing the child PID. Attached clients receive a reconnect request,
 acknowledge an input-ordering boundary, and reconnect to the replacement while
-remaining in raw mode. An exited shell currently prevents graceful replacement;
-persisting its final terminal state is the next handoff milestone.
+remaining in raw mode. Exited shells transfer their final run metadata and
+bounded reconstructed terminal state without a PTY, pidfd, or replacement
+process. Cold startup and crash recovery remain metadata-only and restore shells
+as pending.
 
 ## Next Technical Steps
 
 The detailed design, acceptance criteria, and manual test matrix are tracked in
 [`native-terminal-follow-up.md`](native-terminal-follow-up.md).
 
-1. Evaluate explicit exited-shell terminal-state transfer separately from live
-   process handoff.
+1. Add stable versioned JSON output, typed errors, and capability reporting for
+   integrations.

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -28,13 +28,15 @@ The private handoff channel will carry a versioned manifest followed by Unix
 - One PTY master per running shell
 - Shell and run IDs, terminal profile, PID/session identity, output revision,
   and sanitized VT state
+- Exited-shell run identity, exit status, output revision, terminal profile, and
+  sanitized final VT state without process descriptors
 
 The PTY master is full duplex, so reader and writer duplicates do not need to be
 transferred separately. The replacement cannot inherit Unix parenthood; process
 monitoring and cleanup therefore need an imported-process representation, with
 a Linux pidfd where available.
 
-Bootstrap starts with the `BOOMUXH2` version header and has bounded read/write
+Bootstrap starts with the `BOOMUXH3` version header and has bounded read/write
 deadlines. The receiver validates the listener path/type, forces nonblocking
 mode, matches both lock-file inodes, and establishes exclusive flock ownership
 before acknowledging readiness. Explicit abort closes every received duplicate
@@ -48,6 +50,11 @@ rollback cannot consume output belonging to the old daemon.
 PTY/session identity is cross-checked with `TIOCGSID`, terminal reconstructions
 use separate bounded frames, and imported process/session cleanup uses pidfds to
 avoid signaling a reused numeric PID.
+
+Exited shells use a separate static transfer record and bounded reconstruction
+frame. The replacement validates that the transferred identity and exit status
+match the persisted completed run, then restores the exited lifecycle without
+opening a PTY or starting a process.
 
 ## Delivery Slices
 
@@ -65,6 +72,8 @@ avoid signaling a reused numeric PID.
    `Reconnect`/`ReconnectAck` framing. Input sent before the ACK is processed by
    the old daemon; later terminal input remains queued while the client retries
    the replacement in raw mode.
+6. [Complete] Transfer exited-run metadata and bounded final terminal state as
+   static lifecycle records alongside any live runtimes.
 
 ## First Acceptance Test
 

--- a/docs/native-terminal-follow-up.md
+++ b/docs/native-terminal-follow-up.md
@@ -274,8 +274,9 @@ its mutated environment.
 
 An explicit `boomux daemon restart` instead uses the separate transactional Unix
 PTY handoff documented in [`live-pty-handoff.md`](live-pty-handoff.md). It
-transfers running processes and reconnects active attachment clients; this does
-not change the guarantees of metadata-only recovery.
+transfers running processes, preserves static exited-run terminal state, and
+reconnects active attachment clients; this does not change the guarantees of
+metadata-only recovery.
 
 ## Manual Test Matrix
 
@@ -293,6 +294,7 @@ Run each scenario in Alacritty and Ghostty first, then Kitty if available:
 | Cross-emulator reattach | Compatibility warning and behavior match policy |
 | Graceful restart while detached | Process PID and subsequent input/output survive |
 | Graceful restart while attached | Client reconnects without leaving raw mode |
+| Graceful restart after shell exit | Run identity, exit status, and final terminal state survive without a new process |
 | Daemon stop | All owned process sessions terminate and socket is removed |
 
 Record the terminal environment visible inside each child:
@@ -311,6 +313,8 @@ stty size
    lines.
 4. [Complete] Add atomic metadata persistence.
 5. [Complete] Add transactional live PTY handoff and active-client reconnection.
+6. [Complete] Preserve exited-run metadata and final terminal state during
+   graceful handoff.
 
 ## Definition Of Done
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -80,8 +80,8 @@ eternal process.
 1. [Complete] Add a `ShellRun` identity beneath each durable shell, including
    generation, lifecycle timestamps, exit reason, output revision, and
    `BOOMUX_RUN_ID`.
-2. Preserve final exited-run metadata and terminal state across graceful daemon
-   restart without starting a replacement process implicitly.
+2. [Complete] Preserve final exited-run metadata and terminal state across
+   graceful daemon restart without starting a replacement process implicitly.
 3. Add stable versioned JSON output, typed errors, and capability reporting for
    integrations.
 4. Add a monotonic daemon event stream with reconnectable cursors and

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -55,6 +55,7 @@ pub fn receive_handoff(channel: i32) -> io::Result<()> {
             runtime_lock,
             state_lock,
             runtimes,
+            exited,
         } => {
             let store = StateStore::from_transferred_lock(state_lock)?;
             let socket_path = client::socket_path()?;
@@ -64,6 +65,7 @@ pub fn receive_handoff(channel: i32) -> io::Result<()> {
                 SocketCleanup::disarmed(socket_path),
                 store,
                 runtimes,
+                exited,
                 Some(&mut channel),
             )
         }
@@ -92,6 +94,7 @@ pub fn run() -> io::Result<()> {
         socket_cleanup,
         StateStore::from_environment()?,
         Vec::new(),
+        Vec::new(),
         None,
     )
 }
@@ -102,10 +105,11 @@ fn run_daemon(
     mut socket_cleanup: SocketCleanup,
     store: StateStore,
     transferred_runtimes: Vec<handoff::TransferredRuntime>,
+    transferred_exited: Vec<handoff::TransferredExited>,
     committed: Option<&mut UnixStream>,
 ) -> io::Result<()> {
     let registry = Arc::new(Registry::restore(store, committed.is_some())?);
-    let gated_readers = registry.import_runtimes(transferred_runtimes)?;
+    let gated_readers = registry.import_handoff(transferred_runtimes, transferred_exited)?;
     if let Some(channel) = committed {
         channel.write_all(&[handoff::PREPARED])?;
         let mut decision = [0];
@@ -282,21 +286,40 @@ fn launch_replacement(
     let mut paused = Vec::new();
     let result = (|| {
         registry.quiesce_controllers()?;
-        let state = lock(&registry.state)?;
+        let shells = lock(&registry.state)?
+            .shells
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
         let mut transfers = Vec::new();
-        for shell in state.shells.values() {
-            let (profile, run, runtime) = match &*lock(&shell.lifecycle)? {
+        let mut exited = Vec::new();
+        for shell in shells {
+            let lifecycle = lock(&shell.lifecycle)?;
+            let (profile, run, runtime) = match &*lifecycle {
                 ShellLifecycle::Pending => continue,
                 ShellLifecycle::Running {
                     profile,
                     run,
                     runtime,
                 } => (profile.clone(), Arc::clone(run), Arc::clone(runtime)),
-                ShellLifecycle::Exited { .. } => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Unsupported,
-                        "exited shell runtime transfer is not supported",
-                    ));
+                ShellLifecycle::Exited {
+                    code,
+                    profile,
+                    run,
+                    terminal,
+                    ..
+                } => {
+                    exited.push(OutgoingExited {
+                        manifest: handoff::ExitedManifest {
+                            shell_id: shell.id.clone(),
+                            run_id: run.id.clone(),
+                            output_revision: run.output_revision.load(Ordering::Acquire),
+                            profile: profile.clone(),
+                            code: *code,
+                        },
+                        reconstruction: lock(terminal)?.reconstruction(),
+                    });
+                    continue;
                 }
                 ShellLifecycle::Closed => return Err(not_found("shell", &shell.id)),
             };
@@ -317,13 +340,13 @@ fn launch_replacement(
                 reconstruction,
             });
         }
-        drop(state);
         let state_lock = registry.state_lock_descriptor()?;
         launch_replacement_process(
             listener.as_fd(),
             daemon_lock.as_fd(),
             state_lock,
             &transfers,
+            &exited,
         )
     })();
     if result.is_err() {
@@ -340,6 +363,7 @@ fn launch_replacement_process(
     runtime_lock: BorrowedFd<'_>,
     state_lock: BorrowedFd<'_>,
     runtimes: &[OutgoingRuntime],
+    exited: &[OutgoingExited],
 ) -> io::Result<()> {
     let (mut channel, child_channel) = UnixStream::pair()?;
     let child_channel_fd = child_channel.as_raw_fd();
@@ -379,6 +403,7 @@ fn launch_replacement_process(
                     .iter()
                     .map(|runtime| runtime.manifest.clone())
                     .collect(),
+                exited: exited.iter().map(|shell| shell.manifest.clone()).collect(),
             },
         )?;
         send_descriptor(&channel, listener, handoff::LISTENER_MARKER)?;
@@ -389,6 +414,9 @@ fn launch_replacement_process(
             send_descriptor(&channel, master.descriptor.as_fd(), handoff::PTY_MARKER)?;
             send_descriptor(&channel, runtime.pidfd.as_fd(), handoff::PIDFD_MARKER)?;
             protocol::write_message(&mut channel, &runtime.reconstruction)?;
+        }
+        for shell in exited {
+            protocol::write_message(&mut channel, &shell.reconstruction)?;
         }
         let mut acknowledgement = [0];
         channel.read_exact(&mut acknowledgement)?;
@@ -598,7 +626,8 @@ enum ShellLifecycle {
         code: Option<u32>,
         profile: TerminalProfile,
         run: Arc<ShellRun>,
-        runtime: Arc<ShellRuntime>,
+        runtime: Option<Arc<ShellRuntime>>,
+        terminal: Arc<Mutex<TerminalState>>,
     },
     Closed,
 }
@@ -691,7 +720,7 @@ struct ShellRuntime {
     control: Mutex<()>,
     master: Mutex<PtyMaster>,
     process: Mutex<ManagedProcess>,
-    terminal: Mutex<TerminalState>,
+    terminal: Arc<Mutex<TerminalState>>,
     controller: Mutex<Option<Controller>>,
     reader: Mutex<Option<ReaderTask>>,
 }
@@ -710,6 +739,11 @@ struct OutgoingRuntime {
     manifest: handoff::RuntimeManifest,
     runtime: Arc<ShellRuntime>,
     pidfd: OwnedFd,
+    reconstruction: Vec<u8>,
+}
+
+struct OutgoingExited {
+    manifest: handoff::ExitedManifest,
     reconstruction: Vec<u8>,
 }
 
@@ -1178,9 +1212,10 @@ impl Registry {
         Ok(registry)
     }
 
-    fn import_runtimes(
+    fn import_handoff(
         self: &Arc<Self>,
         transferred: Vec<handoff::TransferredRuntime>,
+        transferred_exited: Vec<handoff::TransferredExited>,
     ) -> io::Result<Vec<Arc<ShellRuntime>>> {
         let state = lock(&self.state)?;
         let mut prepared = Vec::with_capacity(transferred.len());
@@ -1247,11 +1282,57 @@ impl Registry {
                 control: Mutex::new(()),
                 master: Mutex::new(master),
                 process: Mutex::new(ManagedProcess::Imported(process)),
-                terminal: Mutex::new(terminal),
+                terminal: Arc::new(Mutex::new(terminal)),
                 controller: Mutex::new(None),
                 reader: Mutex::new(None),
             });
             prepared.push((shell, saved_run, run, runtime, reader));
+        }
+        let mut prepared_exited = Vec::with_capacity(transferred_exited.len());
+        for transferred in transferred_exited {
+            let manifest = transferred.manifest;
+            validate_terminal_profile(&manifest.profile)?;
+            let shell = state
+                .shells
+                .get(&manifest.shell_id)
+                .cloned()
+                .ok_or_else(|| not_found("persisted shell", &manifest.shell_id))?;
+            imported_shell_ids.insert(shell.id.clone());
+            if !matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "transferred exited shell is not pending in restored metadata",
+                ));
+            }
+            let mut saved_run = lock(&shell.last_run)?.clone().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "transferred exited shell has no persisted run",
+                )
+            })?;
+            if saved_run.id != manifest.run_id
+                || saved_run.exit_reason
+                    != Some(ShellRunExitReason::Exited {
+                        code: manifest.code,
+                    })
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "transferred exited shell does not match its persisted run",
+                ));
+            }
+            saved_run.profile = manifest.profile.clone();
+            saved_run.output_revision = manifest.output_revision;
+            let run = Arc::new(ShellRun::from_persisted(&saved_run));
+            let mut terminal = TerminalState::new(manifest.profile.rows, manifest.profile.cols);
+            terminal.process(&transferred.reconstruction);
+            prepared_exited.push((
+                shell,
+                saved_run,
+                run,
+                Arc::new(Mutex::new(terminal)),
+                manifest,
+            ));
         }
         let mut interrupted_untransferred_run = false;
         for shell in state.shells.values() {
@@ -1288,7 +1369,17 @@ impl Registry {
             )?;
             readers.push(runtime);
         }
-        if interrupted_untransferred_run || !readers.is_empty() {
+        for (shell, saved_run, run, terminal, manifest) in prepared_exited {
+            *lock(&shell.last_run)? = Some(saved_run);
+            *lock(&shell.lifecycle)? = ShellLifecycle::Exited {
+                code: manifest.code,
+                profile: manifest.profile,
+                run,
+                runtime: None,
+                terminal,
+            };
+        }
+        if interrupted_untransferred_run || !readers.is_empty() || !imported_shell_ids.is_empty() {
             self.persist()?;
         }
         Ok(readers)
@@ -1509,7 +1600,8 @@ impl Registry {
             code,
             profile,
             run: Arc::clone(run),
-            runtime: Arc::clone(runtime),
+            runtime: Some(Arc::clone(runtime)),
+            terminal: Arc::clone(&runtime.terminal),
         };
         drop(lifecycle);
         self.persist()
@@ -1734,15 +1826,14 @@ impl Registry {
     fn read_shell(&self, shell_id: &str, max_bytes: usize) -> io::Result<Vec<u8>> {
         let shell = self.shell(shell_id)?;
         let lifecycle = lock(&shell.lifecycle)?;
-        let runtime = match &*lifecycle {
+        let terminal = match &*lifecycle {
             ShellLifecycle::Pending => return Ok(Vec::new()),
-            ShellLifecycle::Running { runtime, .. } | ShellLifecycle::Exited { runtime, .. } => {
-                Arc::clone(runtime)
-            }
+            ShellLifecycle::Running { runtime, .. } => Arc::clone(&runtime.terminal),
+            ShellLifecycle::Exited { terminal, .. } => Arc::clone(terminal),
             ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
         };
         drop(lifecycle);
-        let text = lock(&runtime.terminal)?.plain_text();
+        let text = lock(&terminal)?.plain_text();
         Ok(tail_utf8(&text, max_bytes.min(MAX_SHELL_READ_BYTES))
             .as_bytes()
             .to_vec())
@@ -1887,10 +1978,13 @@ impl Shell {
                     *lifecycle = ShellLifecycle::Closed;
                     return Ok(());
                 }
-                ShellLifecycle::Running { runtime, .. }
-                | ShellLifecycle::Exited { runtime, .. } => Arc::clone(runtime),
+                ShellLifecycle::Running { runtime, .. } => Some(Arc::clone(runtime)),
+                ShellLifecycle::Exited { runtime, .. } => runtime.clone(),
                 ShellLifecycle::Closed => return Ok(()),
             }
+        };
+        let Some(runtime) = runtime else {
+            return Ok(());
         };
         if let Some(controller) = lock(&runtime.controller)?.take() {
             let _ = controller.connection.shutdown(std::net::Shutdown::Both);
@@ -1945,7 +2039,10 @@ impl Shell {
                 run,
                 runtime: current,
                 ..
-            } if Arc::ptr_eq(current, &runtime) => {
+            } if current
+                .as_ref()
+                .is_some_and(|current| Arc::ptr_eq(current, &runtime)) =>
+            {
                 *lock(&self.last_run)? = Some(run.persisted(profile.clone())?);
                 *lifecycle = ShellLifecycle::Closed;
             }
@@ -2068,7 +2165,7 @@ fn spawn_runtime(
             control: Mutex::new(()),
             master: Mutex::new(master),
             process: Mutex::new(ManagedProcess::Owned(child)),
-            terminal: Mutex::new(TerminalState::new(profile.rows, profile.cols)),
+            terminal: Arc::new(Mutex::new(TerminalState::new(profile.rows, profile.cols))),
             controller: Mutex::new(None),
             reader: Mutex::new(None),
         }),
@@ -2269,7 +2366,7 @@ fn handle_attach(
     let (output, receiver) = mpsc::sync_channel(CONTROLLER_QUEUE);
     let connection = stream.try_clone()?;
     let previous_run = lock(&shell.last_run)?.clone();
-    let (runtime, startup_profile, running, started) = {
+    let (runtime, terminal, startup_profile, running, started) = {
         let mut lifecycle = lock(&shell.lifecycle)?;
         let mut started = false;
         if !registry.contains_shell(&shell)? {
@@ -2340,10 +2437,16 @@ fn handle_attach(
         match &*lifecycle {
             ShellLifecycle::Running {
                 profile, runtime, ..
-            } => (Arc::clone(runtime), profile.clone(), true, started),
+            } => (
+                Some(Arc::clone(runtime)),
+                Arc::clone(&runtime.terminal),
+                profile.clone(),
+                true,
+                started,
+            ),
             ShellLifecycle::Exited {
-                profile, runtime, ..
-            } => (Arc::clone(runtime), profile.clone(), false, started),
+                profile, terminal, ..
+            } => (None, Arc::clone(terminal), profile.clone(), false, started),
             ShellLifecycle::Pending => unreachable!(),
             ShellLifecycle::Closed => {
                 return send_response(
@@ -2375,10 +2478,28 @@ fn handle_attach(
         );
     }
     if started {
-        runtime.resume_reader()?;
+        runtime
+            .as_ref()
+            .expect("started shell has a runtime")
+            .resume_reader()?;
+    }
+    let warning = term_mismatch_warning(startup_profile.term.as_deref(), profile.term.as_deref());
+    if !running {
+        lock(&terminal)?.resize(profile.rows, profile.cols);
+        stream.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
+        send_response(
+            &mut stream,
+            Response::Attached {
+                token,
+                reconstruction: lock(&terminal)?.reconstruction(),
+                warning,
+            },
+        )?;
+        stream.set_write_timeout(None)?;
+        return AttachFrame::Detached.write_to(&mut stream);
     }
     drop(mutation);
-    let warning = term_mismatch_warning(startup_profile.term.as_deref(), profile.term.as_deref());
+    let runtime = runtime.expect("running shell has a runtime");
     let control = lock(&runtime.control)?;
     if !registry.contains_shell(&shell)? {
         return send_response(
@@ -2399,14 +2520,12 @@ fn handle_attach(
             );
         }
     }
-    if running {
-        lock(&runtime.master)?.resize(profile_size(&profile))?;
-        update_runtime_dimensions(&shell, &runtime, profile_size(&profile))?;
-    }
-    lock(&runtime.terminal)?.resize(profile.rows, profile.cols);
+    lock(&runtime.master)?.resize(profile_size(&profile))?;
+    update_runtime_dimensions(&shell, &runtime, profile_size(&profile))?;
+    lock(&terminal)?.resize(profile.rows, profile.cols);
     // Keep terminal state locked until the controller is installed so the
     // reconstruction ends exactly where live delivery begins.
-    let terminal = lock(&runtime.terminal)?;
+    let terminal = lock(&terminal)?;
     stream.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
     send_response(
         &mut stream,
@@ -2417,9 +2536,6 @@ fn handle_attach(
         },
     )?;
     stream.set_write_timeout(None)?;
-    if !running {
-        return AttachFrame::Detached.write_to(&mut stream);
-    }
     let lifecycle = lock(&shell.lifecycle)?;
     let still_running = registry.contains_shell(&shell)?
         && matches!(
@@ -2600,11 +2716,6 @@ fn update_runtime_dimensions(
     let mut lifecycle = lock(&shell.lifecycle)?;
     let profile = match &mut *lifecycle {
         ShellLifecycle::Running {
-            profile,
-            runtime: current,
-            ..
-        }
-        | ShellLifecycle::Exited {
             profile,
             runtime: current,
             ..

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -15,7 +15,7 @@ use crate::state_store;
 
 const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 pub(crate) const CHANNEL_FD: RawFd = 198;
-pub(crate) const HEADER: &[u8; 8] = b"BOOMUXH2";
+pub(crate) const HEADER: &[u8; 8] = b"BOOMUXH3";
 pub(crate) const LISTENER_MARKER: u8 = 1;
 pub(crate) const RUNTIME_LOCK_MARKER: u8 = 2;
 pub(crate) const STATE_LOCK_MARKER: u8 = 3;
@@ -31,6 +31,7 @@ pub(crate) const PIDFD_MARKER: u8 = 11;
 #[derive(Serialize, Deserialize)]
 pub(crate) struct Manifest {
     pub(crate) runtimes: Vec<RuntimeManifest>,
+    pub(crate) exited: Vec<ExitedManifest>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -44,10 +45,24 @@ pub(crate) struct RuntimeManifest {
     pub(crate) pid: u32,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct ExitedManifest {
+    pub(crate) shell_id: String,
+    pub(crate) run_id: String,
+    pub(crate) output_revision: u64,
+    pub(crate) profile: TerminalProfile,
+    pub(crate) code: Option<u32>,
+}
+
 pub(crate) struct TransferredRuntime {
     pub(crate) manifest: RuntimeManifest,
     pub(crate) pty: OwnedFd,
     pub(crate) pidfd: OwnedFd,
+    pub(crate) reconstruction: Vec<u8>,
+}
+
+pub(crate) struct TransferredExited {
+    pub(crate) manifest: ExitedManifest,
     pub(crate) reconstruction: Vec<u8>,
 }
 
@@ -59,6 +74,7 @@ pub(crate) enum Bootstrap {
         runtime_lock: OwnedFd,
         state_lock: OwnedFd,
         runtimes: Vec<TransferredRuntime>,
+        exited: Vec<TransferredExited>,
     },
 }
 
@@ -99,6 +115,20 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             reconstruction,
         });
     }
+    let mut exited = Vec::with_capacity(manifest.exited.len());
+    for manifest in manifest.exited {
+        let reconstruction: Vec<u8> = protocol::read_message(&mut channel)?;
+        if reconstruction.len() > protocol::MAX_ATTACH_FRAME {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "transferred exited terminal reconstruction exceeds the size limit",
+            ));
+        }
+        exited.push(TransferredExited {
+            manifest,
+            reconstruction,
+        });
+    }
 
     let expected_socket = client::socket_path()?;
     let listener = UnixListener::from(listener);
@@ -127,6 +157,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             runtime_lock,
             state_lock,
             runtimes,
+            exited,
         }),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -177,7 +208,12 @@ fn validate_pidfd(descriptor: &OwnedFd, expected_pid: u32) -> io::Result<()> {
 }
 
 fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
-    if manifest.runtimes.len() > 1_024 {
+    if manifest
+        .runtimes
+        .len()
+        .saturating_add(manifest.exited.len())
+        > 1_024
+    {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "handoff manifest contains too many runtimes",
@@ -194,6 +230,16 @@ fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "handoff manifest contains an invalid runtime",
+            ));
+        }
+    }
+    for exited in &manifest.exited {
+        let valid_run =
+            uuid::Uuid::parse_str(&exited.run_id).is_ok() && run_ids.insert(&exited.run_id);
+        if !shell_ids.insert(&exited.shell_id) || !valid_run {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "handoff manifest contains an invalid exited shell",
             ));
         }
     }

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -184,8 +184,12 @@ fn replacement_bootstrap_receives_listener_and_lock_ownership() {
 
     parent_channel.set_read_timeout(Some(TIMEOUT)).unwrap();
     parent_channel.set_write_timeout(Some(TIMEOUT)).unwrap();
-    parent_channel.write_all(b"BOOMUXH2").unwrap();
-    protocol::write_message(&mut parent_channel, &serde_json::json!({ "runtimes": [] })).unwrap();
+    parent_channel.write_all(b"BOOMUXH3").unwrap();
+    protocol::write_message(
+        &mut parent_channel,
+        &serde_json::json!({ "runtimes": [], "exited": [] }),
+    )
+    .unwrap();
     send_descriptor(&parent_channel, listener.as_raw_fd(), 1);
     send_descriptor(&parent_channel, runtime_lock.as_raw_fd(), 2);
     send_descriptor(&parent_channel, state_lock.as_raw_fd(), 3);
@@ -432,6 +436,111 @@ fn exited_run_persistence_retries_after_storage_recovers() {
         },
         "exited run was not persisted after storage recovered",
     );
+
+    daemon.client.close_workspace(&workspace.id).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn graceful_restart_preserves_exited_run_and_terminal_state() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "exited-handoff",
+            vec![
+                ShellSpec::login("finished", std::env::temp_dir()),
+                ShellSpec::login("live", std::env::temp_dir()),
+            ],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let live_shell_id = workspace.shells[1].id.clone();
+    let mut live = daemon
+        .client
+        .attach(&live_shell_id, false, profile())
+        .unwrap()
+        .stream;
+    AttachFrame::Input(b"printf 'live-during-exited-handoff\\n'\n".to_vec())
+        .write_to(&mut live)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut live, b"live-during-exited-handoff"),
+        b"live-during-exited-handoff"
+    ));
+    drop(live);
+    let mut attachment = daemon
+        .client
+        .attach(&shell_id, false, profile())
+        .unwrap()
+        .stream;
+    AttachFrame::Input(b"printf 'final-exited-output\\n'; exit 7\n".to_vec())
+        .write_to(&mut attachment)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut attachment, b"final-exited-output"),
+        b"final-exited-output"
+    ));
+    drop(attachment);
+    wait_until(
+        || {
+            matches!(
+                daemon.client.get_shell(&shell_id).unwrap().status,
+                ShellStatus::Exited { code: Some(7) }
+            )
+        },
+        "shell did not record its final exit",
+    );
+    let before = daemon.client.get_shell(&shell_id).unwrap();
+    let before_run = before.run.clone().unwrap();
+    let before_output = daemon.client.read_shell(&shell_id, 1024 * 1024).unwrap();
+    assert!(contains(&before_output, b"final-exited-output"));
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "exited-shell restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+
+    let after = daemon.client.get_shell(&shell_id).unwrap();
+    assert_eq!(after.status, ShellStatus::Exited { code: Some(7) });
+    assert_eq!(after.run.as_ref(), Some(&before_run));
+    assert_eq!(
+        daemon.client.get_shell(&live_shell_id).unwrap().status,
+        ShellStatus::Running
+    );
+    let after_output = daemon.client.read_shell(&shell_id, 1024 * 1024).unwrap();
+    assert_eq!(after_output, before_output);
+    let mut restored = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    assert!(contains(&restored.reconstruction, b"final-exited-output"));
+    assert!(matches!(
+        AttachFrame::read_from(&mut restored.stream).unwrap(),
+        AttachFrame::Detached
+    ));
+    assert_eq!(
+        daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id,
+        before_run.id
+    );
+
+    let state_directory = daemon.runtime_dir.join("state/boomux");
+    let saved_directory = daemon.runtime_dir.join("saved-exited-handoff-state");
+    fs::rename(&state_directory, &saved_directory).unwrap();
+    fs::write(&state_directory, b"not a directory").unwrap();
+    assert!(daemon.client.close_shell(&shell_id).is_err());
+    let rolled_back = daemon.client.get_shell(&shell_id).unwrap();
+    assert_eq!(rolled_back.status, ShellStatus::Exited { code: Some(7) });
+    assert_eq!(rolled_back.run.as_ref(), Some(&before_run));
+    assert!(contains(
+        &daemon.client.read_shell(&shell_id, 1024 * 1024).unwrap(),
+        b"final-exited-output"
+    ));
+    fs::remove_file(&state_directory).unwrap();
+    fs::rename(&saved_directory, &state_directory).unwrap();
 
     daemon.client.close_workspace(&workspace.id).unwrap();
     daemon.stop_with_cli();


### PR DESCRIPTION
## Summary
- transfer exited-run identity, exit status, profile, output revision, and final terminal reconstruction during graceful handoff
- restore exited shells as static lifecycles without PTY/process descriptors or implicit process startup
- preserve close rollback semantics and document the completed foundation milestone

## Verification
- cargo test --all-targets
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check