### PR TITLE
Add OpenCode lifecycle integration

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boomux
-description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, and run-scoped agent instances. Use when asked to discover shells or agents, read terminal output, report an agent lifecycle state, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
+description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, and integrations. Use when asked to discover shells or agents, read terminal output, report an agent lifecycle state, install the OpenCode integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
 compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; agent mutation requires exact shell-run context.
 metadata:
   author: boomux
-  version: "4"
+  version: "5"
 ---
 
 # Boomux
@@ -40,8 +40,8 @@ boomux workspace inspect "<workspace-name-or-id>"
 boomux shell inspect "<shell-name-or-id>" --workspace "<workspace-name-or-id>"
 ```
 
-For machine-readable inspection, add `--json`. Supported read-only commands emit
-the stable `boomux.cli/v1` envelope. Discover the exact command, feature, and
+For machine-readable inspection, add `--json`. Supported commands emit the
+stable `boomux.cli/v1` envelope. Discover the exact command, feature, and
 typed-error capabilities without starting the daemon:
 
 ```console
@@ -49,7 +49,8 @@ boomux capabilities --json
 ```
 
 Parse `data` on success and `error.code` on a nonzero exit; do not parse human
-tables or `error.message`. Mutation commands do not yet support `--json`.
+tables or `error.message`. JSON mutation support is limited to `agent register`,
+`agent ensure`, and `agent report`.
 
 Use `boomux events --json` for an immediate snapshot and cursor. Poll again with
 `--after CURSOR --wait-ms 30000` to observe later transitions. If
@@ -87,27 +88,35 @@ Use these mutation commands only for a lifecycle integration that directly
 observes the external agent session:
 
 ```console
-boomux agent register "<name>" --integration "<integration>" --external-session-id "<id>" --shell-id "<shell-id>" --run-id "<run-id>" --state working --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100
-boomux agent report "<exact-agent-id>" --shell-id "<same-shell-id>" --run-id "<original-run-id>" --state blocked --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100
-boomux agent report "<exact-agent-id>" --shell-id "<same-shell-id>" --run-id "<original-run-id>" --state done --authority lifecycle-integration --evidence "<completion evidence>" --confidence 100
+boomux agent register "<name>" --integration "<integration>" --external-session-id "<id>" --shell-id "<shell-id>" --run-id "<run-id>" --state working --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100 --json
+boomux agent ensure "<name>" --integration "<integration>" --external-session-id "<id>" --shell-id "<shell-id>" --run-id "<run-id>" --state working --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100 --json
+boomux agent report "<exact-agent-id>" --shell-id "<same-shell-id>" --run-id "<original-run-id>" --state blocked --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100 --json
+boomux agent report "<exact-agent-id>" --shell-id "<same-shell-id>" --run-id "<original-run-id>" --state done --authority lifecycle-integration --evidence "<completion evidence>" --confidence 100 --json
 ```
 
-`--external-session-id` is optional. Inside the target managed process,
+`--external-session-id` is optional for `register` and required for `ensure`.
+Use `ensure` when an integration needs idempotent identity recovery after a
+reload. Its key is integration, external session ID, shell ID, and run ID; a
+match returns the existing durable snapshot without applying the supplied name
+or observation. Inside the target managed process,
 `--shell-id` and `--run-id` default to `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID`;
 otherwise pass both explicitly. Retain the exact agent ID returned by
-`register` and use it for every later report. Also retain the original run ID:
+`register` or `ensure` and use it for every later report. Also retain the original run ID:
 never replace it with a newer run from the durable shell.
 
-Every registration and report requires an explicit state (`unknown`, `working`,
-`blocked`, `idle`, or `done`), authority (`lifecycle-integration`,
-`process-adapter`, `terminal-heuristic`, or `daemon-lifecycle`), nonempty
-evidence, and confidence from 0 through 100. Report only what the stated
-authority actually observed. In particular, report `done` only after direct
+Every register, ensure, and report command requires an explicit state (`unknown`, `working`,
+`blocked`, `idle`, or `done`), external authority (`lifecycle-integration`,
+`process-adapter`, or `terminal-heuristic`), nonempty evidence, and confidence
+from 0 through 100. `daemon-lifecycle` is reserved and public mutations reject
+it. Authority precedence is lifecycle integration over process adapter over
+terminal heuristic. Lower-authority and exact duplicate reports are successful
+no-ops; equal-authority changed reports update the observation. Report only what
+the stated authority actually observed. In particular, report `done` only after direct
 lifecycle completion evidence, never because output is quiet, a prompt appears,
-or the shell exits. `done` is terminal; the durable completed instance remains
-inspectable and rejects later reports.
+or the shell exits. `done` is terminal; retrying the exact completion is safe,
+while conflicting later reports are rejected.
 
-If `register` or `report` returns `run_changed`, stop reporting for that
+If `register`, `ensure`, or `report` returns `run_changed`, stop reporting for that
 instance and reacquire exact lifecycle context. Do not guess the replacement
 run. Boomux does not yet provide agent heuristics, adapters, wait/read commands,
 notifications, or control.
@@ -248,6 +257,28 @@ boomux skill install --force
 The skill is installed at `~/.agents/skills/boomux/SKILL.md`. Use `--force` to
 replace different existing content. The installer removes an untouched legacy
 `boomux-shells` skill; it preserves and warns about customized legacy content.
+
+## Install The OpenCode Integration
+
+```console
+boomux opencode install
+boomux opencode install --force
+```
+
+The installer writes `$XDG_CONFIG_HOME/opencode/plugins/boomux.js`, falling back
+to `~/.config/opencode/plugins/boomux.js`. OpenCode discovers that global
+config-time plugin automatically; no `opencode.json` edit is made. Identical
+content is left alone, different content requires `--force`, and detected
+symlinks or non-regular path targets are rejected. Quit and restart OpenCode after
+installing or replacing the plugin.
+
+The plugin activates only in a managed shell run. It identifies one agent by the
+root OpenCode session and aggregates child/subagent activity. Work, tool, chat,
+and compaction events map to `working`; outstanding permission/questions and
+errors map to `blocked`; only root idle maps to `idle`; and only explicit root
+session deletion maps to `done`. Child deletion and process exit do not report
+completion. Unmanaged or unavailable Boomux is fail-open. If Boomux returns
+`run_changed`, reporting for that root is disabled rather than redirected.
 
 ## Environment And Integration
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,4 +18,11 @@ daemon lifecycle transitions. A shell is distinct from a workspace launcher.
 A durable identity for one external agent session associated with exactly one shell run. Its
 observed state records authority, evidence, confidence, and time. A completed agent instance
 remains inspectable; subagents and individual tool calls are not separate agent instances unless
-they establish independent external sessions.
+they establish independent external sessions. Integrations can reacquire an instance by ensuring
+the key of integration, external session ID, shell ID, and run ID; ensure returns existing durable
+state rather than treating its supplied observation as a reload update.
+
+External observation authority descends from lifecycle integration to process adapter to terminal
+heuristic. Equal authority may advance an observation; exact duplicate and lower-authority reports
+are no-ops. Daemon lifecycle authority is reserved for daemon-originated observations and is not an
+external integration authority.

--- a/README.md
+++ b/README.md
@@ -124,11 +124,13 @@ boomux launcher remove <launcher-name-or-id> [--workspace <name-or-id>]
 boomux agent list [--workspace <name-or-id>]
 boomux agent inspect <agent-id>
 boomux agent register <name> --integration <integration> [--external-session-id <id>] [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
+boomux agent ensure <name> --integration <integration> --external-session-id <id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux agent report <agent-id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux daemon status
 boomux daemon restart
 boomux daemon stop
 boomux skill install [--force]
+boomux opencode install [--force]
 ```
 
 `boomux shells` lists shells in the current workspace. `boomux read` and
@@ -162,13 +164,24 @@ Boomux does not track or terminate applications it previously launched.
 
 Agent instances are durable records for external agent sessions. Each instance
 has its own exact ID and is bound to exactly one shell run, not merely to a
-durable shell. `register` and `report` require explicit `unknown`, `working`,
-`blocked`, `idle`, or `done` state plus authority, evidence, and confidence.
-The authority values are `lifecycle-integration`, `process-adapter`,
-`terminal-heuristic`, and `daemon-lifecycle`. A `done` report completes the
-instance permanently; completed instances remain inspectable across daemon
-restart. Boomux does not yet infer agent state, wait for agents, read through an
-agent API, or control agents.
+durable shell. Protocol 10 adds `agent ensure`, an idempotent registration keyed
+by integration, external session ID, shell ID, and run ID. It requires
+`--external-session-id`; an existing match is returned unchanged, including
+after an integration or daemon reload, while a different shell run creates a
+different identity. `register`, `ensure`, and `report` require explicit
+`unknown`, `working`, `blocked`, `idle`, or `done` state plus authority,
+evidence, and confidence.
+
+External reports use this precedence: `lifecycle-integration` over
+`process-adapter` over `terminal-heuristic`. A lower-authority report is a
+successful no-op. At equal authority, an exact duplicate is a no-op, while any
+changed state, evidence, or confidence replaces the observation and increments
+its revision. `daemon-lifecycle` exists in snapshots but is reserved for daemon
+observations and cannot be supplied to public mutation commands. A `done` report
+completes the instance permanently. Retrying the exact completion is an
+idempotent success; a different later report is rejected. Completed instances
+remain inspectable across daemon restart. Boomux does not yet provide process
+adapters, terminal heuristics, agent waits, agent reads, or agent control.
 
 `boomux read` reads plain rendered text from the daemon's shadow VT state. It
 understands cursor rewrites and terminal soft wrapping, retains up to 2,000
@@ -225,7 +238,7 @@ identifies one process incarnation and changes when a durable shell starts a
 new process after recovery. A live process transferred from a pre-run-identity
 daemon receives a daemon-side run identity, but its existing environment cannot
 be retrofitted; `shell inspect` reports that compatibility case as
-`environment_has_run_id: false`. Agent `register` and `report` default their
+`environment_has_run_id: false`. Agent `register`, `ensure`, and `report` default their
 shell and run arguments from `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID`.
 Integrations outside that exact environment must pass both IDs and must not
 guess a run from shell status or retained output. A dynamic
@@ -252,6 +265,37 @@ workspaces and shells, and to inspect and explicitly report run-scoped agent
 lifecycle, through the full public CLI. Re-run with `--force` to replace an
 older customized installation. An untouched legacy `boomux-shells` skill is
 removed automatically; customized legacy content is preserved with a warning.
+
+## OpenCode Integration
+
+Install the bundled config-time OpenCode lifecycle plugin with:
+
+```console
+boomux opencode install
+```
+
+The destination is `$XDG_CONFIG_HOME/opencode/plugins/boomux.js`, or
+`~/.config/opencode/plugins/boomux.js` when `XDG_CONFIG_HOME` is unset. OpenCode
+discovers files in that global plugin directory automatically; the installer
+does not edit `opencode.json` or other plugins. An identical file is left
+unchanged. Different content requires `--force`, and detected symlinked or
+non-regular path components and targets are rejected even with `--force`. Because OpenCode
+loads config-time plugins at startup, quit and restart OpenCode after installing
+or replacing the plugin.
+
+Inside a Boomux-managed shell, the plugin groups each root OpenCode session and
+all child/subagent sessions into one durable agent instance keyed by the root
+session ID. OpenCode status, chat, tool, compaction, permission/question, error,
+idle, and deletion events produce explainable `working`, `blocked`, `idle`, and
+`done` observations. Child activity contributes to the root; only root idle can
+make it idle, and only explicit deletion of the root reports `done`. Process or
+shell exit does not report completion.
+
+The plugin is fail-open: outside a managed Boomux run, when Boomux is
+unavailable, or when OpenCode session ancestry cannot be resolved, OpenCode
+continues and reporting errors are rate-limited. A `run_changed` response
+permanently disables reports for that tracked root so events cannot leak into
+another process run.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,8 @@ The daemon supports:
 - One writable attachment with explicit takeover
 - PTY input and resize forwarding
 - Pending shell metadata and first-attachment terminal negotiation
-- Run-scoped agent registration, inspection, and explicit state reports
+- Run-scoped agent registration, idempotent ensure, inspection, and explicit
+  state reports
 
 An empty shell specification list remains empty. When an explicit populated
 creation is requested, the daemon stages every child before publishing any of
@@ -175,6 +176,52 @@ durable storage. External lifecycle integrations own the meaning and evidence
 of their reports; this slice does not discover processes, parse terminal output,
 wait for agents, or control them.
 
+Protocol 10 adds `EnsureAgent`. Its durable identity key is integration,
+external session ID, shell ID, and run ID; the external session ID is mandatory
+for ensure. A unique existing match is returned without changing its name,
+observation, revision, timestamps, persistence, or event stream. This lets an
+integration reload and reacquire the daemon-owned agent ID. A different run is a
+different identity. Multiple matching legacy records are accepted only when
+exactly one is active; otherwise ensure fails rather than guessing.
+
+External observation authority is ordered lifecycle integration, process
+adapter, then terminal heuristic. Lower-authority reports are successful no-ops.
+At equal authority an exact duplicate is also a no-op, but a changed report is
+accepted, so a source can advance its own state and evidence. Higher-authority
+reports replace lower-authority observations. `daemon_lifecycle` is a wire and
+snapshot value reserved for daemon-originated observations and is not exposed by
+the public mutation CLI. Exact retries of an accepted `done` report return the
+completed snapshot without another revision, write, or event; conflicting
+reports after completion are rejected.
+
+### OpenCode Lifecycle Plugin
+
+`integrations/opencode/boomux.js` is a config-time OpenCode plugin installed by
+`boomux opencode install [--force]`. The installer targets
+`$XDG_CONFIG_HOME/opencode/plugins/boomux.js`, falling back to
+`~/.config/opencode/plugins/boomux.js`. It creates regular directories, rejects
+detected symlinks and special targets, leaves identical content alone, and
+requires `--force` to replace different regular-file content. OpenCode discovers
+the global plugin file without a configuration edit, but must be quit and
+restarted after installation or replacement.
+
+The plugin activates only when both `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID` are
+present. It resolves every event's OpenCode ancestry and uses the root session
+ID as `external_session_id`; child and subagent events aggregate into that one
+root agent instance. Busy/active work, chat, tools, compaction, and resolved
+prompts map to `working`; outstanding permission or question requests and
+session errors map to `blocked`; only root idle maps to `idle`. Blockers are
+tracked as a set, and errors remain latched until later work is observed. Only
+explicit root `session.deleted` maps to `done`: child deletion and process or
+shell exit do not complete the instance.
+
+On first relevant event, or after plugin reload, the plugin calls `agent ensure`
+and then reports a changed derived observation when the reused durable record
+does not already match. Calls use exact argument vectors, a one-second timeout,
+bounded output, and the stable JSON envelope. Unmanaged sessions are a no-op;
+Boomux or ancestry failures are rate-limited and fail open so OpenCode continues.
+`run_changed` disables all later reports for that tracked root.
+
 ### Transition Coordinator
 
 The daemon serializes observable runtime transitions through one coordinator. A
@@ -202,7 +249,7 @@ not persisted per chunk, but output revision mutation and `output_changed`
 publication cross the coordinator together. A non-blocking terminal lock keeps
 output processing from holding global locks while waiting on terminal snapshots.
 
-Agent registration and reports use the same durable mutation coordinator.
+Agent registration, ensure, and reports use the same durable mutation coordinator.
 Persistence and `agent_registered`, `agent_state_changed`, or
 `agent_completed` publication therefore share the normal ordering boundary and
 baseline snapshots include the exact coordinated cut.

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -1,7 +1,7 @@
 # CLI JSON Contract
 
-Boomux exposes a versioned JSON contract for read-only integrations. Human
-output remains the default; pass `--json` to a supported command to emit one
+Boomux exposes a versioned JSON contract for integrations. Human output remains
+the default; pass `--json` to a supported command to emit one
 JSON document on stdout:
 
 ```json
@@ -36,11 +36,15 @@ The following commands support `--json`:
 - `boomux launcher inspect`
 - `boomux agent list`
 - `boomux agent inspect`
+- `boomux agent register`
+- `boomux agent ensure`
+- `boomux agent report`
 - `boomux daemon status`
 
-Mutation commands intentionally retain human output for now. Passing `--json`
-to an unsupported command fails with `invalid_argument` before performing the
-operation.
+JSON mutations are deliberately narrow: only `agent register`, `agent ensure`,
+and `agent report` support the contract. Other mutation commands retain human
+output. Passing `--json` to an unsupported command fails with
+`invalid_argument` before performing the operation.
 
 Command payloads are:
 
@@ -57,6 +61,8 @@ Command payloads are:
 - `launcher.inspect`: one `launcher` object.
 - `agent.list`: an `agents` array, optionally limited by `--workspace`.
 - `agent.inspect`: one `agent` object selected by exact agent ID.
+- `agent.register`, `agent.ensure`, and `agent.report`: one resulting `agent`
+  object. The command field identifies the specific mutation.
 - `read`: shell/run identity, observed output revision, and rendered output.
 - `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
   bounded event array.
@@ -85,9 +91,22 @@ Agent objects include stable fields `id`, `workspace_id`, `workspace_name`,
 Agent `state` is `unknown`, `working`, `blocked`, `idle`, or `done`. `authority`
 is `lifecycle_integration`, `process_adapter`, `terminal_heuristic`, or
 `daemon_lifecycle`; CLI arguments use hyphens instead of underscores. Confidence
-is an integer from 0 through 100. Observation revisions begin at 1 and increase
-with each accepted report. `done` is terminal and has a non-null `ended_at_ms`;
-completed records remain durable and inspectable.
+is an integer from 0 through 100. Public mutations accept the first three
+authorities; `daemon_lifecycle` is reserved for daemon-originated observations.
+External precedence is lifecycle integration over process adapter over terminal
+heuristic. Observation revisions begin at 1 and increase with each accepted
+changed report. Lower-authority and exact duplicate reports return success with
+the unchanged snapshot. Equal-authority changed reports update the observation.
+`done` is terminal and has a non-null `ended_at_ms`; an exact completion retry is
+an unchanged success, while conflicting later reports fail. Completed records
+remain durable and inspectable.
+
+`agent.ensure` requires `--external-session-id` and protocol 10. Its identity key
+is `integration`, `external_session_id`, `shell_id`, and `run_id`. When that key
+already identifies a unique record, ensure returns the stored snapshot without
+applying the supplied name or report. This is the intended identity-recovery
+path after an integration reload. Otherwise it creates the record with the same
+shape and validation as `agent.register`.
 
 `read` returns `shell_id`, `run_id`, `output_revision`, `changed`, `status`, and
 `output`. Output is a JSON string containing the same bounded plain rendered text

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -2,7 +2,8 @@
 
 Boomux protocol 7 added bounded long polling for daemon events and atomic,
 revision-aware terminal reads. Protocol 9 adds run-scoped agent snapshots and
-events while retaining negotiation with older management clients.
+events while retaining negotiation with older management clients. Protocol 10
+adds idempotent agent ensure without adding an event type.
 
 ## Cursors
 
@@ -44,12 +45,20 @@ and run IDs and the latest state, authority, evidence, confidence, observation
 revision, and timestamps. Registration emits `agent_registered`; registration
 as `done` also emits `agent_completed`. Later reports emit
 `agent_state_changed`, except the terminal `done` report emits
-`agent_completed`. Completed instances reject further reports.
+`agent_completed`.
+
+An ensure that reuses an identity emits no event and does not change its
+observation revision. Lower-authority reports and exact duplicates are also
+successful no-ops with no event. Equal-authority reports with changed content
+are updates and emit the normal state-change or completion event. Retrying the
+exact accepted `done` report is idempotent and emits no second completion event;
+other reports against a completed instance are rejected.
 
 Protocol-8 and older event clients do not receive protocol-9 agent snapshots or
 agent events. Filtering does not rewrite the journal: their returned cursor
 still advances across filtered agent events, preserving the stream's total
-publication order. Agent requests themselves require protocol 9.
+publication order. Agent get, register, and report requests require protocol 9;
+ensure requires protocol 10.
 
 Event IDs provide one total publication order. The daemon transition coordinator
 couples durable lifecycle mutation, persistence, and event publication. Events

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -93,15 +93,17 @@ eternal process.
 
 1. [Complete] Model agent instances separately from shells and runs, with
    explicit state authority, evidence, and confidence.
-2. Prefer lifecycle integrations, then process adapters, then conservative
-   terminal-screen heuristics for `working`, `blocked`, `idle`, `done`, and
-   `unknown` states.
-3. Aggregate agent states as workspace counts and provide an explainable,
+2. [Complete] Establish authority precedence and explicit OpenCode lifecycle
+   integration for `working`, `blocked`, `idle`, and explicit completion.
+3. Add process adapters beneath lifecycle-integration authority.
+4. Add conservative terminal-screen heuristics beneath process-adapter
+   authority, without inferring completion from quiet output or shell exit.
+5. Aggregate agent states as workspace counts and provide an explainable,
    persistent attention queue for blocked and completed work.
-4. Add notifications and revision-aware `agent wait` and `agent read` commands.
-5. Add guarded prompts and common responses only after defining run-scoped
+6. Add notifications and revision-aware `agent wait` and `agent read` commands.
+7. Add guarded prompts and common responses only after defining run-scoped
    leases, user-controller precedence, idempotency, and audit events.
-6. Run hooks, tests, notifications, or focus actions from durable transitions.
+8. Run hooks, tests, notifications, or focus actions from durable transitions.
 
 ## Distribution And Polish
 

--- a/integrations/opencode/boomux.js
+++ b/integrations/opencode/boomux.js
@@ -1,0 +1,574 @@
+const MAX_EVIDENCE = 160;
+const MAX_OUTPUT = 64 * 1024;
+const COMMAND_TIMEOUT_MS = 1_000;
+const LOG_INTERVAL_MS = 30_000;
+const LIFECYCLE_AUTHORITY = "lifecycle_integration";
+const LIFECYCLE_CONFIDENCE = 100;
+
+function text(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function boundedEvidence(value) {
+  const clean = String(value ?? "OpenCode lifecycle event")
+    .replace(/\s+/g, " ")
+    .trim();
+  return (clean || "OpenCode lifecycle event").slice(0, MAX_EVIDENCE);
+}
+
+function sessionID(event) {
+  const properties = event?.properties ?? {};
+  return (
+    text(properties.sessionID) ??
+    text(properties.sessionId) ??
+    text(properties.info?.id) ??
+    text(properties.part?.sessionID) ??
+    text(properties.message?.sessionID) ??
+    text(event?.sessionID)
+  );
+}
+
+function statusKind(status) {
+  const value = typeof status === "string" ? status : status?.type;
+  return typeof value === "string" ? value.toLowerCase() : undefined;
+}
+
+function requestID(properties) {
+  return (
+    text(properties?.requestID) ??
+    text(properties?.permissionID) ??
+    text(properties?.id)
+  );
+}
+
+function errorEvidence(error) {
+  const name = text(error?.name) ?? text(error?.data?.name);
+  const message =
+    text(error?.message) ?? text(error?.data?.message) ?? "session error";
+  return boundedEvidence(
+    name ? `OpenCode error: ${name}: ${message}` : `OpenCode error: ${message}`,
+  );
+}
+
+function classifyEvent(event) {
+  const type = text(event?.type);
+  const properties = event?.properties ?? {};
+  const id = sessionID(event);
+  if (!type || !id) return undefined;
+
+  if (type === "session.status") {
+    const kind = statusKind(properties.status);
+    if (
+      [
+        "busy",
+        "retry",
+        "active",
+        "pending",
+        "running",
+        "streaming",
+        "working",
+      ].includes(kind)
+    ) {
+      return {
+        kind: "working",
+        sessionID: id,
+        evidence: `OpenCode session ${kind}`,
+      };
+    }
+    if (kind === "idle") {
+      return {
+        kind: "idle",
+        sessionID: id,
+        evidence: "OpenCode root session idle",
+      };
+    }
+    return undefined;
+  }
+
+  if (type === "session.idle") {
+    return {
+      kind: "idle",
+      sessionID: id,
+      evidence: "OpenCode root session idle",
+    };
+  }
+  if (type === "session.error") {
+    return {
+      kind: "error",
+      sessionID: id,
+      evidence: errorEvidence(properties.error),
+    };
+  }
+  if (type === "session.deleted") {
+    return {
+      kind: "deleted",
+      sessionID: id,
+      evidence: "OpenCode session deleted",
+    };
+  }
+  if (
+    ["permission.asked", "permission.updated", "question.asked"].includes(type)
+  ) {
+    const blocker = requestID(properties);
+    if (!blocker) return undefined;
+    const label = type.startsWith("question") ? "question" : "permission";
+    return {
+      kind: "block",
+      sessionID: id,
+      requestID: `${label}:${blocker}`,
+      evidence: `OpenCode awaiting ${label}`,
+    };
+  }
+  if (
+    ["permission.replied", "question.replied", "question.rejected"].includes(
+      type,
+    )
+  ) {
+    const blocker = requestID(properties);
+    if (!blocker) return undefined;
+    const label = type.startsWith("question") ? "question" : "permission";
+    return {
+      kind: "unblock",
+      sessionID: id,
+      requestID: `${label}:${blocker}`,
+      evidence: `OpenCode ${label} resolved`,
+    };
+  }
+  if (
+    [
+      "chat.message",
+      "tool.execute.before",
+      "tool.execute.after",
+      "session.compacted",
+      "session.compacting",
+      "experimental.session.compacting",
+    ].includes(type)
+  ) {
+    return { kind: "working", sessionID: id, evidence: `OpenCode ${type}` };
+  }
+  if (type === "message.part.updated") {
+    const partType = text(properties.part?.type)?.toLowerCase();
+    if (["tool", "retry", "compaction"].includes(partType)) {
+      return {
+        kind: "working",
+        sessionID: id,
+        evidence: `OpenCode ${partType}`,
+      };
+    }
+  }
+  return undefined;
+}
+
+function createReducerState() {
+  return {
+    blockers: new Map(),
+    errors: new Set(),
+    lastEvidence: undefined,
+    lastState: undefined,
+    terminal: false,
+  };
+}
+
+function blockerCount(state) {
+  let count = 0;
+  for (const blockers of state.blockers.values()) count += blockers.size;
+  return count;
+}
+
+function isBlocked(state) {
+  return blockerCount(state) > 0 || state.errors.size > 0;
+}
+
+function reduce(state, action, isRootEvent) {
+  if (state.terminal) return undefined;
+  let next;
+  let evidence = action.evidence;
+
+  switch (action.kind) {
+    case "block": {
+      let blockers = state.blockers.get(action.sessionID);
+      if (!blockers) {
+        blockers = new Set();
+        state.blockers.set(action.sessionID, blockers);
+      }
+      blockers.add(action.requestID);
+      next = "blocked";
+      evidence = `${action.evidence} (${blockerCount(state)} pending)`;
+      break;
+    }
+    case "unblock": {
+      const blockers = state.blockers.get(action.sessionID);
+      blockers?.delete(action.requestID);
+      if (blockers?.size === 0) state.blockers.delete(action.sessionID);
+      next = isBlocked(state) ? "blocked" : "working";
+      break;
+    }
+    case "error":
+      state.errors.add(action.sessionID);
+      next = "blocked";
+      break;
+    case "working":
+      state.errors.delete(action.sessionID);
+      next = isBlocked(state) ? "blocked" : "working";
+      break;
+    case "idle":
+      if (!isRootEvent) return undefined;
+      next = isBlocked(state) ? "blocked" : "idle";
+      break;
+    case "deleted": {
+      if (isRootEvent) {
+        state.terminal = true;
+        next = "done";
+        break;
+      }
+      const removedBlockers = state.blockers.delete(action.sessionID);
+      const removedError = state.errors.delete(action.sessionID);
+      if (!removedBlockers && !removedError) return undefined;
+      next = isBlocked(state) ? "blocked" : "working";
+      break;
+    }
+    default:
+      return undefined;
+  }
+
+  const bounded = boundedEvidence(evidence);
+  if (next === state.lastState && bounded === state.lastEvidence)
+    return undefined;
+  state.lastEvidence = bounded;
+  state.lastState = next;
+  return { state: next, evidence: bounded };
+}
+
+function unwrapSession(response) {
+  const value = response?.data ?? response;
+  return value?.session ?? value;
+}
+
+function createRootResolver(client) {
+  const sessions = new Map();
+
+  function remember(info) {
+    const id = text(info?.id);
+    if (id) sessions.set(id, { id, parentID: text(info.parentID) });
+  }
+
+  async function load(id) {
+    if (sessions.has(id)) return sessions.get(id);
+    const info = unwrapSession(await client.session.get({ path: { id } }));
+    if (!text(info?.id)) throw new Error(`OpenCode session not found: ${id}`);
+    remember(info);
+    return sessions.get(id);
+  }
+
+  async function root(id) {
+    let current = id;
+    const seen = new Set();
+    while (current && !seen.has(current)) {
+      seen.add(current);
+      const info = await load(current);
+      if (!info.parentID) return current;
+      current = info.parentID;
+    }
+    throw new Error(`invalid OpenCode session ancestry for ${id}`);
+  }
+
+  return { remember, root };
+}
+
+function parseJSON(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error("boomux returned empty JSON output");
+  }
+  const parsed = JSON.parse(value);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("boomux returned invalid JSON output");
+  }
+  return parsed;
+}
+
+async function readBounded(stream, limit, onOverflow) {
+  if (!stream) return "";
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let result = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > limit) {
+      onOverflow();
+      throw new Error("boomux output limit exceeded");
+    }
+    result += decoder.decode(value, { stream: true });
+  }
+  return result + decoder.decode();
+}
+
+function createProcessRunner(options = {}) {
+  const spawn = options.spawn ?? globalThis.Bun?.spawn;
+  const timeoutMs = options.timeoutMs ?? COMMAND_TIMEOUT_MS;
+  const maxOutput = options.maxOutput ?? MAX_OUTPUT;
+  if (typeof spawn !== "function") {
+    return async () => {
+      throw new Error("Bun.spawn is unavailable");
+    };
+  }
+
+  return async (argv) => {
+    const child = spawn(argv, {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      shell: false,
+    });
+    let timedOut = false;
+    const kill = () => child.kill?.();
+    const timer = setTimeout(() => {
+      timedOut = true;
+      kill();
+    }, timeoutMs);
+    try {
+      const [stdout, stderr, exitCode] = await Promise.all([
+        readBounded(child.stdout, maxOutput, kill),
+        readBounded(child.stderr, maxOutput, kill),
+        child.exited,
+      ]);
+      if (timedOut) throw new Error("boomux command timed out");
+      const parsed = parseJSON(stdout.trim() ? stdout : stderr);
+      if (exitCode !== 0 || parsed.error) {
+        const failure = new Error(
+          boundedEvidence(
+            parsed.error?.message ?? stderr ?? "boomux command failed",
+          ),
+        );
+        failure.code = parsed.error?.code;
+        throw failure;
+      }
+      return parsed;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+function ensureArgv(shellID, runID, rootID, state, evidence) {
+  return [
+    "boomux",
+    "agent",
+    "ensure",
+    "OpenCode",
+    "--integration",
+    "opencode",
+    "--external-session-id",
+    rootID,
+    "--shell-id",
+    shellID,
+    "--run-id",
+    runID,
+    "--state",
+    state,
+    "--authority",
+    "lifecycle-integration",
+    "--evidence",
+    boundedEvidence(evidence),
+    "--confidence",
+    "100",
+    "--json",
+  ];
+}
+
+function reportArgv(agentID, shellID, runID, state, evidence) {
+  return [
+    "boomux",
+    "agent",
+    "report",
+    agentID,
+    "--shell-id",
+    shellID,
+    "--run-id",
+    runID,
+    "--state",
+    state,
+    "--authority",
+    "lifecycle-integration",
+    "--evidence",
+    boundedEvidence(evidence),
+    "--confidence",
+    "100",
+    "--json",
+  ];
+}
+
+function agentFromJSON(result) {
+  return result?.data?.agent ?? result?.agent ?? result?.data;
+}
+
+function observationMatches(observation, derived) {
+  return (
+    observation?.state === derived.state &&
+    observation?.authority === LIFECYCLE_AUTHORITY &&
+    observation?.evidence === derived.evidence &&
+    observation?.confidence === LIFECYCLE_CONFIDENCE
+  );
+}
+
+function rateLimitedLogger(log, now = Date.now) {
+  let last = -Infinity;
+  let suppressed = 0;
+  return (error) => {
+    const time = now();
+    if (time - last < LOG_INTERVAL_MS) {
+      suppressed += 1;
+      return;
+    }
+    const suffix = suppressed
+      ? ` (${suppressed} similar errors suppressed)`
+      : "";
+    suppressed = 0;
+    last = time;
+    log(
+      `[boomux-opencode] ${boundedEvidence(error?.message ?? error)}${suffix}`,
+    );
+  };
+}
+
+function createLifecycle({ client, env, run, log = console.error, now }) {
+  const shellID = text(env?.BOOMUX_SHELL_ID);
+  const runID = text(env?.BOOMUX_RUN_ID);
+  if (!shellID || !runID) return undefined;
+
+  const resolver = createRootResolver(client);
+  const roots = new Map();
+  const reportError = rateLimitedLogger(log, now);
+  let queue = Promise.resolve();
+
+  function tracked(rootID) {
+    let value = roots.get(rootID);
+    if (!value) {
+      value = {
+        reducer: createReducerState(),
+        agentID: undefined,
+        disabled: false,
+      };
+      roots.set(rootID, value);
+    }
+    return value;
+  }
+
+  async function send(rootID, derived) {
+    const item = tracked(rootID);
+    if (item.disabled) return;
+    try {
+      if (!item.agentID) {
+        const result = await run(
+          ensureArgv(shellID, runID, rootID, derived.state, derived.evidence),
+        );
+        const agent = agentFromJSON(result);
+        item.agentID = text(agent?.id);
+        if (!item.agentID)
+          throw new Error("boomux ensure response has no agent id");
+        if (
+          agent?.ended_at_ms != null ||
+          agent?.observation?.state === "done"
+        ) {
+          item.disabled = true;
+          item.reducer.terminal = true;
+          return;
+        }
+        if (observationMatches(agent?.observation, derived)) return;
+      }
+      await run(
+        reportArgv(
+          item.agentID,
+          shellID,
+          runID,
+          derived.state,
+          derived.evidence,
+        ),
+      );
+    } catch (error) {
+      if (error?.code === "run_changed") item.disabled = true;
+      throw error;
+    }
+  }
+
+  async function handle(event) {
+    const info = event?.properties?.info;
+    if (info) resolver.remember(info);
+    const action = classifyEvent(event);
+    if (!action) return;
+    const rootID = await resolver.root(action.sessionID);
+    const item = tracked(rootID);
+    if (item.disabled) return;
+    const previous = {
+      blockers: new Map(
+        [...item.reducer.blockers].map(([id, blockers]) => [
+          id,
+          new Set(blockers),
+        ]),
+      ),
+      errors: new Set(item.reducer.errors),
+      lastEvidence: item.reducer.lastEvidence,
+      lastState: item.reducer.lastState,
+      terminal: item.reducer.terminal,
+    };
+    const derived = reduce(item.reducer, action, action.sessionID === rootID);
+    if (!derived) return;
+    try {
+      await send(rootID, derived);
+    } catch (error) {
+      if (!item.disabled) {
+        item.reducer.blockers = previous.blockers;
+        item.reducer.errors = previous.errors;
+        item.reducer.lastEvidence = previous.lastEvidence;
+        item.reducer.lastState = previous.lastState;
+        item.reducer.terminal = previous.terminal;
+      }
+      throw error;
+    }
+  }
+
+  function enqueue(event) {
+    const pending = queue.then(() => handle(event));
+    queue = pending.catch(reportError);
+    return queue;
+  }
+
+  return { enqueue, resolver, roots };
+}
+
+function hookEvent(type, input) {
+  return { type, properties: { ...input, sessionID: input?.sessionID } };
+}
+
+export async function BoomuxOpenCodePlugin({ client }) {
+  const lifecycle = createLifecycle({
+    client,
+    env: globalThis.process?.env ?? {},
+    run: createProcessRunner(),
+  });
+  if (!lifecycle) return {};
+
+  return {
+    event: ({ event }) => lifecycle.enqueue(event),
+    "chat.message": (input) =>
+      lifecycle.enqueue(hookEvent("chat.message", input)),
+    "tool.execute.before": (input) =>
+      lifecycle.enqueue(hookEvent("tool.execute.before", input)),
+    "tool.execute.after": (input) =>
+      lifecycle.enqueue(hookEvent("tool.execute.after", input)),
+    "experimental.session.compacting": (input) =>
+      lifecycle.enqueue(hookEvent("experimental.session.compacting", input)),
+  };
+}
+
+// OpenCode treats every ESM export as a plugin. Keep test seams on the sole
+// plugin function so this asset remains directly auto-loadable.
+BoomuxOpenCodePlugin.__internal = Object.freeze({
+  classifyEvent,
+  createLifecycle,
+  createProcessRunner,
+  createReducerState,
+  reduce,
+});

--- a/integrations/opencode/boomux.test.js
+++ b/integrations/opencode/boomux.test.js
@@ -1,0 +1,654 @@
+import { describe, expect, test } from "bun:test";
+import { BoomuxOpenCodePlugin } from "./boomux.js";
+
+const {
+  classifyEvent,
+  createLifecycle,
+  createProcessRunner,
+  createReducerState,
+  reduce,
+} = BoomuxOpenCodePlugin.__internal;
+
+const env = {
+  BOOMUX_SHELL_ID: "shell;not-a-command",
+  BOOMUX_RUN_ID: "run $(false)",
+};
+
+function event(type, properties) {
+  return { type, properties };
+}
+
+function successfulEnsure(
+  id = "agent-1",
+  state = "working",
+  evidence = "OpenCode session busy",
+) {
+  return {
+    data: {
+      agent: {
+        id,
+        observation: {
+          state,
+          authority: "lifecycle_integration",
+          evidence,
+          confidence: 100,
+        },
+        ended_at_ms: null,
+      },
+    },
+  };
+}
+
+describe("event mapping and reducer", () => {
+  test("maps structural status, chat, tool, compaction, waits, and errors", () => {
+    expect(
+      classifyEvent(
+        event("session.status", { sessionID: "s", status: { type: "retry" } }),
+      ).kind,
+    ).toBe("working");
+    expect(classifyEvent(event("chat.message", { sessionID: "s" })).kind).toBe(
+      "working",
+    );
+    expect(
+      classifyEvent(event("tool.execute.before", { sessionID: "s" })).kind,
+    ).toBe("working");
+    expect(
+      classifyEvent(
+        event("message.part.updated", {
+          part: { sessionID: "s", type: "compaction" },
+        }),
+      ).kind,
+    ).toBe("working");
+    expect(
+      classifyEvent(event("permission.updated", { sessionID: "s", id: "p" }))
+        .kind,
+    ).toBe("block");
+    expect(
+      classifyEvent(event("question.asked", { sessionID: "s", id: "q" })).kind,
+    ).toBe("block");
+    expect(
+      classifyEvent(
+        event("session.error", { sessionID: "s", error: { message: "bad" } }),
+      ).kind,
+    ).toBe("error");
+  });
+
+  test("tracks multiple blockers and latches errors", () => {
+    const state = createReducerState();
+    expect(
+      reduce(
+        state,
+        {
+          kind: "block",
+          sessionID: "root",
+          requestID: "p:1",
+          evidence: "wait",
+        },
+        true,
+      ).state,
+    ).toBe("blocked");
+    expect(
+      reduce(
+        state,
+        {
+          kind: "block",
+          sessionID: "root",
+          requestID: "p:2",
+          evidence: "wait",
+        },
+        true,
+      ).evidence,
+    ).toBe("wait (2 pending)");
+    expect(
+      reduce(
+        state,
+        {
+          kind: "unblock",
+          sessionID: "root",
+          requestID: "p:1",
+          evidence: "one",
+        },
+        true,
+      ).state,
+    ).toBe("blocked");
+    expect(
+      reduce(
+        state,
+        {
+          kind: "unblock",
+          sessionID: "root",
+          requestID: "p:2",
+          evidence: "two",
+        },
+        true,
+      ).state,
+    ).toBe("working");
+    expect(
+      reduce(
+        state,
+        { kind: "error", sessionID: "root", evidence: "error" },
+        true,
+      ).state,
+    ).toBe("blocked");
+    expect(
+      reduce(state, { kind: "idle", sessionID: "root", evidence: "idle" }, true)
+        .state,
+    ).toBe("blocked");
+    expect(
+      reduce(
+        state,
+        { kind: "working", sessionID: "root", evidence: "retry" },
+        true,
+      ).state,
+    ).toBe("working");
+  });
+
+  test("updates working evidence and suppresses only exact duplicates", () => {
+    const state = createReducerState();
+    const chat = {
+      kind: "working",
+      sessionID: "root",
+      evidence: "OpenCode chat.message",
+    };
+    const tool = {
+      kind: "working",
+      sessionID: "root",
+      evidence: "OpenCode tool.execute.before",
+    };
+
+    expect(reduce(state, chat, true).evidence).toBe("OpenCode chat.message");
+    expect(reduce(state, tool, true).evidence).toBe(
+      "OpenCode tool.execute.before",
+    );
+    expect(reduce(state, tool, true)).toBeUndefined();
+  });
+});
+
+describe("root aggregation", () => {
+  test("resolves unknown nested ancestry through the client", async () => {
+    const calls = [];
+    const sessions = {
+      child: { id: "child", parentID: "middle" },
+      middle: { id: "middle", parentID: "root" },
+      root: { id: "root" },
+    };
+    const client = {
+      session: { get: async ({ path }) => ({ data: sessions[path.id] }) },
+    };
+    const lifecycle = createLifecycle({
+      client,
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return successfulEnsure();
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue(
+      event("session.status", { sessionID: "child", status: { type: "busy" } }),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("root");
+    expect(calls[0]).not.toContain("child");
+  });
+
+  test("child deletion never reports done while root deletion does", async () => {
+    const calls = [];
+    const client = {
+      session: {
+        get: async () => {
+          throw new Error("unexpected get");
+        },
+      },
+    };
+    const lifecycle = createLifecycle({
+      client,
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return successfulEnsure();
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    await lifecycle.enqueue(
+      event("session.created", { info: { id: "child", parentID: "root" } }),
+    );
+    await lifecycle.enqueue(
+      event("session.deleted", { info: { id: "child", parentID: "root" } }),
+    );
+    expect(calls).toHaveLength(0);
+    await lifecycle.enqueue(event("session.deleted", { info: { id: "root" } }));
+    expect(calls[0]).toContain("done");
+  });
+
+  test("child deletion clears its sole permission blocker", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: { session: { get: async () => {} } },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return calls.length === 1
+          ? successfulEnsure(
+              "agent",
+              "blocked",
+              "OpenCode awaiting permission (1 pending)",
+            )
+          : { data: {} };
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    await lifecycle.enqueue(
+      event("session.created", { info: { id: "child", parentID: "root" } }),
+    );
+
+    await lifecycle.enqueue(
+      event("permission.asked", { sessionID: "child", id: "permission-1" }),
+    );
+    await lifecycle.enqueue(
+      event("session.deleted", { info: { id: "child", parentID: "root" } }),
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].slice(0, 4)).toEqual([
+      "boomux",
+      "agent",
+      "report",
+      "agent",
+    ]);
+    expect(calls[1][calls[1].indexOf("--state") + 1]).toBe("working");
+    expect(calls[1]).not.toContain("done");
+  });
+
+  test("child deletion preserves another child's blocker", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: { session: { get: async () => {} } },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return calls.length === 1
+          ? successfulEnsure(
+              "agent",
+              "blocked",
+              "OpenCode awaiting permission (1 pending)",
+            )
+          : { data: {} };
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    for (const id of ["first", "second"]) {
+      await lifecycle.enqueue(
+        event("session.created", { info: { id, parentID: "root" } }),
+      );
+      await lifecycle.enqueue(
+        event("permission.asked", { sessionID: id, id: `permission-${id}` }),
+      );
+    }
+
+    await lifecycle.enqueue(
+      event("session.deleted", { info: { id: "first", parentID: "root" } }),
+    );
+    expect(calls).toHaveLength(3);
+    expect(calls[2][calls[2].indexOf("--state") + 1]).toBe("blocked");
+    await lifecycle.enqueue(
+      event("session.deleted", { info: { id: "second", parentID: "root" } }),
+    );
+    expect(calls).toHaveLength(4);
+    expect(calls[3][calls[3].indexOf("--state") + 1]).toBe("working");
+  });
+
+  test("child deletion clears its latched error", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: { session: { get: async () => {} } },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return calls.length === 1
+          ? successfulEnsure("agent", "blocked", "OpenCode error: child failed")
+          : { data: {} };
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    await lifecycle.enqueue(
+      event("session.created", { info: { id: "child", parentID: "root" } }),
+    );
+
+    await lifecycle.enqueue(
+      event("session.error", {
+        sessionID: "child",
+        error: { message: "child failed" },
+      }),
+    );
+    await lifecycle.enqueue(
+      event("session.status", { sessionID: "root", status: "busy" }),
+    );
+    expect(calls).toHaveLength(2);
+    expect(calls[1][calls[1].indexOf("--state") + 1]).toBe("blocked");
+    await lifecycle.enqueue(
+      event("session.deleted", { info: { id: "child", parentID: "root" } }),
+    );
+
+    expect(calls).toHaveLength(3);
+    expect(calls[2][calls[2].indexOf("--state") + 1]).toBe("working");
+  });
+});
+
+describe("Boomux commands", () => {
+  test("uses exact argv and never invokes a shell", async () => {
+    let received;
+    const encoder = new TextEncoder();
+    const stream = (value) =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(value));
+          controller.close();
+        },
+      });
+    const runner = createProcessRunner({
+      spawn: (argv, options) => {
+        received = { argv, options };
+        return {
+          stdout: stream('{"data":{"agent":{"id":"a"}}}'),
+          stderr: stream(""),
+          exited: Promise.resolve(0),
+          kill() {},
+        };
+      },
+    });
+    const argv = [
+      "boomux",
+      "agent",
+      "ensure",
+      env.BOOMUX_SHELL_ID,
+      env.BOOMUX_RUN_ID,
+    ];
+    await runner(argv);
+    expect(received.argv).toEqual(argv);
+    expect(received.options.shell).toBe(false);
+  });
+
+  test("parses structured stderr failures", async () => {
+    const encoder = new TextEncoder();
+    const stream = (value) =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(value));
+          controller.close();
+        },
+      });
+    const runner = createProcessRunner({
+      spawn: () => ({
+        stdout: stream(""),
+        stderr: stream(
+          '{"error":{"code":"run_changed","message":"different run"}}',
+        ),
+        exited: Promise.resolve(1),
+        kill() {},
+      }),
+    });
+    let failure;
+    try {
+      await runner(["boomux"]);
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure?.code).toBe("run_changed");
+  });
+
+  test("builds ensure and report argv with preserved shell and run", async () => {
+    const calls = [];
+    const client = {
+      session: { get: async ({ path }) => ({ data: { id: path.id } }) },
+    };
+    const lifecycle = createLifecycle({
+      client,
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return calls.length === 1 ? successfulEnsure("a1") : { data: {} };
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(
+      event("session.status", { sessionID: "root", status: "busy" }),
+    );
+    expect(calls).toHaveLength(1);
+    await lifecycle.enqueue(event("session.idle", { sessionID: "root" }));
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual([
+      "boomux",
+      "agent",
+      "ensure",
+      "OpenCode",
+      "--integration",
+      "opencode",
+      "--external-session-id",
+      "root",
+      "--shell-id",
+      env.BOOMUX_SHELL_ID,
+      "--run-id",
+      env.BOOMUX_RUN_ID,
+      "--state",
+      "working",
+      "--authority",
+      "lifecycle-integration",
+      "--evidence",
+      "OpenCode session busy",
+      "--confidence",
+      "100",
+      "--json",
+    ]);
+    expect(calls[1].slice(0, 5)).toEqual([
+      "boomux",
+      "agent",
+      "report",
+      "a1",
+      "--shell-id",
+    ]);
+    expect(calls[1]).toContain(env.BOOMUX_RUN_ID);
+  });
+
+  test("same-state Ensure with different evidence reports immediately", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: {
+        session: { get: async ({ path }) => ({ data: { id: path.id } }) },
+      },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return calls.length === 1
+          ? successfulEnsure("existing", "working", "stale evidence")
+          : { data: {} };
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue(
+      event("session.status", { sessionID: "root", status: "busy" }),
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].slice(0, 4)).toEqual([
+      "boomux",
+      "agent",
+      "report",
+      "existing",
+    ]);
+    expect(calls[1][calls[1].indexOf("--state") + 1]).toBe("working");
+    expect(calls[1][calls[1].indexOf("--evidence") + 1]).toBe(
+      "OpenCode session busy",
+    );
+  });
+
+  test("reattached working agent reports the first idle event", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: {
+        session: { get: async ({ path }) => ({ data: { id: path.id } }) },
+      },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return calls.length === 1
+          ? successfulEnsure("existing", "working")
+          : { data: {} };
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue(event("session.idle", { sessionID: "root" }));
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].slice(0, 4)).toEqual([
+      "boomux",
+      "agent",
+      "ensure",
+      "OpenCode",
+    ]);
+    expect(calls[0][calls[0].indexOf("--state") + 1]).toBe("idle");
+    expect(calls[1].slice(0, 4)).toEqual([
+      "boomux",
+      "agent",
+      "report",
+      "existing",
+    ]);
+    expect(calls[1][calls[1].indexOf("--state") + 1]).toBe("idle");
+  });
+
+  test("reattached idle agent reports root deletion as done", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: {
+        session: { get: async ({ path }) => ({ data: { id: path.id } }) },
+      },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return calls.length === 1
+          ? successfulEnsure("existing", "idle")
+          : { data: {} };
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue(event("session.deleted", { info: { id: "root" } }));
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0][calls[0].indexOf("--state") + 1]).toBe("done");
+    expect(calls[1].slice(0, 4)).toEqual([
+      "boomux",
+      "agent",
+      "report",
+      "existing",
+    ]);
+    expect(calls[1][calls[1].indexOf("--state") + 1]).toBe("done");
+  });
+
+  test("does not reopen a completed reused agent", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: {
+        session: { get: async ({ path }) => ({ data: { id: path.id } }) },
+      },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return {
+          data: {
+            agent: {
+              id: "done",
+              ended_at_ms: 1,
+              observation: { state: "done" },
+            },
+          },
+        };
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(
+      event("session.status", { sessionID: "root", status: "busy" }),
+    );
+    await lifecycle.enqueue(event("session.idle", { sessionID: "root" }));
+    expect(calls).toHaveLength(1);
+  });
+
+  test("run_changed permanently disables that tracked root", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: {
+        session: { get: async ({ path }) => ({ data: { id: path.id } }) },
+      },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        const error = new Error("different run");
+        error.code = "run_changed";
+        throw error;
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(
+      event("session.status", { sessionID: "root", status: "busy" }),
+    );
+    await lifecycle.enqueue(event("session.idle", { sessionID: "root" }));
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("queue and activation", () => {
+  test("serializes handling and fails open after runner failure", async () => {
+    const order = [];
+    let count = 0;
+    const lifecycle = createLifecycle({
+      client: {
+        session: { get: async ({ path }) => ({ data: { id: path.id } }) },
+      },
+      env,
+      run: async () => {
+        const current = ++count;
+        order.push(`start${current}`);
+        await Bun.sleep(10);
+        order.push(`end${current}`);
+        if (current === 1) throw new Error("offline");
+        return successfulEnsure();
+      },
+      log: () => {},
+    });
+    const first = lifecycle.enqueue(
+      event("session.status", { sessionID: "root", status: "busy" }),
+    );
+    const second = lifecycle.enqueue(
+      event("session.status", { sessionID: "root", status: "busy" }),
+    );
+    await Promise.all([first, second]);
+    expect(order).toEqual(["start1", "end1", "start2", "end2"]);
+  });
+
+  test("missing environment is a no-op", async () => {
+    expect(
+      createLifecycle({ client: {}, env: {}, run: async () => {} }),
+    ).toBeUndefined();
+    const oldShell = process.env.BOOMUX_SHELL_ID;
+    const oldRun = process.env.BOOMUX_RUN_ID;
+    delete process.env.BOOMUX_SHELL_ID;
+    delete process.env.BOOMUX_RUN_ID;
+    try {
+      expect(await BoomuxOpenCodePlugin({ client: {} })).toEqual({});
+    } finally {
+      if (oldShell === undefined) delete process.env.BOOMUX_SHELL_ID;
+      else process.env.BOOMUX_SHELL_ID = oldShell;
+      if (oldRun === undefined) delete process.env.BOOMUX_RUN_ID;
+      else process.env.BOOMUX_RUN_ID = oldRun;
+    }
+  });
+});

--- a/src/client.rs
+++ b/src/client.rs
@@ -398,6 +398,22 @@ impl Client {
         }
     }
 
+    pub fn ensure_agent(
+        &self,
+        shell_id: impl Into<String>,
+        run_id: impl Into<String>,
+        spec: AgentRegistrationSpec,
+    ) -> io::Result<AgentInstanceSnapshot> {
+        match self.request(Request::EnsureAgent {
+            shell_id: shell_id.into(),
+            run_id: run_id.into(),
+            spec,
+        })? {
+            Response::Agent { agent } => Ok(agent),
+            other => unexpected(other),
+        }
+    }
+
     pub fn report_agent(
         &self,
         agent_id: impl Into<String>,
@@ -585,6 +601,7 @@ fn request_minimum_version(request: &Request) -> u32 {
         | Request::RenameLauncher { .. }
         | Request::RemoveLauncher { .. } => 8,
         Request::GetAgent { .. } | Request::RegisterAgent { .. } | Request::ReportAgent { .. } => 9,
+        Request::EnsureAgent { .. } => 10,
         Request::ReadShellAt { .. } | Request::Events { .. } => 7,
         _ => protocol::MIN_PROTOCOL_VERSION,
     }
@@ -735,12 +752,50 @@ mod tests {
     }
 
     #[test]
+    fn ensure_agent_requires_protocol_ten() {
+        assert_eq!(
+            request_minimum_version(&Request::EnsureAgent {
+                shell_id: "s1".into(),
+                run_id: "r1".into(),
+                spec: AgentRegistrationSpec {
+                    name: "agent".into(),
+                    integration: "test".into(),
+                    external_session_id: Some("external-1".into()),
+                    report: AgentReport {
+                        state: protocol::AgentState::Working,
+                        authority: protocol::AgentAuthority::LifecycleIntegration,
+                        evidence: "working".into(),
+                        confidence: 90,
+                    },
+                },
+            }),
+            10
+        );
+    }
+
+    #[test]
     fn negotiates_protocol_seven_without_losing_version_seven_requests() {
         let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 10);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    10,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 9);
@@ -750,7 +805,7 @@ mod tests {
                 &Envelope::with_version(
                     9,
                     Response::Error {
-                        message: "expected an older protocol".into(),
+                        message: "expected protocol 7".into(),
                         code: Some(ErrorCode::UnsupportedVersion),
                     },
                 ),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,10 +23,11 @@ use crate::client;
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::protocol::{
-    self, AgentInstanceSnapshot, AgentObservationSnapshot, AgentRegistrationSpec, AgentReport,
-    AgentState, AttachFrame, DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor,
-    Request, Response, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus,
-    Snapshot, TerminalProfile, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    self, AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot, AgentRegistrationSpec,
+    AgentReport, AgentState, AttachFrame, DaemonEvent, DaemonEventKind, Envelope, ErrorCode,
+    EventCursor, Request, Response, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec,
+    ShellStatus, Snapshot, TerminalProfile, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
+    WorkspaceSnapshot,
 };
 use crate::state_store::{
     PersistedAgentInstance, PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
@@ -600,6 +601,16 @@ fn handle_connection(
             ),
         );
     }
+    if response_version < 10 && matches!(request.message, Request::EnsureAgent { .. }) {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "request requires daemon protocol 10",
+            ),
+        );
+    }
 
     if let Request::Attach {
         shell_id,
@@ -815,6 +826,11 @@ struct Registry {
     persist_lock: Mutex<()>,
     stopping: AtomicBool,
     persistence_dirty: AtomicBool,
+}
+
+enum DurableMutation<T> {
+    Changed(T, Vec<DaemonEventKind>),
+    Unchanged(T),
 }
 
 #[derive(Default)]
@@ -1557,12 +1573,38 @@ impl Registry {
                 }
                 Ok((Response::Agent { agent }, events))
             }),
+            Request::EnsureAgent {
+                shell_id,
+                run_id,
+                spec,
+            } => self.durable_mutation_outcome(|| {
+                let (agent, created) = self.ensure_agent(&shell_id, &run_id, spec)?;
+                if !created {
+                    return Ok(DurableMutation::Unchanged(Response::Agent { agent }));
+                }
+                let mut events = vec![DaemonEventKind::AgentRegistered {
+                    workspace_id: agent.workspace_id.clone(),
+                    shell_id: agent.shell_id.clone(),
+                    agent: agent.clone(),
+                }];
+                if agent.ended_at_ms.is_some() {
+                    events.push(DaemonEventKind::AgentCompleted {
+                        workspace_id: agent.workspace_id.clone(),
+                        shell_id: agent.shell_id.clone(),
+                        agent: agent.clone(),
+                    });
+                }
+                Ok(DurableMutation::Changed(Response::Agent { agent }, events))
+            }),
             Request::ReportAgent {
                 agent_id,
                 run_id,
                 report,
-            } => self.durable_mutation(|| {
-                let (agent, completed) = self.report_agent(&agent_id, &run_id, report)?;
+            } => self.durable_mutation_outcome(|| {
+                let (agent, changed, completed) = self.report_agent(&agent_id, &run_id, report)?;
+                if !changed {
+                    return Ok(DurableMutation::Unchanged(Response::Agent { agent }));
+                }
                 let event = if completed {
                     DaemonEventKind::AgentCompleted {
                         workspace_id: agent.workspace_id.clone(),
@@ -1576,7 +1618,10 @@ impl Registry {
                         agent: agent.clone(),
                     }
                 };
-                Ok((Response::Agent { agent }, vec![event]))
+                Ok(DurableMutation::Changed(
+                    Response::Agent { agent },
+                    vec![event],
+                ))
             }),
             Request::ReadShell {
                 shell_id,
@@ -2072,6 +2117,16 @@ impl Registry {
         &self,
         operation: impl FnOnce() -> io::Result<(T, Vec<DaemonEventKind>)>,
     ) -> io::Result<T> {
+        self.durable_mutation_outcome(|| {
+            let (value, events) = operation()?;
+            Ok(DurableMutation::Changed(value, events))
+        })
+    }
+
+    fn durable_mutation_outcome<T>(
+        &self,
+        operation: impl FnOnce() -> io::Result<DurableMutation<T>>,
+    ) -> io::Result<T> {
         let _mutation = lock(&self.mutation_lock)?;
         let mut transition = lock(&self.transitions)?;
         let _persistence = lock(&self.persist_lock)?;
@@ -2080,7 +2135,8 @@ impl Registry {
         self.flush_pending_locked(&mut transition, &mut events)?;
         let backup = self.backup()?;
         match operation() {
-            Ok((value, kinds)) => {
+            Ok(DurableMutation::Unchanged(value)) => Ok(value),
+            Ok(DurableMutation::Changed(value, kinds)) => {
                 if let Err(error) = EventLog::ensure_capacity(&events, kinds.len()) {
                     self.restore_backup(backup)?;
                     return Err(error);
@@ -2749,6 +2805,7 @@ impl Registry {
         spec: AgentRegistrationSpec,
     ) -> io::Result<AgentInstanceSnapshot> {
         validate_agent_registration(&spec)?;
+        validate_external_agent_authority(spec.report.authority)?;
         let shell = self.shell(shell_id)?;
         let lifecycle = lock(&shell.lifecycle)?;
         match &*lifecycle {
@@ -2804,13 +2861,71 @@ impl Registry {
         Ok(snapshot)
     }
 
+    fn ensure_agent(
+        &self,
+        shell_id: &str,
+        run_id: &str,
+        spec: AgentRegistrationSpec,
+    ) -> io::Result<(AgentInstanceSnapshot, bool)> {
+        validate_agent_registration(&spec)?;
+        validate_external_agent_authority(spec.report.authority)?;
+        let external_session_id = spec.external_session_id.as_deref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "agent external_session_id is required for ensure",
+            )
+        })?;
+        let matches = {
+            let state = lock(&self.state)?;
+            state
+                .agents
+                .values()
+                .filter(|agent| {
+                    agent.integration == spec.integration
+                        && agent.external_session_id.as_deref() == Some(external_session_id)
+                        && agent.shell_id == shell_id
+                        && agent.run_id == run_id
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        let existing = match matches.as_slice() {
+            [] => None,
+            [agent] => Some(Arc::clone(agent)),
+            agents => {
+                let mut active = Vec::new();
+                for agent in agents {
+                    if lock(&agent.state)?.ended_at_ms.is_none() {
+                        active.push(Arc::clone(agent));
+                    }
+                }
+                match active.as_slice() {
+                    [agent] => Some(Arc::clone(agent)),
+                    _ => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::AlreadyExists,
+                            "multiple agent instances match the ensured identity",
+                        ));
+                    }
+                }
+            }
+        };
+        if let Some(agent) = existing {
+            return Ok((agent.snapshot()?, false));
+        }
+
+        self.register_agent(shell_id, run_id, spec)
+            .map(|agent| (agent, true))
+    }
+
     fn report_agent(
         &self,
         agent_id: &str,
         run_id: &str,
         report: AgentReport,
-    ) -> io::Result<(AgentInstanceSnapshot, bool)> {
+    ) -> io::Result<(AgentInstanceSnapshot, bool, bool)> {
         validate_agent_report(&report)?;
+        validate_external_agent_authority(report.authority)?;
         let agent = self.agent(agent_id)?;
         if agent.run_id != run_id {
             return Err(coded_error(
@@ -2820,10 +2935,21 @@ impl Registry {
         }
         let mut state = lock(&agent.state)?;
         if state.ended_at_ms.is_some() {
+            if observation_matches_report(&state.observation, &report) {
+                drop(state);
+                return Ok((agent.snapshot()?, false, true));
+            }
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "completed agent instance cannot be reported again",
             ));
+        }
+        if observation_matches_report(&state.observation, &report)
+            || agent_authority_rank(report.authority)
+                < agent_authority_rank(state.observation.authority)
+        {
+            drop(state);
+            return Ok((agent.snapshot()?, false, false));
         }
         let revision = state
             .observation
@@ -2846,7 +2972,7 @@ impl Registry {
             state.ended_at_ms = Some(observed_at_ms);
         }
         drop(state);
-        Ok((agent.snapshot()?, completed))
+        Ok((agent.snapshot()?, true, completed))
     }
 
     fn rename_launcher(&self, launcher_id: &str, name: String) -> io::Result<()> {
@@ -4509,6 +4635,35 @@ fn validate_agent_report(report: &AgentReport) -> io::Result<()> {
     Ok(())
 }
 
+fn validate_external_agent_authority(authority: AgentAuthority) -> io::Result<()> {
+    if authority == AgentAuthority::DaemonLifecycle {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "daemon_lifecycle authority is reserved for daemon observations",
+        ));
+    }
+    Ok(())
+}
+
+fn observation_matches_report(
+    observation: &AgentObservationSnapshot,
+    report: &AgentReport,
+) -> bool {
+    observation.state == report.state
+        && observation.authority == report.authority
+        && observation.evidence == report.evidence
+        && observation.confidence == report.confidence
+}
+
+fn agent_authority_rank(authority: AgentAuthority) -> u8 {
+    match authority {
+        AgentAuthority::LifecycleIntegration => 3,
+        AgentAuthority::ProcessAdapter => 2,
+        AgentAuthority::TerminalHeuristic => 1,
+        AgentAuthority::DaemonLifecycle => 4,
+    }
+}
+
 fn validate_required_agent_string(kind: &str, value: &str, max_bytes: usize) -> io::Result<()> {
     if value.trim().is_empty() || value.len() > max_bytes {
         return Err(io::Error::new(
@@ -4589,6 +4744,15 @@ mod tests {
                 evidence: "test observation".into(),
                 confidence: 90,
             },
+        }
+    }
+
+    fn agent_report(state: AgentState, authority: AgentAuthority, evidence: &str) -> AgentReport {
+        AgentReport {
+            state,
+            authority,
+            evidence: evidence.into(),
+            confidence: 90,
         }
     }
 
@@ -4937,6 +5101,289 @@ mod tests {
     }
 
     #[test]
+    fn ensure_agent_reuses_identity_without_events_or_revision_changes() {
+        let registry = Registry::default();
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let spec = agent_spec(AgentState::Working);
+
+        let Response::Agent { agent: created } = registry
+            .dispatch(Request::EnsureAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec: spec.clone(),
+            })
+            .unwrap()
+        else {
+            panic!("expected ensured agent");
+        };
+        let event_id = lock(&registry.events.state).unwrap().latest_id;
+        let Response::Agent { agent: reused } = registry
+            .dispatch(Request::EnsureAgent {
+                shell_id: shell.id.clone(),
+                run_id,
+                spec,
+            })
+            .unwrap()
+        else {
+            panic!("expected reused agent");
+        };
+
+        assert_eq!(reused, created);
+        assert_eq!(lock(&registry.events.state).unwrap().latest_id, event_id);
+        assert_eq!(registry.snapshot().unwrap().workspaces[0].agents.len(), 1);
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn concurrent_ensure_agent_creates_one_identity() {
+        let registry = Arc::new(Registry::default());
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let barrier = Arc::new(Barrier::new(3));
+        let mut threads = Vec::new();
+        for _ in 0..2 {
+            let registry = Arc::clone(&registry);
+            let shell_id = shell.id.clone();
+            let run_id = run_id.clone();
+            let barrier = Arc::clone(&barrier);
+            threads.push(thread::spawn(move || {
+                barrier.wait();
+                let Response::Agent { agent } = registry
+                    .dispatch(Request::EnsureAgent {
+                        shell_id,
+                        run_id,
+                        spec: agent_spec(AgentState::Working),
+                    })
+                    .unwrap()
+                else {
+                    panic!("expected ensured agent");
+                };
+                agent.id
+            }));
+        }
+        barrier.wait();
+        let ids = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids[0], ids[1]);
+        assert_eq!(registry.snapshot().unwrap().workspaces[0].agents.len(), 1);
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn ensure_agent_resolves_only_a_unique_active_legacy_match() {
+        let registry = Registry::default();
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let completed = registry
+            .register_agent(&shell.id, &run_id, agent_spec(AgentState::Done))
+            .unwrap();
+        let active = registry
+            .register_agent(&shell.id, &run_id, agent_spec(AgentState::Working))
+            .unwrap();
+
+        let (ensured, created) = registry
+            .ensure_agent(&shell.id, &run_id, agent_spec(AgentState::Working))
+            .unwrap();
+        assert!(!created);
+        assert_eq!(ensured.id, active.id);
+        assert_ne!(ensured.id, completed.id);
+
+        registry
+            .register_agent(&shell.id, &run_id, agent_spec(AgentState::Working))
+            .unwrap();
+        assert_eq!(
+            registry
+                .ensure_agent(&shell.id, &run_id, agent_spec(AgentState::Working))
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::AlreadyExists
+        );
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn ensure_agent_requires_external_id_and_distinguishes_runs() {
+        let registry = Registry::default();
+        let (workspace, shell, runtime) = running_shell(&registry);
+        let first_run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let mut missing_id = agent_spec(AgentState::Working);
+        missing_id.external_session_id = None;
+        assert_eq!(
+            registry
+                .dispatch(Request::EnsureAgent {
+                    shell_id: shell.id.clone(),
+                    run_id: first_run_id.clone(),
+                    spec: missing_id,
+                })
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        let Response::Agent { agent: first } = registry
+            .dispatch(Request::EnsureAgent {
+                shell_id: shell.id.clone(),
+                run_id: first_run_id.clone(),
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected first agent");
+        };
+
+        let second_run = Arc::new(ShellRun::new(2));
+        *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
+            profile: profile(),
+            run: Arc::clone(&second_run),
+            runtime: Arc::clone(&runtime),
+        };
+        let Response::Agent { agent: recovered } = registry
+            .dispatch(Request::EnsureAgent {
+                shell_id: shell.id.clone(),
+                run_id: first_run_id,
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected recovered first agent");
+        };
+        let Response::Agent { agent: second } = registry
+            .dispatch(Request::EnsureAgent {
+                shell_id: shell.id.clone(),
+                run_id: second_run.id.clone(),
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected second agent");
+        };
+
+        assert_eq!(recovered.id, first.id);
+        assert_ne!(second.id, first.id);
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn reports_obey_authority_and_idempotent_completion_rules() {
+        let registry = Registry::default();
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let mut spec = agent_spec(AgentState::Working);
+        spec.report = agent_report(
+            AgentState::Working,
+            AgentAuthority::ProcessAdapter,
+            "process working",
+        );
+        let Response::Agent { agent } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec,
+            })
+            .unwrap()
+        else {
+            panic!("expected agent");
+        };
+        let registered_event_id = lock(&registry.events.state).unwrap().latest_id;
+
+        for report in [
+            agent_report(
+                AgentState::Done,
+                AgentAuthority::TerminalHeuristic,
+                "weak done",
+            ),
+            agent_report(
+                AgentState::Working,
+                AgentAuthority::ProcessAdapter,
+                "process working",
+            ),
+        ] {
+            let Response::Agent { agent: unchanged } = registry
+                .dispatch(Request::ReportAgent {
+                    agent_id: agent.id.clone(),
+                    run_id: run_id.clone(),
+                    report,
+                })
+                .unwrap()
+            else {
+                panic!("expected unchanged agent");
+            };
+            assert_eq!(unchanged, agent);
+        }
+        assert_eq!(
+            lock(&registry.events.state).unwrap().latest_id,
+            registered_event_id
+        );
+
+        let completion = agent_report(
+            AgentState::Done,
+            AgentAuthority::LifecycleIntegration,
+            "lifecycle done",
+        );
+        let Response::Agent { agent: completed } = registry
+            .dispatch(Request::ReportAgent {
+                agent_id: agent.id.clone(),
+                run_id: run_id.clone(),
+                report: completion.clone(),
+            })
+            .unwrap()
+        else {
+            panic!("expected completed agent");
+        };
+        let completion_event_id = lock(&registry.events.state).unwrap().latest_id;
+        let Response::Agent { agent: retried } = registry
+            .dispatch(Request::ReportAgent {
+                agent_id: agent.id.clone(),
+                run_id: run_id.clone(),
+                report: completion,
+            })
+            .unwrap()
+        else {
+            panic!("expected retried completion");
+        };
+        assert_eq!(retried, completed);
+        assert_eq!(
+            lock(&registry.events.state).unwrap().latest_id,
+            completion_event_id
+        );
+        assert!(
+            registry
+                .dispatch(Request::ReportAgent {
+                    agent_id: agent.id.clone(),
+                    run_id: run_id.clone(),
+                    report: agent_report(
+                        AgentState::Done,
+                        AgentAuthority::LifecycleIntegration,
+                        "conflicting done",
+                    ),
+                })
+                .is_err()
+        );
+        assert!(
+            registry
+                .dispatch(Request::ReportAgent {
+                    agent_id: agent.id,
+                    run_id,
+                    report: agent_report(
+                        AgentState::Done,
+                        AgentAuthority::DaemonLifecycle,
+                        "external daemon claim",
+                    ),
+                })
+                .is_err()
+        );
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
     fn failed_agent_mutation_restores_observation_revision() {
         let registry = Registry::default();
         let (workspace, shell, _runtime) = running_shell(&registry);
@@ -4964,12 +5411,14 @@ mod tests {
         let path = directory.join("state/state.json");
         let registry = Registry::restore(StateStore::at(path.clone()), false, None).unwrap();
         let (_workspace, shell, runtime) = running_shell(&registry);
+        let shell_id = shell.id.clone();
         let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let spec = agent_spec(AgentState::Working);
         let Response::Agent { agent } = registry
-            .dispatch(Request::RegisterAgent {
-                shell_id: shell.id.clone(),
-                run_id,
-                spec: agent_spec(AgentState::Working),
+            .dispatch(Request::EnsureAgent {
+                shell_id: shell_id.clone(),
+                run_id: run_id.clone(),
+                spec: spec.clone(),
             })
             .unwrap()
         else {
@@ -4988,8 +5437,19 @@ mod tests {
         );
         assert_eq!(
             restored.snapshot().unwrap().workspaces[0].agents,
-            vec![agent]
+            vec![agent.clone()]
         );
+        let Response::Agent { agent: ensured } = restored
+            .dispatch(Request::EnsureAgent {
+                shell_id,
+                run_id,
+                spec,
+            })
+            .unwrap()
+        else {
+            panic!("expected restored ensured agent");
+        };
+        assert_eq!(ensured, agent);
         drop(restored);
         fs::remove_dir_all(directory).unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::process::{Command, ExitCode, Stdio};
 use std::thread;
 
 use clap::error::ErrorKind as ClapErrorKind;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use uuid::Uuid;
 
 use boomux::protocol::{
@@ -27,6 +27,41 @@ mod terminal;
 mod tui;
 
 const BOOMUX_SKILL: &str = include_str!("../.agents/skills/boomux/SKILL.md");
+const BOOMUX_OPENCODE_PLUGIN: &str = include_str!("../integrations/opencode/boomux.js");
+const JSON_COMMANDS: &[&str] = &[
+    "capabilities",
+    "list",
+    "shells",
+    "read",
+    "events",
+    "workspace.list",
+    "workspace.inspect",
+    "shell.inspect",
+    "launcher.list",
+    "launcher.inspect",
+    "agent.list",
+    "agent.inspect",
+    "agent.register",
+    "agent.ensure",
+    "agent.report",
+    "daemon.status",
+];
+const INTEGRATION_FEATURES: &[&str] = &[
+    "typed_errors",
+    "shell_run_identity",
+    "rendered_scrollback",
+    "graceful_live_handoff",
+    "graceful_exited_handoff",
+    "daemon_events",
+    "reconnectable_event_cursors",
+    "revision_aware_reads",
+    "workspace_launchers",
+    "run_scoped_agent_instances",
+    "protocol_10",
+    "idempotent_agent_ensure",
+    "agent_authority_precedence",
+    "opencode_lifecycle_plugin",
+];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
 description: Read output and logs from Boomux workspace shells. Use when asked to inspect another shell by name, read shell2, examine terminal output, check logs from another terminal, or inspect a Boomux shell ID.
@@ -165,6 +200,11 @@ enum Commands {
         #[command(subcommand)]
         command: SkillCommands,
     },
+    /// Manage the Boomux OpenCode integration
+    Opencode {
+        #[command(subcommand)]
+        command: OpenCodeCommands,
+    },
     /// Open a shell in a new terminal window
     Open {
         shell_id: String,
@@ -287,25 +327,9 @@ enum AgentCommands {
     #[command(alias = "get")]
     Inspect { agent_id: String },
     /// Register an agent instance for a shell run
-    Register {
-        name: String,
-        #[arg(long)]
-        integration: String,
-        #[arg(long)]
-        external_session_id: Option<String>,
-        #[arg(long)]
-        shell_id: Option<String>,
-        #[arg(long)]
-        run_id: Option<String>,
-        #[arg(long, value_enum)]
-        state: CliAgentState,
-        #[arg(long, value_enum)]
-        authority: CliAgentAuthority,
-        #[arg(long)]
-        evidence: String,
-        #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-        confidence: u8,
-    },
+    Register(AgentRegistrationArgs),
+    /// Ensure an idempotent agent instance for a shell run
+    Ensure(AgentRegistrationArgs),
     /// Report state for an agent instance by exact ID
     Report {
         agent_id: String,
@@ -322,6 +346,27 @@ enum AgentCommands {
         #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
         confidence: u8,
     },
+}
+
+#[derive(Args)]
+struct AgentRegistrationArgs {
+    name: String,
+    #[arg(long)]
+    integration: String,
+    #[arg(long)]
+    external_session_id: Option<String>,
+    #[arg(long)]
+    shell_id: Option<String>,
+    #[arg(long)]
+    run_id: Option<String>,
+    #[arg(long, value_enum)]
+    state: CliAgentState,
+    #[arg(long, value_enum)]
+    authority: CliAgentAuthority,
+    #[arg(long)]
+    evidence: String,
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    confidence: u8,
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -350,7 +395,6 @@ enum CliAgentAuthority {
     LifecycleIntegration,
     ProcessAdapter,
     TerminalHeuristic,
-    DaemonLifecycle,
 }
 
 impl From<CliAgentAuthority> for AgentAuthority {
@@ -359,7 +403,6 @@ impl From<CliAgentAuthority> for AgentAuthority {
             CliAgentAuthority::LifecycleIntegration => Self::LifecycleIntegration,
             CliAgentAuthority::ProcessAdapter => Self::ProcessAdapter,
             CliAgentAuthority::TerminalHeuristic => Self::TerminalHeuristic,
-            CliAgentAuthority::DaemonLifecycle => Self::DaemonLifecycle,
         }
     }
 }
@@ -367,6 +410,15 @@ impl From<CliAgentAuthority> for AgentAuthority {
 #[derive(Subcommand)]
 enum SkillCommands {
     /// Install the Boomux CLI skill under ~/.agents/skills
+    Install {
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum OpenCodeCommands {
+    /// Install the Boomux plugin in the global OpenCode configuration
     Install {
         #[arg(long)]
         force: bool,
@@ -508,6 +560,9 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
         }) => install_skill(force),
+        Some(Commands::Opencode {
+            command: OpenCodeCommands::Install { force },
+        }) => install_opencode(force),
         Some(Commands::Open {
             shell_id,
             title,
@@ -551,18 +606,27 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Agent {
             command: AgentCommands::Inspect { .. },
         }) => "agent.inspect",
+        Some(Commands::Agent {
+            command: AgentCommands::Register(..),
+        }) => "agent.register",
+        Some(Commands::Agent {
+            command: AgentCommands::Ensure(..),
+        }) => "agent.ensure",
+        Some(Commands::Agent {
+            command: AgentCommands::Report { .. },
+        }) => "agent.report",
         Some(Commands::Daemon {
             command: DaemonCommands::Status,
         }) => "daemon.status",
         Some(Commands::Workspace { .. }) => "workspace",
         Some(Commands::Shell { .. }) => "shell",
         Some(Commands::Launcher { .. }) => "launcher",
-        Some(Commands::Agent { .. }) => "agent",
         Some(Commands::Daemon { .. }) => "daemon",
         Some(Commands::Ui) | None => "ui",
         Some(Commands::Doctor) => "doctor",
         Some(Commands::Close { .. }) => "close",
         Some(Commands::Skill { .. }) => "skill",
+        Some(Commands::Opencode { .. }) => "opencode",
         Some(Commands::Open { .. }) => "open",
         Some(Commands::Prompt) => "prompt",
         Some(Commands::Attach { .. }) => "attach",
@@ -585,7 +649,11 @@ fn supports_json(cli: &Cli) -> bool {
         }) | Some(Commands::Launcher {
             command: LauncherCommands::List { .. } | LauncherCommands::Inspect { .. }
         }) | Some(Commands::Agent {
-            command: AgentCommands::List { .. } | AgentCommands::Inspect { .. }
+            command: AgentCommands::List { .. }
+                | AgentCommands::Inspect { .. }
+                | AgentCommands::Register(..)
+                | AgentCommands::Ensure(..)
+                | AgentCommands::Report { .. }
         }) | Some(Commands::Daemon {
             command: DaemonCommands::Status
         })
@@ -1009,33 +1077,6 @@ fn unique_shell_name(base_name: &str, shells: &[ShellSnapshot]) -> String {
 }
 
 fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
-    let commands = [
-        "capabilities",
-        "list",
-        "shells",
-        "read",
-        "events",
-        "workspace.list",
-        "workspace.inspect",
-        "shell.inspect",
-        "launcher.list",
-        "launcher.inspect",
-        "agent.list",
-        "agent.inspect",
-        "daemon.status",
-    ];
-    let features = [
-        "typed_errors",
-        "shell_run_identity",
-        "rendered_scrollback",
-        "graceful_live_handoff",
-        "graceful_exited_handoff",
-        "daemon_events",
-        "reconnectable_event_cursors",
-        "revision_aware_reads",
-        "workspace_launchers",
-        "run_scoped_agent_instances",
-    ];
     let error_codes = [
         "invalid_argument",
         "not_found",
@@ -1062,8 +1103,8 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
                 "cli_version": env!("CARGO_PKG_VERSION"),
                 "daemon_protocol_version": protocol::PROTOCOL_VERSION,
                 "json_schemas": [cli_output::SCHEMA],
-                "json_commands": commands,
-                "features": features,
+                "json_commands": JSON_COMMANDS,
+                "features": INTEGRATION_FEATURES,
                 "error_codes": error_codes,
             }),
         );
@@ -1071,8 +1112,8 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
     println!("CLI VERSION\t{}", env!("CARGO_PKG_VERSION"));
     println!("DAEMON PROTOCOL\t{}", protocol::PROTOCOL_VERSION);
     println!("JSON SCHEMAS\t{}", cli_output::SCHEMA);
-    println!("JSON COMMANDS\t{}", commands.join(","));
-    println!("FEATURES\t{}", features.join(","));
+    println!("JSON COMMANDS\t{}", JSON_COMMANDS.join(","));
+    println!("FEATURES\t{}", INTEGRATION_FEATURES.join(","));
     println!("ERROR CODES\t{}", error_codes.join(","));
     Ok(())
 }
@@ -1488,39 +1529,11 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
             }
             print_agent(&agent, &workspace.name);
         }
-        AgentCommands::Register {
-            name,
-            integration,
-            external_session_id,
-            shell_id,
-            run_id,
-            state,
-            authority,
-            evidence,
-            confidence,
-        } => {
-            let (shell_id, run_id) = resolve_agent_context(
-                shell_id,
-                run_id,
-                env::var("BOOMUX_SHELL_ID").ok(),
-                env::var("BOOMUX_RUN_ID").ok(),
-            )?;
-            let agent = client.register_agent(
-                shell_id,
-                run_id,
-                AgentRegistrationSpec {
-                    name: cli_name(name, "agent")?,
-                    integration,
-                    external_session_id,
-                    report: AgentReport {
-                        state: state.into(),
-                        authority: authority.into(),
-                        evidence,
-                        confidence,
-                    },
-                },
-            )?;
-            println!("Registered agent {} ({})", agent.name, agent.id);
+        AgentCommands::Register(arguments) => {
+            register_or_ensure_agent(&client, arguments, json, false)?;
+        }
+        AgentCommands::Ensure(arguments) => {
+            register_or_ensure_agent(&client, arguments, json, true)?;
         }
         AgentCommands::Report {
             agent_id,
@@ -1560,6 +1573,14 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
                     confidence,
                 },
             )?;
+            if json {
+                return cli_output::print(
+                    "agent.report",
+                    serde_json::json!({
+                        "agent": cli_output::agent(&agent, None),
+                    }),
+                );
+            }
             println!(
                 "Reported {} for agent {} (revision {})",
                 cli_output::agent_state(agent.observation.state),
@@ -1568,6 +1589,55 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
             );
         }
     }
+    Ok(())
+}
+
+fn register_or_ensure_agent(
+    client: &client::Client,
+    arguments: AgentRegistrationArgs,
+    json: bool,
+    ensure: bool,
+) -> Result<(), Box<dyn Error>> {
+    let (shell_id, run_id) = resolve_agent_context(
+        arguments.shell_id,
+        arguments.run_id,
+        env::var("BOOMUX_SHELL_ID").ok(),
+        env::var("BOOMUX_RUN_ID").ok(),
+    )?;
+    let spec = AgentRegistrationSpec {
+        name: cli_name(arguments.name, "agent")?,
+        integration: arguments.integration,
+        external_session_id: arguments.external_session_id,
+        report: AgentReport {
+            state: arguments.state.into(),
+            authority: arguments.authority.into(),
+            evidence: arguments.evidence,
+            confidence: arguments.confidence,
+        },
+    };
+    let agent = if ensure {
+        client.ensure_agent(shell_id, run_id, spec)?
+    } else {
+        client.register_agent(shell_id, run_id, spec)?
+    };
+    if json {
+        return cli_output::print(
+            if ensure {
+                "agent.ensure"
+            } else {
+                "agent.register"
+            },
+            serde_json::json!({
+                "agent": cli_output::agent(&agent, None),
+            }),
+        );
+    }
+    println!(
+        "{} agent {} ({})",
+        if ensure { "Ensured" } else { "Registered" },
+        agent.name,
+        agent.id
+    );
     Ok(())
 }
 
@@ -2171,28 +2241,14 @@ fn install_skill(force: bool) -> Result<(), Box<dyn Error>> {
 }
 
 fn install_skill_at(home: &Path, force: bool) -> Result<(), Box<dyn Error>> {
-    let directory = ensure_skill_directory(home, "boomux")?;
+    require_absolute_root(home, "HOME")?;
+    let directory = ensure_safe_directory(&home.join(".agents/skills/boomux"))?;
     let path = skill_install_path(home);
-    let already_installed = if let Some(existing) = read_regular_file(&path)? {
-        if existing == BOOMUX_SKILL {
-            true
-        } else if !force {
-            return Err(format!(
-                "{} already exists; rerun with --force to replace it",
-                path.display()
-            )
-            .into());
-        } else {
-            false
-        }
-    } else {
-        false
-    };
+    let already_installed = install_asset_at(&directory, &path, BOOMUX_SKILL, force)?;
 
     if already_installed {
         println!("Boomux skill is already installed at {}", path.display());
     } else {
-        write_skill_atomically(&directory, &path, BOOMUX_SKILL)?;
         println!("Installed Boomux skill at {}", path.display());
     }
     migrate_legacy_skill(home)?;
@@ -2216,7 +2272,7 @@ fn migrate_legacy_skill(home: &Path) -> Result<(), Box<dyn Error>> {
     let path = legacy_skill_install_path(home);
     if let Some(existing) = read_regular_file(&path)? {
         let entries = fs::read_dir(&directory)?.collect::<Result<Vec<_>, _>>()?;
-        let untouched = existing == LEGACY_BOOMUX_SHELLS_SKILL
+        let untouched = existing == LEGACY_BOOMUX_SHELLS_SKILL.as_bytes()
             && entries.len() == 1
             && entries[0].file_name() == "SKILL.md";
         if untouched {
@@ -2235,15 +2291,57 @@ fn migrate_legacy_skill(home: &Path) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn ensure_skill_directory(home: &Path, skill: &str) -> Result<PathBuf, Box<dyn Error>> {
-    let mut directory = home.to_owned();
-    for component in [".agents", "skills", skill] {
+fn install_opencode(force: bool) -> Result<(), Box<dyn Error>> {
+    let config_root = opencode_config_root(env::var_os("XDG_CONFIG_HOME"), env::var_os("HOME"))?;
+    install_opencode_at(&config_root, force)
+}
+
+fn opencode_config_root(
+    xdg_config_home: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let root = if let Some(root) = xdg_config_home {
+        PathBuf::from(root)
+    } else {
+        PathBuf::from(home.ok_or("HOME must be set to install the Boomux OpenCode plugin")?)
+            .join(".config")
+    };
+    require_absolute_root(&root, "XDG configuration root")?;
+    Ok(root)
+}
+
+fn install_opencode_at(config_root: &Path, force: bool) -> Result<(), Box<dyn Error>> {
+    require_absolute_root(config_root, "XDG configuration root")?;
+    let directory = ensure_safe_directory(&config_root.join("opencode/plugins"))?;
+    let path = opencode_install_path(config_root);
+    if install_asset_at(&directory, &path, BOOMUX_OPENCODE_PLUGIN, force)? {
+        println!(
+            "Boomux OpenCode plugin is already installed at {}",
+            path.display()
+        );
+    } else {
+        println!("Installed Boomux OpenCode plugin at {}", path.display());
+    }
+    Ok(())
+}
+
+fn require_absolute_root(root: &Path, name: &str) -> Result<(), Box<dyn Error>> {
+    if !root.is_absolute() {
+        return Err(format!("{name} must be an absolute path").into());
+    }
+    Ok(())
+}
+
+fn ensure_safe_directory(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
+    require_absolute_root(path, "install directory")?;
+    let mut directory = PathBuf::new();
+    for component in path.components() {
         directory.push(component);
         match fs::symlink_metadata(&directory) {
             Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
             Ok(_) => {
                 return Err(format!(
-                    "skill path component is not a regular directory: {}",
+                    "install path component is not a regular directory: {}",
                     directory.display()
                 )
                 .into());
@@ -2257,23 +2355,45 @@ fn ensure_skill_directory(home: &Path, skill: &str) -> Result<PathBuf, Box<dyn E
     Ok(directory)
 }
 
-fn read_regular_file(path: &Path) -> Result<Option<String>, Box<dyn Error>> {
+fn read_regular_file(path: &Path) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {
-            Ok(Some(fs::read_to_string(path)?))
+            Ok(Some(fs::read(path)?))
         }
-        Ok(_) => Err(format!("skill path is not a regular file: {}", path.display()).into()),
+        Ok(_) => Err(format!("install path is not a regular file: {}", path.display()).into()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error.into()),
     }
 }
 
-fn write_skill_atomically(
+fn install_asset_at(
+    directory: &Path,
+    path: &Path,
+    content: &str,
+    force: bool,
+) -> Result<bool, Box<dyn Error>> {
+    if let Some(existing) = read_regular_file(path)? {
+        if existing == content.as_bytes() {
+            return Ok(true);
+        }
+        if !force {
+            return Err(format!(
+                "{} already exists; rerun with --force to replace it",
+                path.display()
+            )
+            .into());
+        }
+    }
+    write_asset_atomically(directory, path, content)?;
+    Ok(false)
+}
+
+fn write_asset_atomically(
     directory: &Path,
     path: &Path,
     content: &str,
 ) -> Result<(), Box<dyn Error>> {
-    let temporary = directory.join(format!(".SKILL-{}.tmp", Uuid::new_v4()));
+    let temporary = directory.join(format!(".boomux-install-{}.tmp", Uuid::new_v4()));
     let result = (|| {
         let mut file = OpenOptions::new()
             .write(true)
@@ -2292,6 +2412,10 @@ fn write_skill_atomically(
 
 fn skill_install_path(home: &Path) -> PathBuf {
     home.join(".agents/skills/boomux/SKILL.md")
+}
+
+fn opencode_install_path(config_root: &Path) -> PathBuf {
+    config_root.join("opencode/plugins/boomux.js")
 }
 
 fn legacy_skill_install_path(home: &Path) -> PathBuf {
@@ -2478,6 +2602,8 @@ mod tests {
         }
         let cli = Cli::try_parse_from(["boomux", "workspace", "create", "test", "--json"]).unwrap();
         assert!(!supports_json(&cli));
+        let cli = Cli::try_parse_from(["boomux", "opencode", "install", "--json"]).unwrap();
+        assert!(!supports_json(&cli));
         assert!(
             Cli::try_parse_from([
                 "boomux",
@@ -2613,9 +2739,36 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Commands::Agent {
-                command: AgentCommands::Register { confidence: 95, .. }
+                command: AgentCommands::Register(AgentRegistrationArgs { confidence: 95, .. })
             })
         ));
+
+        let ensure = Cli::try_parse_from([
+            "boomux",
+            "agent",
+            "ensure",
+            "OpenCode",
+            "--integration",
+            "opencode",
+            "--external-session-id",
+            "session-1",
+            "--shell-id",
+            "s1",
+            "--run-id",
+            "r1",
+            "--state",
+            "working",
+            "--authority",
+            "lifecycle-integration",
+            "--evidence",
+            "tool call",
+            "--confidence",
+            "100",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(command_name(&ensure), "agent.ensure");
+        assert!(supports_json(&ensure));
 
         let cli = Cli::try_parse_from([
             "boomux",
@@ -2646,7 +2799,45 @@ mod tests {
             "--json",
         ])
         .unwrap();
-        assert!(!supports_json(&cli));
+        assert_eq!(command_name(&cli), "agent.report");
+        assert!(supports_json(&cli));
+        let register = Cli::try_parse_from([
+            "boomux",
+            "agent",
+            "register",
+            "agent",
+            "--integration",
+            "test",
+            "--state",
+            "working",
+            "--authority",
+            "process-adapter",
+            "--evidence",
+            "running",
+            "--confidence",
+            "80",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(command_name(&register), "agent.register");
+        assert!(supports_json(&register));
+        assert!(
+            Cli::try_parse_from([
+                "boomux",
+                "agent",
+                "report",
+                "a1",
+                "--state",
+                "done",
+                "--authority",
+                "daemon-lifecycle",
+                "--evidence",
+                "complete",
+                "--confidence",
+                "100",
+            ])
+            .is_err()
+        );
         assert!(
             Cli::try_parse_from([
                 "boomux",
@@ -2924,6 +3115,137 @@ mod tests {
             legacy_skill_install_path(Path::new("/home/example")),
             PathBuf::from("/home/example/.agents/skills/boomux-shells/SKILL.md")
         );
+    }
+
+    #[test]
+    fn parses_opencode_install_and_uses_global_plugin_path() {
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "opencode", "install", "--force"])
+                .unwrap()
+                .command,
+            Some(Commands::Opencode {
+                command: OpenCodeCommands::Install { force: true }
+            })
+        ));
+        assert_eq!(
+            opencode_install_path(Path::new("/config")),
+            PathBuf::from("/config/opencode/plugins/boomux.js")
+        );
+        assert_eq!(
+            opencode_config_root(Some("/xdg".into()), Some("/home/example".into())).unwrap(),
+            PathBuf::from("/xdg")
+        );
+        assert_eq!(
+            opencode_config_root(None, Some("/home/example".into())).unwrap(),
+            PathBuf::from("/home/example/.config")
+        );
+        assert!(opencode_config_root(Some("relative".into()), None).is_err());
+        assert!(install_opencode_at(Path::new("relative"), false).is_err());
+    }
+
+    #[test]
+    fn opencode_install_is_idempotent_and_requires_force_for_changes() {
+        let config = test_skill_home("opencode-content");
+        let plugin = opencode_install_path(&config);
+        let herdr = config.join("opencode/plugins/herdr.js");
+        let opencode_json = config.join("opencode/opencode.json");
+        fs::create_dir_all(herdr.parent().unwrap()).unwrap();
+        fs::write(&herdr, "herdr plugin").unwrap();
+        fs::write(&opencode_json, "{\"plugin\":[\"herdr\"]}").unwrap();
+
+        install_opencode_at(&config, false).unwrap();
+        assert_eq!(fs::read_to_string(&plugin).unwrap(), BOOMUX_OPENCODE_PLUGIN);
+        assert_eq!(fs::read_to_string(&herdr).unwrap(), "herdr plugin");
+        assert_eq!(
+            fs::read_to_string(&opencode_json).unwrap(),
+            "{\"plugin\":[\"herdr\"]}"
+        );
+        install_opencode_at(&config, false).unwrap();
+        fs::write(&plugin, "custom plugin").unwrap();
+        assert!(install_opencode_at(&config, false).is_err());
+        assert_eq!(fs::read_to_string(&plugin).unwrap(), "custom plugin");
+        install_opencode_at(&config, true).unwrap();
+        assert_eq!(fs::read_to_string(&plugin).unwrap(), BOOMUX_OPENCODE_PLUGIN);
+
+        fs::remove_dir_all(config).unwrap();
+    }
+
+    #[test]
+    fn capabilities_advertise_phase_two_agent_integration_surface() {
+        for command in ["agent.register", "agent.ensure", "agent.report"] {
+            assert!(JSON_COMMANDS.contains(&command));
+        }
+        for feature in [
+            "protocol_10",
+            "idempotent_agent_ensure",
+            "agent_authority_precedence",
+            "opencode_lifecycle_plugin",
+        ] {
+            assert!(INTEGRATION_FEATURES.contains(&feature));
+        }
+        assert_eq!(protocol::PROTOCOL_VERSION, 10);
+    }
+
+    #[test]
+    fn opencode_install_rejects_symlinks_and_special_targets_even_with_force() {
+        use std::os::unix::fs::symlink;
+
+        let config = test_skill_home("opencode-symlink-directory");
+        let outside = test_skill_home("opencode-symlink-directory-target");
+        fs::create_dir_all(&config).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, config.join("opencode")).unwrap();
+        assert!(install_opencode_at(&config, true).is_err());
+        assert!(fs::read_dir(&outside).unwrap().next().is_none());
+        fs::remove_dir_all(&config).unwrap();
+        fs::remove_dir_all(&outside).unwrap();
+
+        let config = test_skill_home("opencode-symlink-file");
+        let outside = test_skill_home("opencode-symlink-file-target");
+        let plugin = opencode_install_path(&config);
+        fs::create_dir_all(plugin.parent().unwrap()).unwrap();
+        fs::write(&outside, "do not replace").unwrap();
+        symlink(&outside, &plugin).unwrap();
+        assert!(install_opencode_at(&config, true).is_err());
+        assert_eq!(fs::read_to_string(&outside).unwrap(), "do not replace");
+        fs::remove_dir_all(&config).unwrap();
+        fs::remove_file(&outside).unwrap();
+
+        let config = test_skill_home("opencode-special-file");
+        let plugin = opencode_install_path(&config);
+        fs::create_dir_all(&plugin).unwrap();
+        assert!(install_opencode_at(&config, true).is_err());
+        assert!(plugin.is_dir());
+        fs::remove_dir_all(config).unwrap();
+    }
+
+    #[test]
+    fn bundled_opencode_plugin_has_lifecycle_contract_without_shell_interpolation() {
+        for expected in [
+            "session.status",
+            "session.idle",
+            "session.error",
+            "session.deleted",
+            "permission.asked",
+            "question.asked",
+            "BOOMUX_SHELL_ID",
+            "BOOMUX_RUN_ID",
+            "agent\",\n    \"ensure",
+            "agent\",\n    \"report",
+            "--json",
+            "shell: false",
+        ] {
+            assert!(
+                BOOMUX_OPENCODE_PLUGIN.contains(expected),
+                "OpenCode plugin omits {expected}"
+            );
+        }
+        for forbidden in ["Bun.$", "exec(", "sh -c", "${BOOMUX_"] {
+            assert!(
+                !BOOMUX_OPENCODE_PLUGIN.contains(forbidden),
+                "OpenCode plugin contains shell interpolation marker {forbidden}"
+            );
+        }
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 9;
+pub const PROTOCOL_VERSION: u32 = 10;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -330,6 +330,11 @@ pub enum Request {
         spec: WorkspaceLauncherSpec,
     },
     RegisterAgent {
+        shell_id: String,
+        run_id: String,
+        spec: AgentRegistrationSpec,
+    },
+    EnsureAgent {
         shell_id: String,
         run_id: String,
         spec: AgentRegistrationSpec,
@@ -718,9 +723,32 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_nine_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 9);
+    fn protocol_version_is_ten_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 10);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
+    }
+
+    #[test]
+    fn ensure_agent_uses_registration_shape() {
+        let request = Request::EnsureAgent {
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            spec: AgentRegistrationSpec {
+                name: "agent".into(),
+                integration: "plugin".into(),
+                external_session_id: Some("session-1".into()),
+                report: AgentReport {
+                    state: AgentState::Working,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "working".into(),
+                    confidence: 90,
+                },
+            },
+        };
+
+        let encoded = serde_json::to_value(&request).unwrap();
+        assert_eq!(encoded["request"], "ensure_agent");
+        assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -984,54 +984,195 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
         },
     };
 
-    let error = daemon
-        .client
-        .register_agent(&shell_id, Uuid::new_v4().to_string(), registration.clone())
-        .unwrap_err();
-    assert_remote_code(&error, ErrorCode::RunChanged);
-    let registered = daemon
-        .client
-        .register_agent(&shell_id, &run_id, registration)
-        .unwrap();
-    assert_eq!(registered.workspace_id, workspace.id);
-    assert_eq!(registered.shell_id, shell_id);
-    assert_eq!(registered.run_id, run_id);
-    assert_eq!(registered.observation.revision, 1);
-    assert_eq!(registered.observation.state, AgentState::Working);
-    assert!(registered.ended_at_ms.is_none());
-    assert_eq!(daemon.client.get_agent(&registered.id).unwrap(), registered);
-    let snapshot_agent = daemon
-        .client
-        .snapshot()
-        .unwrap()
-        .workspaces
-        .into_iter()
-        .find(|current| current.id == workspace.id)
-        .unwrap()
-        .agents
-        .into_iter()
-        .find(|agent| agent.id == registered.id)
-        .unwrap();
-    assert_eq!(snapshot_agent, registered);
+    let ensure_agent = |daemon: &TestDaemon| {
+        let output = daemon
+            .command()
+            .args([
+                "agent",
+                "ensure",
+                "runtime-agent",
+                "--integration",
+                "native-test",
+                "--external-session-id",
+                "session-1",
+                "--shell-id",
+                &shell_id,
+                "--run-id",
+                &run_id,
+                "--state",
+                "working",
+                "--authority",
+                "lifecycle-integration",
+                "--evidence",
+                "registered",
+                "--confidence",
+                "90",
+                "--json",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap()
+    };
+    let ensure = ensure_agent(&daemon);
+    assert_eq!(ensure["schema"], "boomux.cli/v1");
+    assert_eq!(ensure["command"], "agent.ensure");
+    let agent_id = ensure["data"]["agent"]["id"].as_str().unwrap().to_owned();
+    assert_eq!(ensure["data"]["agent"]["shell_id"], shell_id);
+    assert_eq!(ensure["data"]["agent"]["run_id"], run_id);
+    assert_eq!(ensure["data"]["agent"]["external_session_id"], "session-1");
+    assert_eq!(ensure["data"]["agent"]["observation"]["revision"], 1);
 
-    let error = daemon
+    let repeated = ensure_agent(&daemon);
+    assert_eq!(repeated["data"]["agent"]["id"], agent_id);
+    assert_eq!(repeated["data"]["agent"]["observation"]["revision"], 1);
+    let ensured_events = daemon
+        .client
+        .events(Some(baseline.clone()), 256, 0)
+        .unwrap();
+    assert_eq!(
+        ensured_events
+            .events
+            .iter()
+            .filter(|event| matches!(
+                &event.kind,
+                protocol::DaemonEventKind::AgentRegistered { agent, .. }
+                    if agent.id == agent_id
+            ))
+            .count(),
+        1
+    );
+    let workspace_agents = daemon.client.get_workspace(&workspace.id).unwrap().agents;
+    assert_eq!(workspace_agents.len(), 1);
+    assert_eq!(workspace_agents[0].id, agent_id);
+
+    drop(attachment.stream);
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "{}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    let recovered = ensure_agent(&daemon);
+    assert_eq!(recovered["data"]["agent"]["id"], agent_id);
+    assert_eq!(recovered["data"]["agent"]["observation"]["revision"], 1);
+    let recovered = daemon.client.get_agent(&agent_id).unwrap();
+
+    let weak_report_cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    for report in [
+        AgentReport {
+            state: AgentState::Blocked,
+            authority: AgentAuthority::ProcessAdapter,
+            evidence: "process thinks blocked".into(),
+            confidence: 80,
+        },
+        AgentReport {
+            state: AgentState::Done,
+            authority: AgentAuthority::TerminalHeuristic,
+            evidence: "prompt disappeared".into(),
+            confidence: 40,
+        },
+    ] {
+        assert_eq!(
+            daemon
+                .client
+                .report_agent(&agent_id, &run_id, report)
+                .unwrap(),
+            recovered
+        );
+    }
+    assert!(
+        daemon
+            .client
+            .events(Some(weak_report_cursor), 256, 0)
+            .unwrap()
+            .events
+            .is_empty()
+    );
+
+    let register = daemon
+        .command()
+        .args([
+            "agent",
+            "register",
+            "adapter-agent",
+            "--integration",
+            "native-test",
+            "--shell-id",
+            &shell_id,
+            "--run-id",
+            &run_id,
+            "--state",
+            "idle",
+            "--authority",
+            "terminal-heuristic",
+            "--evidence",
+            "prompt visible",
+            "--confidence",
+            "30",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        register.status.success(),
+        "{}",
+        String::from_utf8_lossy(&register.stderr)
+    );
+    let register: serde_json::Value = serde_json::from_slice(&register.stdout).unwrap();
+    assert_eq!(register["schema"], "boomux.cli/v1");
+    assert_eq!(register["command"], "agent.register");
+    assert_eq!(register["data"]["agent"]["observation"]["revision"], 1);
+    let adapter_id = register["data"]["agent"]["id"].as_str().unwrap().to_owned();
+
+    let report_cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let report = daemon
+        .command()
+        .args([
+            "agent",
+            "report",
+            &adapter_id,
+            "--shell-id",
+            &shell_id,
+            "--run-id",
+            &run_id,
+            "--state",
+            "blocked",
+            "--authority",
+            "process-adapter",
+            "--evidence",
+            "waiting for input",
+            "--confidence",
+            "80",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        report.status.success(),
+        "{}",
+        String::from_utf8_lossy(&report.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&report.stdout).unwrap();
+    assert_eq!(report["schema"], "boomux.cli/v1");
+    assert_eq!(report["command"], "agent.report");
+    assert_eq!(report["data"]["agent"]["observation"]["revision"], 2);
+    assert_eq!(
+        report["data"]["agent"]["observation"]["authority"],
+        "process_adapter"
+    );
+    let duplicate = daemon
         .client
         .report_agent(
-            &registered.id,
-            Uuid::new_v4().to_string(),
-            AgentReport {
-                state: AgentState::Blocked,
-                authority: AgentAuthority::ProcessAdapter,
-                evidence: "wrong run".into(),
-                confidence: 50,
-            },
-        )
-        .unwrap_err();
-    assert_remote_code(&error, ErrorCode::RunChanged);
-    let blocked = daemon
-        .client
-        .report_agent(
-            &registered.id,
+            &adapter_id,
             &run_id,
             AgentReport {
                 state: AgentState::Blocked,
@@ -1041,65 +1182,136 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
             },
         )
         .unwrap();
-    assert_eq!(blocked.observation.revision, 2);
-    assert_eq!(blocked.observation.state, AgentState::Blocked);
-    assert!(blocked.ended_at_ms.is_none());
-    assert!(blocked.observation.observed_at_ms >= registered.observation.observed_at_ms);
+    assert_eq!(duplicate.observation.revision, 2);
+    let report_events = daemon.client.events(Some(report_cursor), 256, 0).unwrap();
+    assert_eq!(
+        report_events
+            .events
+            .iter()
+            .filter(|event| matches!(
+                &event.kind,
+                protocol::DaemonEventKind::AgentStateChanged { agent, .. }
+                    if agent.id == adapter_id
+            ))
+            .count(),
+        1
+    );
+
+    let completion = AgentReport {
+        state: AgentState::Done,
+        authority: AgentAuthority::LifecycleIntegration,
+        evidence: "completed".into(),
+        confidence: 100,
+    };
+    let done_cursor = report_events.cursor;
     let done = daemon
         .client
-        .report_agent(
-            &registered.id,
-            &run_id,
-            AgentReport {
-                state: AgentState::Done,
-                authority: AgentAuthority::LifecycleIntegration,
-                evidence: "completed".into(),
-                confidence: 100,
-            },
-        )
+        .report_agent(&adapter_id, &run_id, completion.clone())
         .unwrap();
     assert_eq!(done.observation.revision, 3);
     assert_eq!(done.observation.state, AgentState::Done);
     assert_eq!(done.ended_at_ms, Some(done.observation.observed_at_ms));
+    assert_eq!(
+        daemon
+            .client
+            .report_agent(&adapter_id, &run_id, completion)
+            .unwrap(),
+        done
+    );
+    let done_events = daemon.client.events(Some(done_cursor), 256, 0).unwrap();
+    assert_eq!(
+        done_events
+            .events
+            .iter()
+            .filter(|event| matches!(
+                &event.kind,
+                protocol::DaemonEventKind::AgentCompleted { agent, .. }
+                    if agent.id == adapter_id
+            ))
+            .count(),
+        1
+    );
     let error = daemon
         .client
         .report_agent(
-            &registered.id,
+            &adapter_id,
             &run_id,
             AgentReport {
-                state: AgentState::Idle,
-                authority: AgentAuthority::TerminalHeuristic,
-                evidence: "too late".into(),
-                confidence: 10,
+                state: AgentState::Done,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "conflicting completion".into(),
+                confidence: 100,
             },
         )
         .unwrap_err();
     assert_remote_code(&error, ErrorCode::InvalidArgument);
 
-    let events = daemon
-        .client
-        .events(Some(baseline.clone()), 256, 0)
+    for request in [
+        protocol::Request::RegisterAgent {
+            shell_id: shell_id.clone(),
+            run_id: run_id.clone(),
+            spec: AgentRegistrationSpec {
+                report: AgentReport {
+                    authority: AgentAuthority::DaemonLifecycle,
+                    ..registration.report.clone()
+                },
+                ..registration.clone()
+            },
+        },
+        protocol::Request::EnsureAgent {
+            shell_id: shell_id.clone(),
+            run_id: run_id.clone(),
+            spec: AgentRegistrationSpec {
+                report: AgentReport {
+                    authority: AgentAuthority::DaemonLifecycle,
+                    ..registration.report.clone()
+                },
+                ..registration.clone()
+            },
+        },
+        protocol::Request::ReportAgent {
+            agent_id: agent_id.clone(),
+            run_id: run_id.clone(),
+            report: AgentReport {
+                authority: AgentAuthority::DaemonLifecycle,
+                ..registration.report.clone()
+            },
+        },
+    ] {
+        assert!(matches!(
+            versioned_request(&daemon.client, 10, request),
+            protocol::Response::Error {
+                code: Some(ErrorCode::InvalidArgument),
+                ..
+            }
+        ));
+    }
+    let reserved_cli = daemon
+        .command()
+        .args([
+            "agent",
+            "report",
+            &agent_id,
+            "--state",
+            "done",
+            "--authority",
+            "daemon-lifecycle",
+            "--evidence",
+            "reserved",
+            "--confidence",
+            "100",
+            "--json",
+        ])
+        .output()
         .unwrap();
-    assert!(events.events.iter().any(|event| matches!(
-        &event.kind,
-        protocol::DaemonEventKind::AgentRegistered { agent, .. }
-            if agent.id == registered.id && agent.observation.revision == 1
-    )));
-    assert!(events.events.iter().any(|event| matches!(
-        &event.kind,
-        protocol::DaemonEventKind::AgentStateChanged { agent, .. }
-            if agent.id == registered.id && agent.observation.revision == 2
-    )));
-    assert!(events.events.iter().any(|event| matches!(
-        &event.kind,
-        protocol::DaemonEventKind::AgentCompleted { agent, .. }
-            if agent.id == registered.id && agent.observation.revision == 3
-    )));
+    assert!(!reserved_cli.status.success());
+    let reserved_cli: serde_json::Value = serde_json::from_slice(&reserved_cli.stderr).unwrap();
+    assert_eq!(reserved_cli["error"]["code"], "invalid_argument");
 
     let list = daemon.command().args(["agent", "list"]).output().unwrap();
     assert!(list.status.success());
     assert!(contains(&list.stdout, b"runtime-agent"));
-    assert!(contains(&list.stdout, registered.id.as_bytes()));
+    assert!(contains(&list.stdout, agent_id.as_bytes()));
     let list = daemon
         .command()
         .args(["agent", "list", "--json"])
@@ -1108,11 +1320,11 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert!(list.status.success());
     let list: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
     assert_eq!(list["command"], "agent.list");
-    assert_eq!(list["data"]["agents"][0]["id"], registered.id);
-    assert_eq!(list["data"]["agents"][0]["observation"]["revision"], 3);
+    assert_eq!(list["data"]["agents"][0]["id"], agent_id);
+    assert_eq!(list["data"]["agents"][0]["observation"]["revision"], 1);
     let inspect = daemon
         .command()
-        .args(["agent", "inspect", &registered.id])
+        .args(["agent", "inspect", &adapter_id])
         .output()
         .unwrap();
     assert!(inspect.status.success());
@@ -1120,15 +1332,55 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert!(contains(&inspect.stdout, b"REVISION\t3"));
     let inspect = daemon
         .command()
-        .args(["agent", "inspect", &registered.id, "--json"])
+        .args(["agent", "inspect", &adapter_id, "--json"])
         .output()
         .unwrap();
     assert!(inspect.status.success());
     let inspect: serde_json::Value = serde_json::from_slice(&inspect.stdout).unwrap();
     assert_eq!(inspect["command"], "agent.inspect");
-    assert_eq!(inspect["data"]["agent"]["id"], registered.id);
+    assert_eq!(inspect["data"]["agent"]["id"], adapter_id);
     assert_eq!(inspect["data"]["agent"]["observation"]["state"], "done");
 
+    assert!(matches!(
+        versioned_request(
+            &daemon.client,
+            9,
+            protocol::Request::EnsureAgent {
+                shell_id: shell_id.clone(),
+                run_id: run_id.clone(),
+                spec: registration.clone(),
+            },
+        ),
+        protocol::Response::Error {
+            code: Some(ErrorCode::UnsupportedVersion),
+            ..
+        }
+    ));
+    assert!(matches!(
+        versioned_request(
+            &daemon.client,
+            9,
+            protocol::Request::GetAgent {
+                agent_id: agent_id.clone(),
+            },
+        ),
+        protocol::Response::Agent { agent } if agent.id == agent_id
+    ));
+    assert!(matches!(
+        versioned_request(
+            &daemon.client,
+            9,
+            protocol::Request::ReportAgent {
+                agent_id: agent_id.clone(),
+                run_id: run_id.clone(),
+                report: registration.report.clone(),
+            },
+        ),
+        protocol::Response::Agent { agent }
+            if agent.id == agent_id && agent.observation.revision == 1
+    ));
+
+    let legacy_baseline = daemon.client.events(None, 256, 0).unwrap().cursor;
     let protocol_eight_snapshot = versioned_request(&daemon.client, 8, protocol::Request::Snapshot);
     let protocol::Response::Snapshot { snapshot } = protocol_eight_snapshot else {
         panic!("expected protocol-8 snapshot response");
@@ -1143,7 +1395,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
         &daemon.client,
         8,
         protocol::Request::Events {
-            after: Some(baseline),
+            after: Some(legacy_baseline),
             limit: 256,
             wait_ms: 0,
         },
@@ -1179,10 +1431,6 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     )));
     assert!(cursor.event_id > filtered_cursor.event_id);
 
-    drop(attachment.stream);
-    daemon.stop_with_cli();
-    daemon.restart();
-    assert_eq!(daemon.client.get_agent(&registered.id).unwrap(), done);
     daemon.stop_with_cli();
 }
 
@@ -1508,21 +1756,21 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 9);
-    assert!(
-        capabilities["data"]["json_commands"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|command| command == "events")
-    );
-    assert!(
-        capabilities["data"]["features"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|feature| feature == "revision_aware_reads")
-    );
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 10);
+    let json_commands = capabilities["data"]["json_commands"].as_array().unwrap();
+    for command in ["events", "agent.register", "agent.ensure", "agent.report"] {
+        assert!(json_commands.iter().any(|current| current == command));
+    }
+    let features = capabilities["data"]["features"].as_array().unwrap();
+    for feature in [
+        "revision_aware_reads",
+        "protocol_10",
+        "idempotent_agent_ensure",
+        "agent_authority_precedence",
+        "opencode_lifecycle_plugin",
+    ] {
+        assert!(features.iter().any(|current| current == feature));
+    }
 
     let status = daemon
         .command()
@@ -1530,7 +1778,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 9"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 10"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- add protocol-10 idempotent agent ensure and daemon-enforced observation authority precedence
- add stable JSON lifecycle mutations and a safe OpenCode plugin installer
- aggregate root and child OpenCode lifecycle events into durable run-scoped Agent instances
- document reload, completion, mixed-version, and failure-open semantics

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- bun test integrations/opencode