### PR TITLE
Improve agent shell dashboard

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -82,6 +82,10 @@ Shell status meanings:
 - `running`: the process and PTY are live, attached or detached.
 - `exited`: the process ended; bounded reconstructed terminal state remains.
 
+The dashboard `KIND` is `shell` when the slot starts a login shell and `command`
+when it starts a stored exact argument vector. Interrupting the primary process
+of a command ends its run; an active agent presentation takes precedence.
+
 ## Report Agent Lifecycle
 
 Use these mutation commands only for a lifecycle integration that directly
@@ -260,7 +264,9 @@ boomux --terminal "kitty.desktop" open "<shell-id>"
 ```
 
 `--takeover` disconnects the current writable controller. Do not use it without
-the user's consent.
+the user's consent. Opening an exited shell explicitly restarts its stored
+command as a new run on the same durable shell identity; use `boomux read` when
+the goal is only to inspect retained output.
 
 ## Manage The Daemon
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,7 +11,16 @@ shell or shell run.
 ## Shell
 
 A durable workspace slot whose process runs are retained and observable across attachments and
-daemon lifecycle transitions. A shell is distinct from a workspace launcher.
+daemon lifecycle transitions. Explicitly opening an exited shell starts its stored command as a
+new run on the same shell identity. A shell is distinct from a workspace launcher.
+
+## Command
+
+The dashboard presentation of a durable shell whose stored startup argument vector is non-empty.
+Its exact command is the run's primary process, so interrupting or exiting that process ends the
+run and closes its attached terminal. A command retains shell identity and run history; it is not a
+workspace launcher. An active agent presentation takes precedence over command presentation while
+retaining the shell's durable name.
 
 ## Agent Instance
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or create that explicitly named container:
 boomux . --name feature-x
 ```
 
-Run a one-off command instead of the login shell by placing its exact arguments
+Run a command instead of the login shell by placing its exact arguments
 after `--`:
 
 ```console
@@ -43,7 +43,10 @@ boomux . --name feature-x --new -- lazygit
 
 Boomux executes the command directly without shell parsing. Use an explicit
 shell such as `sh -lc` when pipelines, redirects, or variable expansion are
-required.
+required. The dashboard labels this durable slot as `command`; the exact command
+is its primary process, so interrupting or exiting it ends the run and closes the
+attached terminal. A `shell` row instead starts a login shell, where `Ctrl-C`
+normally interrupts a child program and returns to the prompt.
 
 Open the shell in Omarchy's selected terminal instead of attaching in place:
 
@@ -82,13 +85,20 @@ Dashboard controls:
 - `r` refreshes immediately.
 - `q` or `Esc` quits.
 
-The selected workspace's shell table also includes configured launchers. A
-launcher row shows its command and working directory; pressing `Enter` invokes
-only that launcher.
+The selected workspace's item table identifies login shells, PTY-backed exact
+commands, active agent shells, and configured launchers in a `KIND` column. A
+`command` row shows its stored argv, while a launcher row shows its detached
+command and working directory. Pressing `Enter` invokes only the selected item.
 
-The table also shows registered agent instances, including completed instances.
-Agent rows are read-only: they can be inspected but not opened, renamed, or
-closed from the dashboard.
+When an active Agent instance is bound to a shell's current run, that shell row
+morphs into an agent row instead of adding a duplicate item. It keeps the
+shell's name, ID, directory, and open, rename, and close actions while showing the
+Agent's lifecycle state and evidence. Completed and historical Agent instances
+remain available through CLI inspection rather than occupying extra dashboard
+rows. A foreground `opencode` process also supplies a presentation-only agent
+hint, so the row morphs immediately before the first prompt creates a durable
+OpenCode session. The hint displays `idle` without creating a durable lifecycle
+observation; lifecycle state replaces that hint once available.
 
 Closing a terminal window only disconnects its attachment. The Boomux daemon
 retains the PTY and child process until the shell exits, the workspace is
@@ -142,6 +152,9 @@ The `workspace` and `shell` command groups expose explicit lifecycle operations
 for scripts and integrations. `shell create` records a pending shell; its PTY
 and process start when the shell is first opened. Shell names require current
 workspace context or `--workspace`; IDs remain globally addressable.
+Explicitly opening an exited shell, including through dashboard `Enter` or
+`workspace open`, starts its stored command as a new run on the same durable
+shell identity. Retained output remains readable until that reopen.
 New workspace and shell names are limited to 256 UTF-8 bytes so retained event
 payloads remain bounded. Existing persisted names remain loadable.
 
@@ -162,6 +175,9 @@ boomux workspace open boomux
 Opening continues after individual launcher or terminal spawn failures and
 reports all failures at the end. Removing a launcher affects future opens only;
 Boomux does not track or terminate applications it previously launched.
+
+Protocol 11 adds the explicit exited-shell restart used by open and restore.
+Low-level attachment can still inspect a completed run without restarting it.
 
 Agent instances are durable records for external agent sessions. Each instance
 has its own exact ID and is bound to exactly one shell run, not merely to a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,10 +121,14 @@ not historical OSC or graphics commands.
 `src/terminal.rs` uses Omarchy's `xdg-terminal-exec` metadata to launch:
 
 ```console
-boomux __attach <shell-id> --takeover
+boomux __attach <shell-id> --takeover --restart-exited
 ```
 
 No emulator-specific adapter or compositor window ID is required.
+Spawned terminal windows start in independent process sessions with null
+standard streams, so exiting the dashboard cannot close their attachments.
+The internal attachment process restarts an exited shell only after the terminal
+window has spawned, preserving retained output when terminal preparation fails.
 
 ### Dashboard
 
@@ -136,9 +140,25 @@ Git information is collected independently from shell directories and cached;
 empty or mixed-directory workspaces have no workspace-level directory or Git
 identity.
 
-Agent instances appear as workspace counts and read-only rows. Completed rows
-remain visible and inspectable; dashboard actions do not open, rename, close, or
-otherwise control an agent.
+Shell snapshots include their additive stored startup argument vector. The
+dashboard presents an empty vector as `shell` and a non-empty vector as
+`command`, making primary-process exit behavior visible without splitting the
+durable shell model. Command rows show the stored argv in their detail column.
+Agent presentation takes precedence when the current run has an active Agent or
+an exact `opencode` foreground hint.
+
+An active Agent instance bound to a shell's exact current run decorates that
+shell as an agent-shell row rather than adding a second item. The row retains
+the shell's durable identity, name, directory, Git context, and open, rename, and
+close actions while displaying Agent lifecycle state and evidence. If multiple
+active instances match one run, the most recently observed instance is shown
+with an Agent-ID tie-break. Completed, stale-run, and orphaned Agent records
+remain available through CLI inspection but do not occupy dashboard rows. A
+running shell snapshot may also expose its PTY foreground process name. The
+dashboard recognizes exact `opencode` as a presentation-only agent-shell hint
+before a canonical OpenCode session exists; this hint creates no AgentInstance,
+durable state observation, persistence, or events. It displays `idle` until
+lifecycle data exists, then yields to that authoritative observation.
 
 ### Agent Skill
 
@@ -183,6 +203,12 @@ observation, revision, timestamps, persistence, or event stream. This lets an
 integration reload and reacquire the daemon-owned agent ID. A different run is a
 different identity. Multiple matching legacy records are accepted only when
 exactly one is active; otherwise ensure fails rather than guessing.
+
+Protocol 11 adds an explicit exited-shell restart request. Opening one shell or
+restoring a workspace first moves each exited durable shell back to pending, so
+its stored argument vector starts as a new run on attachment while preserving
+the shell identity and incrementing the run generation. Plain attachment to an
+exited run remains non-mutating and can replay its retained terminal state.
 
 External observation authority is ordered lifecycle integration, process
 adapter, then terminal heuristic. Lower-authority reports are successful no-ops.

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -3,7 +3,9 @@
 Boomux protocol 7 added bounded long polling for daemon events and atomic,
 revision-aware terminal reads. Protocol 9 adds run-scoped agent snapshots and
 events while retaining negotiation with older management clients. Protocol 10
-adds idempotent agent ensure without adding an event type.
+adds idempotent agent ensure without adding an event type. Protocol 11 adds an
+explicit exited-shell restart; the subsequent attachment emits the existing
+`run_started` event for the new generation.
 
 ## Cursors
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -52,10 +52,6 @@ commitments.
 See [`native-terminal-follow-up.md`](native-terminal-follow-up.md) for the
 terminal handshake, VT reconstruction, and restart-persistence plan.
 
-- Aggregate multiple agent states as counts instead of one workspace-level
-  value.
-- Notify when an agent becomes blocked, finishes, or needs input.
-- Show an opt-in, read-only preview of the selected terminal.
 - Search workspaces and actions from a command palette.
 - Launch workspace templates such as editor, agent, tests, and LazyGit.
 - Duplicate a workspace structure for another branch or worktree.
@@ -98,19 +94,35 @@ eternal process.
 3. [Complete] Add an explicit-session process supervisor that preserves exact
    argv and inherited stdio, propagates child exit, reports only `unknown`
    process start/exit evidence, and fails open when Boomux reporting fails.
-4. [In progress] Add remaining automatic or integration-specific process
-   adapters beneath lifecycle-integration authority. OpenCode discovery must not
-   infer a selected canonical root from process identity, argv, database state,
-   or API access; fresh, continue, fork, and session switching require a caller
-   that already knows the canonical root ID.
-5. Add conservative terminal-screen heuristics beneath process-adapter
-   authority, without inferring completion from quiet output or shell exit.
-6. Aggregate agent states as workspace counts and provide an explainable,
+
+### Near-Term Priorities
+
+1. Validate the OpenCode lifecycle plugin during normal work before expanding
+   the observation model. Confirm reload identity, root/subagent aggregation,
+   blocked prompts, idle transitions, explicit completion, and graceful daemon
+   replacement against real sessions.
+2. Aggregate agent states into workspace counts and add an explainable,
    persistent attention queue for blocked and completed work.
-7. Add notifications and revision-aware `agent wait` and `agent read` commands.
-8. Add guarded prompts and common responses only after defining run-scoped
-   leases, user-controller precedence, idempotency, and audit events.
-9. Run hooks, tests, notifications, or focus actions from durable transitions.
+3. Add revision-aware `agent wait` so scripts can await durable state
+   transitions without polling human output.
+4. Add deduplicated notifications for blocked and completed transitions after
+   the attention and wait semantics are established.
+5. Make installed-binary upgrades restart-safe. Replacing a running executable
+   currently leaves the old daemon's `/proc/.../exe` path marked deleted, so a
+   graceful handoff needs a temporary alias.
+
+### Deferred Agent Work
+
+- Defer automatic and integration-specific process discovery until a target can
+  provide canonical external-session identity without guessing from PID, argv,
+  database recency, or API activity. The explicit-session supervisor remains the
+  safe fallback.
+- Defer terminal-screen heuristics until real usage demonstrates a visibility
+  gap that lifecycle integrations and explicit process evidence do not cover.
+- Defer guarded prompts and common responses until run-scoped leases,
+  user-controller precedence, idempotency, and audit events are defined.
+- Defer hooks, tests, focus actions, and other automatic reactions until waits,
+  notification deduplication, and durable transition semantics are proven.
 
 ## Distribution And Polish
 

--- a/integrations/opencode/boomux.js
+++ b/integrations/opencode/boomux.js
@@ -357,7 +357,7 @@ function ensureArgv(shellID, runID, rootID, state, evidence) {
     "boomux",
     "agent",
     "ensure",
-    "OpenCode",
+    "opencode",
     "--integration",
     "opencode",
     "--external-session-id",

--- a/integrations/opencode/boomux.test.js
+++ b/integrations/opencode/boomux.test.js
@@ -428,7 +428,7 @@ describe("Boomux commands", () => {
       "boomux",
       "agent",
       "ensure",
-      "OpenCode",
+      "opencode",
       "--integration",
       "opencode",
       "--external-session-id",
@@ -513,7 +513,7 @@ describe("Boomux commands", () => {
       "boomux",
       "agent",
       "ensure",
-      "OpenCode",
+      "opencode",
     ]);
     expect(calls[0][calls[0].indexOf("--state") + 1]).toBe("idle");
     expect(calls[1].slice(0, 4)).toEqual([

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -28,7 +28,7 @@ impl Drop for RawMode {
     }
 }
 
-pub fn run(shell_id: &str, takeover: bool) -> io::Result<()> {
+pub fn run(shell_id: &str, takeover: bool, restart_exited: bool) -> io::Result<()> {
     let mut profile = terminal_profile()?;
     let mut size = (
         profile.rows,
@@ -37,7 +37,11 @@ pub fn run(shell_id: &str, takeover: bool) -> io::Result<()> {
         profile.pixel_height,
     );
     let client = client::connect_or_start()?;
-    let mut attachment = client.attach(shell_id, takeover, profile.clone())?;
+    let mut attachment = if restart_exited {
+        client.attach_restarting(shell_id, takeover, profile.clone())?
+    } else {
+        client.attach(shell_id, takeover, profile.clone())?
+    };
     let _raw_mode = RawMode::enter()?;
     let mut stdin = io::stdin().lock();
     let mut stdout = io::stdout().lock();

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -52,8 +52,11 @@ pub(crate) struct ShellData {
     pub(crate) workspace_name: Option<String>,
     pub(crate) name: String,
     pub(crate) cwd: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) command: Vec<String>,
     pub(crate) status: &'static str,
     pub(crate) exit_code: Option<u32>,
+    pub(crate) foreground_process: Option<String>,
     pub(crate) run: Option<RunData>,
 }
 
@@ -165,8 +168,10 @@ pub(crate) fn shell(shell: &ShellSnapshot, workspace_name: Option<&str>) -> Shel
         workspace_name: workspace_name.map(str::to_owned),
         name: shell.name.clone(),
         cwd: shell.cwd.display().to_string(),
+        command: shell.command.clone(),
         status,
         exit_code,
+        foreground_process: shell.foreground_process.clone(),
         run: shell.run.as_ref().map(|run| {
             let (exit_reason, exit_code) = match run.exit_reason.as_ref() {
                 Some(ShellRunExitReason::Exited { code }) => (Some("exited"), *code),

--- a/src/client.rs
+++ b/src/client.rs
@@ -567,15 +567,44 @@ impl Client {
         )
     }
 
+    pub fn restart_shell(&self, shell_id: impl Into<String>) -> io::Result<ShellSnapshot> {
+        match self.request(Request::RestartShell {
+            shell_id: shell_id.into(),
+        })? {
+            Response::Shell { shell } => Ok(shell),
+            other => unexpected(other),
+        }
+    }
+
     pub fn attach(
         &self,
         shell_id: impl Into<String>,
         takeover: bool,
         profile: TerminalProfile,
     ) -> io::Result<Attachment> {
+        self.attach_with_restart(shell_id.into(), takeover, false, profile)
+    }
+
+    pub fn attach_restarting(
+        &self,
+        shell_id: impl Into<String>,
+        takeover: bool,
+        profile: TerminalProfile,
+    ) -> io::Result<Attachment> {
+        self.attach_with_restart(shell_id.into(), takeover, true, profile)
+    }
+
+    fn attach_with_restart(
+        &self,
+        shell_id: String,
+        takeover: bool,
+        restart_exited: bool,
+        profile: TerminalProfile,
+    ) -> io::Result<Attachment> {
         let (stream, response) = self.send(Request::Attach {
-            shell_id: shell_id.into(),
+            shell_id,
             takeover,
+            restart_exited,
             profile,
         })?;
         match response {
@@ -602,6 +631,11 @@ fn request_minimum_version(request: &Request) -> u32 {
         | Request::RemoveLauncher { .. } => 8,
         Request::GetAgent { .. } | Request::RegisterAgent { .. } | Request::ReportAgent { .. } => 9,
         Request::EnsureAgent { .. } => 10,
+        Request::RestartShell { .. }
+        | Request::Attach {
+            restart_exited: true,
+            ..
+        } => 11,
         Request::ReadShellAt { .. } | Request::Events { .. } => 7,
         _ => protocol::MIN_PROTOCOL_VERSION,
     }
@@ -774,12 +808,70 @@ mod tests {
     }
 
     #[test]
+    fn restart_shell_requires_protocol_eleven() {
+        assert_eq!(
+            request_minimum_version(&Request::RestartShell {
+                shell_id: "s1".into(),
+            }),
+            11
+        );
+    }
+
+    #[test]
+    fn restarting_attach_requires_protocol_eleven() {
+        let profile = TerminalProfile {
+            term: None,
+            colorterm: None,
+            term_program: None,
+            term_program_version: None,
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        assert_eq!(
+            request_minimum_version(&Request::Attach {
+                shell_id: "s1".into(),
+                takeover: false,
+                restart_exited: true,
+                profile: profile.clone(),
+            }),
+            11
+        );
+        assert_eq!(
+            request_minimum_version(&Request::Attach {
+                shell_id: "s1".into(),
+                takeover: false,
+                restart_exited: false,
+                profile,
+            }),
+            protocol::MIN_PROTOCOL_VERSION
+        );
+    }
+
+    #[test]
     fn negotiates_protocol_seven_without_losing_version_seven_requests() {
         let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 11);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    10,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 10);
@@ -789,7 +881,7 @@ mod tests {
                 &Envelope::with_version(
                     10,
                     Response::Error {
-                        message: "expected an older protocol".into(),
+                        message: "expected protocol 7".into(),
                         code: Some(ErrorCode::UnsupportedVersion),
                     },
                 ),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -48,6 +48,7 @@ const MAX_TERMINAL_ROWS: u16 = 1_000;
 const MAX_TERMINAL_COLS: u16 = 1_000;
 const MAX_TERMINAL_CELLS: usize = 1_000_000;
 const MAX_SHELL_READ_BYTES: usize = 1024 * 1024;
+const MAX_FOREGROUND_PROCESS_BYTES: usize = 64;
 const MAX_RETAINED_EVENTS: usize = 8_192;
 const MAX_EVENT_BATCH: u16 = 256;
 const MAX_EVENT_WAIT: Duration = Duration::from_secs(30);
@@ -611,10 +612,30 @@ fn handle_connection(
             ),
         );
     }
+    if response_version < 11
+        && matches!(
+            request.message,
+            Request::RestartShell { .. }
+                | Request::Attach {
+                    restart_exited: true,
+                    ..
+                }
+        )
+    {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "request requires daemon protocol 11",
+            ),
+        );
+    }
 
     if let Request::Attach {
         shell_id,
         takeover,
+        restart_exited,
         profile,
     } = request.message
     {
@@ -624,6 +645,7 @@ fn handle_connection(
             &registry,
             &shell_id,
             takeover,
+            restart_exited,
             profile,
         );
     }
@@ -1356,6 +1378,23 @@ impl PtyMaster {
         Ok(())
     }
 
+    fn foreground_process(&self) -> Option<String> {
+        let mut process_group: libc::pid_t = 0;
+        // The descriptor is a live Unix PTY master and process_group is writable.
+        if unsafe {
+            libc::ioctl(
+                self.descriptor.as_raw_fd(),
+                libc::TIOCGPGRP,
+                &mut process_group,
+            )
+        } == -1
+            || process_group <= 0
+        {
+            return None;
+        }
+        read_process_name(process_group as u32)
+    }
+
     fn write(&self, bytes: &[u8]) -> io::Result<usize> {
         // The byte slice is valid for the duration of this write.
         let result = unsafe {
@@ -1700,6 +1739,9 @@ impl Registry {
                 self.close_shell(&shell_id)?;
                 Ok(Response::Ok)
             }
+            Request::RestartShell { shell_id } => Ok(Response::Shell {
+                shell: self.restart_shell(&shell_id)?,
+            }),
             Request::RemoveLauncher { launcher_id } => self.durable_mutation(|| {
                 let launcher = self.remove_launcher(&launcher_id)?;
                 Ok((
@@ -3380,6 +3422,36 @@ impl Registry {
         self.events.changed.notify_all();
         Ok(())
     }
+
+    fn restart_shell(&self, shell_id: &str) -> io::Result<ShellSnapshot> {
+        let _mutation = lock(&self.mutation_lock)?;
+        self.ensure_running()?;
+        let shell = self.shell(shell_id)?;
+        let _transition = lock(&self.transitions)?;
+        let old_runtime = {
+            let mut lifecycle = lock(&shell.lifecycle)?;
+            let old_runtime = match &*lifecycle {
+                ShellLifecycle::Pending => {
+                    drop(lifecycle);
+                    return shell.snapshot();
+                }
+                ShellLifecycle::Running { .. } => {
+                    return Err(coded_error(
+                        ErrorCode::Busy,
+                        format!("shell is still running: {shell_id}"),
+                    ));
+                }
+                ShellLifecycle::Exited { runtime, .. } => runtime.clone(),
+                ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
+            };
+            *lifecycle = ShellLifecycle::Pending;
+            old_runtime
+        };
+        if let Some(runtime) = old_runtime {
+            runtime.stop_reader()?;
+        }
+        shell.snapshot()
+    }
 }
 
 impl Workspace {
@@ -3489,22 +3561,38 @@ impl AgentInstance {
 
 impl Shell {
     fn snapshot(&self) -> io::Result<ShellSnapshot> {
-        let lifecycle = lock(&self.lifecycle)?;
-        let (status, run) = match &*lifecycle {
-            ShellLifecycle::Pending => (ShellStatus::Pending, None),
-            ShellLifecycle::Running { run, .. } => (ShellStatus::Running, Some(run.snapshot()?)),
-            ShellLifecycle::Exited { code, run, .. } => {
-                (ShellStatus::Exited { code: *code }, Some(run.snapshot()?))
-            }
+        let (status, run, runtime) = match &*lock(&self.lifecycle)? {
+            ShellLifecycle::Pending => (ShellStatus::Pending, None, None),
+            ShellLifecycle::Running { run, runtime, .. } => (
+                ShellStatus::Running,
+                Some(run.snapshot()?),
+                Some(Arc::clone(runtime)),
+            ),
+            ShellLifecycle::Exited { code, run, .. } => (
+                ShellStatus::Exited { code: *code },
+                Some(run.snapshot()?),
+                None,
+            ),
             ShellLifecycle::Closed => return Err(not_found("shell", &self.id)),
         };
+        let foreground_process = runtime.and_then(|runtime| {
+            lock(&runtime.master)
+                .ok()
+                .and_then(|master| master.foreground_process())
+                .or_else(|| {
+                    let pid = lock(&runtime.process).ok()?.process_id()?;
+                    foreground_process_for_session_leader(pid)
+                })
+        });
         Ok(ShellSnapshot {
             id: self.id.clone(),
             workspace_id: self.workspace_id.clone(),
             name: lock(&self.name)?.clone(),
             cwd: self.cwd.clone(),
+            command: self.command.clone(),
             status,
             run,
+            foreground_process,
         })
     }
 
@@ -3963,6 +4051,7 @@ fn handle_attach(
     registry: &Arc<Registry>,
     shell_id: &str,
     takeover: bool,
+    restart_exited: bool,
     profile: TerminalProfile,
 ) -> io::Result<()> {
     if let Err(error) = validate_terminal_profile(&profile) {
@@ -3993,11 +4082,27 @@ fn handle_attach(
     let token = Uuid::new_v4().to_string();
     let (output, receiver) = mpsc::sync_channel(CONTROLLER_QUEUE);
     let connection = stream.try_clone()?;
-    let previous_run = lock(&shell.last_run)?.clone();
-    let needs_start = matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending);
-    let mut transition = needs_start
+    let mut transition = restart_exited
         .then(|| lock(&registry.transitions))
         .transpose()?;
+    if restart_exited {
+        let old_runtime = match &*lock(&shell.lifecycle)? {
+            ShellLifecycle::Exited { runtime, .. } => runtime.clone(),
+            _ => None,
+        };
+        if let Some(runtime) = old_runtime {
+            runtime.stop_reader()?;
+        }
+        let mut lifecycle = lock(&shell.lifecycle)?;
+        if matches!(*lifecycle, ShellLifecycle::Exited { .. }) {
+            *lifecycle = ShellLifecycle::Pending;
+        }
+    }
+    let previous_run = lock(&shell.last_run)?.clone();
+    let needs_start = matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending);
+    if needs_start && transition.is_none() {
+        transition = Some(lock(&registry.transitions)?);
+    }
     let persistence = needs_start
         .then(|| lock(&registry.persist_lock))
         .transpose()?;
@@ -4550,6 +4655,32 @@ fn proc_session_id(stat: &str) -> Option<libc::pid_t> {
         .ok()
 }
 
+fn proc_foreground_process_group(stat: &str) -> Option<libc::pid_t> {
+    stat.rsplit_once(')')?
+        .1
+        .split_whitespace()
+        .nth(5)?
+        .parse()
+        .ok()
+}
+
+fn foreground_process_for_session_leader(pid: u32) -> Option<String> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let process_group = proc_foreground_process_group(&stat)?;
+    (process_group > 0)
+        .then(|| read_process_name(process_group as u32))
+        .flatten()
+}
+
+fn read_process_name(pid: u32) -> Option<String> {
+    let file = File::open(format!("/proc/{pid}/comm")).ok()?;
+    let mut bytes = Vec::with_capacity(MAX_FOREGROUND_PROCESS_BYTES + 1);
+    file.take((MAX_FOREGROUND_PROCESS_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    parse_process_name(&bytes)
+}
+
 fn validate_shell_specs(specs: &[ShellSpec]) -> io::Result<()> {
     let mut names = HashSet::with_capacity(specs.len());
     for spec in specs {
@@ -4707,6 +4838,23 @@ fn not_found(kind: &str, id: &str) -> io::Error {
     io::Error::new(io::ErrorKind::NotFound, format!("{kind} not found: {id}"))
 }
 
+fn parse_process_name(bytes: &[u8]) -> Option<String> {
+    let name = String::from_utf8_lossy(bytes);
+    let mut sanitized = String::new();
+    for character in name.trim().chars() {
+        let character = if character.is_control() {
+            '?'
+        } else {
+            character
+        };
+        if sanitized.len() + character.len_utf8() > MAX_FOREGROUND_PROCESS_BYTES {
+            break;
+        }
+        sanitized.push(character);
+    }
+    (!sanitized.is_empty()).then_some(sanitized)
+}
+
 fn lock<T>(mutex: &Mutex<T>) -> io::Result<MutexGuard<'_, T>> {
     mutex
         .lock()
@@ -4855,6 +5003,63 @@ mod tests {
     fn rendered_output_tail_preserves_utf8_boundaries() {
         assert_eq!(tail_utf8("one-λ", 2), "λ");
         assert_eq!(tail_utf8("one-λ", 3), "-λ");
+    }
+
+    #[test]
+    fn process_name_is_trimmed_sanitized_and_bounded() {
+        assert_eq!(parse_process_name(b"  sleep\n"), Some("sleep".into()));
+        assert_eq!(parse_process_name(b" \n\t "), None);
+        assert_eq!(parse_process_name(b"bad\0name\n"), Some("bad?name".into()));
+        assert_eq!(
+            parse_process_name(&[b'x'; MAX_FOREGROUND_PROCESS_BYTES + 1]),
+            Some("x".repeat(MAX_FOREGROUND_PROCESS_BYTES))
+        );
+        assert_eq!(
+            proc_foreground_process_group("123 (shell name) S 1 123 123 34826 456 0"),
+            Some(456)
+        );
+    }
+
+    #[test]
+    fn pending_and_exited_shell_snapshots_have_no_foreground_process() {
+        let shell = create_pending_shell(
+            "workspace-id",
+            ShellSpec::login("snapshot-test", env::temp_dir()),
+        )
+        .unwrap();
+        assert!(shell.snapshot().unwrap().foreground_process.is_none());
+
+        let run = Arc::new(ShellRun::new(1));
+        run.finish(ShellRunExitReason::Exited { code: Some(0) })
+            .unwrap();
+        *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Exited {
+            code: Some(0),
+            profile: profile(),
+            run,
+            runtime: None,
+            terminal: Arc::new(Mutex::new(TerminalState::new(24, 80))),
+        };
+        assert!(shell.snapshot().unwrap().foreground_process.is_none());
+    }
+
+    #[test]
+    fn running_shell_snapshot_reports_real_pty_foreground_process() {
+        let registry = Registry::default();
+        let (_workspace, shell, _runtime) = running_shell(&registry);
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let foreground_process = shell.snapshot().unwrap().foreground_process;
+            if foreground_process.as_deref() == Some("sleep") {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "sleep did not become the foreground process; last observed {foreground_process:?}"
+            );
+            thread::sleep(IO_RETRY_DELAY);
+        }
+        shell.kill().unwrap();
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,8 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "workspace_launchers",
     "run_scoped_agent_instances",
     "protocol_10",
+    "protocol_11",
+    "restartable_exited_shells",
     "idempotent_agent_ensure",
     "agent_authority_precedence",
     "opencode_lifecycle_plugin",
@@ -228,6 +230,8 @@ enum Commands {
         shell_id: String,
         #[arg(long)]
         takeover: bool,
+        #[arg(long)]
+        restart_exited: bool,
     },
 }
 
@@ -546,8 +550,12 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             daemon::receive_handoff(*channel)?;
             return Ok(CliExit::Success);
         }
-        Some(Commands::Attach { shell_id, takeover }) => {
-            attach::run(shell_id, *takeover)?;
+        Some(Commands::Attach {
+            shell_id,
+            takeover,
+            restart_exited,
+        }) => {
+            attach::run(shell_id, *takeover, *restart_exited)?;
             return Ok(CliExit::Success);
         }
         _ => {}
@@ -923,13 +931,57 @@ fn dashboard_views(
         .map(|workspace| {
             let shells = workspace.shells.iter().map(|shell| {
                 let git = git_cache.inspect(&shell.cwd);
-                tui::WorkspaceItemView::Shell(tui::TerminalView {
+                let shell_view = tui::TerminalView {
                     id: shell.id.clone(),
                     name: shell.name.clone(),
                     status: shell_status(&shell.status).into(),
                     directory: shell.cwd.display().to_string(),
                     branch: git.branch,
-                })
+                    command: shell.command.join(" "),
+                };
+                let agent = matches!(shell.status, ShellStatus::Running)
+                    .then(|| {
+                        shell.run.as_ref().and_then(|run| {
+                            workspace
+                                .agents
+                                .iter()
+                                .filter(|agent| {
+                                    agent.workspace_id == workspace.id
+                                        && agent.shell_id == shell.id
+                                        && agent.run_id == run.id
+                                        && agent.ended_at_ms.is_none()
+                                        && agent.observation.state != AgentState::Done
+                                })
+                                .max_by(|left, right| {
+                                    left.observation
+                                        .observed_at_ms
+                                        .cmp(&right.observation.observed_at_ms)
+                                        .then_with(|| left.id.cmp(&right.id))
+                                })
+                        })
+                    })
+                    .flatten();
+                match (agent, shell.foreground_process.as_deref()) {
+                    (Some(agent), _) => tui::WorkspaceItemView::AgentShell(tui::AgentShellView {
+                        shell: shell_view,
+                        agent: Some(tui::AgentView {
+                            id: agent.id.clone(),
+                            state: cli_output::agent_state(agent.observation.state).into(),
+                            integration: agent.integration.clone(),
+                            authority: cli_output::agent_authority(agent.observation.authority)
+                                .into(),
+                            confidence: agent.observation.confidence,
+                            evidence: agent.observation.evidence.clone(),
+                        }),
+                    }),
+                    (None, Some("opencode")) => {
+                        tui::WorkspaceItemView::AgentShell(tui::AgentShellView {
+                            shell: shell_view,
+                            agent: None,
+                        })
+                    }
+                    (None, _) => tui::WorkspaceItemView::Shell(shell_view),
+                }
             });
             let launchers = workspace.launchers.iter().map(|launcher| {
                 tui::WorkspaceItemView::Launcher(tui::LauncherView {
@@ -939,34 +991,10 @@ fn dashboard_views(
                     command: launcher.command.join(" "),
                 })
             });
-            let agents = workspace.agents.iter().map(|agent| {
-                let shell_name = workspace
-                    .shells
-                    .iter()
-                    .find(|shell| shell.id == agent.shell_id)
-                    .map_or("-", |shell| shell.name.as_str());
-                tui::WorkspaceItemView::Agent(tui::AgentView {
-                    id: agent.id.clone(),
-                    workspace_id: agent.workspace_id.clone(),
-                    run_id: agent.run_id.clone(),
-                    shell_id: agent.shell_id.clone(),
-                    shell_name: shell_name.into(),
-                    name: agent.name.clone(),
-                    state: cli_output::agent_state(agent.observation.state).into(),
-                    integration: agent.integration.clone(),
-                    authority: cli_output::agent_authority(agent.observation.authority).into(),
-                    confidence: agent.observation.confidence,
-                    evidence: agent.observation.evidence.clone(),
-                    external_session_id: agent.external_session_id.clone(),
-                    started_at_ms: agent.started_at_ms,
-                    observed_at_ms: agent.observation.observed_at_ms,
-                    ended_at_ms: agent.ended_at_ms,
-                })
-            });
             tui::WorkspaceView {
                 id: workspace.id.clone(),
                 name: workspace.name.clone(),
-                items: shells.chain(launchers).chain(agents).collect(),
+                items: shells.chain(launchers).collect(),
             }
         })
         .collect()
@@ -1024,7 +1052,7 @@ fn open_directory(
             terminal,
         )
     } else {
-        Ok(attach::run(&shell.id, true)?)
+        Ok(attach::run(&shell.id, true, false)?)
     }
 }
 
@@ -2577,8 +2605,18 @@ mod tests {
             workspace_id: workspace_id.into(),
             name: name.into(),
             cwd: PathBuf::from("/tmp/project"),
+            command: Vec::new(),
             status: ShellStatus::Running,
-            run: None,
+            run: Some(protocol::ShellRunSnapshot {
+                id: "r1".into(),
+                generation: 1,
+                started_at_ms: 1,
+                ended_at_ms: None,
+                exit_reason: None,
+                output_revision: 0,
+                environment_has_run_id: true,
+            }),
+            foreground_process: None,
         }
     }
 
@@ -2598,8 +2636,8 @@ mod tests {
             workspace_id: workspace_id.into(),
             shell_id: shell_id.into(),
             run_id: "r1".into(),
-            name: "opencode".into(),
-            integration: "plugin".into(),
+            name: "OpenCode".into(),
+            integration: "opencode".into(),
             external_session_id: Some("external-1".into()),
             started_at_ms: 10,
             ended_at_ms: None,
@@ -2631,10 +2669,16 @@ mod tests {
         assert!(Cli::try_parse_from(["boomux", "daemon", "run"]).is_ok());
         assert!(Cli::try_parse_from(["boomux", "daemon", "restart"]).is_ok());
         assert!(Cli::try_parse_from(["boomux", "daemon", "stop"]).is_ok());
-        let cli = Cli::try_parse_from(["boomux", "__attach", "s1", "--takeover"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["boomux", "__attach", "s1", "--takeover", "--restart-exited"])
+                .unwrap();
         assert!(matches!(
             cli.command,
-            Some(Commands::Attach { takeover: true, .. })
+            Some(Commands::Attach {
+                takeover: true,
+                restart_exited: true,
+                ..
+            })
         ));
     }
 
@@ -3128,20 +3172,212 @@ mod tests {
     }
 
     #[test]
-    fn workspace_view_maps_agent_runtime_details() {
-        let mut workspace = workspace("w1", "project", vec![shell("s1", "w1", "terminal")]);
+    fn workspace_view_classifies_stored_argv_as_a_command() {
+        let mut command = shell("s1", "w1", "clock");
+        command.command = vec!["watch".into(), "-n".into(), "1".into(), "date".into()];
+        let workspace = workspace("w1", "project", vec![command]);
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        let tui::WorkspaceItemView::Shell(command) = &views[0].items[0] else {
+            panic!("expected command-backed shell item");
+        };
+        assert_eq!(command.name, "clock");
+        assert_eq!(command.command, "watch -n 1 date");
+    }
+
+    #[test]
+    fn workspace_view_morphs_shell_to_agent_shell_without_adding_a_row() {
+        let mut agent_command = shell("s1", "w1", "terminal");
+        agent_command.command = vec!["opencode".into()];
+        let mut workspace = workspace("w1", "project", vec![agent_command]);
+        workspace.launchers.push(launcher("l1", "w1", "editor"));
         workspace.agents.push(agent("a1", "w1", "s1"));
 
         let views = dashboard_views(&[workspace], &mut git::Cache::default());
 
-        let tui::WorkspaceItemView::Agent(agent) = &views[0].items[1] else {
-            panic!("expected agent item");
+        assert_eq!(views[0].items.len(), 2);
+        let tui::WorkspaceItemView::AgentShell(tui::AgentShellView { shell, agent }) =
+            &views[0].items[0]
+        else {
+            panic!("expected agent-shell item");
         };
-        assert_eq!(agent.name, "opencode");
-        assert_eq!(agent.shell_name, "terminal");
+        assert_eq!(shell.id, "s1");
+        assert_eq!(shell.name, "terminal");
+        assert_eq!(shell.status, "running");
+        assert_eq!(shell.directory, "/tmp/project");
+        assert_eq!(shell.branch, "-");
+        assert_eq!(shell.command, "opencode");
+        let agent = agent.as_ref().expect("durable agent");
         assert_eq!(agent.state, "working");
         assert_eq!(agent.authority, "lifecycle_integration");
         assert_eq!(agent.confidence, 95);
+        assert!(matches!(
+            views[0].items[1],
+            tui::WorkspaceItemView::Launcher(_)
+        ));
+    }
+
+    #[test]
+    fn workspace_view_hints_exact_opencode_foreground_process_before_first_prompt() {
+        let mut hinted = shell("s1", "w1", "terminal");
+        hinted.foreground_process = Some("opencode".into());
+        let workspace = workspace("w1", "project", vec![hinted]);
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        let tui::WorkspaceItemView::AgentShell(item) = &views[0].items[0] else {
+            panic!("expected hinted agent-shell item");
+        };
+        assert_eq!(item.shell.id, "s1");
+        assert_eq!(item.shell.status, "running");
+        assert_eq!(item.shell.name, "terminal");
+        assert!(item.agent.is_none());
+    }
+
+    #[test]
+    fn workspace_view_does_not_treat_arbitrary_foreground_process_as_agent() {
+        let mut ordinary = shell("s1", "w1", "terminal");
+        ordinary.foreground_process = Some("OpenCode".into());
+        let workspace = workspace("w1", "project", vec![ordinary]);
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert!(matches!(
+            views[0].items[0],
+            tui::WorkspaceItemView::Shell(_)
+        ));
+    }
+
+    #[test]
+    fn workspace_view_prefers_lifecycle_agent_over_foreground_hint() {
+        let mut hinted = shell("s1", "w1", "terminal");
+        hinted.foreground_process = Some("opencode".into());
+        let mut workspace = workspace("w1", "project", vec![hinted]);
+        let mut durable = agent("a1", "w1", "s1");
+        durable.name = "reviewer".into();
+        durable.integration = "custom".into();
+        durable.observation.state = AgentState::Blocked;
+        durable.observation.evidence = "needs approval".into();
+        workspace.agents.push(durable);
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        let tui::WorkspaceItemView::AgentShell(item) = &views[0].items[0] else {
+            panic!("expected durable agent-shell item");
+        };
+        assert_eq!(item.shell.name, "terminal");
+        let agent = item.agent.as_ref().expect("durable agent");
+        assert_eq!(agent.id, "a1");
+        assert_eq!(agent.state, "blocked");
+        assert_eq!(agent.evidence, "needs approval");
+    }
+
+    #[test]
+    fn workspace_view_preserves_live_four_shell_three_agent_shape() {
+        let mut hinted = shell("s1", "w1", "hinted");
+        hinted.foreground_process = Some("opencode".into());
+        let mut workspace = workspace(
+            "w1",
+            "project",
+            vec![
+                hinted,
+                shell("s2", "w1", "durable-1"),
+                shell("s3", "w1", "durable-2"),
+                shell("s4", "w1", "ordinary"),
+            ],
+        );
+        workspace.agents = vec![agent("a2", "w1", "s2"), agent("a3", "w1", "s3")];
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert_eq!(views[0].items.len(), 4);
+        assert_eq!(
+            views[0]
+                .items
+                .iter()
+                .filter(|item| matches!(item, tui::WorkspaceItemView::AgentShell(_)))
+                .count(),
+            3
+        );
+        assert_eq!(
+            views[0]
+                .items
+                .iter()
+                .filter(|item| matches!(item, tui::WorkspaceItemView::Shell(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn workspace_view_selects_latest_active_agent_with_stable_id_tie_break() {
+        let mut workspace = workspace("w1", "project", vec![shell("s1", "w1", "terminal")]);
+        let mut older = agent("older", "w1", "s1");
+        older.observation.observed_at_ms = 20;
+        let mut tied_first = agent("agent-a", "w1", "s1");
+        tied_first.observation.observed_at_ms = 30;
+        tied_first.name = "first".into();
+        tied_first.integration = "other".into();
+        let mut tied_last = agent("agent-z", "w1", "s1");
+        tied_last.observation.observed_at_ms = 30;
+        tied_last.name = "latest".into();
+        tied_last.integration = "other".into();
+        workspace.agents = vec![tied_last, older, tied_first];
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        let tui::WorkspaceItemView::AgentShell(item) = &views[0].items[0] else {
+            panic!("expected agent-shell item");
+        };
+        assert_eq!(item.agent.as_ref().unwrap().id, "agent-z");
+    }
+
+    #[test]
+    fn workspace_view_ignores_completed_stale_wrong_run_and_orphan_agents() {
+        let mut second_shell = shell("s2", "w1", "second");
+        second_shell.run.as_mut().unwrap().id = "r2".into();
+        let mut workspace = workspace(
+            "w1",
+            "project",
+            vec![shell("s1", "w1", "first"), second_shell],
+        );
+        let mut ended = agent("ended", "w1", "s1");
+        ended.ended_at_ms = Some(12);
+        let mut done = agent("done", "w1", "s1");
+        done.observation.state = AgentState::Done;
+        let mut stale = agent("stale", "w1", "s1");
+        stale.run_id = "old-run".into();
+        let wrong_pair = agent("wrong-pair", "w1", "s2");
+        let orphan = agent("orphan", "w1", "missing");
+        let mut wrong_workspace = agent("wrong-workspace", "w2", "s1");
+        wrong_workspace.run_id = "r1".into();
+        workspace.agents = vec![ended, done, stale, wrong_pair, orphan, wrong_workspace];
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert_eq!(views[0].items.len(), 2);
+        assert!(
+            views[0]
+                .items
+                .iter()
+                .all(|item| matches!(item, tui::WorkspaceItemView::Shell(_)))
+        );
+    }
+
+    #[test]
+    fn workspace_view_does_not_present_an_exited_shell_as_an_active_agent() {
+        let mut exited = shell("s1", "w1", "agent");
+        exited.status = ShellStatus::Exited { code: Some(1) };
+        let mut workspace = workspace("w1", "project", vec![exited]);
+        workspace.agents.push(agent("a1", "w1", "s1"));
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert!(matches!(
+            views[0].items[0],
+            tui::WorkspaceItemView::Shell(_)
+        ));
     }
 
     #[test]
@@ -3313,7 +3549,7 @@ mod tests {
         ] {
             assert!(INTEGRATION_FEATURES.contains(&feature));
         }
-        assert_eq!(protocol::PROTOCOL_VERSION, 10);
+        assert_eq!(protocol::PROTOCOL_VERSION, 11);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 10;
+pub const PROTOCOL_VERSION: u32 = 11;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -125,9 +125,13 @@ pub struct ShellSnapshot {
     pub workspace_id: String,
     pub name: String,
     pub cwd: PathBuf,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub command: Vec<String>,
     pub status: ShellStatus,
     #[serde(default)]
     pub run: Option<ShellRunSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreground_process: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -384,12 +388,17 @@ pub enum Request {
     CloseShell {
         shell_id: String,
     },
+    RestartShell {
+        shell_id: String,
+    },
     RemoveLauncher {
         launcher_id: String,
     },
     Attach {
         shell_id: String,
         takeover: bool,
+        #[serde(default)]
+        restart_exited: bool,
         profile: TerminalProfile,
     },
 }
@@ -583,6 +592,7 @@ mod tests {
         let value = Envelope::new(Request::Attach {
             shell_id: "s1".into(),
             takeover: false,
+            restart_exited: true,
             profile: TerminalProfile {
                 term: Some("xterm-256color".into()),
                 colorterm: Some("truecolor".into()),
@@ -642,13 +652,21 @@ mod tests {
     }
 
     #[test]
-    fn shell_snapshot_accepts_protocol_six_payload_without_run_identity() {
+    fn shell_snapshot_defaults_fields_omitted_by_old_daemons() {
         let snapshot = serde_json::from_str::<ShellSnapshot>(
             r#"{"id":"s1","workspace_id":"w1","name":"shell","cwd":"/tmp","status":"running"}"#,
         )
         .unwrap();
 
+        assert!(snapshot.command.is_empty());
         assert!(snapshot.run.is_none());
+        assert!(snapshot.foreground_process.is_none());
+        assert!(
+            serde_json::to_value(snapshot)
+                .unwrap()
+                .get("foreground_process")
+                .is_none()
+        );
     }
 
     #[test]
@@ -723,8 +741,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_ten_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 10);
+    fn protocol_version_is_eleven_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 11);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -769,12 +787,13 @@ mod tests {
     }
 
     #[test]
-    fn protocol_six_client_ignores_additive_run_identity() {
+    fn protocol_six_client_ignores_additive_shell_snapshot_fields() {
         let snapshot = ShellSnapshot {
             id: "s1".into(),
             workspace_id: "w1".into(),
             name: "shell".into(),
             cwd: "/tmp".into(),
+            command: vec!["sleep".into(), "1".into()],
             status: ShellStatus::Running,
             run: Some(ShellRunSnapshot {
                 id: "r1".into(),
@@ -785,6 +804,7 @@ mod tests {
                 output_revision: 2,
                 environment_has_run_id: true,
             }),
+            foreground_process: Some("sleep".into()),
         };
 
         let legacy: ProtocolSixShellSnapshot =

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -2,8 +2,9 @@ use std::env;
 use std::error::Error;
 use std::ffi::OsString;
 use std::fs;
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
-use std::process::{self, Command};
+use std::process::{self, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 static TEMPORARY_DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
@@ -45,7 +46,7 @@ pub(crate) fn open(
         .arg(format!("--title={title}"))
         .arg("--")
         .arg(env::current_exe()?)
-        .args(["__attach", shell_id]);
+        .args(["__attach", shell_id, "--restart-exited"]);
     if takeover {
         resolver.arg("--takeover");
     }
@@ -58,8 +59,24 @@ pub(crate) fn open(
     let (program, arguments) = arguments
         .split_first()
         .ok_or("xdg-terminal-exec returned an empty terminal command")?;
-    Command::new(program)
+    let mut command = Command::new(program);
+    command
         .args(arguments)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // The child has not executed user code yet; `setsid` detaches the terminal
+    // window from the dashboard process and its controlling terminal.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    command
         .spawn()
         .map_err(|error| format!("could not launch {selected}: {error}"))?;
     Ok(())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -28,28 +28,33 @@ pub(crate) struct WorkspaceView {
     pub(crate) items: Vec<WorkspaceItemView>,
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum WorkspaceItemView {
     Shell(TerminalView),
+    AgentShell(AgentShellView),
     Launcher(LauncherView),
-    Agent(AgentView),
+}
+
+pub(crate) struct AgentShellView {
+    pub(crate) shell: TerminalView,
+    pub(crate) agent: Option<AgentView>,
+}
+
+impl AgentShellView {
+    fn status(&self) -> &str {
+        self.agent
+            .as_ref()
+            .map_or("idle", |agent| agent.state.as_str())
+    }
 }
 
 pub(crate) struct AgentView {
     pub(crate) id: String,
-    pub(crate) workspace_id: String,
-    pub(crate) run_id: String,
-    pub(crate) shell_id: String,
-    pub(crate) shell_name: String,
-    pub(crate) name: String,
     pub(crate) state: String,
     pub(crate) integration: String,
     pub(crate) authority: String,
     pub(crate) confidence: u8,
     pub(crate) evidence: String,
-    pub(crate) external_session_id: Option<String>,
-    pub(crate) started_at_ms: u64,
-    pub(crate) observed_at_ms: u64,
-    pub(crate) ended_at_ms: Option<u64>,
 }
 
 pub(crate) struct LauncherView {
@@ -80,13 +85,37 @@ pub(crate) struct TerminalView {
     pub(crate) status: String,
     pub(crate) directory: String,
     pub(crate) branch: String,
+    pub(crate) command: String,
+}
+
+impl TerminalView {
+    fn kind(&self) -> &'static str {
+        if self.command.is_empty() {
+            "shell"
+        } else {
+            "command"
+        }
+    }
+
+    fn detail(&self) -> &str {
+        if self.command.is_empty() {
+            &self.branch
+        } else {
+            &self.command
+        }
+    }
 }
 
 impl WorkspaceView {
     fn shell_count(&self) -> usize {
         self.items
             .iter()
-            .filter(|item| matches!(item, WorkspaceItemView::Shell(_)))
+            .filter(|item| {
+                matches!(
+                    item,
+                    WorkspaceItemView::Shell(_) | WorkspaceItemView::AgentShell(_)
+                )
+            })
             .count()
     }
 
@@ -100,7 +129,7 @@ impl WorkspaceView {
     fn agent_count(&self) -> usize {
         self.items
             .iter()
-            .filter(|item| matches!(item, WorkspaceItemView::Agent(_)))
+            .filter(|item| matches!(item, WorkspaceItemView::AgentShell(_)))
             .count()
     }
 }
@@ -135,7 +164,6 @@ enum Focus {
 enum ItemIdentity {
     Shell(String),
     Launcher(String),
-    Agent(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -440,12 +468,14 @@ impl App {
             Focus::Workspaces => self
                 .selected()
                 .map(|workspace| RenameTarget::Workspace(workspace.id.clone())),
-            Focus::Items => self.selected_item().and_then(|item| match item {
-                WorkspaceItemView::Shell(shell) => Some(RenameTarget::Shell(shell.id.clone())),
-                WorkspaceItemView::Launcher(launcher) => {
-                    Some(RenameTarget::Launcher(launcher.id.clone()))
+            Focus::Items => self.selected_item().map(|item| match item {
+                WorkspaceItemView::Shell(shell) => RenameTarget::Shell(shell.id.clone()),
+                WorkspaceItemView::AgentShell(agent_shell) => {
+                    RenameTarget::Shell(agent_shell.shell.id.clone())
                 }
-                WorkspaceItemView::Agent(_) => None,
+                WorkspaceItemView::Launcher(launcher) => {
+                    RenameTarget::Launcher(launcher.id.clone())
+                }
             }),
         };
         if let Some(target) = target {
@@ -511,13 +541,15 @@ impl App {
         let Some(workspace_id) = self.selected().map(|workspace| workspace.id.clone()) else {
             return false;
         };
-        let Some(target) = self.selected_item().and_then(|item| match item {
-            WorkspaceItemView::Shell(shell) => Some(OpenTarget::Shell(shell.id.clone())),
-            WorkspaceItemView::Launcher(launcher) => Some(OpenTarget::Launcher {
+        let Some(target) = self.selected_item().map(|item| match item {
+            WorkspaceItemView::Shell(shell) => OpenTarget::Shell(shell.id.clone()),
+            WorkspaceItemView::AgentShell(agent_shell) => {
+                OpenTarget::Shell(agent_shell.shell.id.clone())
+            }
+            WorkspaceItemView::Launcher(launcher) => OpenTarget::Launcher {
                 workspace_id,
                 launcher_id: launcher.id.clone(),
-            }),
-            WorkspaceItemView::Agent(_) => None,
+            },
         }) else {
             return false;
         };
@@ -533,20 +565,25 @@ impl App {
                 shell_count: workspace.shell_count(),
                 launcher_count: workspace.launcher_count(),
             }),
-            Focus::Items => self.selected_item().and_then(|item| match item {
-                WorkspaceItemView::Shell(shell) => Some(PendingClose {
+            Focus::Items => self.selected_item().map(|item| match item {
+                WorkspaceItemView::Shell(shell) => PendingClose {
                     target: CloseTarget::Shell(shell.id.clone()),
                     name: shell.name.clone(),
                     shell_count: 1,
                     launcher_count: 0,
-                }),
-                WorkspaceItemView::Launcher(launcher) => Some(PendingClose {
+                },
+                WorkspaceItemView::AgentShell(agent_shell) => PendingClose {
+                    target: CloseTarget::Shell(agent_shell.shell.id.clone()),
+                    name: agent_shell.shell.name.clone(),
+                    shell_count: 1,
+                    launcher_count: 0,
+                },
+                WorkspaceItemView::Launcher(launcher) => PendingClose {
                     target: CloseTarget::Launcher(launcher.id.clone()),
                     name: launcher.name.clone(),
                     shell_count: 0,
                     launcher_count: 1,
-                }),
-                WorkspaceItemView::Agent(_) => None,
+                },
             }),
         };
     }
@@ -579,8 +616,10 @@ impl App {
         let selected_id = self.selected().map(|workspace| workspace.id.clone());
         let selected_item = self.selected_item().map(|item| match item {
             WorkspaceItemView::Shell(shell) => ItemIdentity::Shell(shell.id.clone()),
+            WorkspaceItemView::AgentShell(agent_shell) => {
+                ItemIdentity::Shell(agent_shell.shell.id.clone())
+            }
             WorkspaceItemView::Launcher(launcher) => ItemIdentity::Launcher(launcher.id.clone()),
-            WorkspaceItemView::Agent(agent) => ItemIdentity::Agent(agent.id.clone()),
         });
         let previous_index = self.selected_index().unwrap_or(0);
         let selected_index = selected_id
@@ -593,15 +632,14 @@ impl App {
             selected_item
                 .and_then(|target| {
                     match target {
-                    ItemIdentity::Shell(id) => workspace.items.iter().position(
-                        |item| matches!(item, WorkspaceItemView::Shell(shell) if shell.id == id),
-                    ),
+                    ItemIdentity::Shell(id) => workspace.items.iter().position(|item| match item {
+                        WorkspaceItemView::Shell(shell) => shell.id == id,
+                        WorkspaceItemView::AgentShell(agent_shell) => agent_shell.shell.id == id,
+                        WorkspaceItemView::Launcher(_) => false,
+                    }),
                     ItemIdentity::Launcher(id) => workspace.items.iter().position(|item| {
                         matches!(item, WorkspaceItemView::Launcher(launcher) if launcher.id == id)
                     }),
-                    ItemIdentity::Agent(id) => workspace.items.iter().position(
-                        |item| matches!(item, WorkspaceItemView::Agent(agent) if agent.id == id),
-                    ),
                 }
                 })
                 .or_else(|| (!workspace.items.is_empty()).then_some(0))
@@ -1033,7 +1071,7 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
 }
 
 fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
-    let header = Row::new(["NAME", "STATUS", "DIRECTORY", "DETAIL", "ID"])
+    let header = Row::new(["KIND", "NAME", "STATUS", "DIRECTORY", "DETAIL", "ID"])
         .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD));
     let selected = app
         .workspace_state
@@ -1057,45 +1095,64 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         .flat_map(|workspace| {
             workspace.items.iter().map(|item| match item {
                 WorkspaceItemView::Shell(terminal) => Row::new(vec![
+                    Cell::from(Span::styled(
+                        terminal.kind(),
+                        Style::new().fg(if terminal.command.is_empty() {
+                            TEXT
+                        } else {
+                            YELLOW
+                        }),
+                    )),
                     Cell::from(terminal.name.as_str()),
                     Cell::from(Span::styled(
                         terminal.status.as_str(),
                         Style::new().fg(status_color(&terminal.status)),
                     )),
                     Cell::from(terminal.directory.as_str()),
-                    Cell::from(terminal.branch.as_str()),
+                    Cell::from(terminal.detail()),
                     Cell::from(if show_full_ids {
                         terminal.id.clone()
                     } else {
                         short_id(&terminal.id)
                     }),
                 ]),
+                WorkspaceItemView::AgentShell(agent_shell) => Row::new(vec![
+                    Cell::from(Span::styled("agent", Style::new().fg(TEAL))),
+                    Cell::from(agent_shell.shell.name.as_str()),
+                    Cell::from(Span::styled(
+                        agent_shell.status(),
+                        Style::new().fg(status_color(agent_shell.status())),
+                    )),
+                    Cell::from(agent_shell.shell.directory.as_str()),
+                    Cell::from(agent_shell.agent.as_ref().map_or_else(
+                        || format!("foreground process | {}", agent_shell.shell.branch),
+                        |agent| {
+                            format!(
+                                "{} | {} | {} / {} {}%",
+                                agent.evidence,
+                                agent_shell.shell.branch,
+                                agent.integration,
+                                agent.authority,
+                                agent.confidence
+                            )
+                        },
+                    )),
+                    Cell::from(if show_full_ids {
+                        agent_shell.shell.id.clone()
+                    } else {
+                        short_id(&agent_shell.shell.id)
+                    }),
+                ]),
                 WorkspaceItemView::Launcher(launcher) => Row::new(vec![
-                    Cell::from(launcher.name.as_str()),
                     Cell::from(Span::styled("launcher", Style::new().fg(YELLOW))),
+                    Cell::from(launcher.name.as_str()),
+                    Cell::from("-"),
                     Cell::from(launcher.directory.as_str()),
                     Cell::from(launcher.command.as_str()),
                     Cell::from(if show_full_ids {
                         launcher.id.clone()
                     } else {
                         short_id(&launcher.id)
-                    }),
-                ]),
-                WorkspaceItemView::Agent(agent) => Row::new(vec![
-                    Cell::from(agent.name.as_str()),
-                    Cell::from(Span::styled(
-                        agent.state.as_str(),
-                        Style::new().fg(status_color(&agent.state)),
-                    )),
-                    Cell::from(agent.shell_name.as_str()),
-                    Cell::from(format!(
-                        "{} / {} {}%: {}",
-                        agent.integration, agent.authority, agent.confidence, agent.evidence
-                    )),
-                    Cell::from(if show_full_ids {
-                        agent.id.clone()
-                    } else {
-                        short_id(&agent.id)
                     }),
                 ]),
             })
@@ -1106,13 +1163,8 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
     let table_area = if show_full_ids {
         inner
     } else {
-        let detail_height = if matches!(app.selected_item(), Some(WorkspaceItemView::Agent(_))) {
-            3
-        } else {
-            1
-        };
         let [detail_area, table_area] =
-            Layout::vertical([Constraint::Length(detail_height), Constraint::Fill(1)]).areas(inner);
+            Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(inner);
         let detail = app.selected_item().map_or_else(
             || {
                 vec![Line::from(Span::styled(
@@ -1139,56 +1191,54 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
 
 fn item_detail_lines(item: &WorkspaceItemView) -> Vec<Line<'_>> {
     match item {
-        WorkspaceItemView::Shell(shell) => vec![Line::from(vec![
-            Span::styled(" ID ", Style::new().fg(SUBTEXT)),
-            Span::styled(shell.id.as_str(), Style::new().fg(TEXT)),
-        ])],
+        WorkspaceItemView::Shell(shell) => {
+            let mut spans = vec![
+                Span::styled(" ID ", Style::new().fg(SUBTEXT)),
+                Span::styled(shell.id.as_str(), Style::new().fg(TEXT)),
+            ];
+            if !shell.command.is_empty() {
+                spans.extend([
+                    Span::styled("  Command ", Style::new().fg(SUBTEXT)),
+                    Span::styled(shell.command.as_str(), Style::new().fg(TEXT)),
+                ]);
+            }
+            vec![Line::from(spans)]
+        }
         WorkspaceItemView::Launcher(launcher) => vec![Line::from(vec![
             Span::styled(" ID ", Style::new().fg(SUBTEXT)),
             Span::styled(launcher.id.as_str(), Style::new().fg(TEXT)),
         ])],
-        WorkspaceItemView::Agent(agent) => vec![
-            Line::from(format!(
-                " Agent {}  Workspace {}  Run {}  Shell {} ({})",
-                agent.id, agent.workspace_id, agent.run_id, agent.shell_name, agent.shell_id
-            )),
-            Line::from(format!(
-                " {}  {}  {}  confidence {}%  external {}",
-                agent.state,
-                agent.integration,
-                agent.authority,
-                agent.confidence,
-                agent.external_session_id.as_deref().unwrap_or("-")
-            )),
-            Line::from(format!(
-                " started {}  observed {}  ended {}  {}",
-                agent.started_at_ms,
-                agent.observed_at_ms,
-                agent
-                    .ended_at_ms
-                    .map_or_else(|| "-".to_owned(), |timestamp| timestamp.to_string()),
-                agent.evidence
-            )),
-        ],
+        WorkspaceItemView::AgentShell(agent_shell) => vec![Line::from(match &agent_shell.agent {
+            Some(agent) => format!(
+                " Shell {}  Agent {}  Branch {}",
+                agent_shell.shell.id, agent.id, agent_shell.shell.branch
+            ),
+            None => format!(
+                " Shell {}  Branch {}",
+                agent_shell.shell.id, agent_shell.shell.branch
+            ),
+        })],
     }
 }
 
 fn shell_column_widths(width: u16, show_full_ids: bool) -> Vec<Constraint> {
-    let (name, status, branch, id, directory_min, directory_max) = if show_full_ids {
+    let (name, status, detail, id, directory_min, directory_max) = if show_full_ids {
         (18, 10, 30, 36, 24, 42)
     } else {
         (16, 10, 18, 8, 16, 36)
     };
-    // Four column gaps and the highlight marker also consume table width.
-    let fixed = name + status + branch + id + 6;
+    let kind = 8;
+    // Five column gaps and the highlight marker also consume table width.
+    let fixed = kind + name + status + detail + id + 7;
     let directory = width
         .saturating_sub(fixed)
         .clamp(directory_min, directory_max);
     vec![
+        Constraint::Length(kind),
         Constraint::Length(name),
         Constraint::Length(status),
         Constraint::Length(directory),
-        Constraint::Length(branch),
+        Constraint::Length(detail),
         Constraint::Length(id),
     ]
 }
@@ -1240,8 +1290,6 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         ))
     } else {
         let launcher_selected = matches!(app.selected_item(), Some(WorkspaceItemView::Launcher(_)));
-        let agent_selected = app.focus == Focus::Items
-            && matches!(app.selected_item(), Some(WorkspaceItemView::Agent(_)));
         let mut spans = vec![
             Span::styled(" j/k", Style::new().fg(TEAL)),
             Span::styled(
@@ -1258,51 +1306,47 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 Style::new().fg(SUBTEXT),
             ),
         ];
-        if !agent_selected {
-            spans.extend([
-                Span::styled("e", Style::new().fg(YELLOW)),
-                Span::styled(
-                    if app.focus == Focus::Workspaces {
-                        " rename workspace  "
-                    } else if launcher_selected {
-                        " rename launcher  "
-                    } else {
-                        " rename shell  "
-                    },
-                    Style::new().fg(SUBTEXT),
-                ),
-                Span::styled("enter", Style::new().fg(GREEN)),
-                Span::styled(
-                    if app.focus == Focus::Workspaces {
-                        " restore workspace  "
-                    } else if launcher_selected {
-                        " launch command  "
-                    } else {
-                        " open shell  "
-                    },
-                    Style::new().fg(SUBTEXT),
-                ),
-            ]);
-        }
+        spans.extend([
+            Span::styled("e", Style::new().fg(YELLOW)),
+            Span::styled(
+                if app.focus == Focus::Workspaces {
+                    " rename workspace  "
+                } else if launcher_selected {
+                    " rename launcher  "
+                } else {
+                    " rename shell  "
+                },
+                Style::new().fg(SUBTEXT),
+            ),
+            Span::styled("enter", Style::new().fg(GREEN)),
+            Span::styled(
+                if app.focus == Focus::Workspaces {
+                    " restore workspace  "
+                } else if launcher_selected {
+                    " launch command  "
+                } else {
+                    " open shell  "
+                },
+                Style::new().fg(SUBTEXT),
+            ),
+        ]);
         spans.extend([
             Span::styled("r", Style::new().fg(BLUE)),
             Span::styled(" refresh  ", Style::new().fg(SUBTEXT)),
         ]);
-        if !agent_selected {
-            spans.extend([
-                Span::styled("x", Style::new().fg(RED)),
-                Span::styled(
-                    if app.focus == Focus::Workspaces {
-                        " close workspace  "
-                    } else if launcher_selected {
-                        " remove launcher  "
-                    } else {
-                        " close shell  "
-                    },
-                    Style::new().fg(SUBTEXT),
-                ),
-            ]);
-        }
+        spans.extend([
+            Span::styled("x", Style::new().fg(RED)),
+            Span::styled(
+                if app.focus == Focus::Workspaces {
+                    " close workspace  "
+                } else if launcher_selected {
+                    " remove launcher  "
+                } else {
+                    " close shell  "
+                },
+                Style::new().fg(SUBTEXT),
+            ),
+        ]);
         spans.extend([
             Span::styled("q", Style::new().fg(RED)),
             Span::styled(" quit", Style::new().fg(SUBTEXT)),
@@ -1362,6 +1406,7 @@ mod tests {
                 status: "running".into(),
                 directory: "/tmp/boomux".into(),
                 branch: "main".into(),
+                command: String::new(),
             })],
         }
     }
@@ -1369,20 +1414,39 @@ mod tests {
     fn agent() -> AgentView {
         AgentView {
             id: "agent-1".into(),
-            workspace_id: "w1".into(),
-            run_id: "run-1".into(),
-            shell_id: "term_1".into(),
-            shell_name: "agent".into(),
-            name: "reviewer".into(),
             state: "working".into(),
             integration: "opencode".into(),
             authority: "lifecycle_integration".into(),
             confidence: 95,
             evidence: "tool call in progress".into(),
-            external_session_id: Some("session-1".into()),
-            started_at_ms: 100,
-            observed_at_ms: 120,
-            ended_at_ms: None,
+        }
+    }
+
+    fn agent_shell() -> AgentShellView {
+        AgentShellView {
+            shell: TerminalView {
+                id: "term_1".into(),
+                name: "agent".into(),
+                status: "running".into(),
+                directory: "/tmp/boomux".into(),
+                branch: "main".into(),
+                command: String::new(),
+            },
+            agent: Some(agent()),
+        }
+    }
+
+    fn hinted_agent_shell() -> AgentShellView {
+        AgentShellView {
+            shell: TerminalView {
+                id: "term_1".into(),
+                name: "agent".into(),
+                status: "running".into(),
+                directory: "/tmp/boomux".into(),
+                branch: "main".into(),
+                command: String::new(),
+            },
+            agent: None,
         }
     }
 
@@ -1407,6 +1471,7 @@ mod tests {
         assert_eq!(
             shell_column_widths(180, true),
             vec![
+                Constraint::Length(8),
                 Constraint::Length(18),
                 Constraint::Length(10),
                 Constraint::Length(42),
@@ -1493,6 +1558,7 @@ mod tests {
             status: "pending".into(),
             directory: "/tmp/boomux".into(),
             branch: "main".into(),
+            command: String::new(),
         }));
         refreshed
             .items
@@ -1513,29 +1579,30 @@ mod tests {
     }
 
     #[test]
-    fn refresh_preserves_agent_selection_by_typed_id() {
+    fn refresh_preserves_selection_when_hint_morphs_to_durable_agent() {
         let mut initial = workspace("w1", "boomux");
-        initial.items.push(WorkspaceItemView::Agent(agent()));
+        initial.items[0] = WorkspaceItemView::AgentShell(hinted_agent_shell());
         let mut app = App::new(vec![initial], project_context());
         app.toggle_focus();
-        app.next();
 
         let mut refreshed = workspace("w1", "boomux");
-        refreshed
-            .items
-            .push(WorkspaceItemView::Launcher(LauncherView {
-                id: "agent-1".into(),
-                name: "same-id".into(),
+        refreshed.items[0] = WorkspaceItemView::AgentShell(agent_shell());
+        refreshed.items.insert(
+            0,
+            WorkspaceItemView::Launcher(LauncherView {
+                id: "launcher-1".into(),
+                name: "editor".into(),
                 directory: "/tmp/boomux".into(),
                 command: "true".into(),
-            }));
-        refreshed.items.push(WorkspaceItemView::Agent(agent()));
+            }),
+        );
         app.replace_workspaces(vec![refreshed]);
 
-        assert_eq!(app.item_state.selected(), Some(2));
+        assert_eq!(app.item_state.selected(), Some(1));
         assert!(matches!(
             app.selected_item(),
-            Some(WorkspaceItemView::Agent(current)) if current.id == "agent-1"
+            Some(WorkspaceItemView::AgentShell(current))
+                if current.shell.id == "term_1" && current.agent.is_some()
         ));
     }
 
@@ -1771,23 +1838,36 @@ mod tests {
     }
 
     #[test]
-    fn agent_rows_dispatch_no_open_rename_or_close_actions() {
+    fn agent_shell_rows_dispatch_shell_open_rename_and_close_actions() {
         let mut app = app();
-        app.workspaces[0].items = vec![WorkspaceItemView::Agent(agent())];
+        app.workspaces[0].items = vec![WorkspaceItemView::AgentShell(agent_shell())];
         app.toggle_focus();
-        let mut opened = false;
+        let mut opened = None;
 
-        let dispatched = app.open_selected_item(&mut |_| {
-            opened = true;
+        let dispatched = app.open_selected_item(&mut |target| {
+            opened = Some(target.clone());
             Ok(String::new())
         });
         app.request_rename();
+        assert!(matches!(
+            app.mode,
+            Mode::Rename {
+                target: RenameTarget::Shell(ref id),
+                ..
+            } if id == "term_1"
+        ));
+        app.mode = Mode::Normal;
         app.request_close();
 
-        assert!(!opened);
-        assert!(!dispatched);
-        assert!(matches!(app.mode, Mode::Normal));
-        assert!(app.pending_close.is_none());
+        assert!(dispatched);
+        assert_eq!(opened, Some(OpenTarget::Shell("term_1".into())));
+        assert!(matches!(
+            app.pending_close,
+            Some(PendingClose {
+                target: CloseTarget::Shell(ref id),
+                ..
+            }) if id == "term_1"
+        ));
     }
 
     #[test]
@@ -2046,15 +2126,14 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_renders_agent_counts_rows_details_and_read_only_footer() {
+    fn dashboard_renders_one_actionable_agent_shell_row_with_counts_and_details() {
         let backend = TestBackend::new(120, 34);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = app();
-        app.workspaces[0]
-            .items
-            .push(WorkspaceItemView::Agent(agent()));
+        let mut agent_shell = agent_shell();
+        agent_shell.shell.name = "keepname".into();
+        app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell);
         app.toggle_focus();
-        app.next();
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
         let text: String = terminal
@@ -2066,17 +2145,75 @@ mod tests {
             .collect();
 
         assert_eq!(app.workspaces[0].agent_count(), 1);
+        assert_eq!(app.workspaces[0].shell_count(), 1);
         assert!(text.contains("1 agents"));
+        assert!(text.contains("1 shells"));
         assert!(text.contains("AGENTS"));
-        assert!(text.contains("Items: boomux (2)"));
-        assert!(text.contains("reviewer"));
+        assert!(text.contains("Items: boomux (1)"));
+        assert!(text.contains("KIND"));
+        assert!(text.contains("agent"));
+        assert!(text.contains("keepname"));
         assert!(text.contains("working"));
-        assert!(text.contains("Agent agent-1"));
-        assert!(text.contains("lifecycle_integration"));
-        assert!(text.contains("started 100"));
-        assert!(!text.contains("rename shell"));
-        assert!(!text.contains("open shell"));
-        assert!(!text.contains("close shell"));
+        assert!(text.contains("Shell term_1  Agent agent-1"));
+        assert!(text.contains("tool call"));
+        assert!(text.contains("main"));
+        assert!(text.contains("rename shell"));
+        assert!(text.contains("open shell"));
+        assert!(text.contains("close shell"));
+    }
+
+    #[test]
+    fn dashboard_renders_command_kind_and_stored_argv() {
+        let backend = TestBackend::new(120, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+        let WorkspaceItemView::Shell(command) = &mut app.workspaces[0].items[0] else {
+            panic!("expected shell item");
+        };
+        command.name = "clock".into();
+        command.command = "watch -n 1 date".into();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(text.contains("command"));
+        assert!(text.contains("clock"));
+        assert!(text.contains("watch -n 1 date"));
+    }
+
+    #[test]
+    fn compact_dashboard_renders_hinted_agent_in_one_detail_line() {
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+        let mut agent_shell = hinted_agent_shell();
+        agent_shell.shell.name = "keepname".into();
+        app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell);
+        app.toggle_focus();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let buffer = terminal.backend().buffer();
+        let lines: Vec<String> = (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect()
+            })
+            .collect();
+
+        assert_eq!(app.workspaces[0].agent_count(), 1);
+        assert!(lines.iter().any(|line| line.contains("Shell term_1")));
+        assert!(!lines.iter().any(|line| line.contains("Agent agent-1")));
+        assert!(lines.iter().any(|line| line.contains("foreground process")));
+        assert!(lines.iter().any(|line| line.contains("keepname")));
+        assert!(!lines.iter().any(|line| line.contains("opencode")));
+        assert!(lines.iter().any(|line| line.contains("idle")));
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -729,6 +729,66 @@ fn graceful_restart_preserves_exited_run_and_terminal_state() {
 }
 
 #[test]
+fn restart_on_attach_reopens_an_exited_durable_shell() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "restart-exited",
+            vec![ShellSpec {
+                name: "command".into(),
+                cwd: std::env::temp_dir(),
+                command: vec!["/bin/sh".into()],
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let mut first = daemon
+        .client
+        .attach(&shell_id, false, profile())
+        .unwrap()
+        .stream;
+    AttachFrame::Input(b"printf 'restartable-run\\n'; exit 0\n".to_vec())
+        .write_to(&mut first)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut first, b"restartable-run"),
+        b"restartable-run"
+    ));
+    drop(first);
+    wait_until(
+        || {
+            matches!(
+                daemon.client.get_shell(&shell_id).unwrap().status,
+                ShellStatus::Exited { .. }
+            )
+        },
+        "first shell run did not exit",
+    );
+    let first_run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+
+    let mut second = daemon
+        .client
+        .attach_restarting(&shell_id, false, profile())
+        .unwrap()
+        .stream;
+    AttachFrame::Input(b"printf 'restartable-run\\n'\n".to_vec())
+        .write_to(&mut second)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut second, b"restartable-run"),
+        b"restartable-run"
+    ));
+    let second_run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+    assert_ne!(second_run.id, first_run.id);
+    assert_eq!(second_run.generation, 2);
+
+    drop(second);
+    daemon.client.close_workspace(&workspace.id).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn daemon_events_and_revision_reads_survive_handoff() {
     let mut daemon = TestDaemon::start();
     let baseline = daemon.client.events(None, 256, 0).unwrap();
@@ -1916,7 +1976,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 10);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 11);
     let json_commands = capabilities["data"]["json_commands"].as_array().unwrap();
     for command in ["events", "agent.register", "agent.ensure", "agent.report"] {
         assert!(json_commands.iter().any(|current| current == command));
@@ -1925,6 +1985,8 @@ fn native_daemon_lifecycle() {
     for feature in [
         "revision_aware_reads",
         "protocol_10",
+        "protocol_11",
+        "restartable_exited_shells",
         "idempotent_agent_ensure",
         "agent_authority_precedence",
         "opencode_lifecycle_plugin",
@@ -1939,7 +2001,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 10"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 11"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- morph shell rows into actionable agent rows while preserving shell identity and names
- distinguish command-backed PTYs, add foreground OpenCode hints, and report hinted sessions as idle
- restart exited shells atomically on explicit open and detach spawned terminal windows from the dashboard
- expose stored argv and foreground process diagnostics, advance protocol support, and update roadmap/docs

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- bun test integrations/opencode
- git diff --check