### PR TITLE
Add Pi lifecycle integration

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: boomux
-description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, process supervision, and integrations. Use when asked to discover shells or agents, read terminal output, supervise an explicitly identified external session, report agent lifecycle state, install the OpenCode integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
+description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, process supervision, and integrations. Use when asked to discover shells or agents, read terminal output, supervise an explicitly identified external session, report agent lifecycle state, install the OpenCode or Pi integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
 compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; agent mutation and supervision require exact shell-run context, and supervision requires a caller-supplied canonical external session ID.
 metadata:
   author: boomux
@@ -314,6 +314,24 @@ errors map to `blocked`; only root idle maps to `idle`; and only explicit root
 session deletion maps to `done`. Child deletion and process exit do not report
 completion. Unmanaged or unavailable Boomux is fail-open. If Boomux returns
 `run_changed`, reporting for that root is disabled rather than redirected.
+
+## Install The Pi Integration
+
+```console
+boomux pi install
+boomux pi install --force
+```
+
+The installer writes `$PI_CODING_AGENT_DIR/extensions/boomux.js`, falling back
+to `~/.pi/agent/extensions/boomux.js`. Identical content is left alone,
+different content requires `--force`, and symlinks or non-regular targets are
+rejected. Restart Pi after installing or replacing the extension.
+
+The extension activates only in a managed shell run and keys the Agent instance
+by Pi's canonical project session ID. Session start and settled events report
+`idle`; agent start reports `working`; session shutdown reports `inactive`
+because Pi sessions are resumable. Inactive records remain durable but do not
+occupy dashboard agent rows. Reporting is serialized and fail-open.
 
 ## Environment And Integration
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,9 @@ heuristic. Equal authority may advance an observation; exact duplicate and lower
 are no-ops. Daemon lifecycle authority is reserved for daemon-originated observations and is not an
 external integration authority.
 
+Inactive means a resumable external session is not currently active. It remains durable and can
+return to idle or working, but does not decorate a dashboard shell. Done is permanent completion.
+
 ## Process Adapter
 
 A process-bound observer for an agent instance whose evidence is limited to process events. The

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ morphs into an agent row instead of adding a duplicate item. It keeps the
 shell's name, ID, directory, and open, rename, and close actions while showing the
 Agent's lifecycle state and evidence. Completed and historical Agent instances
 remain available through CLI inspection rather than occupying extra dashboard
-rows. A foreground `opencode` process also supplies a presentation-only agent
-hint, so the row morphs immediately before the first prompt creates a durable
-OpenCode session. The hint displays `idle` without creating a durable lifecycle
+rows. A foreground `opencode` or `pi` process also supplies a presentation-only agent
+hint, so the row morphs immediately while the lifecycle integration establishes
+a durable Agent session. The hint displays `idle` without creating a durable lifecycle
 observation; lifecycle state replaces that hint once available.
 
 Closing a terminal window only disconnects its attachment. The Boomux daemon
@@ -142,6 +142,7 @@ boomux daemon restart
 boomux daemon stop
 boomux skill install [--force]
 boomux opencode install [--force]
+boomux pi install [--force]
 ```
 
 `boomux shells` lists shells in the current workspace. `boomux read` and
@@ -186,7 +187,7 @@ by integration, external session ID, shell ID, and run ID. It requires
 `--external-session-id`; an existing match is returned unchanged, including
 after an integration or daemon reload, while a different shell run creates a
 different identity. `register`, `ensure`, and `report` require explicit
-`unknown`, `working`, `blocked`, `idle`, or `done` state plus authority,
+`unknown`, `working`, `blocked`, `idle`, `inactive`, or `done` state plus authority,
 evidence, and confidence.
 
 External reports use this precedence: `lifecycle-integration` over
@@ -347,6 +348,29 @@ caller already has the selected canonical root ID and passes it explicitly as
 `--external-session-id`. This is not a reason to wrap ordinary OpenCode launches
 when the lifecycle plugin is available: the plugin resolves canonical ancestry
 and provides stronger, meaningful lifecycle observations.
+
+## Pi Integration
+
+Install the bundled global Pi lifecycle extension with:
+
+```console
+boomux pi install
+```
+
+The destination is `$PI_CODING_AGENT_DIR/extensions/boomux.js`, or
+`~/.pi/agent/extensions/boomux.js` when that environment variable is unset. Pi
+discovers the extension automatically. Identical content is left unchanged;
+different content requires `--force`, and symlinked or non-regular install paths
+are rejected. Restart Pi after installing or replacing the extension.
+
+Inside a Boomux-managed shell, the extension uses Pi's canonical project session
+ID and lifecycle hooks. Session start reports `idle`, agent start reports
+`working`, and `agent_settled` reports `idle` only after retries, compaction, and
+queued continuations have finished. Session shutdown reports `inactive` rather
+than permanent completion because Pi sessions are resumable. Inactive instances
+remain durable but do not occupy agent rows until the session starts again.
+Calls use exact argument vectors, bounded JSON output, and fail open when Boomux
+is unavailable.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ dashboard presents an empty vector as `shell` and a non-empty vector as
 `command`, making primary-process exit behavior visible without splitting the
 durable shell model. Command rows show the stored argv in their detail column.
 Agent presentation takes precedence when the current run has an active Agent or
-an exact `opencode` foreground hint.
+an exact `opencode` or `pi` foreground hint.
 
 An active Agent instance bound to a shell's exact current run decorates that
 shell as an agent-shell row rather than adding a second item. The row retains
@@ -155,8 +155,8 @@ active instances match one run, the most recently observed instance is shown
 with an Agent-ID tie-break. Completed, stale-run, and orphaned Agent records
 remain available through CLI inspection but do not occupy dashboard rows. A
 running shell snapshot may also expose its PTY foreground process name. The
-dashboard recognizes exact `opencode` as a presentation-only agent-shell hint
-before a canonical OpenCode session exists; this hint creates no AgentInstance,
+dashboard recognizes exact `opencode` and `pi` as presentation-only agent-shell hints
+before a canonical Agent session exists; this hint creates no AgentInstance,
 durable state observation, persistence, or events. It displays `idle` until
 lifecycle data exists, then yields to that authoritative observation.
 
@@ -286,6 +286,29 @@ does not already match. Calls use exact argument vectors, a one-second timeout,
 bounded output, and the stable JSON envelope. Unmanaged sessions are a no-op;
 Boomux or ancestry failures are rate-limited and fail open so OpenCode continues.
 `run_changed` disables all later reports for that tracked root.
+
+### Pi Lifecycle Extension
+
+`integrations/pi/boomux.js` is a global Pi extension installed by
+`boomux pi install [--force]`. The installer targets
+`$PI_CODING_AGENT_DIR/extensions/boomux.js`, falling back to
+`~/.pi/agent/extensions/boomux.js`, with the same regular-file, symlink, atomic
+replacement, and `--force` rules as other bundled integrations.
+
+The extension activates only when `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID` are
+present and uses `sessionManager.getSessionId()` as canonical external identity.
+`session_start` reports `idle`, `agent_start` reports `working`, and
+`agent_settled` reports `idle` after automatic retries, compaction, and queued
+continuations have drained. `session_shutdown` reports `inactive` rather than
+`done` because Pi sessions can be resumed. Inactive records remain durable but
+do not decorate dashboard shells. Session switches reset the local agent ID and
+ensure the new canonical session identity. Reports are serialized, use exact
+argument vectors and bounded JSON output, and fail open with rate-limited
+diagnostics.
+
+Protocol 12 adds `inactive`. Protocol-9 through protocol-11 clients receive that
+observation as `unknown`, while protocol-12 clients can distinguish a resumable
+session that is not currently active from permanent `done` completion.
 
 ### Transition Coordinator
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -88,7 +88,7 @@ Agent objects include stable fields `id`, `workspace_id`, `workspace_name`,
 `revision`, `state`, `authority`, `evidence`, `confidence`, and
 `observed_at_ms`. Missing optional values are JSON `null`.
 
-Agent `state` is `unknown`, `working`, `blocked`, `idle`, or `done`. `authority`
+Agent `state` is `unknown`, `working`, `blocked`, `idle`, `inactive`, or `done`. `authority`
 is `lifecycle_integration`, `process_adapter`, `terminal_heuristic`, or
 `daemon_lifecycle`; CLI arguments use hyphens instead of underscores. Confidence
 is an integer from 0 through 100. Public mutations accept the first three

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -5,7 +5,9 @@ revision-aware terminal reads. Protocol 9 adds run-scoped agent snapshots and
 events while retaining negotiation with older management clients. Protocol 10
 adds idempotent agent ensure without adding an event type. Protocol 11 adds an
 explicit exited-shell restart; the subsequent attachment emits the existing
-`run_started` event for the new generation.
+`run_started` event for the new generation. Protocol 12 adds resumable
+`inactive` Agent observations; older Agent-capable clients receive them as
+`unknown`.
 
 ## Cursors
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -97,10 +97,11 @@ eternal process.
 
 ### Near-Term Priorities
 
-1. Validate the OpenCode lifecycle plugin during normal work before expanding
-   the observation model. Confirm reload identity, root/subagent aggregation,
-   blocked prompts, idle transitions, explicit completion, and graceful daemon
-   replacement against real sessions.
+1. Validate the OpenCode and Pi lifecycle integrations during normal work before
+   expanding the observation model. Confirm reload identity, session switching,
+   root/subagent aggregation where available, blocked prompts, idle transitions,
+   explicit completion semantics, and graceful daemon replacement against real
+   sessions.
 2. Aggregate agent states into workspace counts and add an explainable,
    persistent attention queue for blocked and completed work.
 3. Add revision-aware `agent wait` so scripts can await durable state

--- a/integrations/pi/boomux.js
+++ b/integrations/pi/boomux.js
@@ -1,0 +1,281 @@
+import { spawn } from "node:child_process";
+
+const MAX_EVIDENCE = 160;
+const MAX_OUTPUT = 64 * 1024;
+const COMMAND_TIMEOUT_MS = 1_000;
+const LOG_INTERVAL_MS = 30_000;
+const LIFECYCLE_AUTHORITY = "lifecycle_integration";
+const LIFECYCLE_CONFIDENCE = 100;
+
+function text(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function boundedEvidence(value) {
+  const clean = String(value ?? "Pi lifecycle event")
+    .replace(/\s+/g, " ")
+    .trim();
+  return (clean || "Pi lifecycle event").slice(0, MAX_EVIDENCE);
+}
+
+function parseJSON(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error("boomux returned empty JSON output");
+  }
+  const parsed = JSON.parse(value);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("boomux returned invalid JSON output");
+  }
+  return parsed;
+}
+
+function createProcessRunner(options = {}) {
+  const spawnProcess = options.spawn ?? spawn;
+  const timeoutMs = options.timeoutMs ?? COMMAND_TIMEOUT_MS;
+  const maxOutput = options.maxOutput ?? MAX_OUTPUT;
+  const killGraceMs = options.killGraceMs ?? 250;
+
+  return (argv) =>
+    new Promise((resolve, reject) => {
+      const child = spawnProcess(argv[0], argv.slice(1), {
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: false,
+      });
+      let stdout = "";
+      let stderr = "";
+      let size = 0;
+      let settled = false;
+      let failure;
+      let timer;
+      let killTimer;
+      let abandonTimer;
+      const finish = (callback) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        clearTimeout(killTimer);
+        clearTimeout(abandonTimer);
+        callback();
+      };
+      const terminate = (error) => {
+        if (failure) return;
+        failure = error;
+        child.kill();
+        killTimer = setTimeout(() => {
+          child.kill("SIGKILL");
+          abandonTimer = setTimeout(() => {
+            child.stdout?.destroy();
+            child.stderr?.destroy();
+            finish(() => reject(failure));
+          }, killGraceMs);
+        }, killGraceMs);
+      };
+      const append = (chunk, target) => {
+        if (failure) return;
+        size += chunk.length;
+        if (size > maxOutput) {
+          terminate(new Error("boomux output limit exceeded"));
+          return;
+        }
+        if (target === "stdout") stdout += chunk.toString();
+        else stderr += chunk.toString();
+      };
+      child.stdout?.on("data", (chunk) => append(chunk, "stdout"));
+      child.stderr?.on("data", (chunk) => append(chunk, "stderr"));
+      child.on("error", (error) => finish(() => reject(error)));
+      child.on("close", (code) =>
+        finish(() => {
+          if (failure) {
+            reject(failure);
+            return;
+          }
+          try {
+            const parsed = parseJSON(stdout.trim() ? stdout : stderr);
+            if (code !== 0 || parsed.error) {
+              const error = new Error(
+                boundedEvidence(
+                  parsed.error?.message ?? stderr ?? "boomux command failed",
+                ),
+              );
+              error.code = parsed.error?.code;
+              reject(error);
+              return;
+            }
+            resolve(parsed);
+          } catch (error) {
+            reject(error);
+          }
+        }),
+      );
+      timer = setTimeout(
+        () => terminate(new Error("boomux command timed out")),
+        timeoutMs,
+      );
+    });
+}
+
+function ensureArgv(shellID, runID, sessionID, state, evidence) {
+  return [
+    "boomux",
+    "agent",
+    "ensure",
+    "pi",
+    "--integration",
+    "pi",
+    "--external-session-id",
+    sessionID,
+    "--shell-id",
+    shellID,
+    "--run-id",
+    runID,
+    "--state",
+    state,
+    "--authority",
+    "lifecycle-integration",
+    "--evidence",
+    boundedEvidence(evidence),
+    "--confidence",
+    "100",
+    "--json",
+  ];
+}
+
+function reportArgv(agentID, shellID, runID, state, evidence) {
+  return [
+    "boomux",
+    "agent",
+    "report",
+    agentID,
+    "--shell-id",
+    shellID,
+    "--run-id",
+    runID,
+    "--state",
+    state,
+    "--authority",
+    "lifecycle-integration",
+    "--evidence",
+    boundedEvidence(evidence),
+    "--confidence",
+    "100",
+    "--json",
+  ];
+}
+
+function agentFromJSON(result) {
+  return result?.data?.agent ?? result?.agent ?? result?.data;
+}
+
+function observationMatches(observation, state, evidence) {
+  return (
+    observation?.state === state &&
+    observation?.authority === LIFECYCLE_AUTHORITY &&
+    observation?.evidence === evidence &&
+    observation?.confidence === LIFECYCLE_CONFIDENCE
+  );
+}
+
+function rateLimitedLogger(log, now = Date.now) {
+  let last = -Infinity;
+  let suppressed = 0;
+  return (error) => {
+    const time = now();
+    if (time - last < LOG_INTERVAL_MS) {
+      suppressed += 1;
+      return;
+    }
+    const suffix = suppressed
+      ? ` (${suppressed} similar errors suppressed)`
+      : "";
+    suppressed = 0;
+    last = time;
+    log(`[boomux-pi] ${boundedEvidence(error?.message ?? error)}${suffix}`);
+  };
+}
+
+function createLifecycle({ env, run, log = console.error, now }) {
+  const shellID = text(env?.BOOMUX_SHELL_ID);
+  const runID = text(env?.BOOMUX_RUN_ID);
+  if (!shellID || !runID) return undefined;
+
+  const reportError = rateLimitedLogger(log, now);
+  let queue = Promise.resolve();
+  let sessionID;
+  let agentID;
+  let disabled = false;
+
+  async function send(nextSessionID, state, rawEvidence) {
+    if (nextSessionID !== sessionID) {
+      sessionID = nextSessionID;
+      agentID = undefined;
+      disabled = false;
+    }
+    if (disabled) return;
+
+    const evidence = boundedEvidence(rawEvidence);
+    try {
+      if (!agentID) {
+        const result = await run(
+          ensureArgv(shellID, runID, sessionID, state, evidence),
+        );
+        const agent = agentFromJSON(result);
+        agentID = text(agent?.id);
+        if (!agentID) throw new Error("boomux ensure response has no agent id");
+        if (agent?.ended_at_ms != null || agent?.observation?.state === "done") {
+          disabled = true;
+          return;
+        }
+        if (observationMatches(agent?.observation, state, evidence)) return;
+      }
+      await run(reportArgv(agentID, shellID, runID, state, evidence));
+    } catch (error) {
+      if (error?.code === "run_changed") disabled = true;
+      throw error;
+    }
+  }
+
+  function enqueue(nextSessionID, state, evidence) {
+    if (!text(nextSessionID)) return Promise.resolve();
+    const pending = queue.then(() => send(nextSessionID, state, evidence));
+    queue = pending.catch(reportError);
+    return queue;
+  }
+
+  return { enqueue };
+}
+
+function currentSessionID(ctx) {
+  return text(ctx?.sessionManager?.getSessionId?.());
+}
+
+export default function BoomuxPiExtension(pi) {
+  const lifecycle = createLifecycle({
+    env: globalThis.process?.env ?? {},
+    run: createProcessRunner(),
+  });
+  if (!lifecycle) return;
+
+  const report = (ctx, state, evidence) =>
+    lifecycle.enqueue(currentSessionID(ctx), state, evidence);
+
+  pi.on("session_start", (_event, ctx) =>
+    report(ctx, "idle", "Pi session idle"),
+  );
+  pi.on("agent_start", (_event, ctx) =>
+    report(ctx, "working", "Pi agent working"),
+  );
+  pi.on("agent_settled", (_event, ctx) =>
+    report(ctx, "idle", "Pi agent settled"),
+  );
+  pi.on("session_shutdown", (_event, ctx) =>
+    report(ctx, "inactive", "Pi session inactive"),
+  );
+}
+
+export const __internal = Object.freeze({
+  boundedEvidence,
+  createLifecycle,
+  createProcessRunner,
+  ensureArgv,
+  reportArgv,
+});

--- a/integrations/pi/boomux.test.js
+++ b/integrations/pi/boomux.test.js
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import BoomuxPiExtension, { __internal } from "./boomux.js";
+
+function agent(id, state, evidence) {
+  return {
+    data: {
+      agent: {
+        id,
+        ended_at_ms: null,
+        observation: {
+          state,
+          authority: "lifecycle_integration",
+          evidence,
+          confidence: 100,
+        },
+      },
+    },
+  };
+}
+
+function context(sessionID) {
+  return {
+    sessionManager: {
+      getSessionId: () => sessionID,
+    },
+  };
+}
+
+describe("Pi lifecycle", () => {
+  test("registers exact lifecycle hooks", () => {
+    const handlers = new Map();
+    const previous = process.env.BOOMUX_SHELL_ID;
+    const previousRun = process.env.BOOMUX_RUN_ID;
+    try {
+      delete process.env.BOOMUX_SHELL_ID;
+      delete process.env.BOOMUX_RUN_ID;
+      BoomuxPiExtension({ on: (event, handler) => handlers.set(event, handler) });
+      expect([...handlers.keys()]).toEqual([]);
+
+      process.env.BOOMUX_SHELL_ID = "shell-1";
+      process.env.BOOMUX_RUN_ID = "run-1";
+      BoomuxPiExtension({ on: (event, handler) => handlers.set(event, handler) });
+    } finally {
+      if (previous === undefined) delete process.env.BOOMUX_SHELL_ID;
+      else process.env.BOOMUX_SHELL_ID = previous;
+      if (previousRun === undefined) delete process.env.BOOMUX_RUN_ID;
+      else process.env.BOOMUX_RUN_ID = previousRun;
+    }
+    expect([...handlers.keys()]).toEqual([
+      "session_start",
+      "agent_start",
+      "agent_settled",
+      "session_shutdown",
+    ]);
+  });
+
+  test("reports idle working settled and inactive states", async () => {
+    const calls = [];
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        return argv[2] === "ensure"
+          ? agent("agent-1", argv[argv.indexOf("--state") + 1], argv[argv.indexOf("--evidence") + 1])
+          : { data: { ok: true } };
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue("session-1", "idle", "Pi session idle");
+    await lifecycle.enqueue("session-1", "working", "Pi agent working");
+    await lifecycle.enqueue("session-1", "idle", "Pi agent settled");
+    await lifecycle.enqueue("session-1", "inactive", "Pi session inactive");
+
+    expect(calls[0].slice(0, 8)).toEqual([
+      "boomux",
+      "agent",
+      "ensure",
+      "pi",
+      "--integration",
+      "pi",
+      "--external-session-id",
+      "session-1",
+    ]);
+    expect(calls.slice(1).map((argv) => argv[argv.indexOf("--state") + 1])).toEqual([
+      "working",
+      "idle",
+      "inactive",
+    ]);
+    expect(calls.every((argv) => argv.includes("--json"))).toBe(true);
+  });
+
+  test("ensures a new identity when Pi switches sessions", async () => {
+    const calls = [];
+    let next = 0;
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        next += 1;
+        return agent(`agent-${next}`, "idle", "Pi session idle");
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue("session-1", "idle", "Pi session idle");
+    await lifecycle.enqueue("session-2", "idle", "Pi session idle");
+
+    expect(calls).toHaveLength(2);
+    expect(calls.map((argv) => argv[7])).toEqual(["session-1", "session-2"]);
+  });
+
+  test("bounds lifecycle evidence", () => {
+    expect(__internal.boundedEvidence(`  ${"x".repeat(200)}  `)).toHaveLength(160);
+  });
+
+  test("waits for a timed out process to close before settling", async () => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    const signals = [];
+    child.kill = (signal) => {
+      signals.push(signal ?? "SIGTERM");
+      return true;
+    };
+    const runner = __internal.createProcessRunner({
+      spawn: () => child,
+      timeoutMs: 5,
+      killGraceMs: 5,
+    });
+    let settled = false;
+    const outcome = runner(["boomux"]).then(
+      () => undefined,
+      (error) => error,
+    );
+    outcome.then(() => {
+      settled = true;
+    });
+
+    await Bun.sleep(8);
+    expect(settled).toBe(false);
+    expect(signals).toEqual(["SIGTERM"]);
+
+    child.emit("close", null);
+    expect((await outcome).message).toBe("boomux command timed out");
+    expect(settled).toBe(true);
+  });
+
+  test("settles after escalating a timed out process that never closes", async () => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    const signals = [];
+    child.kill = (signal) => {
+      signals.push(signal ?? "SIGTERM");
+      return true;
+    };
+    const runner = __internal.createProcessRunner({
+      spawn: () => child,
+      timeoutMs: 5,
+      killGraceMs: 5,
+    });
+
+    const outcome = await runner(["boomux"]).then(
+      () => undefined,
+      (error) => error,
+    );
+
+    expect(outcome.message).toBe("boomux command timed out");
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(child.stdout.destroyed).toBe(true);
+    expect(child.stderr.destroyed).toBe(true);
+  });
+});

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -236,6 +236,7 @@ pub(crate) fn agent_state(state: AgentState) -> &'static str {
         AgentState::Working => "working",
         AgentState::Blocked => "blocked",
         AgentState::Idle => "idle",
+        AgentState::Inactive => "inactive",
         AgentState::Done => "done",
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -625,6 +625,12 @@ impl Client {
 
 fn request_minimum_version(request: &Request) -> u32 {
     match request {
+        Request::RegisterAgent { spec, .. } | Request::EnsureAgent { spec, .. }
+            if spec.report.state == protocol::AgentState::Inactive =>
+        {
+            12
+        }
+        Request::ReportAgent { report, .. } if report.state == protocol::AgentState::Inactive => 12,
         Request::GetLauncher { .. }
         | Request::CreateLauncher { .. }
         | Request::RenameLauncher { .. }
@@ -850,6 +856,23 @@ mod tests {
     }
 
     #[test]
+    fn inactive_agent_reports_require_protocol_twelve() {
+        assert_eq!(
+            request_minimum_version(&Request::ReportAgent {
+                agent_id: "a1".into(),
+                run_id: "r1".into(),
+                report: AgentReport {
+                    state: protocol::AgentState::Inactive,
+                    authority: protocol::AgentAuthority::LifecycleIntegration,
+                    evidence: "inactive".into(),
+                    confidence: 100,
+                },
+            }),
+            12
+        );
+    }
+
+    #[test]
     fn negotiates_protocol_seven_without_losing_version_seven_requests() {
         let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
@@ -858,14 +881,30 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 12);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    11,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 11);
             assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    10,
+                    11,
                     Response::Error {
-                        message: "expected an older protocol".into(),
+                        message: "expected protocol 7".into(),
                         code: Some(ErrorCode::UnsupportedVersion),
                     },
                 ),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -447,7 +447,7 @@ fn launch_replacement_process(
 ) -> io::Result<()> {
     let (mut channel, child_channel) = UnixStream::pair()?;
     let child_channel_fd = child_channel.as_raw_fd();
-    let mut command = Command::new(env::current_exe()?);
+    let mut command = Command::new(replacement_executable()?);
     command
         .args([
             "daemon",
@@ -527,6 +527,38 @@ fn launch_replacement_process(
         let _ = replacement.wait();
     }
     result
+}
+
+fn replacement_executable() -> io::Result<PathBuf> {
+    let current = env::current_exe()?;
+    Ok(select_replacement_executable(
+        current,
+        env::args_os().next().map(PathBuf::from),
+    ))
+}
+
+fn select_replacement_executable(current: PathBuf, argument_zero: Option<PathBuf>) -> PathBuf {
+    if current.exists() {
+        return current;
+    }
+    if let Some(argument_zero) = argument_zero
+        && argument_zero.is_absolute()
+        && argument_zero.exists()
+    {
+        return argument_zero;
+    }
+    current
+}
+
+fn request_requires_protocol_twelve(request: &Request) -> bool {
+    matches!(
+        request,
+        Request::RegisterAgent { spec, .. } | Request::EnsureAgent { spec, .. }
+            if spec.report.state == AgentState::Inactive
+    ) || matches!(
+        request,
+        Request::ReportAgent { report, .. } if report.state == AgentState::Inactive
+    )
 }
 
 fn handle_connection(
@@ -628,6 +660,16 @@ fn handle_connection(
             error_response(
                 ErrorCode::UnsupportedVersion,
                 "request requires daemon protocol 11",
+            ),
+        );
+    }
+    if response_version < 12 && request_requires_protocol_twelve(&request.message) {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "inactive agent state requires daemon protocol 12",
             ),
         );
     }
@@ -737,6 +779,10 @@ fn handle_connection(
 }
 
 fn response_for_version(response: Response, version: u32) -> Response {
+    let mut response = response;
+    if version < 12 {
+        downgrade_inactive_agent_states(&mut response);
+    }
     if version >= 9 {
         return response;
     }
@@ -784,6 +830,50 @@ fn response_for_version(response: Response, version: u32) -> Response {
             }
         }
         response => response,
+    }
+}
+
+fn downgrade_inactive_agent_states(response: &mut Response) {
+    fn downgrade(agent: &mut AgentInstanceSnapshot) {
+        if agent.observation.state == AgentState::Inactive {
+            agent.observation.state = AgentState::Unknown;
+        }
+    }
+
+    match response {
+        Response::Snapshot { snapshot } => {
+            for workspace in &mut snapshot.workspaces {
+                for agent in &mut workspace.agents {
+                    downgrade(agent);
+                }
+            }
+        }
+        Response::Workspace { workspace } => {
+            for agent in &mut workspace.agents {
+                downgrade(agent);
+            }
+        }
+        Response::Agent { agent } => downgrade(agent),
+        Response::Events {
+            snapshot, events, ..
+        } => {
+            if let Some(snapshot) = snapshot {
+                for workspace in &mut snapshot.workspaces {
+                    for agent in &mut workspace.agents {
+                        downgrade(agent);
+                    }
+                }
+            }
+            for event in events {
+                match &mut event.kind {
+                    DaemonEventKind::AgentRegistered { agent, .. }
+                    | DaemonEventKind::AgentStateChanged { agent, .. }
+                    | DaemonEventKind::AgentCompleted { agent, .. } => downgrade(agent),
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
     }
 }
 
@@ -4940,6 +5030,24 @@ mod tests {
     }
 
     #[test]
+    fn replacement_uses_absolute_argument_zero_after_binary_replacement() {
+        let directory = env::temp_dir().join(format!("boomux-replacement-{}", Uuid::new_v4()));
+        let installed = directory.join("boomux");
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(&installed, b"replacement").unwrap();
+
+        assert_eq!(
+            select_replacement_executable(
+                directory.join("boomux (deleted)"),
+                Some(installed.clone())
+            ),
+            installed
+        );
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
     fn event_batches_are_monotonic_and_paginated() {
         let registry = Registry::default();
         let Response::Events {
@@ -5619,7 +5727,7 @@ mod tests {
         let shell_id = shell.id.clone();
         let run_id = shell.snapshot().unwrap().run.unwrap().id;
         let spec = agent_spec(AgentState::Working);
-        let Response::Agent { agent } = registry
+        let Response::Agent { agent: registered } = registry
             .dispatch(Request::EnsureAgent {
                 shell_id: shell_id.clone(),
                 run_id: run_id.clone(),
@@ -5629,6 +5737,18 @@ mod tests {
         else {
             panic!("expected registered agent");
         };
+        let Response::Agent { agent } = registry
+            .dispatch(Request::ReportAgent {
+                agent_id: registered.id,
+                run_id: run_id.clone(),
+                report: agent_spec(AgentState::Inactive).report,
+            })
+            .unwrap()
+        else {
+            panic!("expected inactive agent");
+        };
+        assert_eq!(agent.observation.state, AgentState::Inactive);
+        assert_eq!(agent.ended_at_ms, None);
 
         shell.kill().unwrap();
         drop(runtime);
@@ -5655,6 +5775,20 @@ mod tests {
             panic!("expected restored ensured agent");
         };
         assert_eq!(ensured, agent);
+        let Response::Agent { agent: reactivated } = restored
+            .dispatch(Request::ReportAgent {
+                agent_id: ensured.id,
+                run_id: ensured.run_id,
+                report: agent_spec(AgentState::Idle).report,
+            })
+            .unwrap()
+        else {
+            panic!("expected reactivated agent");
+        };
+        assert_eq!(reactivated.id, agent.id);
+        assert_eq!(reactivated.observation.state, AgentState::Idle);
+        assert_eq!(reactivated.ended_at_ms, None);
+        assert_eq!(restored.snapshot().unwrap().workspaces[0].agents.len(), 1);
         drop(restored);
         fs::remove_dir_all(directory).unwrap();
     }
@@ -5736,6 +5870,134 @@ mod tests {
         let encoded =
             serde_json::to_value(response_for_version(Response::Snapshot { snapshot }, 8)).unwrap();
         assert!(encoded["snapshot"]["workspaces"][0].get("agents").is_none());
+    }
+
+    #[test]
+    fn protocol_eleven_responses_downgrade_inactive_agent_state() {
+        let agent = AgentInstanceSnapshot {
+            id: "a1".into(),
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            name: "pi".into(),
+            integration: "pi".into(),
+            external_session_id: Some("session-1".into()),
+            started_at_ms: 1,
+            ended_at_ms: None,
+            observation: AgentObservationSnapshot {
+                revision: 2,
+                state: AgentState::Inactive,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "Pi session inactive".into(),
+                confidence: 100,
+                observed_at_ms: 2,
+            },
+        };
+
+        let Response::Agent { agent: downgraded } = response_for_version(
+            Response::Agent {
+                agent: agent.clone(),
+            },
+            11,
+        ) else {
+            panic!("expected agent response");
+        };
+        assert_eq!(downgraded.observation.state, AgentState::Unknown);
+
+        let Response::Agent { agent: current } = response_for_version(
+            Response::Agent {
+                agent: agent.clone(),
+            },
+            12,
+        ) else {
+            panic!("expected agent response");
+        };
+        assert_eq!(current.observation.state, AgentState::Inactive);
+
+        let workspace = WorkspaceSnapshot {
+            id: "w1".into(),
+            name: "workspace".into(),
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: vec![agent.clone()],
+        };
+        let Response::Workspace {
+            workspace: downgraded_workspace,
+        } = response_for_version(
+            Response::Workspace {
+                workspace: workspace.clone(),
+            },
+            11,
+        )
+        else {
+            panic!("expected workspace response");
+        };
+        assert_eq!(
+            downgraded_workspace.agents[0].observation.state,
+            AgentState::Unknown
+        );
+
+        let Response::Events {
+            snapshot: Some(snapshot),
+            events,
+            ..
+        } = response_for_version(
+            Response::Events {
+                stream_id: "stream".into(),
+                cursor: EventCursor {
+                    stream_id: "stream".into(),
+                    event_id: 1,
+                },
+                snapshot: Some(Snapshot {
+                    workspaces: vec![workspace],
+                }),
+                events: vec![DaemonEvent {
+                    id: 1,
+                    at_ms: 1,
+                    kind: DaemonEventKind::AgentStateChanged {
+                        workspace_id: "w1".into(),
+                        shell_id: "s1".into(),
+                        agent,
+                    },
+                }],
+            },
+            11,
+        )
+        else {
+            panic!("expected events response");
+        };
+        assert_eq!(
+            snapshot.workspaces[0].agents[0].observation.state,
+            AgentState::Unknown
+        );
+        let DaemonEventKind::AgentStateChanged { agent, .. } = &events[0].kind else {
+            panic!("expected agent state event");
+        };
+        assert_eq!(agent.observation.state, AgentState::Unknown);
+    }
+
+    #[test]
+    fn inactive_agent_mutations_require_protocol_twelve() {
+        assert!(request_requires_protocol_twelve(&Request::EnsureAgent {
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            spec: agent_spec(AgentState::Inactive),
+        }));
+        assert!(request_requires_protocol_twelve(&Request::RegisterAgent {
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            spec: agent_spec(AgentState::Inactive),
+        }));
+        assert!(request_requires_protocol_twelve(&Request::ReportAgent {
+            agent_id: "a1".into(),
+            run_id: "r1".into(),
+            report: agent_spec(AgentState::Inactive).report,
+        }));
+        assert!(!request_requires_protocol_twelve(&Request::EnsureAgent {
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            spec: agent_spec(AgentState::Idle),
+        }));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod tui;
 
 const BOOMUX_SKILL: &str = include_str!("../.agents/skills/boomux/SKILL.md");
 const BOOMUX_OPENCODE_PLUGIN: &str = include_str!("../integrations/opencode/boomux.js");
+const BOOMUX_PI_EXTENSION: &str = include_str!("../integrations/pi/boomux.js");
 const JSON_COMMANDS: &[&str] = &[
     "capabilities",
     "list",
@@ -60,10 +61,13 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "run_scoped_agent_instances",
     "protocol_10",
     "protocol_11",
+    "protocol_12",
     "restartable_exited_shells",
+    "inactive_agent_state",
     "idempotent_agent_ensure",
     "agent_authority_precedence",
     "opencode_lifecycle_plugin",
+    "pi_lifecycle_extension",
     "process_adapters",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
@@ -208,6 +212,11 @@ enum Commands {
     Opencode {
         #[command(subcommand)]
         command: OpenCodeCommands,
+    },
+    /// Manage the Boomux Pi integration
+    Pi {
+        #[command(subcommand)]
+        command: PiCommands,
     },
     /// Open a shell in a new terminal window
     Open {
@@ -398,6 +407,7 @@ enum CliAgentState {
     Working,
     Blocked,
     Idle,
+    Inactive,
     Done,
 }
 
@@ -408,6 +418,7 @@ impl From<CliAgentState> for AgentState {
             CliAgentState::Working => Self::Working,
             CliAgentState::Blocked => Self::Blocked,
             CliAgentState::Idle => Self::Idle,
+            CliAgentState::Inactive => Self::Inactive,
             CliAgentState::Done => Self::Done,
         }
     }
@@ -442,6 +453,15 @@ enum SkillCommands {
 #[derive(Subcommand)]
 enum OpenCodeCommands {
     /// Install the Boomux plugin in the global OpenCode configuration
+    Install {
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum PiCommands {
+    /// Install the Boomux extension in the global Pi configuration
     Install {
         #[arg(long)]
         force: bool,
@@ -621,6 +641,9 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Opencode {
             command: OpenCodeCommands::Install { force },
         }) => install_opencode(force),
+        Some(Commands::Pi {
+            command: PiCommands::Install { force },
+        }) => install_pi(force),
         Some(Commands::Open {
             shell_id,
             title,
@@ -690,6 +713,7 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Close { .. }) => "close",
         Some(Commands::Skill { .. }) => "skill",
         Some(Commands::Opencode { .. }) => "opencode",
+        Some(Commands::Pi { .. }) => "pi",
         Some(Commands::Open { .. }) => "open",
         Some(Commands::Prompt) => "prompt",
         Some(Commands::Attach { .. }) => "attach",
@@ -950,7 +974,10 @@ fn dashboard_views(
                                         && agent.shell_id == shell.id
                                         && agent.run_id == run.id
                                         && agent.ended_at_ms.is_none()
-                                        && agent.observation.state != AgentState::Done
+                                        && !matches!(
+                                            agent.observation.state,
+                                            AgentState::Inactive | AgentState::Done
+                                        )
                                 })
                                 .max_by(|left, right| {
                                     left.observation
@@ -961,6 +988,19 @@ fn dashboard_views(
                         })
                     })
                     .flatten();
+                let suppress_foreground_hint = shell.run.as_ref().is_some_and(|run| {
+                    workspace.agents.iter().any(|agent| {
+                        agent.shell_id == shell.id
+                            && agent.run_id == run.id
+                            && shell.foreground_process.as_deref()
+                                == Some(agent.integration.as_str())
+                            && (agent.ended_at_ms.is_some()
+                                || matches!(
+                                    agent.observation.state,
+                                    AgentState::Inactive | AgentState::Done
+                                ))
+                    })
+                });
                 match (agent, shell.foreground_process.as_deref()) {
                     (Some(agent), _) => tui::WorkspaceItemView::AgentShell(tui::AgentShellView {
                         shell: shell_view,
@@ -974,7 +1014,7 @@ fn dashboard_views(
                             evidence: agent.observation.evidence.clone(),
                         }),
                     }),
-                    (None, Some("opencode")) => {
+                    (None, Some("opencode" | "pi")) if !suppress_foreground_hint => {
                         tui::WorkspaceItemView::AgentShell(tui::AgentShellView {
                             shell: shell_view,
                             agent: None,
@@ -2430,6 +2470,50 @@ fn install_opencode_at(config_root: &Path, force: bool) -> Result<(), Box<dyn Er
     Ok(())
 }
 
+fn install_pi(force: bool) -> Result<(), Box<dyn Error>> {
+    let config_root = pi_config_root(env::var_os("PI_CODING_AGENT_DIR"), env::var_os("HOME"))?;
+    install_pi_at(&config_root, force)
+}
+
+fn pi_config_root(
+    pi_coding_agent_dir: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let home = || -> Result<PathBuf, Box<dyn Error>> {
+        home.clone()
+            .map(PathBuf::from)
+            .ok_or_else(|| "HOME must be set to install the Boomux Pi extension".into())
+    };
+    let root = match pi_coding_agent_dir.filter(|value| !value.is_empty()) {
+        Some(root) => {
+            let root = PathBuf::from(root);
+            if let Ok(suffix) = root.strip_prefix("~") {
+                home()?.join(suffix)
+            } else {
+                root
+            }
+        }
+        None => home()?.join(".pi/agent"),
+    };
+    require_absolute_root(&root, "Pi configuration root")?;
+    Ok(root)
+}
+
+fn install_pi_at(config_root: &Path, force: bool) -> Result<(), Box<dyn Error>> {
+    require_absolute_root(config_root, "Pi configuration root")?;
+    let directory = ensure_safe_directory(&config_root.join("extensions"))?;
+    let path = pi_install_path(config_root);
+    if install_asset_at(&directory, &path, BOOMUX_PI_EXTENSION, force)? {
+        println!(
+            "Boomux Pi extension is already installed at {}",
+            path.display()
+        );
+    } else {
+        println!("Installed Boomux Pi extension at {}", path.display());
+    }
+    Ok(())
+}
+
 fn require_absolute_root(root: &Path, name: &str) -> Result<(), Box<dyn Error>> {
     if !root.is_absolute() {
         return Err(format!("{name} must be an absolute path").into());
@@ -2521,6 +2605,10 @@ fn skill_install_path(home: &Path) -> PathBuf {
 
 fn opencode_install_path(config_root: &Path) -> PathBuf {
     config_root.join("opencode/plugins/boomux.js")
+}
+
+fn pi_install_path(config_root: &Path) -> PathBuf {
+    config_root.join("extensions/boomux.js")
 }
 
 fn legacy_skill_install_path(home: &Path) -> PathBuf {
@@ -3236,6 +3324,40 @@ mod tests {
     }
 
     #[test]
+    fn workspace_view_hints_exact_pi_foreground_process_before_first_prompt() {
+        let mut hinted = shell("s1", "w1", "terminal");
+        hinted.foreground_process = Some("pi".into());
+        let workspace = workspace("w1", "project", vec![hinted]);
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        let tui::WorkspaceItemView::AgentShell(item) = &views[0].items[0] else {
+            panic!("expected hinted agent-shell item");
+        };
+        assert_eq!(item.shell.name, "terminal");
+        assert!(item.agent.is_none());
+    }
+
+    #[test]
+    fn workspace_view_does_not_hint_an_inactive_pi_session() {
+        let mut hinted = shell("s1", "w1", "terminal");
+        hinted.foreground_process = Some("pi".into());
+        let mut workspace = workspace("w1", "project", vec![hinted]);
+        let mut inactive = agent("inactive", "w1", "s1");
+        inactive.name = "Pi".into();
+        inactive.integration = "pi".into();
+        inactive.observation.state = AgentState::Inactive;
+        workspace.agents.push(inactive);
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert!(matches!(
+            views[0].items[0],
+            tui::WorkspaceItemView::Shell(_)
+        ));
+    }
+
+    #[test]
     fn workspace_view_does_not_treat_arbitrary_foreground_process_as_agent() {
         let mut ordinary = shell("s1", "w1", "terminal");
         ordinary.foreground_process = Some("OpenCode".into());
@@ -3346,13 +3468,23 @@ mod tests {
         ended.ended_at_ms = Some(12);
         let mut done = agent("done", "w1", "s1");
         done.observation.state = AgentState::Done;
+        let mut inactive = agent("inactive", "w1", "s1");
+        inactive.observation.state = AgentState::Inactive;
         let mut stale = agent("stale", "w1", "s1");
         stale.run_id = "old-run".into();
         let wrong_pair = agent("wrong-pair", "w1", "s2");
         let orphan = agent("orphan", "w1", "missing");
         let mut wrong_workspace = agent("wrong-workspace", "w2", "s1");
         wrong_workspace.run_id = "r1".into();
-        workspace.agents = vec![ended, done, stale, wrong_pair, orphan, wrong_workspace];
+        workspace.agents = vec![
+            ended,
+            done,
+            inactive,
+            stale,
+            wrong_pair,
+            orphan,
+            wrong_workspace,
+        ];
 
         let views = dashboard_views(&[workspace], &mut git::Cache::default());
 
@@ -3537,19 +3669,90 @@ mod tests {
     }
 
     #[test]
+    fn parses_pi_install_and_uses_global_extension_path() {
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "pi", "install", "--force"])
+                .unwrap()
+                .command,
+            Some(Commands::Pi {
+                command: PiCommands::Install { force: true }
+            })
+        ));
+        assert_eq!(
+            pi_install_path(Path::new("/pi-agent")),
+            PathBuf::from("/pi-agent/extensions/boomux.js")
+        );
+        assert_eq!(
+            pi_config_root(Some("/custom/pi".into()), Some("/home/example".into())).unwrap(),
+            PathBuf::from("/custom/pi")
+        );
+        assert_eq!(
+            pi_config_root(None, Some("/home/example".into())).unwrap(),
+            PathBuf::from("/home/example/.pi/agent")
+        );
+        assert_eq!(
+            pi_config_root(Some("".into()), Some("/home/example".into())).unwrap(),
+            PathBuf::from("/home/example/.pi/agent")
+        );
+        assert_eq!(
+            pi_config_root(Some("~/.config/pi".into()), Some("/home/example".into())).unwrap(),
+            PathBuf::from("/home/example/.config/pi")
+        );
+        assert!(pi_config_root(Some("relative".into()), None).is_err());
+        assert!(install_pi_at(Path::new("relative"), false).is_err());
+    }
+
+    #[test]
+    fn pi_install_is_idempotent_and_requires_force_for_changes() {
+        let config = test_skill_home("pi-content");
+        let extension = pi_install_path(&config);
+
+        install_pi_at(&config, false).unwrap();
+        assert_eq!(fs::read_to_string(&extension).unwrap(), BOOMUX_PI_EXTENSION);
+        install_pi_at(&config, false).unwrap();
+        fs::write(&extension, "custom extension").unwrap();
+        assert!(install_pi_at(&config, false).is_err());
+        assert_eq!(fs::read_to_string(&extension).unwrap(), "custom extension");
+        install_pi_at(&config, true).unwrap();
+        assert_eq!(fs::read_to_string(&extension).unwrap(), BOOMUX_PI_EXTENSION);
+
+        fs::remove_dir_all(config).unwrap();
+    }
+
+    #[test]
+    fn pi_install_rejects_symlinked_extension_directory() {
+        use std::os::unix::fs::symlink;
+
+        let config = test_skill_home("pi-symlink-directory");
+        let outside = test_skill_home("pi-symlink-directory-target");
+        fs::create_dir_all(&config).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, config.join("extensions")).unwrap();
+
+        assert!(install_pi_at(&config, true).is_err());
+        assert!(fs::read_dir(&outside).unwrap().next().is_none());
+
+        fs::remove_dir_all(config).unwrap();
+        fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[test]
     fn capabilities_advertise_phase_two_agent_integration_surface() {
         for command in ["agent.register", "agent.ensure", "agent.report"] {
             assert!(JSON_COMMANDS.contains(&command));
         }
         for feature in [
             "protocol_10",
+            "protocol_12",
+            "inactive_agent_state",
             "idempotent_agent_ensure",
             "agent_authority_precedence",
             "opencode_lifecycle_plugin",
+            "pi_lifecycle_extension",
         ] {
             assert!(INTEGRATION_FEATURES.contains(&feature));
         }
-        assert_eq!(protocol::PROTOCOL_VERSION, 11);
+        assert_eq!(protocol::PROTOCOL_VERSION, 12);
     }
 
     #[test]
@@ -3615,6 +3818,34 @@ mod tests {
     }
 
     #[test]
+    fn bundled_pi_extension_has_lifecycle_contract_without_shell_interpolation() {
+        for expected in [
+            "session_start",
+            "agent_start",
+            "agent_settled",
+            "session_shutdown",
+            "getSessionId",
+            "BOOMUX_SHELL_ID",
+            "BOOMUX_RUN_ID",
+            "agent\",\n    \"ensure",
+            "agent\",\n    \"report",
+            "--json",
+            "shell: false",
+        ] {
+            assert!(
+                BOOMUX_PI_EXTENSION.contains(expected),
+                "Pi extension omits {expected}"
+            );
+        }
+        for forbidden in ["exec(", "sh -c", "${BOOMUX_"] {
+            assert!(
+                !BOOMUX_PI_EXTENSION.contains(forbidden),
+                "Pi extension contains shell interpolation marker {forbidden}"
+            );
+        }
+    }
+
+    #[test]
     fn bundled_skill_covers_every_public_command_group() {
         for command in [
             "boomux ui",
@@ -3634,6 +3865,8 @@ mod tests {
             "boomux shell rename",
             "boomux shell close",
             "boomux skill install",
+            "boomux opencode install",
+            "boomux pi install",
             "boomux daemon status",
             "boomux daemon restart",
             "boomux daemon stop",

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 11;
+pub const PROTOCOL_VERSION: u32 = 12;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -51,6 +51,7 @@ pub enum AgentState {
     Working,
     Blocked,
     Idle,
+    Inactive,
     Done,
 }
 
@@ -741,8 +742,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_eleven_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 11);
+    fn protocol_version_is_twelve_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 12);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1976,7 +1976,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 11);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 12);
     let json_commands = capabilities["data"]["json_commands"].as_array().unwrap();
     for command in ["events", "agent.register", "agent.ensure", "agent.report"] {
         assert!(json_commands.iter().any(|current| current == command));
@@ -1985,6 +1985,8 @@ fn native_daemon_lifecycle() {
     for feature in [
         "revision_aware_reads",
         "protocol_10",
+        "protocol_12",
+        "inactive_agent_state",
         "protocol_11",
         "restartable_exited_shells",
         "idempotent_agent_ensure",
@@ -2001,7 +2003,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 11"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 12"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- add a bundled Pi lifecycle extension and safe `boomux pi install` workflow
- add protocol 12 resumable `inactive` agent state with backward-compatible response downgrades
- integrate Pi foreground and lifecycle state into dashboard presentation
- make daemon replacement robust after the installed executable is replaced

## Validation
- `cargo test --all-targets --all-features` (201 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `bun test integrations/opencode integrations/pi` (24 passed)
- `git diff --check`
- live Pi inactive/reactivation identity test
- live protocol-12 daemon replacement after binary reinstall