### PR TITLE
Improve Pi lifecycle compatibility

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -295,6 +295,9 @@ replace different existing content. The installer removes an untouched legacy
 
 ## Install The OpenCode Integration
 
+The bundled plugin is validated against `opencode-ai` `1.18.14`; this is a
+compatibility test point rather than a runtime pin.
+
 ```console
 boomux opencode install
 boomux opencode install --force
@@ -317,6 +320,10 @@ completion. Unmanaged or unavailable Boomux is fail-open. If Boomux returns
 
 ## Install The Pi Integration
 
+The bundled extension is validated against
+`@earendil-works/pi-coding-agent` `0.83.0`; this is a compatibility test point
+rather than a runtime pin.
+
 ```console
 boomux pi install
 boomux pi install --force
@@ -328,10 +335,11 @@ different content requires `--force`, and symlinks or non-regular targets are
 rejected. Restart Pi after installing or replacing the extension.
 
 The extension activates only in a managed shell run and keys the Agent instance
-by Pi's canonical project session ID. Session start and settled events report
-`idle`; agent start reports `working`; session shutdown reports `inactive`
-because Pi sessions are resumable. Inactive records remain durable but do not
-occupy dashboard agent rows. Reporting is serialized and fail-open.
+by Pi's canonical project session ID. Session start reports `idle`; agent start
+reports `working`; final assistant errors report `blocked` after the agent fully
+settles; and session shutdown reports `inactive` because Pi sessions are
+resumable. Inactive records remain durable but do not occupy dashboard agent
+rows. Reporting is serialized and fail-open.
 
 ## Environment And Integration
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,20 @@ the full public CLI. Re-run with `--force` to replace an older customized
 installation. An untouched legacy `boomux-shells` skill is removed
 automatically; customized legacy content is preserved with a warning.
 
+## Integration Compatibility
+
+Boomux currently validates its bundled integrations against these host releases:
+
+| Integration | Package | Validated version |
+| --- | --- | --- |
+| OpenCode | `opencode-ai` | `1.18.14` |
+| Pi | `@earendil-works/pi-coding-agent` | `0.83.0` |
+
+These versions are compatibility test points, not runtime pins. Older or newer
+releases may work when their plugin APIs remain compatible, but are not claimed
+as supported until validated. `boomux capabilities --json` exposes the same
+matrix under `integration_hosts`.
+
 ## OpenCode Integration
 
 Install the bundled config-time OpenCode lifecycle plugin with:
@@ -365,12 +379,15 @@ are rejected. Restart Pi after installing or replacing the extension.
 
 Inside a Boomux-managed shell, the extension uses Pi's canonical project session
 ID and lifecycle hooks. Session start reports `idle`, agent start reports
-`working`, and `agent_settled` reports `idle` only after retries, compaction, and
-queued continuations have finished. Session shutdown reports `inactive` rather
-than permanent completion because Pi sessions are resumable. Inactive instances
+`working`, and `agent_end` records a final assistant error when present.
+`agent_settled` reports that terminal error as `blocked`, or `idle` only after
+retries, compaction, and queued continuations have finished. A new agent run
+clears the latched error. Session shutdown reports `inactive` rather than
+permanent completion because Pi sessions are resumable. Inactive instances
 remain durable but do not occupy agent rows until the session starts again.
 Calls use exact argument vectors, bounded JSON output, and fail open when Boomux
-is unavailable.
+is unavailable. Session shutdown retries its `inactive` report once after a
+transient failure.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -261,6 +261,9 @@ the stronger lifecycle evidence described below.
 
 ### OpenCode Lifecycle Plugin
 
+The bundled plugin is validated against `opencode-ai` `1.18.14`. This is a
+compatibility test point rather than a runtime version pin.
+
 `integrations/opencode/boomux.js` is a config-time OpenCode plugin installed by
 `boomux opencode install [--force]`. The installer targets
 `$XDG_CONFIG_HOME/opencode/plugins/boomux.js`, falling back to
@@ -289,6 +292,10 @@ Boomux or ancestry failures are rate-limited and fail open so OpenCode continues
 
 ### Pi Lifecycle Extension
 
+The bundled extension is validated against
+`@earendil-works/pi-coding-agent` `0.83.0`. This is a compatibility test point
+rather than a runtime version pin.
+
 `integrations/pi/boomux.js` is a global Pi extension installed by
 `boomux pi install [--force]`. The installer targets
 `$PI_CODING_AGENT_DIR/extensions/boomux.js`, falling back to
@@ -297,14 +304,18 @@ replacement, and `--force` rules as other bundled integrations.
 
 The extension activates only when `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID` are
 present and uses `sessionManager.getSessionId()` as canonical external identity.
-`session_start` reports `idle`, `agent_start` reports `working`, and
-`agent_settled` reports `idle` after automatic retries, compaction, and queued
-continuations have drained. `session_shutdown` reports `inactive` rather than
-`done` because Pi sessions can be resumed. Inactive records remain durable but
-do not decorate dashboard shells. Session switches reset the local agent ID and
-ensure the new canonical session identity. Reports are serialized, use exact
-argument vectors and bounded JSON output, and fail open with rate-limited
-diagnostics.
+`session_start` reports `idle` and `agent_start` reports `working`. `agent_end`
+records an error only when the final assistant message has `stopReason: "error"`;
+recoverable tool errors and earlier failed attempts do not become blockers.
+After automatic retries, compaction, and queued continuations have drained,
+`agent_settled` reports the final error as `blocked` or reports `idle`. A later
+agent start clears the latched error. `session_shutdown` reports `inactive`
+rather than `done` because Pi sessions can be resumed. Inactive records remain
+durable but do not decorate dashboard shells. Session switches reset the local
+agent ID and ensure the new canonical session identity. Reports are serialized,
+use exact argument vectors and bounded JSON output, and fail open with
+rate-limited diagnostics. Session shutdown makes one bounded retry so a
+transient reporting failure is less likely to leave the old session active.
 
 Protocol 12 adds `inactive`. Protocol-9 through protocol-11 clients receive that
 observation as `unknown`, while protocol-12 clients can distinguish a resumable

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -20,7 +20,9 @@ Future incompatible output will use a different schema value.
 
 `boomux capabilities --json` does not start or contact the daemon. It reports
 the CLI version, daemon protocol version, supported JSON schemas and commands,
-stable error codes, and feature names.
+stable error codes, feature names, and the package and validated version for
+each bundled integration host under `integration_hosts`. Validated versions are
+compatibility test points, not runtime pins or minimum-version guarantees.
 
 The following commands support `--json`:
 
@@ -48,8 +50,8 @@ output. Passing `--json` to an unsupported command fails with
 
 Command payloads are:
 
-- `capabilities`: CLI/protocol versions plus arrays of schemas, commands,
-  features, and error codes.
+- `capabilities`: CLI/protocol versions, integration host compatibility, plus
+  arrays of schemas, commands, features, and error codes.
 - `list`: a `shells` array.
 - `shells`: workspace identity plus a `shells` array.
 - `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`,

--- a/integrations/pi/boomux.js
+++ b/integrations/pi/boomux.js
@@ -18,6 +18,40 @@ function boundedEvidence(value) {
   return (clean || "Pi lifecycle event").slice(0, MAX_EVIDENCE);
 }
 
+function agentErrorEvidence(messages) {
+  if (!Array.isArray(messages)) return undefined;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "assistant") continue;
+    if (message.stopReason !== "error") return undefined;
+    return boundedEvidence(
+      `Pi error: ${text(message.errorMessage) ?? "assistant request failed"}`,
+    );
+  }
+  return undefined;
+}
+
+function createOutcomeTracker() {
+  const errors = new Map();
+  return {
+    clear(sessionID) {
+      if (text(sessionID)) errors.delete(sessionID);
+    },
+    record(sessionID, messages) {
+      if (!text(sessionID)) return;
+      const evidence = agentErrorEvidence(messages);
+      if (evidence) errors.set(sessionID, evidence);
+      else errors.delete(sessionID);
+    },
+    settled(sessionID) {
+      const evidence = errors.get(sessionID);
+      return evidence
+        ? { state: "blocked", evidence }
+        : { state: "idle", evidence: "Pi agent settled" };
+    },
+  };
+}
+
 function parseJSON(value) {
   if (typeof value !== "string" || value.trim() === "") {
     throw new Error("boomux returned empty JSON output");
@@ -234,9 +268,25 @@ function createLifecycle({ env, run, log = console.error, now }) {
     }
   }
 
-  function enqueue(nextSessionID, state, evidence) {
+  async function sendWithAttempts(nextSessionID, state, evidence, attempts) {
+    let lastError;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      try {
+        await send(nextSessionID, state, evidence);
+        return;
+      } catch (error) {
+        lastError = error;
+        if (disabled || error?.code === "run_changed") break;
+      }
+    }
+    throw lastError;
+  }
+
+  function enqueue(nextSessionID, state, evidence, attempts = 1) {
     if (!text(nextSessionID)) return Promise.resolve();
-    const pending = queue.then(() => send(nextSessionID, state, evidence));
+    const pending = queue.then(() =>
+      sendWithAttempts(nextSessionID, state, evidence, attempts),
+    );
     queue = pending.catch(reportError);
     return queue;
   }
@@ -254,27 +304,42 @@ export default function BoomuxPiExtension(pi) {
     run: createProcessRunner(),
   });
   if (!lifecycle) return;
+  const outcomes = createOutcomeTracker();
 
   const report = (ctx, state, evidence) =>
     lifecycle.enqueue(currentSessionID(ctx), state, evidence);
 
-  pi.on("session_start", (_event, ctx) =>
-    report(ctx, "idle", "Pi session idle"),
-  );
-  pi.on("agent_start", (_event, ctx) =>
-    report(ctx, "working", "Pi agent working"),
-  );
-  pi.on("agent_settled", (_event, ctx) =>
-    report(ctx, "idle", "Pi agent settled"),
-  );
-  pi.on("session_shutdown", (_event, ctx) =>
-    report(ctx, "inactive", "Pi session inactive"),
-  );
+  pi.on("session_start", (_event, ctx) => {
+    outcomes.clear(currentSessionID(ctx));
+    return report(ctx, "idle", "Pi session idle");
+  });
+  pi.on("agent_start", (_event, ctx) => {
+    outcomes.clear(currentSessionID(ctx));
+    return report(ctx, "working", "Pi agent working");
+  });
+  pi.on("agent_end", (event, ctx) => {
+    outcomes.record(currentSessionID(ctx), event?.messages);
+  });
+  pi.on("agent_settled", (_event, ctx) => {
+    const outcome = outcomes.settled(currentSessionID(ctx));
+    return report(ctx, outcome.state, outcome.evidence);
+  });
+  pi.on("session_shutdown", (_event, ctx) => {
+    outcomes.clear(currentSessionID(ctx));
+    return lifecycle.enqueue(
+      currentSessionID(ctx),
+      "inactive",
+      "Pi session inactive",
+      2,
+    );
+  });
 }
 
 export const __internal = Object.freeze({
+  agentErrorEvidence,
   boundedEvidence,
   createLifecycle,
+  createOutcomeTracker,
   createProcessRunner,
   ensureArgv,
   reportArgv,

--- a/integrations/pi/boomux.test.js
+++ b/integrations/pi/boomux.test.js
@@ -52,9 +52,40 @@ describe("Pi lifecycle", () => {
     expect([...handlers.keys()]).toEqual([
       "session_start",
       "agent_start",
+      "agent_end",
       "agent_settled",
       "session_shutdown",
     ]);
+  });
+
+  test("reports only final assistant errors as blocked", () => {
+    const outcomes = __internal.createOutcomeTracker();
+    outcomes.record("session-1", [
+      { role: "toolResult", isError: true },
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "provider unavailable",
+      },
+    ]);
+    expect(outcomes.settled("session-1")).toEqual({
+      state: "blocked",
+      evidence: "Pi error: provider unavailable",
+    });
+
+    outcomes.clear("session-1");
+    outcomes.record("session-1", [
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "recovered",
+      },
+      { role: "assistant", stopReason: "stop" },
+    ]);
+    expect(outcomes.settled("session-1")).toEqual({
+      state: "idle",
+      evidence: "Pi agent settled",
+    });
   });
 
   test("reports idle working settled and inactive states", async () => {
@@ -111,6 +142,37 @@ describe("Pi lifecycle", () => {
 
     expect(calls).toHaveLength(2);
     expect(calls.map((argv) => argv[7])).toEqual(["session-1", "session-2"]);
+  });
+
+  test("retries an inactive report without creating another identity", async () => {
+    const calls = [];
+    let inactiveAttempts = 0;
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        if (argv[2] === "ensure") {
+          return agent("agent-1", "idle", "Pi session idle");
+        }
+        if (argv[argv.indexOf("--state") + 1] === "inactive") {
+          inactiveAttempts += 1;
+          if (inactiveAttempts === 1) throw new Error("temporary failure");
+        }
+        return { data: { ok: true } };
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue("session-1", "idle", "Pi session idle");
+    await lifecycle.enqueue(
+      "session-1",
+      "inactive",
+      "Pi session inactive",
+      2,
+    );
+
+    expect(inactiveAttempts).toBe(2);
+    expect(calls.filter((argv) => argv[2] === "ensure")).toHaveLength(1);
   });
 
   test("bounds lifecycle evidence", () => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ mod tui;
 const BOOMUX_SKILL: &str = include_str!("../.agents/skills/boomux/SKILL.md");
 const BOOMUX_OPENCODE_PLUGIN: &str = include_str!("../integrations/opencode/boomux.js");
 const BOOMUX_PI_EXTENSION: &str = include_str!("../integrations/pi/boomux.js");
+const VALIDATED_OPENCODE_VERSION: &str = "1.18.14";
+const VALIDATED_PI_VERSION: &str = "0.83.0";
 const JSON_COMMANDS: &[&str] = &[
     "capabilities",
     "list",
@@ -1228,6 +1230,16 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
                 "json_schemas": [cli_output::SCHEMA],
                 "json_commands": JSON_COMMANDS,
                 "features": INTEGRATION_FEATURES,
+                "integration_hosts": {
+                    "opencode": {
+                        "package": "opencode-ai",
+                        "validated_version": VALIDATED_OPENCODE_VERSION,
+                    },
+                    "pi": {
+                        "package": "@earendil-works/pi-coding-agent",
+                        "validated_version": VALIDATED_PI_VERSION,
+                    },
+                },
                 "error_codes": error_codes,
             }),
         );
@@ -1237,6 +1249,7 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
     println!("JSON SCHEMAS\t{}", cli_output::SCHEMA);
     println!("JSON COMMANDS\t{}", JSON_COMMANDS.join(","));
     println!("FEATURES\t{}", INTEGRATION_FEATURES.join(","));
+    println!("INTEGRATION HOSTS\topencode={VALIDATED_OPENCODE_VERSION},pi={VALIDATED_PI_VERSION}");
     println!("ERROR CODES\t{}", error_codes.join(","));
     Ok(())
 }
@@ -3752,6 +3765,8 @@ mod tests {
         ] {
             assert!(INTEGRATION_FEATURES.contains(&feature));
         }
+        assert_eq!(VALIDATED_OPENCODE_VERSION, "1.18.14");
+        assert_eq!(VALIDATED_PI_VERSION, "0.83.0");
         assert_eq!(protocol::PROTOCOL_VERSION, 12);
     }
 
@@ -3822,8 +3837,10 @@ mod tests {
         for expected in [
             "session_start",
             "agent_start",
+            "agent_end",
             "agent_settled",
             "session_shutdown",
+            "stopReason",
             "getSessionId",
             "BOOMUX_SHELL_ID",
             "BOOMUX_RUN_ID",

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1977,6 +1977,22 @@ fn native_daemon_lifecycle() {
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
     assert_eq!(capabilities["data"]["daemon_protocol_version"], 12);
+    assert_eq!(
+        capabilities["data"]["integration_hosts"]["opencode"]["validated_version"],
+        "1.18.14"
+    );
+    assert_eq!(
+        capabilities["data"]["integration_hosts"]["opencode"]["package"],
+        "opencode-ai"
+    );
+    assert_eq!(
+        capabilities["data"]["integration_hosts"]["pi"]["validated_version"],
+        "0.83.0"
+    );
+    assert_eq!(
+        capabilities["data"]["integration_hosts"]["pi"]["package"],
+        "@earendil-works/pi-coding-agent"
+    );
     let json_commands = capabilities["data"]["json_commands"].as_array().unwrap();
     for command in ["events", "agent.register", "agent.ensure", "agent.report"] {
         assert!(json_commands.iter().any(|current| current == command));


### PR DESCRIPTION
## Summary
- report final Pi assistant errors as blocked after retries and continuations settle
- clear stale Pi errors on later work and retry inactive shutdown reporting once
- publish validated OpenCode 1.18.14 and Pi 0.83.0 host compatibility through docs and capabilities JSON

## Validation
- `cargo test --all-targets --all-features` (201 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `bun test integrations/opencode integrations/pi` (26 passed)
- `cargo fmt --all -- --check`
- `git diff --check`