### PR TITLE
Add contextual agent session browser

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,6 +84,9 @@ eternal process.
    revision-aware output reads.
 5. [Complete] Route runtime transitions through one coordinator so persistence
    and events share an ordering boundary.
+6. [Complete] Make installed-binary upgrades restart-safe by falling back to the
+   daemon's absolute invocation path when its replaced `/proc/.../exe` target is
+   marked deleted.
 
 ### Agent Runtime
 
@@ -108,9 +111,20 @@ eternal process.
    transitions without polling human output.
 4. Add deduplicated notifications for blocked and completed transitions after
    the attention and wait semantics are established.
-5. Make installed-binary upgrades restart-safe. Replacing a running executable
-   currently leaves the old daemon's `/proc/.../exe` path marked deleted, so a
-   graceful handoff needs a temporary alias.
+5. Add explicit cross-harness session inspection so Pi can read an OpenCode
+   session and OpenCode can read a Pi session. Do not treat bounded rendered
+   terminal output as the full session: host adapters must expose canonical
+   session identity, bounded and redacted messages and tool activity, versioned
+   capabilities, and an explicit access policy.
+6. Add contextual, categorized Agent Session browsing to selected agent rows in
+   the Boomux UI. Keep inactive and completed workspace sessions visible without
+   adding duplicate shell rows, grouped by active and recent time windows with
+   integration, canonical identity, associated shell and run, lifecycle state,
+   and timestamps. Bounded asynchronous host catalog adapters provide OpenCode
+   generated titles and Pi names or first-user-message summaries; future adapters
+   may provide transcripts and tool activity. Expose the resulting session inspection
+   surface through versioned CLI/API commands so authorized agents can discover
+   and read other sessions.
 
 ### Deferred Agent Work
 

--- a/src/host_session_titles.rs
+++ b/src/host_session_titles.rs
@@ -1,0 +1,850 @@
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::Read;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Component, Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime};
+
+const SUCCESS_TTL: Duration = Duration::from_secs(30);
+const FAILURE_TTL: Duration = Duration::from_secs(5);
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(15);
+const MAX_OPENCODE_STDOUT_BYTES: u64 = 1024 * 1024;
+const MAX_PI_FILE_BYTES: u64 = 256 * 1024;
+const MAX_PI_CATALOG_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_SESSIONS: usize = 100;
+const MAX_TITLE_CHARS: usize = 160;
+
+type Titles = HashMap<String, String>;
+type Inspector = dyn Fn(&str, &Path) -> Option<Titles> + Send + Sync;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct CacheKey {
+    integration: String,
+    directory: PathBuf,
+}
+
+struct CachedTitles {
+    value: Option<Titles>,
+    inspected_at: Instant,
+}
+
+pub(crate) struct Cache {
+    entries: HashMap<CacheKey, CachedTitles>,
+    pending: HashSet<CacheKey>,
+    requests: Sender<CacheKey>,
+    results: Receiver<(CacheKey, Option<Titles>)>,
+}
+
+impl Default for Cache {
+    fn default() -> Self {
+        Self::with_inspector(Arc::new(inspect))
+    }
+}
+
+impl Cache {
+    fn with_inspector(inspector: Arc<Inspector>) -> Self {
+        let (request_sender, request_receiver) = mpsc::channel::<CacheKey>();
+        let (result_sender, result_receiver) = mpsc::channel();
+        thread::spawn(move || {
+            while let Ok(key) = request_receiver.recv() {
+                let titles = inspector(&key.integration, &key.directory);
+                if result_sender.send((key, titles)).is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            entries: HashMap::new(),
+            pending: HashSet::new(),
+            requests: request_sender,
+            results: result_receiver,
+        }
+    }
+
+    pub(crate) fn title(
+        &mut self,
+        integration: &str,
+        directory: &Path,
+        external_session_id: &str,
+    ) -> Option<String> {
+        for (key, value) in self.results.try_iter() {
+            self.pending.remove(&key);
+            self.entries.insert(
+                key,
+                CachedTitles {
+                    value,
+                    inspected_at: Instant::now(),
+                },
+            );
+        }
+
+        if !is_supported(integration) {
+            return None;
+        }
+
+        let key = CacheKey {
+            integration: integration.to_owned(),
+            directory: directory.to_owned(),
+        };
+        let fresh = self.entries.get(&key).is_some_and(|cached| {
+            cached.inspected_at.elapsed()
+                < if cached.value.is_some() {
+                    SUCCESS_TTL
+                } else {
+                    FAILURE_TTL
+                }
+        });
+        if !fresh && !self.pending.contains(&key) && self.requests.send(key.clone()).is_ok() {
+            self.pending.insert(key.clone());
+        }
+
+        self.entries
+            .get(&key)
+            .and_then(|cached| cached.value.as_ref())
+            .and_then(|titles| titles.get(external_session_id))
+            .cloned()
+    }
+}
+
+fn is_supported(integration: &str) -> bool {
+    matches!(integration, "opencode" | "pi")
+}
+
+fn inspect(integration: &str, directory: &Path) -> Option<Titles> {
+    match integration {
+        "opencode" => inspect_opencode(directory),
+        "pi" => inspect_pi(directory, &PiEnvironment::from_process()),
+        _ => None,
+    }
+}
+
+fn inspect_opencode(directory: &Path) -> Option<Titles> {
+    let stdout = run_opencode(directory)?;
+    parse_opencode_titles(&stdout)
+}
+
+fn run_opencode(directory: &Path) -> Option<Vec<u8>> {
+    let mut child = Command::new("opencode")
+        .args(["session", "list", "--format", "json", "-n", "100"])
+        .current_dir(directory)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let mut stdout = child.stdout.take()?;
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let result = stdout
+            .by_ref()
+            .take(MAX_OPENCODE_STDOUT_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map(|_| bytes);
+        let _ = sender.send(result);
+    });
+
+    let deadline = Instant::now() + COMMAND_TIMEOUT;
+    let mut output = None;
+    let mut status = None;
+    loop {
+        if output.is_none() {
+            match receiver.try_recv() {
+                Ok(Ok(bytes)) => output = Some(bytes),
+                Ok(Err(_)) | Err(TryRecvError::Disconnected) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                Err(TryRecvError::Empty) => {}
+            }
+        }
+        if output
+            .as_ref()
+            .is_some_and(|bytes| bytes.len() as u64 > MAX_OPENCODE_STDOUT_BYTES)
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        if status.is_none() {
+            status = child.try_wait().ok()?;
+        }
+        if let (Some(status), Some(bytes)) = (status.as_ref(), output.as_ref()) {
+            return status.success().then(|| bytes.clone());
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct OpenCodeSession {
+    id: String,
+    title: String,
+    #[serde(rename = "updated")]
+    _updated: serde_json::Value,
+    #[serde(rename = "created")]
+    _created: serde_json::Value,
+    #[serde(rename = "directory")]
+    _directory: String,
+}
+
+fn parse_opencode_titles(output: &[u8]) -> Option<Titles> {
+    if output.len() as u64 > MAX_OPENCODE_STDOUT_BYTES {
+        return None;
+    }
+    let sessions: Vec<OpenCodeSession> = serde_json::from_slice(output).ok()?;
+    let mut titles = HashMap::new();
+    for session in sessions.into_iter().take(MAX_SESSIONS) {
+        if session.id.is_empty() {
+            continue;
+        }
+        if let Some(title) = sanitize_title(&session.title) {
+            titles.insert(session.id, title);
+        }
+    }
+    Some(titles)
+}
+
+#[derive(Clone, Debug, Default)]
+struct PiEnvironment {
+    coding_agent_dir: Option<OsString>,
+    session_dir: Option<OsString>,
+    home: Option<OsString>,
+}
+
+impl PiEnvironment {
+    fn from_process() -> Self {
+        Self {
+            coding_agent_dir: std::env::var_os("PI_CODING_AGENT_DIR"),
+            session_dir: std::env::var_os("PI_CODING_AGENT_SESSION_DIR"),
+            home: std::env::var_os("HOME"),
+        }
+    }
+}
+
+fn inspect_pi(directory: &Path, environment: &PiEnvironment) -> Option<Titles> {
+    let normalized_directory = normalize_absolute(directory)?;
+    let catalog_directory = pi_session_directory(&normalized_directory, environment)?;
+    let files = pi_catalog_files(&catalog_directory)?;
+    let mut remaining_bytes = MAX_PI_CATALOG_BYTES;
+    let mut titles = HashMap::new();
+
+    for path in files {
+        if remaining_bytes == 0 {
+            break;
+        }
+        let limit = MAX_PI_FILE_BYTES.min(remaining_bytes);
+        let Some(prefix) = read_regular_file_prefix(&path, limit) else {
+            continue;
+        };
+        remaining_bytes = remaining_bytes.saturating_sub(prefix.scanned_bytes);
+        if let Some((id, title)) = parse_pi_session(&prefix.bytes, &normalized_directory) {
+            titles.entry(id).or_insert(title);
+        }
+    }
+    Some(titles)
+}
+
+fn pi_session_directory(directory: &Path, environment: &PiEnvironment) -> Option<PathBuf> {
+    if let Some(session_directory) = nonempty(environment.session_dir.as_ref()) {
+        return expand_home(session_directory, environment.home.as_ref());
+    }
+    let root = match nonempty(environment.coding_agent_dir.as_ref()) {
+        Some(root) => expand_home(root, environment.home.as_ref())?,
+        None => PathBuf::from(nonempty(environment.home.as_ref())?).join(".pi/agent"),
+    };
+    root.is_absolute().then(|| {
+        root.join("sessions")
+            .join(pi_encoded_session_directory(directory))
+    })
+}
+
+fn nonempty(value: Option<&OsString>) -> Option<&OsString> {
+    value.filter(|value| !value.is_empty())
+}
+
+fn expand_home(value: &OsString, home: Option<&OsString>) -> Option<PathBuf> {
+    let path = PathBuf::from(value);
+    let expanded = if path == Path::new("~") {
+        PathBuf::from(nonempty(home)?)
+    } else if let Ok(suffix) = path.strip_prefix("~/") {
+        PathBuf::from(nonempty(home)?).join(suffix)
+    } else {
+        path
+    };
+    expanded.is_absolute().then_some(expanded)
+}
+
+fn pi_encoded_session_directory(directory: &Path) -> String {
+    let directory = directory.to_string_lossy();
+    let encoded: String = directory
+        .trim_start_matches('/')
+        .chars()
+        .map(|character| match character {
+            '/' | '\\' | ':' => '-',
+            other => other,
+        })
+        .collect();
+    format!("--{encoded}--")
+}
+
+fn normalize_absolute(path: &Path) -> Option<PathBuf> {
+    if !path.is_absolute() {
+        return None;
+    }
+    let mut normalized = PathBuf::from("/");
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::Normal(component) => normalized.push(component),
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Prefix(_) => return None,
+        }
+    }
+    Some(normalized)
+}
+
+fn pi_catalog_files(directory: &Path) -> Option<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for entry in fs::read_dir(directory).ok()?.flatten() {
+        let path = entry.path();
+        if path
+            .extension()
+            .is_none_or(|extension| extension != "jsonl")
+        {
+            continue;
+        }
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if !metadata.file_type().is_file() {
+            continue;
+        }
+        files.push((path, metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH)));
+    }
+    files.sort_by(|(left_path, left_time), (right_path, right_time)| {
+        right_time
+            .cmp(left_time)
+            .then_with(|| left_path.cmp(right_path))
+    });
+    files.truncate(MAX_SESSIONS);
+    Some(files.into_iter().map(|(path, _)| path).collect())
+}
+
+struct FilePrefix {
+    bytes: Vec<u8>,
+    scanned_bytes: u64,
+}
+
+// Prefix-only inspection keeps I/O bounded; session_info names beyond this prefix are unavailable.
+fn read_regular_file_prefix(path: &Path, limit: u64) -> Option<FilePrefix> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .ok()?;
+    let metadata = file.metadata().ok()?;
+    if !metadata.file_type().is_file() {
+        return None;
+    }
+    let mut bytes = Vec::new();
+    file.by_ref().take(limit).read_to_end(&mut bytes).ok()?;
+    let scanned_bytes = bytes.len() as u64;
+    if metadata.len() > scanned_bytes {
+        let complete_length = bytes
+            .iter()
+            .rposition(|byte| *byte == b'\n')
+            .map_or(0, |index| index + 1);
+        bytes.truncate(complete_length);
+    }
+    Some(FilePrefix {
+        bytes,
+        scanned_bytes,
+    })
+}
+
+fn parse_pi_session(output: &[u8], requested_directory: &Path) -> Option<(String, String)> {
+    let mut entries = output
+        .split(|byte| *byte == b'\n')
+        .filter_map(|line| serde_json::from_slice::<serde_json::Value>(line).ok());
+    let header = entries.next()?;
+    if header.get("type")?.as_str()? != "session" {
+        return None;
+    }
+    let id = header.get("id")?.as_str()?;
+    if id.is_empty() {
+        return None;
+    }
+    let header_directory = normalize_absolute(Path::new(header.get("cwd")?.as_str()?))?;
+    if header_directory != requested_directory {
+        return None;
+    }
+
+    let mut explicit_name = None;
+    let mut saw_session_info = false;
+    let mut first_user_summary = None;
+    for entry in entries {
+        match entry.get("type").and_then(serde_json::Value::as_str) {
+            Some("session_info") => {
+                saw_session_info = true;
+                explicit_name = entry
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(sanitize_title);
+            }
+            Some("message") if first_user_summary.is_none() => {
+                let Some(message) = entry.get("message") else {
+                    continue;
+                };
+                if message.get("role").and_then(serde_json::Value::as_str) != Some("user") {
+                    continue;
+                }
+                first_user_summary = message
+                    .get("content")
+                    .and_then(pi_message_text)
+                    .and_then(|text| sanitize_title(&text));
+            }
+            _ => {}
+        }
+    }
+    match (saw_session_info, explicit_name) {
+        (true, Some(name)) => Some(name),
+        _ => first_user_summary,
+    }
+    .map(|title| (id.to_owned(), title))
+}
+
+fn pi_message_text(content: &serde_json::Value) -> Option<String> {
+    if let Some(text) = content.as_str() {
+        return Some(text.to_owned());
+    }
+    let blocks = content.as_array()?;
+    let text = blocks
+        .iter()
+        .filter(|block| block.get("type").and_then(serde_json::Value::as_str) == Some("text"))
+        .filter_map(|block| block.get("text").and_then(serde_json::Value::as_str))
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!text.is_empty()).then_some(text)
+}
+
+fn sanitize_title(title: &str) -> Option<String> {
+    let sanitized: String = title
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(MAX_TITLE_CHARS)
+        .collect();
+    (!sanitized.is_empty()).then_some(sanitized)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{File, FileTimes};
+    use std::os::unix::fs::symlink;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("boomux-pi-sessions-{nonce}"));
+            fs::create_dir(&path).expect("create test directory");
+            Self(path)
+        }
+
+        fn environment(&self) -> PiEnvironment {
+            PiEnvironment {
+                session_dir: Some(self.0.clone().into_os_string()),
+                home: Some("/home/test".into()),
+                ..PiEnvironment::default()
+            }
+        }
+
+        fn write(&self, name: &str, contents: &str) -> PathBuf {
+            let path = self.0.join(name);
+            fs::write(&path, contents).expect("write session");
+            path
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn pi_header(id: &str, cwd: &str) -> String {
+        format!(r#"{{"type":"session","id":"{id}","cwd":"{cwd}"}}"#)
+    }
+
+    #[test]
+    fn parses_opencode_catalog_by_canonical_session_id() {
+        let titles = parse_opencode_titles(
+            br#"[
+                {"id":"ses_one","title":"Review cache","updated":2,"created":1,"directory":"/repo"},
+                {"id":"ses_two","title":"Implement panel","updated":4,"created":3,"directory":"/repo"}
+            ]"#,
+        )
+        .expect("valid catalog");
+
+        assert_eq!(
+            titles.get("ses_one").map(String::as_str),
+            Some("Review cache")
+        );
+        assert_eq!(
+            titles.get("ses_two").map(String::as_str),
+            Some("Implement panel")
+        );
+    }
+
+    #[test]
+    fn sanitizes_and_bounds_titles() {
+        assert_eq!(
+            sanitize_title("  Review\n\t cache\0  ").as_deref(),
+            Some("Review cache")
+        );
+        let long = "x".repeat(MAX_TITLE_CHARS + 20);
+        assert_eq!(
+            sanitize_title(&long).expect("title").chars().count(),
+            MAX_TITLE_CHARS
+        );
+        assert_eq!(sanitize_title(" \n\t "), None);
+    }
+
+    #[test]
+    fn malformed_and_oversized_opencode_catalogs_fail_open() {
+        assert!(parse_opencode_titles(b"not json").is_none());
+        assert!(
+            parse_opencode_titles(&vec![b'x'; MAX_OPENCODE_STDOUT_BYTES as usize + 1]).is_none()
+        );
+    }
+
+    #[test]
+    fn derives_default_pi_directory_with_documented_encoding_and_home_expansion() {
+        let environment = PiEnvironment {
+            coding_agent_dir: Some("~/.local/pi".into()),
+            home: Some("/home/test".into()),
+            ..PiEnvironment::default()
+        };
+
+        assert_eq!(
+            pi_session_directory(Path::new("/home/test/work:tree\\repo"), &environment),
+            Some(PathBuf::from(
+                "/home/test/.local/pi/sessions/--home-test-work-tree-repo--"
+            ))
+        );
+        assert_eq!(
+            pi_session_directory(
+                Path::new("/home/test/repo"),
+                &PiEnvironment {
+                    coding_agent_dir: Some(OsString::new()),
+                    home: Some("/home/test".into()),
+                    ..PiEnvironment::default()
+                }
+            ),
+            Some(PathBuf::from(
+                "/home/test/.pi/agent/sessions/--home-test-repo--"
+            ))
+        );
+    }
+
+    #[test]
+    fn custom_pi_session_directory_expands_home_without_recursing() {
+        let environment = PiEnvironment {
+            session_dir: Some("~/sessions/project".into()),
+            home: Some("/home/test".into()),
+            ..PiEnvironment::default()
+        };
+
+        assert_eq!(
+            pi_session_directory(Path::new("/repo"), &environment),
+            Some(PathBuf::from("/home/test/sessions/project"))
+        );
+    }
+
+    #[test]
+    fn pi_headers_must_match_the_normalized_requested_directory() {
+        let test = TestDirectory::new();
+        test.write(
+            "sessions.jsonl",
+            &format!(
+                "{}\n{}\n",
+                pi_header("matching", "/repo/./src/.."),
+                r#"{"type":"session_info","name":"Matching title"}"#
+            ),
+        );
+        test.write(
+            "other.jsonl",
+            &format!(
+                "{}\n{}\n",
+                pi_header("other", "/other"),
+                r#"{"type":"session_info","name":"Wrong project"}"#
+            ),
+        );
+
+        let titles = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+
+        assert_eq!(
+            titles.get("matching").map(String::as_str),
+            Some("Matching title")
+        );
+        assert!(!titles.contains_key("other"));
+    }
+
+    #[test]
+    fn pi_prefers_the_latest_explicit_session_name() {
+        let output = format!(
+            "{}\n{}\n{}\n{}\n",
+            pi_header("pi-one", "/repo"),
+            r#"{"type":"session_info","name":"Initial name"}"#,
+            r#"{"type":"message","message":{"role":"user","content":"Fallback prompt"}}"#,
+            r#"{"type":"session_info","name":"  Final\n name  "}"#
+        );
+
+        assert_eq!(
+            parse_pi_session(output.as_bytes(), Path::new("/repo")),
+            Some(("pi-one".into(), "Final name".into()))
+        );
+    }
+
+    #[test]
+    fn pi_uses_the_first_user_message_as_a_fallback() {
+        let output = format!(
+            "not json\n{}\n{}\n{}\n",
+            pi_header("pi-one", "/repo"),
+            r#"{"type":"message","message":{"role":"assistant","content":"Ignore me"}}"#,
+            r#"{"type":"message","message":{"role":"user","content":"  Fix\n the cache  "}}"#
+        );
+
+        assert_eq!(
+            parse_pi_session(output.as_bytes(), Path::new("/repo")),
+            Some(("pi-one".into(), "Fix the cache".into()))
+        );
+    }
+
+    #[test]
+    fn pi_extracts_text_from_user_content_blocks() {
+        let output = format!(
+            "{}\n{}\n",
+            pi_header("pi-blocks", "/repo"),
+            r#"{"type":"message","message":{"role":"user","content":[{"type":"image","data":"ignored"},{"type":"text","text":"Review"},{"type":"text","text":"this panel"}]}}"#
+        );
+
+        assert_eq!(
+            parse_pi_session(output.as_bytes(), Path::new("/repo")),
+            Some(("pi-blocks".into(), "Review this panel".into()))
+        );
+    }
+
+    #[test]
+    fn pi_skips_image_only_and_empty_user_messages_before_text() {
+        let output = format!(
+            "{}\n{}\n{}\n{}\n",
+            pi_header("pi-later-text", "/repo"),
+            r#"{"type":"message","message":{"role":"user","content":[{"type":"image","data":"ignored"}]}}"#,
+            r#"{"type":"message","message":{"role":"user","content":"   "}}"#,
+            r#"{"type":"message","message":{"role":"user","content":"Use this summary"}}"#
+        );
+
+        assert_eq!(
+            parse_pi_session(output.as_bytes(), Path::new("/repo")),
+            Some(("pi-later-text".into(), "Use this summary".into()))
+        );
+    }
+
+    #[test]
+    fn pi_empty_latest_explicit_name_clears_an_older_name() {
+        let output = format!(
+            "{}\n{}\n{}\n{}\n",
+            pi_header("pi-cleared", "/repo"),
+            r#"{"type":"session_info","name":"Old name"}"#,
+            r#"{"type":"message","message":{"role":"user","content":"Prompt fallback"}}"#,
+            r#"{"type":"session_info","name":"  \n  "}"#
+        );
+
+        assert_eq!(
+            parse_pi_session(output.as_bytes(), Path::new("/repo")),
+            Some(("pi-cleared".into(), "Prompt fallback".into()))
+        );
+    }
+
+    #[test]
+    fn oversized_pi_file_uses_complete_prefix_and_may_miss_a_late_name() {
+        let test = TestDirectory::new();
+        let header = pi_header("pi-oversized", "/repo");
+        let message =
+            r#"{"type":"message","message":{"role":"user","content":"Bounded prefix fallback"}}"#;
+        let filler = "x".repeat(MAX_PI_FILE_BYTES as usize);
+        test.write(
+            "oversized.jsonl",
+            &format!(
+                "{header}\n{message}\n{filler}\n{{\"type\":\"session_info\",\"name\":\"Late unavailable name\"}}\n"
+            ),
+        );
+
+        let titles = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+
+        assert_eq!(
+            titles.get("pi-oversized").map(String::as_str),
+            Some("Bounded prefix fallback")
+        );
+    }
+
+    #[test]
+    fn pi_skips_malformed_oversized_and_symlinked_files() {
+        let test = TestDirectory::new();
+        test.write("malformed.jsonl", "{}\nnot a session\n");
+        fs::create_dir(test.0.join("special.jsonl")).expect("create special entry");
+        let oversized = test.0.join("oversized.jsonl");
+        fs::write(&oversized, vec![b'x'; MAX_PI_FILE_BYTES as usize + 1])
+            .expect("write oversized session");
+        let target = test.write(
+            "target.txt",
+            &format!(
+                "{}\n{}\n",
+                pi_header("linked", "/repo"),
+                r#"{"type":"session_info","name":"Linked title"}"#
+            ),
+        );
+        symlink(&target, test.0.join("linked.jsonl")).expect("create symlink");
+        test.write(
+            "valid.jsonl",
+            &format!(
+                "{}\n{}\n",
+                pi_header("valid", "/repo"),
+                r#"{"type":"session_info","name":"Valid title"}"#
+            ),
+        );
+
+        let titles = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+
+        assert_eq!(titles.len(), 1);
+        assert_eq!(titles.get("valid").map(String::as_str), Some("Valid title"));
+    }
+
+    #[test]
+    fn pi_catalog_uses_only_the_100_newest_files() {
+        let test = TestDirectory::new();
+        for index in 0..=MAX_SESSIONS {
+            let id = format!("pi-{index:03}");
+            let header = pi_header(&id, "/repo");
+            let path = test.write(
+                &format!("session-{index:03}.jsonl"),
+                &format!("{header}\n{{\"type\":\"session_info\",\"name\":\"Title {index}\"}}\n"),
+            );
+            File::options()
+                .write(true)
+                .open(path)
+                .expect("open session timestamp")
+                .set_times(
+                    FileTimes::new().set_modified(UNIX_EPOCH + Duration::from_secs(index as u64)),
+                )
+                .expect("set session timestamp");
+        }
+
+        let titles = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+
+        assert_eq!(titles.len(), MAX_SESSIONS);
+        assert!(titles.contains_key("pi-100"));
+        assert!(!titles.contains_key("pi-000"));
+    }
+
+    #[test]
+    fn cache_is_async_deduplicated_and_routes_opencode_and_pi() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let worker_calls = Arc::clone(&calls);
+        let (finished_sender, finished_receiver) = mpsc::channel();
+        let mut cache = Cache::with_inspector(Arc::new(move |integration, directory| {
+            worker_calls
+                .lock()
+                .expect("calls lock")
+                .push((integration.to_owned(), directory.to_owned()));
+            let _ = finished_sender.send(integration.to_owned());
+            Some(HashMap::from([(
+                format!("{integration}-id"),
+                format!("{integration} title"),
+            )]))
+        }));
+
+        assert_eq!(
+            cache.title("opencode", Path::new("/repo"), "opencode-id"),
+            None
+        );
+        assert_eq!(
+            cache.title("opencode", Path::new("/repo"), "opencode-id"),
+            None
+        );
+        assert_eq!(cache.title("pi", Path::new("/repo"), "pi-id"), None);
+        finished_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("first inspection");
+        finished_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("second inspection");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let opencode = cache.title("opencode", Path::new("/repo"), "opencode-id");
+            let pi = cache.title("pi", Path::new("/repo"), "pi-id");
+            if opencode.as_deref() == Some("opencode title") && pi.as_deref() == Some("pi title") {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "cache results were not published"
+            );
+            thread::yield_now();
+        }
+        assert_eq!(calls.lock().expect("calls lock").len(), 2);
+    }
+
+    #[test]
+    fn failures_are_cached_and_unsupported_integrations_do_not_request_catalogs() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let worker_calls = Arc::clone(&calls);
+        let (finished_sender, finished_receiver) = mpsc::channel();
+        let mut cache = Cache::with_inspector(Arc::new(move |_, _| {
+            worker_calls.fetch_add(1, Ordering::SeqCst);
+            let _ = finished_sender.send(());
+            None
+        }));
+
+        assert_eq!(cache.title("other", Path::new("/repo"), "other-one"), None);
+        assert_eq!(cache.title("pi", Path::new("/repo"), "pi-one"), None);
+        finished_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("inspection completed");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !cache.pending.is_empty() {
+            let _ = cache.title("pi", Path::new("/repo"), "pi-one");
+            assert!(Instant::now() < deadline, "failure was not published");
+            thread::yield_now();
+        }
+        assert_eq!(cache.title("pi", Path::new("/repo"), "pi-one"), None);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::env;
 use std::error::Error;
 use std::fs;
@@ -22,6 +23,7 @@ use boomux::{attach, client, daemon, protocol};
 mod cli_output;
 mod config;
 mod git;
+mod host_session_titles;
 mod process_adapter;
 mod projects;
 mod terminal;
@@ -797,7 +799,9 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     let launch_cwd = resolve_directory(Path::new("."))?;
     let client = client::connect_or_start()?;
     let mut git_cache = git::Cache::default();
-    let views = dashboard_views(&client.snapshot()?.workspaces, &mut git_cache);
+    let mut title_cache = host_session_titles::Cache::default();
+    let mut views = dashboard_views(&client.snapshot()?.workspaces, &mut git_cache);
+    enrich_session_titles(&mut views, &mut title_cache);
     let config = config::load()?;
     let terminal = terminal_override
         .map(str::to_owned)
@@ -923,7 +927,9 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             },
             on_refresh: || {
                 let snapshot = client.snapshot().map_err(|error| error.to_string())?;
-                Ok(dashboard_views(&snapshot.workspaces, &mut git_cache))
+                let mut views = dashboard_views(&snapshot.workspaces, &mut git_cache);
+                enrich_session_titles(&mut views, &mut title_cache);
+                Ok(views)
             },
         },
     )?;
@@ -955,6 +961,7 @@ fn dashboard_views(
     workspaces
         .iter()
         .map(|workspace| {
+            let sessions = workspace_session_views(workspace);
             let shells = workspace.shells.iter().map(|shell| {
                 let git = git_cache.inspect(&shell.cwd);
                 let shell_view = tui::TerminalView {
@@ -1037,9 +1044,181 @@ fn dashboard_views(
                 id: workspace.id.clone(),
                 name: workspace.name.clone(),
                 items: shells.chain(launchers).collect(),
+                sessions,
             }
         })
         .collect()
+}
+
+fn workspace_session_views(workspace: &WorkspaceSnapshot) -> Vec<tui::AgentSessionView> {
+    let shell_names: BTreeMap<_, _> = workspace
+        .shells
+        .iter()
+        .map(|shell| (shell.id.as_str(), shell.name.as_str()))
+        .collect();
+    let mut groups: BTreeMap<(String, String), Vec<&AgentInstanceSnapshot>> = BTreeMap::new();
+    for agent in &workspace.agents {
+        let key = match &agent.external_session_id {
+            Some(external_id) => (agent.integration.clone(), format!("external:{external_id}")),
+            None => (agent.integration.clone(), format!("instance:{}", agent.id)),
+        };
+        groups.entry(key).or_default().push(agent);
+    }
+
+    let mut sessions: Vec<_> = groups
+        .into_iter()
+        .map(|((integration, identity), mut agents)| {
+            agents.sort_by(|left, right| {
+                left.started_at_ms
+                    .cmp(&right.started_at_ms)
+                    .then_with(|| left.id.cmp(&right.id))
+            });
+            let first = agents[0];
+            let latest = agents
+                .iter()
+                .copied()
+                .max_by(|left, right| {
+                    left.observation
+                        .observed_at_ms
+                        .cmp(&right.observation.observed_at_ms)
+                        .then_with(|| left.started_at_ms.cmp(&right.started_at_ms))
+                        .then_with(|| left.id.cmp(&right.id))
+                })
+                .expect("session group is non-empty");
+            let active: Vec<_> = agents
+                .iter()
+                .copied()
+                .filter(|agent| {
+                    agent.workspace_id == workspace.id
+                        && agent.ended_at_ms.is_none()
+                        && !matches!(
+                            agent.observation.state,
+                            AgentState::Inactive | AgentState::Done
+                        )
+                        && workspace.shells.iter().any(|shell| {
+                            matches!(shell.status, ShellStatus::Running)
+                                && shell.id == agent.shell_id
+                                && shell.run.as_ref().is_some_and(|run| run.id == agent.run_id)
+                        })
+                })
+                .collect();
+            let (state_source, state_is_current) = if active.is_empty() {
+                (latest, false)
+            } else {
+                (
+                    active
+                        .into_iter()
+                        .min_by(|left, right| {
+                            agent_state_priority(left.observation.state)
+                                .cmp(&agent_state_priority(right.observation.state))
+                                .then_with(|| {
+                                    right
+                                        .observation
+                                        .observed_at_ms
+                                        .cmp(&left.observation.observed_at_ms)
+                                })
+                                .then_with(|| left.id.cmp(&right.id))
+                        })
+                        .expect("active session occurrence is non-empty"),
+                    true,
+                )
+            };
+            let last_at_ms = agents
+                .iter()
+                .map(|agent| {
+                    agent
+                        .ended_at_ms
+                        .unwrap_or(agent.observation.observed_at_ms)
+                        .max(agent.observation.observed_at_ms)
+                })
+                .max()
+                .unwrap_or(first.started_at_ms);
+            let runs = agents
+                .into_iter()
+                .map(|agent| tui::AgentSessionRunView {
+                    shell_name: shell_names
+                        .get(agent.shell_id.as_str())
+                        .map(|name| (*name).into()),
+                    directory: workspace
+                        .shells
+                        .iter()
+                        .find(|shell| shell.id == agent.shell_id)
+                        .map(|shell| shell.cwd.clone()),
+                })
+                .collect();
+
+            tui::AgentSessionView {
+                id: stable_session_id(&integration, &identity),
+                label: latest.name.clone(),
+                integration,
+                external_session_id: first.external_session_id.clone(),
+                state: cli_output::agent_state(state_source.observation.state).into(),
+                state_is_current,
+                last_at_ms,
+                runs,
+            }
+        })
+        .collect();
+    sessions.sort_by(|left, right| {
+        right
+            .last_at_ms
+            .cmp(&left.last_at_ms)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    sessions
+}
+
+fn enrich_session_titles(
+    workspaces: &mut [tui::WorkspaceView],
+    title_cache: &mut host_session_titles::Cache,
+) {
+    enrich_session_titles_with(workspaces, |integration, directory, external_session_id| {
+        title_cache.title(integration, directory, external_session_id)
+    });
+}
+
+fn enrich_session_titles_with<F>(workspaces: &mut [tui::WorkspaceView], mut title: F)
+where
+    F: FnMut(&str, &Path, &str) -> Option<String>,
+{
+    for session in workspaces
+        .iter_mut()
+        .flat_map(|workspace| workspace.sessions.iter_mut())
+    {
+        let Some(external_session_id) = session.external_session_id.as_deref() else {
+            continue;
+        };
+        let Some(directory) = session
+            .runs
+            .iter()
+            .rev()
+            .find_map(|run| run.directory.as_deref())
+        else {
+            continue;
+        };
+        if let Some(host_title) = title(&session.integration, directory, external_session_id) {
+            session.label = host_title;
+        }
+    }
+}
+
+fn stable_session_id(integration: &str, identity: &str) -> String {
+    format!(
+        "{}:{integration}:{}:{identity}",
+        integration.len(),
+        identity.len()
+    )
+}
+
+fn agent_state_priority(state: AgentState) -> u8 {
+    match state {
+        AgentState::Blocked => 0,
+        AgentState::Working => 1,
+        AgentState::Idle => 2,
+        AgentState::Inactive => 3,
+        AgentState::Done => 4,
+        AgentState::Unknown => 5,
+    }
 }
 
 fn open_directory(
@@ -3255,6 +3434,241 @@ mod tests {
         );
 
         assert!(views[0].items.is_empty());
+        assert!(views[0].sessions.is_empty());
+    }
+
+    #[test]
+    fn workspace_view_groups_external_session_occurrences_across_runs() {
+        let mut second_shell = shell("s2", "w1", "review");
+        second_shell.run.as_mut().unwrap().id = "r2".into();
+        let mut workspace = workspace(
+            "w1",
+            "project",
+            vec![shell("s1", "w1", "build"), second_shell],
+        );
+        let mut first = agent("agent-old", "w1", "s1");
+        first.started_at_ms = 10;
+        first.ended_at_ms = Some(20);
+        first.observation.state = AgentState::Inactive;
+        first.observation.observed_at_ms = 20;
+        let mut second = agent("agent-new", "w1", "s2");
+        second.run_id = "r2".into();
+        second.started_at_ms = 30;
+        second.observation.state = AgentState::Blocked;
+        second.observation.evidence = "approval needed".into();
+        second.observation.observed_at_ms = 40;
+        workspace.agents = vec![second, first];
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert_eq!(views[0].sessions.len(), 1);
+        let session = &views[0].sessions[0];
+        assert_eq!(
+            session.id,
+            stable_session_id("opencode", "external:external-1")
+        );
+        assert_eq!(session.state, "blocked");
+        assert!(session.state_is_current);
+        assert_eq!(session.runs.len(), 2);
+        assert_eq!(session.runs[0].shell_name.as_deref(), Some("build"));
+        assert_eq!(session.runs[1].shell_name.as_deref(), Some("review"));
+        assert_eq!(
+            session.runs[1].directory.as_deref(),
+            Some(Path::new("/tmp/project"))
+        );
+    }
+
+    #[test]
+    fn enriches_only_the_matching_integration_and_external_session() {
+        let mut workspace = workspace("w1", "project", vec![shell("s1", "w1", "agent")]);
+        workspace.agents = vec![agent("agent-1", "w1", "s1")];
+        let mut views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        enrich_session_titles_with(&mut views, |integration, directory, external_id| {
+            (integration == "opencode"
+                && directory == Path::new("/tmp/project")
+                && external_id == "external-1")
+                .then(|| "Review async title cache".into())
+        });
+
+        assert_eq!(views[0].sessions[0].label, "Review async title cache");
+    }
+
+    #[test]
+    fn enriches_from_the_newest_available_session_directory() {
+        let mut views = vec![tui::WorkspaceView {
+            id: "w1".into(),
+            name: "project".into(),
+            items: Vec::new(),
+            sessions: vec![tui::AgentSessionView {
+                id: "session".into(),
+                label: "opencode".into(),
+                integration: "opencode".into(),
+                external_session_id: Some("external-1".into()),
+                state: "inactive".into(),
+                state_is_current: false,
+                last_at_ms: 30,
+                runs: vec![
+                    tui::AgentSessionRunView {
+                        shell_name: Some("old-shell".into()),
+                        directory: Some("/tmp/project".into()),
+                    },
+                    tui::AgentSessionRunView {
+                        shell_name: None,
+                        directory: None,
+                    },
+                ],
+            }],
+        }];
+
+        enrich_session_titles_with(&mut views, |_, directory, _| {
+            (directory == Path::new("/tmp/project")).then(|| "Historical title".into())
+        });
+
+        assert_eq!(views[0].sessions[0].label, "Historical title");
+    }
+
+    #[test]
+    fn workspace_view_keeps_agents_without_external_ids_isolated() {
+        let mut workspace = workspace("w1", "project", vec![shell("s1", "w1", "agent")]);
+        let mut first = agent("agent-a", "w1", "s1");
+        first.external_session_id = None;
+        let mut second = agent("agent-b", "w1", "s1");
+        second.external_session_id = None;
+        workspace.agents = vec![first, second];
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert_eq!(views[0].sessions.len(), 2);
+        assert!(
+            views[0]
+                .sessions
+                .iter()
+                .all(|session| session.runs.len() == 1)
+        );
+    }
+
+    #[test]
+    fn workspace_session_state_prioritizes_active_blocked_occurrences() {
+        let mut workspace = workspace("w1", "project", vec![shell("s1", "w1", "agent")]);
+        let mut working = agent("working", "w1", "s1");
+        working.observation.observed_at_ms = 30;
+        let mut blocked = agent("blocked", "w1", "s1");
+        blocked.observation.state = AgentState::Blocked;
+        blocked.observation.observed_at_ms = 20;
+        workspace.agents = vec![working, blocked];
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert_eq!(views[0].sessions[0].state, "blocked");
+    }
+
+    #[test]
+    fn workspace_session_state_ignores_stale_blocked_occurrence() {
+        let mut current_shell = shell("s1", "w1", "agent");
+        current_shell.run.as_mut().unwrap().id = "current-run".into();
+        let mut workspace = workspace("w1", "project", vec![current_shell]);
+        let mut stale = agent("stale", "w1", "s1");
+        stale.run_id = "old-run".into();
+        stale.observation.state = AgentState::Blocked;
+        stale.observation.observed_at_ms = 30;
+        let mut current = agent("current", "w1", "s1");
+        current.run_id = "current-run".into();
+        current.observation.state = AgentState::Working;
+        current.observation.observed_at_ms = 20;
+        workspace.agents = vec![stale, current];
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert_eq!(views[0].sessions[0].state, "working");
+        assert!(views[0].sessions[0].state_is_current);
+    }
+
+    #[test]
+    fn workspace_session_state_marks_stale_history_as_last_known() {
+        let mut workspace = workspace("w1", "project", vec![shell("s1", "w1", "agent")]);
+        let mut stale = agent("stale", "w1", "s1");
+        stale.run_id = "old-run".into();
+        stale.observation.state = AgentState::Blocked;
+        workspace.agents = vec![stale];
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert_eq!(views[0].sessions[0].state, "blocked");
+        assert!(!views[0].sessions[0].state_is_current);
+    }
+
+    #[test]
+    fn workspace_session_id_is_stable_when_equal_timestamp_occurrence_is_added() {
+        let mut workspace = workspace("w1", "project", vec![shell("s1", "w1", "agent")]);
+        let mut first = agent("agent-z", "w1", "s1");
+        first.started_at_ms = 10;
+        workspace.agents = vec![first.clone()];
+        let initial_id = workspace_session_views(&workspace)[0].id.clone();
+
+        let mut added = agent("agent-a", "w1", "s1");
+        added.started_at_ms = 10;
+        workspace.agents.push(added);
+        let sessions = workspace_session_views(&workspace);
+
+        assert_eq!(sessions[0].id, initial_id);
+        assert_eq!(sessions[0].runs.len(), 2);
+        assert_eq!(
+            sessions[0].id,
+            stable_session_id("opencode", "external:external-1")
+        );
+    }
+
+    #[test]
+    fn workspace_session_state_priority_matches_attention_order() {
+        let states = [
+            AgentState::Blocked,
+            AgentState::Working,
+            AgentState::Idle,
+            AgentState::Inactive,
+            AgentState::Done,
+            AgentState::Unknown,
+        ];
+
+        assert_eq!(states.map(agent_state_priority), [0, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn workspace_session_catalog_retains_inactive_and_done_sessions() {
+        let mut workspace = workspace("w1", "project", vec![]);
+        let mut inactive = agent("inactive", "w1", "removed-a");
+        inactive.external_session_id = Some("inactive-session".into());
+        inactive.ended_at_ms = Some(20);
+        inactive.observation.state = AgentState::Inactive;
+        inactive.observation.observed_at_ms = 20;
+        let mut done = agent("done", "w1", "removed-b");
+        done.external_session_id = Some("done-session".into());
+        done.ended_at_ms = Some(30);
+        done.observation.state = AgentState::Done;
+        done.observation.observed_at_ms = 30;
+        workspace.agents = vec![inactive, done];
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        assert_eq!(views[0].sessions.len(), 2);
+        assert!(
+            views[0]
+                .sessions
+                .iter()
+                .any(|session| session.state == "inactive")
+        );
+        assert!(
+            views[0]
+                .sessions
+                .iter()
+                .any(|session| session.state == "done")
+        );
+        assert!(
+            views[0]
+                .sessions
+                .iter()
+                .all(|session| session.runs[0].shell_name.is_none())
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,6 @@
 use std::io;
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::Frame;
@@ -26,6 +26,23 @@ pub(crate) struct WorkspaceView {
     pub(crate) id: String,
     pub(crate) name: String,
     pub(crate) items: Vec<WorkspaceItemView>,
+    pub(crate) sessions: Vec<AgentSessionView>,
+}
+
+pub(crate) struct AgentSessionView {
+    pub(crate) id: String,
+    pub(crate) label: String,
+    pub(crate) integration: String,
+    pub(crate) external_session_id: Option<String>,
+    pub(crate) state: String,
+    pub(crate) state_is_current: bool,
+    pub(crate) last_at_ms: u64,
+    pub(crate) runs: Vec<AgentSessionRunView>,
+}
+
+pub(crate) struct AgentSessionRunView {
+    pub(crate) shell_name: Option<String>,
+    pub(crate) directory: Option<PathBuf>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -131,6 +148,10 @@ impl WorkspaceView {
             .iter()
             .filter(|item| matches!(item, WorkspaceItemView::AgentShell(_)))
             .count()
+    }
+
+    fn session_count(&self) -> usize {
+        self.sessions.len()
     }
 }
 
@@ -1002,6 +1023,11 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         .map(WorkspaceView::launcher_count)
         .sum();
     let agent_count: usize = app.workspaces.iter().map(WorkspaceView::agent_count).sum();
+    let session_count: usize = app
+        .workspaces
+        .iter()
+        .map(WorkspaceView::session_count)
+        .sum();
     let line = Line::from(vec![
         Span::styled(
             " BOOMUX ",
@@ -1019,7 +1045,12 @@ fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Style::new().fg(YELLOW),
         ),
         Span::styled("  |  ", Style::new().fg(OVERLAY)),
-        Span::styled(format!("{agent_count} agents"), Style::new().fg(TEAL)),
+        Span::styled(
+            format!("{agent_count} active agents"),
+            Style::new().fg(TEAL),
+        ),
+        Span::styled("  |  ", Style::new().fg(OVERLAY)),
+        Span::styled(format!("{session_count} sessions"), Style::new().fg(YELLOW)),
         Span::styled(
             "    tab/h/l/arrows switches panes",
             Style::new().fg(SUBTEXT),
@@ -1047,7 +1078,7 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
         ],
     )
     .header(
-        Row::new(["NAME", "SHELLS", "LAUNCHERS", "AGENTS"])
+        Row::new(["NAME", "SHELLS", "LAUNCHERS", "ACTIVE"])
             .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)),
     )
     .column_spacing(1)
@@ -1089,7 +1120,18 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         },
     ));
     let inner = block.inner(area);
-    let show_full_ids = inner.width >= 150;
+    let contextual_panel = (inner.height >= 9)
+        .then(|| contextual_session_panel(app))
+        .flatten();
+    let (items_inner, sessions_area) = contextual_panel.as_ref().map_or((inner, None), |panel| {
+        let panel_height = (panel.content_height + 2)
+            .min(inner.height.saturating_sub(6))
+            .max(3);
+        let [items_area, sessions_area] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(panel_height)]).areas(inner);
+        (items_area, Some(sessions_area))
+    });
+    let show_full_ids = items_inner.width >= 150;
     let rows: Vec<_> = selected
         .into_iter()
         .flat_map(|workspace| {
@@ -1158,13 +1200,13 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
             })
         })
         .collect();
-    let widths = shell_column_widths(inner.width, show_full_ids);
+    let widths = shell_column_widths(items_inner.width, show_full_ids);
     frame.render_widget(block, area);
     let table_area = if show_full_ids {
-        inner
+        items_inner
     } else {
         let [detail_area, table_area] =
-            Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(inner);
+            Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(items_inner);
         let detail = app.selected_item().map_or_else(
             || {
                 vec![Line::from(Span::styled(
@@ -1187,6 +1229,198 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         )
         .highlight_symbol("> ");
     frame.render_stateful_widget(table, table_area, &mut app.item_state);
+    if let (Some(panel), Some(panel_area)) = (contextual_panel, sessions_area) {
+        render_contextual_sessions(frame, panel_area, panel);
+    }
+}
+
+struct ContextualSessionPanel {
+    title: String,
+    rows: Vec<Row<'static>>,
+    content_height: u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionCategory {
+    Active,
+    Last24Hours,
+    Last7Days,
+    Older,
+}
+
+impl SessionCategory {
+    const ALL: [Self; 4] = [
+        Self::Active,
+        Self::Last24Hours,
+        Self::Last7Days,
+        Self::Older,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Active => "ACTIVE",
+            Self::Last24Hours => "LAST 24 HOURS",
+            Self::Last7Days => "LAST 7 DAYS",
+            Self::Older => "OLDER",
+        }
+    }
+}
+
+fn session_category(session: &AgentSessionView, now_ms: u64) -> SessionCategory {
+    if session.state_is_current {
+        return SessionCategory::Active;
+    }
+    match now_ms.saturating_sub(session.last_at_ms) {
+        0..=86_400_000 => SessionCategory::Last24Hours,
+        86_400_001..=604_800_000 => SessionCategory::Last7Days,
+        _ => SessionCategory::Older,
+    }
+}
+
+fn contextual_session_panel(app: &App) -> Option<ContextualSessionPanel> {
+    let WorkspaceItemView::AgentShell(agent_shell) = app.selected_item()? else {
+        return None;
+    };
+    let agent = agent_shell.agent.as_ref()?;
+    let workspace = app.selected()?;
+    let sessions: Vec<_> = workspace
+        .sessions
+        .iter()
+        .filter(|session| session.integration == agent.integration)
+        .collect();
+    if sessions.is_empty() {
+        return None;
+    }
+    let now_ms = current_time_ms();
+    let mut rows = Vec::new();
+    let mut content_height = 0;
+    for category in SessionCategory::ALL {
+        let categorized: Vec<_> = sessions
+            .iter()
+            .copied()
+            .filter(|session| session_category(session, now_ms) == category)
+            .collect();
+        if categorized.is_empty() {
+            continue;
+        }
+        let categorized_count = categorized.len() as u16;
+        rows.push(
+            Row::new([
+                Cell::from(""),
+                Cell::from(category.label()),
+                Cell::from(""),
+                Cell::from(""),
+            ])
+            .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)),
+        );
+        content_height += 1;
+        rows.extend(categorized.into_iter().map(|session| {
+            let label = best_session_label(session);
+            let external_identity = session
+                .external_session_id
+                .as_deref()
+                .map(short_id)
+                .unwrap_or_else(|| short_id(&session.id));
+            let shell = session
+                .runs
+                .last()
+                .and_then(|run| run.shell_name.as_deref())
+                .unwrap_or("removed shell");
+            let occurrences = session.runs.len();
+            let currency = if session.state_is_current {
+                "current"
+            } else {
+                "last known"
+            };
+            Row::new([
+                Cell::from(Span::styled(
+                    session_state_symbol(&session.state),
+                    Style::new().fg(session_state_color(&session.state)),
+                )),
+                Cell::from(vec![
+                    Line::from(Span::styled(
+                        label,
+                        Style::new().add_modifier(Modifier::BOLD),
+                    )),
+                    Line::from(Span::styled(
+                        format!(
+                            "{shell}  {external_identity}  {occurrences} occurrence{}  {currency}",
+                            if occurrences == 1 { "" } else { "s" }
+                        ),
+                        Style::new().fg(SUBTEXT),
+                    )),
+                ]),
+                Cell::from(session.state.clone()),
+                Cell::from(compact_recency(session.last_at_ms)),
+            ])
+            .height(2)
+        }));
+        content_height += categorized_count * 2;
+    }
+    Some(ContextualSessionPanel {
+        title: format!(
+            " {} sessions ",
+            integration_display_name(&agent.integration)
+        ),
+        rows,
+        content_height,
+    })
+}
+
+fn best_session_label(session: &AgentSessionView) -> String {
+    let label = session.label.trim();
+    if !label.is_empty()
+        && !label.eq_ignore_ascii_case(&session.integration)
+        && !label.eq_ignore_ascii_case(integration_display_name(&session.integration))
+    {
+        return label.to_owned();
+    }
+    let identity = session
+        .external_session_id
+        .as_deref()
+        .map(short_id)
+        .unwrap_or_else(|| short_id(&session.id));
+    session
+        .runs
+        .iter()
+        .rev()
+        .find_map(|run| run.shell_name.as_deref())
+        .map_or_else(
+            || {
+                format!(
+                    "{} {identity}",
+                    integration_display_name(&session.integration)
+                )
+            },
+            |shell| format!("{shell} ({identity})"),
+        )
+}
+
+fn integration_display_name(integration: &str) -> &str {
+    match integration {
+        "opencode" => "OpenCode",
+        "pi" => "Pi",
+        other => other,
+    }
+}
+
+fn render_contextual_sessions(frame: &mut Frame, area: Rect, panel: ContextualSessionPanel) {
+    let table = Table::new(
+        panel.rows,
+        [
+            Constraint::Length(2),
+            Constraint::Fill(1),
+            Constraint::Length(10),
+            Constraint::Length(9),
+        ],
+    )
+    .column_spacing(1)
+    .block(
+        Block::bordered()
+            .title(panel.title)
+            .border_style(Style::new().fg(OVERLAY)),
+    );
+    frame.render_widget(table, area);
 }
 
 fn item_detail_lines(item: &WorkspaceItemView) -> Vec<Line<'_>> {
@@ -1245,6 +1479,45 @@ fn shell_column_widths(width: u16, show_full_ids: bool) -> Vec<Constraint> {
 
 fn short_id(id: &str) -> String {
     id.chars().take(8).collect()
+}
+
+fn compact_recency(timestamp_ms: u64) -> String {
+    let seconds = current_time_ms().saturating_sub(timestamp_ms) / 1_000;
+    match seconds {
+        0..=59 => "now".into(),
+        60..=3_599 => format!("{}m ago", seconds / 60),
+        3_600..=86_399 => format!("{}h ago", seconds / 3_600),
+        _ => format!("{}d ago", seconds / 86_400),
+    }
+}
+
+fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn session_state_symbol(state: &str) -> &'static str {
+    match state {
+        "blocked" => "!",
+        "working" => ">",
+        "idle" => ".",
+        "inactive" => "-",
+        "done" => "x",
+        _ => "?",
+    }
+}
+
+fn session_state_color(state: &str) -> Color {
+    match state {
+        "blocked" => RED,
+        "working" => TEAL,
+        "idle" => GREEN,
+        "inactive" => SUBTEXT,
+        "done" => BLUE,
+        _ => YELLOW,
+    }
 }
 
 fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
@@ -1408,6 +1681,7 @@ mod tests {
                 branch: "main".into(),
                 command: String::new(),
             })],
+            sessions: Vec::new(),
         }
     }
 
@@ -1434,6 +1708,26 @@ mod tests {
             },
             agent: Some(agent()),
         }
+    }
+
+    fn session(id: &str, state: &str) -> AgentSessionView {
+        AgentSessionView {
+            id: id.into(),
+            label: "OpenCode review".into(),
+            integration: "opencode".into(),
+            external_session_id: Some(format!("external-{id}")),
+            state: state.into(),
+            state_is_current: true,
+            last_at_ms: 30,
+            runs: vec![AgentSessionRunView {
+                shell_name: Some("agent".into()),
+                directory: Some("/tmp/boomux".into()),
+            }],
+        }
+    }
+
+    fn focus_items(app: &mut App) {
+        app.set_focus(Focus::Items);
     }
 
     fn hinted_agent_shell() -> AgentShellView {
@@ -1492,7 +1786,7 @@ mod tests {
     fn terminal_navigation_uses_the_focused_table() {
         let mut app = app();
 
-        app.toggle_focus();
+        focus_items(&mut app);
         assert_eq!(app.focus, Focus::Items);
         app.next();
 
@@ -1519,11 +1813,21 @@ mod tests {
     }
 
     #[test]
+    fn tab_cycles_through_original_two_panes() {
+        let mut app = app();
+
+        app.toggle_focus();
+        assert_eq!(app.focus, Focus::Items);
+        app.toggle_focus();
+        assert_eq!(app.focus, Focus::Workspaces);
+    }
+
+    #[test]
     fn refresh_keeps_terminal_focus_for_an_empty_workspace() {
         let mut empty = workspace("w1", "empty");
         empty.items.clear();
         let mut app = App::new(vec![empty], project_context());
-        app.toggle_focus();
+        focus_items(&mut app);
 
         let mut refreshed = workspace("w1", "empty");
         refreshed.items.clear();
@@ -1544,7 +1848,7 @@ mod tests {
         let mut initial = workspace("w1", "boomux");
         initial.items.push(WorkspaceItemView::Launcher(launcher()));
         let mut app = App::new(vec![initial], project_context());
-        app.toggle_focus();
+        focus_items(&mut app);
         app.next();
         assert!(matches!(
             app.selected_item(),
@@ -1583,7 +1887,7 @@ mod tests {
         let mut initial = workspace("w1", "boomux");
         initial.items[0] = WorkspaceItemView::AgentShell(hinted_agent_shell());
         let mut app = App::new(vec![initial], project_context());
-        app.toggle_focus();
+        focus_items(&mut app);
 
         let mut refreshed = workspace("w1", "boomux");
         refreshed.items[0] = WorkspaceItemView::AgentShell(agent_shell());
@@ -1611,7 +1915,7 @@ mod tests {
         let mut empty = workspace("w1", "empty");
         empty.items.clear();
         let mut app = App::new(vec![empty], project_context());
-        app.toggle_focus();
+        focus_items(&mut app);
         let mut selected_workspace = None;
 
         let changed = app.request_add(&mut |workspace_id| {
@@ -1748,7 +2052,7 @@ mod tests {
     fn add_creates_a_shell_from_terminal_focus() {
         let mut app = app();
         let mut workspace_id = None;
-        app.toggle_focus();
+        focus_items(&mut app);
 
         let changed = app.request_add(&mut |selected_workspace_id| {
             workspace_id = Some(selected_workspace_id.to_owned());
@@ -1764,7 +2068,7 @@ mod tests {
     fn enter_on_terminal_opens_only_the_selected_shell() {
         let mut app = app();
         let mut opened = None;
-        app.toggle_focus();
+        focus_items(&mut app);
 
         app.open_selected_item(&mut |target| {
             opened = Some(target.clone());
@@ -1785,7 +2089,7 @@ mod tests {
                 directory: "/tmp/boomux".into(),
                 command: "zeditor .".into(),
             }));
-        app.toggle_focus();
+        focus_items(&mut app);
         app.next();
         let mut opened = None;
 
@@ -1815,7 +2119,7 @@ mod tests {
         app.workspaces[0]
             .items
             .push(WorkspaceItemView::Launcher(launcher));
-        app.toggle_focus();
+        focus_items(&mut app);
         app.next();
 
         app.request_rename();
@@ -1841,7 +2145,7 @@ mod tests {
     fn agent_shell_rows_dispatch_shell_open_rename_and_close_actions() {
         let mut app = app();
         app.workspaces[0].items = vec![WorkspaceItemView::AgentShell(agent_shell())];
-        app.toggle_focus();
+        focus_items(&mut app);
         let mut opened = None;
 
         let dispatched = app.open_selected_item(&mut |target| {
@@ -1874,7 +2178,7 @@ mod tests {
     fn rename_mode_dispatches_the_selected_shell_and_name() {
         let mut app = app();
         let mut renamed = None;
-        app.toggle_focus();
+        focus_items(&mut app);
         app.request_rename();
 
         for character in ['a', 'p', 'i'] {
@@ -1990,7 +2294,7 @@ mod tests {
     fn closing_a_shell_uses_terminal_focus() {
         let mut app = app();
         let mut closed = None;
-        app.toggle_focus();
+        focus_items(&mut app);
 
         app.request_close();
         let pending = app.pending_close.as_ref().expect("pending close");
@@ -2107,7 +2411,7 @@ mod tests {
                 command: format!("command-{index}"),
             })
         }));
-        app.toggle_focus();
+        focus_items(&mut app);
         assert_eq!(app.focus, Focus::Items);
         for _ in 0..20 {
             app.next();
@@ -2127,13 +2431,13 @@ mod tests {
 
     #[test]
     fn dashboard_renders_one_actionable_agent_shell_row_with_counts_and_details() {
-        let backend = TestBackend::new(120, 34);
+        let backend = TestBackend::new(180, 34);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = app();
         let mut agent_shell = agent_shell();
         agent_shell.shell.name = "keepname".into();
         app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell);
-        app.toggle_focus();
+        focus_items(&mut app);
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
         let text: String = terminal
@@ -2146,9 +2450,9 @@ mod tests {
 
         assert_eq!(app.workspaces[0].agent_count(), 1);
         assert_eq!(app.workspaces[0].shell_count(), 1);
-        assert!(text.contains("1 agents"));
+        assert!(text.contains("1 active agents"));
         assert!(text.contains("1 shells"));
-        assert!(text.contains("AGENTS"));
+        assert!(text.contains("ACTIVE"));
         assert!(text.contains("Items: boomux (1)"));
         assert!(text.contains("KIND"));
         assert!(text.contains("agent"));
@@ -2195,7 +2499,7 @@ mod tests {
         let mut agent_shell = hinted_agent_shell();
         agent_shell.shell.name = "keepname".into();
         app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell);
-        app.toggle_focus();
+        focus_items(&mut app);
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
         let buffer = terminal.backend().buffer();
@@ -2229,7 +2533,7 @@ mod tests {
                 command: "zeditor .".into(),
             }));
 
-        app.toggle_focus();
+        focus_items(&mut app);
         assert_eq!(app.focus, Focus::Items);
         assert!(matches!(
             app.selected_item(),
@@ -2256,6 +2560,142 @@ mod tests {
         assert!(text.contains("DIRECTORY"));
         assert!(text.contains("main"));
         assert!(!text.contains("REPOSITORY"));
+    }
+
+    #[test]
+    fn selected_durable_agent_renders_filtered_categorized_sessions() {
+        let backend = TestBackend::new(180, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+        app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell());
+        focus_items(&mut app);
+        let now = current_time_ms();
+        let mut active = session("active", "working");
+        active.label = "Current work".into();
+        active.last_at_ms = now;
+        let mut recent = session("recent", "inactive");
+        recent.label = "Recent review".into();
+        recent.state_is_current = false;
+        recent.last_at_ms = now - 2 * 60 * 60 * 1_000;
+        let mut week = session("week", "done");
+        week.label = "Finished build".into();
+        week.state_is_current = false;
+        week.last_at_ms = now - 2 * 24 * 60 * 60 * 1_000;
+        let mut older = session("older", "inactive");
+        older.label = "Dormant review".into();
+        older.state_is_current = false;
+        older.last_at_ms = now - 8 * 24 * 60 * 60 * 1_000;
+        let mut pi = session("pi", "done");
+        pi.integration = "pi".into();
+        pi.label = "Pi session must be filtered".into();
+        app.workspaces[0].sessions = vec![active, recent, week, older, pi];
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let buffer = terminal.backend().buffer();
+        let lines: Vec<String> = (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect()
+            })
+            .collect();
+        let text = lines.join("\n");
+
+        assert!(text.contains("OpenCode sessions"));
+        assert!(text.contains("ACTIVE"));
+        assert!(text.contains("LAST 24 HOURS"));
+        assert!(text.contains("LAST 7 DAYS"));
+        assert!(text.contains("OLDER"));
+        assert!(text.contains("Current work"));
+        assert!(text.contains("Recent review"));
+        assert!(text.contains("Dormant review"));
+        assert!(text.contains("Finished build"));
+        assert!(!text.contains("Pi session must be filtered"));
+        assert!(text.contains("Items: boomux (1)"));
+        assert!(lines.iter().any(|line| {
+            line.contains("Current work") && line.contains("working") && line.contains("now")
+        }));
+        assert!(lines.iter().any(|line| {
+            line.contains("agent")
+                && line.contains("external")
+                && line.contains("1 occurrence")
+                && line.contains("current")
+        }));
+        assert!(!text.contains("first "));
+        assert!(!text.contains("observed "));
+        assert!(!text.contains("tool call in progress"));
+    }
+
+    #[test]
+    fn ordinary_shell_and_launcher_hide_contextual_sessions() {
+        let backend = TestBackend::new(180, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = app();
+        app.workspaces[0].sessions.push(session("hidden", "done"));
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let shell_text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(!shell_text.contains("OpenCode sessions"));
+
+        app.workspaces[0]
+            .items
+            .push(WorkspaceItemView::Launcher(LauncherView {
+                id: "launcher".into(),
+                name: "editor".into(),
+                directory: "/tmp/boomux".into(),
+                command: "editor .".into(),
+            }));
+        focus_items(&mut app);
+        app.next();
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let launcher_text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(!launcher_text.contains("OpenCode sessions"));
+    }
+
+    #[test]
+    fn session_categories_are_non_overlapping_at_boundaries() {
+        let now = 1_000_000_000;
+        let mut view = session("category", "idle");
+        view.state_is_current = true;
+        assert_eq!(session_category(&view, now), SessionCategory::Active);
+        view.state_is_current = false;
+        view.last_at_ms = now - 86_400_000;
+        assert_eq!(session_category(&view, now), SessionCategory::Last24Hours);
+        view.last_at_ms -= 1;
+        assert_eq!(session_category(&view, now), SessionCategory::Last7Days);
+        view.last_at_ms = now - 604_800_001;
+        assert_eq!(session_category(&view, now), SessionCategory::Older);
+    }
+
+    #[test]
+    fn generic_agent_names_fall_back_to_shell_and_identity() {
+        let mut view = session("generic", "idle");
+        view.label = "opencode".into();
+        view.external_session_id = Some("ses_123456789".into());
+
+        assert_eq!(best_session_label(&view), "agent (ses_1234)");
+    }
+
+    #[test]
+    fn pi_sessions_keep_the_shell_and_identity_fallback() {
+        let mut view = session("pi-generic", "idle");
+        view.integration = "pi".into();
+        view.label = "Pi".into();
+        view.external_session_id = Some("pi_123456789".into());
+
+        assert_eq!(best_session_label(&view), "agent (pi_12345)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- project durable Boomux Agent Instances into categorized contextual session history
- enrich observed OpenCode and Pi sessions with bounded asynchronous host descriptions
- preserve the two-pane dashboard and show history only for the selected agent integration
- document future cross-harness session inspection separately

Host catalogs only describe sessions Boomux already observed; they do not import unrelated host history.

## Validation
- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check