### PR TITLE
Add reconnectable daemon event stream

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -51,6 +51,13 @@ boomux capabilities --json
 Parse `data` on success and `error.code` on a nonzero exit; do not parse human
 tables or `error.message`. Mutation commands do not yet support `--json`.
 
+Use `boomux events --json` for an immediate snapshot and cursor. Poll again with
+`--after CURSOR --wait-ms 30000` to observe later transitions. If
+`error.code` is `cursor_expired`, discard the cursor and request a new baseline.
+Use `boomux read TARGET --json --run-id RUN_ID --after-revision REVISION
+--wait-ms 30000` to wait for run-scoped output changes; handle `run_changed` by
+inspecting the shell again.
+
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.
 `boomux read` and top-level `boomux close` require an exact shell ID outside a

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ boomux capabilities [--json]
 boomux list
 boomux shells
 boomux read <shell-name-or-shell-id> [--lines <count>]
+boomux events [--after <cursor>] [--limit <count>] [--wait-ms <milliseconds>]
 boomux close <shell-name-or-shell-id>
 boomux open <shell-id> [--title <title>] [--takeover]
 boomux workspace list
@@ -118,6 +119,8 @@ The `workspace` and `shell` command groups expose explicit lifecycle operations
 for scripts and integrations. `shell create` records a pending shell; its PTY
 and process start when the shell is first opened. Shell names require current
 workspace context or `--workspace`; IDs remain globally addressable.
+New workspace and shell names are limited to 256 UTF-8 bytes so retained event
+payloads remain bounded. Existing persisted names remain loadable.
 
 `boomux read` reads plain rendered text from the daemon's shadow VT state. It
 understands cursor rewrites and terminal soft wrapping, retains up to 2,000
@@ -127,6 +130,8 @@ Read-only integration commands accept `--json` and emit the stable
 `boomux.cli/v1` envelope. Run `boomux capabilities --json` to discover supported
 commands, features, and typed error codes without starting the daemon. See
 [`docs/cli-json.md`](docs/cli-json.md) for the contract.
+Daemon events and revision-aware reads are documented in
+[`docs/event-stream.md`](docs/event-stream.md).
 
 ## Configuration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,6 +136,13 @@ requiring a daemon. Protocol 6 error responses carry an additive optional code;
 new clients expose it through a typed `RemoteError`, while mixed-version peers
 retain message compatibility.
 
+Protocol 7 adds a bounded in-memory daemon event journal and atomic output-state
+reads. Clients reconnect through stream UUID/event-ID cursors and recover from
+retention or cold-restart expiry by requesting a fresh snapshot baseline.
+Graceful handoff version 4 transfers retained events before publishing a
+`handoff_completed` boundary and resuming PTY readers. See
+[`event-stream.md`](event-stream.md).
+
 ## Runtime Semantics
 
 Closing a terminal window closes only its socket attachment. The daemon retains
@@ -175,5 +182,5 @@ as pending.
 The detailed design, acceptance criteria, and manual test matrix are tracked in
 [`native-terminal-follow-up.md`](native-terminal-follow-up.md).
 
-1. Add a monotonic daemon event stream with reconnectable cursors and
-   revision-aware output reads.
+1. Route runtime transitions through one coordinator so persistence and events
+   share an ordering boundary.

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -28,6 +28,7 @@ The following commands support `--json`:
 - `boomux list`
 - `boomux shells`
 - `boomux read`
+- `boomux events`
 - `boomux workspace list`
 - `boomux workspace inspect`
 - `boomux shell inspect`
@@ -48,6 +49,8 @@ Command payloads are:
   `shells`.
 - `shell.inspect`: one `shell` object.
 - `read`: shell/run identity, observed output revision, and rendered output.
+- `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
+  bounded event array.
 - `daemon.status`: `status`, `protocol_version`, and `socket_path`.
 
 ## Shell Data
@@ -61,10 +64,14 @@ A run object includes `id`, `generation`, `started_at_ms`, `ended_at_ms`,
 `exit_reason`, `exit_code`, `output_revision`, and `environment_has_run_id`.
 `exit_reason` is `exited`, `terminated`, `interrupted`, or `null`.
 
-`read` returns `shell_id`, `run_id`, `output_revision`, and `output`. Output is a
-JSON string containing the same bounded plain rendered text as human mode. The
-identity and revision come from the snapshot immediately before the separate
-output read; they are observational metadata, not an atomic read cursor.
+`read` returns `shell_id`, `run_id`, `output_revision`, `changed`, `status`, and
+`output`. Output is a JSON string containing the same bounded plain rendered text
+as human mode. These fields come from one atomic daemon observation. Conditional
+reads can wait for a specific run to advance beyond a supplied revision.
+
+`events` returns an opaque `<stream-uuid>:<event-id>` cursor. See
+[`event-stream.md`](event-stream.md) for retention, graceful restart, cold
+restart, and revision semantics.
 
 ## Errors
 
@@ -85,6 +92,6 @@ Failures detected while parsing command-line arguments use `"command": "cli"`
 because no valid command was selected.
 
 The stable codes are reported by `boomux capabilities --json`. Messages remain
-human-readable context and are not stable parsing targets. Daemon protocol 6
-adds the error code as an optional field: older clients ignore it, while newer
-clients classify errors from older daemons as `unknown`.
+human-readable context and are not stable parsing targets. Daemon protocol 7
+retains the additive protocol-6 error field and adds `cursor_expired`,
+`run_changed`, and `revision_ahead`.

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -1,0 +1,61 @@
+# Daemon Event Stream
+
+Boomux protocol 7 adds bounded long polling for daemon events and atomic,
+revision-aware terminal reads. Protocol-6 management clients remain compatible;
+new clients negotiate down for legacy requests and reject protocol-7-only
+requests with `unsupported_version`.
+
+## Cursors
+
+An event cursor is `<stream-uuid>:<event-id>`. Event IDs increase strictly within
+one stream. `boomux events` without `--after` returns an immediate registry
+snapshot and a cursor at that baseline. Supplying `--after` returns only newer
+events, waits up to `--wait-ms`, and returns a new cursor.
+
+The daemon retains 8,192 events and returns at most 256 per request. A cursor is
+invalid when its stream differs, its event was evicted, or it points beyond the
+latest event. The typed `cursor_expired` error tells consumers to request a new
+baseline.
+
+Retained payloads are bounded as well as counted. New workspace and shell names
+are limited to 256 UTF-8 bytes; legacy persisted names remain loadable.
+
+The stream ID, latest ID, and retained events transfer across transactional
+graceful daemon restart. Cold startup creates a new stream, so cursors from a
+stopped or crashed daemon expire. Event history is intentionally memory-backed;
+the durable registry remains the cold-recovery authority.
+
+## Events
+
+The initial event vocabulary is:
+
+- `workspace_created`, `workspace_renamed`, `workspace_closed`
+- `shell_created`, `shell_renamed`, `shell_closed`
+- `run_started`, `output_changed`, `run_exited`
+- `handoff_completed`
+
+Output events carry run identity and the latest output revision, not raw PTY
+bytes. Consumers use revision-aware reads to retrieve the current bounded,
+rendered terminal state.
+
+Event IDs provide one total publication order. Existing mutation paths publish
+after their current persistence or lifecycle boundary. Foundation phase 5 will
+route all transitions through one coordinator so persistence and event
+publication share a single commit boundary.
+
+## Revision Reads
+
+`boomux read --json` returns `run_id`, `output_revision`, `changed`, `status`, and
+`output` from one terminal/lifecycle observation. Conditional reads provide both
+`--run-id` and `--after-revision`, with optional `--wait-ms`.
+
+- A newer revision returns the complete current rendered output and
+  `changed: true`.
+- An equal revision waits or returns empty output with `changed: false`.
+- A different run returns `run_changed`.
+- A future revision returns `revision_ahead`.
+- Exit and daemon restart wake waiting reads.
+
+Revisions are run-scoped reader-batch counters, not byte offsets. Rendered output
+can rewrite earlier cells, so successful reads return complete bounded state
+rather than byte deltas.

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -36,7 +36,7 @@ transferred separately. The replacement cannot inherit Unix parenthood; process
 monitoring and cleanup therefore need an imported-process representation, with
 a Linux pidfd where available.
 
-Bootstrap starts with the `BOOMUXH3` version header and has bounded read/write
+Bootstrap starts with the `BOOMUXH4` version header and has bounded read/write
 deadlines. The receiver validates the listener path/type, forces nonblocking
 mode, matches both lock-file inodes, and establishes exclusive flock ownership
 before acknowledging readiness. Explicit abort closes every received duplicate
@@ -55,6 +55,11 @@ Exited shells use a separate static transfer record and bounded reconstruction
 frame. The replacement validates that the transferred identity and exit status
 match the persisted completed run, then restores the exited lifecycle without
 opening a PTY or starting a process.
+
+Handoff version 4 also transfers the event stream UUID, high-water mark, and
+bounded retained events. The replacement publishes `handoff_completed` before
+resuming readers, so output revisions remain ordered after the ownership
+boundary.
 
 ## Delivery Slices
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,7 +84,7 @@ eternal process.
    graceful daemon restart without starting a replacement process implicitly.
 3. [Complete] Add stable versioned JSON output, typed errors, and capability
    reporting for integrations.
-4. Add a monotonic daemon event stream with reconnectable cursors and
+4. [Complete] Add a monotonic daemon event stream with reconnectable cursors and
    revision-aware output reads.
 5. Route runtime transitions through one coordinator so persistence and events
    share an ordering boundary.

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -199,6 +199,9 @@ fn protocol_error_code(code: ErrorCode) -> &'static str {
         ErrorCode::PersistenceFailed => "persistence_failed",
         ErrorCode::Timeout => "timeout",
         ErrorCode::UnsupportedVersion => "unsupported_version",
+        ErrorCode::CursorExpired => "cursor_expired",
+        ErrorCode::RunChanged => "run_changed",
+        ErrorCode::RevisionAhead => "revision_ahead",
         ErrorCode::Internal => "internal",
         ErrorCode::Unknown => "unknown",
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,12 +7,14 @@ use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::thread;
 use std::time::Duration;
 
 use crate::protocol::{
-    self, Envelope, ErrorCode, Request, Response, ShellSnapshot, ShellSpec, Snapshot,
-    TerminalProfile, WorkspaceSnapshot,
+    self, DaemonEvent, Envelope, ErrorCode, EventCursor, Request, Response, ShellSnapshot,
+    ShellSpec, ShellStatus, Snapshot, TerminalProfile, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -22,6 +24,7 @@ const SHUTDOWN_ATTEMPTS: usize = 200;
 #[derive(Debug, Clone)]
 pub struct Client {
     socket_path: PathBuf,
+    protocol_version: Arc<AtomicU32>,
 }
 
 #[derive(Debug)]
@@ -30,6 +33,23 @@ pub struct Attachment {
     pub token: String,
     pub reconstruction: Vec<u8>,
     pub warning: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct OutputState {
+    pub bytes: Vec<u8>,
+    pub run_id: Option<String>,
+    pub output_revision: Option<u64>,
+    pub changed: bool,
+    pub status: ShellStatus,
+}
+
+#[derive(Debug)]
+pub struct EventBatch {
+    pub stream_id: String,
+    pub cursor: EventCursor,
+    pub snapshot: Option<Snapshot>,
+    pub events: Vec<DaemonEvent>,
 }
 
 #[derive(Debug)]
@@ -129,16 +149,25 @@ pub fn connect() -> io::Result<Client> {
 fn connect_client() -> io::Result<Client> {
     Ok(Client {
         socket_path: socket_path()?,
+        protocol_version: Arc::new(AtomicU32::new(protocol::PROTOCOL_VERSION)),
     })
 }
 
 impl Client {
     pub fn from_socket_path(socket_path: PathBuf) -> Self {
-        Self { socket_path }
+        Self {
+            socket_path,
+            protocol_version: Arc::new(AtomicU32::new(protocol::PROTOCOL_VERSION)),
+        }
     }
 
     pub fn socket_path(&self) -> &Path {
         &self.socket_path
+    }
+
+    pub fn protocol_version(&self) -> io::Result<u32> {
+        let _ = self.probe_latest()?;
+        Ok(self.protocol_version.load(Ordering::Acquire))
     }
 
     pub fn request(&self, request: Request) -> io::Result<Response> {
@@ -146,22 +175,45 @@ impl Client {
     }
 
     fn send(&self, request: Request) -> io::Result<(UnixStream, Response)> {
+        let mut version = self.protocol_version.load(Ordering::Acquire);
+        if version < request_minimum_version(&request) {
+            if !self.probe_latest()? {
+                return Err(remote_error(
+                    ErrorCode::UnsupportedVersion,
+                    "daemon does not support this request",
+                ));
+            }
+            version = self.protocol_version.load(Ordering::Acquire);
+        }
+        match self.send_with_version(request.clone(), version) {
+            Err(error)
+                if version > protocol::MIN_PROTOCOL_VERSION
+                    && request_minimum_version(&request) <= protocol::MIN_PROTOCOL_VERSION
+                    && remote_code(&error) == Some(ErrorCode::UnsupportedVersion) =>
+            {
+                self.protocol_version
+                    .store(protocol::MIN_PROTOCOL_VERSION, Ordering::Release);
+                self.send_with_version(request, protocol::MIN_PROTOCOL_VERSION)
+            }
+            result => result,
+        }
+    }
+
+    fn send_with_version(
+        &self,
+        request: Request,
+        version: u32,
+    ) -> io::Result<(UnixStream, Response)> {
         let mut stream = UnixStream::connect(&self.socket_path)?;
-        protocol::write_message(&mut stream, &Envelope::new(request))?;
+        protocol::write_message(&mut stream, &Envelope::with_version(version, request))?;
         let response: Envelope<Response> = protocol::read_message(&mut stream)?;
-        if response.version != protocol::PROTOCOL_VERSION {
+        if response.version != version {
             if let Response::Error {
                 message,
                 code: Some(ErrorCode::UnsupportedVersion),
             } = response.message
             {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    RemoteError {
-                        code: Some(ErrorCode::UnsupportedVersion),
-                        message,
-                    },
-                ));
+                return Err(remote_error(ErrorCode::UnsupportedVersion, message));
             }
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -174,6 +226,23 @@ impl Client {
                 RemoteError { code, message },
             )),
             response => Ok((stream, response)),
+        }
+    }
+
+    fn probe_latest(&self) -> io::Result<bool> {
+        match self.send_with_version(Request::Ping, protocol::PROTOCOL_VERSION) {
+            Ok((_, Response::Pong)) => {
+                self.protocol_version
+                    .store(protocol::PROTOCOL_VERSION, Ordering::Release);
+                Ok(true)
+            }
+            Ok((_, response)) => unexpected(response),
+            Err(error) if remote_code(&error) == Some(ErrorCode::UnsupportedVersion) => {
+                self.protocol_version
+                    .store(protocol::MIN_PROTOCOL_VERSION, Ordering::Release);
+                Ok(false)
+            }
+            Err(error) => Err(error),
         }
     }
 
@@ -281,6 +350,64 @@ impl Client {
         }
     }
 
+    pub fn read_shell_at(
+        &self,
+        shell_id: impl Into<String>,
+        max_bytes: usize,
+        run_id: Option<String>,
+        after_revision: Option<u64>,
+        wait_ms: u32,
+    ) -> io::Result<OutputState> {
+        match self.request(Request::ReadShellAt {
+            shell_id: shell_id.into(),
+            max_bytes,
+            run_id,
+            after_revision,
+            wait_ms,
+        })? {
+            Response::OutputState {
+                bytes,
+                run_id,
+                output_revision,
+                changed,
+                status,
+            } => Ok(OutputState {
+                bytes,
+                run_id,
+                output_revision,
+                changed,
+                status,
+            }),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn events(
+        &self,
+        after: Option<EventCursor>,
+        limit: u16,
+        wait_ms: u32,
+    ) -> io::Result<EventBatch> {
+        match self.request(Request::Events {
+            after,
+            limit,
+            wait_ms,
+        })? {
+            Response::Events {
+                stream_id,
+                cursor,
+                snapshot,
+                events,
+            } => Ok(EventBatch {
+                stream_id,
+                cursor,
+                snapshot,
+                events,
+            }),
+            other => unexpected(other),
+        }
+    }
+
     pub fn rename_workspace(
         &self,
         workspace_id: impl Into<String>,
@@ -352,6 +479,30 @@ impl Client {
             other => unexpected(other),
         }
     }
+}
+
+fn request_minimum_version(request: &Request) -> u32 {
+    match request {
+        Request::ReadShellAt { .. } | Request::Events { .. } => 7,
+        _ => protocol::MIN_PROTOCOL_VERSION,
+    }
+}
+
+fn remote_code(error: &io::Error) -> Option<ErrorCode> {
+    error
+        .get_ref()
+        .and_then(|error| error.downcast_ref::<RemoteError>())
+        .and_then(|error| error.code)
+}
+
+fn remote_error(code: ErrorCode, message: impl Into<String>) -> io::Error {
+    io::Error::new(
+        error_kind(Some(code)),
+        RemoteError {
+            code: Some(code),
+            message: message.into(),
+        },
+    )
 }
 
 fn error_kind(code: Option<ErrorCode>) -> io::ErrorKind {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{self, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex, MutexGuard, Weak};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -23,9 +23,9 @@ use crate::client;
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::protocol::{
-    self, AttachFrame, Envelope, ErrorCode, Request, Response, ShellRunExitReason,
-    ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalProfile,
-    WorkspaceSnapshot,
+    self, AttachFrame, DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, Request,
+    Response, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus,
+    Snapshot, TerminalProfile, WorkspaceSnapshot,
 };
 use crate::state_store::{
     PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace, StateStore,
@@ -39,10 +39,14 @@ const RESTART_TIMEOUT: Duration = Duration::from_secs(10);
 const IO_RETRY_DELAY: Duration = Duration::from_millis(2);
 const PERSIST_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_TERMINAL_ENV_VALUE: usize = 256;
+const MAX_NAME_BYTES: usize = 256;
 const MAX_TERMINAL_ROWS: u16 = 1_000;
 const MAX_TERMINAL_COLS: u16 = 1_000;
 const MAX_TERMINAL_CELLS: usize = 1_000_000;
 const MAX_SHELL_READ_BYTES: usize = 1024 * 1024;
+const MAX_RETAINED_EVENTS: usize = 8_192;
+const MAX_EVENT_BATCH: u16 = 256;
+const MAX_EVENT_WAIT: Duration = Duration::from_secs(30);
 const TRANSITION_IDLE: u8 = 0;
 const TRANSITION_RESTART: u8 = 1;
 const TRANSITION_SHUTDOWN: u8 = 2;
@@ -57,6 +61,7 @@ pub fn receive_handoff(channel: i32) -> io::Result<()> {
             state_lock,
             runtimes,
             exited,
+            event_stream,
         } => {
             let store = StateStore::from_transferred_lock(state_lock)?;
             let socket_path = client::socket_path()?;
@@ -65,8 +70,11 @@ pub fn receive_handoff(channel: i32) -> io::Result<()> {
                 File::from(runtime_lock),
                 SocketCleanup::disarmed(socket_path),
                 store,
-                runtimes,
-                exited,
+                TransferredState {
+                    runtimes,
+                    exited,
+                    events: Some(event_stream),
+                },
                 Some(&mut channel),
             )
         }
@@ -94,10 +102,16 @@ pub fn run() -> io::Result<()> {
         daemon_lock,
         socket_cleanup,
         StateStore::from_environment()?,
-        Vec::new(),
-        Vec::new(),
+        TransferredState::default(),
         None,
     )
+}
+
+#[derive(Default)]
+struct TransferredState {
+    runtimes: Vec<handoff::TransferredRuntime>,
+    exited: Vec<handoff::TransferredExited>,
+    events: Option<handoff::EventStreamManifest>,
 }
 
 fn run_daemon(
@@ -105,12 +119,15 @@ fn run_daemon(
     daemon_lock: File,
     mut socket_cleanup: SocketCleanup,
     store: StateStore,
-    transferred_runtimes: Vec<handoff::TransferredRuntime>,
-    transferred_exited: Vec<handoff::TransferredExited>,
+    transferred: TransferredState,
     committed: Option<&mut UnixStream>,
 ) -> io::Result<()> {
-    let registry = Arc::new(Registry::restore(store, committed.is_some())?);
-    let gated_readers = registry.import_handoff(transferred_runtimes, transferred_exited)?;
+    let registry = Arc::new(Registry::restore(
+        store,
+        committed.is_some(),
+        transferred.events,
+    )?);
+    let gated_readers = registry.import_handoff(transferred.runtimes, transferred.exited)?;
     if let Some(channel) = committed {
         channel.write_all(&[handoff::PREPARED])?;
         let mut decision = [0];
@@ -119,6 +136,7 @@ fn run_daemon(
             handoff::ABORT => return Ok(()),
             handoff::FINALIZE => {
                 socket_cleanup.arm();
+                registry.events.publish(DaemonEventKind::HandoffCompleted)?;
                 for runtime in gated_readers {
                     runtime.resume_reader()?;
                 }
@@ -142,11 +160,19 @@ fn run_daemon(
     let shutdown = Arc::new(AtomicBool::new(false));
     let transition = Arc::new(AtomicU8::new(TRANSITION_IDLE));
     let (restart_sender, restart_receiver) = mpsc::channel::<RestartRequest>();
-    let mut handlers = Vec::new();
+    let mut handlers: Vec<thread::JoinHandle<()>> = Vec::new();
     let mut handed_off = false;
     let mut last_persistence_retry = Instant::now();
 
     while !shutdown.load(Ordering::Acquire) {
+        let mut index = 0;
+        while index < handlers.len() {
+            if handlers[index].is_finished() {
+                let _ = handlers.swap_remove(index).join();
+            } else {
+                index += 1;
+            }
+        }
         if registry.persistence_dirty.load(Ordering::Acquire)
             && last_persistence_retry.elapsed() >= PERSIST_RETRY_INTERVAL
         {
@@ -210,6 +236,20 @@ struct RestartRequest {
 
 #[derive(Debug)]
 struct PersistenceError(io::Error);
+
+#[derive(Debug)]
+struct DaemonCodeError {
+    code: ErrorCode,
+    message: String,
+}
+
+impl std::fmt::Display for DaemonCodeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for DaemonCodeError {}
 
 impl std::fmt::Display for PersistenceError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -293,12 +333,14 @@ fn launch_replacement(
     daemon_lock: &File,
     registry: &Registry,
 ) -> io::Result<()> {
+    let _event_commit = lock(&registry.event_commit_lock)?;
     let _mutation = lock(&registry.mutation_lock)?;
     registry.ensure_running()?;
     if registry.persistence_dirty.load(Ordering::Acquire) {
         registry.persist().map_err(persistence_error)?;
     }
     registry.stopping.store(true, Ordering::Release);
+    registry.events.notify();
     let mut paused = Vec::new();
     let result = (|| {
         registry.quiesce_controllers()?;
@@ -356,6 +398,7 @@ fn launch_replacement(
                 reconstruction,
             });
         }
+        let event_stream = registry.events.transfer()?;
         let state_lock = registry.state_lock_descriptor()?;
         launch_replacement_process(
             listener.as_fd(),
@@ -363,6 +406,7 @@ fn launch_replacement(
             state_lock,
             &transfers,
             &exited,
+            &event_stream,
         )
     })();
     if result.is_err() {
@@ -380,6 +424,7 @@ fn launch_replacement_process(
     state_lock: BorrowedFd<'_>,
     runtimes: &[OutgoingRuntime],
     exited: &[OutgoingExited],
+    event_stream: &handoff::EventStreamManifest,
 ) -> io::Result<()> {
     let (mut channel, child_channel) = UnixStream::pair()?;
     let child_channel_fd = child_channel.as_raw_fd();
@@ -420,6 +465,7 @@ fn launch_replacement_process(
                     .map(|runtime| runtime.manifest.clone())
                     .collect(),
                 exited: exited.iter().map(|shell| shell.manifest.clone()).collect(),
+                event_stream: event_stream.clone(),
             },
         )?;
         send_descriptor(&channel, listener, handoff::LISTENER_MARKER)?;
@@ -474,9 +520,10 @@ fn handle_connection(
     stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
     let request: Envelope<Request> = protocol::read_message(&mut stream)?;
     stream.set_read_timeout(None)?;
-    if request.version != protocol::PROTOCOL_VERSION {
+    if !(protocol::MIN_PROTOCOL_VERSION..=protocol::PROTOCOL_VERSION).contains(&request.version) {
         return send_response(
             &mut stream,
+            protocol::PROTOCOL_VERSION,
             error_response(
                 ErrorCode::UnsupportedVersion,
                 format!(
@@ -487,6 +534,22 @@ fn handle_connection(
             ),
         );
     }
+    let response_version = request.version;
+    if response_version < 7
+        && matches!(
+            request.message,
+            Request::ReadShellAt { .. } | Request::Events { .. }
+        )
+    {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "request requires daemon protocol 7",
+            ),
+        );
+    }
 
     if let Request::Attach {
         shell_id,
@@ -494,7 +557,14 @@ fn handle_connection(
         profile,
     } = request.message
     {
-        return handle_attach(stream, &registry, &shell_id, takeover, profile);
+        return handle_attach(
+            stream,
+            response_version,
+            &registry,
+            &shell_id,
+            takeover,
+            profile,
+        );
     }
     if matches!(request.message, Request::Shutdown) {
         if transition
@@ -508,6 +578,7 @@ fn handle_connection(
         {
             return send_response(
                 &mut stream,
+                response_version,
                 error_response(
                     ErrorCode::Busy,
                     "another daemon transition is already in progress",
@@ -517,12 +588,13 @@ fn handle_connection(
         return match registry.shutdown() {
             Ok(()) => {
                 shutdown.store(true, Ordering::Release);
-                send_response(&mut stream, Response::Ok)
+                send_response(&mut stream, response_version, Response::Ok)
             }
             Err(error) => {
                 transition.store(TRANSITION_IDLE, Ordering::Release);
                 send_response(
                     &mut stream,
+                    response_version,
                     error_response(
                         error_code(&error),
                         format!("could not stop Boomux daemon: {error}"),
@@ -543,6 +615,7 @@ fn handle_connection(
         {
             return send_response(
                 &mut stream,
+                response_version,
                 error_response(ErrorCode::Busy, "daemon restart is already in progress"),
             );
         }
@@ -552,13 +625,15 @@ fn handle_connection(
             return Err(io::Error::other("daemon restart coordinator stopped"));
         }
         return match response.recv_timeout(RESTART_TIMEOUT) {
-            Ok(Ok(())) => send_response(&mut stream, Response::Ok),
+            Ok(Ok(())) => send_response(&mut stream, response_version, Response::Ok),
             Ok(Err(error)) => send_response(
                 &mut stream,
+                response_version,
                 error_response(error_code(&error), error.to_string()),
             ),
             Err(error) => send_response(
                 &mut stream,
+                response_version,
                 error_response(
                     ErrorCode::Timeout,
                     format!("daemon restart timed out: {error}"),
@@ -567,14 +642,35 @@ fn handle_connection(
         };
     }
 
-    let response = registry
-        .dispatch(request.message)
-        .unwrap_or_else(|error| error_response(error_code(&error), error.to_string()));
-    send_response(&mut stream, response)
+    let event_request = request.message.clone();
+    let _event_commit = request_publishes_events(&event_request)
+        .then(|| lock(&registry.event_commit_lock))
+        .transpose()?;
+    let response = match registry.dispatch(request.message) {
+        Ok(response) => {
+            registry.publish_request_events(&event_request, &response)?;
+            response
+        }
+        Err(error) => error_response(error_code(&error), error.to_string()),
+    };
+    drop(_event_commit);
+    send_response(&mut stream, response_version, response)
 }
 
-fn send_response(stream: &mut UnixStream, response: Response) -> io::Result<()> {
-    protocol::write_message(stream, &Envelope::new(response))
+fn request_publishes_events(request: &Request) -> bool {
+    matches!(
+        request,
+        Request::CreateWorkspace { .. }
+            | Request::CreateShell { .. }
+            | Request::RenameWorkspace { .. }
+            | Request::RenameShell { .. }
+            | Request::CloseWorkspace { .. }
+            | Request::CloseShell { .. }
+    )
+}
+
+fn send_response(stream: &mut UnixStream, version: u32, response: Response) -> io::Result<()> {
+    protocol::write_message(stream, &Envelope::with_version(version, response))
 }
 
 fn error_response(code: ErrorCode, message: impl Into<String>) -> Response {
@@ -585,6 +681,12 @@ fn error_response(code: ErrorCode, message: impl Into<String>) -> Response {
 }
 
 fn error_code(error: &io::Error) -> ErrorCode {
+    if let Some(error) = error
+        .get_ref()
+        .and_then(|error| error.downcast_ref::<DaemonCodeError>())
+    {
+        return error.code;
+    }
     if error
         .get_ref()
         .is_some_and(|error| error.downcast_ref::<PersistenceError>().is_some())
@@ -606,13 +708,101 @@ fn persistence_error(error: io::Error) -> io::Error {
     io::Error::new(error.kind(), PersistenceError(error))
 }
 
+fn coded_error(code: ErrorCode, message: impl Into<String>) -> io::Error {
+    io::Error::other(DaemonCodeError {
+        code,
+        message: message.into(),
+    })
+}
+
 struct Registry {
     state: Mutex<RegistryState>,
     store: Option<StateStore>,
+    events: EventLog,
+    event_commit_lock: Mutex<()>,
     mutation_lock: Mutex<()>,
     persist_lock: Mutex<()>,
     stopping: AtomicBool,
     persistence_dirty: AtomicBool,
+}
+
+struct EventLog {
+    state: Mutex<EventLogState>,
+    changed: Condvar,
+}
+
+struct EventLogState {
+    stream_id: String,
+    latest_id: u64,
+    events: VecDeque<DaemonEvent>,
+}
+
+impl EventLog {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(EventLogState {
+                stream_id: Uuid::new_v4().to_string(),
+                latest_id: 0,
+                events: VecDeque::new(),
+            }),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn from_transfer(transfer: Option<handoff::EventStreamManifest>) -> Self {
+        let state = transfer.map_or_else(
+            || EventLogState {
+                stream_id: Uuid::new_v4().to_string(),
+                latest_id: 0,
+                events: VecDeque::new(),
+            },
+            |transfer| EventLogState {
+                stream_id: transfer.stream_id,
+                latest_id: transfer.latest_id,
+                events: transfer.events.into(),
+            },
+        );
+        Self {
+            state: Mutex::new(state),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn transfer(&self) -> io::Result<handoff::EventStreamManifest> {
+        let state = lock(&self.state)?;
+        Ok(handoff::EventStreamManifest {
+            stream_id: state.stream_id.clone(),
+            latest_id: state.latest_id,
+            events: state.events.iter().cloned().collect(),
+        })
+    }
+
+    fn publish(&self, kind: DaemonEventKind) -> io::Result<DaemonEvent> {
+        let mut state = lock(&self.state)?;
+        state.latest_id = state
+            .latest_id
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("daemon event ID exhausted"))?;
+        let event = DaemonEvent {
+            id: state.latest_id,
+            at_ms: unix_time_ms(),
+            kind,
+        };
+        state.events.push_back(event.clone());
+        if state.events.len() > MAX_RETAINED_EVENTS {
+            state.events.pop_front();
+        }
+        drop(state);
+        self.changed.notify_all();
+        Ok(event)
+    }
+
+    fn notify(&self) {
+        if let Ok(state) = self.state.lock() {
+            self.changed.notify_all();
+            drop(state);
+        }
+    }
 }
 
 #[derive(Default)]
@@ -634,6 +824,8 @@ impl Default for Registry {
         Self {
             state: Mutex::new(RegistryState::default()),
             store: None,
+            events: EventLog::new(),
+            event_commit_lock: Mutex::new(()),
             mutation_lock: Mutex::new(()),
             persist_lock: Mutex::new(()),
             stopping: AtomicBool::new(false),
@@ -1139,6 +1331,24 @@ impl Registry {
             } => Ok(Response::Output {
                 bytes: self.read_shell(&shell_id, max_bytes)?,
             }),
+            Request::ReadShellAt {
+                shell_id,
+                max_bytes,
+                run_id,
+                after_revision,
+                wait_ms,
+            } => self.read_shell_at(
+                &shell_id,
+                max_bytes,
+                run_id.as_deref(),
+                after_revision,
+                wait_ms,
+            ),
+            Request::Events {
+                after,
+                limit,
+                wait_ms,
+            } => self.read_events(after.as_ref(), limit, wait_ms),
             Request::RenameWorkspace { workspace_id, name } => self.durable_mutation(|| {
                 validate_name(&name)?;
                 let workspace = self.workspace(&workspace_id)?;
@@ -1170,7 +1380,150 @@ impl Registry {
         }
     }
 
-    fn restore(store: StateStore, live_handoff: bool) -> io::Result<Self> {
+    fn publish_request_events(&self, request: &Request, response: &Response) -> io::Result<()> {
+        let kinds =
+            match (request, response) {
+                (Request::CreateWorkspace { .. }, Response::Workspace { workspace }) => {
+                    let mut kinds = vec![DaemonEventKind::WorkspaceCreated {
+                        workspace_id: workspace.id.clone(),
+                        name: workspace.name.clone(),
+                    }];
+                    kinds.extend(workspace.shells.iter().map(|shell| {
+                        DaemonEventKind::ShellCreated {
+                            workspace_id: workspace.id.clone(),
+                            shell_id: shell.id.clone(),
+                            name: shell.name.clone(),
+                        }
+                    }));
+                    kinds
+                }
+                (Request::CreateShell { workspace_id, .. }, Response::Shell { shell }) => {
+                    let mut kinds = Vec::new();
+                    if workspace_id.is_none() {
+                        let workspace = self.workspace(&shell.workspace_id)?;
+                        kinds.push(DaemonEventKind::WorkspaceCreated {
+                            workspace_id: workspace.id.clone(),
+                            name: lock(&workspace.name)?.clone(),
+                        });
+                    }
+                    kinds.push(DaemonEventKind::ShellCreated {
+                        workspace_id: shell.workspace_id.clone(),
+                        shell_id: shell.id.clone(),
+                        name: shell.name.clone(),
+                    });
+                    kinds
+                }
+                (Request::RenameWorkspace { workspace_id, name }, Response::Ok) => {
+                    vec![DaemonEventKind::WorkspaceRenamed {
+                        workspace_id: workspace_id.clone(),
+                        name: name.clone(),
+                    }]
+                }
+                (Request::RenameShell { shell_id, name }, Response::Ok) => {
+                    let shell = self.shell(shell_id)?;
+                    vec![DaemonEventKind::ShellRenamed {
+                        workspace_id: shell.workspace_id.clone(),
+                        shell_id: shell_id.clone(),
+                        name: name.clone(),
+                    }]
+                }
+                (Request::CloseWorkspace { workspace_id }, Response::Ok) => {
+                    vec![DaemonEventKind::WorkspaceClosed {
+                        workspace_id: workspace_id.clone(),
+                    }]
+                }
+                (Request::CloseShell { shell_id }, Response::Ok) => {
+                    vec![DaemonEventKind::ShellClosed {
+                        workspace_id: None,
+                        shell_id: shell_id.clone(),
+                    }]
+                }
+                _ => Vec::new(),
+            };
+        for kind in kinds {
+            self.events.publish(kind)?;
+        }
+        Ok(())
+    }
+
+    fn read_events(
+        &self,
+        after: Option<&EventCursor>,
+        limit: u16,
+        wait_ms: u32,
+    ) -> io::Result<Response> {
+        let limit = usize::from(limit.clamp(1, MAX_EVENT_BATCH));
+        let deadline =
+            Instant::now() + Duration::from_millis(u64::from(wait_ms)).min(MAX_EVENT_WAIT);
+        let mut state = lock(&self.events.state)?;
+        if after.is_none() {
+            let snapshot = self.snapshot()?;
+            let cursor = EventCursor {
+                stream_id: state.stream_id.clone(),
+                event_id: state.latest_id,
+            };
+            return Ok(Response::Events {
+                stream_id: state.stream_id.clone(),
+                cursor,
+                snapshot: Some(snapshot),
+                events: Vec::new(),
+            });
+        }
+        let after = after.expect("checked above");
+        loop {
+            let earliest = state
+                .events
+                .front()
+                .map_or(state.latest_id, |event| event.id.saturating_sub(1));
+            if after.stream_id != state.stream_id
+                || after.event_id < earliest
+                || after.event_id > state.latest_id
+            {
+                return Err(coded_error(
+                    ErrorCode::CursorExpired,
+                    "event cursor is no longer available",
+                ));
+            }
+            let events = state
+                .events
+                .iter()
+                .filter(|event| event.id > after.event_id)
+                .take(limit)
+                .cloned()
+                .collect::<Vec<_>>();
+            if !events.is_empty() || wait_ms == 0 || Instant::now() >= deadline {
+                let event_id = events.last().map_or(after.event_id, |event| event.id);
+                return Ok(Response::Events {
+                    stream_id: state.stream_id.clone(),
+                    cursor: EventCursor {
+                        stream_id: state.stream_id.clone(),
+                        event_id,
+                    },
+                    snapshot: None,
+                    events,
+                });
+            }
+            if self.stopping.load(Ordering::Acquire) {
+                return Err(coded_error(
+                    ErrorCode::DaemonStopping,
+                    "Boomux daemon is stopping",
+                ));
+            }
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            let (next, _) = self
+                .events
+                .changed
+                .wait_timeout(state, timeout)
+                .map_err(|_| io::Error::other("daemon event lock poisoned"))?;
+            state = next;
+        }
+    }
+
+    fn restore(
+        store: StateStore,
+        live_handoff: bool,
+        transferred_events: Option<handoff::EventStreamManifest>,
+    ) -> io::Result<Self> {
         let persisted = store.load()?.unwrap_or_default();
         let mut state = RegistryState::default();
         let mut workspace_names = HashSet::new();
@@ -1178,7 +1531,7 @@ impl Registry {
         let mut recovered_interrupted_run = false;
         for saved_workspace in persisted.workspaces {
             validate_id("workspace", &saved_workspace.id)?;
-            validate_name(&saved_workspace.name)?;
+            validate_persisted_name(&saved_workspace.name)?;
             if !workspace_names.insert(saved_workspace.name.clone())
                 || state.workspaces.contains_key(&saved_workspace.id)
             {
@@ -1191,7 +1544,7 @@ impl Registry {
             let mut shell_ids = Vec::with_capacity(saved_workspace.shells.len());
             for mut saved_shell in saved_workspace.shells {
                 validate_id("shell", &saved_shell.id)?;
-                validate_name(&saved_shell.name)?;
+                validate_persisted_name(&saved_shell.name)?;
                 validate_persisted_cwd(&saved_shell.cwd)?;
                 if let Some(run) = &mut saved_shell.last_run {
                     validate_id("run", &run.id)?;
@@ -1244,6 +1597,8 @@ impl Registry {
         let registry = Self {
             state: Mutex::new(state),
             store: Some(store),
+            events: EventLog::from_transfer(transferred_events),
+            event_commit_lock: Mutex::new(()),
             mutation_lock: Mutex::new(()),
             persist_lock: Mutex::new(()),
             stopping: AtomicBool::new(false),
@@ -1647,6 +2002,11 @@ impl Registry {
             terminal: Arc::clone(&runtime.terminal),
         };
         drop(lifecycle);
+        self.events.publish(DaemonEventKind::RunExited {
+            workspace_id: shell.workspace_id.clone(),
+            shell_id: shell.id.clone(),
+            run: run.snapshot()?,
+        })?;
         self.persist()
     }
 
@@ -1666,6 +2026,7 @@ impl Registry {
         if self.stopping.swap(true, Ordering::AcqRel) {
             return Ok(());
         }
+        self.events.notify();
         let shells = {
             let state = lock(&self.state)?;
             state.shells.values().cloned().collect::<Vec<_>>()
@@ -1880,6 +2241,156 @@ impl Registry {
         Ok(tail_utf8(&text, max_bytes.min(MAX_SHELL_READ_BYTES))
             .as_bytes()
             .to_vec())
+    }
+
+    fn read_shell_at(
+        &self,
+        shell_id: &str,
+        max_bytes: usize,
+        expected_run_id: Option<&str>,
+        after_revision: Option<u64>,
+        wait_ms: u32,
+    ) -> io::Result<Response> {
+        if expected_run_id.is_some() != after_revision.is_some() {
+            return Err(coded_error(
+                ErrorCode::InvalidArgument,
+                "run_id and after_revision must be provided together",
+            ));
+        }
+        let deadline =
+            Instant::now() + Duration::from_millis(u64::from(wait_ms)).min(MAX_EVENT_WAIT);
+        loop {
+            let observed_event_id = lock(&self.events.state)?.latest_id;
+            let shell = self.shell(shell_id)?;
+            let lifecycle = lock(&shell.lifecycle)?;
+            let (status, run, terminal) = match &*lifecycle {
+                ShellLifecycle::Pending => {
+                    if expected_run_id.is_some() {
+                        return Err(coded_error(
+                            ErrorCode::RunChanged,
+                            "shell no longer has the requested run",
+                        ));
+                    }
+                    return Ok(Response::OutputState {
+                        bytes: Vec::new(),
+                        run_id: None,
+                        output_revision: None,
+                        changed: true,
+                        status: ShellStatus::Pending,
+                    });
+                }
+                ShellLifecycle::Running { run, runtime, .. } => (
+                    ShellStatus::Running,
+                    Arc::clone(run),
+                    Arc::clone(&runtime.terminal),
+                ),
+                ShellLifecycle::Exited {
+                    code,
+                    run,
+                    terminal,
+                    ..
+                } => (
+                    ShellStatus::Exited { code: *code },
+                    Arc::clone(run),
+                    Arc::clone(terminal),
+                ),
+                ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
+            };
+            drop(lifecycle);
+            let terminal_state = lock(&terminal)?;
+            let revision = run.output_revision.load(Ordering::Acquire);
+            let changed = after_revision.is_none_or(|after| after < revision);
+            let bytes = if changed || after_revision.is_none() {
+                let text = terminal_state.plain_text();
+                tail_utf8(&text, max_bytes.min(MAX_SHELL_READ_BYTES))
+                    .as_bytes()
+                    .to_vec()
+            } else {
+                Vec::new()
+            };
+            drop(terminal_state);
+            let lifecycle = lock(&shell.lifecycle)?;
+            let observation_is_current = match (&*lifecycle, &status) {
+                (
+                    ShellLifecycle::Running {
+                        run: current_run,
+                        runtime,
+                        ..
+                    },
+                    ShellStatus::Running,
+                ) => Arc::ptr_eq(current_run, &run) && Arc::ptr_eq(&runtime.terminal, &terminal),
+                (
+                    ShellLifecycle::Exited {
+                        code,
+                        run: current_run,
+                        terminal: current_terminal,
+                        ..
+                    },
+                    ShellStatus::Exited { code: current_code },
+                ) => {
+                    code == current_code
+                        && Arc::ptr_eq(current_run, &run)
+                        && Arc::ptr_eq(current_terminal, &terminal)
+                }
+                _ => false,
+            };
+            drop(lifecycle);
+            if !observation_is_current {
+                continue;
+            }
+            if expected_run_id.is_some_and(|expected| expected != run.id) {
+                return Err(coded_error(
+                    ErrorCode::RunChanged,
+                    "shell run identity changed",
+                ));
+            }
+            if after_revision.is_some_and(|after| after > revision) {
+                return Err(coded_error(
+                    ErrorCode::RevisionAhead,
+                    "requested output revision is ahead of the current run",
+                ));
+            }
+            if changed || !matches!(status, ShellStatus::Running) || wait_ms == 0 {
+                return Ok(Response::OutputState {
+                    bytes,
+                    run_id: Some(run.id.clone()),
+                    output_revision: Some(revision),
+                    changed,
+                    status,
+                });
+            }
+            if Instant::now() >= deadline {
+                return Ok(Response::OutputState {
+                    bytes: Vec::new(),
+                    run_id: Some(run.id.clone()),
+                    output_revision: Some(revision),
+                    changed: false,
+                    status,
+                });
+            }
+            if self.stopping.load(Ordering::Acquire) {
+                return Err(coded_error(
+                    ErrorCode::DaemonStopping,
+                    "Boomux daemon is stopping",
+                ));
+            }
+            let state = lock(&self.events.state)?;
+            if self.stopping.load(Ordering::Acquire) {
+                return Err(coded_error(
+                    ErrorCode::DaemonStopping,
+                    "Boomux daemon is stopping",
+                ));
+            }
+            if state.latest_id != observed_event_id {
+                continue;
+            }
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            let _ = self
+                .events
+                .changed
+                .wait_timeout(state, timeout)
+                .map_err(|_| io::Error::other("daemon event lock poisoned"))?;
+        }
     }
 
     fn remove_shell(&self, shell_id: &str) -> io::Result<Arc<Shell>> {
@@ -2292,15 +2803,18 @@ fn start_pty_reader(
                     Ok(0) => break,
                     Ok(count) => {
                         let bytes = &buffer[..count];
+                        let mut output_revision = None;
                         if let Ok(mut terminal) = reader_runtime.terminal.lock() {
                             terminal.process(bytes);
-                            let revision = reader_run
-                                .output_revision
-                                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |revision| {
-                                    Some(revision.saturating_add(1))
-                                })
-                                .unwrap_or_else(|revision| revision)
-                                .saturating_add(1);
+                            let Ok(previous_revision) = reader_run.output_revision.fetch_update(
+                                Ordering::AcqRel,
+                                Ordering::Acquire,
+                                |revision| revision.checked_add(1),
+                            ) else {
+                                break;
+                            };
+                            let revision = previous_revision + 1;
+                            output_revision = Some(revision);
                             if let Ok(mut last_run) = shell.last_run.lock()
                                 && let Some(last_run) = last_run.as_mut()
                                 && last_run.id == reader_run.id
@@ -2320,6 +2834,16 @@ fn start_pty_reader(
                                     let _ = current.connection.shutdown(std::net::Shutdown::Both);
                                 }
                             }
+                        }
+                        if let Some(output_revision) = output_revision
+                            && let Some(registry) = registry.upgrade()
+                        {
+                            let _ = registry.events.publish(DaemonEventKind::OutputChanged {
+                                workspace_id: shell.workspace_id.clone(),
+                                shell_id: shell.id.clone(),
+                                run_id: reader_run.id.clone(),
+                                output_revision,
+                            });
                         }
                     }
                     Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
@@ -2372,6 +2896,7 @@ fn tail_utf8(text: &str, max_bytes: usize) -> &str {
 
 fn handle_attach(
     mut stream: UnixStream,
+    response_version: u32,
     registry: &Arc<Registry>,
     shell_id: &str,
     takeover: bool,
@@ -2380,6 +2905,7 @@ fn handle_attach(
     if let Err(error) = validate_terminal_profile(&profile) {
         return send_response(
             &mut stream,
+            response_version,
             error_response(ErrorCode::InvalidArgument, error.to_string()),
         );
     }
@@ -2388,6 +2914,7 @@ fn handle_attach(
         Err(error) => {
             return send_response(
                 &mut stream,
+                response_version,
                 error_response(error_code(&error), error.to_string()),
             );
         }
@@ -2396,6 +2923,7 @@ fn handle_attach(
     if registry.stopping.load(Ordering::Acquire) {
         return send_response(
             &mut stream,
+            response_version,
             error_response(ErrorCode::DaemonStopping, "Boomux daemon is stopping"),
         );
     }
@@ -2409,6 +2937,7 @@ fn handle_attach(
         if !registry.contains_shell(&shell)? {
             return send_response(
                 &mut stream,
+                response_version,
                 error_response(ErrorCode::NotFound, format!("shell not found: {shell_id}")),
             );
         }
@@ -2428,6 +2957,7 @@ fn handle_attach(
                     Err(error) => {
                         return send_response(
                             &mut stream,
+                            response_version,
                             error_response(
                                 ErrorCode::ShellStartFailed,
                                 format!("could not start shell: {error}"),
@@ -2457,6 +2987,7 @@ fn handle_attach(
                 }
                 return send_response(
                     &mut stream,
+                    response_version,
                     error_response(
                         ErrorCode::ShellStartFailed,
                         cleanup.map_or_else(
@@ -2488,6 +3019,7 @@ fn handle_attach(
             ShellLifecycle::Closed => {
                 return send_response(
                     &mut stream,
+                    response_version,
                     error_response(ErrorCode::NotFound, format!("shell not found: {shell_id}")),
                 );
             }
@@ -2500,6 +3032,7 @@ fn handle_attach(
         }
         return send_response(
             &mut stream,
+            response_version,
             error_response(
                 ErrorCode::PersistenceFailed,
                 cleanup.map_or_else(
@@ -2514,6 +3047,15 @@ fn handle_attach(
         );
     }
     if started {
+        let run = shell
+            .snapshot()?
+            .run
+            .ok_or_else(|| io::Error::other("started shell has no run identity"))?;
+        registry.events.publish(DaemonEventKind::RunStarted {
+            workspace_id: shell.workspace_id.clone(),
+            shell_id: shell.id.clone(),
+            run,
+        })?;
         runtime
             .as_ref()
             .expect("started shell has a runtime")
@@ -2525,6 +3067,7 @@ fn handle_attach(
         stream.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
         send_response(
             &mut stream,
+            response_version,
             Response::Attached {
                 token,
                 reconstruction: lock(&terminal)?.reconstruction(),
@@ -2540,6 +3083,7 @@ fn handle_attach(
     if !registry.contains_shell(&shell)? {
         return send_response(
             &mut stream,
+            response_version,
             error_response(ErrorCode::NotFound, format!("shell not found: {shell_id}")),
         );
     }
@@ -2548,6 +3092,7 @@ fn handle_attach(
         if controller.is_some() && !takeover {
             return send_response(
                 &mut stream,
+                response_version,
                 error_response(
                     ErrorCode::Busy,
                     "shell already has an active controller; use takeover",
@@ -2564,6 +3109,7 @@ fn handle_attach(
     stream.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
     send_response(
         &mut stream,
+        response_version,
         Response::Attached {
             token: token.clone(),
             reconstruction: terminal.reconstruction(),
@@ -2817,10 +3363,21 @@ fn term_mismatch_warning(started: Option<&str>, attached: Option<&str>) -> Optio
 }
 
 fn validate_name(name: &str) -> io::Result<()> {
-    if name.trim().is_empty() {
+    if name.trim().is_empty() || name.len() > MAX_NAME_BYTES {
         Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "name cannot be empty",
+            format!("name must be nonempty and at most {MAX_NAME_BYTES} bytes"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_persisted_name(name: &str) -> io::Result<()> {
+    if name.trim().is_empty() {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "persisted name cannot be empty",
         ))
     } else {
         Ok(())
@@ -2993,6 +3550,66 @@ mod tests {
     }
 
     #[test]
+    fn event_batches_are_monotonic_and_paginated() {
+        let registry = Registry::default();
+        let Response::Events {
+            cursor, snapshot, ..
+        } = registry.read_events(None, 256, 0).unwrap()
+        else {
+            panic!("expected event baseline");
+        };
+        assert!(snapshot.is_some());
+        registry
+            .events
+            .publish(DaemonEventKind::WorkspaceClosed {
+                workspace_id: "w1".into(),
+            })
+            .unwrap();
+        registry
+            .events
+            .publish(DaemonEventKind::WorkspaceClosed {
+                workspace_id: "w2".into(),
+            })
+            .unwrap();
+
+        let Response::Events {
+            cursor: first_cursor,
+            events,
+            ..
+        } = registry.read_events(Some(&cursor), 1, 0).unwrap()
+        else {
+            panic!("expected event page");
+        };
+        assert_eq!(events.len(), 1);
+        let Response::Events { events, .. } =
+            registry.read_events(Some(&first_cursor), 256, 0).unwrap()
+        else {
+            panic!("expected second event page");
+        };
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, first_cursor.event_id + 1);
+    }
+
+    #[test]
+    fn event_cursor_expires_after_retention() {
+        let registry = Registry::default();
+        let Response::Events { cursor, .. } = registry.read_events(None, 256, 0).unwrap() else {
+            panic!("expected event baseline");
+        };
+        for index in 0..=MAX_RETAINED_EVENTS {
+            registry
+                .events
+                .publish(DaemonEventKind::WorkspaceClosed {
+                    workspace_id: format!("w{index}"),
+                })
+                .unwrap();
+        }
+
+        let error = registry.read_events(Some(&cursor), 256, 0).unwrap_err();
+        assert_eq!(error_code(&error), ErrorCode::CursorExpired);
+    }
+
+    #[test]
     fn rendered_output_tail_preserves_utf8_boundaries() {
         assert_eq!(tail_utf8("one-λ", 2), "λ");
         assert_eq!(tail_utf8("one-λ", 3), "-λ");
@@ -3033,11 +3650,25 @@ mod tests {
     }
 
     #[test]
+    fn bounds_new_names_without_rejecting_legacy_persisted_names() {
+        let long_name = "x".repeat(MAX_NAME_BYTES + 1);
+        assert_eq!(
+            validate_name(&long_name).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert!(validate_persisted_name(&long_name).is_ok());
+    }
+
+    #[test]
     fn failed_persistence_rolls_back_registry_mutation() {
         let directory = env::temp_dir().join(format!("boomux-rollback-{}", Uuid::new_v4()));
         let state_directory = directory.join("state");
-        let registry =
-            Registry::restore(StateStore::at(state_directory.join("state.json")), false).unwrap();
+        let registry = Registry::restore(
+            StateStore::at(state_directory.join("state.json")),
+            false,
+            None,
+        )
+        .unwrap();
         fs::remove_dir(&state_directory).unwrap();
         fs::write(&state_directory, b"not a directory").unwrap();
 

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -10,12 +10,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::client;
 use crate::fd_transfer::receive_descriptor;
-use crate::protocol::{self, TerminalProfile};
+use crate::protocol::{self, DaemonEvent, TerminalProfile};
 use crate::state_store;
 
 const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 pub(crate) const CHANNEL_FD: RawFd = 198;
-pub(crate) const HEADER: &[u8; 8] = b"BOOMUXH3";
+pub(crate) const HEADER: &[u8; 8] = b"BOOMUXH4";
 pub(crate) const LISTENER_MARKER: u8 = 1;
 pub(crate) const RUNTIME_LOCK_MARKER: u8 = 2;
 pub(crate) const STATE_LOCK_MARKER: u8 = 3;
@@ -32,6 +32,14 @@ pub(crate) const PIDFD_MARKER: u8 = 11;
 pub(crate) struct Manifest {
     pub(crate) runtimes: Vec<RuntimeManifest>,
     pub(crate) exited: Vec<ExitedManifest>,
+    pub(crate) event_stream: EventStreamManifest,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct EventStreamManifest {
+    pub(crate) stream_id: String,
+    pub(crate) latest_id: u64,
+    pub(crate) events: Vec<DaemonEvent>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -75,6 +83,7 @@ pub(crate) enum Bootstrap {
         state_lock: OwnedFd,
         runtimes: Vec<TransferredRuntime>,
         exited: Vec<TransferredExited>,
+        event_stream: EventStreamManifest,
     },
 }
 
@@ -92,6 +101,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
     }
     let manifest: Manifest = protocol::read_message(&mut channel)?;
     validate_manifest(&manifest)?;
+    let event_stream = manifest.event_stream.clone();
     let listener = receive_descriptor(&channel, LISTENER_MARKER)?;
     let runtime_lock = receive_descriptor(&channel, RUNTIME_LOCK_MARKER)?;
     let state_lock = receive_descriptor(&channel, STATE_LOCK_MARKER)?;
@@ -158,6 +168,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             state_lock,
             runtimes,
             exited,
+            event_stream,
         }),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -242,6 +253,24 @@ fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
                 "handoff manifest contains an invalid exited shell",
             ));
         }
+    }
+    if uuid::Uuid::parse_str(&manifest.event_stream.stream_id).is_err()
+        || manifest.event_stream.events.len() > 8_192
+        || manifest
+            .event_stream
+            .events
+            .windows(2)
+            .any(|events| events[0].id.checked_add(1) != Some(events[1].id))
+        || manifest
+            .event_stream
+            .events
+            .last()
+            .is_some_and(|event| event.id != manifest.event_stream.latest_id)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "handoff manifest contains an invalid event stream",
+        ));
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,9 @@ use clap::error::ErrorKind as ClapErrorKind;
 use clap::{Parser, Subcommand};
 use uuid::Uuid;
 
-use boomux::protocol::{ShellSnapshot, ShellSpec, ShellStatus, Snapshot, WorkspaceSnapshot};
+use boomux::protocol::{
+    EventCursor, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, WorkspaceSnapshot,
+};
 use boomux::{attach, client, daemon, protocol};
 
 mod cli_output;
@@ -116,6 +118,21 @@ enum Commands {
         target: String,
         #[arg(long, default_value_t = 200, value_parser = clap::value_parser!(u32).range(1..))]
         lines: u32,
+        #[arg(long, requires = "after_revision")]
+        run_id: Option<String>,
+        #[arg(long, requires = "run_id")]
+        after_revision: Option<u64>,
+        #[arg(long, default_value_t = 0, requires = "after_revision")]
+        wait_ms: u32,
+    },
+    /// Read a bounded batch of daemon events
+    Events {
+        #[arg(long)]
+        after: Option<String>,
+        #[arg(long, default_value_t = 256, value_parser = clap::value_parser!(u16).range(1..=256))]
+        limit: u16,
+        #[arg(long, default_value_t = 0)]
+        wait_ms: u32,
     },
     /// Close a shell by name or shell ID
     Close { target: String },
@@ -320,7 +337,25 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         Some(Commands::Capabilities) => capabilities(cli.json),
         Some(Commands::List) => list_shells(cli.json),
         Some(Commands::Shells) => list_workspace_shells(cli.json),
-        Some(Commands::Read { target, lines }) => read_shell(&target, lines, cli.json),
+        Some(Commands::Read {
+            target,
+            lines,
+            run_id,
+            after_revision,
+            wait_ms,
+        }) => read_shell(
+            &target,
+            lines,
+            cli.json,
+            run_id.as_deref(),
+            after_revision,
+            wait_ms,
+        ),
+        Some(Commands::Events {
+            after,
+            limit,
+            wait_ms,
+        }) => read_events(after.as_deref(), limit, wait_ms, cli.json),
         Some(Commands::Close { target }) => close_shell(&target),
         Some(Commands::Workspace { command }) => workspace_command(command, cli.json),
         Some(Commands::Shell { command }) => shell_command(command, cli.json),
@@ -348,6 +383,7 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::List) => "list",
         Some(Commands::Shells) => "shells",
         Some(Commands::Read { .. }) => "read",
+        Some(Commands::Events { .. }) => "events",
         Some(Commands::Workspace {
             command: WorkspaceCommands::List,
         }) => "workspace.list",
@@ -376,33 +412,39 @@ fn command_name(cli: &Cli) -> &'static str {
 fn supports_json(cli: &Cli) -> bool {
     matches!(
         cli.command.as_ref(),
-        Some(Commands::Capabilities | Commands::List | Commands::Shells | Commands::Read { .. })
-            | Some(Commands::Workspace {
-                command: WorkspaceCommands::List | WorkspaceCommands::Inspect { .. }
-            })
-            | Some(Commands::Shell {
-                command: ShellCommands::Inspect { .. }
-            })
-            | Some(Commands::Daemon {
-                command: DaemonCommands::Status
-            })
+        Some(
+            Commands::Capabilities
+                | Commands::List
+                | Commands::Shells
+                | Commands::Read { .. }
+                | Commands::Events { .. }
+        ) | Some(Commands::Workspace {
+            command: WorkspaceCommands::List | WorkspaceCommands::Inspect { .. }
+        }) | Some(Commands::Shell {
+            command: ShellCommands::Inspect { .. }
+        }) | Some(Commands::Daemon {
+            command: DaemonCommands::Status
+        })
     )
 }
 
 fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect()?;
     match command {
-        DaemonCommands::Status if json => cli_output::print(
-            "daemon.status",
-            serde_json::json!({
-                "status": "running",
-                "protocol_version": protocol::PROTOCOL_VERSION,
-                "socket_path": client.socket_path().display().to_string(),
-            }),
-        )?,
+        DaemonCommands::Status if json => {
+            let protocol_version = client.protocol_version()?;
+            cli_output::print(
+                "daemon.status",
+                serde_json::json!({
+                    "status": "running",
+                    "protocol_version": protocol_version,
+                    "socket_path": client.socket_path().display().to_string(),
+                }),
+            )?
+        }
         DaemonCommands::Status => println!(
             "running (protocol {}, {})",
-            protocol::PROTOCOL_VERSION,
+            client.protocol_version()?,
             client.socket_path().display()
         ),
         DaemonCommands::Restart => {
@@ -721,6 +763,7 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "list",
         "shells",
         "read",
+        "events",
         "workspace.list",
         "workspace.inspect",
         "shell.inspect",
@@ -732,6 +775,9 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "rendered_scrollback",
         "graceful_live_handoff",
         "graceful_exited_handoff",
+        "daemon_events",
+        "reconnectable_event_cursors",
+        "revision_aware_reads",
     ];
     let error_codes = [
         "invalid_argument",
@@ -744,6 +790,9 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "persistence_failed",
         "timeout",
         "unsupported_version",
+        "cursor_expired",
+        "run_changed",
+        "revision_ahead",
         "context_required",
         "ambiguous_target",
         "internal",
@@ -1010,31 +1059,136 @@ fn list_workspace_shells(json: bool) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn read_shell(target: &str, lines: u32, json: bool) -> Result<(), Box<dyn Error>> {
+fn read_events(
+    after: Option<&str>,
+    limit: u16,
+    wait_ms: u32,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let after = after.map(parse_event_cursor).transpose()?;
+    let batch = client::connect_or_start()?.events(after, limit, wait_ms)?;
+    let cursor = format_event_cursor(&batch.cursor);
+    if json {
+        let snapshot = batch.snapshot.map(json_snapshot).transpose()?;
+        return cli_output::print(
+            "events",
+            serde_json::json!({
+                "stream_id": batch.stream_id,
+                "cursor": cursor,
+                "snapshot": snapshot,
+                "events": batch.events,
+            }),
+        );
+    }
+    println!("CURSOR\t{cursor}");
+    if let Some(snapshot) = batch.snapshot {
+        println!("SNAPSHOT\t{}", snapshot.workspaces.len());
+    }
+    for event in batch.events {
+        let value = serde_json::to_value(&event.kind)?;
+        println!(
+            "{}\t{}\t{}",
+            event.id,
+            event.at_ms,
+            value["event"].as_str().unwrap_or("unknown")
+        );
+    }
+    Ok(())
+}
+
+fn parse_event_cursor(value: &str) -> Result<EventCursor, Box<dyn Error>> {
+    let (stream_id, event_id) = value.split_once(':').ok_or_else(|| {
+        cli_output::failure(
+            "invalid_argument",
+            "event cursor must have the form <stream-uuid>:<event-id>",
+        )
+    })?;
+    Uuid::parse_str(stream_id).map_err(|_| {
+        cli_output::failure("invalid_argument", "event cursor stream ID is invalid")
+    })?;
+    let event_id = event_id
+        .parse::<u64>()
+        .map_err(|_| cli_output::failure("invalid_argument", "event cursor event ID is invalid"))?;
+    Ok(EventCursor {
+        stream_id: stream_id.into(),
+        event_id,
+    })
+}
+
+fn format_event_cursor(cursor: &EventCursor) -> String {
+    format!("{}:{}", cursor.stream_id, cursor.event_id)
+}
+
+fn json_snapshot(snapshot: Snapshot) -> Result<serde_json::Value, Box<dyn Error>> {
+    let workspaces = snapshot
+        .workspaces
+        .iter()
+        .map(|workspace| {
+            let shells = workspace
+                .shells
+                .iter()
+                .map(|shell| cli_output::shell(shell, Some(&workspace.name)))
+                .collect::<Vec<_>>();
+            serde_json::json!({
+                "id": workspace.id,
+                "name": workspace.name,
+                "shells": shells,
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(serde_json::json!({ "workspaces": workspaces }))
+}
+
+fn read_shell(
+    target: &str,
+    lines: u32,
+    json: bool,
+    run_id: Option<&str>,
+    after_revision: Option<u64>,
+    wait_ms: u32,
+) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let snapshot = client.snapshot()?;
     let current_workspace_id = env::var("BOOMUX_SHELL_ID")
         .ok()
         .and_then(|id| find_shell(&snapshot, &id).map(|shell| shell.workspace_id.clone()));
     let shell = resolve_shell_target(&snapshot, current_workspace_id.as_deref(), target)?;
+    if json || run_id.is_some() {
+        let state = client.read_shell_at(
+            &shell.id,
+            READ_BYTES,
+            run_id.map(str::to_owned),
+            after_revision,
+            wait_ms,
+        )?;
+        let output = recent_lines(&String::from_utf8_lossy(&state.bytes), lines as usize);
+        if json {
+            return cli_output::print(
+                "read",
+                serde_json::json!({
+                    "shell_id": shell.id,
+                    "run_id": state.run_id,
+                    "output_revision": state.output_revision,
+                    "changed": state.changed,
+                    "status": shell_status(&state.status),
+                    "output": output,
+                }),
+            );
+        }
+        print_output(&output);
+        return Ok(());
+    }
     let bytes = client.read_shell(&shell.id, READ_BYTES)?;
     let output = recent_lines(&String::from_utf8_lossy(&bytes), lines as usize);
-    if json {
-        return cli_output::print(
-            "read",
-            serde_json::json!({
-                "shell_id": shell.id,
-                "run_id": shell.run.as_ref().map(|run| &run.id),
-                "output_revision": shell.run.as_ref().map(|run| run.output_revision),
-                "output": output,
-            }),
-        );
-    }
+    print_output(&output);
+    Ok(())
+}
+
+fn print_output(output: &str) {
     print!("{output}");
     if !output.is_empty() && !output.ends_with('\n') {
         println!();
     }
-    Ok(())
 }
 
 fn close_shell(target: &str) -> Result<(), Box<dyn Error>> {
@@ -1539,6 +1693,33 @@ mod tests {
         }
         let cli = Cli::try_parse_from(["boomux", "workspace", "create", "test", "--json"]).unwrap();
         assert!(!supports_json(&cli));
+        assert!(
+            Cli::try_parse_from([
+                "boomux",
+                "events",
+                "--after",
+                "00000000-0000-0000-0000-000000000000:4",
+                "--wait-ms",
+                "1000",
+                "--json",
+            ])
+            .is_ok()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "boomux",
+                "read",
+                "shell",
+                "--run-id",
+                "run",
+                "--after-revision",
+                "4",
+                "--wait-ms",
+                "1000",
+            ])
+            .is_ok()
+        );
+        assert!(Cli::try_parse_from(["boomux", "read", "shell", "--run-id", "run"]).is_err());
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 6;
+pub const PROTOCOL_VERSION: u32 = 7;
+pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
 
@@ -20,6 +21,10 @@ impl<T> Envelope<T> {
             version: PROTOCOL_VERSION,
             message,
         }
+    }
+
+    pub fn with_version(version: u32, message: T) -> Self {
+        Self { version, message }
     }
 }
 
@@ -85,9 +90,73 @@ pub enum ErrorCode {
     PersistenceFailed,
     Timeout,
     UnsupportedVersion,
+    CursorExpired,
+    RunChanged,
+    RevisionAhead,
     Internal,
     #[serde(other)]
     Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventCursor {
+    pub stream_id: String,
+    pub event_id: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonEvent {
+    pub id: u64,
+    pub at_ms: u64,
+    #[serde(flatten)]
+    pub kind: DaemonEventKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum DaemonEventKind {
+    WorkspaceCreated {
+        workspace_id: String,
+        name: String,
+    },
+    WorkspaceRenamed {
+        workspace_id: String,
+        name: String,
+    },
+    WorkspaceClosed {
+        workspace_id: String,
+    },
+    ShellCreated {
+        workspace_id: String,
+        shell_id: String,
+        name: String,
+    },
+    ShellRenamed {
+        workspace_id: String,
+        shell_id: String,
+        name: String,
+    },
+    ShellClosed {
+        workspace_id: Option<String>,
+        shell_id: String,
+    },
+    RunStarted {
+        workspace_id: String,
+        shell_id: String,
+        run: ShellRunSnapshot,
+    },
+    OutputChanged {
+        workspace_id: String,
+        shell_id: String,
+        run_id: String,
+        output_revision: u64,
+    },
+    RunExited {
+        workspace_id: String,
+        shell_id: String,
+        run: ShellRunSnapshot,
+    },
+    HandoffCompleted,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -146,6 +215,24 @@ pub enum Request {
         shell_id: String,
         max_bytes: usize,
     },
+    ReadShellAt {
+        shell_id: String,
+        max_bytes: usize,
+        #[serde(default)]
+        run_id: Option<String>,
+        #[serde(default)]
+        after_revision: Option<u64>,
+        #[serde(default)]
+        wait_ms: u32,
+    },
+    Events {
+        #[serde(default)]
+        after: Option<EventCursor>,
+        #[serde(default = "default_event_limit")]
+        limit: u16,
+        #[serde(default)]
+        wait_ms: u32,
+    },
     RenameWorkspace {
         workspace_id: String,
         name: String,
@@ -183,6 +270,19 @@ pub enum Response {
     Output {
         bytes: Vec<u8>,
     },
+    OutputState {
+        bytes: Vec<u8>,
+        run_id: Option<String>,
+        output_revision: Option<u64>,
+        changed: bool,
+        status: ShellStatus,
+    },
+    Events {
+        stream_id: String,
+        cursor: EventCursor,
+        snapshot: Option<Snapshot>,
+        events: Vec<DaemonEvent>,
+    },
     Attached {
         token: String,
         reconstruction: Vec<u8>,
@@ -194,6 +294,10 @@ pub enum Response {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         code: Option<ErrorCode>,
     },
+}
+
+fn default_event_limit() -> u16 {
+    256
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -16,7 +16,7 @@ use boomux::protocol::{
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use uuid::Uuid;
 
-const TIMEOUT: Duration = Duration::from_secs(5);
+const TIMEOUT: Duration = Duration::from_secs(10);
 const HANDOFF_CHANNEL_FD: RawFd = 198;
 
 struct TestDaemon {
@@ -146,6 +146,14 @@ fn json_cli_parse_and_daemon_start_failures_use_typed_envelopes() {
     assert_eq!(parse_failure["schema"], "boomux.cli/v1");
     assert_eq!(parse_failure["command"], "cli");
     assert_eq!(parse_failure["error"]["code"], "invalid_argument");
+    let cursor_failure = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["events", "--after", "invalid", "--json"])
+        .output()
+        .unwrap();
+    assert!(!cursor_failure.status.success());
+    let cursor_failure: serde_json::Value = serde_json::from_slice(&cursor_failure.stderr).unwrap();
+    assert_eq!(cursor_failure["command"], "events");
+    assert_eq!(cursor_failure["error"]["code"], "invalid_argument");
 
     let root = std::env::temp_dir().join(format!("boomux-json-start-{}", Uuid::new_v4()));
     fs::create_dir(&root).unwrap();
@@ -215,10 +223,18 @@ fn replacement_bootstrap_receives_listener_and_lock_ownership() {
 
     parent_channel.set_read_timeout(Some(TIMEOUT)).unwrap();
     parent_channel.set_write_timeout(Some(TIMEOUT)).unwrap();
-    parent_channel.write_all(b"BOOMUXH3").unwrap();
+    parent_channel.write_all(b"BOOMUXH4").unwrap();
     protocol::write_message(
         &mut parent_channel,
-        &serde_json::json!({ "runtimes": [], "exited": [] }),
+        &serde_json::json!({
+            "runtimes": [],
+            "exited": [],
+            "event_stream": {
+                "stream_id": Uuid::new_v4().to_string(),
+                "latest_id": 0,
+                "events": []
+            }
+        }),
     )
     .unwrap();
     send_descriptor(&parent_channel, listener.as_raw_fd(), 1);
@@ -585,6 +601,230 @@ fn graceful_restart_preserves_exited_run_and_terminal_state() {
 }
 
 #[test]
+fn daemon_events_and_revision_reads_survive_handoff() {
+    let mut daemon = TestDaemon::start();
+    let baseline = daemon.client.events(None, 256, 0).unwrap();
+    assert!(baseline.snapshot.is_some());
+    assert!(baseline.events.is_empty());
+    let stream_id = baseline.stream_id.clone();
+    let mut cursor = baseline.cursor;
+
+    let polling_client = daemon.client.clone();
+    let polling_cursor = cursor.clone();
+    let poll = thread::spawn(move || polling_client.events(Some(polling_cursor), 256, 2_000));
+    thread::sleep(Duration::from_millis(50));
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "events",
+            vec![ShellSpec::login("agent", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let created = poll.join().unwrap().unwrap();
+    assert!(created.snapshot.is_none());
+    assert!(
+        created
+            .events
+            .windows(2)
+            .all(|events| events[0].id < events[1].id)
+    );
+    assert!(created.events.iter().any(|event| matches!(
+        event.kind,
+        protocol::DaemonEventKind::WorkspaceCreated { .. }
+    )));
+    assert!(
+        created
+            .events
+            .iter()
+            .any(|event| matches!(event.kind, protocol::DaemonEventKind::ShellCreated { .. }))
+    );
+    cursor = created.cursor;
+
+    let mut attachment = daemon
+        .client
+        .attach(&shell_id, false, profile())
+        .unwrap()
+        .stream;
+    AttachFrame::Input(b"printf 'event-output-one\\n'\n".to_vec())
+        .write_to(&mut attachment)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut attachment, b"event-output-one"),
+        b"event-output-one"
+    ));
+    drop(attachment);
+    let changed = daemon.client.events(Some(cursor), 256, 1_000).unwrap();
+    assert!(
+        changed
+            .events
+            .iter()
+            .any(|event| matches!(event.kind, protocol::DaemonEventKind::RunStarted { .. }))
+    );
+    assert!(
+        changed
+            .events
+            .iter()
+            .any(|event| matches!(event.kind, protocol::DaemonEventKind::OutputChanged { .. }))
+    );
+    cursor = changed.cursor;
+
+    let observed = daemon
+        .client
+        .read_shell_at(&shell_id, 1024 * 1024, None, None, 0)
+        .unwrap();
+    assert!(contains(&observed.bytes, b"event-output-one"));
+    let run_id = observed.run_id.clone().unwrap();
+    let revision = observed.output_revision.unwrap();
+    let unchanged = daemon
+        .client
+        .read_shell_at(
+            &shell_id,
+            1024 * 1024,
+            Some(run_id.clone()),
+            Some(revision),
+            10,
+        )
+        .unwrap();
+    assert!(!unchanged.changed);
+    assert!(unchanged.bytes.is_empty());
+    let waiting_client = daemon.client.clone();
+    let waiting_shell_id = shell_id.clone();
+    let waiting_run_id = run_id.clone();
+    let wait = thread::spawn(move || {
+        waiting_client.read_shell_at(
+            waiting_shell_id,
+            1024 * 1024,
+            Some(waiting_run_id),
+            Some(revision),
+            2_000,
+        )
+    });
+    thread::sleep(Duration::from_millis(50));
+    let mut attachment = daemon
+        .client
+        .attach(&shell_id, false, profile())
+        .unwrap()
+        .stream;
+    AttachFrame::Input(b"printf 'event-output-two\\n'\n".to_vec())
+        .write_to(&mut attachment)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut attachment, b"event-output-two"),
+        b"event-output-two"
+    ));
+    drop(attachment);
+    let advanced = wait.join().unwrap().unwrap();
+    assert!(advanced.changed);
+    let advanced_revision = advanced.output_revision.unwrap();
+    assert!(advanced_revision > revision);
+    assert!(contains(&advanced.bytes, b"event-output-two"));
+    let error = daemon
+        .client
+        .read_shell_at(
+            &shell_id,
+            1024,
+            Some(Uuid::new_v4().to_string()),
+            Some(revision),
+            0,
+        )
+        .unwrap_err();
+    assert_eq!(
+        error
+            .get_ref()
+            .and_then(|error| error.downcast_ref::<RemoteError>())
+            .and_then(|error| error.code),
+        Some(ErrorCode::RunChanged)
+    );
+    let error = daemon
+        .client
+        .read_shell_at(&shell_id, 1024, Some(run_id.clone()), Some(u64::MAX), 0)
+        .unwrap_err();
+    assert_eq!(
+        error
+            .get_ref()
+            .and_then(|error| error.downcast_ref::<RemoteError>())
+            .and_then(|error| error.code),
+        Some(ErrorCode::RevisionAhead)
+    );
+
+    let waiting_client = daemon.client.clone();
+    let waiting_shell_id = shell_id.clone();
+    let wait = thread::spawn(move || {
+        waiting_client.read_shell_at(
+            waiting_shell_id,
+            1024,
+            Some(run_id),
+            Some(advanced_revision),
+            5_000,
+        )
+    });
+    thread::sleep(Duration::from_millis(50));
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    let error = wait.join().unwrap().unwrap_err();
+    assert_eq!(
+        error
+            .get_ref()
+            .and_then(|error| error.downcast_ref::<RemoteError>())
+            .and_then(|error| error.code),
+        Some(ErrorCode::DaemonStopping)
+    );
+    let handed_off = daemon.client.events(Some(cursor), 256, 1_000).unwrap();
+    assert_eq!(handed_off.stream_id, stream_id);
+    assert!(
+        handed_off
+            .events
+            .iter()
+            .any(|event| matches!(event.kind, protocol::DaemonEventKind::HandoffCompleted))
+    );
+    cursor = handed_off.cursor;
+
+    let events_cli = daemon
+        .command()
+        .args([
+            "events",
+            "--after",
+            &format!("{}:{}", cursor.stream_id, cursor.event_id),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(events_cli.status.success());
+    let events_cli: serde_json::Value = serde_json::from_slice(&events_cli.stdout).unwrap();
+    assert_eq!(events_cli["command"], "events");
+    assert_eq!(events_cli["data"]["stream_id"], stream_id);
+
+    daemon.stop_with_cli();
+    daemon.restart();
+    let error = daemon.client.events(Some(cursor), 256, 0).unwrap_err();
+    assert_eq!(
+        error
+            .get_ref()
+            .and_then(|error| error.downcast_ref::<RemoteError>())
+            .and_then(|error| error.code),
+        Some(ErrorCode::CursorExpired)
+    );
+    let baseline = daemon.client.events(None, 256, 0).unwrap();
+    let waiting_client = daemon.client.clone();
+    let wait = thread::spawn(move || waiting_client.events(Some(baseline.cursor), 256, 5_000));
+    thread::sleep(Duration::from_millis(50));
+    daemon.stop_with_cli();
+    let error = wait.join().unwrap().unwrap_err();
+    assert_eq!(
+        error
+            .get_ref()
+            .and_then(|error| error.downcast_ref::<RemoteError>())
+            .and_then(|error| error.code),
+        Some(ErrorCode::DaemonStopping)
+    );
+}
+
+#[test]
 fn native_daemon_handoffs_multiple_detached_shells() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon
@@ -743,7 +983,21 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 6);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 7);
+    assert!(
+        capabilities["data"]["json_commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|command| command == "events")
+    );
+    assert!(
+        capabilities["data"]["features"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|feature| feature == "revision_aware_reads")
+    );
 
     let status = daemon
         .command()
@@ -751,7 +1005,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 6"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 7"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])
@@ -760,6 +1014,16 @@ fn native_daemon_lifecycle() {
     let status: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
     assert_eq!(status["schema"], "boomux.cli/v1");
     assert_eq!(status["data"]["status"], "running");
+    let mut protocol_six = UnixStream::connect(daemon.client.socket_path()).unwrap();
+    protocol::write_message(
+        &mut protocol_six,
+        &protocol::Envelope::with_version(6, protocol::Request::Ping),
+    )
+    .unwrap();
+    let response: protocol::Envelope<protocol::Response> =
+        protocol::read_message(&mut protocol_six).unwrap();
+    assert_eq!(response.version, 6);
+    assert_eq!(response.message, protocol::Response::Pong);
 
     let missing_id = Uuid::new_v4().to_string();
     let error = daemon.client.get_shell(&missing_id).unwrap_err();
@@ -1291,7 +1555,13 @@ fn native_daemon_lifecycle() {
     second
         .set_read_timeout(Some(Duration::from_secs(1)))
         .unwrap();
-    assert!(AttachFrame::read_from(&mut second).is_err());
+    loop {
+        match AttachFrame::read_from(&mut second) {
+            Ok(AttachFrame::Output(_)) => continue,
+            Err(_) => break,
+            Ok(frame) => panic!("old controller received unexpected frame: {frame:?}"),
+        }
+    }
 
     AttachFrame::Resize {
         rows: 40,


### PR DESCRIPTION
## Summary
- add protocol 7 negotiation while preserving protocol-6 management compatibility
- add bounded long-poll daemon events with monotonic cursors, retention expiry, and graceful handoff continuity
- add atomic run-scoped revision reads with conditional waiting and typed stale/ahead errors
- expose events and revision reads through the stable JSON CLI contract and capability report

## Verification
- cargo test --all-targets
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check