### PR TITLE
Add explicit process supervisor

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boomux
-description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, and integrations. Use when asked to discover shells or agents, read terminal output, report an agent lifecycle state, install the OpenCode integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
-compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; agent mutation requires exact shell-run context.
+description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, process supervision, and integrations. Use when asked to discover shells or agents, read terminal output, supervise an explicitly identified external session, report agent lifecycle state, install the OpenCode integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
+compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; agent mutation and supervision require exact shell-run context, and supervision requires a caller-supplied canonical external session ID.
 metadata:
   author: boomux
-  version: "5"
+  version: "6"
 ---
 
 # Boomux
@@ -118,8 +118,37 @@ while conflicting later reports are rejected.
 
 If `register`, `ensure`, or `report` returns `run_changed`, stop reporting for that
 instance and reacquire exact lifecycle context. Do not guess the replacement
-run. Boomux does not yet provide agent heuristics, adapters, wait/read commands,
+run. Boomux does not yet provide terminal heuristics, agent wait/read commands,
 notifications, or control.
+
+## Supervise An Explicit Process
+
+Use the process adapter only when the caller already knows the canonical root
+external session ID:
+
+```console
+boomux agent supervise "<name>" --integration "<integration>" --external-session-id "<canonical-root-id>" --shell-id "<shell-id>" --run-id "<run-id>" -- command arg
+```
+
+Inside the target managed process, `--shell-id` and `--run-id` default to
+`BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID`. Arguments after `--` are an exact argv,
+not shell syntax. The child inherits stdin, stdout, and stderr, and the
+supervisor returns its exit code or `128 + signal`.
+
+The supervisor ensures the exact integration, external session ID, shell ID,
+and run ID key. It reports child start and exit only as `unknown` with
+`process-adapter` authority and PID plus exit-code/signal evidence. It never
+infers `done`, `working`, `blocked`, or `idle`. Reporting failures warn and fail
+open so the child continues and retains its exit result; spawn and wait failures
+still fail the command. Lifecycle-integration authority wins. A different value
+in any key field creates or reacquires a distinct coexisting agent instance.
+
+Never automatically wrap OpenCode based on process discovery. Its process,
+argv, database, and API do not identify the canonical root session selected by
+the user. Fresh, continue, fork, and in-process session switching are unsupported
+unless the caller already has that canonical root ID. When the OpenCode
+lifecycle plugin is available, use ordinary OpenCode without this wrapper: the
+plugin resolves ancestry and reports stronger lifecycle evidence.
 
 ## Read Shell Output
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,3 +26,12 @@ External observation authority descends from lifecycle integration to process ad
 heuristic. Equal authority may advance an observation; exact duplicate and lower-authority reports
 are no-ops. Daemon lifecycle authority is reserved for daemon-originated observations and is not an
 external integration authority.
+
+## Process Adapter
+
+A process-bound observer for an agent instance whose evidence is limited to process events. The
+explicit supervisor executes an exact argument vector with inherited standard streams and reports
+start and exit as Unknown at ProcessAdapter authority. Process exit is not agent completion, and a
+process adapter cannot infer Done, Working, Blocked, or Idle. It does not discover canonical
+external session identity; callers must supply the complete integration, external session, shell,
+and run key. Reporting failures are fail-open and lifecycle-integration authority wins.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ boomux agent list [--workspace <name-or-id>]
 boomux agent inspect <agent-id>
 boomux agent register <name> --integration <integration> [--external-session-id <id>] [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux agent ensure <name> --integration <integration> --external-session-id <id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
+boomux agent supervise <name> --integration <integration> --external-session-id <canonical-root-id> [--shell-id <shell-id>] [--run-id <run-id>] -- <command>...
 boomux agent report <agent-id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux daemon status
 boomux daemon restart
@@ -180,8 +181,32 @@ its revision. `daemon-lifecycle` exists in snapshots but is reserved for daemon
 observations and cannot be supplied to public mutation commands. A `done` report
 completes the instance permanently. Retrying the exact completion is an
 idempotent success; a different later report is rejected. Completed instances
-remain inspectable across daemon restart. Boomux does not yet provide process
-adapters, terminal heuristics, agent waits, agent reads, or agent control.
+remain inspectable across daemon restart. Boomux does not yet provide terminal
+heuristics, agent waits, agent reads, or agent control.
+
+The first explicit process-adapter supervisor runs one exact argument vector:
+
+```console
+boomux agent supervise Agent --integration example --external-session-id <canonical-root-id> -- agent-bin --flag
+```
+
+`--shell-id` and `--run-id` have the same managed-environment defaults as the
+other agent mutations. The command is executed directly, without shell parsing,
+and inherits stdin, stdout, and stderr. The supervisor propagates a normal child
+exit code and maps signal termination to `128 + signal`. It ensures the exact
+integration, external session ID, shell ID, and run ID key, then reports process
+start and exit evidence at state `unknown`, authority `process-adapter`, and
+confidence 100. Exit evidence includes the child PID and exit code or signal.
+Process existence provides no basis for `done`, `working`, `blocked`, or `idle`,
+so the supervisor never infers those states.
+
+Reporting is fail-open: ensure or report failures emit a warning but do not stop
+the child or replace its exit status. A spawn or wait failure is still a
+supervisor command failure. Lifecycle-integration observations outrank these
+process-adapter observations and therefore remain unchanged. Identity matching
+uses the complete exact key: a supervisor using the lifecycle integration's
+same key contributes to that instance, while a different integration, external
+session ID, shell ID, or run ID coexists as a distinct instance.
 
 `boomux read` reads plain rendered text from the daemon's shadow VT state. It
 understands cursor rewrites and terminal soft wrapping, retains up to 2,000
@@ -262,9 +287,10 @@ boomux skill install
 It is written to `~/.agents/skills/boomux/SKILL.md` and teaches compatible
 agents to discover, inspect, read, create, open, rename, and close Boomux
 workspaces and shells, and to inspect and explicitly report run-scoped agent
-lifecycle, through the full public CLI. Re-run with `--force` to replace an
-older customized installation. An untouched legacy `boomux-shells` skill is
-removed automatically; customized legacy content is preserved with a warning.
+lifecycle or supervise a process with caller-supplied exact identity, through
+the full public CLI. Re-run with `--force` to replace an older customized
+installation. An untouched legacy `boomux-shells` skill is removed
+automatically; customized legacy content is preserved with a warning.
 
 ## OpenCode Integration
 
@@ -296,6 +322,15 @@ unavailable, or when OpenCode session ancestry cannot be resolved, OpenCode
 continues and reporting errors are rate-limited. A `run_changed` response
 permanently disables reports for that tracked root so events cannot leak into
 another process run.
+
+Do not use automatic OpenCode process discovery to supply `agent supervise`.
+OpenCode process identity, argv, database state, and API access do not identify
+which canonical root session the user selected. Fresh sessions, continue, fork,
+and in-process session switching are unsupported by this supervisor unless the
+caller already has the selected canonical root ID and passes it explicitly as
+`--external-session-id`. This is not a reason to wrap ordinary OpenCode launches
+when the lifecycle plugin is available: the plugin resolves canonical ancestry
+and provides stronger, meaningful lifecycle observations.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,6 +194,45 @@ the public mutation CLI. Exact retries of an accepted `done` report return the
 completed snapshot without another revision, write, or event; conflicting
 reports after completion are rejected.
 
+### Explicit Process-Adapter Supervisor
+
+`src/process_adapter.rs` implements the first process-adapter foundation behind:
+
+```console
+boomux agent supervise <name> --integration <integration> --external-session-id <canonical-root-id> [--shell-id <shell-id>] [--run-id <run-id>] -- <exact argv>
+```
+
+Shell and run IDs default from `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID`. The
+supervisor validates the supplied identity, spawns the exact argv directly with
+inherited stdin, stdout, and stderr, and waits for that child. It returns the
+child's exit code, or `128 + signal` for signal termination. There is no PTY,
+shell interpretation, output capture, or detached process ownership in this
+adapter.
+
+After spawn, it idempotently ensures the integration, external session ID,
+shell ID, and run ID key. Both process start and process exit are observations
+with state `unknown`, authority `process_adapter`, and confidence 100; evidence
+names the child PID and the exit code or signal. A process boundary is evidence
+only of a process boundary. It never reports `done` and does not infer
+`working`, `blocked`, or `idle` from process existence or termination.
+
+Reporting is fail-open. Ensure, start-report, and exit-report failures warn but
+do not terminate the child or alter its exit result; spawn and wait failures are
+ordinary supervisor failures. A completed ensured instance receives no further
+reports. Lower process-adapter authority cannot overwrite lifecycle-integration
+state. Exact-key matching also means records with any different integration,
+external session ID, shell ID, or run ID coexist, while a supervisor supplied
+the lifecycle integration's complete key reacquires that same durable instance.
+
+This primitive intentionally does not discover an external session identity.
+For OpenCode in particular, a process, argv, local database, or API does not
+identify the canonical root session selected by the user. Automatic handling of
+fresh, continue, fork, or in-process session switching is unsafe and unsupported
+unless the caller already possesses the selected canonical root ID. Ordinary
+OpenCode should not be wrapped merely to obtain process evidence when the
+lifecycle plugin is available; that plugin resolves root ancestry and reports
+the stronger lifecycle evidence described below.
+
 ### OpenCode Lifecycle Plugin
 
 `integrations/opencode/boomux.js` is a config-time OpenCode plugin installed by
@@ -291,6 +330,7 @@ as pending.
 
 ## Next Technical Steps
 
-Future agent runtime work is tracked in [`roadmap.md`](roadmap.md). Process
-adapters, terminal heuristics, aggregation, waits, notifications, and control are
-not part of the first agent runtime slice.
+Future agent runtime work is tracked in [`roadmap.md`](roadmap.md). The explicit
+process-adapter supervisor is only a foundation; automatic and
+integration-specific adapters, terminal heuristics, aggregation, waits,
+notifications, and control remain future work.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,15 +95,22 @@ eternal process.
    explicit state authority, evidence, and confidence.
 2. [Complete] Establish authority precedence and explicit OpenCode lifecycle
    integration for `working`, `blocked`, `idle`, and explicit completion.
-3. Add process adapters beneath lifecycle-integration authority.
-4. Add conservative terminal-screen heuristics beneath process-adapter
+3. [Complete] Add an explicit-session process supervisor that preserves exact
+   argv and inherited stdio, propagates child exit, reports only `unknown`
+   process start/exit evidence, and fails open when Boomux reporting fails.
+4. [In progress] Add remaining automatic or integration-specific process
+   adapters beneath lifecycle-integration authority. OpenCode discovery must not
+   infer a selected canonical root from process identity, argv, database state,
+   or API access; fresh, continue, fork, and session switching require a caller
+   that already knows the canonical root ID.
+5. Add conservative terminal-screen heuristics beneath process-adapter
    authority, without inferring completion from quiet output or shell exit.
-5. Aggregate agent states as workspace counts and provide an explainable,
+6. Aggregate agent states as workspace counts and provide an explainable,
    persistent attention queue for blocked and completed work.
-6. Add notifications and revision-aware `agent wait` and `agent read` commands.
-7. Add guarded prompts and common responses only after defining run-scoped
+7. Add notifications and revision-aware `agent wait` and `agent read` commands.
+8. Add guarded prompts and common responses only after defining run-scoped
    leases, user-controller precedence, idempotency, and audit events.
-8. Run hooks, tests, notifications, or focus actions from durable transitions.
+9. Run hooks, tests, notifications, or focus actions from durable transitions.
 
 ## Distribution And Polish
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use boomux::{attach, client, daemon, protocol};
 mod cli_output;
 mod config;
 mod git;
+mod process_adapter;
 mod projects;
 mod terminal;
 mod tui;
@@ -61,6 +62,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "idempotent_agent_ensure",
     "agent_authority_precedence",
     "opencode_lifecycle_plugin",
+    "process_adapters",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -330,6 +332,8 @@ enum AgentCommands {
     Register(AgentRegistrationArgs),
     /// Ensure an idempotent agent instance for a shell run
     Ensure(AgentRegistrationArgs),
+    /// Supervise one exact external agent process
+    Supervise(AgentSuperviseArgs),
     /// Report state for an agent instance by exact ID
     Report {
         agent_id: String,
@@ -346,6 +350,21 @@ enum AgentCommands {
         #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
         confidence: u8,
     },
+}
+
+#[derive(Args)]
+struct AgentSuperviseArgs {
+    name: String,
+    #[arg(long)]
+    integration: String,
+    #[arg(long)]
+    external_session_id: String,
+    #[arg(long)]
+    shell_id: Option<String>,
+    #[arg(long)]
+    run_id: Option<String>,
+    #[arg(last = true, num_args = 1.., required = true, value_name = "COMMAND")]
+    command: Vec<String>,
 }
 
 #[derive(Args)]
@@ -444,6 +463,26 @@ enum DaemonCommands {
     Stop,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CliExit {
+    Success,
+    Child(process_adapter::ProcessExit),
+}
+
+impl CliExit {
+    fn code(self) -> ExitCode {
+        match self {
+            Self::Success | Self::Child(process_adapter::ProcessExit::Code(0)) => ExitCode::SUCCESS,
+            Self::Child(process_adapter::ProcessExit::Code(code)) => {
+                ExitCode::from(u8::try_from(code).unwrap_or(1))
+            }
+            Self::Child(process_adapter::ProcessExit::Signal(signal)) => {
+                ExitCode::from(u8::try_from(128_i32.saturating_add(signal)).unwrap_or(1))
+            }
+        }
+    }
+}
+
 fn main() -> ExitCode {
     let json_requested = env::args_os().any(|argument| argument == "--json");
     let cli = match Cli::try_parse() {
@@ -474,7 +513,7 @@ fn main() -> ExitCode {
     let json = cli.json;
     let command = command_name(&cli);
     match run(cli) {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(outcome) => outcome.code(),
         Err(error) => {
             if json {
                 cli_output::print_error(command, error.as_ref());
@@ -486,7 +525,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
+fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
     if cli.json && !supports_json(&cli) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -497,12 +536,19 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
     match cli.command.as_ref() {
         Some(Commands::Daemon {
             command: DaemonCommands::Run,
-        }) => return Ok(daemon::run()?),
+        }) => {
+            daemon::run()?;
+            return Ok(CliExit::Success);
+        }
         Some(Commands::Daemon {
             command: DaemonCommands::ReceiveHandoff { channel },
-        }) => return Ok(daemon::receive_handoff(*channel)?),
+        }) => {
+            daemon::receive_handoff(*channel)?;
+            return Ok(CliExit::Success);
+        }
         Some(Commands::Attach { shell_id, takeover }) => {
-            return Ok(attach::run(shell_id, *takeover)?);
+            attach::run(shell_id, *takeover)?;
+            return Ok(CliExit::Success);
         }
         _ => {}
     }
@@ -516,16 +562,17 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             .then(|| effective_terminal(cli.terminal.as_deref()))
             .transpose()?
             .flatten();
-        return open_directory(
+        open_directory(
             &path,
             cli.name.as_deref(),
             &cli.startup_command,
             new_window,
             terminal.as_deref(),
-        );
+        )?;
+        return Ok(CliExit::Success);
     }
 
-    match cli.command {
+    let result = match cli.command {
         Some(Commands::Ui) => dashboard(cli.terminal.as_deref()),
         Some(Commands::Doctor) => doctor(cli.terminal.as_deref()),
         Some(Commands::Capabilities) => capabilities(cli.json),
@@ -556,6 +603,9 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         }
         Some(Commands::Shell { command }) => shell_command(command, cli.json),
         Some(Commands::Launcher { command }) => launcher_command(command, cli.json),
+        Some(Commands::Agent {
+            command: AgentCommands::Supervise(arguments),
+        }) => return supervise_agent(arguments).map(CliExit::Child),
         Some(Commands::Agent { command }) => agent_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
@@ -575,7 +625,9 @@ fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         Some(Commands::Daemon { command }) => daemon_control(command, cli.json),
         Some(Commands::Attach { .. }) => unreachable!(),
         None => dashboard(cli.terminal.as_deref()),
-    }
+    };
+    result?;
+    Ok(CliExit::Success)
 }
 
 fn command_name(cli: &Cli) -> &'static str {
@@ -612,6 +664,9 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Agent {
             command: AgentCommands::Ensure(..),
         }) => "agent.ensure",
+        Some(Commands::Agent {
+            command: AgentCommands::Supervise(..),
+        }) => "agent.supervise",
         Some(Commands::Agent {
             command: AgentCommands::Report { .. },
         }) => "agent.report",
@@ -1535,6 +1590,7 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
         AgentCommands::Ensure(arguments) => {
             register_or_ensure_agent(&client, arguments, json, true)?;
         }
+        AgentCommands::Supervise(_) => unreachable!(),
         AgentCommands::Report {
             agent_id,
             shell_id,
@@ -1590,6 +1646,27 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
         }
     }
     Ok(())
+}
+
+fn supervise_agent(
+    arguments: AgentSuperviseArgs,
+) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
+    let (shell_id, run_id) = resolve_agent_context(
+        arguments.shell_id,
+        arguments.run_id,
+        env::var("BOOMUX_SHELL_ID").ok(),
+        env::var("BOOMUX_RUN_ID").ok(),
+    )?;
+    Ok(process_adapter::supervise(
+        process_adapter::SuperviseSpec {
+            name: arguments.name,
+            integration: arguments.integration,
+            external_session_id: arguments.external_session_id,
+            shell_id,
+            run_id,
+            command: arguments.command,
+        },
+    )?)
 }
 
 fn register_or_ensure_agent(
@@ -2854,6 +2931,59 @@ mod tests {
                 "101",
             ])
             .is_err()
+        );
+
+        let supervise = Cli::try_parse_from([
+            "boomux",
+            "agent",
+            "supervise",
+            "OpenCode",
+            "--integration",
+            "opencode",
+            "--external-session-id",
+            "session-1",
+            "--shell-id",
+            "s1",
+            "--run-id",
+            "r1",
+            "--",
+            "agent-bin",
+            "literal; argument",
+        ])
+        .unwrap();
+        assert_eq!(command_name(&supervise), "agent.supervise");
+        assert!(!supports_json(&supervise));
+        assert!(matches!(
+            supervise.command,
+            Some(Commands::Agent {
+                command: AgentCommands::Supervise(AgentSuperviseArgs { command, .. })
+            }) if command == ["agent-bin", "literal; argument"]
+        ));
+        assert!(
+            Cli::try_parse_from([
+                "boomux",
+                "agent",
+                "supervise",
+                "agent",
+                "--integration",
+                "test",
+                "--external-session-id",
+                "session-1",
+            ])
+            .is_err()
+        );
+        assert!(INTEGRATION_FEATURES.contains(&"process_adapters"));
+    }
+
+    #[test]
+    fn child_exit_outcomes_map_to_unix_cli_codes() {
+        assert_eq!(
+            CliExit::Child(process_adapter::ProcessExit::Code(23)).code(),
+            ExitCode::from(23)
+        );
+        assert_eq!(
+            CliExit::Child(process_adapter::ProcessExit::Signal(9)).code(),
+            ExitCode::from(137)
         );
     }
 

--- a/src/process_adapter.rs
+++ b/src/process_adapter.rs
@@ -1,0 +1,532 @@
+use std::error::Error;
+use std::fmt;
+use std::io;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Child, Command, Stdio};
+
+use boomux::client;
+use boomux::protocol::{
+    AgentAuthority, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentState,
+};
+
+const CONFIDENCE: u8 = 100;
+
+pub struct SuperviseSpec {
+    pub name: String,
+    pub integration: String,
+    pub external_session_id: String,
+    pub shell_id: String,
+    pub run_id: String,
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessExit {
+    Code(i32),
+    Signal(i32),
+}
+
+#[derive(Debug)]
+pub enum SuperviseError {
+    Invalid(&'static str),
+    Spawn(io::Error),
+    Wait(io::Error),
+}
+
+impl fmt::Display for SuperviseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid(message) => formatter.write_str(message),
+            Self::Spawn(error) => write!(formatter, "cannot start supervised process: {error}"),
+            Self::Wait(error) => write!(formatter, "cannot wait for supervised process: {error}"),
+        }
+    }
+}
+
+impl Error for SuperviseError {}
+
+trait SupervisedChild {
+    fn id(&self) -> u32;
+    fn wait(&mut self) -> io::Result<ProcessExit>;
+}
+
+impl SupervisedChild for Child {
+    fn id(&self) -> u32 {
+        Child::id(self)
+    }
+
+    fn wait(&mut self) -> io::Result<ProcessExit> {
+        let status = Child::wait(self)?;
+        if let Some(code) = status.code() {
+            Ok(ProcessExit::Code(code))
+        } else if let Some(signal) = status.signal() {
+            Ok(ProcessExit::Signal(signal))
+        } else {
+            Err(io::Error::other("child exited without a code or signal"))
+        }
+    }
+}
+
+trait Runner {
+    fn spawn(&mut self, argv: &[String]) -> io::Result<Box<dyn SupervisedChild>>;
+}
+
+struct CommandRunner;
+
+impl Runner for CommandRunner {
+    fn spawn(&mut self, argv: &[String]) -> io::Result<Box<dyn SupervisedChild>> {
+        Command::new(&argv[0])
+            .args(&argv[1..])
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map(|child| Box::new(child) as Box<dyn SupervisedChild>)
+    }
+}
+
+trait Reporter {
+    fn ensure(
+        &mut self,
+        shell_id: &str,
+        run_id: &str,
+        spec: AgentRegistrationSpec,
+    ) -> io::Result<AgentInstanceSnapshot>;
+    fn report(
+        &mut self,
+        agent_id: &str,
+        run_id: &str,
+        report: AgentReport,
+    ) -> io::Result<AgentInstanceSnapshot>;
+}
+
+#[derive(Default)]
+struct BoomuxReporter {
+    client: Option<client::Client>,
+}
+
+impl BoomuxReporter {
+    fn client(&mut self) -> io::Result<&client::Client> {
+        if self.client.is_none() {
+            self.client = Some(client::connect_or_start()?);
+        }
+        Ok(self.client.as_ref().expect("client was initialized"))
+    }
+}
+
+impl Reporter for BoomuxReporter {
+    fn ensure(
+        &mut self,
+        shell_id: &str,
+        run_id: &str,
+        spec: AgentRegistrationSpec,
+    ) -> io::Result<AgentInstanceSnapshot> {
+        self.client()?.ensure_agent(shell_id, run_id, spec)
+    }
+
+    fn report(
+        &mut self,
+        agent_id: &str,
+        run_id: &str,
+        report: AgentReport,
+    ) -> io::Result<AgentInstanceSnapshot> {
+        self.client()?.report_agent(agent_id, run_id, report)
+    }
+}
+
+trait Warnings {
+    fn warn(&mut self, message: &str);
+}
+
+#[derive(Default)]
+struct StderrWarnings {
+    emitted: bool,
+}
+
+impl Warnings for StderrWarnings {
+    fn warn(&mut self, message: &str) {
+        if !self.emitted {
+            eprintln!("boomux: warning: {message}");
+            self.emitted = true;
+        }
+    }
+}
+
+pub fn supervise(spec: SuperviseSpec) -> Result<ProcessExit, SuperviseError> {
+    supervise_with(
+        spec,
+        &mut CommandRunner,
+        &mut BoomuxReporter::default(),
+        &mut StderrWarnings::default(),
+    )
+}
+
+fn supervise_with(
+    spec: SuperviseSpec,
+    runner: &mut dyn Runner,
+    reporter: &mut dyn Reporter,
+    warnings: &mut dyn Warnings,
+) -> Result<ProcessExit, SuperviseError> {
+    validate(&spec)?;
+    let mut child = runner.spawn(&spec.command).map_err(SuperviseError::Spawn)?;
+    let pid = child.id();
+    let start_report = observation(format!("supervised process {pid} started"));
+    let registration = AgentRegistrationSpec {
+        name: spec.name,
+        integration: spec.integration,
+        external_session_id: Some(spec.external_session_id),
+        report: start_report.clone(),
+    };
+
+    let agent = match reporter.ensure(&spec.shell_id, &spec.run_id, registration) {
+        Ok(agent) => Some(agent),
+        Err(error) => {
+            warnings.warn(&format!("agent ensure failed: {error}"));
+            None
+        }
+    };
+    let agent_id = agent.as_ref().and_then(|agent| {
+        if agent.ended_at_ms.is_some() {
+            None
+        } else {
+            if let Err(error) = reporter.report(&agent.id, &spec.run_id, start_report) {
+                warnings.warn(&format!("agent start report failed: {error}"));
+            }
+            Some(agent.id.clone())
+        }
+    });
+
+    let exit = child.wait().map_err(SuperviseError::Wait)?;
+    if let Some(agent_id) = agent_id {
+        let evidence = match exit {
+            ProcessExit::Code(code) => format!("supervised process {pid} exited with code {code}"),
+            ProcessExit::Signal(signal) => {
+                format!("supervised process {pid} exited from signal {signal}")
+            }
+        };
+        if let Err(error) = reporter.report(&agent_id, &spec.run_id, observation(evidence)) {
+            warnings.warn(&format!("agent exit report failed: {error}"));
+        }
+    }
+    Ok(exit)
+}
+
+fn validate(spec: &SuperviseSpec) -> Result<(), SuperviseError> {
+    for (value, message) in [
+        (&spec.name, "agent name cannot be empty"),
+        (&spec.integration, "agent integration cannot be empty"),
+        (
+            &spec.external_session_id,
+            "agent external session ID cannot be empty",
+        ),
+        (&spec.shell_id, "agent shell ID cannot be empty"),
+        (&spec.run_id, "agent run ID cannot be empty"),
+    ] {
+        if value.trim().is_empty() {
+            return Err(SuperviseError::Invalid(message));
+        }
+    }
+    if spec.command.is_empty() || spec.command[0].is_empty() {
+        return Err(SuperviseError::Invalid(
+            "supervised command cannot be empty",
+        ));
+    }
+    Ok(())
+}
+
+fn observation(evidence: String) -> AgentReport {
+    AgentReport {
+        state: AgentState::Unknown,
+        authority: AgentAuthority::ProcessAdapter,
+        evidence,
+        confidence: CONFIDENCE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use boomux::protocol::AgentObservationSnapshot;
+
+    use super::*;
+
+    struct FakeChild {
+        exit: ProcessExit,
+    }
+
+    impl SupervisedChild for FakeChild {
+        fn id(&self) -> u32 {
+            42
+        }
+
+        fn wait(&mut self) -> io::Result<ProcessExit> {
+            Ok(self.exit)
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeRunner {
+        argv: Rc<RefCell<Vec<String>>>,
+    }
+
+    impl Runner for FakeRunner {
+        fn spawn(&mut self, argv: &[String]) -> io::Result<Box<dyn SupervisedChild>> {
+            *self.argv.borrow_mut() = argv.to_vec();
+            Ok(Box::new(FakeChild {
+                exit: ProcessExit::Code(23),
+            }))
+        }
+    }
+
+    struct FakeReporter {
+        ensured: AgentInstanceSnapshot,
+        reports: Vec<AgentReport>,
+        fail_ensure: bool,
+        fail_reports: bool,
+    }
+
+    impl Reporter for FakeReporter {
+        fn ensure(
+            &mut self,
+            _shell_id: &str,
+            _run_id: &str,
+            spec: AgentRegistrationSpec,
+        ) -> io::Result<AgentInstanceSnapshot> {
+            assert_eq!(spec.external_session_id.as_deref(), Some("session-1"));
+            assert_report(&spec.report);
+            if self.fail_ensure {
+                Err(io::Error::other("offline"))
+            } else {
+                Ok(self.ensured.clone())
+            }
+        }
+
+        fn report(
+            &mut self,
+            _agent_id: &str,
+            _run_id: &str,
+            report: AgentReport,
+        ) -> io::Result<AgentInstanceSnapshot> {
+            self.reports.push(report);
+            if self.fail_reports {
+                Err(io::Error::other("offline"))
+            } else {
+                Ok(self.ensured.clone())
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeWarnings(Vec<String>);
+
+    impl Warnings for FakeWarnings {
+        fn warn(&mut self, message: &str) {
+            self.0.push(message.into());
+        }
+    }
+
+    fn spec(command: &[&str]) -> SuperviseSpec {
+        SuperviseSpec {
+            name: "agent".into(),
+            integration: "test".into(),
+            external_session_id: "session-1".into(),
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            command: command.iter().map(|value| (*value).into()).collect(),
+        }
+    }
+
+    fn snapshot(authority: AgentAuthority, completed: bool) -> AgentInstanceSnapshot {
+        AgentInstanceSnapshot {
+            id: "a1".into(),
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            name: "agent".into(),
+            integration: "test".into(),
+            external_session_id: Some("session-1".into()),
+            started_at_ms: 1,
+            ended_at_ms: completed.then_some(2),
+            observation: AgentObservationSnapshot {
+                revision: 1,
+                state: AgentState::Working,
+                authority,
+                evidence: "existing observation".into(),
+                confidence: 100,
+                observed_at_ms: 1,
+            },
+        }
+    }
+
+    fn assert_report(report: &AgentReport) {
+        assert_eq!(report.state, AgentState::Unknown);
+        assert_eq!(report.authority, AgentAuthority::ProcessAdapter);
+        assert_eq!(report.confidence, 100);
+        assert!(report.evidence.len() < 128);
+    }
+
+    #[test]
+    fn preserves_exact_argv_and_propagates_child_exit() {
+        let mut runner = FakeRunner::default();
+        let argv = Rc::clone(&runner.argv);
+        let mut reporter = FakeReporter {
+            ensured: snapshot(AgentAuthority::ProcessAdapter, false),
+            reports: Vec::new(),
+            fail_ensure: false,
+            fail_reports: false,
+        };
+
+        let exit = supervise_with(
+            spec(&["printf", "%s; exit 9", "literal value"]),
+            &mut runner,
+            &mut reporter,
+            &mut FakeWarnings::default(),
+        )
+        .unwrap();
+
+        assert_eq!(exit, ProcessExit::Code(23));
+        assert_eq!(&*argv.borrow(), &["printf", "%s; exit 9", "literal value"]);
+    }
+
+    #[test]
+    fn sends_start_and_exit_unknown_observations() {
+        let mut reporter = FakeReporter {
+            ensured: snapshot(AgentAuthority::ProcessAdapter, false),
+            reports: Vec::new(),
+            fail_ensure: false,
+            fail_reports: false,
+        };
+        supervise_with(
+            spec(&["agent"]),
+            &mut FakeRunner::default(),
+            &mut reporter,
+            &mut FakeWarnings::default(),
+        )
+        .unwrap();
+
+        assert_eq!(reporter.reports.len(), 2);
+        reporter.reports.iter().for_each(assert_report);
+        assert!(reporter.reports[0].evidence.contains("started"));
+        assert!(reporter.reports[1].evidence.contains("code 23"));
+    }
+
+    #[test]
+    fn unchanged_lifecycle_snapshot_does_not_stop_exit_reporting() {
+        let mut reporter = FakeReporter {
+            ensured: snapshot(AgentAuthority::LifecycleIntegration, false),
+            reports: Vec::new(),
+            fail_ensure: false,
+            fail_reports: false,
+        };
+        supervise_with(
+            spec(&["agent"]),
+            &mut FakeRunner::default(),
+            &mut reporter,
+            &mut FakeWarnings::default(),
+        )
+        .unwrap();
+
+        assert_eq!(reporter.reports.len(), 2);
+        assert_eq!(
+            reporter.ensured.observation.evidence,
+            "existing observation"
+        );
+    }
+
+    #[test]
+    fn completed_agent_skips_start_and_exit_reports() {
+        let mut reporter = FakeReporter {
+            ensured: snapshot(AgentAuthority::DaemonLifecycle, true),
+            reports: Vec::new(),
+            fail_ensure: false,
+            fail_reports: false,
+        };
+        supervise_with(
+            spec(&["agent"]),
+            &mut FakeRunner::default(),
+            &mut reporter,
+            &mut FakeWarnings::default(),
+        )
+        .unwrap();
+
+        assert!(reporter.reports.is_empty());
+    }
+
+    #[test]
+    fn reporting_failure_is_fail_open() {
+        let mut reporter = FakeReporter {
+            ensured: snapshot(AgentAuthority::ProcessAdapter, false),
+            reports: Vec::new(),
+            fail_ensure: false,
+            fail_reports: true,
+        };
+        let mut warnings = FakeWarnings::default();
+
+        let exit = supervise_with(
+            spec(&["agent"]),
+            &mut FakeRunner::default(),
+            &mut reporter,
+            &mut warnings,
+        )
+        .unwrap();
+
+        assert_eq!(exit, ProcessExit::Code(23));
+        assert_eq!(reporter.reports.len(), 2);
+        assert_eq!(warnings.0.len(), 2);
+    }
+
+    #[test]
+    fn ensure_failure_is_fail_open() {
+        let mut reporter = FakeReporter {
+            ensured: snapshot(AgentAuthority::ProcessAdapter, false),
+            reports: Vec::new(),
+            fail_ensure: true,
+            fail_reports: false,
+        };
+        let mut warnings = FakeWarnings::default();
+
+        let exit = supervise_with(
+            spec(&["agent"]),
+            &mut FakeRunner::default(),
+            &mut reporter,
+            &mut warnings,
+        )
+        .unwrap();
+
+        assert_eq!(exit, ProcessExit::Code(23));
+        assert!(reporter.reports.is_empty());
+        assert_eq!(warnings.0.len(), 1);
+    }
+
+    #[test]
+    fn command_runner_does_not_interpret_shell_metacharacters() {
+        let mut child = CommandRunner
+            .spawn(&["/usr/bin/test".into(), "literal;false".into()])
+            .unwrap();
+
+        assert_eq!(child.wait().unwrap(), ProcessExit::Code(0));
+    }
+
+    #[test]
+    fn validates_identity_and_argv_before_spawn() {
+        let mut invalid = spec(&[]);
+        invalid.integration = " ".into();
+        let runner = &mut FakeRunner::default();
+        let argv = Rc::clone(&runner.argv);
+        let result = supervise_with(
+            invalid,
+            runner,
+            &mut FakeReporter {
+                ensured: snapshot(AgentAuthority::ProcessAdapter, false),
+                reports: Vec::new(),
+                fail_ensure: false,
+                fail_reports: false,
+            },
+            &mut FakeWarnings::default(),
+        );
+        assert!(matches!(result, Err(SuperviseError::Invalid(_))));
+        assert!(argv.borrow().is_empty());
+    }
+}

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1435,6 +1435,166 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
 }
 
 #[test]
+fn explicit_process_supervisor_preserves_child_io_exit_and_agent_authority() {
+    let daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "process-supervisor",
+            vec![ShellSpec {
+                name: "supervised".into(),
+                command: vec!["/bin/sh".into(), "-c".into(), "sleep 30".into()],
+                cwd: std::env::temp_dir(),
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let _attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon
+        .client
+        .get_shell(&shell_id)
+        .unwrap()
+        .run
+        .expect("started supervisor shell has no run identity")
+        .id;
+    let external_session_id = "native-process-supervisor-session";
+    let baseline = daemon.client.events(None, 256, 0).unwrap().cursor;
+
+    let output = daemon
+        .command()
+        .args([
+            "agent",
+            "supervise",
+            "native-supervisor",
+            "--integration",
+            "native-test",
+            "--external-session-id",
+            external_session_id,
+            "--shell-id",
+            &shell_id,
+            "--run-id",
+            &run_id,
+            "--",
+            "/bin/sh",
+            "-c",
+            "printf 'supervisor stdout\\n'; printf 'supervisor stderr\\n' >&2; exit 23",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(23));
+    assert_eq!(output.stdout, b"supervisor stdout\n");
+    assert_eq!(output.stderr, b"supervisor stderr\n");
+
+    let agents = daemon.client.get_workspace(&workspace.id).unwrap().agents;
+    assert_eq!(agents.len(), 1);
+    let supervised = &agents[0];
+    assert_eq!(supervised.shell_id, shell_id);
+    assert_eq!(supervised.run_id, run_id);
+    assert_eq!(
+        supervised.external_session_id.as_deref(),
+        Some(external_session_id)
+    );
+    assert_eq!(supervised.observation.revision, 2);
+    assert_eq!(supervised.observation.state, AgentState::Unknown);
+    assert_eq!(
+        supervised.observation.authority,
+        AgentAuthority::ProcessAdapter
+    );
+    assert!(
+        supervised
+            .observation
+            .evidence
+            .contains("exited with code 23")
+    );
+    assert_eq!(supervised.ended_at_ms, None);
+    let agent_id = supervised.id.clone();
+    let supervisor_events = daemon.client.events(Some(baseline), 256, 0).unwrap();
+    assert!(supervisor_events.events.iter().any(|event| matches!(
+        &event.kind,
+        protocol::DaemonEventKind::AgentRegistered { agent, .. } if agent.id == agent_id
+    )));
+    assert!(supervisor_events.events.iter().any(|event| matches!(
+        &event.kind,
+        protocol::DaemonEventKind::AgentStateChanged { agent, .. } if agent.id == agent_id
+    )));
+    assert!(!supervisor_events.events.iter().any(|event| matches!(
+        &event.kind,
+        protocol::DaemonEventKind::AgentCompleted { agent, .. } if agent.id == agent_id
+    )));
+
+    let lifecycle_report = AgentReport {
+        state: AgentState::Working,
+        authority: AgentAuthority::LifecycleIntegration,
+        evidence: "lifecycle integration owns session".into(),
+        confidence: 100,
+    };
+    let ensured = daemon
+        .client
+        .ensure_agent(
+            &shell_id,
+            &run_id,
+            AgentRegistrationSpec {
+                name: "native-supervisor".into(),
+                integration: "native-test".into(),
+                external_session_id: Some(external_session_id.into()),
+                report: lifecycle_report.clone(),
+            },
+        )
+        .unwrap();
+    assert_eq!(ensured.id, agent_id);
+    assert_eq!(ensured.observation.revision, 2);
+    let lifecycle = daemon
+        .client
+        .report_agent(&agent_id, &run_id, lifecycle_report)
+        .unwrap();
+    assert_eq!(lifecycle.id, agent_id);
+    assert_eq!(lifecycle.observation.revision, 3);
+    assert_eq!(lifecycle.observation.state, AgentState::Working);
+    assert_eq!(
+        lifecycle.observation.authority,
+        AgentAuthority::LifecycleIntegration
+    );
+
+    let lower_authority_cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let repeated = daemon
+        .command()
+        .args([
+            "agent",
+            "supervise",
+            "native-supervisor",
+            "--integration",
+            "native-test",
+            "--external-session-id",
+            external_session_id,
+            "--shell-id",
+            &shell_id,
+            "--run-id",
+            &run_id,
+            "--",
+            "/bin/sh",
+            "-c",
+            "exit 0",
+        ])
+        .output()
+        .unwrap();
+    assert!(repeated.status.success());
+    assert!(repeated.stdout.is_empty());
+    assert!(repeated.stderr.is_empty());
+    assert_eq!(daemon.client.get_agent(&agent_id).unwrap(), lifecycle);
+    let repeated_events = daemon
+        .client
+        .events(Some(lower_authority_cursor), 256, 0)
+        .unwrap();
+    assert!(!repeated_events.events.iter().any(|event| matches!(
+        &event.kind,
+        protocol::DaemonEventKind::AgentRegistered { agent, .. }
+            | protocol::DaemonEventKind::AgentStateChanged { agent, .. }
+            | protocol::DaemonEventKind::AgentCompleted { agent, .. }
+            if agent.id == agent_id
+    )));
+}
+
+#[test]
 fn native_daemon_handoffs_multiple_detached_shells() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon
@@ -1768,6 +1928,7 @@ fn native_daemon_lifecycle() {
         "idempotent_agent_ensure",
         "agent_authority_precedence",
         "opencode_lifecycle_plugin",
+        "process_adapters",
     ] {
         assert!(features.iter().any(|current| current == feature));
     }


### PR DESCRIPTION
## Summary
- add an explicit canonical-session process supervisor with exact argv and inherited stdio
- record conservative unknown/process-adapter start and exit observations without inferring completion
- preserve child exit semantics and fail open when Boomux reporting is unavailable
- document why automatic OpenCode process discovery cannot safely identify durable root sessions

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- bun test integrations/opencode