### PR TITLE
Add workspace launchers

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boomux
-description: Inspect and manage Boomux persistent terminal workspaces and shells. Use when asked to discover shells, read terminal output, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
+description: Inspect and manage Boomux persistent terminal workspaces, launchers, and shells. Use when asked to discover shells, read terminal output, create or open workspaces and shells, configure desktop application launchers, inspect status, rename or close targets, or manage the Boomux daemon.
 compatibility: Requires boomux on PATH. Some shell-name operations require Boomux workspace context or an explicit --workspace.
 metadata:
   author: boomux
-  version: "2"
+  version: "3"
 ---
 
 # Boomux
@@ -114,6 +114,7 @@ when `BOOMUX_SHELL_ID` is set. `boomux doctor` can run in either context.
 ```console
 boomux workspace list
 boomux workspace create "<name>"
+boomux workspace open "<name-or-id>"
 boomux workspace inspect "<name-or-id>"
 boomux workspace rename "<name-or-id>" "<new-name>"
 boomux workspace close "<name-or-id>"
@@ -122,6 +123,28 @@ boomux workspace close "<name-or-id>"
 `workspace create` creates an empty workspace. `workspace close` removes the
 workspace and terminates all of its running shell sessions. A workspace cannot
 close itself from one of its own shells.
+
+`workspace open` invokes every configured workspace launcher in creation order,
+then opens all shell terminal windows with takeover. It also supports a
+launcher-only workspace. Merely selecting a dashboard row does not invoke
+launchers.
+
+## Manage Workspace Launchers
+
+```console
+boomux launcher list --workspace "<workspace-name-or-id>"
+boomux launcher create "<name>" --workspace "<workspace-name-or-id>" --cwd "/path" -- command arg
+boomux launcher inspect "<name-or-id>" --workspace "<workspace-name-or-id>"
+boomux launcher rename "<name-or-id>" "<new-name>" --workspace "<workspace-name-or-id>"
+boomux launcher remove "<name-or-id>" --workspace "<workspace-name-or-id>"
+```
+
+Launchers are durable ordered definitions, but each invocation is a detached,
+ephemeral process without a PTY or retained output. Commands are exact argument
+vectors; use an explicit shell for pipelines or expansion. `--cwd` defaults to
+the current directory. Removing a launcher does not terminate applications from
+earlier invocations. Exact launcher IDs resolve globally; names require current
+workspace context or `--workspace`.
 
 ## Manage Shells
 
@@ -194,6 +217,10 @@ BOOMUX_SHELL_ID
 BOOMUX_SHELL_NAME
 BOOMUX_RUN_ID
 ```
+
+Detached launcher invocations inherit the invoking client's environment and
+receive `BOOMUX_WORKSPACE_ID`, `BOOMUX_WORKSPACE`, `BOOMUX_LAUNCHER_ID`, and
+`BOOMUX_LAUNCHER_NAME`. Shell and run context variables are removed.
 
 `BOOMUX_RUN_ID` identifies the current process incarnation. It remains stable
 across attachment changes and graceful daemon handoff, but changes when the same

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,14 @@
+# Domain Glossary
+
+## Workspace Launcher
+
+A durable detached argument-vector command associated with a workspace and invoked on every
+explicit open or restore of that workspace. Dashboard selection alone does not invoke it. Each
+launcher has a durable identity and name, owns its working directory, and belongs to an ordered
+workspace collection. Each invocation is ephemeral, has no PTY, and does not create or appear as a
+shell or shell run.
+
+## Shell
+
+A durable workspace slot whose process runs are retained and observable across attachments and
+daemon lifecycle transitions. A shell is distinct from a workspace launcher.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ place. When no workspace name is supplied, Boomux creates the next available
 boomux .
 ```
 
-Each unnamed invocation creates a new generated workspace. A workspace is only
-a named shell container with a UUID; each shell independently owns its working
-directory. Use `--name` to add the shell to an existing named workspace or
-create that explicitly named container:
+Each unnamed invocation creates a new generated workspace. A workspace is a
+named container with a UUID; each shell and launcher independently owns its
+working directory. Use `--name` to add the shell to an existing named workspace
+or create that explicitly named container:
 
 ```console
 boomux . --name feature-x
@@ -98,6 +98,7 @@ boomux close <shell-name-or-shell-id>
 boomux open <shell-id> [--title <title>] [--takeover]
 boomux workspace list
 boomux workspace create <name>
+boomux workspace open <name-or-id>
 boomux workspace inspect <name-or-id>
 boomux workspace rename <name-or-id> <new-name>
 boomux workspace close <name-or-id>
@@ -105,6 +106,11 @@ boomux shell create <workspace-name-or-id> [--name <name>] [--cwd <path>] [-- <c
 boomux shell inspect <shell-name-or-id> [--workspace <name-or-id>]
 boomux shell rename <shell-name-or-id> <new-name> [--workspace <name-or-id>]
 boomux shell close <shell-name-or-id> [--workspace <name-or-id>]
+boomux launcher list --workspace <name-or-id>
+boomux launcher create <name> --workspace <name-or-id> [--cwd <path>] -- <command>...
+boomux launcher inspect <launcher-name-or-id> [--workspace <name-or-id>]
+boomux launcher rename <launcher-name-or-id> <new-name> [--workspace <name-or-id>]
+boomux launcher remove <launcher-name-or-id> [--workspace <name-or-id>]
 boomux daemon status
 boomux daemon restart
 boomux daemon stop
@@ -121,6 +127,24 @@ and process start when the shell is first opened. Shell names require current
 workspace context or `--workspace`; IDs remain globally addressable.
 New workspace and shell names are limited to 256 UTF-8 bytes so retained event
 payloads remain bounded. Existing persisted names remain loadable.
+
+Workspace launchers are durable commands that run on every explicit workspace
+open, including dashboard `Enter` and `boomux workspace open`. They are detached
+client-side processes without PTYs, retained output, or shell-run history. A
+launcher-only workspace is valid. Commands are exact argument vectors, `--cwd`
+defaults to the current directory, and multiple launchers run in creation order
+before terminal windows open:
+
+```console
+boomux workspace create boomux
+boomux launcher create editor --workspace boomux --cwd . -- zeditor .
+boomux launcher create browser --workspace boomux -- firefox http://localhost:3000
+boomux workspace open boomux
+```
+
+Opening continues after individual launcher or terminal spawn failures and
+reports all failures at the end. Removing a launcher affects future opens only;
+Boomux does not track or terminate applications it previously launched.
 
 `boomux read` reads plain rendered text from the daemon's shadow VT state. It
 understands cursor rewrites and terminal soft wrapping, retains up to 2,000
@@ -165,6 +189,11 @@ BOOMUX_SHELL_ID
 BOOMUX_SHELL_NAME
 BOOMUX_RUN_ID
 ```
+
+Workspace launcher invocations instead receive `BOOMUX_WORKSPACE_ID`,
+`BOOMUX_WORKSPACE`, `BOOMUX_LAUNCHER_ID`, and `BOOMUX_LAUNCHER_NAME`. They
+inherit the invoking client's desktop environment, while shell/run context is
+removed.
 
 Workspace and shell IDs remain authoritative after a rename. `BOOMUX_RUN_ID`
 identifies one process incarnation and changes when a durable shell starts a

--- a/docs/adr/0001-separate-workspace-launchers-from-shells.md
+++ b/docs/adr/0001-separate-workspace-launchers-from-shells.md
@@ -1,0 +1,6 @@
+# Separate Workspace Launchers From Shells
+
+Workspace launchers are durable workspace configuration with ephemeral, detached invocations;
+they are not auto-deleting or hidden shells. This preserves shells as observable durable process
+slots while allowing every explicit workspace open to start desktop applications without PTYs,
+retained runs, or lifecycle ownership.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ name resolution, and conversion from daemon snapshots into TUI view models.
 with a four-byte big-endian length prefix. Attachment traffic uses small binary
 frames for input, output, resize, and detach events.
 
-The domain has three durable identities:
+The domain has four durable identities:
 
 - A workspace is a globally named shell container with a UUID. It has no path
   or working directory.
@@ -43,6 +43,9 @@ The domain has three durable identities:
   timestamps, exit reason, and output revision.
   Runs created by Boomux export `BOOMUX_RUN_ID`; a process imported from a
   legacy daemon is marked when its existing environment lacks that variable.
+- A workspace launcher is a named, ordered, exact argument-vector command with
+  its own working directory. Its identity is durable, but each detached
+  invocation is ephemeral and has no PTY or retained runtime state.
 
 There are no separate tab, pane, and terminal identity layers.
 
@@ -53,6 +56,12 @@ There are no separate tab, pane, and terminal identity layers.
 waits for the protocol ping to succeed, and exposes typed management requests.
 An owner-held file lock prevents concurrent daemons from unlinking each other's
 sockets or splitting the registry.
+
+Explicit workspace open is client-side orchestration. The client invokes each
+workspace launcher in creation order using its own desktop environment, then
+opens native terminal windows for the workspace shells. Launcher processes are
+detached into their own sessions and reaped while the invoking client remains
+alive, but Boomux does not retain or manage their runtime lifecycle.
 
 ### Daemon
 
@@ -65,6 +74,7 @@ The daemon supports:
 - Atomic shell creation with an implicit `workspace-N` container when no
   workspace is selected
 - Additional shell creation
+- Ordered workspace launcher creation, inspection, rename, and removal
 - Workspace and shell snapshots
 - Shell and workspace rename operations
 - Shell and workspace closure
@@ -114,7 +124,7 @@ No emulator-specific adapter or compositor window ID is required.
 
 `src/tui.rs` remains a control plane. It receives backend-neutral view models
 and callback functions rather than opening sockets itself. One daemon snapshot
-contains each workspace and its shells, avoiding races between separate list
+contains each workspace, its launchers, and its shells, avoiding races between separate list
 operations. Configured project roots provide workspace-name suggestions only.
 Git information is collected independently from shell directories and cached;
 empty or mixed-directory workspaces have no workspace-level directory or Git
@@ -142,6 +152,11 @@ retention or cold-restart expiry by requesting a fresh snapshot baseline.
 Graceful handoff version 4 transfers retained events before publishing a
 `handoff_completed` boundary and resuming PTY readers. See
 [`event-stream.md`](event-stream.md).
+
+Protocol 8 adds durable workspace launcher definitions. Protocol-7 clients can
+still read workspace snapshots because launcher lists are additive; launcher
+events are filtered from protocol-7 event pages while their cursors continue to
+advance.
 
 ### Transition Coordinator
 
@@ -185,9 +200,9 @@ to the complete registry and removes the runtime socket.
 
 The daemon atomically writes reproducible registry metadata to
 `$XDG_STATE_HOME/boomux/state.json`, falling back to
-`~/.local/state/boomux/state.json`. Workspace and shell IDs, names, grouping,
-shell working directories, startup commands, and last terminal profiles survive
-restart. The last run record also preserves its identity and outcome. Recovered
+`~/.local/state/boomux/state.json`. Workspace, launcher, and shell IDs, names,
+grouping, working directories, argument vectors, and last terminal profiles
+survive restart. The last run record also preserves its identity and outcome. Recovered
 shells are pending: Boomux does not claim that arbitrary
 processes, mutated environments, or PTYs survive daemon restart or crash.
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -32,6 +32,8 @@ The following commands support `--json`:
 - `boomux workspace list`
 - `boomux workspace inspect`
 - `boomux shell inspect`
+- `boomux launcher list`
+- `boomux launcher inspect`
 - `boomux daemon status`
 
 Mutation commands intentionally retain human output for now. Passing `--json`
@@ -44,10 +46,13 @@ Command payloads are:
   features, and error codes.
 - `list`: a `shells` array.
 - `shells`: workspace identity plus a `shells` array.
-- `workspace.list`: a `workspaces` array of `id`, `name`, and `shell_count`.
+- `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`, and
+  `launcher_count`.
 - `workspace.inspect`: one `workspace` object containing `id`, `name`, and
-  `shells`.
+  `shells` and `launchers` arrays.
 - `shell.inspect`: one `shell` object.
+- `launcher.list`: workspace identity plus a `launchers` array.
+- `launcher.inspect`: one `launcher` object.
 - `read`: shell/run identity, observed output revision, and rendered output.
 - `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
   bounded event array.
@@ -63,6 +68,9 @@ not omitted or represented as human placeholders. `status` is `pending`,
 A run object includes `id`, `generation`, `started_at_ms`, `ended_at_ms`,
 `exit_reason`, `exit_code`, `output_revision`, and `environment_has_run_id`.
 `exit_reason` is `exited`, `terminated`, `interrupted`, or `null`.
+
+Launcher objects include `id`, `workspace_id`, `workspace_name`, `name`, `cwd`,
+and `command`. `command` is the exact executable-and-arguments array.
 
 `read` returns `shell_id`, `run_id`, `output_revision`, `changed`, `status`, and
 `output`. Output is a JSON string containing the same bounded plain rendered text

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -31,6 +31,7 @@ The initial event vocabulary is:
 
 - `workspace_created`, `workspace_renamed`, `workspace_closed`
 - `shell_created`, `shell_renamed`, `shell_closed`
+- `launcher_created`, `launcher_renamed`, `launcher_removed`
 - `run_started`, `output_changed`, `run_exited`
 - `handoff_completed`
 

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -4,7 +4,9 @@ use std::io;
 use serde::Serialize;
 
 use boomux::client::RemoteError;
-use boomux::protocol::{ErrorCode, ShellRunExitReason, ShellSnapshot, ShellStatus};
+use boomux::protocol::{
+    ErrorCode, ShellRunExitReason, ShellSnapshot, ShellStatus, WorkspaceLauncherSnapshot,
+};
 
 pub(crate) const SCHEMA: &str = "boomux.cli/v1";
 
@@ -71,6 +73,17 @@ pub(crate) struct WorkspaceSummary {
     pub(crate) id: String,
     pub(crate) name: String,
     pub(crate) shell_count: usize,
+    pub(crate) launcher_count: usize,
+}
+
+#[derive(Serialize)]
+pub(crate) struct LauncherData {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) workspace_name: Option<String>,
+    pub(crate) name: String,
+    pub(crate) cwd: String,
+    pub(crate) command: Vec<String>,
 }
 
 pub(crate) fn print<T: Serialize>(command: &str, data: T) -> Result<(), Box<dyn Error>> {
@@ -145,6 +158,20 @@ pub(crate) fn shell(shell: &ShellSnapshot, workspace_name: Option<&str>) -> Shel
                 environment_has_run_id: run.environment_has_run_id,
             }
         }),
+    }
+}
+
+pub(crate) fn launcher(
+    launcher: &WorkspaceLauncherSnapshot,
+    workspace_name: Option<&str>,
+) -> LauncherData {
+    LauncherData {
+        id: launcher.id.clone(),
+        workspace_id: launcher.workspace_id.clone(),
+        workspace_name: workspace_name.map(str::to_owned),
+        name: launcher.name.clone(),
+        cwd: launcher.cwd.display().to_string(),
+        command: launcher.command.clone(),
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,8 @@ use std::time::Duration;
 
 use crate::protocol::{
     self, DaemonEvent, Envelope, ErrorCode, EventCursor, Request, Response, ShellSnapshot,
-    ShellSpec, ShellStatus, Snapshot, TerminalProfile, WorkspaceSnapshot,
+    ShellSpec, ShellStatus, Snapshot, TerminalProfile, WorkspaceLauncherSnapshot,
+    WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -177,23 +178,29 @@ impl Client {
     fn send(&self, request: Request) -> io::Result<(UnixStream, Response)> {
         let mut version = self.protocol_version.load(Ordering::Acquire);
         if version < request_minimum_version(&request) {
-            if !self.probe_latest()? {
+            self.probe_latest()?;
+            version = self.protocol_version.load(Ordering::Acquire);
+            if version < request_minimum_version(&request) {
                 return Err(remote_error(
                     ErrorCode::UnsupportedVersion,
                     "daemon does not support this request",
                 ));
             }
-            version = self.protocol_version.load(Ordering::Acquire);
         }
         match self.send_with_version(request.clone(), version) {
             Err(error)
                 if version > protocol::MIN_PROTOCOL_VERSION
-                    && request_minimum_version(&request) <= protocol::MIN_PROTOCOL_VERSION
                     && remote_code(&error) == Some(ErrorCode::UnsupportedVersion) =>
             {
-                self.protocol_version
-                    .store(protocol::MIN_PROTOCOL_VERSION, Ordering::Release);
-                self.send_with_version(request, protocol::MIN_PROTOCOL_VERSION)
+                self.probe_latest()?;
+                let negotiated = self.protocol_version.load(Ordering::Acquire);
+                if negotiated < request_minimum_version(&request) {
+                    return Err(remote_error(
+                        ErrorCode::UnsupportedVersion,
+                        "daemon does not support this request",
+                    ));
+                }
+                self.send_with_version(request, negotiated)
             }
             result => result,
         }
@@ -230,20 +237,21 @@ impl Client {
     }
 
     fn probe_latest(&self) -> io::Result<bool> {
-        match self.send_with_version(Request::Ping, protocol::PROTOCOL_VERSION) {
-            Ok((_, Response::Pong)) => {
-                self.protocol_version
-                    .store(protocol::PROTOCOL_VERSION, Ordering::Release);
-                Ok(true)
+        for version in (protocol::MIN_PROTOCOL_VERSION..=protocol::PROTOCOL_VERSION).rev() {
+            match self.send_with_version(Request::Ping, version) {
+                Ok((_, Response::Pong)) => {
+                    self.protocol_version.store(version, Ordering::Release);
+                    return Ok(version == protocol::PROTOCOL_VERSION);
+                }
+                Ok((_, response)) => return unexpected(response),
+                Err(error) if remote_code(&error) == Some(ErrorCode::UnsupportedVersion) => {}
+                Err(error) => return Err(error),
             }
-            Ok((_, response)) => unexpected(response),
-            Err(error) if remote_code(&error) == Some(ErrorCode::UnsupportedVersion) => {
-                self.protocol_version
-                    .store(protocol::MIN_PROTOCOL_VERSION, Ordering::Release);
-                Ok(false)
-            }
-            Err(error) => Err(error),
         }
+        Err(remote_error(
+            ErrorCode::UnsupportedVersion,
+            "daemon has no compatible protocol version",
+        ))
     }
 
     pub fn ping(&self) -> io::Result<()> {
@@ -302,6 +310,18 @@ impl Client {
         }
     }
 
+    pub fn get_launcher(
+        &self,
+        launcher_id: impl Into<String>,
+    ) -> io::Result<WorkspaceLauncherSnapshot> {
+        match self.request(Request::GetLauncher {
+            launcher_id: launcher_id.into(),
+        })? {
+            Response::Launcher { launcher } => Ok(launcher),
+            other => unexpected(other),
+        }
+    }
+
     pub fn create_workspace(
         &self,
         name: impl Into<String>,
@@ -336,6 +356,20 @@ impl Client {
             shell,
         })? {
             Response::Shell { shell } => Ok(shell),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn create_launcher(
+        &self,
+        workspace_id: impl Into<String>,
+        spec: WorkspaceLauncherSpec,
+    ) -> io::Result<WorkspaceLauncherSnapshot> {
+        match self.request(Request::CreateLauncher {
+            workspace_id: workspace_id.into(),
+            spec,
+        })? {
+            Response::Launcher { launcher } => Ok(launcher),
             other => unexpected(other),
         }
     }
@@ -436,6 +470,29 @@ impl Client {
         )
     }
 
+    pub fn rename_launcher(
+        &self,
+        launcher_id: impl Into<String>,
+        name: impl Into<String>,
+    ) -> io::Result<()> {
+        expect_ok(
+            self.request(Request::RenameLauncher {
+                launcher_id: launcher_id.into(),
+                name: name.into(),
+            })?,
+            Response::Ok,
+        )
+    }
+
+    pub fn remove_launcher(&self, launcher_id: impl Into<String>) -> io::Result<()> {
+        expect_ok(
+            self.request(Request::RemoveLauncher {
+                launcher_id: launcher_id.into(),
+            })?,
+            Response::Ok,
+        )
+    }
+
     pub fn close_workspace(&self, workspace_id: impl Into<String>) -> io::Result<()> {
         expect_ok(
             self.request(Request::CloseWorkspace {
@@ -483,6 +540,10 @@ impl Client {
 
 fn request_minimum_version(request: &Request) -> u32 {
     match request {
+        Request::GetLauncher { .. }
+        | Request::CreateLauncher { .. }
+        | Request::RenameLauncher { .. }
+        | Request::RemoveLauncher { .. } => 8,
         Request::ReadShellAt { .. } | Request::Events { .. } => 7,
         _ => protocol::MIN_PROTOCOL_VERSION,
     }
@@ -554,4 +615,120 @@ fn unexpected<T>(response: Response) -> io::Result<T> {
         io::ErrorKind::InvalidData,
         format!("unexpected daemon response: {response:?}"),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::net::UnixListener;
+
+    use uuid::Uuid;
+
+    #[test]
+    fn launcher_requests_require_protocol_eight() {
+        let requests = [
+            Request::GetLauncher {
+                launcher_id: "l1".into(),
+            },
+            Request::CreateLauncher {
+                workspace_id: "w1".into(),
+                spec: WorkspaceLauncherSpec {
+                    name: "editor".into(),
+                    command: vec!["editor".into()],
+                    cwd: "/tmp".into(),
+                },
+            },
+            Request::RenameLauncher {
+                launcher_id: "l1".into(),
+                name: "renamed".into(),
+            },
+            Request::RemoveLauncher {
+                launcher_id: "l1".into(),
+            },
+        ];
+
+        for request in requests {
+            assert_eq!(request_minimum_version(&request), 8);
+        }
+    }
+
+    #[test]
+    fn negotiates_protocol_seven_without_losing_version_seven_requests() {
+        let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 8);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    7,
+                    Response::Error {
+                        message: "expected protocol 7".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 7);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(&mut stream, &Envelope::with_version(7, Response::Pong))
+                .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 7);
+            assert!(matches!(request.message, Request::Events { .. }));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    7,
+                    Response::Events {
+                        stream_id: "stream".into(),
+                        cursor: EventCursor {
+                            stream_id: "stream".into(),
+                            event_id: 0,
+                        },
+                        snapshot: None,
+                        events: Vec::new(),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 7);
+            assert!(matches!(request.message, Request::ReadShellAt { .. }));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    7,
+                    Response::OutputState {
+                        bytes: Vec::new(),
+                        run_id: None,
+                        output_revision: None,
+                        changed: true,
+                        status: ShellStatus::Pending,
+                    },
+                ),
+            )
+            .unwrap();
+        });
+
+        let client = Client::from_socket_path(socket);
+        assert_eq!(client.protocol_version().unwrap(), 7);
+        assert!(client.events(None, 1, 0).is_ok());
+        assert!(client.read_shell_at("shell", 1, None, None, 0).is_ok());
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -25,10 +25,11 @@ use crate::handoff;
 use crate::protocol::{
     self, AttachFrame, DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, Request,
     Response, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus,
-    Snapshot, TerminalProfile, WorkspaceSnapshot,
+    Snapshot, TerminalProfile, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::state_store::{
-    PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace, StateStore,
+    PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
+    PersistedWorkspaceLauncher, StateStore,
 };
 use crate::terminal_state::TerminalState;
 
@@ -564,6 +565,24 @@ fn handle_connection(
             ),
         );
     }
+    if response_version < 8
+        && matches!(
+            request.message,
+            Request::GetLauncher { .. }
+                | Request::CreateLauncher { .. }
+                | Request::RenameLauncher { .. }
+                | Request::RemoveLauncher { .. }
+        )
+    {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "request requires daemon protocol 8",
+            ),
+        );
+    }
 
     if let Request::Attach {
         shell_id,
@@ -660,7 +679,41 @@ fn handle_connection(
         Ok(response) => response,
         Err(error) => error_response(error_code(&error), error.to_string()),
     };
-    send_response(&mut stream, response_version, response)
+    send_response(
+        &mut stream,
+        response_version,
+        response_for_version(response, response_version),
+    )
+}
+
+fn response_for_version(response: Response, version: u32) -> Response {
+    if version >= 8 {
+        return response;
+    }
+    match response {
+        Response::Events {
+            stream_id,
+            cursor,
+            snapshot,
+            mut events,
+        } => {
+            events.retain(|event| {
+                !matches!(
+                    event.kind,
+                    DaemonEventKind::LauncherCreated { .. }
+                        | DaemonEventKind::LauncherRenamed { .. }
+                        | DaemonEventKind::LauncherRemoved { .. }
+                )
+            });
+            Response::Events {
+                stream_id,
+                cursor,
+                snapshot,
+                events,
+            }
+        }
+        response => response,
+    }
 }
 
 fn send_response(stream: &mut UnixStream, version: u32, response: Response) -> io::Result<()> {
@@ -823,14 +876,18 @@ impl EventLog {
 struct RegistryState {
     workspaces: HashMap<String, Arc<Workspace>>,
     shells: HashMap<String, Arc<Shell>>,
+    launchers: HashMap<String, Arc<WorkspaceLauncher>>,
 }
 
 struct RegistryBackup {
     workspaces: HashMap<String, Arc<Workspace>>,
     shells: HashMap<String, Arc<Shell>>,
+    launchers: HashMap<String, Arc<WorkspaceLauncher>>,
     workspace_names: HashMap<String, String>,
     workspace_shell_ids: HashMap<String, Vec<String>>,
+    workspace_launcher_ids: HashMap<String, Vec<String>>,
     shell_names: HashMap<String, String>,
+    launcher_names: HashMap<String, String>,
 }
 
 impl Default for Registry {
@@ -852,6 +909,15 @@ struct Workspace {
     id: String,
     name: Mutex<String>,
     shell_ids: Mutex<Vec<String>>,
+    launcher_ids: Mutex<Vec<String>>,
+}
+
+struct WorkspaceLauncher {
+    id: String,
+    workspace_id: String,
+    name: Mutex<String>,
+    cwd: PathBuf,
+    command: Vec<String>,
 }
 
 struct Shell {
@@ -1360,6 +1426,9 @@ impl Registry {
             Request::GetShell { shell_id } => Ok(Response::Shell {
                 shell: self.shell(&shell_id)?.snapshot()?,
             }),
+            Request::GetLauncher { launcher_id } => Ok(Response::Launcher {
+                launcher: self.launcher(&launcher_id)?.snapshot()?,
+            }),
             Request::CreateWorkspace { name, shells } => self.durable_mutation(|| {
                 let workspace = self.create_workspace(name, shells)?;
                 let events = workspace_created_events(&workspace);
@@ -1388,6 +1457,15 @@ impl Registry {
                     name: shell.name.clone(),
                 });
                 Ok((Response::Shell { shell }, events))
+            }),
+            Request::CreateLauncher { workspace_id, spec } => self.durable_mutation(|| {
+                let launcher = self.create_launcher(&workspace_id, spec)?;
+                let event = DaemonEventKind::LauncherCreated {
+                    workspace_id,
+                    launcher_id: launcher.id.clone(),
+                    name: launcher.name.clone(),
+                };
+                Ok((Response::Launcher { launcher }, vec![event]))
             }),
             Request::ReadShell {
                 shell_id,
@@ -1446,6 +1524,18 @@ impl Registry {
                     }],
                 ))
             }),
+            Request::RenameLauncher { launcher_id, name } => self.durable_mutation(|| {
+                self.rename_launcher(&launcher_id, name.clone())?;
+                let launcher = self.launcher(&launcher_id)?;
+                Ok((
+                    Response::Ok,
+                    vec![DaemonEventKind::LauncherRenamed {
+                        workspace_id: launcher.workspace_id.clone(),
+                        launcher_id,
+                        name,
+                    }],
+                ))
+            }),
             Request::CloseWorkspace { workspace_id } => {
                 self.close_workspace(&workspace_id)?;
                 Ok(Response::Ok)
@@ -1454,6 +1544,16 @@ impl Registry {
                 self.close_shell(&shell_id)?;
                 Ok(Response::Ok)
             }
+            Request::RemoveLauncher { launcher_id } => self.durable_mutation(|| {
+                let launcher = self.remove_launcher(&launcher_id)?;
+                Ok((
+                    Response::Ok,
+                    vec![DaemonEventKind::LauncherRemoved {
+                        workspace_id: launcher.workspace_id.clone(),
+                        launcher_id,
+                    }],
+                ))
+            }),
             Request::Attach { .. } => unreachable!("attach is handled before dispatch"),
         }
     }
@@ -1609,10 +1709,41 @@ impl Registry {
                 shell_ids.push(shell.id.clone());
                 state.shells.insert(shell.id.clone(), shell);
             }
+            let mut launcher_names = HashSet::new();
+            let mut launcher_ids = Vec::with_capacity(saved_workspace.launchers.len());
+            for saved_launcher in saved_workspace.launchers {
+                validate_id("workspace launcher", &saved_launcher.id)?;
+                validate_persisted_name(&saved_launcher.name)?;
+                validate_persisted_cwd(&saved_launcher.cwd)?;
+                if validate_launcher_command(&saved_launcher.command).is_err() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "persisted workspace launcher command requires a non-empty executable",
+                    ));
+                }
+                if !launcher_names.insert(saved_launcher.name.clone())
+                    || state.launchers.contains_key(&saved_launcher.id)
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Boomux state contains a duplicate workspace launcher",
+                    ));
+                }
+                let launcher = Arc::new(WorkspaceLauncher {
+                    id: saved_launcher.id,
+                    workspace_id: saved_workspace.id.clone(),
+                    name: Mutex::new(saved_launcher.name),
+                    cwd: saved_launcher.cwd,
+                    command: saved_launcher.command,
+                });
+                launcher_ids.push(launcher.id.clone());
+                state.launchers.insert(launcher.id.clone(), launcher);
+            }
             let workspace = Arc::new(Workspace {
                 id: saved_workspace.id.clone(),
                 name: Mutex::new(saved_workspace.name),
                 shell_ids: Mutex::new(shell_ids),
+                launcher_ids: Mutex::new(launcher_ids),
             });
             state.workspaces.insert(saved_workspace.id, workspace);
         }
@@ -2007,20 +2138,30 @@ impl Registry {
         let state = lock(&self.state)?;
         let mut workspace_names = HashMap::new();
         let mut workspace_shell_ids = HashMap::new();
+        let mut workspace_launcher_ids = HashMap::new();
         for workspace in state.workspaces.values() {
             workspace_names.insert(workspace.id.clone(), lock(&workspace.name)?.clone());
             workspace_shell_ids.insert(workspace.id.clone(), lock(&workspace.shell_ids)?.clone());
+            workspace_launcher_ids
+                .insert(workspace.id.clone(), lock(&workspace.launcher_ids)?.clone());
         }
         let mut shell_names = HashMap::new();
         for shell in state.shells.values() {
             shell_names.insert(shell.id.clone(), lock(&shell.name)?.clone());
         }
+        let mut launcher_names = HashMap::new();
+        for launcher in state.launchers.values() {
+            launcher_names.insert(launcher.id.clone(), lock(&launcher.name)?.clone());
+        }
         Ok(RegistryBackup {
             workspaces: state.workspaces.clone(),
             shells: state.shells.clone(),
+            launchers: state.launchers.clone(),
             workspace_names,
             workspace_shell_ids,
+            workspace_launcher_ids,
             shell_names,
+            launcher_names,
         })
     }
 
@@ -2033,14 +2174,23 @@ impl Registry {
             if let Some(ids) = backup.workspace_shell_ids.get(&workspace.id) {
                 *lock(&workspace.shell_ids)? = ids.clone();
             }
+            if let Some(ids) = backup.workspace_launcher_ids.get(&workspace.id) {
+                *lock(&workspace.launcher_ids)? = ids.clone();
+            }
         }
         for shell in backup.shells.values() {
             if let Some(name) = backup.shell_names.get(&shell.id) {
                 *lock(&shell.name)? = name.clone();
             }
         }
+        for launcher in backup.launchers.values() {
+            if let Some(name) = backup.launcher_names.get(&launcher.id) {
+                *lock(&launcher.name)? = name.clone();
+            }
+        }
         state.workspaces = backup.workspaces;
         state.shells = backup.shells;
+        state.launchers = backup.launchers;
         Ok(())
     }
 
@@ -2072,10 +2222,24 @@ impl Registry {
                     last_run: lock(&shell.last_run)?.clone(),
                 });
             }
+            let ids = lock(&workspace.launcher_ids)?.clone();
+            let mut launchers = Vec::with_capacity(ids.len());
+            for id in ids {
+                let Some(launcher) = state.launchers.get(&id) else {
+                    continue;
+                };
+                launchers.push(PersistedWorkspaceLauncher {
+                    id: launcher.id.clone(),
+                    name: lock(&launcher.name)?.clone(),
+                    cwd: launcher.cwd.clone(),
+                    command: launcher.command.clone(),
+                });
+            }
             saved.workspaces.push(PersistedWorkspace {
                 id: workspace.id.clone(),
                 name: lock(&workspace.name)?.clone(),
                 shells,
+                launchers,
             });
         }
         drop(state);
@@ -2218,6 +2382,7 @@ impl Registry {
         let mut state = lock(&self.state)?;
         state.workspaces.clear();
         state.shells.clear();
+        state.launchers.clear();
         drop(state);
         drop(events);
         drop(transition);
@@ -2241,6 +2406,14 @@ impl Registry {
             .get(id)
             .cloned()
             .ok_or_else(|| not_found("shell", id))
+    }
+
+    fn launcher(&self, id: &str) -> io::Result<Arc<WorkspaceLauncher>> {
+        lock(&self.state)?
+            .launchers
+            .get(id)
+            .cloned()
+            .ok_or_else(|| not_found("workspace launcher", id))
     }
 
     fn contains_shell(&self, shell: &Arc<Shell>) -> io::Result<bool> {
@@ -2277,6 +2450,7 @@ impl Registry {
             id: workspace_id.clone(),
             name: Mutex::new(name),
             shell_ids: Mutex::new(shells.iter().map(|shell| shell.id.clone()).collect()),
+            launcher_ids: Mutex::new(Vec::new()),
         });
         {
             let mut state = lock(&self.state)?;
@@ -2353,6 +2527,92 @@ impl Registry {
                 Err(error) => return Err(error),
             }
         }
+    }
+
+    fn create_launcher(
+        &self,
+        workspace_id: &str,
+        spec: WorkspaceLauncherSpec,
+    ) -> io::Result<WorkspaceLauncherSnapshot> {
+        validate_name(&spec.name)?;
+        validate_cwd(&spec.cwd)?;
+        validate_launcher_command(&spec.command)?;
+        let workspace = self.workspace(workspace_id)?;
+        let launcher = Arc::new(WorkspaceLauncher {
+            id: Uuid::new_v4().to_string(),
+            workspace_id: workspace_id.into(),
+            name: Mutex::new(spec.name),
+            cwd: spec.cwd,
+            command: spec.command,
+        });
+        let snapshot = launcher.snapshot()?;
+        let mut state = lock(&self.state)?;
+        let Some(current) = state.workspaces.get(workspace_id) else {
+            return Err(not_found("workspace", workspace_id));
+        };
+        if !Arc::ptr_eq(current, &workspace) {
+            return Err(not_found("workspace", workspace_id));
+        }
+        let mut launcher_ids = lock(&workspace.launcher_ids)?;
+        if launcher_ids.iter().any(|id| {
+            state
+                .launchers
+                .get(id)
+                .and_then(|existing| existing.name.lock().ok())
+                .is_some_and(|name| *name == snapshot.name)
+        }) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("workspace launcher name already exists: {}", snapshot.name),
+            ));
+        }
+        state
+            .launchers
+            .insert(launcher.id.clone(), Arc::clone(&launcher));
+        launcher_ids.push(launcher.id.clone());
+        Ok(snapshot)
+    }
+
+    fn rename_launcher(&self, launcher_id: &str, name: String) -> io::Result<()> {
+        validate_name(&name)?;
+        let launcher = self.launcher(launcher_id)?;
+        let workspace = self.workspace(&launcher.workspace_id)?;
+        let state = lock(&self.state)?;
+        let launcher_ids = lock(&workspace.launcher_ids)?;
+        if launcher_ids
+            .iter()
+            .filter(|id| id.as_str() != launcher_id)
+            .any(|id| {
+                state
+                    .launchers
+                    .get(id)
+                    .and_then(|existing| existing.name.lock().ok())
+                    .is_some_and(|existing| *existing == name)
+            })
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("workspace launcher name already exists: {name}"),
+            ));
+        }
+        *lock(&launcher.name)? = name;
+        Ok(())
+    }
+
+    fn remove_launcher(&self, launcher_id: &str) -> io::Result<Arc<WorkspaceLauncher>> {
+        let (launcher, workspace) = {
+            let mut state = lock(&self.state)?;
+            let launcher = state
+                .launchers
+                .remove(launcher_id)
+                .ok_or_else(|| not_found("workspace launcher", launcher_id))?;
+            let workspace = state.workspaces.get(&launcher.workspace_id).cloned();
+            (launcher, workspace)
+        };
+        if let Some(workspace) = workspace {
+            lock(&workspace.launcher_ids)?.retain(|id| id != launcher_id);
+        }
+        Ok(launcher)
     }
 
     fn next_workspace_name(&self) -> io::Result<String> {
@@ -2588,6 +2848,9 @@ impl Registry {
                 .workspaces
                 .remove(workspace_id)
                 .ok_or_else(|| not_found("workspace", workspace_id))?;
+            for id in lock(&workspace.launcher_ids)?.iter() {
+                state.launchers.remove(id);
+            }
             let ids = lock(&workspace.shell_ids)?.clone();
             ids.into_iter()
                 .filter_map(|id| state.shells.remove(&id))
@@ -2716,21 +2979,45 @@ impl Registry {
 
 impl Workspace {
     fn snapshot(&self, registry: &Registry) -> io::Result<WorkspaceSnapshot> {
-        let shells = {
+        let (shells, launchers) = {
             let state = lock(&registry.state)?;
-            let ids = lock(&self.shell_ids)?;
-            ids.iter()
+            let shell_ids = lock(&self.shell_ids)?;
+            let shells = shell_ids
+                .iter()
                 .filter_map(|id| state.shells.get(id).cloned())
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+            let launcher_ids = lock(&self.launcher_ids)?;
+            let launchers = launcher_ids
+                .iter()
+                .filter_map(|id| state.launchers.get(id).cloned())
+                .collect::<Vec<_>>();
+            (shells, launchers)
         };
         let shells = shells
             .iter()
             .map(|shell| shell.snapshot())
             .collect::<io::Result<_>>()?;
+        let launchers = launchers
+            .iter()
+            .map(|launcher| launcher.snapshot())
+            .collect::<io::Result<_>>()?;
         Ok(WorkspaceSnapshot {
             id: self.id.clone(),
             name: lock(&self.name)?.clone(),
             shells,
+            launchers,
+        })
+    }
+}
+
+impl WorkspaceLauncher {
+    fn snapshot(&self) -> io::Result<WorkspaceLauncherSnapshot> {
+        Ok(WorkspaceLauncherSnapshot {
+            id: self.id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            name: lock(&self.name)?.clone(),
+            command: self.command.clone(),
+            cwd: self.cwd.clone(),
         })
     }
 }
@@ -3812,6 +4099,20 @@ fn validate_shell_specs(specs: &[ShellSpec]) -> io::Result<()> {
     Ok(())
 }
 
+fn validate_launcher_command(command: &[String]) -> io::Result<()> {
+    if command
+        .first()
+        .is_some_and(|executable| !executable.is_empty())
+    {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "workspace launcher command requires a non-empty executable",
+        ))
+    }
+}
+
 fn validate_cwd(cwd: &Path) -> io::Result<()> {
     if cwd.is_absolute() && cwd.is_dir() {
         Ok(())
@@ -4064,6 +4365,103 @@ mod tests {
                 .skip(1)
                 .all(|event| matches!(event.kind, DaemonEventKind::ShellCreated { .. }))
         );
+    }
+
+    #[test]
+    fn launcher_mutations_are_coordinated_and_names_are_unique_per_workspace() {
+        let registry = Registry::default();
+        let Response::Workspace { workspace } = registry
+            .dispatch(Request::CreateWorkspace {
+                name: "launchers".into(),
+                shells: Vec::new(),
+            })
+            .unwrap()
+        else {
+            panic!("expected workspace");
+        };
+        let spec = WorkspaceLauncherSpec {
+            name: "editor".into(),
+            command: vec!["zeditor".into(), ".".into()],
+            cwd: env::temp_dir(),
+        };
+        let Response::Launcher { launcher } = registry
+            .dispatch(Request::CreateLauncher {
+                workspace_id: workspace.id.clone(),
+                spec: spec.clone(),
+            })
+            .unwrap()
+        else {
+            panic!("expected launcher");
+        };
+        assert!(
+            registry
+                .dispatch(Request::CreateLauncher {
+                    workspace_id: workspace.id.clone(),
+                    spec,
+                })
+                .is_err()
+        );
+        let snapshot = registry
+            .workspace(&workspace.id)
+            .unwrap()
+            .snapshot(&registry)
+            .unwrap();
+        assert_eq!(snapshot.launchers, vec![launcher]);
+        assert_eq!(
+            lock(&registry.events.state)
+                .unwrap()
+                .events
+                .iter()
+                .filter(|event| matches!(event.kind, DaemonEventKind::LauncherCreated { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn protocol_seven_event_pages_hide_launcher_events() {
+        let cursor = EventCursor {
+            stream_id: "stream".into(),
+            event_id: 2,
+        };
+        let response = Response::Events {
+            stream_id: "stream".into(),
+            cursor: cursor.clone(),
+            snapshot: None,
+            events: vec![
+                DaemonEvent {
+                    id: 1,
+                    at_ms: 1,
+                    kind: DaemonEventKind::LauncherCreated {
+                        workspace_id: "workspace".into(),
+                        launcher_id: "launcher".into(),
+                        name: "editor".into(),
+                    },
+                },
+                DaemonEvent {
+                    id: 2,
+                    at_ms: 2,
+                    kind: DaemonEventKind::WorkspaceRenamed {
+                        workspace_id: "workspace".into(),
+                        name: "renamed".into(),
+                    },
+                },
+            ],
+        };
+        let Response::Events {
+            cursor: filtered_cursor,
+            events,
+            ..
+        } = response_for_version(response, 7)
+        else {
+            panic!("expected events");
+        };
+        assert_eq!(filtered_cursor, cursor);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0].kind,
+            DaemonEventKind::WorkspaceRenamed { .. }
+        ));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,15 +3,18 @@ use std::error::Error;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::{self, Write};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitCode};
+use std::process::{Command, ExitCode, Stdio};
+use std::thread;
 
 use clap::error::ErrorKind as ClapErrorKind;
 use clap::{Parser, Subcommand};
 use uuid::Uuid;
 
 use boomux::protocol::{
-    EventCursor, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, WorkspaceSnapshot,
+    EventCursor, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, WorkspaceLauncherSnapshot,
+    WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use boomux::{attach, client, daemon, protocol};
 
@@ -146,6 +149,11 @@ enum Commands {
         #[command(subcommand)]
         command: ShellCommands,
     },
+    /// Manage workspace launchers
+    Launcher {
+        #[command(subcommand)]
+        command: LauncherCommands,
+    },
     /// Manage the vendor-neutral Boomux Agent Skill
     Skill {
         #[command(subcommand)]
@@ -181,12 +189,52 @@ enum WorkspaceCommands {
     List,
     /// Create an empty workspace
     Create { name: String },
+    /// Open terminal windows and invoke launchers
+    Open { target: String },
     /// Show a workspace and its shells
     Inspect { target: String },
     /// Rename a workspace
     Rename { target: String, name: String },
     /// Close a workspace and all of its shells
     Close { target: String },
+}
+
+#[derive(Subcommand)]
+enum LauncherCommands {
+    /// List launchers in a workspace
+    List {
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: String,
+    },
+    /// Create a launcher in a workspace
+    Create {
+        name: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: String,
+        #[arg(long, default_value = ".")]
+        cwd: PathBuf,
+        #[arg(last = true, num_args = 1.., required = true, value_name = "COMMAND")]
+        command: Vec<String>,
+    },
+    /// Show launcher details
+    Inspect {
+        target: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+    /// Rename a launcher
+    Rename {
+        target: String,
+        name: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+    /// Remove a launcher without affecting previously launched applications
+    Remove {
+        target: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -357,8 +405,11 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             wait_ms,
         }) => read_events(after.as_deref(), limit, wait_ms, cli.json),
         Some(Commands::Close { target }) => close_shell(&target),
-        Some(Commands::Workspace { command }) => workspace_command(command, cli.json),
+        Some(Commands::Workspace { command }) => {
+            workspace_command(command, cli.json, cli.terminal.as_deref())
+        }
         Some(Commands::Shell { command }) => shell_command(command, cli.json),
+        Some(Commands::Launcher { command }) => launcher_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
         }) => install_skill(force),
@@ -393,11 +444,18 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Shell {
             command: ShellCommands::Inspect { .. },
         }) => "shell.inspect",
+        Some(Commands::Launcher {
+            command: LauncherCommands::List { .. },
+        }) => "launcher.list",
+        Some(Commands::Launcher {
+            command: LauncherCommands::Inspect { .. },
+        }) => "launcher.inspect",
         Some(Commands::Daemon {
             command: DaemonCommands::Status,
         }) => "daemon.status",
         Some(Commands::Workspace { .. }) => "workspace",
         Some(Commands::Shell { .. }) => "shell",
+        Some(Commands::Launcher { .. }) => "launcher",
         Some(Commands::Daemon { .. }) => "daemon",
         Some(Commands::Ui) | None => "ui",
         Some(Commands::Doctor) => "doctor",
@@ -422,6 +480,8 @@ fn supports_json(cli: &Cli) -> bool {
             command: WorkspaceCommands::List | WorkspaceCommands::Inspect { .. }
         }) | Some(Commands::Shell {
             command: ShellCommands::Inspect { .. }
+        }) | Some(Commands::Launcher {
+            command: LauncherCommands::List { .. } | LauncherCommands::Inspect { .. }
         }) | Some(Commands::Daemon {
             command: DaemonCommands::Status
         })
@@ -507,10 +567,14 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 let workspace = client
                     .get_workspace(workspace_id)
                     .map_err(|error| error.to_string())?;
-                let count = workspace.shells.len();
                 open_workspace(&workspace, terminal.as_deref())
                     .map_err(|error| error.to_string())?;
-                Ok(format!("Restored {count} shell(s) for {}", workspace.name))
+                Ok(format!(
+                    "Opened {} launcher(s) and {} shell(s) for {}",
+                    workspace.launchers.len(),
+                    workspace.shells.len(),
+                    workspace.name
+                ))
             },
             on_open: |shell_id: &str| {
                 open_dashboard_shell(&client, shell_id, terminal.as_deref())
@@ -525,7 +589,9 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     client
                         .close_workspace(workspace_id)
                         .map_err(|error| error.to_string())?;
-                    Ok(format!("Closed {name} and all of its shells"))
+                    Ok(format!(
+                        "Closed {name}, its launchers, and all of its shells"
+                    ))
                 }
                 tui::CloseTarget::Shell(shell_id) => {
                     let name = client
@@ -593,6 +659,7 @@ fn dashboard_views(
                 id: workspace.id.clone(),
                 name: workspace.name.clone(),
                 terminals,
+                launcher_count: workspace.launchers.len(),
             }
         })
         .collect()
@@ -767,6 +834,8 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "workspace.list",
         "workspace.inspect",
         "shell.inspect",
+        "launcher.list",
+        "launcher.inspect",
         "daemon.status",
     ];
     let features = [
@@ -778,6 +847,7 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "daemon_events",
         "reconnectable_event_cursors",
         "revision_aware_reads",
+        "workspace_launchers",
     ];
     let error_codes = [
         "invalid_argument",
@@ -851,7 +921,11 @@ fn list_shells(json: bool) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn workspace_command(command: WorkspaceCommands, json: bool) -> Result<(), Box<dyn Error>> {
+fn workspace_command(
+    command: WorkspaceCommands,
+    json: bool,
+    terminal_override: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     match command {
         WorkspaceCommands::List => {
@@ -863,6 +937,7 @@ fn workspace_command(command: WorkspaceCommands, json: bool) -> Result<(), Box<d
                         id: workspace.id.clone(),
                         name: workspace.name.clone(),
                         shell_count: workspace.shells.len(),
+                        launcher_count: workspace.launchers.len(),
                     })
                     .collect::<Vec<_>>();
                 return cli_output::print(
@@ -870,13 +945,14 @@ fn workspace_command(command: WorkspaceCommands, json: bool) -> Result<(), Box<d
                     serde_json::json!({ "workspaces": workspaces }),
                 );
             }
-            println!("NAME\tWORKSPACE ID\tSHELLS");
+            println!("NAME\tWORKSPACE ID\tSHELLS\tLAUNCHERS");
             for workspace in workspaces {
                 println!(
-                    "{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}",
                     workspace.name,
                     workspace.id,
-                    workspace.shells.len()
+                    workspace.shells.len(),
+                    workspace.launchers.len()
                 );
             }
         }
@@ -884,6 +960,18 @@ fn workspace_command(command: WorkspaceCommands, json: bool) -> Result<(), Box<d
             let name = cli_name(name, "workspace")?;
             let workspace = client.create_workspace(name, Vec::new())?;
             println!("Created workspace {} ({})", workspace.name, workspace.id);
+        }
+        WorkspaceCommands::Open { target } => {
+            let snapshot = client.snapshot()?;
+            let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
+            let terminal = effective_terminal(terminal_override)?;
+            open_workspace(workspace, terminal.as_deref())?;
+            println!(
+                "Opened {} launcher(s) and {} shell(s) for {}",
+                workspace.launchers.len(),
+                workspace.shells.len(),
+                workspace.name
+            );
         }
         WorkspaceCommands::Inspect { target } => {
             let snapshot = client.snapshot()?;
@@ -901,6 +989,9 @@ fn workspace_command(command: WorkspaceCommands, json: bool) -> Result<(), Box<d
                             "id": workspace.id,
                             "name": workspace.name,
                             "shells": shells,
+                            "launchers": workspace.launchers.iter()
+                                .map(|launcher| cli_output::launcher(launcher, Some(&workspace.name)))
+                                .collect::<Vec<_>>(),
                         }
                     }),
                 );
@@ -908,6 +999,7 @@ fn workspace_command(command: WorkspaceCommands, json: bool) -> Result<(), Box<d
             println!("ID\t{}", workspace.id);
             println!("NAME\t{}", workspace.name);
             println!("SHELLS\t{}", workspace.shells.len());
+            println!("LAUNCHERS\t{}", workspace.launchers.len());
             if !workspace.shells.is_empty() {
                 println!("\nNAME\tSHELL ID\tRUN ID\tSTATUS\tCWD");
                 for shell in &workspace.shells {
@@ -918,6 +1010,18 @@ fn workspace_command(command: WorkspaceCommands, json: bool) -> Result<(), Box<d
                         shell.run.as_ref().map_or("-", |run| run.id.as_str()),
                         shell_status(&shell.status),
                         shell.cwd.display()
+                    );
+                }
+            }
+            if !workspace.launchers.is_empty() {
+                println!("\nNAME\tLAUNCHER ID\tCWD\tCOMMAND");
+                for launcher in &workspace.launchers {
+                    println!(
+                        "{}\t{}\t{}\t{}",
+                        launcher.name,
+                        launcher.id,
+                        launcher.cwd.display(),
+                        launcher.command.join(" ")
                     );
                 }
             }
@@ -1027,6 +1131,105 @@ fn shell_command(command: ShellCommands, json: bool) -> Result<(), Box<dyn Error
     Ok(())
 }
 
+fn launcher_command(command: LauncherCommands, json: bool) -> Result<(), Box<dyn Error>> {
+    let client = client::connect_or_start()?;
+    match command {
+        LauncherCommands::List { workspace } => {
+            let snapshot = client.snapshot()?;
+            let workspace = resolve_workspace_target(&snapshot.workspaces, &workspace)?;
+            if json {
+                let launchers = workspace
+                    .launchers
+                    .iter()
+                    .map(|launcher| cli_output::launcher(launcher, Some(&workspace.name)))
+                    .collect::<Vec<_>>();
+                return cli_output::print(
+                    "launcher.list",
+                    serde_json::json!({
+                        "workspace_id": workspace.id,
+                        "workspace_name": workspace.name,
+                        "launchers": launchers,
+                    }),
+                );
+            }
+            println!("NAME\tLAUNCHER ID\tCWD\tCOMMAND");
+            for launcher in &workspace.launchers {
+                println!(
+                    "{}\t{}\t{}\t{}",
+                    launcher.name,
+                    launcher.id,
+                    launcher.cwd.display(),
+                    launcher.command.join(" ")
+                );
+            }
+        }
+        LauncherCommands::Create {
+            name,
+            workspace,
+            cwd,
+            command,
+        } => {
+            let name = cli_name(name, "workspace launcher")?;
+            let snapshot = client.snapshot()?;
+            let workspace = resolve_workspace_target(&snapshot.workspaces, &workspace)?;
+            let launcher = client.create_launcher(
+                &workspace.id,
+                WorkspaceLauncherSpec {
+                    name,
+                    cwd: resolve_directory(&cwd)?,
+                    command,
+                },
+            )?;
+            println!(
+                "Created launcher {} ({}) in {}",
+                launcher.name, launcher.id, workspace.name
+            );
+        }
+        LauncherCommands::Inspect { target, workspace } => {
+            let snapshot = client.snapshot()?;
+            let launcher = resolve_cli_launcher(&snapshot, &target, workspace.as_deref())?;
+            let workspace = snapshot
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.id == launcher.workspace_id)
+                .ok_or_else(|| {
+                    cli_output::failure("not_found", "launcher workspace no longer exists")
+                })?;
+            if json {
+                return cli_output::print(
+                    "launcher.inspect",
+                    serde_json::json!({
+                        "launcher": cli_output::launcher(launcher, Some(&workspace.name)),
+                    }),
+                );
+            }
+            println!("ID\t{}", launcher.id);
+            println!("NAME\t{}", launcher.name);
+            println!("WORKSPACE\t{}", workspace.name);
+            println!("CWD\t{}", launcher.cwd.display());
+            println!("COMMAND\t{}", launcher.command.join(" "));
+        }
+        LauncherCommands::Rename {
+            target,
+            name,
+            workspace,
+        } => {
+            let name = cli_name(name, "workspace launcher")?;
+            let snapshot = client.snapshot()?;
+            let launcher = resolve_cli_launcher(&snapshot, &target, workspace.as_deref())?;
+            client.rename_launcher(&launcher.id, &name)?;
+            println!("Renamed launcher {} to {name}", launcher.name);
+        }
+        LauncherCommands::Remove { target, workspace } => {
+            let snapshot = client.snapshot()?;
+            let launcher = resolve_cli_launcher(&snapshot, &target, workspace.as_deref())?;
+            client.remove_launcher(&launcher.id)?;
+            println!("Removed launcher {}", launcher.name);
+        }
+    }
+    Ok(())
+}
+
 fn list_workspace_shells(json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let shell = current_shell(&client)?;
@@ -1129,10 +1332,16 @@ fn json_snapshot(snapshot: Snapshot) -> Result<serde_json::Value, Box<dyn Error>
                 .iter()
                 .map(|shell| cli_output::shell(shell, Some(&workspace.name)))
                 .collect::<Vec<_>>();
+            let launchers = workspace
+                .launchers
+                .iter()
+                .map(|launcher| cli_output::launcher(launcher, Some(&workspace.name)))
+                .collect::<Vec<_>>();
             serde_json::json!({
                 "id": workspace.id,
                 "name": workspace.name,
                 "shells": shells,
+                "launchers": launchers,
             })
         })
         .collect::<Vec<_>>();
@@ -1251,6 +1460,58 @@ fn resolve_cli_shell<'a>(
     resolve_shell_target(snapshot, Some(workspace_id), target)
 }
 
+fn resolve_cli_launcher<'a>(
+    snapshot: &'a Snapshot,
+    target: &str,
+    workspace: Option<&str>,
+) -> Result<&'a WorkspaceLauncherSnapshot, Box<dyn Error>> {
+    if let Some(launcher) = find_launcher(snapshot, target) {
+        return Ok(launcher);
+    }
+    let workspace_id = if let Some(workspace) = workspace {
+        resolve_workspace_target(&snapshot.workspaces, workspace)?
+            .id
+            .as_str()
+    } else {
+        let current_shell_id = env::var("BOOMUX_SHELL_ID").map_err(|_| {
+            cli_output::failure(
+                "context_required",
+                format!(
+                    "launcher name {target:?} requires --workspace outside a Boomux-managed shell"
+                ),
+            )
+        })?;
+        find_shell(snapshot, &current_shell_id)
+            .map(|shell| shell.workspace_id.as_str())
+            .ok_or_else(|| {
+                cli_output::failure("not_found", "current Boomux shell no longer exists")
+            })?
+    };
+    let workspace = snapshot
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == workspace_id)
+        .ok_or_else(|| cli_output::failure("not_found", "current workspace no longer exists"))?;
+    workspace
+        .launchers
+        .iter()
+        .find(|launcher| launcher.name == target)
+        .ok_or_else(|| {
+            let available = workspace
+                .launchers
+                .iter()
+                .map(|launcher| launcher.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            cli_output::failure(
+                "not_found",
+                format!(
+                    "launcher {target:?} was not found in this workspace; available launchers: {available}"
+                ),
+            )
+        })
+}
+
 fn resolve_shell_target<'a>(
     snapshot: &'a Snapshot,
     current_workspace_id: Option<&str>,
@@ -1313,6 +1574,14 @@ fn find_shell<'a>(snapshot: &'a Snapshot, id: &str) -> Option<&'a ShellSnapshot>
         .find(|shell| shell.id == id)
 }
 
+fn find_launcher<'a>(snapshot: &'a Snapshot, id: &str) -> Option<&'a WorkspaceLauncherSnapshot> {
+    snapshot
+        .workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.launchers)
+        .find(|launcher| launcher.id == id)
+}
+
 fn current_shell(client: &client::Client) -> Result<ShellSnapshot, Box<dyn Error>> {
     let shell_id = env::var("BOOMUX_SHELL_ID").map_err(|_| {
         cli_output::failure(
@@ -1364,17 +1633,76 @@ fn open_workspace(
     workspace: &WorkspaceSnapshot,
     terminal: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
-    if workspace.shells.is_empty() {
-        return Err(format!("workspace {} has no shells", workspace.name).into());
+    if workspace.shells.is_empty() && workspace.launchers.is_empty() {
+        return Err(format!("workspace {} has no shells or launchers", workspace.name).into());
+    }
+    let mut failures = Vec::new();
+    for launcher in &workspace.launchers {
+        if let Err(error) = invoke_workspace_launcher(workspace, launcher) {
+            failures.push(format!("launcher {}: {error}", launcher.name));
+        }
     }
     for shell in &workspace.shells {
-        open_terminal(
+        if let Err(error) = open_terminal(
             &shell.id,
             &format!("{} - {}", workspace.name, shell.name),
             true,
             terminal,
-        )?;
+        ) {
+            failures.push(format!("shell {}: {error}", shell.name));
+        }
     }
+    if !failures.is_empty() {
+        return Err(io::Error::other(format!(
+            "workspace {} opened with failures: {}",
+            workspace.name,
+            failures.join("; ")
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+fn invoke_workspace_launcher(
+    workspace: &WorkspaceSnapshot,
+    launcher: &WorkspaceLauncherSnapshot,
+) -> io::Result<()> {
+    let (executable, arguments) = launcher
+        .command
+        .split_first()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "launcher command is empty"))?;
+    let mut command = Command::new(executable);
+    command
+        .args(arguments)
+        .current_dir(&launcher.cwd)
+        .env("BOOMUX_WORKSPACE_ID", &workspace.id)
+        .env("BOOMUX_WORKSPACE", &workspace.name)
+        .env("BOOMUX_LAUNCHER_ID", &launcher.id)
+        .env("BOOMUX_LAUNCHER_NAME", &launcher.name)
+        .env_remove("BOOMUX_SHELL_ID")
+        .env_remove("BOOMUX_SHELL_NAME")
+        .env_remove("BOOMUX_RUN_ID")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // The child has not executed user code yet; `setsid` detaches it from the
+    // invoking terminal while preserving the client's desktop environment.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command.spawn()?;
+    thread::Builder::new()
+        .name(format!("launcher-reaper-{}", launcher.id))
+        .spawn(move || {
+            let _ = child.wait();
+        })
+        .map_err(|error| io::Error::other(format!("could not start launcher reaper: {error}")))?;
     Ok(())
 }
 
@@ -1643,6 +1971,17 @@ mod tests {
             id: id.into(),
             name: name.into(),
             shells,
+            launchers: Vec::new(),
+        }
+    }
+
+    fn launcher(id: &str, workspace_id: &str, name: &str) -> WorkspaceLauncherSnapshot {
+        WorkspaceLauncherSnapshot {
+            id: id.into(),
+            workspace_id: workspace_id.into(),
+            name: name.into(),
+            cwd: PathBuf::from("/tmp/project"),
+            command: vec!["zeditor".into(), ".".into()],
         }
     }
 
@@ -1685,6 +2024,14 @@ mod tests {
             vec!["boomux", "--json", "capabilities"],
             vec!["boomux", "list", "--json"],
             vec!["boomux", "workspace", "list", "--json"],
+            vec![
+                "boomux",
+                "launcher",
+                "list",
+                "--workspace",
+                "project",
+                "--json",
+            ],
             vec!["boomux", "daemon", "status", "--json"],
         ] {
             let cli = Cli::try_parse_from(arguments).unwrap();
@@ -1746,6 +2093,42 @@ mod tests {
             }) if name == "project"
         ));
         let cli = Cli::try_parse_from([
+            "boomux",
+            "launcher",
+            "create",
+            "editor",
+            "--workspace",
+            "project",
+            "--cwd",
+            "/tmp",
+            "--",
+            "zeditor",
+            ".",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Launcher {
+                command: LauncherCommands::Create {
+                    name,
+                    workspace,
+                    cwd,
+                    command,
+                }
+            }) if name == "editor"
+                && workspace == "project"
+                && cwd == Path::new("/tmp")
+                && command == ["zeditor", "."]
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "workspace", "open", "project"])
+                .unwrap()
+                .command,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::Open { target }
+            }) if target == "project"
+        ));
+        let cli = Cli::try_parse_from([
             "boomux", "shell", "create", "project", "--name", "tests", "--cwd", "/tmp", "--",
             "cargo", "test",
         ])
@@ -1768,8 +2151,10 @@ mod tests {
 
     #[test]
     fn resolves_workspaces_and_shell_names_for_cli_commands() {
+        let mut project = workspace("w1", "project", vec![shell("s1", "w1", "tests")]);
+        project.launchers.push(launcher("l1", "w1", "editor"));
         let snapshot = Snapshot {
-            workspaces: vec![workspace("w1", "project", vec![shell("s1", "w1", "tests")])],
+            workspaces: vec![project],
         };
 
         assert_eq!(
@@ -1783,6 +2168,16 @@ mod tests {
                 .unwrap()
                 .id,
             "s1"
+        );
+        assert_eq!(
+            resolve_cli_launcher(&snapshot, "editor", Some("project"))
+                .unwrap()
+                .id,
+            "l1"
+        );
+        assert_eq!(
+            resolve_cli_launcher(&snapshot, "l1", None).unwrap().name,
+            "editor"
         );
         assert!(resolve_workspace_target(&snapshot.workspaces, "missing").is_err());
     }
@@ -1848,6 +2243,45 @@ mod tests {
         let error = open_workspace(&workspace("w1", "empty", Vec::new()), None).unwrap_err();
 
         assert!(error.to_string().contains("workspace empty has no shells"));
+    }
+
+    #[test]
+    fn workspace_open_continues_after_a_launcher_spawn_failure() {
+        let marker = env::temp_dir().join(format!("boomux-launcher-{}", Uuid::new_v4()));
+        let mut workspace = workspace("w1", "launchers", Vec::new());
+        workspace.launchers = vec![
+            WorkspaceLauncherSnapshot {
+                id: "l1".into(),
+                workspace_id: "w1".into(),
+                name: "missing".into(),
+                cwd: env::temp_dir(),
+                command: vec!["/boomux-command-does-not-exist".into()],
+            },
+            WorkspaceLauncherSnapshot {
+                id: "l2".into(),
+                workspace_id: "w1".into(),
+                name: "later".into(),
+                cwd: env::temp_dir(),
+                command: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    "printf launched > \"$1\"".into(),
+                    "launcher".into(),
+                    marker.display().to_string(),
+                ],
+            },
+        ];
+
+        let error = open_workspace(&workspace, None).unwrap_err();
+        assert!(error.to_string().contains("launcher missing"));
+        for _ in 0..100 {
+            if marker.is_file() {
+                break;
+            }
+            thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert_eq!(fs::read_to_string(&marker).unwrap(), "launched");
+        fs::remove_file(marker).unwrap();
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 7;
+pub const PROTOCOL_VERSION: u32 = 8;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -38,6 +38,24 @@ pub struct WorkspaceSnapshot {
     pub id: String,
     pub name: String,
     pub shells: Vec<ShellSnapshot>,
+    #[serde(default)]
+    pub launchers: Vec<WorkspaceLauncherSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceLauncherSpec {
+    pub name: String,
+    pub command: Vec<String>,
+    pub cwd: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceLauncherSnapshot {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+    pub command: Vec<String>,
+    pub cwd: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -140,6 +158,20 @@ pub enum DaemonEventKind {
         workspace_id: Option<String>,
         shell_id: String,
     },
+    LauncherCreated {
+        workspace_id: String,
+        launcher_id: String,
+        name: String,
+    },
+    LauncherRenamed {
+        workspace_id: String,
+        launcher_id: String,
+        name: String,
+    },
+    LauncherRemoved {
+        workspace_id: String,
+        launcher_id: String,
+    },
     RunStarted {
         workspace_id: String,
         shell_id: String,
@@ -202,6 +234,9 @@ pub enum Request {
     GetShell {
         shell_id: String,
     },
+    GetLauncher {
+        launcher_id: String,
+    },
     CreateWorkspace {
         name: String,
         shells: Vec<ShellSpec>,
@@ -210,6 +245,10 @@ pub enum Request {
         #[serde(default)]
         workspace_id: Option<String>,
         shell: ShellSpec,
+    },
+    CreateLauncher {
+        workspace_id: String,
+        spec: WorkspaceLauncherSpec,
     },
     ReadShell {
         shell_id: String,
@@ -241,11 +280,18 @@ pub enum Request {
         shell_id: String,
         name: String,
     },
+    RenameLauncher {
+        launcher_id: String,
+        name: String,
+    },
     CloseWorkspace {
         workspace_id: String,
     },
     CloseShell {
         shell_id: String,
+    },
+    RemoveLauncher {
+        launcher_id: String,
     },
     Attach {
         shell_id: String,
@@ -266,6 +312,9 @@ pub enum Response {
     },
     Shell {
         shell: ShellSnapshot,
+    },
+    Launcher {
+        launcher: WorkspaceLauncherSnapshot,
     },
     Output {
         bytes: Vec<u8>,
@@ -503,6 +552,33 @@ mod tests {
         .unwrap();
 
         assert!(snapshot.run.is_none());
+    }
+
+    #[test]
+    fn workspace_snapshot_accepts_protocol_seven_payload_without_launchers() {
+        let snapshot = serde_json::from_str::<WorkspaceSnapshot>(
+            r#"{"id":"w1","name":"workspace","shells":[]}"#,
+        )
+        .unwrap();
+
+        assert!(snapshot.launchers.is_empty());
+    }
+
+    #[test]
+    fn launcher_request_round_trips_exact_argv() {
+        let request = Request::CreateLauncher {
+            workspace_id: "w1".into(),
+            spec: WorkspaceLauncherSpec {
+                name: "editor".into(),
+                command: vec!["editor".into(), "".into(), "two words".into()],
+                cwd: "/tmp/project".into(),
+            },
+        };
+
+        let encoded = serde_json::to_vec(&request).unwrap();
+        let decoded: Request = serde_json::from_slice(&encoded).unwrap();
+
+        assert_eq!(decoded, request);
     }
 
     #[test]

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -11,7 +11,8 @@ use uuid::Uuid;
 
 use crate::protocol::{ShellRunExitReason, TerminalProfile};
 
-const STATE_VERSION: u32 = 2;
+const STATE_VERSION: u32 = 3;
+const PREVIOUS_STATE_VERSION: u32 = 2;
 const LEGACY_STATE_VERSION: u32 = 1;
 const MAX_STATE_BYTES: u64 = 8 * 1024 * 1024;
 
@@ -37,6 +38,16 @@ pub(crate) struct PersistedWorkspace {
     pub(crate) id: String,
     pub(crate) name: String,
     pub(crate) shells: Vec<PersistedShell>,
+    pub(crate) launchers: Vec<PersistedWorkspaceLauncher>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PersistedWorkspaceLauncher {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) cwd: PathBuf,
+    pub(crate) command: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -65,6 +76,21 @@ pub(crate) struct PersistedShellRun {
 #[derive(Deserialize)]
 struct StateVersion {
     version: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PreviousPersistedState {
+    version: u32,
+    workspaces: Vec<PreviousPersistedWorkspace>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PreviousPersistedWorkspace {
+    id: String,
+    name: String,
+    shells: Vec<PersistedShell>,
 }
 
 #[derive(Deserialize)]
@@ -186,6 +212,12 @@ impl StateStore {
         })?;
         let state = match version.version {
             STATE_VERSION => parse_state(&bytes, &self.path)?,
+            PREVIOUS_STATE_VERSION => {
+                let previous: PreviousPersistedState = parse_state(&bytes, &self.path)?;
+                let state = migrate_previous_state(previous);
+                self.save(&state)?;
+                state
+            }
             LEGACY_STATE_VERSION => {
                 let legacy: LegacyPersistedState = parse_state(&bytes, &self.path)?;
                 let state = migrate_legacy_state(legacy);
@@ -276,6 +308,24 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
                         }),
                     })
                     .collect(),
+                launchers: Vec::new(),
+            })
+            .collect(),
+    }
+}
+
+fn migrate_previous_state(previous: PreviousPersistedState) -> PersistedState {
+    debug_assert_eq!(previous.version, PREVIOUS_STATE_VERSION);
+    PersistedState {
+        version: STATE_VERSION,
+        workspaces: previous
+            .workspaces
+            .into_iter()
+            .map(|workspace| PersistedWorkspace {
+                id: workspace.id,
+                name: workspace.name,
+                shells: workspace.shells,
+                launchers: Vec::new(),
             })
             .collect(),
     }
@@ -339,6 +389,20 @@ mod tests {
                 id: Uuid::new_v4().to_string(),
                 name: "saved".into(),
                 shells: Vec::new(),
+                launchers: vec![
+                    PersistedWorkspaceLauncher {
+                        id: "launcher-1".into(),
+                        name: "editor".into(),
+                        cwd: "/tmp/project".into(),
+                        command: vec!["editor".into(), "".into(), "two words".into()],
+                    },
+                    PersistedWorkspaceLauncher {
+                        id: "launcher-2".into(),
+                        name: "server".into(),
+                        cwd: "/tmp/project/server".into(),
+                        command: vec!["server".into()],
+                    },
+                ],
             }],
         };
 
@@ -346,6 +410,21 @@ mod tests {
         let restored = store.load().unwrap().unwrap();
 
         assert_eq!(restored.workspaces[0].name, "saved");
+        assert_eq!(restored.workspaces[0].launchers[0].id, "launcher-1");
+        assert_eq!(restored.workspaces[0].launchers[0].name, "editor");
+        assert_eq!(
+            restored.workspaces[0].launchers[0].cwd,
+            Path::new("/tmp/project")
+        );
+        assert_eq!(
+            restored.workspaces[0].launchers[0].command,
+            vec![
+                String::from("editor"),
+                String::new(),
+                String::from("two words")
+            ]
+        );
+        assert_eq!(restored.workspaces[0].launchers[1].id, "launcher-2");
         assert_eq!(
             fs::metadata(directory.join("boomux/state.json"))
                 .unwrap()
@@ -422,8 +501,9 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 2")
+                .contains("\"version\": 3")
         );
+        assert!(migrated.workspaces[0].launchers.is_empty());
 
         let reloaded = store.load().unwrap().unwrap();
         assert_eq!(
@@ -433,6 +513,44 @@ mod tests {
                 .unwrap()
                 .id,
             run_id
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_two_to_empty_launcher_lists() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            br#"{
+  "version": 2,
+  "workspaces": [{
+    "id": "5bb1712a-8d4e-4998-bca2-a79aa673ca8f",
+    "name": "version-two",
+    "shells": [{
+      "id": "75dd46b5-6cd3-407a-813a-13e1b10f3614",
+      "name": "agent",
+      "cwd": "/tmp",
+      "command": ["opencode"],
+      "last_run": null
+    }]
+  }]
+}"#,
+        )
+        .unwrap();
+        let store = StateStore::at(path.clone());
+
+        let migrated = store.load().unwrap().unwrap();
+
+        assert_eq!(migrated.workspaces[0].name, "version-two");
+        assert_eq!(migrated.workspaces[0].shells[0].name, "agent");
+        assert!(migrated.workspaces[0].launchers.is_empty());
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("\"version\": 3")
         );
         fs::remove_dir_all(directory).unwrap();
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -26,6 +26,7 @@ pub(crate) struct WorkspaceView {
     pub(crate) id: String,
     pub(crate) name: String,
     pub(crate) terminals: Vec<TerminalView>,
+    pub(crate) launcher_count: usize,
 }
 
 #[derive(Clone)]
@@ -133,6 +134,7 @@ struct PendingClose {
     target: CloseTarget,
     name: String,
     shell_count: usize,
+    launcher_count: usize,
 }
 
 impl ProjectPicker {
@@ -449,11 +451,13 @@ impl App {
                 target: CloseTarget::Workspace(workspace.id.clone()),
                 name: workspace.name.clone(),
                 shell_count: workspace.terminals.len(),
+                launcher_count: workspace.launcher_count,
             }),
             Focus::Terminals => self.selected_terminal().map(|terminal| PendingClose {
                 target: CloseTarget::Shell(terminal.id.clone()),
                 name: terminal.name.clone(),
                 shell_count: 1,
+                launcher_count: 0,
             }),
         };
     }
@@ -730,9 +734,9 @@ fn render(frame: &mut Frame, app: &mut App) {
     .areas(area);
 
     render_header(frame, header_area, app);
-    if dashboard_area.width >= 108 {
+    if dashboard_area.width >= 114 {
         let [workspace_area, terminal_area] =
-            Layout::horizontal([Constraint::Length(28), Constraint::Fill(1)]).areas(dashboard_area);
+            Layout::horizontal([Constraint::Length(34), Constraint::Fill(1)]).areas(dashboard_area);
         render_workspaces(frame, workspace_area, app);
         render_terminals(frame, terminal_area, app);
     } else {
@@ -853,6 +857,11 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         .iter()
         .map(|workspace| workspace.terminals.len())
         .sum();
+    let launcher_count: usize = app
+        .workspaces
+        .iter()
+        .map(|workspace| workspace.launcher_count)
+        .sum();
     let line = Line::from(vec![
         Span::styled(
             " BOOMUX ",
@@ -864,6 +873,11 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         ),
         Span::styled("  |  ", Style::new().fg(OVERLAY)),
         Span::styled(format!("{shell_count} shells"), Style::new().fg(BLUE)),
+        Span::styled("  |  ", Style::new().fg(OVERLAY)),
+        Span::styled(
+            format!("{launcher_count} launchers"),
+            Style::new().fg(YELLOW),
+        ),
         Span::styled(
             "    tab/h/l/arrows switches panes",
             Style::new().fg(SUBTEXT),
@@ -877,28 +891,37 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
         Row::new([
             Cell::from(workspace.name.as_str()),
             Cell::from(workspace.terminals.len().to_string()),
+            Cell::from(workspace.launcher_count.to_string()),
         ])
     });
-    let table = Table::new(rows, [Constraint::Min(12), Constraint::Length(6)])
-        .header(
-            Row::new(["NAME", "SHELLS"]).style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)),
-        )
-        .column_spacing(1)
-        .block(
-            Block::bordered()
-                .title(format!(" Workspaces ({}) ", app.workspaces.len()))
-                .border_style(Style::new().fg(if app.focus == Focus::Workspaces {
-                    TEAL
-                } else {
-                    OVERLAY
-                })),
-        )
-        .row_highlight_style(
-            Style::new()
-                .fg(TEXT)
-                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
-        )
-        .highlight_symbol("> ");
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Min(8),
+            Constraint::Length(6),
+            Constraint::Length(9),
+        ],
+    )
+    .header(
+        Row::new(["NAME", "SHELLS", "LAUNCHERS"])
+            .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)),
+    )
+    .column_spacing(1)
+    .block(
+        Block::bordered()
+            .title(format!(" Workspaces ({}) ", app.workspaces.len()))
+            .border_style(Style::new().fg(if app.focus == Focus::Workspaces {
+                TEAL
+            } else {
+                OVERLAY
+            })),
+    )
+    .row_highlight_style(
+        Style::new()
+            .fg(TEXT)
+            .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+    )
+    .highlight_symbol("> ");
 
     frame.render_stateful_widget(table, area, &mut app.workspace_state);
 }
@@ -1008,8 +1031,8 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
     let line = if let Some(pending) = &app.pending_close {
         let prompt = match pending.target {
             CloseTarget::Workspace(_) => format!(
-                " Close workspace '{}' and terminate {} shell(s)?  ",
-                pending.name, pending.shell_count
+                " Close workspace '{}', terminate {} shell(s), and remove {} launcher(s)?  ",
+                pending.name, pending.shell_count, pending.launcher_count
             ),
             CloseTarget::Shell(_) => {
                 format!(
@@ -1150,6 +1173,7 @@ mod tests {
                 directory: "/tmp/boomux".into(),
                 branch: "main".into(),
             }],
+            launcher_count: 0,
         }
     }
 

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 use boomux::client::{Attachment, Client, RemoteError};
 use boomux::protocol::{
     self, AttachFrame, ErrorCode, ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile,
+    WorkspaceLauncherSpec,
 };
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use uuid::Uuid;
@@ -1098,6 +1099,169 @@ fn attachment_client_reconnects_across_daemon_restart() {
 }
 
 #[test]
+fn workspace_launchers_persist_emit_events_and_open_without_shells() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace("launcher-only", Vec::new())
+        .unwrap();
+    let cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let output = daemon.runtime_dir.join("launcher-output");
+    let first = daemon
+        .client
+        .create_launcher(
+            &workspace.id,
+            WorkspaceLauncherSpec {
+                name: "editor".into(),
+                cwd: daemon.runtime_dir.clone(),
+                command: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    "printf '%s|%s|%s|%s|%s' \"$PWD\" \"$BOOMUX_WORKSPACE_ID\" \"$BOOMUX_WORKSPACE\" \"$BOOMUX_LAUNCHER_ID\" \"$BOOMUX_LAUNCHER_NAME\" > \"$1\"".into(),
+                    "launcher".into(),
+                    output.display().to_string(),
+                ],
+            },
+        )
+        .unwrap();
+    let second = daemon
+        .client
+        .create_launcher(
+            &workspace.id,
+            WorkspaceLauncherSpec {
+                name: "browser".into(),
+                cwd: daemon.runtime_dir.clone(),
+                command: vec!["/bin/true".into()],
+            },
+        )
+        .unwrap();
+    let snapshot = daemon.client.get_workspace(&workspace.id).unwrap();
+    assert_eq!(
+        snapshot
+            .launchers
+            .iter()
+            .map(|launcher| launcher.name.as_str())
+            .collect::<Vec<_>>(),
+        ["editor", "browser"]
+    );
+    let events = daemon.client.events(Some(cursor.clone()), 256, 0).unwrap();
+    assert_eq!(
+        events
+            .events
+            .iter()
+            .filter(|event| matches!(
+                event.kind,
+                protocol::DaemonEventKind::LauncherCreated { .. }
+            ))
+            .count(),
+        2
+    );
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    let restored = daemon.client.get_workspace(&workspace.id).unwrap();
+    assert_eq!(restored.launchers[0].id, first.id);
+    assert_eq!(restored.launchers[1].id, second.id);
+    let listed = daemon
+        .command()
+        .args(["launcher", "list", "--workspace", &workspace.id, "--json"])
+        .output()
+        .unwrap();
+    assert!(listed.status.success());
+    let listed: serde_json::Value = serde_json::from_slice(&listed.stdout).unwrap();
+    assert_eq!(listed["schema"], "boomux.cli/v1");
+    assert_eq!(listed["command"], "launcher.list");
+    assert_eq!(listed["data"]["launchers"][0]["id"], first.id);
+    assert_eq!(
+        listed["data"]["launchers"][0]["command"],
+        serde_json::json!(first.command)
+    );
+
+    let opened = daemon
+        .command()
+        .args(["workspace", "open", &workspace.id])
+        .output()
+        .unwrap();
+    assert!(
+        opened.status.success(),
+        "launcher-only workspace failed to open: {}",
+        String::from_utf8_lossy(&opened.stderr)
+    );
+    wait_until(|| output.is_file(), "workspace launcher did not run");
+    assert_eq!(
+        fs::read_to_string(&output).unwrap(),
+        format!(
+            "{}|{}|{}|{}|{}",
+            daemon.runtime_dir.display(),
+            workspace.id,
+            workspace.name,
+            first.id,
+            first.name
+        )
+    );
+
+    daemon.client.rename_launcher(&first.id, "zed").unwrap();
+    assert_eq!(daemon.client.get_launcher(&first.id).unwrap().name, "zed");
+    daemon.client.remove_launcher(&second.id).unwrap();
+    assert_eq!(
+        daemon
+            .client
+            .get_workspace(&workspace.id)
+            .unwrap()
+            .launchers
+            .len(),
+        1
+    );
+    let events = daemon.client.events(Some(cursor), 256, 0).unwrap();
+    assert!(events.events.iter().any(|event| matches!(
+        event.kind,
+        protocol::DaemonEventKind::LauncherRenamed { .. }
+    )));
+    assert!(events.events.iter().any(|event| matches!(
+        event.kind,
+        protocol::DaemonEventKind::LauncherRemoved { .. }
+    )));
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    assert_eq!(
+        daemon
+            .client
+            .get_workspace(&workspace.id)
+            .unwrap()
+            .launchers
+            .iter()
+            .map(|launcher| launcher.name.as_str())
+            .collect::<Vec<_>>(),
+        ["zed"]
+    );
+    daemon.client.close_workspace(&workspace.id).unwrap();
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    assert!(
+        daemon
+            .client
+            .snapshot()
+            .unwrap()
+            .workspaces
+            .iter()
+            .all(|current| current.id != workspace.id)
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn native_daemon_lifecycle() {
     let mut daemon = TestDaemon::start();
 
@@ -1110,7 +1274,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 7);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 8);
     assert!(
         capabilities["data"]["json_commands"]
             .as_array()
@@ -1132,7 +1296,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 7"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 8"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- add durable ordered workspace launcher definitions with protocol-8 CRUD, persistence migration, coordinator events, and protocol-7 compatibility
- invoke detached exact-argv launchers on every explicit workspace open before restoring shell windows, including launcher-only workspaces and aggregate failure reporting
- add CLI management, JSON inspection, dashboard counts, documentation, glossary, ADR, Agent Skill coverage, and end-to-end tests

## Verification
- `cargo test --all-targets` (128 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`