### PR TITLE
Add stable JSON integration API

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -40,6 +40,17 @@ boomux workspace inspect "<workspace-name-or-id>"
 boomux shell inspect "<shell-name-or-id>" --workspace "<workspace-name-or-id>"
 ```
 
+For machine-readable inspection, add `--json`. Supported read-only commands emit
+the stable `boomux.cli/v1` envelope. Discover the exact command, feature, and
+typed-error capabilities without starting the daemon:
+
+```console
+boomux capabilities --json
+```
+
+Parse `data` on success and `error.code` on a nonzero exit; do not parse human
+tables or `error.message`. Mutation commands do not yet support `--json`.
+
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.
 `boomux read` and top-level `boomux close` require an exact shell ID outside a

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ closed, or the daemon stops.
 ```console
 boomux ui
 boomux doctor
+boomux capabilities [--json]
 boomux list
 boomux shells
 boomux read <shell-name-or-shell-id> [--lines <count>]
@@ -121,6 +122,11 @@ workspace context or `--workspace`; IDs remain globally addressable.
 `boomux read` reads plain rendered text from the daemon's shadow VT state. It
 understands cursor rewrites and terminal soft wrapping, retains up to 2,000
 scrollback rows per shell, and never returns ANSI control sequences.
+
+Read-only integration commands accept `--json` and emit the stable
+`boomux.cli/v1` envelope. Run `boomux capabilities --json` to discover supported
+commands, features, and typed error codes without starting the daemon. See
+[`docs/cli-json.md`](docs/cli-json.md) for the contract.
 
 ## Configuration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,13 @@ lifecycle operations, native-terminal opening, and daemon management.
 globally addressable within the daemon. The installer safely removes an
 untouched legacy `boomux-shells` skill and preserves customized copies.
 
+Read-only CLI integrations use the separate `boomux.cli/v1` JSON envelope rather
+than serializing daemon protocol snapshots directly. `boomux capabilities`
+advertises supported commands, features, schemas, and error codes without
+requiring a daemon. Protocol 6 error responses carry an additive optional code;
+new clients expose it through a typed `RemoteError`, while mixed-version peers
+retain message compatibility.
+
 ## Runtime Semantics
 
 Closing a terminal window closes only its socket attachment. The daemon retains
@@ -168,5 +175,5 @@ as pending.
 The detailed design, acceptance criteria, and manual test matrix are tracked in
 [`native-terminal-follow-up.md`](native-terminal-follow-up.md).
 
-1. Add stable versioned JSON output, typed errors, and capability reporting for
-   integrations.
+1. Add a monotonic daemon event stream with reconnectable cursors and
+   revision-aware output reads.

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -1,0 +1,90 @@
+# CLI JSON Contract
+
+Boomux exposes a versioned JSON contract for read-only integrations. Human
+output remains the default; pass `--json` to a supported command to emit one
+JSON document on stdout:
+
+```json
+{
+  "schema": "boomux.cli/v1",
+  "command": "shell.inspect",
+  "data": {}
+}
+```
+
+The `schema` value defines field semantics independently from the daemon wire
+protocol. Fields documented by `boomux.cli/v1` will not change type or meaning.
+Future incompatible output will use a different schema value.
+
+## Discovery
+
+`boomux capabilities --json` does not start or contact the daemon. It reports
+the CLI version, daemon protocol version, supported JSON schemas and commands,
+stable error codes, and feature names.
+
+The following commands support `--json`:
+
+- `boomux capabilities`
+- `boomux list`
+- `boomux shells`
+- `boomux read`
+- `boomux workspace list`
+- `boomux workspace inspect`
+- `boomux shell inspect`
+- `boomux daemon status`
+
+Mutation commands intentionally retain human output for now. Passing `--json`
+to an unsupported command fails with `invalid_argument` before performing the
+operation.
+
+Command payloads are:
+
+- `capabilities`: CLI/protocol versions plus arrays of schemas, commands,
+  features, and error codes.
+- `list`: a `shells` array.
+- `shells`: workspace identity plus a `shells` array.
+- `workspace.list`: a `workspaces` array of `id`, `name`, and `shell_count`.
+- `workspace.inspect`: one `workspace` object containing `id`, `name`, and
+  `shells`.
+- `shell.inspect`: one `shell` object.
+- `read`: shell/run identity, observed output revision, and rendered output.
+- `daemon.status`: `status`, `protocol_version`, and `socket_path`.
+
+## Shell Data
+
+Shell objects use stable scalar fields: `id`, `workspace_id`, `workspace_name`,
+`name`, `cwd`, `status`, `exit_code`, and `run`. Missing values are JSON `null`,
+not omitted or represented as human placeholders. `status` is `pending`,
+`running`, or `exited`.
+
+A run object includes `id`, `generation`, `started_at_ms`, `ended_at_ms`,
+`exit_reason`, `exit_code`, `output_revision`, and `environment_has_run_id`.
+`exit_reason` is `exited`, `terminated`, `interrupted`, or `null`.
+
+`read` returns `shell_id`, `run_id`, `output_revision`, and `output`. Output is a
+JSON string containing the same bounded plain rendered text as human mode. The
+identity and revision come from the snapshot immediately before the separate
+output read; they are observational metadata, not an atomic read cursor.
+
+## Errors
+
+JSON failures write one document to stderr and exit nonzero:
+
+```json
+{
+  "schema": "boomux.cli/v1",
+  "command": "shells",
+  "error": {
+    "code": "not_found",
+    "message": "shell not found: ..."
+  }
+}
+```
+
+Failures detected while parsing command-line arguments use `"command": "cli"`
+because no valid command was selected.
+
+The stable codes are reported by `boomux capabilities --json`. Messages remain
+human-readable context and are not stable parsing targets. Daemon protocol 6
+adds the error code as an optional field: older clients ignore it, while newer
+clients classify errors from older daemons as `unknown`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,8 +82,8 @@ eternal process.
    `BOOMUX_RUN_ID`.
 2. [Complete] Preserve final exited-run metadata and terminal state across
    graceful daemon restart without starting a replacement process implicitly.
-3. Add stable versioned JSON output, typed errors, and capability reporting for
-   integrations.
+3. [Complete] Add stable versioned JSON output, typed errors, and capability
+   reporting for integrations.
 4. Add a monotonic daemon event stream with reconnectable cursors and
    revision-aware output reads.
 5. Route runtime transitions through one coordinator so persistence and events

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -1,0 +1,205 @@
+use std::error::Error;
+use std::io;
+
+use serde::Serialize;
+
+use boomux::client::RemoteError;
+use boomux::protocol::{ErrorCode, ShellRunExitReason, ShellSnapshot, ShellStatus};
+
+pub(crate) const SCHEMA: &str = "boomux.cli/v1";
+
+#[derive(Serialize)]
+struct Envelope<'a, T> {
+    schema: &'static str,
+    command: &'a str,
+    data: T,
+}
+
+#[derive(Serialize)]
+struct ErrorEnvelope<'a> {
+    schema: &'static str,
+    command: &'a str,
+    error: ErrorData<'a>,
+}
+
+#[derive(Serialize)]
+struct ErrorData<'a> {
+    code: &'a str,
+    message: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct CliError {
+    code: &'static str,
+    message: String,
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for CliError {}
+
+#[derive(Serialize)]
+pub(crate) struct ShellData {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) workspace_name: Option<String>,
+    pub(crate) name: String,
+    pub(crate) cwd: String,
+    pub(crate) status: &'static str,
+    pub(crate) exit_code: Option<u32>,
+    pub(crate) run: Option<RunData>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct RunData {
+    id: String,
+    generation: u64,
+    started_at_ms: u64,
+    ended_at_ms: Option<u64>,
+    exit_reason: Option<&'static str>,
+    exit_code: Option<u32>,
+    output_revision: u64,
+    environment_has_run_id: bool,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WorkspaceSummary {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) shell_count: usize,
+}
+
+pub(crate) fn print<T: Serialize>(command: &str, data: T) -> Result<(), Box<dyn Error>> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&Envelope {
+            schema: SCHEMA,
+            command,
+            data,
+        })?
+    );
+    Ok(())
+}
+
+pub(crate) fn print_error(command: &str, error: &(dyn Error + 'static)) {
+    print_error_message(command, classify_error(command, error), error.to_string());
+}
+
+pub(crate) fn print_error_message(command: &str, code: &str, message: impl Into<String>) {
+    let envelope = ErrorEnvelope {
+        schema: SCHEMA,
+        command,
+        error: ErrorData {
+            code,
+            message: message.into(),
+        },
+    };
+    match serde_json::to_string_pretty(&envelope) {
+        Ok(json) => eprintln!("{json}"),
+        Err(_) => eprintln!(
+            "{{\"schema\":\"boomux.cli/v1\",\"command\":\"unknown\",\"error\":{{\"code\":\"internal\",\"message\":\"could not serialize error\"}}}}"
+        ),
+    }
+}
+
+pub(crate) fn failure(code: &'static str, message: impl Into<String>) -> Box<dyn Error> {
+    Box::new(CliError {
+        code,
+        message: message.into(),
+    })
+}
+
+pub(crate) fn shell(shell: &ShellSnapshot, workspace_name: Option<&str>) -> ShellData {
+    let (status, exit_code) = match shell.status {
+        ShellStatus::Pending => ("pending", None),
+        ShellStatus::Running => ("running", None),
+        ShellStatus::Exited { code } => ("exited", code),
+    };
+    ShellData {
+        id: shell.id.clone(),
+        workspace_id: shell.workspace_id.clone(),
+        workspace_name: workspace_name.map(str::to_owned),
+        name: shell.name.clone(),
+        cwd: shell.cwd.display().to_string(),
+        status,
+        exit_code,
+        run: shell.run.as_ref().map(|run| {
+            let (exit_reason, exit_code) = match run.exit_reason.as_ref() {
+                Some(ShellRunExitReason::Exited { code }) => (Some("exited"), *code),
+                Some(ShellRunExitReason::Terminated) => (Some("terminated"), None),
+                Some(ShellRunExitReason::Interrupted) => (Some("interrupted"), None),
+                None => (None, None),
+            };
+            RunData {
+                id: run.id.clone(),
+                generation: run.generation,
+                started_at_ms: run.started_at_ms,
+                ended_at_ms: run.ended_at_ms,
+                exit_reason,
+                exit_code,
+                output_revision: run.output_revision,
+                environment_has_run_id: run.environment_has_run_id,
+            }
+        }),
+    }
+}
+
+fn classify_error(command: &str, error: &(dyn Error + 'static)) -> &'static str {
+    let mut current = Some(error);
+    while let Some(candidate) = current {
+        if let Some(cli) = candidate.downcast_ref::<CliError>() {
+            return cli.code;
+        }
+        if let Some(remote) = candidate.downcast_ref::<RemoteError>() {
+            return remote.code.map_or("unknown", protocol_error_code);
+        }
+        if let Some(io_error) = candidate.downcast_ref::<io::Error>() {
+            if let Some(remote) = io_error
+                .get_ref()
+                .and_then(|inner| inner.downcast_ref::<RemoteError>())
+            {
+                return remote.code.map_or("unknown", protocol_error_code);
+            }
+            if command == "daemon.status"
+                && matches!(
+                    io_error.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+                )
+            {
+                return "daemon_unavailable";
+            }
+            return match io_error.kind() {
+                io::ErrorKind::InvalidInput | io::ErrorKind::InvalidData => "invalid_argument",
+                io::ErrorKind::NotFound => "not_found",
+                io::ErrorKind::AlreadyExists => "already_exists",
+                io::ErrorKind::WouldBlock | io::ErrorKind::AddrInUse => "busy",
+                io::ErrorKind::ConnectionAborted => "daemon_stopping",
+                io::ErrorKind::ConnectionRefused => "daemon_unavailable",
+                io::ErrorKind::TimedOut => "timeout",
+                _ => "internal",
+            };
+        }
+        current = candidate.source();
+    }
+    "internal"
+}
+
+fn protocol_error_code(code: ErrorCode) -> &'static str {
+    match code {
+        ErrorCode::InvalidArgument => "invalid_argument",
+        ErrorCode::NotFound => "not_found",
+        ErrorCode::AlreadyExists => "already_exists",
+        ErrorCode::Busy => "busy",
+        ErrorCode::DaemonStopping => "daemon_stopping",
+        ErrorCode::ShellStartFailed => "shell_start_failed",
+        ErrorCode::PersistenceFailed => "persistence_failed",
+        ErrorCode::Timeout => "timeout",
+        ErrorCode::UnsupportedVersion => "unsupported_version",
+        ErrorCode::Internal => "internal",
+        ErrorCode::Unknown => "unknown",
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::error::Error;
 use std::fs::OpenOptions;
 use std::io;
 use std::os::fd::AsRawFd;
@@ -10,8 +11,8 @@ use std::thread;
 use std::time::Duration;
 
 use crate::protocol::{
-    self, Envelope, Request, Response, ShellSnapshot, ShellSpec, Snapshot, TerminalProfile,
-    WorkspaceSnapshot,
+    self, Envelope, ErrorCode, Request, Response, ShellSnapshot, ShellSpec, Snapshot,
+    TerminalProfile, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -31,6 +32,20 @@ pub struct Attachment {
     pub warning: Option<String>,
 }
 
+#[derive(Debug)]
+pub struct RemoteError {
+    pub code: Option<ErrorCode>,
+    pub message: String,
+}
+
+impl std::fmt::Display for RemoteError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RemoteError {}
+
 pub fn socket_path() -> io::Result<PathBuf> {
     let runtime = env::var_os("XDG_RUNTIME_DIR")
         .map(PathBuf::from)
@@ -46,8 +61,10 @@ pub fn socket_path() -> io::Result<PathBuf> {
 
 pub fn connect_or_start() -> io::Result<Client> {
     let client = connect_client()?;
-    if client.ping().is_ok() {
-        return Ok(client);
+    match client.ping() {
+        Ok(()) => return Ok(client),
+        Err(error) if !daemon_unreachable(&error) => return Err(error),
+        Err(_) => {}
     }
 
     let mut command = Command::new(env::current_exe()?);
@@ -67,17 +84,40 @@ pub fn connect_or_start() -> io::Result<Client> {
             }
         });
     }
-    command.spawn()?;
+    command.spawn().map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("daemon did not start: {error}"),
+        )
+    })?;
 
     let mut last_error = None;
     for _ in 0..CONNECT_ATTEMPTS {
         match client.ping() {
             Ok(()) => return Ok(client),
+            Err(error) if !daemon_unreachable(&error) => return Err(error),
             Err(error) => last_error = Some(error),
         }
         thread::sleep(CONNECT_DELAY);
     }
-    Err(last_error.unwrap_or_else(|| io::Error::other("daemon did not start")))
+    Err(io::Error::new(
+        io::ErrorKind::ConnectionRefused,
+        last_error.unwrap_or_else(|| io::Error::other("daemon did not start")),
+    ))
+}
+
+fn daemon_unreachable(error: &io::Error) -> bool {
+    error
+        .get_ref()
+        .is_none_or(|error| !error.is::<RemoteError>())
+        && matches!(
+            error.kind(),
+            io::ErrorKind::NotFound
+                | io::ErrorKind::ConnectionRefused
+                | io::ErrorKind::ConnectionReset
+                | io::ErrorKind::BrokenPipe
+                | io::ErrorKind::UnexpectedEof
+        )
 }
 
 pub fn connect() -> io::Result<Client> {
@@ -110,13 +150,29 @@ impl Client {
         protocol::write_message(&mut stream, &Envelope::new(request))?;
         let response: Envelope<Response> = protocol::read_message(&mut stream)?;
         if response.version != protocol::PROTOCOL_VERSION {
+            if let Response::Error {
+                message,
+                code: Some(ErrorCode::UnsupportedVersion),
+            } = response.message
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    RemoteError {
+                        code: Some(ErrorCode::UnsupportedVersion),
+                        message,
+                    },
+                ));
+            }
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "protocol version mismatch",
             ));
         }
         match response.message {
-            Response::Error { message } => Err(io::Error::other(message)),
+            Response::Error { message, code } => Err(io::Error::new(
+                error_kind(code),
+                RemoteError { code, message },
+            )),
             response => Ok((stream, response)),
         }
     }
@@ -295,6 +351,19 @@ impl Client {
             }),
             other => unexpected(other),
         }
+    }
+}
+
+fn error_kind(code: Option<ErrorCode>) -> io::ErrorKind {
+    match code {
+        Some(ErrorCode::InvalidArgument) => io::ErrorKind::InvalidInput,
+        Some(ErrorCode::NotFound) => io::ErrorKind::NotFound,
+        Some(ErrorCode::AlreadyExists) => io::ErrorKind::AlreadyExists,
+        Some(ErrorCode::Busy) => io::ErrorKind::WouldBlock,
+        Some(ErrorCode::DaemonStopping) => io::ErrorKind::ConnectionAborted,
+        Some(ErrorCode::Timeout) => io::ErrorKind::TimedOut,
+        Some(ErrorCode::UnsupportedVersion) => io::ErrorKind::InvalidData,
+        _ => io::ErrorKind::Other,
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,8 +23,9 @@ use crate::client;
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::protocol::{
-    self, AttachFrame, Envelope, Request, Response, ShellRunExitReason, ShellRunSnapshot,
-    ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalProfile, WorkspaceSnapshot,
+    self, AttachFrame, Envelope, ErrorCode, Request, Response, ShellRunExitReason,
+    ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalProfile,
+    WorkspaceSnapshot,
 };
 use crate::state_store::{
     PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace, StateStore,
@@ -207,6 +208,21 @@ struct RestartRequest {
     reply: SyncSender<io::Result<()>>,
 }
 
+#[derive(Debug)]
+struct PersistenceError(io::Error);
+
+impl std::fmt::Display for PersistenceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl std::error::Error for PersistenceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
 struct SocketCleanup {
     path: PathBuf,
     armed: bool,
@@ -280,7 +296,7 @@ fn launch_replacement(
     let _mutation = lock(&registry.mutation_lock)?;
     registry.ensure_running()?;
     if registry.persistence_dirty.load(Ordering::Acquire) {
-        registry.persist()?;
+        registry.persist().map_err(persistence_error)?;
     }
     registry.stopping.store(true, Ordering::Release);
     let mut paused = Vec::new();
@@ -461,13 +477,14 @@ fn handle_connection(
     if request.version != protocol::PROTOCOL_VERSION {
         return send_response(
             &mut stream,
-            Response::Error {
-                message: format!(
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                format!(
                     "protocol version {} is unsupported; expected {}",
                     request.version,
                     protocol::PROTOCOL_VERSION
                 ),
-            },
+            ),
         );
     }
 
@@ -491,9 +508,10 @@ fn handle_connection(
         {
             return send_response(
                 &mut stream,
-                Response::Error {
-                    message: "another daemon transition is already in progress".into(),
-                },
+                error_response(
+                    ErrorCode::Busy,
+                    "another daemon transition is already in progress",
+                ),
             );
         }
         return match registry.shutdown() {
@@ -505,9 +523,10 @@ fn handle_connection(
                 transition.store(TRANSITION_IDLE, Ordering::Release);
                 send_response(
                     &mut stream,
-                    Response::Error {
-                        message: format!("could not stop Boomux daemon: {error}"),
-                    },
+                    error_response(
+                        error_code(&error),
+                        format!("could not stop Boomux daemon: {error}"),
+                    ),
                 )
             }
         };
@@ -524,9 +543,7 @@ fn handle_connection(
         {
             return send_response(
                 &mut stream,
-                Response::Error {
-                    message: "daemon restart is already in progress".into(),
-                },
+                error_response(ErrorCode::Busy, "daemon restart is already in progress"),
             );
         }
         let (reply, response) = mpsc::sync_channel(1);
@@ -538,29 +555,55 @@ fn handle_connection(
             Ok(Ok(())) => send_response(&mut stream, Response::Ok),
             Ok(Err(error)) => send_response(
                 &mut stream,
-                Response::Error {
-                    message: error.to_string(),
-                },
+                error_response(error_code(&error), error.to_string()),
             ),
             Err(error) => send_response(
                 &mut stream,
-                Response::Error {
-                    message: format!("daemon restart timed out: {error}"),
-                },
+                error_response(
+                    ErrorCode::Timeout,
+                    format!("daemon restart timed out: {error}"),
+                ),
             ),
         };
     }
 
     let response = registry
         .dispatch(request.message)
-        .unwrap_or_else(|error| Response::Error {
-            message: error.to_string(),
-        });
+        .unwrap_or_else(|error| error_response(error_code(&error), error.to_string()));
     send_response(&mut stream, response)
 }
 
 fn send_response(stream: &mut UnixStream, response: Response) -> io::Result<()> {
     protocol::write_message(stream, &Envelope::new(response))
+}
+
+fn error_response(code: ErrorCode, message: impl Into<String>) -> Response {
+    Response::Error {
+        message: message.into(),
+        code: Some(code),
+    }
+}
+
+fn error_code(error: &io::Error) -> ErrorCode {
+    if error
+        .get_ref()
+        .is_some_and(|error| error.downcast_ref::<PersistenceError>().is_some())
+    {
+        return ErrorCode::PersistenceFailed;
+    }
+    match error.kind() {
+        io::ErrorKind::InvalidInput | io::ErrorKind::InvalidData => ErrorCode::InvalidArgument,
+        io::ErrorKind::NotFound => ErrorCode::NotFound,
+        io::ErrorKind::AlreadyExists => ErrorCode::AlreadyExists,
+        io::ErrorKind::WouldBlock | io::ErrorKind::AddrInUse => ErrorCode::Busy,
+        io::ErrorKind::ConnectionAborted => ErrorCode::DaemonStopping,
+        io::ErrorKind::TimedOut => ErrorCode::Timeout,
+        _ => ErrorCode::Internal,
+    }
+}
+
+fn persistence_error(error: io::Error) -> io::Error {
+    io::Error::new(error.kind(), PersistenceError(error))
 }
 
 struct Registry {
@@ -1391,7 +1434,7 @@ impl Registry {
         self.ensure_running()?;
         let backup = self.backup()?;
         match operation() {
-            Ok(value) => match self.persist_unlocked() {
+            Ok(value) => match self.persist_unlocked().map_err(persistence_error) {
                 Ok(()) => Ok(value),
                 Err(error) => {
                     self.restore_backup(backup)?;
@@ -1638,7 +1681,7 @@ impl Registry {
             }
             killed.push(Arc::clone(shell));
         }
-        if let Err(error) = self.persist() {
+        if let Err(error) = self.persist().map_err(persistence_error) {
             for shell in killed {
                 shell.reset_pending()?;
             }
@@ -1879,7 +1922,7 @@ impl Registry {
         let killed_run = lock(&shell.last_run)?.clone();
         let _persistence = lock(&self.persist_lock)?;
         self.remove_shell(shell_id)?;
-        if let Err(error) = self.persist_unlocked() {
+        if let Err(error) = self.persist_unlocked().map_err(persistence_error) {
             self.restore_backup(backup)?;
             *lock(&shell.last_run)? = killed_run;
             shell.reset_pending()?;
@@ -1914,7 +1957,7 @@ impl Registry {
         }
         let _persistence = lock(&self.persist_lock)?;
         self.remove_workspace(workspace_id)?;
-        if let Err(error) = self.persist_unlocked() {
+        if let Err(error) = self.persist_unlocked().map_err(persistence_error) {
             self.restore_backup(backup)?;
             for shell in shells {
                 if let Some(run) = killed_runs.get(&shell.id) {
@@ -2337,9 +2380,7 @@ fn handle_attach(
     if let Err(error) = validate_terminal_profile(&profile) {
         return send_response(
             &mut stream,
-            Response::Error {
-                message: error.to_string(),
-            },
+            error_response(ErrorCode::InvalidArgument, error.to_string()),
         );
     }
     let shell = match registry.shell(shell_id) {
@@ -2347,9 +2388,7 @@ fn handle_attach(
         Err(error) => {
             return send_response(
                 &mut stream,
-                Response::Error {
-                    message: error.to_string(),
-                },
+                error_response(error_code(&error), error.to_string()),
             );
         }
     };
@@ -2357,9 +2396,7 @@ fn handle_attach(
     if registry.stopping.load(Ordering::Acquire) {
         return send_response(
             &mut stream,
-            Response::Error {
-                message: "Boomux daemon is stopping".into(),
-            },
+            error_response(ErrorCode::DaemonStopping, "Boomux daemon is stopping"),
         );
     }
     let token = Uuid::new_v4().to_string();
@@ -2372,9 +2409,7 @@ fn handle_attach(
         if !registry.contains_shell(&shell)? {
             return send_response(
                 &mut stream,
-                Response::Error {
-                    message: format!("shell not found: {shell_id}"),
-                },
+                error_response(ErrorCode::NotFound, format!("shell not found: {shell_id}")),
             );
         }
         if matches!(*lifecycle, ShellLifecycle::Pending) {
@@ -2393,9 +2428,10 @@ fn handle_attach(
                     Err(error) => {
                         return send_response(
                             &mut stream,
-                            Response::Error {
-                                message: format!("could not start shell: {error}"),
-                            },
+                            error_response(
+                                ErrorCode::ShellStartFailed,
+                                format!("could not start shell: {error}"),
+                            ),
                         );
                     }
                 };
@@ -2421,8 +2457,9 @@ fn handle_attach(
                 }
                 return send_response(
                     &mut stream,
-                    Response::Error {
-                        message: cleanup.map_or_else(
+                    error_response(
+                        ErrorCode::ShellStartFailed,
+                        cleanup.map_or_else(
                             |cleanup| {
                                 format!(
                                     "could not start shell reader: {error}; process cleanup also failed: {cleanup}"
@@ -2430,7 +2467,7 @@ fn handle_attach(
                             },
                             |()| format!("could not start shell reader: {error}"),
                         ),
-                    },
+                    ),
                 );
             }
         }
@@ -2451,9 +2488,7 @@ fn handle_attach(
             ShellLifecycle::Closed => {
                 return send_response(
                     &mut stream,
-                    Response::Error {
-                        message: format!("shell not found: {shell_id}"),
-                    },
+                    error_response(ErrorCode::NotFound, format!("shell not found: {shell_id}")),
                 );
             }
         }
@@ -2465,8 +2500,9 @@ fn handle_attach(
         }
         return send_response(
             &mut stream,
-            Response::Error {
-                message: cleanup.map_or_else(
+            error_response(
+                ErrorCode::PersistenceFailed,
+                cleanup.map_or_else(
                     |cleanup| {
                         format!(
                             "could not persist started shell: {error}; process cleanup also failed: {cleanup}"
@@ -2474,7 +2510,7 @@ fn handle_attach(
                     },
                     |()| format!("could not persist started shell: {error}"),
                 ),
-            },
+            ),
         );
     }
     if started {
@@ -2504,9 +2540,7 @@ fn handle_attach(
     if !registry.contains_shell(&shell)? {
         return send_response(
             &mut stream,
-            Response::Error {
-                message: format!("shell not found: {shell_id}"),
-            },
+            error_response(ErrorCode::NotFound, format!("shell not found: {shell_id}")),
         );
     }
     {
@@ -2514,9 +2548,10 @@ fn handle_attach(
         if controller.is_some() && !takeover {
             return send_response(
                 &mut stream,
-                Response::Error {
-                    message: "shell already has an active controller; use takeover".into(),
-                },
+                error_response(
+                    ErrorCode::Busy,
+                    "shell already has an active controller; use takeover",
+                ),
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,18 @@ use std::env;
 use std::error::Error;
 use std::fs;
 use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
+use clap::error::ErrorKind as ClapErrorKind;
 use clap::{Parser, Subcommand};
 use uuid::Uuid;
 
 use boomux::protocol::{ShellSnapshot, ShellSpec, ShellStatus, Snapshot, WorkspaceSnapshot};
 use boomux::{attach, client, daemon, protocol};
 
+mod cli_output;
 mod config;
 mod git;
 mod projects;
@@ -69,6 +71,10 @@ const READ_BYTES: usize = 1024 * 1024;
     subcommand_value_name = "SUBCOMMAND"
 )]
 struct Cli {
+    /// Emit the stable boomux.cli/v1 JSON envelope
+    #[arg(long, global = true)]
+    json: bool,
+
     /// Open or create a persistent terminal in this directory
     #[arg(value_name = "PATH")]
     path: Option<PathBuf>,
@@ -99,6 +105,8 @@ enum Commands {
     Ui,
     /// Check that Boomux's dependencies and daemon are available
     Doctor,
+    /// Report stable integration capabilities without starting the daemon
+    Capabilities,
     /// List all managed shells
     List,
     /// List shells in the current Boomux workspace
@@ -226,16 +234,55 @@ enum DaemonCommands {
 }
 
 fn main() -> ExitCode {
-    match run(Cli::parse()) {
+    let json_requested = env::args_os().any(|argument| argument == "--json");
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(error) => {
+            let exit_code = u8::try_from(error.exit_code()).unwrap_or(1);
+            if json_requested
+                && !matches!(
+                    error.kind(),
+                    ClapErrorKind::DisplayHelp | ClapErrorKind::DisplayVersion
+                )
+            {
+                cli_output::print_error_message("cli", "invalid_argument", error.to_string());
+                return ExitCode::from(exit_code);
+            }
+            let success = matches!(
+                error.kind(),
+                ClapErrorKind::DisplayHelp | ClapErrorKind::DisplayVersion
+            );
+            let _ = error.print();
+            return if success {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(exit_code)
+            };
+        }
+    };
+    let json = cli.json;
+    let command = command_name(&cli);
+    match run(cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            eprintln!("boomux: {error}");
+            if json {
+                cli_output::print_error(command, error.as_ref());
+            } else {
+                eprintln!("boomux: {error}");
+            }
             ExitCode::FAILURE
         }
     }
 }
 
 fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
+    if cli.json && !supports_json(&cli) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("--json is not supported for {}", command_name(&cli)),
+        )
+        .into());
+    }
     match cli.command.as_ref() {
         Some(Commands::Daemon {
             command: DaemonCommands::Run,
@@ -270,12 +317,13 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
     match cli.command {
         Some(Commands::Ui) => dashboard(cli.terminal.as_deref()),
         Some(Commands::Doctor) => doctor(cli.terminal.as_deref()),
-        Some(Commands::List) => list_shells(),
-        Some(Commands::Shells) => list_workspace_shells(),
-        Some(Commands::Read { target, lines }) => read_shell(&target, lines),
+        Some(Commands::Capabilities) => capabilities(cli.json),
+        Some(Commands::List) => list_shells(cli.json),
+        Some(Commands::Shells) => list_workspace_shells(cli.json),
+        Some(Commands::Read { target, lines }) => read_shell(&target, lines, cli.json),
         Some(Commands::Close { target }) => close_shell(&target),
-        Some(Commands::Workspace { command }) => workspace_command(command),
-        Some(Commands::Shell { command }) => shell_command(command),
+        Some(Commands::Workspace { command }) => workspace_command(command, cli.json),
+        Some(Commands::Shell { command }) => shell_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
         }) => install_skill(force),
@@ -288,15 +336,70 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             open_shell(&shell_id, title.as_deref(), takeover, terminal.as_deref())
         }
         Some(Commands::Prompt) => print_prompt_label(),
-        Some(Commands::Daemon { command }) => daemon_control(command),
+        Some(Commands::Daemon { command }) => daemon_control(command, cli.json),
         Some(Commands::Attach { .. }) => unreachable!(),
         None => dashboard(cli.terminal.as_deref()),
     }
 }
 
-fn daemon_control(command: DaemonCommands) -> Result<(), Box<dyn Error>> {
+fn command_name(cli: &Cli) -> &'static str {
+    match cli.command.as_ref() {
+        Some(Commands::Capabilities) => "capabilities",
+        Some(Commands::List) => "list",
+        Some(Commands::Shells) => "shells",
+        Some(Commands::Read { .. }) => "read",
+        Some(Commands::Workspace {
+            command: WorkspaceCommands::List,
+        }) => "workspace.list",
+        Some(Commands::Workspace {
+            command: WorkspaceCommands::Inspect { .. },
+        }) => "workspace.inspect",
+        Some(Commands::Shell {
+            command: ShellCommands::Inspect { .. },
+        }) => "shell.inspect",
+        Some(Commands::Daemon {
+            command: DaemonCommands::Status,
+        }) => "daemon.status",
+        Some(Commands::Workspace { .. }) => "workspace",
+        Some(Commands::Shell { .. }) => "shell",
+        Some(Commands::Daemon { .. }) => "daemon",
+        Some(Commands::Ui) | None => "ui",
+        Some(Commands::Doctor) => "doctor",
+        Some(Commands::Close { .. }) => "close",
+        Some(Commands::Skill { .. }) => "skill",
+        Some(Commands::Open { .. }) => "open",
+        Some(Commands::Prompt) => "prompt",
+        Some(Commands::Attach { .. }) => "attach",
+    }
+}
+
+fn supports_json(cli: &Cli) -> bool {
+    matches!(
+        cli.command.as_ref(),
+        Some(Commands::Capabilities | Commands::List | Commands::Shells | Commands::Read { .. })
+            | Some(Commands::Workspace {
+                command: WorkspaceCommands::List | WorkspaceCommands::Inspect { .. }
+            })
+            | Some(Commands::Shell {
+                command: ShellCommands::Inspect { .. }
+            })
+            | Some(Commands::Daemon {
+                command: DaemonCommands::Status
+            })
+    )
+}
+
+fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect()?;
     match command {
+        DaemonCommands::Status if json => cli_output::print(
+            "daemon.status",
+            serde_json::json!({
+                "status": "running",
+                "protocol_version": protocol::PROTOCOL_VERSION,
+                "socket_path": client.socket_path().display().to_string(),
+            }),
+        )?,
         DaemonCommands::Status => println!(
             "running (protocol {}, {})",
             protocol::PROTOCOL_VERSION,
@@ -543,7 +646,10 @@ fn resolve_directory(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
 fn cli_name(name: String, kind: &str) -> Result<String, Box<dyn Error>> {
     let name = name.trim();
     if name.is_empty() {
-        return Err(format!("{kind} name cannot be empty").into());
+        return Err(cli_output::failure(
+            "invalid_argument",
+            format!("{kind} name cannot be empty"),
+        ));
     }
     Ok(name.to_owned())
 }
@@ -562,7 +668,7 @@ fn resolve_workspace_target<'a>(
     workspaces
         .iter()
         .find(|workspace| workspace.id == target || workspace.name == target)
-        .ok_or_else(|| format!("workspace not found: {target}").into())
+        .ok_or_else(|| cli_output::failure("not_found", format!("workspace not found: {target}")))
 }
 
 fn create_dashboard_workspace(
@@ -609,8 +715,77 @@ fn unique_shell_name(base_name: &str, shells: &[ShellSnapshot]) -> String {
     )
 }
 
-fn list_shells() -> Result<(), Box<dyn Error>> {
+fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
+    let commands = [
+        "capabilities",
+        "list",
+        "shells",
+        "read",
+        "workspace.list",
+        "workspace.inspect",
+        "shell.inspect",
+        "daemon.status",
+    ];
+    let features = [
+        "typed_errors",
+        "shell_run_identity",
+        "rendered_scrollback",
+        "graceful_live_handoff",
+        "graceful_exited_handoff",
+    ];
+    let error_codes = [
+        "invalid_argument",
+        "not_found",
+        "already_exists",
+        "busy",
+        "daemon_stopping",
+        "daemon_unavailable",
+        "shell_start_failed",
+        "persistence_failed",
+        "timeout",
+        "unsupported_version",
+        "context_required",
+        "ambiguous_target",
+        "internal",
+        "unknown",
+    ];
+    if json {
+        return cli_output::print(
+            "capabilities",
+            serde_json::json!({
+                "cli_version": env!("CARGO_PKG_VERSION"),
+                "daemon_protocol_version": protocol::PROTOCOL_VERSION,
+                "json_schemas": [cli_output::SCHEMA],
+                "json_commands": commands,
+                "features": features,
+                "error_codes": error_codes,
+            }),
+        );
+    }
+    println!("CLI VERSION\t{}", env!("CARGO_PKG_VERSION"));
+    println!("DAEMON PROTOCOL\t{}", protocol::PROTOCOL_VERSION);
+    println!("JSON SCHEMAS\t{}", cli_output::SCHEMA);
+    println!("JSON COMMANDS\t{}", commands.join(","));
+    println!("FEATURES\t{}", features.join(","));
+    println!("ERROR CODES\t{}", error_codes.join(","));
+    Ok(())
+}
+
+fn list_shells(json: bool) -> Result<(), Box<dyn Error>> {
     let snapshot = client::connect_or_start()?.snapshot()?;
+    if json {
+        let shells = snapshot
+            .workspaces
+            .iter()
+            .flat_map(|workspace| {
+                workspace
+                    .shells
+                    .iter()
+                    .map(|shell| cli_output::shell(shell, Some(&workspace.name)))
+            })
+            .collect::<Vec<_>>();
+        return cli_output::print("list", serde_json::json!({ "shells": shells }));
+    }
     println!("WORKSPACE\tNAME\tSHELL ID\tRUN ID\tSTATUS");
     for workspace in snapshot.workspaces {
         for shell in workspace.shells {
@@ -627,12 +802,27 @@ fn list_shells() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn workspace_command(command: WorkspaceCommands) -> Result<(), Box<dyn Error>> {
+fn workspace_command(command: WorkspaceCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     match command {
         WorkspaceCommands::List => {
+            let workspaces = client.snapshot()?.workspaces;
+            if json {
+                let workspaces = workspaces
+                    .iter()
+                    .map(|workspace| cli_output::WorkspaceSummary {
+                        id: workspace.id.clone(),
+                        name: workspace.name.clone(),
+                        shell_count: workspace.shells.len(),
+                    })
+                    .collect::<Vec<_>>();
+                return cli_output::print(
+                    "workspace.list",
+                    serde_json::json!({ "workspaces": workspaces }),
+                );
+            }
             println!("NAME\tWORKSPACE ID\tSHELLS");
-            for workspace in client.snapshot()?.workspaces {
+            for workspace in workspaces {
                 println!(
                     "{}\t{}\t{}",
                     workspace.name,
@@ -649,6 +839,23 @@ fn workspace_command(command: WorkspaceCommands) -> Result<(), Box<dyn Error>> {
         WorkspaceCommands::Inspect { target } => {
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
+            if json {
+                let shells = workspace
+                    .shells
+                    .iter()
+                    .map(|shell| cli_output::shell(shell, Some(&workspace.name)))
+                    .collect::<Vec<_>>();
+                return cli_output::print(
+                    "workspace.inspect",
+                    serde_json::json!({
+                        "workspace": {
+                            "id": workspace.id,
+                            "name": workspace.name,
+                            "shells": shells,
+                        }
+                    }),
+                );
+            }
             println!("ID\t{}", workspace.id);
             println!("NAME\t{}", workspace.name);
             println!("SHELLS\t{}", workspace.shells.len());
@@ -692,7 +899,7 @@ fn workspace_command(command: WorkspaceCommands) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn shell_command(command: ShellCommands) -> Result<(), Box<dyn Error>> {
+fn shell_command(command: ShellCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     match command {
         ShellCommands::Create {
@@ -718,7 +925,17 @@ fn shell_command(command: ShellCommands) -> Result<(), Box<dyn Error>> {
                 .workspaces
                 .iter()
                 .find(|workspace| workspace.id == shell.workspace_id)
-                .ok_or("shell workspace no longer exists")?;
+                .ok_or_else(|| {
+                    cli_output::failure("not_found", "shell workspace no longer exists")
+                })?;
+            if json {
+                return cli_output::print(
+                    "shell.inspect",
+                    serde_json::json!({
+                        "shell": cli_output::shell(shell, Some(&workspace.name)),
+                    }),
+                );
+            }
             println!("ID\t{}", shell.id);
             println!("NAME\t{}", shell.name);
             println!("WORKSPACE\t{}", workspace.name);
@@ -761,10 +978,25 @@ fn shell_command(command: ShellCommands) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn list_workspace_shells() -> Result<(), Box<dyn Error>> {
+fn list_workspace_shells(json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let shell = current_shell(&client)?;
     let workspace = client.get_workspace(&shell.workspace_id)?;
+    if json {
+        let shells = workspace
+            .shells
+            .iter()
+            .map(|shell| cli_output::shell(shell, Some(&workspace.name)))
+            .collect::<Vec<_>>();
+        return cli_output::print(
+            "shells",
+            serde_json::json!({
+                "workspace_id": workspace.id,
+                "workspace_name": workspace.name,
+                "shells": shells,
+            }),
+        );
+    }
     println!("NAME\tSHELL ID\tRUN ID\tSTATUS");
     for shell in workspace.shells {
         println!(
@@ -778,7 +1010,7 @@ fn list_workspace_shells() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn read_shell(target: &str, lines: u32) -> Result<(), Box<dyn Error>> {
+fn read_shell(target: &str, lines: u32, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let snapshot = client.snapshot()?;
     let current_workspace_id = env::var("BOOMUX_SHELL_ID")
@@ -787,6 +1019,17 @@ fn read_shell(target: &str, lines: u32) -> Result<(), Box<dyn Error>> {
     let shell = resolve_shell_target(&snapshot, current_workspace_id.as_deref(), target)?;
     let bytes = client.read_shell(&shell.id, READ_BYTES)?;
     let output = recent_lines(&String::from_utf8_lossy(&bytes), lines as usize);
+    if json {
+        return cli_output::print(
+            "read",
+            serde_json::json!({
+                "shell_id": shell.id,
+                "run_id": shell.run.as_ref().map(|run| &run.id),
+                "output_revision": shell.run.as_ref().map(|run| run.output_revision),
+                "output": output,
+            }),
+        );
+    }
     print!("{output}");
     if !output.is_empty() && !output.ends_with('\n') {
         println!();
@@ -838,11 +1081,18 @@ fn resolve_cli_shell<'a>(
             .as_str()
     } else {
         let current_shell_id = env::var("BOOMUX_SHELL_ID").map_err(|_| {
-            format!("shell name {target:?} requires --workspace outside a Boomux-managed shell")
+            cli_output::failure(
+                "context_required",
+                format!(
+                    "shell name {target:?} requires --workspace outside a Boomux-managed shell"
+                ),
+            )
         })?;
         find_shell(snapshot, &current_shell_id)
             .map(|shell| shell.workspace_id.as_str())
-            .ok_or("current Boomux shell no longer exists")?
+            .ok_or_else(|| {
+                cli_output::failure("not_found", "current Boomux shell no longer exists")
+            })?
     };
     resolve_shell_target(snapshot, Some(workspace_id), target)
 }
@@ -856,15 +1106,18 @@ fn resolve_shell_target<'a>(
         return Ok(shell);
     }
     let workspace_id = current_workspace_id.ok_or_else(|| {
-        format!(
-            "shell name {target:?} requires a Boomux shell; use an exact shell ID outside Boomux"
+        cli_output::failure(
+            "context_required",
+            format!(
+                "shell name {target:?} requires a Boomux shell; use an exact shell ID outside Boomux"
+            ),
         )
     })?;
     let workspace = snapshot
         .workspaces
         .iter()
         .find(|workspace| workspace.id == workspace_id)
-        .ok_or("current workspace no longer exists")?;
+        .ok_or_else(|| cli_output::failure("not_found", "current workspace no longer exists"))?;
     let matches = workspace
         .shells
         .iter()
@@ -879,12 +1132,17 @@ fn resolve_shell_target<'a>(
                 .map(|shell| shell.name.as_str())
                 .collect::<Vec<_>>()
                 .join(", ");
-            Err(format!(
-                "shell {target:?} was not found in this workspace; available shells: {available}"
-            )
-            .into())
+            Err(cli_output::failure(
+                "not_found",
+                format!(
+                    "shell {target:?} was not found in this workspace; available shells: {available}"
+                ),
+            ))
         }
-        _ => Err(format!("shell name {target:?} is ambiguous in this workspace").into()),
+        _ => Err(cli_output::failure(
+            "ambiguous_target",
+            format!("shell name {target:?} is ambiguous in this workspace"),
+        )),
     }
 }
 
@@ -902,8 +1160,12 @@ fn find_shell<'a>(snapshot: &'a Snapshot, id: &str) -> Option<&'a ShellSnapshot>
 }
 
 fn current_shell(client: &client::Client) -> Result<ShellSnapshot, Box<dyn Error>> {
-    let shell_id = env::var("BOOMUX_SHELL_ID")
-        .map_err(|_| "this command must run inside a Boomux-managed shell")?;
+    let shell_id = env::var("BOOMUX_SHELL_ID").map_err(|_| {
+        cli_output::failure(
+            "context_required",
+            "this command must run inside a Boomux-managed shell",
+        )
+    })?;
     Ok(client.get_shell(shell_id)?)
 }
 
@@ -1261,6 +1523,22 @@ mod tests {
                 .command,
             Some(Commands::Close { target }) if target == "tests"
         ));
+    }
+
+    #[test]
+    fn parses_global_json_for_supported_integration_commands() {
+        for arguments in [
+            vec!["boomux", "--json", "capabilities"],
+            vec!["boomux", "list", "--json"],
+            vec!["boomux", "workspace", "list", "--json"],
+            vec!["boomux", "daemon", "status", "--json"],
+        ] {
+            let cli = Cli::try_parse_from(arguments).unwrap();
+            assert!(cli.json);
+            assert!(supports_json(&cli));
+        }
+        let cli = Cli::try_parse_from(["boomux", "workspace", "create", "test", "--json"]).unwrap();
+        assert!(!supports_json(&cli));
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -73,6 +73,23 @@ pub enum ShellRunExitReason {
     Interrupted,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    InvalidArgument,
+    NotFound,
+    AlreadyExists,
+    Busy,
+    DaemonStopping,
+    ShellStartFailed,
+    PersistenceFailed,
+    Timeout,
+    UnsupportedVersion,
+    Internal,
+    #[serde(other)]
+    Unknown,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TerminalProfile {
     pub term: Option<String>,
@@ -174,6 +191,8 @@ pub enum Response {
     Ok,
     Error {
         message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<ErrorCode>,
     },
 }
 
@@ -303,6 +322,12 @@ mod tests {
         status: ShellStatus,
     }
 
+    #[derive(Deserialize)]
+    #[serde(tag = "response", rename_all = "snake_case")]
+    enum LegacyResponse {
+        Error { message: String },
+    }
+
     #[test]
     fn control_frame_round_trips() {
         let value = Envelope::new(Request::Attach {
@@ -325,6 +350,38 @@ mod tests {
             read_message::<Envelope<Request>>(&mut bytes.as_slice()).unwrap(),
             value
         );
+    }
+
+    #[test]
+    fn typed_errors_are_additive_within_protocol_six() {
+        let legacy: Response =
+            serde_json::from_str(r#"{"response":"error","message":"legacy daemon"}"#).unwrap();
+        assert_eq!(
+            legacy,
+            Response::Error {
+                message: "legacy daemon".into(),
+                code: None,
+            }
+        );
+
+        let coded = Response::Error {
+            message: "missing".into(),
+            code: Some(ErrorCode::NotFound),
+        };
+        let LegacyResponse::Error { message } =
+            serde_json::from_value(serde_json::to_value(coded).unwrap()).unwrap();
+        assert_eq!(message, "missing");
+
+        let unknown: Response =
+            serde_json::from_str(r#"{"response":"error","message":"future","code":"future_code"}"#)
+                .unwrap();
+        assert!(matches!(
+            unknown,
+            Response::Error {
+                code: Some(ErrorCode::Unknown),
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -9,9 +9,9 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use boomux::client::{Attachment, Client};
+use boomux::client::{Attachment, Client, RemoteError};
 use boomux::protocol::{
-    self, AttachFrame, ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile,
+    self, AttachFrame, ErrorCode, ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile,
 };
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use uuid::Uuid;
@@ -132,6 +132,37 @@ fn replacement_bootstrap_rejects_invalid_inherited_descriptor() {
 
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("Bad file descriptor"));
+}
+
+#[test]
+fn json_cli_parse_and_daemon_start_failures_use_typed_envelopes() {
+    let parse_failure = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["--json", "read"])
+        .output()
+        .unwrap();
+    assert!(!parse_failure.status.success());
+    assert!(parse_failure.stdout.is_empty());
+    let parse_failure: serde_json::Value = serde_json::from_slice(&parse_failure.stderr).unwrap();
+    assert_eq!(parse_failure["schema"], "boomux.cli/v1");
+    assert_eq!(parse_failure["command"], "cli");
+    assert_eq!(parse_failure["error"]["code"], "invalid_argument");
+
+    let root = std::env::temp_dir().join(format!("boomux-json-start-{}", Uuid::new_v4()));
+    fs::create_dir(&root).unwrap();
+    let invalid_state_home = root.join("state-file");
+    fs::write(&invalid_state_home, b"not a directory").unwrap();
+    let unavailable = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["list", "--json"])
+        .env("XDG_RUNTIME_DIR", &root)
+        .env("XDG_STATE_HOME", &invalid_state_home)
+        .output()
+        .unwrap();
+    assert!(!unavailable.status.success());
+    assert!(unavailable.stdout.is_empty());
+    let unavailable: serde_json::Value = serde_json::from_slice(&unavailable.stderr).unwrap();
+    assert_eq!(unavailable["command"], "list");
+    assert_eq!(unavailable["error"]["code"], "daemon_unavailable");
+    fs::remove_dir_all(root).unwrap();
 }
 
 #[test]
@@ -531,7 +562,14 @@ fn graceful_restart_preserves_exited_run_and_terminal_state() {
     let saved_directory = daemon.runtime_dir.join("saved-exited-handoff-state");
     fs::rename(&state_directory, &saved_directory).unwrap();
     fs::write(&state_directory, b"not a directory").unwrap();
-    assert!(daemon.client.close_shell(&shell_id).is_err());
+    let error = daemon.client.close_shell(&shell_id).unwrap_err();
+    assert_eq!(
+        error
+            .get_ref()
+            .and_then(|error| error.downcast_ref::<RemoteError>())
+            .and_then(|error| error.code),
+        Some(ErrorCode::PersistenceFailed)
+    );
     let rolled_back = daemon.client.get_shell(&shell_id).unwrap();
     assert_eq!(rolled_back.status, ShellStatus::Exited { code: Some(7) });
     assert_eq!(rolled_back.run.as_ref(), Some(&before_run));
@@ -696,6 +734,17 @@ fn attachment_client_reconnects_across_daemon_restart() {
 fn native_daemon_lifecycle() {
     let mut daemon = TestDaemon::start();
 
+    let capabilities = daemon
+        .command()
+        .args(["capabilities", "--json"])
+        .output()
+        .unwrap();
+    assert!(capabilities.status.success());
+    let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
+    assert_eq!(capabilities["schema"], "boomux.cli/v1");
+    assert_eq!(capabilities["command"], "capabilities");
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 6);
+
     let status = daemon
         .command()
         .args(["daemon", "status"])
@@ -703,6 +752,51 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 6"));
+    let status = daemon
+        .command()
+        .args(["daemon", "status", "--json"])
+        .output()
+        .unwrap();
+    let status: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(status["schema"], "boomux.cli/v1");
+    assert_eq!(status["data"]["status"], "running");
+
+    let missing_id = Uuid::new_v4().to_string();
+    let error = daemon.client.get_shell(&missing_id).unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    let remote = error
+        .get_ref()
+        .and_then(|error| error.downcast_ref::<RemoteError>())
+        .unwrap();
+    assert_eq!(remote.code, Some(ErrorCode::NotFound));
+    let typed_failure = daemon
+        .command()
+        .args(["shells", "--json"])
+        .env("BOOMUX_SHELL_ID", &missing_id)
+        .output()
+        .unwrap();
+    assert!(!typed_failure.status.success());
+    let typed_failure: serde_json::Value = serde_json::from_slice(&typed_failure.stderr).unwrap();
+    assert_eq!(typed_failure["command"], "shells");
+    assert_eq!(typed_failure["error"]["code"], "not_found");
+    let unsupported = daemon
+        .command()
+        .args(["workspace", "create", "must-not-exist", "--json"])
+        .output()
+        .unwrap();
+    assert!(!unsupported.status.success());
+    assert!(unsupported.stdout.is_empty());
+    let unsupported_error: serde_json::Value = serde_json::from_slice(&unsupported.stderr).unwrap();
+    assert_eq!(unsupported_error["error"]["code"], "invalid_argument");
+    assert!(
+        daemon
+            .client
+            .snapshot()
+            .unwrap()
+            .workspaces
+            .iter()
+            .all(|workspace| workspace.name != "must-not-exist")
+    );
 
     let mut duplicate = daemon
         .command()
@@ -798,6 +892,14 @@ fn native_daemon_lifecycle() {
     assert!(String::from_utf8_lossy(&output.stdout).contains("NAME\tcli-test"));
     let output = daemon
         .command()
+        .args(["workspace", "inspect", "cli-test", "--json"])
+        .output()
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(output["command"], "workspace.inspect");
+    assert_eq!(output["data"]["workspace"]["name"], "cli-test");
+    let output = daemon
+        .command()
         .args(["workspace", "rename", "cli-test", "cli-renamed"])
         .output()
         .unwrap();
@@ -837,6 +939,22 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(output.status.success());
     assert!(String::from_utf8_lossy(&output.stdout).contains("STATUS\tpending"));
+    let output = daemon
+        .command()
+        .args([
+            "shell",
+            "inspect",
+            "checks",
+            "--workspace",
+            "cli-renamed",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(output["command"], "shell.inspect");
+    assert_eq!(output["data"]["shell"]["status"], "pending");
+    assert!(output["data"]["shell"]["run"].is_null());
     let output = daemon
         .command()
         .args([
@@ -900,6 +1018,13 @@ fn native_daemon_lifecycle() {
         .attach(&failed_shell.id, false, profile())
         .unwrap_err();
     assert!(error.to_string().contains("could not start shell"));
+    assert_eq!(
+        error
+            .get_ref()
+            .and_then(|error| error.downcast_ref::<RemoteError>())
+            .and_then(|error| error.code),
+        Some(ErrorCode::ShellStartFailed)
+    );
     assert_eq!(
         daemon.client.get_shell(&failed_shell.id).unwrap().status,
         ShellStatus::Pending
@@ -976,6 +1101,20 @@ fn native_daemon_lifecycle() {
         .unwrap();
     let output = read_until(&mut first, b"transport-ok");
     assert!(contains(&output, b"transport-ok"));
+    let output = daemon
+        .command()
+        .args(["read", &shell_id, "--lines", "20", "--json"])
+        .output()
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(output["command"], "read");
+    assert_eq!(output["data"]["run_id"], initial_run.id);
+    assert!(
+        output["data"]["output"]
+            .as_str()
+            .unwrap()
+            .contains("transport-ok")
+    );
     let state_path = daemon.runtime_dir.join("state/boomux/state.json");
     let valid_state = fs::read(&state_path).unwrap();
     fs::write(&state_path, b"invalid active replacement state").unwrap();


### PR DESCRIPTION
## Summary
- add a versioned boomux.cli/v1 JSON envelope for read-only integration commands and offline capability discovery
- add backward-compatible protocol-6 error codes plus downcastable client RemoteError values
- classify parser, daemon availability, persistence, context, and lifecycle failures with stable codes
- document the complete JSON contract and update agent guidance

## Verification
- cargo test --all-targets
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check