### PR TITLE
Add run-scoped agent runtime

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boomux
-description: Inspect and manage Boomux persistent terminal workspaces, launchers, and shells. Use when asked to discover shells, read terminal output, create or open workspaces and shells, configure desktop application launchers, inspect status, rename or close targets, or manage the Boomux daemon.
-compatibility: Requires boomux on PATH. Some shell-name operations require Boomux workspace context or an explicit --workspace.
+description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, and run-scoped agent instances. Use when asked to discover shells or agents, read terminal output, report an agent lifecycle state, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
+compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; agent mutation requires exact shell-run context.
 metadata:
   author: boomux
-  version: "3"
+  version: "4"
 ---
 
 # Boomux
@@ -58,6 +58,18 @@ Use `boomux read TARGET --json --run-id RUN_ID --after-revision REVISION
 --wait-ms 30000` to wait for run-scoped output changes; handle `run_changed` by
 inspecting the shell again.
 
+Discover and inspect durable agent instances with:
+
+```console
+boomux agent list --json
+boomux agent list --workspace "<workspace-name-or-id>" --json
+boomux agent inspect "<exact-agent-id>" --json
+```
+
+Agent lookup is by exact agent ID. Never infer an agent ID or run ID from a
+name, shell status, terminal text, a recently seen row, or an external session
+ID.
+
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.
 `boomux read` and top-level `boomux close` require an exact shell ID outside a
@@ -68,6 +80,37 @@ Shell status meanings:
 - `pending`: metadata exists; the PTY and process start on first attachment.
 - `running`: the process and PTY are live, attached or detached.
 - `exited`: the process ended; bounded reconstructed terminal state remains.
+
+## Report Agent Lifecycle
+
+Use these mutation commands only for a lifecycle integration that directly
+observes the external agent session:
+
+```console
+boomux agent register "<name>" --integration "<integration>" --external-session-id "<id>" --shell-id "<shell-id>" --run-id "<run-id>" --state working --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100
+boomux agent report "<exact-agent-id>" --shell-id "<same-shell-id>" --run-id "<original-run-id>" --state blocked --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100
+boomux agent report "<exact-agent-id>" --shell-id "<same-shell-id>" --run-id "<original-run-id>" --state done --authority lifecycle-integration --evidence "<completion evidence>" --confidence 100
+```
+
+`--external-session-id` is optional. Inside the target managed process,
+`--shell-id` and `--run-id` default to `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID`;
+otherwise pass both explicitly. Retain the exact agent ID returned by
+`register` and use it for every later report. Also retain the original run ID:
+never replace it with a newer run from the durable shell.
+
+Every registration and report requires an explicit state (`unknown`, `working`,
+`blocked`, `idle`, or `done`), authority (`lifecycle-integration`,
+`process-adapter`, `terminal-heuristic`, or `daemon-lifecycle`), nonempty
+evidence, and confidence from 0 through 100. Report only what the stated
+authority actually observed. In particular, report `done` only after direct
+lifecycle completion evidence, never because output is quiet, a prompt appears,
+or the shell exits. `done` is terminal; the durable completed instance remains
+inspectable and rejects later reports.
+
+If `register` or `report` returns `run_changed`, stop reporting for that
+instance and reacquire exact lifecycle context. Do not guess the replacement
+run. Boomux does not yet provide agent heuristics, adapters, wait/read commands,
+notifications, or control.
 
 ## Read Shell Output
 
@@ -227,6 +270,11 @@ across attachment changes and graceful daemon handoff, but changes when the same
 durable shell starts a new process after recovery. A process transferred from a
 legacy daemon may have a daemon-side run identity without this environment
 variable; inspect `environment_has_run_id` before relying on it.
+
+For such a legacy run, do not invent `BOOMUX_RUN_ID` or select a run from
+history. Obtain the exact daemon-side run ID through `shell inspect --json` and
+pass it explicitly only when the lifecycle integration is known to belong to
+that same live process.
 
 `boomux prompt` prints `workspace/shell` inside Boomux and nothing outside it.
 It is intended for prompt integrations. Use `boomux --help` and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,3 +12,10 @@ shell or shell run.
 
 A durable workspace slot whose process runs are retained and observable across attachments and
 daemon lifecycle transitions. A shell is distinct from a workspace launcher.
+
+## Agent Instance
+
+A durable identity for one external agent session associated with exactly one shell run. Its
+observed state records authority, evidence, confidence, and time. A completed agent instance
+remains inspectable; subagents and individual tool calls are not separate agent instances unless
+they establish independent external sessions.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ The selected workspace's shell table also includes configured launchers. A
 launcher row shows its command and working directory; pressing `Enter` invokes
 only that launcher.
 
+The table also shows registered agent instances, including completed instances.
+Agent rows are read-only: they can be inspected but not opened, renamed, or
+closed from the dashboard.
+
 Closing a terminal window only disconnects its attachment. The Boomux daemon
 retains the PTY and child process until the shell exits, the workspace is
 closed, or the daemon stops.
@@ -117,6 +121,10 @@ boomux launcher create <name> --workspace <name-or-id> [--cwd <path>] -- <comman
 boomux launcher inspect <launcher-name-or-id> [--workspace <name-or-id>]
 boomux launcher rename <launcher-name-or-id> <new-name> [--workspace <name-or-id>]
 boomux launcher remove <launcher-name-or-id> [--workspace <name-or-id>]
+boomux agent list [--workspace <name-or-id>]
+boomux agent inspect <agent-id>
+boomux agent register <name> --integration <integration> [--external-session-id <id>] [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
+boomux agent report <agent-id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux daemon status
 boomux daemon restart
 boomux daemon stop
@@ -152,11 +160,22 @@ Opening continues after individual launcher or terminal spawn failures and
 reports all failures at the end. Removing a launcher affects future opens only;
 Boomux does not track or terminate applications it previously launched.
 
+Agent instances are durable records for external agent sessions. Each instance
+has its own exact ID and is bound to exactly one shell run, not merely to a
+durable shell. `register` and `report` require explicit `unknown`, `working`,
+`blocked`, `idle`, or `done` state plus authority, evidence, and confidence.
+The authority values are `lifecycle-integration`, `process-adapter`,
+`terminal-heuristic`, and `daemon-lifecycle`. A `done` report completes the
+instance permanently; completed instances remain inspectable across daemon
+restart. Boomux does not yet infer agent state, wait for agents, read through an
+agent API, or control agents.
+
 `boomux read` reads plain rendered text from the daemon's shadow VT state. It
 understands cursor rewrites and terminal soft wrapping, retains up to 2,000
 scrollback rows per shell, and never returns ANSI control sequences.
 
-Read-only integration commands accept `--json` and emit the stable
+Read-only integration commands, including `agent list` and `agent inspect`,
+accept `--json` and emit the stable
 `boomux.cli/v1` envelope. Run `boomux capabilities --json` to discover supported
 commands, features, and typed error codes without starting the daemon. See
 [`docs/cli-json.md`](docs/cli-json.md) for the contract.
@@ -205,7 +224,11 @@ Workspace and shell IDs remain authoritative after a rename. `BOOMUX_RUN_ID`
 identifies one process incarnation and changes when a durable shell starts a
 new process after recovery. A live process transferred from a pre-run-identity
 daemon receives a daemon-side run identity, but its existing environment cannot
-be retrofitted; `shell inspect` reports that compatibility case. A dynamic
+be retrofitted; `shell inspect` reports that compatibility case as
+`environment_has_run_id: false`. Agent `register` and `report` default their
+shell and run arguments from `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID`.
+Integrations outside that exact environment must pass both IDs and must not
+guess a run from shell status or retained output. A dynamic
 Starship segment can call the hidden prompt command:
 
 ```toml
@@ -225,10 +248,10 @@ boomux skill install
 
 It is written to `~/.agents/skills/boomux/SKILL.md` and teaches compatible
 agents to discover, inspect, read, create, open, rename, and close Boomux
-workspaces and shells through the full public CLI. Re-run with `--force` to
-replace an older customized installation. An untouched legacy `boomux-shells`
-skill is removed automatically; customized legacy content is preserved with a
-warning.
+workspaces and shells, and to inspect and explicitly report run-scoped agent
+lifecycle, through the full public CLI. Re-run with `--force` to replace an
+older customized installation. An untouched legacy `boomux-shells` skill is
+removed automatically; customized legacy content is preserved with a warning.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ name resolution, and conversion from daemon snapshots into TUI view models.
 with a four-byte big-endian length prefix. Attachment traffic uses small binary
 frames for input, output, resize, and detach events.
 
-The domain has four durable identities:
+The domain has five durable identities:
 
 - A workspace is a globally named shell container with a UUID. It has no path
   or working directory.
@@ -46,6 +46,10 @@ The domain has four durable identities:
 - A workspace launcher is a named, ordered, exact argument-vector command with
   its own working directory. Its identity is durable, but each detached
   invocation is ephemeral and has no PTY or retained runtime state.
+- An agent instance identifies one external agent session and is bound to
+  exactly one shell run. It owns no process or PTY. Its latest explicit
+  observation records state, reporting authority, evidence, confidence,
+  revision, and time; completion is terminal and durable.
 
 There are no separate tab, pane, and terminal identity layers.
 
@@ -82,6 +86,7 @@ The daemon supports:
 - One writable attachment with explicit takeover
 - PTY input and resize forwarding
 - Pending shell metadata and first-attachment terminal negotiation
+- Run-scoped agent registration, inspection, and explicit state reports
 
 An empty shell specification list remains empty. When an explicit populated
 creation is requested, the daemon stages every child before publishing any of
@@ -130,6 +135,10 @@ Git information is collected independently from shell directories and cached;
 empty or mixed-directory workspaces have no workspace-level directory or Git
 identity.
 
+Agent instances appear as workspace counts and read-only rows. Completed rows
+remain visible and inspectable; dashboard actions do not open, rename, close, or
+otherwise control an agent.
+
 ### Agent Skill
 
 The optional vendor-neutral `boomux` Agent Skill documents the complete public
@@ -158,6 +167,14 @@ still read workspace snapshots because launcher lists are additive; launcher
 events are filtered from protocol-7 event pages while their cursors continue to
 advance.
 
+Protocol 9 adds agent instances to workspace and event snapshots and adds exact
+ID get, register, and report requests. Protocol-8 and older responses omit agent
+snapshot fields and filter agent events while preserving the unfiltered cursor.
+The daemon owns agent IDs, observation revisions, timestamps, completion, and
+durable storage. External lifecycle integrations own the meaning and evidence
+of their reports; this slice does not discover processes, parse terminal output,
+wait for agents, or control them.
+
 ### Transition Coordinator
 
 The daemon serializes observable runtime transitions through one coordinator. A
@@ -185,6 +202,11 @@ not persisted per chunk, but output revision mutation and `output_changed`
 publication cross the coordinator together. A non-blocking terminal lock keeps
 output processing from holding global locks while waiting on terminal snapshots.
 
+Agent registration and reports use the same durable mutation coordinator.
+Persistence and `agent_registered`, `agent_state_changed`, or
+`agent_completed` publication therefore share the normal ordering boundary and
+baseline snapshots include the exact coordinated cut.
+
 ## Runtime Semantics
 
 Closing a terminal window closes only its socket attachment. The daemon retains
@@ -200,9 +222,10 @@ to the complete registry and removes the runtime socket.
 
 The daemon atomically writes reproducible registry metadata to
 `$XDG_STATE_HOME/boomux/state.json`, falling back to
-`~/.local/state/boomux/state.json`. Workspace, launcher, and shell IDs, names,
-grouping, working directories, argument vectors, and last terminal profiles
-survive restart. The last run record also preserves its identity and outcome. Recovered
+`~/.local/state/boomux/state.json`. Workspace, launcher, shell, and agent IDs;
+names and grouping; working directories; argument vectors; agent observations;
+and last terminal profiles survive restart. The last run record also preserves
+its identity and outcome. Recovered
 shells are pending: Boomux does not claim that arbitrary
 processes, mutated environments, or PTYs survive daemon restart or crash.
 
@@ -221,8 +244,6 @@ as pending.
 
 ## Next Technical Steps
 
-The detailed design, acceptance criteria, and manual test matrix are tracked in
-[`native-terminal-follow-up.md`](native-terminal-follow-up.md).
-
-1. Model agent instances separately from shells and runs, with explicit state
-   authority, evidence, and confidence.
+Future agent runtime work is tracked in [`roadmap.md`](roadmap.md). Process
+adapters, terminal heuristics, aggregation, waits, notifications, and control are
+not part of the first agent runtime slice.

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -34,6 +34,8 @@ The following commands support `--json`:
 - `boomux shell inspect`
 - `boomux launcher list`
 - `boomux launcher inspect`
+- `boomux agent list`
+- `boomux agent inspect`
 - `boomux daemon status`
 
 Mutation commands intentionally retain human output for now. Passing `--json`
@@ -46,13 +48,15 @@ Command payloads are:
   features, and error codes.
 - `list`: a `shells` array.
 - `shells`: workspace identity plus a `shells` array.
-- `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`, and
-  `launcher_count`.
+- `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`,
+  `launcher_count`, and `agent_count`.
 - `workspace.inspect`: one `workspace` object containing `id`, `name`, and
-  `shells` and `launchers` arrays.
+  `shells`, `launchers`, and `agents` arrays.
 - `shell.inspect`: one `shell` object.
 - `launcher.list`: workspace identity plus a `launchers` array.
 - `launcher.inspect`: one `launcher` object.
+- `agent.list`: an `agents` array, optionally limited by `--workspace`.
+- `agent.inspect`: one `agent` object selected by exact agent ID.
 - `read`: shell/run identity, observed output revision, and rendered output.
 - `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
   bounded event array.
@@ -71,6 +75,19 @@ A run object includes `id`, `generation`, `started_at_ms`, `ended_at_ms`,
 
 Launcher objects include `id`, `workspace_id`, `workspace_name`, `name`, `cwd`,
 and `command`. `command` is the exact executable-and-arguments array.
+
+Agent objects include stable fields `id`, `workspace_id`, `workspace_name`,
+`shell_id`, `run_id`, `name`, `integration`, `external_session_id`,
+`started_at_ms`, `ended_at_ms`, and `observation`. The observation contains
+`revision`, `state`, `authority`, `evidence`, `confidence`, and
+`observed_at_ms`. Missing optional values are JSON `null`.
+
+Agent `state` is `unknown`, `working`, `blocked`, `idle`, or `done`. `authority`
+is `lifecycle_integration`, `process_adapter`, `terminal_heuristic`, or
+`daemon_lifecycle`; CLI arguments use hyphens instead of underscores. Confidence
+is an integer from 0 through 100. Observation revisions begin at 1 and increase
+with each accepted report. `done` is terminal and has a non-null `ended_at_ms`;
+completed records remain durable and inspectable.
 
 `read` returns `shell_id`, `run_id`, `output_revision`, `changed`, `status`, and
 `output`. Output is a JSON string containing the same bounded plain rendered text
@@ -100,6 +117,6 @@ Failures detected while parsing command-line arguments use `"command": "cli"`
 because no valid command was selected.
 
 The stable codes are reported by `boomux capabilities --json`. Messages remain
-human-readable context and are not stable parsing targets. Daemon protocol 7
-retains the additive protocol-6 error field and adds `cursor_expired`,
-`run_changed`, and `revision_ahead`.
+human-readable context and are not stable parsing targets. `run_changed` means
+a supplied run ID no longer matches the run-scoped operation; integrations must
+reacquire exact context rather than substitute or guess another run.

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -1,9 +1,8 @@
 # Daemon Event Stream
 
-Boomux protocol 7 adds bounded long polling for daemon events and atomic,
-revision-aware terminal reads. Protocol-6 management clients remain compatible;
-new clients negotiate down for legacy requests and reject protocol-7-only
-requests with `unsupported_version`.
+Boomux protocol 7 added bounded long polling for daemon events and atomic,
+revision-aware terminal reads. Protocol 9 adds run-scoped agent snapshots and
+events while retaining negotiation with older management clients.
 
 ## Cursors
 
@@ -27,17 +26,30 @@ the durable registry remains the cold-recovery authority.
 
 ## Events
 
-The initial event vocabulary is:
+The event vocabulary is:
 
 - `workspace_created`, `workspace_renamed`, `workspace_closed`
 - `shell_created`, `shell_renamed`, `shell_closed`
 - `launcher_created`, `launcher_renamed`, `launcher_removed`
 - `run_started`, `output_changed`, `run_exited`
+- `agent_registered`, `agent_state_changed`, `agent_completed`
 - `handoff_completed`
 
 Output events carry run identity and the latest output revision, not raw PTY
 bytes. Consumers use revision-aware reads to retrieve the current bounded,
 rendered terminal state.
+
+Agent events carry the complete durable agent snapshot, including exact shell
+and run IDs and the latest state, authority, evidence, confidence, observation
+revision, and timestamps. Registration emits `agent_registered`; registration
+as `done` also emits `agent_completed`. Later reports emit
+`agent_state_changed`, except the terminal `done` report emits
+`agent_completed`. Completed instances reject further reports.
+
+Protocol-8 and older event clients do not receive protocol-9 agent snapshots or
+agent events. Filtering does not rewrite the journal: their returned cursor
+still advances across filtered agent events, preserving the stream's total
+publication order. Agent requests themselves require protocol 9.
 
 Event IDs provide one total publication order. The daemon transition coordinator
 couples durable lifecycle mutation, persistence, and event publication. Events
@@ -66,3 +78,7 @@ publication still cross the transition boundary together.
 Revisions are run-scoped reader-batch counters, not byte offsets. Rendered output
 can rewrite earlier cells, so successful reads return complete bounded state
 rather than byte deltas.
+
+`run_changed` is a guard against observing or reporting against another process
+incarnation. Consumers should inspect the shell and decide how to handle the new
+run; they must not silently guess or replace the requested run ID.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,8 +91,8 @@ eternal process.
 
 ### Agent Runtime
 
-1. Model agent instances separately from shells and runs, with explicit state
-   authority, evidence, and confidence.
+1. [Complete] Model agent instances separately from shells and runs, with
+   explicit state authority, evidence, and confidence.
 2. Prefer lifecycle integrations, then process adapters, then conservative
    terminal-screen heuristics for `working`, `blocked`, `idle`, `done`, and
    `unknown` states.

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -5,7 +5,8 @@ use serde::Serialize;
 
 use boomux::client::RemoteError;
 use boomux::protocol::{
-    ErrorCode, ShellRunExitReason, ShellSnapshot, ShellStatus, WorkspaceLauncherSnapshot,
+    AgentAuthority, AgentInstanceSnapshot, AgentState, ErrorCode, ShellRunExitReason,
+    ShellSnapshot, ShellStatus, WorkspaceLauncherSnapshot,
 };
 
 pub(crate) const SCHEMA: &str = "boomux.cli/v1";
@@ -74,6 +75,7 @@ pub(crate) struct WorkspaceSummary {
     pub(crate) name: String,
     pub(crate) shell_count: usize,
     pub(crate) launcher_count: usize,
+    pub(crate) agent_count: usize,
 }
 
 #[derive(Serialize)]
@@ -84,6 +86,31 @@ pub(crate) struct LauncherData {
     pub(crate) name: String,
     pub(crate) cwd: String,
     pub(crate) command: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AgentData {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) workspace_name: Option<String>,
+    pub(crate) shell_id: String,
+    pub(crate) run_id: String,
+    pub(crate) name: String,
+    pub(crate) integration: String,
+    pub(crate) external_session_id: Option<String>,
+    pub(crate) started_at_ms: u64,
+    pub(crate) ended_at_ms: Option<u64>,
+    pub(crate) observation: AgentObservationData,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AgentObservationData {
+    revision: u64,
+    state: &'static str,
+    authority: &'static str,
+    evidence: String,
+    confidence: u8,
+    observed_at_ms: u64,
 }
 
 pub(crate) fn print<T: Serialize>(command: &str, data: T) -> Result<(), Box<dyn Error>> {
@@ -175,6 +202,48 @@ pub(crate) fn launcher(
     }
 }
 
+pub(crate) fn agent(agent: &AgentInstanceSnapshot, workspace_name: Option<&str>) -> AgentData {
+    AgentData {
+        id: agent.id.clone(),
+        workspace_id: agent.workspace_id.clone(),
+        workspace_name: workspace_name.map(str::to_owned),
+        shell_id: agent.shell_id.clone(),
+        run_id: agent.run_id.clone(),
+        name: agent.name.clone(),
+        integration: agent.integration.clone(),
+        external_session_id: agent.external_session_id.clone(),
+        started_at_ms: agent.started_at_ms,
+        ended_at_ms: agent.ended_at_ms,
+        observation: AgentObservationData {
+            revision: agent.observation.revision,
+            state: agent_state(agent.observation.state),
+            authority: agent_authority(agent.observation.authority),
+            evidence: agent.observation.evidence.clone(),
+            confidence: agent.observation.confidence,
+            observed_at_ms: agent.observation.observed_at_ms,
+        },
+    }
+}
+
+pub(crate) fn agent_state(state: AgentState) -> &'static str {
+    match state {
+        AgentState::Unknown => "unknown",
+        AgentState::Working => "working",
+        AgentState::Blocked => "blocked",
+        AgentState::Idle => "idle",
+        AgentState::Done => "done",
+    }
+}
+
+pub(crate) fn agent_authority(authority: AgentAuthority) -> &'static str {
+    match authority {
+        AgentAuthority::LifecycleIntegration => "lifecycle_integration",
+        AgentAuthority::ProcessAdapter => "process_adapter",
+        AgentAuthority::TerminalHeuristic => "terminal_heuristic",
+        AgentAuthority::DaemonLifecycle => "daemon_lifecycle",
+    }
+}
+
 fn classify_error(command: &str, error: &(dyn Error + 'static)) -> &'static str {
     let mut current = Some(error);
     while let Some(candidate) = current {
@@ -231,5 +300,43 @@ fn protocol_error_code(code: ErrorCode) -> &'static str {
         ErrorCode::RevisionAhead => "revision_ahead",
         ErrorCode::Internal => "internal",
         ErrorCode::Unknown => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use boomux::protocol::AgentObservationSnapshot;
+
+    #[test]
+    fn agent_json_uses_the_stable_cli_shape() {
+        let data = agent(
+            &AgentInstanceSnapshot {
+                id: "a1".into(),
+                workspace_id: "w1".into(),
+                shell_id: "s1".into(),
+                run_id: "r1".into(),
+                name: "opencode".into(),
+                integration: "plugin".into(),
+                external_session_id: Some("external-1".into()),
+                started_at_ms: 10,
+                ended_at_ms: None,
+                observation: AgentObservationSnapshot {
+                    revision: 2,
+                    state: AgentState::Working,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "tool call".into(),
+                    confidence: 95,
+                    observed_at_ms: 11,
+                },
+            },
+            Some("project"),
+        );
+
+        let value = serde_json::to_value(data).unwrap();
+        assert_eq!(value["workspace_name"], "project");
+        assert_eq!(value["observation"]["state"], "working");
+        assert_eq!(value["observation"]["authority"], "lifecycle_integration");
+        assert_eq!(value["observation"]["confidence"], 95);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,9 +13,9 @@ use std::thread;
 use std::time::Duration;
 
 use crate::protocol::{
-    self, DaemonEvent, Envelope, ErrorCode, EventCursor, Request, Response, ShellSnapshot,
-    ShellSpec, ShellStatus, Snapshot, TerminalProfile, WorkspaceLauncherSnapshot,
-    WorkspaceLauncherSpec, WorkspaceSnapshot,
+    self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, DaemonEvent, Envelope,
+    ErrorCode, EventCursor, Request, Response, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
+    TerminalProfile, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -321,6 +321,15 @@ impl Client {
         }
     }
 
+    pub fn get_agent(&self, agent_id: impl Into<String>) -> io::Result<AgentInstanceSnapshot> {
+        match self.request(Request::GetAgent {
+            agent_id: agent_id.into(),
+        })? {
+            Response::Agent { agent } => Ok(agent),
+            other => unexpected(other),
+        }
+    }
+
     pub fn create_workspace(
         &self,
         name: impl Into<String>,
@@ -369,6 +378,38 @@ impl Client {
             spec,
         })? {
             Response::Launcher { launcher } => Ok(launcher),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn register_agent(
+        &self,
+        shell_id: impl Into<String>,
+        run_id: impl Into<String>,
+        spec: AgentRegistrationSpec,
+    ) -> io::Result<AgentInstanceSnapshot> {
+        match self.request(Request::RegisterAgent {
+            shell_id: shell_id.into(),
+            run_id: run_id.into(),
+            spec,
+        })? {
+            Response::Agent { agent } => Ok(agent),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn report_agent(
+        &self,
+        agent_id: impl Into<String>,
+        run_id: impl Into<String>,
+        report: AgentReport,
+    ) -> io::Result<AgentInstanceSnapshot> {
+        match self.request(Request::ReportAgent {
+            agent_id: agent_id.into(),
+            run_id: run_id.into(),
+            report,
+        })? {
+            Response::Agent { agent } => Ok(agent),
             other => unexpected(other),
         }
     }
@@ -543,6 +584,7 @@ fn request_minimum_version(request: &Request) -> u32 {
         | Request::CreateLauncher { .. }
         | Request::RenameLauncher { .. }
         | Request::RemoveLauncher { .. } => 8,
+        Request::GetAgent { .. } | Request::RegisterAgent { .. } | Request::ReportAgent { .. } => 9,
         Request::ReadShellAt { .. } | Request::Events { .. } => 7,
         _ => protocol::MIN_PROTOCOL_VERSION,
     }
@@ -659,6 +701,40 @@ mod tests {
     }
 
     #[test]
+    fn agent_requests_require_protocol_nine() {
+        let report = AgentReport {
+            state: protocol::AgentState::Idle,
+            authority: protocol::AgentAuthority::TerminalHeuristic,
+            evidence: "prompt visible".into(),
+            confidence: 70,
+        };
+        let requests = [
+            Request::GetAgent {
+                agent_id: "a1".into(),
+            },
+            Request::RegisterAgent {
+                shell_id: "s1".into(),
+                run_id: "r1".into(),
+                spec: AgentRegistrationSpec {
+                    name: "agent".into(),
+                    integration: "test".into(),
+                    external_session_id: None,
+                    report: report.clone(),
+                },
+            },
+            Request::ReportAgent {
+                agent_id: "a1".into(),
+                run_id: "r1".into(),
+                report,
+            },
+        ];
+
+        for request in requests {
+            assert_eq!(request_minimum_version(&request), 9);
+        }
+    }
+
+    #[test]
     fn negotiates_protocol_seven_without_losing_version_seven_requests() {
         let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
@@ -667,15 +743,31 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 9);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    9,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 8);
             assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    7,
+                    8,
                     Response::Error {
                         message: "expected protocol 7".into(),
-                        code: None,
+                        code: Some(ErrorCode::UnsupportedVersion),
                     },
                 ),
             )

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,12 +23,13 @@ use crate::client;
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::protocol::{
-    self, AttachFrame, DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, Request,
-    Response, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus,
+    self, AgentInstanceSnapshot, AgentObservationSnapshot, AgentRegistrationSpec, AgentReport,
+    AgentState, AttachFrame, DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor,
+    Request, Response, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus,
     Snapshot, TerminalProfile, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::state_store::{
-    PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
+    PersistedAgentInstance, PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
     PersistedWorkspaceLauncher, StateStore,
 };
 use crate::terminal_state::TerminalState;
@@ -41,6 +42,7 @@ const IO_RETRY_DELAY: Duration = Duration::from_millis(2);
 const PERSIST_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_TERMINAL_ENV_VALUE: usize = 256;
 const MAX_NAME_BYTES: usize = 256;
+const MAX_AGENT_EVIDENCE_BYTES: usize = 4 * 1024;
 const MAX_TERMINAL_ROWS: u16 = 1_000;
 const MAX_TERMINAL_COLS: u16 = 1_000;
 const MAX_TERMINAL_CELLS: usize = 1_000_000;
@@ -583,6 +585,21 @@ fn handle_connection(
             ),
         );
     }
+    if response_version < 9
+        && matches!(
+            request.message,
+            Request::GetAgent { .. } | Request::RegisterAgent { .. } | Request::ReportAgent { .. }
+        )
+    {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "request requires daemon protocol 9",
+            ),
+        );
+    }
 
     if let Request::Attach {
         shell_id,
@@ -687,24 +704,45 @@ fn handle_connection(
 }
 
 fn response_for_version(response: Response, version: u32) -> Response {
-    if version >= 8 {
+    if version >= 9 {
         return response;
     }
     match response {
+        Response::Snapshot { mut snapshot } => {
+            remove_agent_snapshots(&mut snapshot);
+            Response::Snapshot { snapshot }
+        }
+        Response::Workspace { mut workspace } => {
+            workspace.agents.clear();
+            Response::Workspace { workspace }
+        }
         Response::Events {
             stream_id,
             cursor,
-            snapshot,
+            mut snapshot,
             mut events,
         } => {
+            if let Some(snapshot) = &mut snapshot {
+                remove_agent_snapshots(snapshot);
+            }
             events.retain(|event| {
                 !matches!(
                     event.kind,
-                    DaemonEventKind::LauncherCreated { .. }
-                        | DaemonEventKind::LauncherRenamed { .. }
-                        | DaemonEventKind::LauncherRemoved { .. }
+                    DaemonEventKind::AgentRegistered { .. }
+                        | DaemonEventKind::AgentStateChanged { .. }
+                        | DaemonEventKind::AgentCompleted { .. }
                 )
             });
+            if version < 8 {
+                events.retain(|event| {
+                    !matches!(
+                        event.kind,
+                        DaemonEventKind::LauncherCreated { .. }
+                            | DaemonEventKind::LauncherRenamed { .. }
+                            | DaemonEventKind::LauncherRemoved { .. }
+                    )
+                });
+            }
             Response::Events {
                 stream_id,
                 cursor,
@@ -713,6 +751,12 @@ fn response_for_version(response: Response, version: u32) -> Response {
             }
         }
         response => response,
+    }
+}
+
+fn remove_agent_snapshots(snapshot: &mut Snapshot) {
+    for workspace in &mut snapshot.workspaces {
+        workspace.agents.clear();
     }
 }
 
@@ -877,17 +921,21 @@ struct RegistryState {
     workspaces: HashMap<String, Arc<Workspace>>,
     shells: HashMap<String, Arc<Shell>>,
     launchers: HashMap<String, Arc<WorkspaceLauncher>>,
+    agents: HashMap<String, Arc<AgentInstance>>,
 }
 
 struct RegistryBackup {
     workspaces: HashMap<String, Arc<Workspace>>,
     shells: HashMap<String, Arc<Shell>>,
     launchers: HashMap<String, Arc<WorkspaceLauncher>>,
+    agents: HashMap<String, Arc<AgentInstance>>,
     workspace_names: HashMap<String, String>,
     workspace_shell_ids: HashMap<String, Vec<String>>,
     workspace_launcher_ids: HashMap<String, Vec<String>>,
+    workspace_agent_ids: HashMap<String, Vec<String>>,
     shell_names: HashMap<String, String>,
     launcher_names: HashMap<String, String>,
+    agent_states: HashMap<String, AgentInstanceState>,
 }
 
 impl Default for Registry {
@@ -910,6 +958,25 @@ struct Workspace {
     name: Mutex<String>,
     shell_ids: Mutex<Vec<String>>,
     launcher_ids: Mutex<Vec<String>>,
+    agent_ids: Mutex<Vec<String>>,
+}
+
+struct AgentInstance {
+    id: String,
+    workspace_id: String,
+    shell_id: String,
+    run_id: String,
+    name: String,
+    integration: String,
+    external_session_id: Option<String>,
+    started_at_ms: u64,
+    state: Mutex<AgentInstanceState>,
+}
+
+#[derive(Clone)]
+struct AgentInstanceState {
+    ended_at_ms: Option<u64>,
+    observation: AgentObservationSnapshot,
 }
 
 struct WorkspaceLauncher {
@@ -1429,6 +1496,9 @@ impl Registry {
             Request::GetLauncher { launcher_id } => Ok(Response::Launcher {
                 launcher: self.launcher(&launcher_id)?.snapshot()?,
             }),
+            Request::GetAgent { agent_id } => Ok(Response::Agent {
+                agent: self.agent(&agent_id)?.snapshot()?,
+            }),
             Request::CreateWorkspace { name, shells } => self.durable_mutation(|| {
                 let workspace = self.create_workspace(name, shells)?;
                 let events = workspace_created_events(&workspace);
@@ -1466,6 +1536,47 @@ impl Registry {
                     name: launcher.name.clone(),
                 };
                 Ok((Response::Launcher { launcher }, vec![event]))
+            }),
+            Request::RegisterAgent {
+                shell_id,
+                run_id,
+                spec,
+            } => self.durable_mutation(|| {
+                let agent = self.register_agent(&shell_id, &run_id, spec)?;
+                let mut events = vec![DaemonEventKind::AgentRegistered {
+                    workspace_id: agent.workspace_id.clone(),
+                    shell_id: agent.shell_id.clone(),
+                    agent: agent.clone(),
+                }];
+                if agent.ended_at_ms.is_some() {
+                    events.push(DaemonEventKind::AgentCompleted {
+                        workspace_id: agent.workspace_id.clone(),
+                        shell_id: agent.shell_id.clone(),
+                        agent: agent.clone(),
+                    });
+                }
+                Ok((Response::Agent { agent }, events))
+            }),
+            Request::ReportAgent {
+                agent_id,
+                run_id,
+                report,
+            } => self.durable_mutation(|| {
+                let (agent, completed) = self.report_agent(&agent_id, &run_id, report)?;
+                let event = if completed {
+                    DaemonEventKind::AgentCompleted {
+                        workspace_id: agent.workspace_id.clone(),
+                        shell_id: agent.shell_id.clone(),
+                        agent: agent.clone(),
+                    }
+                } else {
+                    DaemonEventKind::AgentStateChanged {
+                        workspace_id: agent.workspace_id.clone(),
+                        shell_id: agent.shell_id.clone(),
+                        agent: agent.clone(),
+                    }
+                };
+                Ok((Response::Agent { agent }, vec![event]))
             }),
             Request::ReadShell {
                 shell_id,
@@ -1650,6 +1761,7 @@ impl Registry {
         let mut state = RegistryState::default();
         let mut workspace_names = HashSet::new();
         let mut run_ids = HashSet::new();
+        let mut agent_ids = HashSet::new();
         let mut recovered_interrupted_run = false;
         for saved_workspace in persisted.workspaces {
             validate_id("workspace", &saved_workspace.id)?;
@@ -1739,11 +1851,31 @@ impl Registry {
                 launcher_ids.push(launcher.id.clone());
                 state.launchers.insert(launcher.id.clone(), launcher);
             }
+            let mut workspace_agent_ids = Vec::with_capacity(saved_workspace.agents.len());
+            for saved_agent in saved_workspace.agents {
+                validate_id("agent", &saved_agent.id)?;
+                validate_id("agent shell", &saved_agent.shell_id)?;
+                validate_id("agent run", &saved_agent.run_id)?;
+                validate_persisted_agent(&saved_agent)?;
+                if !agent_ids.insert(saved_agent.id.clone()) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Boomux state contains a duplicate agent instance",
+                    ));
+                }
+                let agent = Arc::new(AgentInstance::from_persisted(
+                    &saved_workspace.id,
+                    saved_agent,
+                ));
+                workspace_agent_ids.push(agent.id.clone());
+                state.agents.insert(agent.id.clone(), agent);
+            }
             let workspace = Arc::new(Workspace {
                 id: saved_workspace.id.clone(),
                 name: Mutex::new(saved_workspace.name),
                 shell_ids: Mutex::new(shell_ids),
                 launcher_ids: Mutex::new(launcher_ids),
+                agent_ids: Mutex::new(workspace_agent_ids),
             });
             state.workspaces.insert(saved_workspace.id, workspace);
         }
@@ -2139,11 +2271,13 @@ impl Registry {
         let mut workspace_names = HashMap::new();
         let mut workspace_shell_ids = HashMap::new();
         let mut workspace_launcher_ids = HashMap::new();
+        let mut workspace_agent_ids = HashMap::new();
         for workspace in state.workspaces.values() {
             workspace_names.insert(workspace.id.clone(), lock(&workspace.name)?.clone());
             workspace_shell_ids.insert(workspace.id.clone(), lock(&workspace.shell_ids)?.clone());
             workspace_launcher_ids
                 .insert(workspace.id.clone(), lock(&workspace.launcher_ids)?.clone());
+            workspace_agent_ids.insert(workspace.id.clone(), lock(&workspace.agent_ids)?.clone());
         }
         let mut shell_names = HashMap::new();
         for shell in state.shells.values() {
@@ -2153,15 +2287,22 @@ impl Registry {
         for launcher in state.launchers.values() {
             launcher_names.insert(launcher.id.clone(), lock(&launcher.name)?.clone());
         }
+        let mut agent_states = HashMap::new();
+        for agent in state.agents.values() {
+            agent_states.insert(agent.id.clone(), lock(&agent.state)?.clone());
+        }
         Ok(RegistryBackup {
             workspaces: state.workspaces.clone(),
             shells: state.shells.clone(),
             launchers: state.launchers.clone(),
+            agents: state.agents.clone(),
             workspace_names,
             workspace_shell_ids,
             workspace_launcher_ids,
+            workspace_agent_ids,
             shell_names,
             launcher_names,
+            agent_states,
         })
     }
 
@@ -2177,6 +2318,9 @@ impl Registry {
             if let Some(ids) = backup.workspace_launcher_ids.get(&workspace.id) {
                 *lock(&workspace.launcher_ids)? = ids.clone();
             }
+            if let Some(ids) = backup.workspace_agent_ids.get(&workspace.id) {
+                *lock(&workspace.agent_ids)? = ids.clone();
+            }
         }
         for shell in backup.shells.values() {
             if let Some(name) = backup.shell_names.get(&shell.id) {
@@ -2188,9 +2332,15 @@ impl Registry {
                 *lock(&launcher.name)? = name.clone();
             }
         }
+        for agent in backup.agents.values() {
+            if let Some(agent_state) = backup.agent_states.get(&agent.id) {
+                *lock(&agent.state)? = agent_state.clone();
+            }
+        }
         state.workspaces = backup.workspaces;
         state.shells = backup.shells;
         state.launchers = backup.launchers;
+        state.agents = backup.agents;
         Ok(())
     }
 
@@ -2235,11 +2385,20 @@ impl Registry {
                     command: launcher.command.clone(),
                 });
             }
+            let ids = lock(&workspace.agent_ids)?.clone();
+            let mut agents = Vec::with_capacity(ids.len());
+            for id in ids {
+                let Some(agent) = state.agents.get(&id) else {
+                    continue;
+                };
+                agents.push(agent.persisted()?);
+            }
             saved.workspaces.push(PersistedWorkspace {
                 id: workspace.id.clone(),
                 name: lock(&workspace.name)?.clone(),
                 shells,
                 launchers,
+                agents,
             });
         }
         drop(state);
@@ -2383,6 +2542,7 @@ impl Registry {
         state.workspaces.clear();
         state.shells.clear();
         state.launchers.clear();
+        state.agents.clear();
         drop(state);
         drop(events);
         drop(transition);
@@ -2414,6 +2574,14 @@ impl Registry {
             .get(id)
             .cloned()
             .ok_or_else(|| not_found("workspace launcher", id))
+    }
+
+    fn agent(&self, id: &str) -> io::Result<Arc<AgentInstance>> {
+        lock(&self.state)?
+            .agents
+            .get(id)
+            .cloned()
+            .ok_or_else(|| not_found("agent instance", id))
     }
 
     fn contains_shell(&self, shell: &Arc<Shell>) -> io::Result<bool> {
@@ -2451,6 +2619,7 @@ impl Registry {
             name: Mutex::new(name),
             shell_ids: Mutex::new(shells.iter().map(|shell| shell.id.clone()).collect()),
             launcher_ids: Mutex::new(Vec::new()),
+            agent_ids: Mutex::new(Vec::new()),
         });
         {
             let mut state = lock(&self.state)?;
@@ -2571,6 +2740,113 @@ impl Registry {
             .insert(launcher.id.clone(), Arc::clone(&launcher));
         launcher_ids.push(launcher.id.clone());
         Ok(snapshot)
+    }
+
+    fn register_agent(
+        &self,
+        shell_id: &str,
+        run_id: &str,
+        spec: AgentRegistrationSpec,
+    ) -> io::Result<AgentInstanceSnapshot> {
+        validate_agent_registration(&spec)?;
+        let shell = self.shell(shell_id)?;
+        let lifecycle = lock(&shell.lifecycle)?;
+        match &*lifecycle {
+            ShellLifecycle::Running { run, .. } if run.id == run_id => {}
+            ShellLifecycle::Running { .. }
+            | ShellLifecycle::Exited { .. }
+            | ShellLifecycle::Pending => {
+                return Err(coded_error(
+                    ErrorCode::RunChanged,
+                    "shell does not have the requested active run",
+                ));
+            }
+            ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
+        }
+        let workspace = self.workspace(&shell.workspace_id)?;
+        let started_at_ms = unix_time_ms();
+        let ended_at_ms = (spec.report.state == AgentState::Done).then_some(started_at_ms);
+        let agent = Arc::new(AgentInstance {
+            id: Uuid::new_v4().to_string(),
+            workspace_id: shell.workspace_id.clone(),
+            shell_id: shell.id.clone(),
+            run_id: run_id.into(),
+            name: spec.name,
+            integration: spec.integration,
+            external_session_id: spec.external_session_id,
+            started_at_ms,
+            state: Mutex::new(AgentInstanceState {
+                ended_at_ms,
+                observation: AgentObservationSnapshot {
+                    revision: 1,
+                    state: spec.report.state,
+                    authority: spec.report.authority,
+                    evidence: spec.report.evidence,
+                    confidence: spec.report.confidence,
+                    observed_at_ms: started_at_ms,
+                },
+            }),
+        });
+        let snapshot = agent.snapshot()?;
+        let mut state = lock(&self.state)?;
+        let Some(current_shell) = state.shells.get(shell_id) else {
+            return Err(not_found("shell", shell_id));
+        };
+        let Some(current_workspace) = state.workspaces.get(&shell.workspace_id) else {
+            return Err(not_found("workspace", &shell.workspace_id));
+        };
+        if !Arc::ptr_eq(current_shell, &shell) || !Arc::ptr_eq(current_workspace, &workspace) {
+            return Err(not_found("shell", shell_id));
+        }
+        state.agents.insert(agent.id.clone(), Arc::clone(&agent));
+        lock(&workspace.agent_ids)?.push(agent.id.clone());
+        drop(lifecycle);
+        Ok(snapshot)
+    }
+
+    fn report_agent(
+        &self,
+        agent_id: &str,
+        run_id: &str,
+        report: AgentReport,
+    ) -> io::Result<(AgentInstanceSnapshot, bool)> {
+        validate_agent_report(&report)?;
+        let agent = self.agent(agent_id)?;
+        if agent.run_id != run_id {
+            return Err(coded_error(
+                ErrorCode::RunChanged,
+                "agent instance is bound to a different shell run",
+            ));
+        }
+        let mut state = lock(&agent.state)?;
+        if state.ended_at_ms.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "completed agent instance cannot be reported again",
+            ));
+        }
+        let revision = state
+            .observation
+            .revision
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("agent observation revision exhausted"))?;
+        let observed_at_ms = unix_time_ms()
+            .max(agent.started_at_ms)
+            .max(state.observation.observed_at_ms);
+        let completed = report.state == AgentState::Done;
+        state.observation = AgentObservationSnapshot {
+            revision,
+            state: report.state,
+            authority: report.authority,
+            evidence: report.evidence,
+            confidence: report.confidence,
+            observed_at_ms,
+        };
+        if completed {
+            state.ended_at_ms = Some(observed_at_ms);
+        }
+        drop(state);
+        Ok((agent.snapshot()?, completed))
     }
 
     fn rename_launcher(&self, launcher_id: &str, name: String) -> io::Result<()> {
@@ -2851,6 +3127,9 @@ impl Registry {
             for id in lock(&workspace.launcher_ids)?.iter() {
                 state.launchers.remove(id);
             }
+            for id in lock(&workspace.agent_ids)?.iter() {
+                state.agents.remove(id);
+            }
             let ids = lock(&workspace.shell_ids)?.clone();
             ids.into_iter()
                 .filter_map(|id| state.shells.remove(&id))
@@ -2979,7 +3258,7 @@ impl Registry {
 
 impl Workspace {
     fn snapshot(&self, registry: &Registry) -> io::Result<WorkspaceSnapshot> {
-        let (shells, launchers) = {
+        let (shells, launchers, agents) = {
             let state = lock(&registry.state)?;
             let shell_ids = lock(&self.shell_ids)?;
             let shells = shell_ids
@@ -2991,7 +3270,12 @@ impl Workspace {
                 .iter()
                 .filter_map(|id| state.launchers.get(id).cloned())
                 .collect::<Vec<_>>();
-            (shells, launchers)
+            let agent_ids = lock(&self.agent_ids)?;
+            let agents = agent_ids
+                .iter()
+                .filter_map(|id| state.agents.get(id).cloned())
+                .collect::<Vec<_>>();
+            (shells, launchers, agents)
         };
         let shells = shells
             .iter()
@@ -3001,11 +3285,16 @@ impl Workspace {
             .iter()
             .map(|launcher| launcher.snapshot())
             .collect::<io::Result<_>>()?;
+        let agents = agents
+            .iter()
+            .map(|agent| agent.snapshot())
+            .collect::<io::Result<_>>()?;
         Ok(WorkspaceSnapshot {
             id: self.id.clone(),
             name: lock(&self.name)?.clone(),
             shells,
             launchers,
+            agents,
         })
     }
 }
@@ -3018,6 +3307,56 @@ impl WorkspaceLauncher {
             name: lock(&self.name)?.clone(),
             command: self.command.clone(),
             cwd: self.cwd.clone(),
+        })
+    }
+}
+
+impl AgentInstance {
+    fn from_persisted(workspace_id: &str, saved: PersistedAgentInstance) -> Self {
+        Self {
+            id: saved.id,
+            workspace_id: workspace_id.into(),
+            shell_id: saved.shell_id,
+            run_id: saved.run_id,
+            name: saved.name,
+            integration: saved.integration,
+            external_session_id: saved.external_session_id,
+            started_at_ms: saved.started_at_ms,
+            state: Mutex::new(AgentInstanceState {
+                ended_at_ms: saved.ended_at_ms,
+                observation: saved.observation,
+            }),
+        }
+    }
+
+    fn snapshot(&self) -> io::Result<AgentInstanceSnapshot> {
+        let state = lock(&self.state)?;
+        Ok(AgentInstanceSnapshot {
+            id: self.id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            shell_id: self.shell_id.clone(),
+            run_id: self.run_id.clone(),
+            name: self.name.clone(),
+            integration: self.integration.clone(),
+            external_session_id: self.external_session_id.clone(),
+            started_at_ms: self.started_at_ms,
+            ended_at_ms: state.ended_at_ms,
+            observation: state.observation.clone(),
+        })
+    }
+
+    fn persisted(&self) -> io::Result<PersistedAgentInstance> {
+        let snapshot = self.snapshot()?;
+        Ok(PersistedAgentInstance {
+            id: snapshot.id,
+            shell_id: snapshot.shell_id,
+            run_id: snapshot.run_id,
+            name: snapshot.name,
+            integration: snapshot.integration,
+            external_session_id: snapshot.external_session_id,
+            started_at_ms: snapshot.started_at_ms,
+            ended_at_ms: snapshot.ended_at_ms,
+            observation: snapshot.observation,
         })
     }
 }
@@ -4150,6 +4489,65 @@ fn validate_id(kind: &str, id: &str) -> io::Result<()> {
     })
 }
 
+fn validate_agent_registration(spec: &AgentRegistrationSpec) -> io::Result<()> {
+    validate_name(&spec.name)?;
+    validate_required_agent_string("integration", &spec.integration, MAX_NAME_BYTES)?;
+    if let Some(external_session_id) = &spec.external_session_id {
+        validate_required_agent_string("external_session_id", external_session_id, MAX_NAME_BYTES)?;
+    }
+    validate_agent_report(&spec.report)
+}
+
+fn validate_agent_report(report: &AgentReport) -> io::Result<()> {
+    validate_required_agent_string("evidence", &report.evidence, MAX_AGENT_EVIDENCE_BYTES)?;
+    if report.confidence > 100 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "agent report confidence must be between 0 and 100",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_required_agent_string(kind: &str, value: &str, max_bytes: usize) -> io::Result<()> {
+    if value.trim().is_empty() || value.len() > max_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("agent {kind} must be nonempty and at most {max_bytes} bytes"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_persisted_agent(agent: &PersistedAgentInstance) -> io::Result<()> {
+    validate_persisted_name(&agent.name)?;
+    validate_agent_registration(&AgentRegistrationSpec {
+        name: agent.name.clone(),
+        integration: agent.integration.clone(),
+        external_session_id: agent.external_session_id.clone(),
+        report: AgentReport {
+            state: agent.observation.state,
+            authority: agent.observation.authority,
+            evidence: agent.observation.evidence.clone(),
+            confidence: agent.observation.confidence,
+        },
+    })
+    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    if agent.observation.revision == 0
+        || agent.observation.observed_at_ms < agent.started_at_ms
+        || agent
+            .ended_at_ms
+            .is_some_and(|ended_at_ms| ended_at_ms < agent.started_at_ms)
+        || (agent.observation.state == AgentState::Done) != agent.ended_at_ms.is_some()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux state contains an invalid agent observation",
+        ));
+    }
+    Ok(())
+}
+
 fn not_found(kind: &str, id: &str) -> io::Error {
     io::Error::new(io::ErrorKind::NotFound, format!("{kind} not found: {id}"))
 }
@@ -4165,6 +4563,8 @@ mod tests {
     use super::*;
     use std::sync::Barrier;
 
+    use crate::protocol::{AgentAuthority, AgentState};
+
     fn profile() -> TerminalProfile {
         TerminalProfile {
             term: Some("xterm-256color".into()),
@@ -4176,6 +4576,44 @@ mod tests {
             pixel_width: 0,
             pixel_height: 0,
         }
+    }
+
+    fn agent_spec(state: AgentState) -> AgentRegistrationSpec {
+        AgentRegistrationSpec {
+            name: "test-agent".into(),
+            integration: "daemon-test".into(),
+            external_session_id: Some("external-1".into()),
+            report: AgentReport {
+                state,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "test observation".into(),
+                confidence: 90,
+            },
+        }
+    }
+
+    fn running_shell(registry: &Registry) -> (WorkspaceSnapshot, Arc<Shell>, Arc<ShellRuntime>) {
+        let workspace = registry
+            .create_workspace(
+                "agents".into(),
+                vec![ShellSpec {
+                    name: "agent-shell".into(),
+                    command: vec!["/bin/sleep".into(), "30".into()],
+                    cwd: env::temp_dir(),
+                }],
+            )
+            .unwrap();
+        let shell = registry.shell(&workspace.shells[0].id).unwrap();
+        let run = Arc::new(ShellRun::new(1));
+        let (runtime, _reader) =
+            spawn_runtime(&shell, &run, "agents", "agent-shell", &profile()).unwrap();
+        *lock(&shell.last_run).unwrap() = Some(run.persisted(profile()).unwrap());
+        *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
+            profile: profile(),
+            run,
+            runtime: Arc::clone(&runtime),
+        };
+        (workspace, shell, runtime)
     }
 
     #[test]
@@ -4416,6 +4854,223 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn agent_registration_and_reports_enforce_run_binding_and_complete_monotonically() {
+        let registry = Registry::default();
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+
+        let wrong_run = registry.dispatch(Request::RegisterAgent {
+            shell_id: shell.id.clone(),
+            run_id: Uuid::new_v4().to_string(),
+            spec: agent_spec(AgentState::Working),
+        });
+        assert_eq!(error_code(&wrong_run.unwrap_err()), ErrorCode::RunChanged);
+
+        let Response::Agent { agent } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected registered agent");
+        };
+        assert_eq!(agent.observation.revision, 1);
+        assert!(agent.ended_at_ms.is_none());
+        assert_eq!(
+            error_code(
+                &registry
+                    .dispatch(Request::ReportAgent {
+                        agent_id: agent.id.clone(),
+                        run_id: Uuid::new_v4().to_string(),
+                        report: agent_spec(AgentState::Idle).report,
+                    })
+                    .unwrap_err()
+            ),
+            ErrorCode::RunChanged
+        );
+
+        let Response::Agent { agent } = registry
+            .dispatch(Request::ReportAgent {
+                agent_id: agent.id.clone(),
+                run_id,
+                report: agent_spec(AgentState::Done).report,
+            })
+            .unwrap()
+        else {
+            panic!("expected completed agent");
+        };
+        assert_eq!(agent.observation.revision, 2);
+        assert_eq!(agent.observation.state, AgentState::Done);
+        assert_eq!(agent.ended_at_ms, Some(agent.observation.observed_at_ms));
+        assert_eq!(
+            registry.snapshot().unwrap().workspaces[0].agents,
+            vec![agent.clone()]
+        );
+        {
+            let event_state = lock(&registry.events.state).unwrap();
+            assert!(matches!(
+                event_state.events[0].kind,
+                DaemonEventKind::AgentRegistered { .. }
+            ));
+            assert!(matches!(
+                event_state.events[1].kind,
+                DaemonEventKind::AgentCompleted { .. }
+            ));
+        }
+        assert!(
+            registry
+                .dispatch(Request::ReportAgent {
+                    agent_id: agent.id,
+                    run_id: agent.run_id,
+                    report: agent_spec(AgentState::Idle).report,
+                })
+                .is_err()
+        );
+
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn failed_agent_mutation_restores_observation_revision() {
+        let registry = Registry::default();
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let agent = registry
+            .register_agent(&shell.id, &run_id, agent_spec(AgentState::Working))
+            .unwrap();
+
+        let result: io::Result<()> = registry.durable_mutation(|| {
+            registry.report_agent(&agent.id, &run_id, agent_spec(AgentState::Blocked).report)?;
+            Err(io::Error::other("force rollback"))
+        });
+
+        assert!(result.is_err());
+        let restored = registry.agent(&agent.id).unwrap().snapshot().unwrap();
+        assert_eq!(restored.observation.revision, 1);
+        assert_eq!(restored.observation.state, AgentState::Working);
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn agent_instances_restore_from_daemon_persistence() {
+        let directory = env::temp_dir().join(format!("boomux-agent-restore-{}", Uuid::new_v4()));
+        let path = directory.join("state/state.json");
+        let registry = Registry::restore(StateStore::at(path.clone()), false, None).unwrap();
+        let (_workspace, shell, runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let Response::Agent { agent } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id,
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected registered agent");
+        };
+
+        shell.kill().unwrap();
+        drop(runtime);
+        drop(shell);
+        drop(registry);
+
+        let restored = Registry::restore(StateStore::at(path), false, None).unwrap();
+        assert_eq!(
+            restored.agent(&agent.id).unwrap().snapshot().unwrap(),
+            agent
+        );
+        assert_eq!(
+            restored.snapshot().unwrap().workspaces[0].agents,
+            vec![agent]
+        );
+        drop(restored);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn protocol_eight_responses_hide_agent_snapshots_and_events() {
+        let agent = AgentInstanceSnapshot {
+            id: "a1".into(),
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            name: "agent".into(),
+            integration: "test".into(),
+            external_session_id: None,
+            started_at_ms: 1,
+            ended_at_ms: None,
+            observation: AgentObservationSnapshot {
+                revision: 1,
+                state: AgentState::Working,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "working".into(),
+                confidence: 90,
+                observed_at_ms: 1,
+            },
+        };
+        let workspace = WorkspaceSnapshot {
+            id: "w1".into(),
+            name: "workspace".into(),
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: vec![agent.clone()],
+        };
+        let response = Response::Events {
+            stream_id: "stream".into(),
+            cursor: EventCursor {
+                stream_id: "stream".into(),
+                event_id: 2,
+            },
+            snapshot: Some(Snapshot {
+                workspaces: vec![workspace],
+            }),
+            events: vec![
+                DaemonEvent {
+                    id: 1,
+                    at_ms: 1,
+                    kind: DaemonEventKind::AgentRegistered {
+                        workspace_id: "w1".into(),
+                        shell_id: "s1".into(),
+                        agent,
+                    },
+                },
+                DaemonEvent {
+                    id: 2,
+                    at_ms: 2,
+                    kind: DaemonEventKind::WorkspaceRenamed {
+                        workspace_id: "w1".into(),
+                        name: "renamed".into(),
+                    },
+                },
+            ],
+        };
+
+        let Response::Events {
+            snapshot: Some(snapshot),
+            events,
+            cursor,
+            ..
+        } = response_for_version(response, 8)
+        else {
+            panic!("expected filtered events");
+        };
+        assert!(snapshot.workspaces[0].agents.is_empty());
+        assert_eq!(events.len(), 1);
+        assert_eq!(cursor.event_id, 2);
+        assert!(matches!(
+            events[0].kind,
+            DaemonEventKind::WorkspaceRenamed { .. }
+        ));
+        let encoded =
+            serde_json::to_value(response_for_version(Response::Snapshot { snapshot }, 8)).unwrap();
+        assert!(encoded["snapshot"]["workspaces"][0].get("agents").is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,11 @@ use std::process::{Command, ExitCode, Stdio};
 use std::thread;
 
 use clap::error::ErrorKind as ClapErrorKind;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use uuid::Uuid;
 
 use boomux::protocol::{
+    AgentAuthority, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentState,
     EventCursor, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, WorkspaceLauncherSnapshot,
     WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
@@ -154,6 +155,11 @@ enum Commands {
         #[command(subcommand)]
         command: LauncherCommands,
     },
+    /// Inspect and report external agent runtime state
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommands,
+    },
     /// Manage the vendor-neutral Boomux Agent Skill
     Skill {
         #[command(subcommand)]
@@ -268,6 +274,94 @@ enum ShellCommands {
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
     },
+}
+
+#[derive(Subcommand)]
+enum AgentCommands {
+    /// List agent instances
+    List {
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+    /// Show an agent instance by exact ID
+    #[command(alias = "get")]
+    Inspect { agent_id: String },
+    /// Register an agent instance for a shell run
+    Register {
+        name: String,
+        #[arg(long)]
+        integration: String,
+        #[arg(long)]
+        external_session_id: Option<String>,
+        #[arg(long)]
+        shell_id: Option<String>,
+        #[arg(long)]
+        run_id: Option<String>,
+        #[arg(long, value_enum)]
+        state: CliAgentState,
+        #[arg(long, value_enum)]
+        authority: CliAgentAuthority,
+        #[arg(long)]
+        evidence: String,
+        #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+        confidence: u8,
+    },
+    /// Report state for an agent instance by exact ID
+    Report {
+        agent_id: String,
+        #[arg(long)]
+        shell_id: Option<String>,
+        #[arg(long)]
+        run_id: Option<String>,
+        #[arg(long, value_enum)]
+        state: CliAgentState,
+        #[arg(long, value_enum)]
+        authority: CliAgentAuthority,
+        #[arg(long)]
+        evidence: String,
+        #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+        confidence: u8,
+    },
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum CliAgentState {
+    Unknown,
+    Working,
+    Blocked,
+    Idle,
+    Done,
+}
+
+impl From<CliAgentState> for AgentState {
+    fn from(state: CliAgentState) -> Self {
+        match state {
+            CliAgentState::Unknown => Self::Unknown,
+            CliAgentState::Working => Self::Working,
+            CliAgentState::Blocked => Self::Blocked,
+            CliAgentState::Idle => Self::Idle,
+            CliAgentState::Done => Self::Done,
+        }
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum CliAgentAuthority {
+    LifecycleIntegration,
+    ProcessAdapter,
+    TerminalHeuristic,
+    DaemonLifecycle,
+}
+
+impl From<CliAgentAuthority> for AgentAuthority {
+    fn from(authority: CliAgentAuthority) -> Self {
+        match authority {
+            CliAgentAuthority::LifecycleIntegration => Self::LifecycleIntegration,
+            CliAgentAuthority::ProcessAdapter => Self::ProcessAdapter,
+            CliAgentAuthority::TerminalHeuristic => Self::TerminalHeuristic,
+            CliAgentAuthority::DaemonLifecycle => Self::DaemonLifecycle,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -410,6 +504,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         }
         Some(Commands::Shell { command }) => shell_command(command, cli.json),
         Some(Commands::Launcher { command }) => launcher_command(command, cli.json),
+        Some(Commands::Agent { command }) => agent_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
         }) => install_skill(force),
@@ -450,12 +545,19 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Launcher {
             command: LauncherCommands::Inspect { .. },
         }) => "launcher.inspect",
+        Some(Commands::Agent {
+            command: AgentCommands::List { .. },
+        }) => "agent.list",
+        Some(Commands::Agent {
+            command: AgentCommands::Inspect { .. },
+        }) => "agent.inspect",
         Some(Commands::Daemon {
             command: DaemonCommands::Status,
         }) => "daemon.status",
         Some(Commands::Workspace { .. }) => "workspace",
         Some(Commands::Shell { .. }) => "shell",
         Some(Commands::Launcher { .. }) => "launcher",
+        Some(Commands::Agent { .. }) => "agent",
         Some(Commands::Daemon { .. }) => "daemon",
         Some(Commands::Ui) | None => "ui",
         Some(Commands::Doctor) => "doctor",
@@ -482,6 +584,8 @@ fn supports_json(cli: &Cli) -> bool {
             command: ShellCommands::Inspect { .. }
         }) | Some(Commands::Launcher {
             command: LauncherCommands::List { .. } | LauncherCommands::Inspect { .. }
+        }) | Some(Commands::Agent {
+            command: AgentCommands::List { .. } | AgentCommands::Inspect { .. }
         }) | Some(Commands::Daemon {
             command: DaemonCommands::Status
         })
@@ -712,10 +816,34 @@ fn dashboard_views(
                     command: launcher.command.join(" "),
                 })
             });
+            let agents = workspace.agents.iter().map(|agent| {
+                let shell_name = workspace
+                    .shells
+                    .iter()
+                    .find(|shell| shell.id == agent.shell_id)
+                    .map_or("-", |shell| shell.name.as_str());
+                tui::WorkspaceItemView::Agent(tui::AgentView {
+                    id: agent.id.clone(),
+                    workspace_id: agent.workspace_id.clone(),
+                    run_id: agent.run_id.clone(),
+                    shell_id: agent.shell_id.clone(),
+                    shell_name: shell_name.into(),
+                    name: agent.name.clone(),
+                    state: cli_output::agent_state(agent.observation.state).into(),
+                    integration: agent.integration.clone(),
+                    authority: cli_output::agent_authority(agent.observation.authority).into(),
+                    confidence: agent.observation.confidence,
+                    evidence: agent.observation.evidence.clone(),
+                    external_session_id: agent.external_session_id.clone(),
+                    started_at_ms: agent.started_at_ms,
+                    observed_at_ms: agent.observation.observed_at_ms,
+                    ended_at_ms: agent.ended_at_ms,
+                })
+            });
             tui::WorkspaceView {
                 id: workspace.id.clone(),
                 name: workspace.name.clone(),
-                items: shells.chain(launchers).collect(),
+                items: shells.chain(launchers).chain(agents).collect(),
             }
         })
         .collect()
@@ -892,6 +1020,8 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "shell.inspect",
         "launcher.list",
         "launcher.inspect",
+        "agent.list",
+        "agent.inspect",
         "daemon.status",
     ];
     let features = [
@@ -904,6 +1034,7 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "reconnectable_event_cursors",
         "revision_aware_reads",
         "workspace_launchers",
+        "run_scoped_agent_instances",
     ];
     let error_codes = [
         "invalid_argument",
@@ -994,6 +1125,7 @@ fn workspace_command(
                         name: workspace.name.clone(),
                         shell_count: workspace.shells.len(),
                         launcher_count: workspace.launchers.len(),
+                        agent_count: workspace.agents.len(),
                     })
                     .collect::<Vec<_>>();
                 return cli_output::print(
@@ -1001,14 +1133,15 @@ fn workspace_command(
                     serde_json::json!({ "workspaces": workspaces }),
                 );
             }
-            println!("NAME\tWORKSPACE ID\tSHELLS\tLAUNCHERS");
+            println!("NAME\tWORKSPACE ID\tSHELLS\tLAUNCHERS\tAGENTS");
             for workspace in workspaces {
                 println!(
-                    "{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}",
                     workspace.name,
                     workspace.id,
                     workspace.shells.len(),
-                    workspace.launchers.len()
+                    workspace.launchers.len(),
+                    workspace.agents.len()
                 );
             }
         }
@@ -1048,6 +1181,9 @@ fn workspace_command(
                             "launchers": workspace.launchers.iter()
                                 .map(|launcher| cli_output::launcher(launcher, Some(&workspace.name)))
                                 .collect::<Vec<_>>(),
+                            "agents": workspace.agents.iter()
+                                .map(|agent| cli_output::agent(agent, Some(&workspace.name)))
+                                .collect::<Vec<_>>(),
                         }
                     }),
                 );
@@ -1056,6 +1192,7 @@ fn workspace_command(
             println!("NAME\t{}", workspace.name);
             println!("SHELLS\t{}", workspace.shells.len());
             println!("LAUNCHERS\t{}", workspace.launchers.len());
+            println!("AGENTS\t{}", workspace.agents.len());
             if !workspace.shells.is_empty() {
                 println!("\nNAME\tSHELL ID\tRUN ID\tSTATUS\tCWD");
                 for shell in &workspace.shells {
@@ -1078,6 +1215,20 @@ fn workspace_command(
                         launcher.id,
                         launcher.cwd.display(),
                         launcher.command.join(" ")
+                    );
+                }
+            }
+            if !workspace.agents.is_empty() {
+                println!("\nNAME\tAGENT ID\tSHELL ID\tRUN ID\tSTATE\tINTEGRATION");
+                for agent in &workspace.agents {
+                    println!(
+                        "{}\t{}\t{}\t{}\t{}\t{}",
+                        agent.name,
+                        agent.id,
+                        agent.shell_id,
+                        agent.run_id,
+                        cli_output::agent_state(agent.observation.state),
+                        agent.integration
                     );
                 }
             }
@@ -1286,6 +1437,208 @@ fn launcher_command(command: LauncherCommands, json: bool) -> Result<(), Box<dyn
     Ok(())
 }
 
+fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error>> {
+    let client = client::connect_or_start()?;
+    match command {
+        AgentCommands::List { workspace } => {
+            let snapshot = client.snapshot()?;
+            let workspaces = if let Some(target) = workspace.as_deref() {
+                vec![resolve_workspace_target(&snapshot.workspaces, target)?]
+            } else {
+                snapshot.workspaces.iter().collect()
+            };
+            if json {
+                let agents = workspaces
+                    .iter()
+                    .flat_map(|workspace| {
+                        workspace
+                            .agents
+                            .iter()
+                            .map(|agent| cli_output::agent(agent, Some(&workspace.name)))
+                    })
+                    .collect::<Vec<_>>();
+                return cli_output::print("agent.list", serde_json::json!({ "agents": agents }));
+            }
+            println!("WORKSPACE\tNAME\tAGENT ID\tSHELL ID\tRUN ID\tSTATE\tCONFIDENCE");
+            for workspace in workspaces {
+                for agent in &workspace.agents {
+                    println!(
+                        "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                        workspace.name,
+                        agent.name,
+                        agent.id,
+                        agent.shell_id,
+                        agent.run_id,
+                        cli_output::agent_state(agent.observation.state),
+                        agent.observation.confidence
+                    );
+                }
+            }
+        }
+        AgentCommands::Inspect { agent_id } => {
+            let agent = client.get_agent(agent_id)?;
+            let workspace = client.get_workspace(&agent.workspace_id)?;
+            if json {
+                return cli_output::print(
+                    "agent.inspect",
+                    serde_json::json!({
+                        "agent": cli_output::agent(&agent, Some(&workspace.name)),
+                    }),
+                );
+            }
+            print_agent(&agent, &workspace.name);
+        }
+        AgentCommands::Register {
+            name,
+            integration,
+            external_session_id,
+            shell_id,
+            run_id,
+            state,
+            authority,
+            evidence,
+            confidence,
+        } => {
+            let (shell_id, run_id) = resolve_agent_context(
+                shell_id,
+                run_id,
+                env::var("BOOMUX_SHELL_ID").ok(),
+                env::var("BOOMUX_RUN_ID").ok(),
+            )?;
+            let agent = client.register_agent(
+                shell_id,
+                run_id,
+                AgentRegistrationSpec {
+                    name: cli_name(name, "agent")?,
+                    integration,
+                    external_session_id,
+                    report: AgentReport {
+                        state: state.into(),
+                        authority: authority.into(),
+                        evidence,
+                        confidence,
+                    },
+                },
+            )?;
+            println!("Registered agent {} ({})", agent.name, agent.id);
+        }
+        AgentCommands::Report {
+            agent_id,
+            shell_id,
+            run_id,
+            state,
+            authority,
+            evidence,
+            confidence,
+        } => {
+            let (shell_id, run_id) = resolve_agent_context(
+                shell_id,
+                run_id,
+                env::var("BOOMUX_SHELL_ID").ok(),
+                env::var("BOOMUX_RUN_ID").ok(),
+            )?;
+            let existing = client.get_agent(&agent_id)?;
+            if existing.shell_id != shell_id {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    format!("agent {agent_id} is not bound to shell {shell_id}"),
+                ));
+            }
+            if existing.run_id != run_id {
+                return Err(cli_output::failure(
+                    "run_changed",
+                    format!("agent {agent_id} is not bound to run {run_id}"),
+                ));
+            }
+            let agent = client.report_agent(
+                agent_id,
+                run_id,
+                AgentReport {
+                    state: state.into(),
+                    authority: authority.into(),
+                    evidence,
+                    confidence,
+                },
+            )?;
+            println!(
+                "Reported {} for agent {} (revision {})",
+                cli_output::agent_state(agent.observation.state),
+                agent.id,
+                agent.observation.revision
+            );
+        }
+    }
+    Ok(())
+}
+
+fn resolve_agent_context(
+    shell_id: Option<String>,
+    run_id: Option<String>,
+    environment_shell_id: Option<String>,
+    environment_run_id: Option<String>,
+) -> Result<(String, String), Box<dyn Error>> {
+    let shell_id = agent_context_value("shell ID", shell_id.or(environment_shell_id))?;
+    let run_id = agent_context_value("run ID", run_id.or(environment_run_id))?;
+    match (shell_id, run_id) {
+        (Some(shell_id), Some(run_id)) => Ok((shell_id, run_id)),
+        _ => Err(cli_output::failure(
+            "context_required",
+            "agent commands require both shell and run identity; pass --shell-id and --run-id or set BOOMUX_SHELL_ID and BOOMUX_RUN_ID",
+        )),
+    }
+}
+
+fn agent_context_value(
+    kind: &str,
+    value: Option<String>,
+) -> Result<Option<String>, Box<dyn Error>> {
+    value
+        .map(|value| {
+            let value = value.trim();
+            if value.is_empty() {
+                Err(cli_output::failure(
+                    "invalid_argument",
+                    format!("agent {kind} cannot be empty"),
+                ))
+            } else {
+                Ok(value.to_owned())
+            }
+        })
+        .transpose()
+}
+
+fn print_agent(agent: &AgentInstanceSnapshot, workspace_name: &str) {
+    println!("ID\t{}", agent.id);
+    println!("NAME\t{}", agent.name);
+    println!("WORKSPACE\t{workspace_name}");
+    println!("SHELL ID\t{}", agent.shell_id);
+    println!("RUN ID\t{}", agent.run_id);
+    println!("INTEGRATION\t{}", agent.integration);
+    println!(
+        "EXTERNAL SESSION ID\t{}",
+        agent.external_session_id.as_deref().unwrap_or("-")
+    );
+    println!("STARTED AT MS\t{}", agent.started_at_ms);
+    println!(
+        "ENDED AT MS\t{}",
+        agent
+            .ended_at_ms
+            .map_or_else(|| "-".into(), |value| value.to_string())
+    );
+    println!("REVISION\t{}", agent.observation.revision);
+    println!(
+        "STATE\t{}",
+        cli_output::agent_state(agent.observation.state)
+    );
+    println!(
+        "AUTHORITY\t{}",
+        cli_output::agent_authority(agent.observation.authority)
+    );
+    println!("EVIDENCE\t{}", agent.observation.evidence);
+    println!("CONFIDENCE\t{}", agent.observation.confidence);
+    println!("OBSERVED AT MS\t{}", agent.observation.observed_at_ms);
+}
+
 fn list_workspace_shells(json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let shell = current_shell(&client)?;
@@ -1393,11 +1746,17 @@ fn json_snapshot(snapshot: Snapshot) -> Result<serde_json::Value, Box<dyn Error>
                 .iter()
                 .map(|launcher| cli_output::launcher(launcher, Some(&workspace.name)))
                 .collect::<Vec<_>>();
+            let agents = workspace
+                .agents
+                .iter()
+                .map(|agent| cli_output::agent(agent, Some(&workspace.name)))
+                .collect::<Vec<_>>();
             serde_json::json!({
                 "id": workspace.id,
                 "name": workspace.name,
                 "shells": shells,
                 "launchers": launchers,
+                "agents": agents,
             })
         })
         .collect::<Vec<_>>();
@@ -2028,6 +2387,29 @@ mod tests {
             name: name.into(),
             shells,
             launchers: Vec::new(),
+            agents: Vec::new(),
+        }
+    }
+
+    fn agent(id: &str, workspace_id: &str, shell_id: &str) -> AgentInstanceSnapshot {
+        AgentInstanceSnapshot {
+            id: id.into(),
+            workspace_id: workspace_id.into(),
+            shell_id: shell_id.into(),
+            run_id: "r1".into(),
+            name: "opencode".into(),
+            integration: "plugin".into(),
+            external_session_id: Some("external-1".into()),
+            started_at_ms: 10,
+            ended_at_ms: None,
+            observation: protocol::AgentObservationSnapshot {
+                revision: 1,
+                state: AgentState::Working,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "tool call".into(),
+                confidence: 95,
+                observed_at_ms: 11,
+            },
         }
     }
 
@@ -2206,6 +2588,121 @@ mod tests {
     }
 
     #[test]
+    fn parses_agent_runtime_commands_and_json_support() {
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "agent",
+            "register",
+            "opencode",
+            "--integration",
+            "plugin",
+            "--shell-id",
+            "s1",
+            "--run-id",
+            "r1",
+            "--state",
+            "working",
+            "--authority",
+            "lifecycle-integration",
+            "--evidence",
+            "tool call",
+            "--confidence",
+            "95",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Agent {
+                command: AgentCommands::Register { confidence: 95, .. }
+            })
+        ));
+
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "agent",
+            "list",
+            "--workspace",
+            "project",
+            "--json",
+        ])
+        .unwrap();
+        assert!(supports_json(&cli));
+        let cli = Cli::try_parse_from(["boomux", "agent", "get", "a1", "--json"]).unwrap();
+        assert_eq!(command_name(&cli), "agent.inspect");
+        assert!(supports_json(&cli));
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "agent",
+            "report",
+            "a1",
+            "--state",
+            "done",
+            "--authority",
+            "lifecycle-integration",
+            "--evidence",
+            "complete",
+            "--confidence",
+            "100",
+            "--json",
+        ])
+        .unwrap();
+        assert!(!supports_json(&cli));
+        assert!(
+            Cli::try_parse_from([
+                "boomux",
+                "agent",
+                "report",
+                "a1",
+                "--state",
+                "done",
+                "--authority",
+                "lifecycle-integration",
+                "--evidence",
+                "complete",
+                "--confidence",
+                "101",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn agent_context_requires_nonempty_shell_and_run_ids() {
+        assert_eq!(
+            resolve_agent_context(
+                Some(" explicit-shell ".into()),
+                None,
+                Some("environment-shell".into()),
+                Some(" environment-run ".into()),
+            )
+            .unwrap(),
+            ("explicit-shell".into(), "environment-run".into())
+        );
+        assert!(resolve_agent_context(Some("s1".into()), None, None, None).is_err());
+        assert!(
+            resolve_agent_context(Some(" ".into()), Some("r1".into()), Some("s1".into()), None,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn event_snapshot_json_includes_stable_agent_data() {
+        let mut project = workspace("w1", "project", vec![shell("s1", "w1", "shell")]);
+        project.agents.push(agent("a1", "w1", "s1"));
+
+        let value = json_snapshot(Snapshot {
+            workspaces: vec![project],
+        })
+        .unwrap();
+
+        assert_eq!(value["workspaces"][0]["agents"][0]["id"], "a1");
+        assert_eq!(
+            value["workspaces"][0]["agents"][0]["observation"]["authority"],
+            "lifecycle_integration"
+        );
+    }
+
+    #[test]
     fn resolves_workspaces_and_shell_names_for_cli_commands() {
         let mut project = workspace("w1", "project", vec![shell("s1", "w1", "tests")]);
         project.launchers.push(launcher("l1", "w1", "editor"));
@@ -2307,6 +2804,23 @@ mod tests {
         assert_eq!(launcher.name, "editor");
         assert_eq!(launcher.command, "zeditor .");
         assert_eq!(launcher.directory, "/tmp/project");
+    }
+
+    #[test]
+    fn workspace_view_maps_agent_runtime_details() {
+        let mut workspace = workspace("w1", "project", vec![shell("s1", "w1", "terminal")]);
+        workspace.agents.push(agent("a1", "w1", "s1"));
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        let tui::WorkspaceItemView::Agent(agent) = &views[0].items[1] else {
+            panic!("expected agent item");
+        };
+        assert_eq!(agent.name, "opencode");
+        assert_eq!(agent.shell_name, "terminal");
+        assert_eq!(agent.state, "working");
+        assert_eq!(agent.authority, "lifecycle_integration");
+        assert_eq!(agent.confidence, 95);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 8;
+pub const PROTOCOL_VERSION: u32 = 9;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -40,6 +40,67 @@ pub struct WorkspaceSnapshot {
     pub shells: Vec<ShellSnapshot>,
     #[serde(default)]
     pub launchers: Vec<WorkspaceLauncherSnapshot>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<AgentInstanceSnapshot>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentState {
+    Unknown,
+    Working,
+    Blocked,
+    Idle,
+    Done,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentAuthority {
+    LifecycleIntegration,
+    ProcessAdapter,
+    TerminalHeuristic,
+    DaemonLifecycle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentReport {
+    pub state: AgentState,
+    pub authority: AgentAuthority,
+    pub evidence: String,
+    pub confidence: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRegistrationSpec {
+    pub name: String,
+    pub integration: String,
+    pub external_session_id: Option<String>,
+    pub report: AgentReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentObservationSnapshot {
+    pub revision: u64,
+    pub state: AgentState,
+    pub authority: AgentAuthority,
+    pub evidence: String,
+    pub confidence: u8,
+    pub observed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentInstanceSnapshot {
+    pub id: String,
+    pub workspace_id: String,
+    pub shell_id: String,
+    pub run_id: String,
+    pub name: String,
+    pub integration: String,
+    pub external_session_id: Option<String>,
+    pub started_at_ms: u64,
+    pub ended_at_ms: Option<u64>,
+    pub observation: AgentObservationSnapshot,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -188,6 +249,21 @@ pub enum DaemonEventKind {
         shell_id: String,
         run: ShellRunSnapshot,
     },
+    AgentRegistered {
+        workspace_id: String,
+        shell_id: String,
+        agent: AgentInstanceSnapshot,
+    },
+    AgentStateChanged {
+        workspace_id: String,
+        shell_id: String,
+        agent: AgentInstanceSnapshot,
+    },
+    AgentCompleted {
+        workspace_id: String,
+        shell_id: String,
+        agent: AgentInstanceSnapshot,
+    },
     HandoffCompleted,
 }
 
@@ -237,6 +313,9 @@ pub enum Request {
     GetLauncher {
         launcher_id: String,
     },
+    GetAgent {
+        agent_id: String,
+    },
     CreateWorkspace {
         name: String,
         shells: Vec<ShellSpec>,
@@ -249,6 +328,16 @@ pub enum Request {
     CreateLauncher {
         workspace_id: String,
         spec: WorkspaceLauncherSpec,
+    },
+    RegisterAgent {
+        shell_id: String,
+        run_id: String,
+        spec: AgentRegistrationSpec,
+    },
+    ReportAgent {
+        agent_id: String,
+        run_id: String,
+        report: AgentReport,
     },
     ReadShell {
         shell_id: String,
@@ -315,6 +404,9 @@ pub enum Response {
     },
     Launcher {
         launcher: WorkspaceLauncherSnapshot,
+    },
+    Agent {
+        agent: AgentInstanceSnapshot,
     },
     Output {
         bytes: Vec<u8>,
@@ -562,6 +654,73 @@ mod tests {
         .unwrap();
 
         assert!(snapshot.launchers.is_empty());
+        assert!(snapshot.agents.is_empty());
+    }
+
+    #[test]
+    fn agent_messages_round_trip_with_snake_case_names() {
+        let report = AgentReport {
+            state: AgentState::Working,
+            authority: AgentAuthority::LifecycleIntegration,
+            evidence: "tool call in progress".into(),
+            confidence: 95,
+        };
+        let request = Request::RegisterAgent {
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            spec: AgentRegistrationSpec {
+                name: "opencode".into(),
+                integration: "opencode-plugin".into(),
+                external_session_id: Some("external-1".into()),
+                report: report.clone(),
+            },
+        };
+
+        let encoded = serde_json::to_value(&request).unwrap();
+        assert_eq!(encoded["request"], "register_agent");
+        assert_eq!(encoded["spec"]["report"]["state"], "working");
+        assert_eq!(
+            encoded["spec"]["report"]["authority"],
+            "lifecycle_integration"
+        );
+        assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
+
+        let agent = AgentInstanceSnapshot {
+            id: "a1".into(),
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            name: "opencode".into(),
+            integration: "opencode-plugin".into(),
+            external_session_id: Some("external-1".into()),
+            started_at_ms: 10,
+            ended_at_ms: None,
+            observation: AgentObservationSnapshot {
+                revision: 1,
+                state: report.state,
+                authority: report.authority,
+                evidence: report.evidence,
+                confidence: report.confidence,
+                observed_at_ms: 11,
+            },
+        };
+        let event = DaemonEventKind::AgentStateChanged {
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            agent,
+        };
+        let encoded = serde_json::to_value(&event).unwrap();
+        assert_eq!(encoded["event"], "agent_state_changed");
+        assert_eq!(
+            serde_json::from_value::<DaemonEventKind>(encoded).unwrap(),
+            event
+        );
+    }
+
+    #[test]
+    fn protocol_version_is_nine_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 9);
+        assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
     #[test]

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -9,10 +9,11 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::protocol::{ShellRunExitReason, TerminalProfile};
+use crate::protocol::{AgentObservationSnapshot, ShellRunExitReason, TerminalProfile};
 
-const STATE_VERSION: u32 = 3;
-const PREVIOUS_STATE_VERSION: u32 = 2;
+const STATE_VERSION: u32 = 4;
+const PREVIOUS_STATE_VERSION: u32 = 3;
+const VERSION_TWO_STATE_VERSION: u32 = 2;
 const LEGACY_STATE_VERSION: u32 = 1;
 const MAX_STATE_BYTES: u64 = 8 * 1024 * 1024;
 
@@ -39,6 +40,21 @@ pub(crate) struct PersistedWorkspace {
     pub(crate) name: String,
     pub(crate) shells: Vec<PersistedShell>,
     pub(crate) launchers: Vec<PersistedWorkspaceLauncher>,
+    pub(crate) agents: Vec<PersistedAgentInstance>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PersistedAgentInstance {
+    pub(crate) id: String,
+    pub(crate) shell_id: String,
+    pub(crate) run_id: String,
+    pub(crate) name: String,
+    pub(crate) integration: String,
+    pub(crate) external_session_id: Option<String>,
+    pub(crate) started_at_ms: u64,
+    pub(crate) ended_at_ms: Option<u64>,
+    pub(crate) observation: AgentObservationSnapshot,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -88,6 +104,22 @@ struct PreviousPersistedState {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PreviousPersistedWorkspace {
+    id: String,
+    name: String,
+    shells: Vec<PersistedShell>,
+    launchers: Vec<PersistedWorkspaceLauncher>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionTwoPersistedState {
+    version: u32,
+    workspaces: Vec<VersionTwoPersistedWorkspace>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionTwoPersistedWorkspace {
     id: String,
     name: String,
     shells: Vec<PersistedShell>,
@@ -218,6 +250,12 @@ impl StateStore {
                 self.save(&state)?;
                 state
             }
+            VERSION_TWO_STATE_VERSION => {
+                let previous: VersionTwoPersistedState = parse_state(&bytes, &self.path)?;
+                let state = migrate_version_two_state(previous);
+                self.save(&state)?;
+                state
+            }
             LEGACY_STATE_VERSION => {
                 let legacy: LegacyPersistedState = parse_state(&bytes, &self.path)?;
                 let state = migrate_legacy_state(legacy);
@@ -309,6 +347,7 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
                     })
                     .collect(),
                 launchers: Vec::new(),
+                agents: Vec::new(),
             })
             .collect(),
     }
@@ -325,7 +364,26 @@ fn migrate_previous_state(previous: PreviousPersistedState) -> PersistedState {
                 id: workspace.id,
                 name: workspace.name,
                 shells: workspace.shells,
+                launchers: workspace.launchers,
+                agents: Vec::new(),
+            })
+            .collect(),
+    }
+}
+
+fn migrate_version_two_state(previous: VersionTwoPersistedState) -> PersistedState {
+    debug_assert_eq!(previous.version, VERSION_TWO_STATE_VERSION);
+    PersistedState {
+        version: STATE_VERSION,
+        workspaces: previous
+            .workspaces
+            .into_iter()
+            .map(|workspace| PersistedWorkspace {
+                id: workspace.id,
+                name: workspace.name,
+                shells: workspace.shells,
                 launchers: Vec::new(),
+                agents: Vec::new(),
             })
             .collect(),
     }
@@ -378,6 +436,7 @@ fn effective_uid() -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::{AgentAuthority, AgentState};
 
     #[test]
     fn atomically_round_trips_state() {
@@ -403,6 +462,44 @@ mod tests {
                         command: vec!["server".into()],
                     },
                 ],
+                agents: vec![
+                    PersistedAgentInstance {
+                        id: "agent-1".into(),
+                        shell_id: "shell-1".into(),
+                        run_id: "run-1".into(),
+                        name: "first".into(),
+                        integration: "test".into(),
+                        external_session_id: Some("external-1".into()),
+                        started_at_ms: 10,
+                        ended_at_ms: None,
+                        observation: AgentObservationSnapshot {
+                            revision: 2,
+                            state: AgentState::Working,
+                            authority: AgentAuthority::LifecycleIntegration,
+                            evidence: "active".into(),
+                            confidence: 90,
+                            observed_at_ms: 11,
+                        },
+                    },
+                    PersistedAgentInstance {
+                        id: "agent-2".into(),
+                        shell_id: "shell-2".into(),
+                        run_id: "run-2".into(),
+                        name: "second".into(),
+                        integration: "adapter".into(),
+                        external_session_id: None,
+                        started_at_ms: 20,
+                        ended_at_ms: Some(30),
+                        observation: AgentObservationSnapshot {
+                            revision: 3,
+                            state: AgentState::Done,
+                            authority: AgentAuthority::DaemonLifecycle,
+                            evidence: "run exited".into(),
+                            confidence: 100,
+                            observed_at_ms: 30,
+                        },
+                    },
+                ],
             }],
         };
 
@@ -425,6 +522,12 @@ mod tests {
             ]
         );
         assert_eq!(restored.workspaces[0].launchers[1].id, "launcher-2");
+        assert_eq!(restored.workspaces[0].agents[0].id, "agent-1");
+        assert_eq!(restored.workspaces[0].agents[1].id, "agent-2");
+        assert_eq!(
+            restored.workspaces[0].agents[1].observation.state,
+            AgentState::Done
+        );
         assert_eq!(
             fs::metadata(directory.join("boomux/state.json"))
                 .unwrap()
@@ -501,9 +604,10 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 3")
+                .contains("\"version\": 4")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
+        assert!(migrated.workspaces[0].agents.is_empty());
 
         let reloaded = store.load().unwrap().unwrap();
         assert_eq!(
@@ -550,7 +654,45 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 3")
+                .contains("\"version\": 4")
+        );
+        assert!(migrated.workspaces[0].agents.is_empty());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_three_to_empty_agent_lists_and_preserves_launchers() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            br#"{
+  "version": 3,
+  "workspaces": [{
+    "id": "w1",
+    "name": "version-three",
+    "shells": [],
+    "launchers": [{
+      "id": "l1",
+      "name": "editor",
+      "cwd": "/tmp/project",
+      "command": ["editor", "two words"]
+    }]
+  }]
+}"#,
+        )
+        .unwrap();
+        let store = StateStore::at(path.clone());
+
+        let migrated = store.load().unwrap().unwrap();
+
+        assert_eq!(migrated.workspaces[0].launchers[0].id, "l1");
+        assert!(migrated.workspaces[0].agents.is_empty());
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("\"version\": 4")
         );
         fs::remove_dir_all(directory).unwrap();
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -31,6 +31,25 @@ pub(crate) struct WorkspaceView {
 pub(crate) enum WorkspaceItemView {
     Shell(TerminalView),
     Launcher(LauncherView),
+    Agent(AgentView),
+}
+
+pub(crate) struct AgentView {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) run_id: String,
+    pub(crate) shell_id: String,
+    pub(crate) shell_name: String,
+    pub(crate) name: String,
+    pub(crate) state: String,
+    pub(crate) integration: String,
+    pub(crate) authority: String,
+    pub(crate) confidence: u8,
+    pub(crate) evidence: String,
+    pub(crate) external_session_id: Option<String>,
+    pub(crate) started_at_ms: u64,
+    pub(crate) observed_at_ms: u64,
+    pub(crate) ended_at_ms: Option<u64>,
 }
 
 pub(crate) struct LauncherView {
@@ -77,6 +96,13 @@ impl WorkspaceView {
             .filter(|item| matches!(item, WorkspaceItemView::Launcher(_)))
             .count()
     }
+
+    fn agent_count(&self) -> usize {
+        self.items
+            .iter()
+            .filter(|item| matches!(item, WorkspaceItemView::Agent(_)))
+            .count()
+    }
 }
 
 pub(crate) struct Actions<R, O, C, W, N, E, F> {
@@ -109,6 +135,7 @@ enum Focus {
 enum ItemIdentity {
     Shell(String),
     Launcher(String),
+    Agent(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -413,11 +440,12 @@ impl App {
             Focus::Workspaces => self
                 .selected()
                 .map(|workspace| RenameTarget::Workspace(workspace.id.clone())),
-            Focus::Items => self.selected_item().map(|item| match item {
-                WorkspaceItemView::Shell(shell) => RenameTarget::Shell(shell.id.clone()),
+            Focus::Items => self.selected_item().and_then(|item| match item {
+                WorkspaceItemView::Shell(shell) => Some(RenameTarget::Shell(shell.id.clone())),
                 WorkspaceItemView::Launcher(launcher) => {
-                    RenameTarget::Launcher(launcher.id.clone())
+                    Some(RenameTarget::Launcher(launcher.id.clone()))
                 }
+                WorkspaceItemView::Agent(_) => None,
             }),
         };
         if let Some(target) = target {
@@ -476,23 +504,25 @@ impl App {
         self.message = Some(Message::from_result(on_restore(&workspace_id)));
     }
 
-    fn open_selected_item<F>(&mut self, on_open: &mut F)
+    fn open_selected_item<F>(&mut self, on_open: &mut F) -> bool
     where
         F: FnMut(&OpenTarget) -> Result<String, String>,
     {
         let Some(workspace_id) = self.selected().map(|workspace| workspace.id.clone()) else {
-            return;
+            return false;
         };
-        let Some(target) = self.selected_item().map(|item| match item {
-            WorkspaceItemView::Shell(shell) => OpenTarget::Shell(shell.id.clone()),
-            WorkspaceItemView::Launcher(launcher) => OpenTarget::Launcher {
+        let Some(target) = self.selected_item().and_then(|item| match item {
+            WorkspaceItemView::Shell(shell) => Some(OpenTarget::Shell(shell.id.clone())),
+            WorkspaceItemView::Launcher(launcher) => Some(OpenTarget::Launcher {
                 workspace_id,
                 launcher_id: launcher.id.clone(),
-            },
+            }),
+            WorkspaceItemView::Agent(_) => None,
         }) else {
-            return;
+            return false;
         };
         self.message = Some(Message::from_result(on_open(&target)));
+        true
     }
 
     fn request_close(&mut self) {
@@ -503,19 +533,20 @@ impl App {
                 shell_count: workspace.shell_count(),
                 launcher_count: workspace.launcher_count(),
             }),
-            Focus::Items => self.selected_item().map(|item| match item {
-                WorkspaceItemView::Shell(shell) => PendingClose {
+            Focus::Items => self.selected_item().and_then(|item| match item {
+                WorkspaceItemView::Shell(shell) => Some(PendingClose {
                     target: CloseTarget::Shell(shell.id.clone()),
                     name: shell.name.clone(),
                     shell_count: 1,
                     launcher_count: 0,
-                },
-                WorkspaceItemView::Launcher(launcher) => PendingClose {
+                }),
+                WorkspaceItemView::Launcher(launcher) => Some(PendingClose {
                     target: CloseTarget::Launcher(launcher.id.clone()),
                     name: launcher.name.clone(),
                     shell_count: 0,
                     launcher_count: 1,
-                },
+                }),
+                WorkspaceItemView::Agent(_) => None,
             }),
         };
     }
@@ -549,6 +580,7 @@ impl App {
         let selected_item = self.selected_item().map(|item| match item {
             WorkspaceItemView::Shell(shell) => ItemIdentity::Shell(shell.id.clone()),
             WorkspaceItemView::Launcher(launcher) => ItemIdentity::Launcher(launcher.id.clone()),
+            WorkspaceItemView::Agent(agent) => ItemIdentity::Agent(agent.id.clone()),
         });
         let previous_index = self.selected_index().unwrap_or(0);
         let selected_index = selected_id
@@ -567,6 +599,9 @@ impl App {
                     ItemIdentity::Launcher(id) => workspace.items.iter().position(|item| {
                         matches!(item, WorkspaceItemView::Launcher(launcher) if launcher.id == id)
                     }),
+                    ItemIdentity::Agent(id) => workspace.items.iter().position(
+                        |item| matches!(item, WorkspaceItemView::Agent(agent) if agent.id == id),
+                    ),
                 }
                 })
                 .or_else(|| (!workspace.items.is_empty()).then_some(0))
@@ -675,12 +710,17 @@ where
             KeyCode::Down | KeyCode::Char('j') => app.next(),
             KeyCode::Up | KeyCode::Char('k') => app.previous(),
             KeyCode::Enter => {
-                match app.focus {
-                    Focus::Workspaces => app.restore_selected(&mut actions.on_restore),
+                let dispatched = match app.focus {
+                    Focus::Workspaces => {
+                        app.restore_selected(&mut actions.on_restore);
+                        true
+                    }
                     Focus::Items => app.open_selected_item(&mut actions.on_open),
+                };
+                if dispatched {
+                    app.refresh(&mut actions.on_refresh);
+                    last_refresh = Instant::now();
                 }
-                app.refresh(&mut actions.on_refresh);
-                last_refresh = Instant::now();
             }
             KeyCode::Char('r') => {
                 app.refresh(&mut actions.on_refresh);
@@ -801,7 +841,7 @@ fn render(frame: &mut Frame, app: &mut App) {
     render_header(frame, header_area, app);
     if dashboard_area.width >= 114 {
         let [workspace_area, terminal_area] =
-            Layout::horizontal([Constraint::Length(34), Constraint::Fill(1)]).areas(dashboard_area);
+            Layout::horizontal([Constraint::Length(42), Constraint::Fill(1)]).areas(dashboard_area);
         render_workspaces(frame, workspace_area, app);
         render_items(frame, terminal_area, app);
     } else {
@@ -923,6 +963,7 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         .iter()
         .map(WorkspaceView::launcher_count)
         .sum();
+    let agent_count: usize = app.workspaces.iter().map(WorkspaceView::agent_count).sum();
     let line = Line::from(vec![
         Span::styled(
             " BOOMUX ",
@@ -939,6 +980,8 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             format!("{launcher_count} launchers"),
             Style::new().fg(YELLOW),
         ),
+        Span::styled("  |  ", Style::new().fg(OVERLAY)),
+        Span::styled(format!("{agent_count} agents"), Style::new().fg(TEAL)),
         Span::styled(
             "    tab/h/l/arrows switches panes",
             Style::new().fg(SUBTEXT),
@@ -953,6 +996,7 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
             Cell::from(workspace.name.as_str()),
             Cell::from(workspace.shell_count().to_string()),
             Cell::from(workspace.launcher_count().to_string()),
+            Cell::from(workspace.agent_count().to_string()),
         ])
     });
     let table = Table::new(
@@ -961,10 +1005,11 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
             Constraint::Min(8),
             Constraint::Length(6),
             Constraint::Length(9),
+            Constraint::Length(6),
         ],
     )
     .header(
-        Row::new(["NAME", "SHELLS", "LAUNCHERS"])
+        Row::new(["NAME", "SHELLS", "LAUNCHERS", "AGENTS"])
             .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)),
     )
     .column_spacing(1)
@@ -995,8 +1040,8 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         .selected()
         .and_then(|index| app.workspaces.get(index));
     let title = selected.map_or_else(
-        || " Shells ".to_owned(),
-        |workspace| format!(" Shells: {} ({}) ", workspace.name, workspace.items.len()),
+        || " Items ".to_owned(),
+        |workspace| format!(" Items: {} ({}) ", workspace.name, workspace.items.len()),
     );
     let block = Block::bordered().title(title).border_style(Style::new().fg(
         if app.focus == Focus::Items {
@@ -1036,6 +1081,23 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
                         short_id(&launcher.id)
                     }),
                 ]),
+                WorkspaceItemView::Agent(agent) => Row::new(vec![
+                    Cell::from(agent.name.as_str()),
+                    Cell::from(Span::styled(
+                        agent.state.as_str(),
+                        Style::new().fg(status_color(&agent.state)),
+                    )),
+                    Cell::from(agent.shell_name.as_str()),
+                    Cell::from(format!(
+                        "{} / {} {}%: {}",
+                        agent.integration, agent.authority, agent.confidence, agent.evidence
+                    )),
+                    Cell::from(if show_full_ids {
+                        agent.id.clone()
+                    } else {
+                        short_id(&agent.id)
+                    }),
+                ]),
             })
         })
         .collect();
@@ -1044,20 +1106,21 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
     let table_area = if show_full_ids {
         inner
     } else {
+        let detail_height = if matches!(app.selected_item(), Some(WorkspaceItemView::Agent(_))) {
+            3
+        } else {
+            1
+        };
         let [detail_area, table_area] =
-            Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(inner);
+            Layout::vertical([Constraint::Length(detail_height), Constraint::Fill(1)]).areas(inner);
         let detail = app.selected_item().map_or_else(
-            || Line::from(Span::styled(" No item selected", Style::new().fg(SUBTEXT))),
-            |item| {
-                let id = match item {
-                    WorkspaceItemView::Shell(shell) => shell.id.as_str(),
-                    WorkspaceItemView::Launcher(launcher) => launcher.id.as_str(),
-                };
-                Line::from(vec![
-                    Span::styled(" ID ", Style::new().fg(SUBTEXT)),
-                    Span::styled(id, Style::new().fg(TEXT)),
-                ])
+            || {
+                vec![Line::from(Span::styled(
+                    " No item selected",
+                    Style::new().fg(SUBTEXT),
+                ))]
             },
+            item_detail_lines,
         );
         frame.render_widget(Paragraph::new(detail), detail_area);
         table_area
@@ -1072,6 +1135,42 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         )
         .highlight_symbol("> ");
     frame.render_stateful_widget(table, table_area, &mut app.item_state);
+}
+
+fn item_detail_lines(item: &WorkspaceItemView) -> Vec<Line<'_>> {
+    match item {
+        WorkspaceItemView::Shell(shell) => vec![Line::from(vec![
+            Span::styled(" ID ", Style::new().fg(SUBTEXT)),
+            Span::styled(shell.id.as_str(), Style::new().fg(TEXT)),
+        ])],
+        WorkspaceItemView::Launcher(launcher) => vec![Line::from(vec![
+            Span::styled(" ID ", Style::new().fg(SUBTEXT)),
+            Span::styled(launcher.id.as_str(), Style::new().fg(TEXT)),
+        ])],
+        WorkspaceItemView::Agent(agent) => vec![
+            Line::from(format!(
+                " Agent {}  Workspace {}  Run {}  Shell {} ({})",
+                agent.id, agent.workspace_id, agent.run_id, agent.shell_name, agent.shell_id
+            )),
+            Line::from(format!(
+                " {}  {}  {}  confidence {}%  external {}",
+                agent.state,
+                agent.integration,
+                agent.authority,
+                agent.confidence,
+                agent.external_session_id.as_deref().unwrap_or("-")
+            )),
+            Line::from(format!(
+                " started {}  observed {}  ended {}  {}",
+                agent.started_at_ms,
+                agent.observed_at_ms,
+                agent
+                    .ended_at_ms
+                    .map_or_else(|| "-".to_owned(), |timestamp| timestamp.to_string()),
+                agent.evidence
+            )),
+        ],
+    }
 }
 
 fn shell_column_widths(width: u16, show_full_ids: bool) -> Vec<Constraint> {
@@ -1141,6 +1240,8 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         ))
     } else {
         let launcher_selected = matches!(app.selected_item(), Some(WorkspaceItemView::Launcher(_)));
+        let agent_selected = app.focus == Focus::Items
+            && matches!(app.selected_item(), Some(WorkspaceItemView::Agent(_)));
         let mut spans = vec![
             Span::styled(" j/k", Style::new().fg(TEAL)),
             Span::styled(
@@ -1157,44 +1258,52 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 Style::new().fg(SUBTEXT),
             ),
         ];
+        if !agent_selected {
+            spans.extend([
+                Span::styled("e", Style::new().fg(YELLOW)),
+                Span::styled(
+                    if app.focus == Focus::Workspaces {
+                        " rename workspace  "
+                    } else if launcher_selected {
+                        " rename launcher  "
+                    } else {
+                        " rename shell  "
+                    },
+                    Style::new().fg(SUBTEXT),
+                ),
+                Span::styled("enter", Style::new().fg(GREEN)),
+                Span::styled(
+                    if app.focus == Focus::Workspaces {
+                        " restore workspace  "
+                    } else if launcher_selected {
+                        " launch command  "
+                    } else {
+                        " open shell  "
+                    },
+                    Style::new().fg(SUBTEXT),
+                ),
+            ]);
+        }
         spans.extend([
-            Span::styled("e", Style::new().fg(YELLOW)),
-            Span::styled(
-                if app.focus == Focus::Workspaces {
-                    " rename workspace  "
-                } else if launcher_selected {
-                    " rename launcher  "
-                } else {
-                    " rename shell  "
-                },
-                Style::new().fg(SUBTEXT),
-            ),
-        ]);
-        spans.extend([
-            Span::styled("enter", Style::new().fg(GREEN)),
-            Span::styled(
-                if app.focus == Focus::Workspaces {
-                    " restore workspace  "
-                } else if launcher_selected {
-                    " launch command  "
-                } else {
-                    " open shell  "
-                },
-                Style::new().fg(SUBTEXT),
-            ),
             Span::styled("r", Style::new().fg(BLUE)),
             Span::styled(" refresh  ", Style::new().fg(SUBTEXT)),
-            Span::styled("x", Style::new().fg(RED)),
-            Span::styled(
-                if app.focus == Focus::Workspaces {
-                    " close workspace  "
-                } else if launcher_selected {
-                    " remove launcher  "
-                } else {
-                    " close shell  "
-                },
-                Style::new().fg(SUBTEXT),
-            ),
+        ]);
+        if !agent_selected {
+            spans.extend([
+                Span::styled("x", Style::new().fg(RED)),
+                Span::styled(
+                    if app.focus == Focus::Workspaces {
+                        " close workspace  "
+                    } else if launcher_selected {
+                        " remove launcher  "
+                    } else {
+                        " close shell  "
+                    },
+                    Style::new().fg(SUBTEXT),
+                ),
+            ]);
+        }
+        spans.extend([
             Span::styled("q", Style::new().fg(RED)),
             Span::styled(" quit", Style::new().fg(SUBTEXT)),
         ]);
@@ -1254,6 +1363,26 @@ mod tests {
                 directory: "/tmp/boomux".into(),
                 branch: "main".into(),
             })],
+        }
+    }
+
+    fn agent() -> AgentView {
+        AgentView {
+            id: "agent-1".into(),
+            workspace_id: "w1".into(),
+            run_id: "run-1".into(),
+            shell_id: "term_1".into(),
+            shell_name: "agent".into(),
+            name: "reviewer".into(),
+            state: "working".into(),
+            integration: "opencode".into(),
+            authority: "lifecycle_integration".into(),
+            confidence: 95,
+            evidence: "tool call in progress".into(),
+            external_session_id: Some("session-1".into()),
+            started_at_ms: 100,
+            observed_at_ms: 120,
+            ended_at_ms: None,
         }
     }
 
@@ -1380,6 +1509,33 @@ mod tests {
         assert!(matches!(
             app.selected_item(),
             Some(WorkspaceItemView::Shell(_))
+        ));
+    }
+
+    #[test]
+    fn refresh_preserves_agent_selection_by_typed_id() {
+        let mut initial = workspace("w1", "boomux");
+        initial.items.push(WorkspaceItemView::Agent(agent()));
+        let mut app = App::new(vec![initial], project_context());
+        app.toggle_focus();
+        app.next();
+
+        let mut refreshed = workspace("w1", "boomux");
+        refreshed
+            .items
+            .push(WorkspaceItemView::Launcher(LauncherView {
+                id: "agent-1".into(),
+                name: "same-id".into(),
+                directory: "/tmp/boomux".into(),
+                command: "true".into(),
+            }));
+        refreshed.items.push(WorkspaceItemView::Agent(agent()));
+        app.replace_workspaces(vec![refreshed]);
+
+        assert_eq!(app.item_state.selected(), Some(2));
+        assert!(matches!(
+            app.selected_item(),
+            Some(WorkspaceItemView::Agent(current)) if current.id == "agent-1"
         ));
     }
 
@@ -1615,6 +1771,26 @@ mod tests {
     }
 
     #[test]
+    fn agent_rows_dispatch_no_open_rename_or_close_actions() {
+        let mut app = app();
+        app.workspaces[0].items = vec![WorkspaceItemView::Agent(agent())];
+        app.toggle_focus();
+        let mut opened = false;
+
+        let dispatched = app.open_selected_item(&mut |_| {
+            opened = true;
+            Ok(String::new())
+        });
+        app.request_rename();
+        app.request_close();
+
+        assert!(!opened);
+        assert!(!dispatched);
+        assert!(matches!(app.mode, Mode::Normal));
+        assert!(app.pending_close.is_none());
+    }
+
+    #[test]
     fn rename_mode_dispatches_the_selected_shell_and_name() {
         let mut app = app();
         let mut renamed = None;
@@ -1803,7 +1979,7 @@ mod tests {
         assert!(text.contains("ID"));
         assert!(text.contains("ID term_1"));
         assert!(text.contains("SHELLS"));
-        assert!(text.contains("Shells: boomux (1)"));
+        assert!(text.contains("Items: boomux (1)"));
         assert!(!text.contains("DIRTY"));
         assert!(!text.contains("WORKTREE"));
     }
@@ -1830,7 +2006,7 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        assert!(text.contains("Shells: boomux (2)"));
+        assert!(text.contains("Items: boomux (2)"));
         assert!(!text.contains("Launchers: boomux"));
         assert!(text.contains("DETAIL"));
         assert!(text.contains("editor"));
@@ -1867,6 +2043,40 @@ mod tests {
             .collect();
         assert_eq!(app.item_state.selected(), Some(20));
         assert!(text.contains("command-19"));
+    }
+
+    #[test]
+    fn dashboard_renders_agent_counts_rows_details_and_read_only_footer() {
+        let backend = TestBackend::new(120, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+        app.workspaces[0]
+            .items
+            .push(WorkspaceItemView::Agent(agent()));
+        app.toggle_focus();
+        app.next();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert_eq!(app.workspaces[0].agent_count(), 1);
+        assert!(text.contains("1 agents"));
+        assert!(text.contains("AGENTS"));
+        assert!(text.contains("Items: boomux (2)"));
+        assert!(text.contains("reviewer"));
+        assert!(text.contains("working"));
+        assert!(text.contains("Agent agent-1"));
+        assert!(text.contains("lifecycle_integration"));
+        assert!(text.contains("started 100"));
+        assert!(!text.contains("rename shell"));
+        assert!(!text.contains("open shell"));
+        assert!(!text.contains("close shell"));
     }
 
     #[test]
@@ -1926,7 +2136,7 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect();
         assert!(text.contains("Workspaces (1)"));
-        assert!(text.contains("Shells: boomux (1)"));
+        assert!(text.contains("Items: boomux (1)"));
         assert!(text.contains("DIRECTORY"));
         assert!(text.contains("DETAIL"));
         assert!(text.contains("ID"));

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -11,8 +11,8 @@ use std::time::{Duration, Instant};
 
 use boomux::client::{Attachment, Client, RemoteError};
 use boomux::protocol::{
-    self, AttachFrame, ErrorCode, ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile,
-    WorkspaceLauncherSpec,
+    self, AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame, ErrorCode,
+    ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile, WorkspaceLauncherSpec,
 };
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use uuid::Uuid;
@@ -953,6 +953,240 @@ fn daemon_events_and_revision_reads_survive_handoff() {
 }
 
 #[test]
+fn agent_runtime_is_revisioned_durable_and_version_compatible() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "agent-runtime",
+            vec![ShellSpec::login("runtime", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon
+        .client
+        .get_shell(&shell_id)
+        .unwrap()
+        .run
+        .expect("started agent shell has no run identity")
+        .id;
+    let baseline = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let registration = AgentRegistrationSpec {
+        name: "runtime-agent".into(),
+        integration: "native-test".into(),
+        external_session_id: Some("session-1".into()),
+        report: AgentReport {
+            state: AgentState::Working,
+            authority: AgentAuthority::LifecycleIntegration,
+            evidence: "registered".into(),
+            confidence: 90,
+        },
+    };
+
+    let error = daemon
+        .client
+        .register_agent(&shell_id, Uuid::new_v4().to_string(), registration.clone())
+        .unwrap_err();
+    assert_remote_code(&error, ErrorCode::RunChanged);
+    let registered = daemon
+        .client
+        .register_agent(&shell_id, &run_id, registration)
+        .unwrap();
+    assert_eq!(registered.workspace_id, workspace.id);
+    assert_eq!(registered.shell_id, shell_id);
+    assert_eq!(registered.run_id, run_id);
+    assert_eq!(registered.observation.revision, 1);
+    assert_eq!(registered.observation.state, AgentState::Working);
+    assert!(registered.ended_at_ms.is_none());
+    assert_eq!(daemon.client.get_agent(&registered.id).unwrap(), registered);
+    let snapshot_agent = daemon
+        .client
+        .snapshot()
+        .unwrap()
+        .workspaces
+        .into_iter()
+        .find(|current| current.id == workspace.id)
+        .unwrap()
+        .agents
+        .into_iter()
+        .find(|agent| agent.id == registered.id)
+        .unwrap();
+    assert_eq!(snapshot_agent, registered);
+
+    let error = daemon
+        .client
+        .report_agent(
+            &registered.id,
+            Uuid::new_v4().to_string(),
+            AgentReport {
+                state: AgentState::Blocked,
+                authority: AgentAuthority::ProcessAdapter,
+                evidence: "wrong run".into(),
+                confidence: 50,
+            },
+        )
+        .unwrap_err();
+    assert_remote_code(&error, ErrorCode::RunChanged);
+    let blocked = daemon
+        .client
+        .report_agent(
+            &registered.id,
+            &run_id,
+            AgentReport {
+                state: AgentState::Blocked,
+                authority: AgentAuthority::ProcessAdapter,
+                evidence: "waiting for input".into(),
+                confidence: 80,
+            },
+        )
+        .unwrap();
+    assert_eq!(blocked.observation.revision, 2);
+    assert_eq!(blocked.observation.state, AgentState::Blocked);
+    assert!(blocked.ended_at_ms.is_none());
+    assert!(blocked.observation.observed_at_ms >= registered.observation.observed_at_ms);
+    let done = daemon
+        .client
+        .report_agent(
+            &registered.id,
+            &run_id,
+            AgentReport {
+                state: AgentState::Done,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "completed".into(),
+                confidence: 100,
+            },
+        )
+        .unwrap();
+    assert_eq!(done.observation.revision, 3);
+    assert_eq!(done.observation.state, AgentState::Done);
+    assert_eq!(done.ended_at_ms, Some(done.observation.observed_at_ms));
+    let error = daemon
+        .client
+        .report_agent(
+            &registered.id,
+            &run_id,
+            AgentReport {
+                state: AgentState::Idle,
+                authority: AgentAuthority::TerminalHeuristic,
+                evidence: "too late".into(),
+                confidence: 10,
+            },
+        )
+        .unwrap_err();
+    assert_remote_code(&error, ErrorCode::InvalidArgument);
+
+    let events = daemon
+        .client
+        .events(Some(baseline.clone()), 256, 0)
+        .unwrap();
+    assert!(events.events.iter().any(|event| matches!(
+        &event.kind,
+        protocol::DaemonEventKind::AgentRegistered { agent, .. }
+            if agent.id == registered.id && agent.observation.revision == 1
+    )));
+    assert!(events.events.iter().any(|event| matches!(
+        &event.kind,
+        protocol::DaemonEventKind::AgentStateChanged { agent, .. }
+            if agent.id == registered.id && agent.observation.revision == 2
+    )));
+    assert!(events.events.iter().any(|event| matches!(
+        &event.kind,
+        protocol::DaemonEventKind::AgentCompleted { agent, .. }
+            if agent.id == registered.id && agent.observation.revision == 3
+    )));
+
+    let list = daemon.command().args(["agent", "list"]).output().unwrap();
+    assert!(list.status.success());
+    assert!(contains(&list.stdout, b"runtime-agent"));
+    assert!(contains(&list.stdout, registered.id.as_bytes()));
+    let list = daemon
+        .command()
+        .args(["agent", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let list: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(list["command"], "agent.list");
+    assert_eq!(list["data"]["agents"][0]["id"], registered.id);
+    assert_eq!(list["data"]["agents"][0]["observation"]["revision"], 3);
+    let inspect = daemon
+        .command()
+        .args(["agent", "inspect", &registered.id])
+        .output()
+        .unwrap();
+    assert!(inspect.status.success());
+    assert!(contains(&inspect.stdout, b"STATE\tdone"));
+    assert!(contains(&inspect.stdout, b"REVISION\t3"));
+    let inspect = daemon
+        .command()
+        .args(["agent", "inspect", &registered.id, "--json"])
+        .output()
+        .unwrap();
+    assert!(inspect.status.success());
+    let inspect: serde_json::Value = serde_json::from_slice(&inspect.stdout).unwrap();
+    assert_eq!(inspect["command"], "agent.inspect");
+    assert_eq!(inspect["data"]["agent"]["id"], registered.id);
+    assert_eq!(inspect["data"]["agent"]["observation"]["state"], "done");
+
+    let protocol_eight_snapshot = versioned_request(&daemon.client, 8, protocol::Request::Snapshot);
+    let protocol::Response::Snapshot { snapshot } = protocol_eight_snapshot else {
+        panic!("expected protocol-8 snapshot response");
+    };
+    assert!(
+        snapshot
+            .workspaces
+            .iter()
+            .all(|workspace| workspace.agents.is_empty())
+    );
+    let protocol_eight_events = versioned_request(
+        &daemon.client,
+        8,
+        protocol::Request::Events {
+            after: Some(baseline),
+            limit: 256,
+            wait_ms: 0,
+        },
+    );
+    let protocol::Response::Events {
+        cursor: filtered_cursor,
+        events,
+        ..
+    } = protocol_eight_events
+    else {
+        panic!("expected protocol-8 events response");
+    };
+    assert!(events.is_empty());
+    daemon
+        .client
+        .rename_shell(&shell_id, "runtime-renamed")
+        .unwrap();
+    let protocol_eight_events = versioned_request(
+        &daemon.client,
+        8,
+        protocol::Request::Events {
+            after: Some(filtered_cursor.clone()),
+            limit: 256,
+            wait_ms: 0,
+        },
+    );
+    let protocol::Response::Events { cursor, events, .. } = protocol_eight_events else {
+        panic!("expected protocol-8 events response after rename");
+    };
+    assert!(events.iter().any(|event| matches!(
+        &event.kind,
+        protocol::DaemonEventKind::ShellRenamed { shell_id: id, .. } if id == &shell_id
+    )));
+    assert!(cursor.event_id > filtered_cursor.event_id);
+
+    drop(attachment.stream);
+    daemon.stop_with_cli();
+    daemon.restart();
+    assert_eq!(daemon.client.get_agent(&registered.id).unwrap(), done);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn native_daemon_handoffs_multiple_detached_shells() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon
@@ -1274,7 +1508,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 8);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 9);
     assert!(
         capabilities["data"]["json_commands"]
             .as_array()
@@ -1296,7 +1530,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 8"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 9"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])
@@ -2072,6 +2306,33 @@ fn contains(haystack: &[u8], needle: &[u8]) -> bool {
     haystack
         .windows(needle.len())
         .any(|window| window == needle)
+}
+
+fn assert_remote_code(error: &io::Error, expected: ErrorCode) {
+    assert_eq!(
+        error
+            .get_ref()
+            .and_then(|error| error.downcast_ref::<RemoteError>())
+            .and_then(|error| error.code),
+        Some(expected)
+    );
+}
+
+fn versioned_request(
+    client: &Client,
+    version: u32,
+    request: protocol::Request,
+) -> protocol::Response {
+    let mut stream = UnixStream::connect(client.socket_path()).unwrap();
+    protocol::write_message(
+        &mut stream,
+        &protocol::Envelope::with_version(version, request),
+    )
+    .unwrap();
+    let response: protocol::Envelope<protocol::Response> =
+        protocol::read_message(&mut stream).unwrap();
+    assert_eq!(response.version, version);
+    response.message
 }
 
 fn parse_child_pid(output: &[u8]) -> Option<libc::pid_t> {


### PR DESCRIPTION
## Summary
- add durable agent instances bound to exact shell runs with revisioned observations
- expose protocol 9 lifecycle requests, events, CLI JSON, and read-only dashboard rows
- preserve agent state across daemon restarts while filtering protocol 9 data for older clients
- document integration semantics and update the Boomux skill

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features