### PR TITLE
Add projected session discovery CLI

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boomux
-description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, process supervision, and integrations. Use when asked to discover shells or agents, read terminal output, supervise an explicitly identified external session, report agent lifecycle state, install the OpenCode or Pi integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
+description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, projected sessions, process supervision, and integrations. Use when asked to discover shells, agents, or sessions, read terminal output, supervise an explicitly identified external session, report agent lifecycle state, install the OpenCode or Pi integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
 compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; agent mutation and supervision require exact shell-run context, and supervision requires a caller-supplied canonical external session ID.
 metadata:
   author: boomux
-  version: "6"
+  version: "7"
 ---
 
 # Boomux
@@ -70,6 +70,22 @@ boomux agent inspect "<exact-agent-id>" --json
 Agent lookup is by exact agent ID. Never infer an agent ID or run ID from a
 name, shell status, terminal text, a recently seen row, or an external session
 ID.
+
+Discover projected session metadata with:
+
+```console
+boomux session list --json
+boomux session list --workspace "<workspace-name-or-id>" --json
+boomux session inspect "<exact-session-id>" --json
+```
+
+Use the exact opaque session ID returned by `session list`. Never guess or
+resolve it from an external session ID, description, shell ID, or Agent ID.
+Session state is marked current only when an occurrence is active on the current
+run of a running retained shell; otherwise it is last-known. `description` is
+the latest stored Boomux Agent registration name, not a host-enriched title.
+These commands expose metadata only; transcript and tool reading is not yet
+available.
 
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1212,7 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm",
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.9"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "v5"] }
 vt100 = "=0.16.2"

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ boomux agent register <name> --integration <integration> [--external-session-id 
 boomux agent ensure <name> --integration <integration> --external-session-id <id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux agent supervise <name> --integration <integration> --external-session-id <canonical-root-id> [--shell-id <shell-id>] [--run-id <run-id>] -- <command>...
 boomux agent report <agent-id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
+boomux session list [--workspace <name-or-id>]
+boomux session inspect <session-id>
 boomux daemon status
 boomux daemon restart
 boomux daemon stop
@@ -212,6 +214,21 @@ idempotent success; a different later report is rejected. Completed instances
 remain inspectable across daemon restart. Boomux does not yet provide terminal
 heuristics, agent waits, agent reads, or agent control.
 
+`boomux session list` and `boomux session inspect` project durable Agent
+instances into workspace session history. Instances are grouped within one
+workspace and integration by external session ID; records without one remain
+isolated. A session is current only while at least one occurrence is active on
+the exact current run of a running retained shell. Otherwise its state is
+explicitly last-known. The CLI `description` is the latest stored Boomux Agent
+registration name. The dashboard may separately enrich its display title from
+bounded host catalogs; the CLI never synchronously calls those adapters.
+
+Projected session IDs are deterministic, globally unique UUIDs, but are opaque.
+Obtain an ID from `session list` and pass that exact value to `session inspect`;
+never guess one from an external session ID, description, shell, or Agent ID.
+Session projection is client-side metadata over daemon protocol 12 snapshots,
+not another persisted daemon entity.
+
 The first explicit process-adapter supervisor runs one exact argument vector:
 
 ```console
@@ -240,8 +257,8 @@ session ID, shell ID, or run ID coexists as a distinct instance.
 understands cursor rewrites and terminal soft wrapping, retains up to 2,000
 scrollback rows per shell, and never returns ANSI control sequences.
 
-Read-only integration commands, including `agent list` and `agent inspect`,
-accept `--json` and emit the stable
+Read-only integration commands, including `agent list`, `agent inspect`,
+`session list`, and `session inspect`, accept `--json` and emit the stable
 `boomux.cli/v1` envelope. Run `boomux capabilities --json` to discover supported
 commands, features, and typed error codes without starting the daemon. See
 [`docs/cli-json.md`](docs/cli-json.md) for the contract.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,8 @@ persistence across attachment disconnects, naming, grouping, and orchestration.
 
 `src/main.rs` owns the CLI, project-name suggestions, dashboard actions, shell
 name resolution, and conversion from daemon snapshots into TUI view models.
+`src/session_projection.rs` is the shared binary projection used by the CLI and
+dashboard to derive session history from one daemon snapshot.
 
 ### Protocol
 
@@ -146,6 +148,21 @@ dashboard presents an empty vector as `shell` and a non-empty vector as
 durable shell model. Command rows show the stored argv in their detail column.
 Agent presentation takes precedence when the current run has an active Agent or
 an exact `opencode` or `pi` foreground hint.
+
+Agent sessions are a client-side projection, not a sixth durable daemon
+identity. The projection groups stored Agent instances by workspace,
+integration, and external session ID, while isolating instances without an
+external ID. It retains original shell/run identity and observations even when a
+shell no longer exists. UUID v5 IDs use a fixed namespace and a versioned,
+length-prefixed encoding of workspace ID, integration, and the external-or-agent
+grouping identity. IDs are globally unique and deterministic but opaque to
+consumers. The dashboard maps retained shells to openable run views and may
+enrich labels asynchronously from bounded host catalogs; CLI descriptions remain
+the latest stored Agent registration name and do not invoke host adapters.
+
+Session list/inspect requires a negotiated protocol-12 snapshot because the
+projection depends on that complete Agent state model. It adds no protocol
+request, wire field, persistence record, event, or protocol-version bump.
 
 An active Agent instance bound to a shell's exact current run decorates that
 shell as an agent-shell row rather than adding a second item. The row retains

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -41,6 +41,8 @@ The following commands support `--json`:
 - `boomux agent register`
 - `boomux agent ensure`
 - `boomux agent report`
+- `boomux session list`
+- `boomux session inspect`
 - `boomux daemon status`
 
 JSON mutations are deliberately narrow: only `agent register`, `agent ensure`,
@@ -65,6 +67,10 @@ Command payloads are:
 - `agent.inspect`: one `agent` object selected by exact agent ID.
 - `agent.register`, `agent.ensure`, and `agent.report`: one resulting `agent`
   object. The command field identifies the specific mutation.
+- `session.list`: a globally newest-first `sessions` array, optionally limited
+  by exact workspace name or ID.
+- `session.inspect`: one projected `session` object selected only by exact
+  opaque session ID.
 - `read`: shell/run identity, observed output revision, and rendered output.
 - `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
   bounded event array.
@@ -109,6 +115,38 @@ already identifies a unique record, ensure returns the stored snapshot without
 applying the supplied name or report. This is the intended identity-recovery
 path after an integration reload. Otherwise it creates the record with the same
 shape and validation as `agent.register`.
+
+## Session Data
+
+Session summaries contain `id`, `workspace_id`, `workspace_name`, `description`,
+`integration`, `external_session_id`, `state`, `state_is_current`,
+`started_at_ms`, `last_at_ms`, and `occurrence_count`. `description` is the
+latest stored Boomux Agent registration name, never a synchronously fetched host
+title. Missing optional values are JSON `null`.
+
+Inspect includes all summary fields plus ordered `occurrences`. Each occurrence
+contains `agent_id`, the original `shell_id` even if that shell was removed,
+`retained_shell_name`, `retained_shell_cwd`, `run_id`, `started_at_ms`,
+`ended_at_ms`, `is_current`, and the full stable Agent `observation` shape.
+Retained shell fields are null after shell removal. State and authority use the
+same spellings documented for Agent observations.
+
+Projection groups Agent instances only when workspace, integration, and external
+session ID match. An Agent without an external session ID forms its own session.
+Current state is selected from occurrences that are incomplete, non-inactive,
+and bound to the current run of a running retained shell; otherwise state is the
+latest stored observation and `state_is_current` is false. List order is newest
+activity first, then workspace ID and session ID.
+
+Session IDs are deterministic globally unique UUID v5 values, but consumers must
+treat them as opaque. At a semantic level, Boomux hashes a frozen namespace and
+versioned, length-prefixed encoding of workspace ID, integration, and grouping
+identity (`external:<id>` or `instance:<agent-id>`). This algorithm is frozen to
+keep emitted IDs stable, not exposed for callers to reproduce or guess. Only an
+exact ID returned by `session.list` resolves; external IDs, descriptions, shell
+IDs, and Agent IDs never resolve through `session.inspect`. Both session commands
+require a negotiated daemon protocol of at least 12 and return
+`unsupported_version` before projection against an older daemon.
 
 `read` returns `shell_id`, `run_id`, `output_revision`, `changed`, `status`, and
 `output`. Output is a JSON string containing the same bounded plain rendered text

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -97,6 +97,8 @@ eternal process.
 3. [Complete] Add an explicit-session process supervisor that preserves exact
    argv and inherited stdio, propagates child exit, reports only `unknown`
    process start/exit evidence, and fails open when Boomux reporting fails.
+4. [Complete] Project run-scoped Agent instances into globally discoverable
+   session metadata with stable list/inspect JSON and human CLI commands.
 
 ### Near-Term Priorities
 
@@ -111,20 +113,20 @@ eternal process.
    transitions without polling human output.
 4. Add deduplicated notifications for blocked and completed transitions after
    the attention and wait semantics are established.
-5. Add explicit cross-harness session inspection so Pi can read an OpenCode
+5. Add explicit cross-harness transcript and tool inspection so Pi can read an OpenCode
    session and OpenCode can read a Pi session. Do not treat bounded rendered
    terminal output as the full session: host adapters must expose canonical
    session identity, bounded and redacted messages and tool activity, versioned
    capabilities, and an explicit access policy.
-6. Add contextual, categorized Agent Session browsing to selected agent rows in
+6. [Complete] Add contextual, categorized Agent Session browsing to selected agent rows in
    the Boomux UI. Keep inactive and completed workspace sessions visible without
    adding duplicate shell rows, grouped by active and recent time windows with
    integration, canonical identity, associated shell and run, lifecycle state,
    and timestamps. Bounded asynchronous host catalog adapters provide OpenCode
    generated titles and Pi names or first-user-message summaries; future adapters
-   may provide transcripts and tool activity. Expose the resulting session inspection
-   surface through versioned CLI/API commands so authorized agents can discover
-   and read other sessions.
+   may provide transcripts and tool activity. Session metadata discovery is
+   exposed through versioned CLI commands; transcript and tool reading remains
+   future work.
 
 ### Deferred Agent Work
 

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -5,9 +5,11 @@ use serde::Serialize;
 
 use boomux::client::RemoteError;
 use boomux::protocol::{
-    AgentAuthority, AgentInstanceSnapshot, AgentState, ErrorCode, ShellRunExitReason,
-    ShellSnapshot, ShellStatus, WorkspaceLauncherSnapshot,
+    AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot, AgentState, ErrorCode,
+    ShellRunExitReason, ShellSnapshot, ShellStatus, WorkspaceLauncherSnapshot,
 };
+
+use crate::session_projection::{SessionOccurrence, SessionProjection};
 
 pub(crate) const SCHEMA: &str = "boomux.cli/v1";
 
@@ -116,6 +118,41 @@ pub(crate) struct AgentObservationData {
     observed_at_ms: u64,
 }
 
+#[derive(Serialize)]
+pub(crate) struct SessionSummaryData {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) workspace_name: String,
+    pub(crate) description: String,
+    pub(crate) integration: String,
+    pub(crate) external_session_id: Option<String>,
+    pub(crate) state: &'static str,
+    pub(crate) state_is_current: bool,
+    pub(crate) started_at_ms: u64,
+    pub(crate) last_at_ms: u64,
+    pub(crate) occurrence_count: usize,
+}
+
+#[derive(Serialize)]
+pub(crate) struct SessionData {
+    #[serde(flatten)]
+    pub(crate) summary: SessionSummaryData,
+    pub(crate) occurrences: Vec<SessionOccurrenceData>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct SessionOccurrenceData {
+    pub(crate) agent_id: String,
+    pub(crate) shell_id: String,
+    pub(crate) retained_shell_name: Option<String>,
+    pub(crate) retained_shell_cwd: Option<String>,
+    pub(crate) run_id: String,
+    pub(crate) started_at_ms: u64,
+    pub(crate) ended_at_ms: Option<u64>,
+    pub(crate) is_current: bool,
+    pub(crate) observation: AgentObservationData,
+}
+
 pub(crate) fn print<T: Serialize>(command: &str, data: T) -> Result<(), Box<dyn Error>> {
     println!(
         "{}",
@@ -219,14 +256,58 @@ pub(crate) fn agent(agent: &AgentInstanceSnapshot, workspace_name: Option<&str>)
         external_session_id: agent.external_session_id.clone(),
         started_at_ms: agent.started_at_ms,
         ended_at_ms: agent.ended_at_ms,
-        observation: AgentObservationData {
-            revision: agent.observation.revision,
-            state: agent_state(agent.observation.state),
-            authority: agent_authority(agent.observation.authority),
-            evidence: agent.observation.evidence.clone(),
-            confidence: agent.observation.confidence,
-            observed_at_ms: agent.observation.observed_at_ms,
-        },
+        observation: agent_observation(&agent.observation),
+    }
+}
+
+pub(crate) fn session_summary(session: &SessionProjection) -> SessionSummaryData {
+    SessionSummaryData {
+        id: session.id.clone(),
+        workspace_id: session.workspace_id.clone(),
+        workspace_name: session.workspace_name.clone(),
+        description: session.description.clone(),
+        integration: session.integration.clone(),
+        external_session_id: session.external_session_id.clone(),
+        state: agent_state(session.state),
+        state_is_current: session.state_is_current,
+        started_at_ms: session.started_at_ms,
+        last_at_ms: session.last_at_ms,
+        occurrence_count: session.occurrences.len(),
+    }
+}
+
+pub(crate) fn session(session: &SessionProjection) -> SessionData {
+    SessionData {
+        summary: session_summary(session),
+        occurrences: session.occurrences.iter().map(session_occurrence).collect(),
+    }
+}
+
+fn session_occurrence(occurrence: &SessionOccurrence) -> SessionOccurrenceData {
+    SessionOccurrenceData {
+        agent_id: occurrence.agent_id.clone(),
+        shell_id: occurrence.shell_id.clone(),
+        retained_shell_name: occurrence.retained_shell_name.clone(),
+        retained_shell_cwd: occurrence
+            .retained_shell_cwd
+            .as_ref()
+            .map(|cwd| cwd.display().to_string()),
+        run_id: occurrence.run_id.clone(),
+        started_at_ms: occurrence.started_at_ms,
+        ended_at_ms: occurrence.ended_at_ms,
+        is_current: occurrence.is_current,
+        observation: agent_observation(&occurrence.observation),
+    }
+}
+
+fn agent_observation(observation: &AgentObservationSnapshot) -> AgentObservationData {
+    AgentObservationData {
+        revision: observation.revision,
+        state: agent_state(observation.state),
+        authority: agent_authority(observation.authority),
+        evidence: observation.evidence.clone(),
+        confidence: observation.confidence,
+        observed_at_ms: observation.observed_at_ms,
     }
 }
 
@@ -290,6 +371,11 @@ fn classify_error(command: &str, error: &(dyn Error + 'static)) -> &'static str 
     "internal"
 }
 
+#[cfg(test)]
+pub(crate) fn classify_for_test(command: &str, error: &(dyn Error + 'static)) -> &'static str {
+    classify_error(command, error)
+}
+
 fn protocol_error_code(code: ErrorCode) -> &'static str {
     match code {
         ErrorCode::InvalidArgument => "invalid_argument",
@@ -344,5 +430,47 @@ mod tests {
         assert_eq!(value["observation"]["state"], "working");
         assert_eq!(value["observation"]["authority"], "lifecycle_integration");
         assert_eq!(value["observation"]["confidence"], 95);
+    }
+
+    #[test]
+    fn session_json_uses_null_for_missing_optional_metadata() {
+        let data = session(&SessionProjection {
+            id: "projected-session".into(),
+            workspace_id: "w1".into(),
+            workspace_name: "project".into(),
+            integration: "plugin".into(),
+            external_session_id: None,
+            description: "Agent".into(),
+            state: AgentState::Inactive,
+            state_is_current: false,
+            started_at_ms: 10,
+            last_at_ms: 11,
+            occurrences: vec![SessionOccurrence {
+                agent_id: "a1".into(),
+                shell_id: "removed-shell".into(),
+                run_id: "r1".into(),
+                started_at_ms: 10,
+                ended_at_ms: None,
+                observation: AgentObservationSnapshot {
+                    revision: 2,
+                    state: AgentState::Inactive,
+                    authority: AgentAuthority::DaemonLifecycle,
+                    evidence: "shell exited".into(),
+                    confidence: 100,
+                    observed_at_ms: 11,
+                },
+                is_current: false,
+                retained_shell_name: None,
+                retained_shell_cwd: None,
+            }],
+        });
+
+        let value = serde_json::to_value(data).unwrap();
+        assert!(value["external_session_id"].is_null());
+        assert!(value["occurrences"][0]["retained_shell_name"].is_null());
+        assert!(value["occurrences"][0]["retained_shell_cwd"].is_null());
+        assert!(value["occurrences"][0]["ended_at_ms"].is_null());
+        assert_eq!(value["occurrences"][0]["shell_id"], "removed-shell");
+        assert_eq!(value["occurrences"][0]["observation"]["state"], "inactive");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::env;
 use std::error::Error;
 use std::fs;
@@ -26,6 +25,7 @@ mod git;
 mod host_session_titles;
 mod process_adapter;
 mod projects;
+mod session_projection;
 mod terminal;
 mod tui;
 
@@ -50,6 +50,8 @@ const JSON_COMMANDS: &[&str] = &[
     "agent.register",
     "agent.ensure",
     "agent.report",
+    "session.list",
+    "session.inspect",
     "daemon.status",
 ];
 const INTEGRATION_FEATURES: &[&str] = &[
@@ -73,6 +75,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "opencode_lifecycle_plugin",
     "pi_lifecycle_extension",
     "process_adapters",
+    "projected_agent_sessions",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -206,6 +209,11 @@ enum Commands {
     Agent {
         #[command(subcommand)]
         command: AgentCommands,
+    },
+    /// Discover projected agent sessions
+    Session {
+        #[command(subcommand)]
+        command: SessionCommands,
     },
     /// Manage the vendor-neutral Boomux Agent Skill
     Skill {
@@ -367,6 +375,18 @@ enum AgentCommands {
         #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
         confidence: u8,
     },
+}
+
+#[derive(Subcommand)]
+enum SessionCommands {
+    /// List projected agent sessions
+    List {
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+    /// Show a projected session by exact opaque ID
+    #[command(alias = "get")]
+    Inspect { session_id: String },
 }
 
 #[derive(Args)]
@@ -639,6 +659,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             command: AgentCommands::Supervise(arguments),
         }) => return supervise_agent(arguments).map(CliExit::Child),
         Some(Commands::Agent { command }) => agent_command(command, cli.json),
+        Some(Commands::Session { command }) => session_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
         }) => install_skill(force),
@@ -705,6 +726,12 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Agent {
             command: AgentCommands::Report { .. },
         }) => "agent.report",
+        Some(Commands::Session {
+            command: SessionCommands::List { .. },
+        }) => "session.list",
+        Some(Commands::Session {
+            command: SessionCommands::Inspect { .. },
+        }) => "session.inspect",
         Some(Commands::Daemon {
             command: DaemonCommands::Status,
         }) => "daemon.status",
@@ -747,6 +774,8 @@ fn supports_json(cli: &Cli) -> bool {
                 | AgentCommands::Report { .. }
         }) | Some(Commands::Daemon {
             command: DaemonCommands::Status
+        }) | Some(Commands::Session {
+            command: SessionCommands::List { .. } | SessionCommands::Inspect { .. }
         })
     )
 }
@@ -1051,126 +1080,33 @@ fn dashboard_views(
 }
 
 fn workspace_session_views(workspace: &WorkspaceSnapshot) -> Vec<tui::AgentSessionView> {
-    let shell_names: BTreeMap<_, _> = workspace
-        .shells
-        .iter()
-        .map(|shell| (shell.id.as_str(), shell.name.as_str()))
-        .collect();
-    let mut groups: BTreeMap<(String, String), Vec<&AgentInstanceSnapshot>> = BTreeMap::new();
-    for agent in &workspace.agents {
-        let key = match &agent.external_session_id {
-            Some(external_id) => (agent.integration.clone(), format!("external:{external_id}")),
-            None => (agent.integration.clone(), format!("instance:{}", agent.id)),
-        };
-        groups.entry(key).or_default().push(agent);
-    }
-
-    let mut sessions: Vec<_> = groups
+    session_projection::project_workspaces(std::slice::from_ref(workspace))
         .into_iter()
-        .map(|((integration, identity), mut agents)| {
-            agents.sort_by(|left, right| {
-                left.started_at_ms
-                    .cmp(&right.started_at_ms)
-                    .then_with(|| left.id.cmp(&right.id))
-            });
-            let first = agents[0];
-            let latest = agents
-                .iter()
-                .copied()
-                .max_by(|left, right| {
-                    left.observation
-                        .observed_at_ms
-                        .cmp(&right.observation.observed_at_ms)
-                        .then_with(|| left.started_at_ms.cmp(&right.started_at_ms))
-                        .then_with(|| left.id.cmp(&right.id))
-                })
-                .expect("session group is non-empty");
-            let active: Vec<_> = agents
-                .iter()
-                .copied()
-                .filter(|agent| {
-                    agent.workspace_id == workspace.id
-                        && agent.ended_at_ms.is_none()
-                        && !matches!(
-                            agent.observation.state,
-                            AgentState::Inactive | AgentState::Done
-                        )
-                        && workspace.shells.iter().any(|shell| {
-                            matches!(shell.status, ShellStatus::Running)
-                                && shell.id == agent.shell_id
-                                && shell.run.as_ref().is_some_and(|run| run.id == agent.run_id)
-                        })
-                })
-                .collect();
-            let (state_source, state_is_current) = if active.is_empty() {
-                (latest, false)
-            } else {
-                (
-                    active
-                        .into_iter()
-                        .min_by(|left, right| {
-                            agent_state_priority(left.observation.state)
-                                .cmp(&agent_state_priority(right.observation.state))
-                                .then_with(|| {
-                                    right
-                                        .observation
-                                        .observed_at_ms
-                                        .cmp(&left.observation.observed_at_ms)
-                                })
-                                .then_with(|| left.id.cmp(&right.id))
-                        })
-                        .expect("active session occurrence is non-empty"),
-                    true,
-                )
-            };
-            let last_at_ms = agents
-                .iter()
-                .map(|agent| {
-                    agent
-                        .ended_at_ms
-                        .unwrap_or(agent.observation.observed_at_ms)
-                        .max(agent.observation.observed_at_ms)
-                })
-                .max()
-                .unwrap_or(first.started_at_ms);
-            let runs = agents
+        .map(|session| {
+            let runs = session
+                .occurrences
                 .into_iter()
-                .map(|agent| tui::AgentSessionRunView {
-                    shell_id: workspace
-                        .shells
-                        .iter()
-                        .find(|shell| shell.id == agent.shell_id)
-                        .map(|shell| shell.id.clone()),
-                    shell_name: shell_names
-                        .get(agent.shell_id.as_str())
-                        .map(|name| (*name).into()),
-                    directory: workspace
-                        .shells
-                        .iter()
-                        .find(|shell| shell.id == agent.shell_id)
-                        .map(|shell| shell.cwd.clone()),
+                .map(|occurrence| tui::AgentSessionRunView {
+                    shell_id: occurrence
+                        .retained_shell_name
+                        .as_ref()
+                        .map(|_| occurrence.shell_id),
+                    shell_name: occurrence.retained_shell_name,
+                    directory: occurrence.retained_shell_cwd,
                 })
                 .collect();
-
             tui::AgentSessionView {
-                id: stable_session_id(&integration, &identity),
-                label: latest.name.clone(),
-                integration,
-                external_session_id: first.external_session_id.clone(),
-                state: cli_output::agent_state(state_source.observation.state).into(),
-                state_is_current,
-                last_at_ms,
+                id: session.id,
+                label: session.description,
+                integration: session.integration,
+                external_session_id: session.external_session_id,
+                state: cli_output::agent_state(session.state).into(),
+                state_is_current: session.state_is_current,
+                last_at_ms: session.last_at_ms,
                 runs,
             }
         })
-        .collect();
-    sessions.sort_by(|left, right| {
-        right
-            .last_at_ms
-            .cmp(&left.last_at_ms)
-            .then_with(|| left.id.cmp(&right.id))
-    });
-    sessions
+        .collect()
 }
 
 fn enrich_session_titles(
@@ -1204,25 +1140,6 @@ where
         if let Some(host_title) = title(&session.integration, directory, external_session_id) {
             session.label = host_title;
         }
-    }
-}
-
-fn stable_session_id(integration: &str, identity: &str) -> String {
-    format!(
-        "{}:{integration}:{}:{identity}",
-        integration.len(),
-        identity.len()
-    )
-}
-
-fn agent_state_priority(state: AgentState) -> u8 {
-    match state {
-        AgentState::Blocked => 0,
-        AgentState::Working => 1,
-        AgentState::Idle => 2,
-        AgentState::Inactive => 3,
-        AgentState::Done => 4,
-        AgentState::Unknown => 5,
     }
 }
 
@@ -1911,6 +1828,157 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
         }
     }
     Ok(())
+}
+
+fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn Error>> {
+    let client = client::connect_or_start()?;
+    validate_session_protocol(client.protocol_version()?)?;
+    let snapshot = client.snapshot()?;
+    let sessions = session_projection::project_snapshot(&snapshot);
+    match command {
+        SessionCommands::List { workspace } => {
+            let workspace_id = workspace
+                .as_deref()
+                .map(|target| resolve_workspace_target(&snapshot.workspaces, target))
+                .transpose()?
+                .map(|workspace| workspace.id.as_str());
+            let sessions = sessions
+                .iter()
+                .filter(|session| {
+                    workspace_id.is_none_or(|workspace_id| session.workspace_id == workspace_id)
+                })
+                .collect::<Vec<_>>();
+            if json {
+                let sessions = sessions
+                    .iter()
+                    .map(|session| cli_output::session_summary(session))
+                    .collect::<Vec<_>>();
+                return cli_output::print(
+                    "session.list",
+                    serde_json::json!({ "sessions": sessions }),
+                );
+            }
+            println!(
+                "WORKSPACE\tDESCRIPTION\tSESSION ID\tINTEGRATION\tSTATE\tLAST ACTIVITY MS\tOCCURRENCES"
+            );
+            for session in sessions {
+                println!(
+                    "{}\t{}\t{}\t{}\t{} ({})\t{}\t{}",
+                    session.workspace_name,
+                    session.description,
+                    session.id,
+                    session.integration,
+                    cli_output::agent_state(session.state),
+                    if session.state_is_current {
+                        "current"
+                    } else {
+                        "last-known"
+                    },
+                    session.last_at_ms,
+                    session.occurrences.len()
+                );
+            }
+        }
+        SessionCommands::Inspect { session_id } => {
+            let session = match session_projection::resolve_exact(&sessions, &session_id) {
+                Ok(session) => session,
+                Err(session_projection::ResolveError::NotFound) => {
+                    return Err(cli_output::failure(
+                        "not_found",
+                        format!("session not found: {session_id}"),
+                    ));
+                }
+                Err(session_projection::ResolveError::DuplicateId) => {
+                    return Err(cli_output::failure(
+                        "internal",
+                        format!("duplicate projected session ID: {session_id}"),
+                    ));
+                }
+            };
+            if json {
+                return cli_output::print(
+                    "session.inspect",
+                    serde_json::json!({ "session": cli_output::session(session) }),
+                );
+            }
+            print_session(session);
+        }
+    }
+    Ok(())
+}
+
+fn validate_session_protocol(negotiated: u32) -> Result<(), Box<dyn Error>> {
+    (negotiated >= 12).then_some(()).ok_or_else(|| {
+        cli_output::failure(
+            "unsupported_version",
+            format!("session projection requires daemon protocol 12; negotiated {negotiated}"),
+        )
+    })
+}
+
+fn print_session(session: &session_projection::SessionProjection) {
+    println!("ID\t{}", session.id);
+    println!("WORKSPACE ID\t{}", session.workspace_id);
+    println!("WORKSPACE\t{}", session.workspace_name);
+    println!("DESCRIPTION\t{}", session.description);
+    println!("INTEGRATION\t{}", session.integration);
+    println!(
+        "EXTERNAL SESSION ID\t{}",
+        session.external_session_id.as_deref().unwrap_or("-")
+    );
+    println!(
+        "STATE\t{} ({})",
+        cli_output::agent_state(session.state),
+        if session.state_is_current {
+            "current"
+        } else {
+            "last-known"
+        }
+    );
+    println!("STARTED AT MS\t{}", session.started_at_ms);
+    println!("LAST ACTIVITY MS\t{}", session.last_at_ms);
+    println!("OCCURRENCES\t{}", session.occurrences.len());
+    for (index, occurrence) in session.occurrences.iter().enumerate() {
+        println!();
+        println!("OCCURRENCE {}", index + 1);
+        println!("AGENT ID\t{}", occurrence.agent_id);
+        println!("SHELL ID\t{}", occurrence.shell_id);
+        println!(
+            "RETAINED SHELL NAME\t{}",
+            occurrence.retained_shell_name.as_deref().unwrap_or("-")
+        );
+        println!(
+            "RETAINED SHELL CWD\t{}",
+            occurrence
+                .retained_shell_cwd
+                .as_ref()
+                .map_or_else(|| "-".into(), |cwd| cwd.display().to_string())
+        );
+        println!("RUN ID\t{}", occurrence.run_id);
+        println!("STARTED AT MS\t{}", occurrence.started_at_ms);
+        println!(
+            "ENDED AT MS\t{}",
+            occurrence
+                .ended_at_ms
+                .map_or_else(|| "-".into(), |ended| ended.to_string())
+        );
+        println!("CURRENT\t{}", occurrence.is_current);
+        println!("OBSERVATION REVISION\t{}", occurrence.observation.revision);
+        println!(
+            "OBSERVATION STATE\t{}",
+            cli_output::agent_state(occurrence.observation.state)
+        );
+        println!(
+            "OBSERVATION AUTHORITY\t{}",
+            cli_output::agent_authority(occurrence.observation.authority)
+        );
+        println!("OBSERVATION EVIDENCE\t{}", occurrence.observation.evidence);
+        println!(
+            "OBSERVATION CONFIDENCE\t{}",
+            occurrence.observation.confidence
+        );
+        println!("OBSERVED AT MS\t{}", occurrence.observation.observed_at_ms);
+    }
 }
 
 fn supervise_agent(
@@ -3317,6 +3385,44 @@ mod tests {
     }
 
     #[test]
+    fn parses_session_discovery_commands_and_json_support() {
+        let list = Cli::try_parse_from([
+            "boomux",
+            "session",
+            "list",
+            "--workspace",
+            "project",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(command_name(&list), "session.list");
+        assert!(supports_json(&list));
+        assert!(matches!(
+            list.command,
+            Some(Commands::Session {
+                command: SessionCommands::List {
+                    workspace: Some(workspace)
+                }
+            }) if workspace == "project"
+        ));
+
+        let inspect =
+            Cli::try_parse_from(["boomux", "session", "get", "opaque", "--json"]).unwrap();
+        assert_eq!(command_name(&inspect), "session.inspect");
+        assert!(supports_json(&inspect));
+    }
+
+    #[test]
+    fn session_commands_require_protocol_twelve() {
+        let error = validate_session_protocol(11).unwrap_err();
+        assert_eq!(
+            cli_output::classify_for_test("session.list", error.as_ref()),
+            "unsupported_version"
+        );
+        assert!(validate_session_protocol(12).is_ok());
+    }
+
+    #[test]
     fn agent_context_requires_nonempty_shell_and_run_ids() {
         assert_eq!(
             resolve_agent_context(
@@ -3468,10 +3574,7 @@ mod tests {
 
         assert_eq!(views[0].sessions.len(), 1);
         let session = &views[0].sessions[0];
-        assert_eq!(
-            session.id,
-            stable_session_id("opencode", "external:external-1")
-        );
+        assert!(Uuid::parse_str(&session.id).is_ok());
         assert_eq!(session.state, "blocked");
         assert!(session.state_is_current);
         assert_eq!(session.runs.len(), 2);
@@ -3622,24 +3725,7 @@ mod tests {
 
         assert_eq!(sessions[0].id, initial_id);
         assert_eq!(sessions[0].runs.len(), 2);
-        assert_eq!(
-            sessions[0].id,
-            stable_session_id("opencode", "external:external-1")
-        );
-    }
-
-    #[test]
-    fn workspace_session_state_priority_matches_attention_order() {
-        let states = [
-            AgentState::Blocked,
-            AgentState::Working,
-            AgentState::Idle,
-            AgentState::Inactive,
-            AgentState::Done,
-            AgentState::Unknown,
-        ];
-
-        assert_eq!(states.map(agent_state_priority), [0, 1, 2, 3, 4, 5]);
+        assert!(Uuid::parse_str(&sessions[0].id).is_ok());
     }
 
     #[test]
@@ -4177,6 +4263,9 @@ mod tests {
         for command in ["agent.register", "agent.ensure", "agent.report"] {
             assert!(JSON_COMMANDS.contains(&command));
         }
+        for command in ["session.list", "session.inspect"] {
+            assert!(JSON_COMMANDS.contains(&command));
+        }
         for feature in [
             "protocol_10",
             "protocol_12",
@@ -4304,6 +4393,8 @@ mod tests {
             "boomux shell inspect",
             "boomux shell rename",
             "boomux shell close",
+            "boomux session list",
+            "boomux session inspect",
             "boomux skill install",
             "boomux opencode install",
             "boomux pi install",

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -1,0 +1,331 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use uuid::Uuid;
+
+use boomux::protocol::{
+    AgentInstanceSnapshot, AgentObservationSnapshot, AgentState, ShellStatus, Snapshot,
+    WorkspaceSnapshot,
+};
+
+// Frozen namespace for opaque boomux projected-session IDs.
+const SESSION_ID_NAMESPACE: Uuid = Uuid::from_u128(0x8ea7578e_7532_5d53_91f6_1d210f960b48);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionProjection {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) workspace_name: String,
+    pub(crate) integration: String,
+    pub(crate) external_session_id: Option<String>,
+    pub(crate) description: String,
+    pub(crate) state: AgentState,
+    pub(crate) state_is_current: bool,
+    pub(crate) started_at_ms: u64,
+    pub(crate) last_at_ms: u64,
+    pub(crate) occurrences: Vec<SessionOccurrence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionOccurrence {
+    pub(crate) agent_id: String,
+    pub(crate) shell_id: String,
+    pub(crate) run_id: String,
+    pub(crate) started_at_ms: u64,
+    pub(crate) ended_at_ms: Option<u64>,
+    pub(crate) observation: AgentObservationSnapshot,
+    pub(crate) is_current: bool,
+    pub(crate) retained_shell_name: Option<String>,
+    pub(crate) retained_shell_cwd: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolveError {
+    NotFound,
+    DuplicateId,
+}
+
+pub(crate) fn project_snapshot(snapshot: &Snapshot) -> Vec<SessionProjection> {
+    project_workspaces(&snapshot.workspaces)
+}
+
+pub(crate) fn project_workspaces(workspaces: &[WorkspaceSnapshot]) -> Vec<SessionProjection> {
+    let mut sessions = workspaces
+        .iter()
+        .flat_map(project_workspace)
+        .collect::<Vec<_>>();
+    sessions.sort_by(|left, right| {
+        right
+            .last_at_ms
+            .cmp(&left.last_at_ms)
+            .then_with(|| left.workspace_id.cmp(&right.workspace_id))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    sessions
+}
+
+pub(crate) fn resolve_exact<'a>(
+    sessions: &'a [SessionProjection],
+    id: &str,
+) -> Result<&'a SessionProjection, ResolveError> {
+    let mut matches = sessions.iter().filter(|session| session.id == id);
+    let session = matches.next().ok_or(ResolveError::NotFound)?;
+    if matches.next().is_some() {
+        return Err(ResolveError::DuplicateId);
+    }
+    Ok(session)
+}
+
+fn project_workspace(workspace: &WorkspaceSnapshot) -> Vec<SessionProjection> {
+    let shells: BTreeMap<_, _> = workspace
+        .shells
+        .iter()
+        .map(|shell| (shell.id.as_str(), shell))
+        .collect();
+    let mut groups: BTreeMap<(String, String), Vec<&AgentInstanceSnapshot>> = BTreeMap::new();
+    for agent in &workspace.agents {
+        let identity = match &agent.external_session_id {
+            Some(external_id) => format!("external:{external_id}"),
+            None => format!("instance:{}", agent.id),
+        };
+        groups
+            .entry((agent.integration.clone(), identity))
+            .or_default()
+            .push(agent);
+    }
+
+    groups
+        .into_iter()
+        .map(|((integration, identity), mut agents)| {
+            agents.sort_by(|left, right| {
+                left.started_at_ms
+                    .cmp(&right.started_at_ms)
+                    .then_with(|| left.id.cmp(&right.id))
+            });
+            let first = agents[0];
+            let latest = agents
+                .iter()
+                .copied()
+                .max_by(|left, right| {
+                    left.observation
+                        .observed_at_ms
+                        .cmp(&right.observation.observed_at_ms)
+                        .then_with(|| left.started_at_ms.cmp(&right.started_at_ms))
+                        .then_with(|| left.id.cmp(&right.id))
+                })
+                .expect("session group is non-empty");
+            let active = agents
+                .iter()
+                .copied()
+                .filter(|agent| occurrence_is_current(workspace, agent));
+            let (state_source, state_is_current) = active
+                .min_by(|left, right| {
+                    state_priority(left.observation.state)
+                        .cmp(&state_priority(right.observation.state))
+                        .then_with(|| {
+                            right
+                                .observation
+                                .observed_at_ms
+                                .cmp(&left.observation.observed_at_ms)
+                        })
+                        .then_with(|| left.id.cmp(&right.id))
+                })
+                .map_or((latest, false), |active| (active, true));
+            let last_at_ms = agents
+                .iter()
+                .map(|agent| {
+                    agent
+                        .ended_at_ms
+                        .unwrap_or(agent.observation.observed_at_ms)
+                        .max(agent.observation.observed_at_ms)
+                })
+                .max()
+                .unwrap_or(first.started_at_ms);
+            let occurrences = agents
+                .into_iter()
+                .map(|agent| {
+                    let retained_shell = shells.get(agent.shell_id.as_str()).copied();
+                    SessionOccurrence {
+                        agent_id: agent.id.clone(),
+                        shell_id: agent.shell_id.clone(),
+                        run_id: agent.run_id.clone(),
+                        started_at_ms: agent.started_at_ms,
+                        ended_at_ms: agent.ended_at_ms,
+                        observation: agent.observation.clone(),
+                        is_current: occurrence_is_current(workspace, agent),
+                        retained_shell_name: retained_shell.map(|shell| shell.name.clone()),
+                        retained_shell_cwd: retained_shell.map(|shell| shell.cwd.clone()),
+                    }
+                })
+                .collect();
+
+            SessionProjection {
+                id: stable_session_id(&workspace.id, &integration, &identity),
+                workspace_id: workspace.id.clone(),
+                workspace_name: workspace.name.clone(),
+                integration,
+                external_session_id: first.external_session_id.clone(),
+                description: latest.name.clone(),
+                state: state_source.observation.state,
+                state_is_current,
+                started_at_ms: first.started_at_ms,
+                last_at_ms,
+                occurrences,
+            }
+        })
+        .collect()
+}
+
+fn occurrence_is_current(workspace: &WorkspaceSnapshot, agent: &AgentInstanceSnapshot) -> bool {
+    agent.workspace_id == workspace.id
+        && agent.ended_at_ms.is_none()
+        && !matches!(
+            agent.observation.state,
+            AgentState::Inactive | AgentState::Done
+        )
+        && workspace.shells.iter().any(|shell| {
+            matches!(shell.status, ShellStatus::Running)
+                && shell.id == agent.shell_id
+                && shell.run.as_ref().is_some_and(|run| run.id == agent.run_id)
+        })
+}
+
+fn stable_session_id(workspace_id: &str, integration: &str, identity: &str) -> String {
+    // UUID v5 hashes a version tag followed by u64-length-prefixed UTF-8 fields.
+    let mut name = b"boomux.session/v1".to_vec();
+    for value in [workspace_id, integration, identity] {
+        name.extend_from_slice(&(value.len() as u64).to_be_bytes());
+        name.extend_from_slice(value.as_bytes());
+    }
+    Uuid::new_v5(&SESSION_ID_NAMESPACE, &name).to_string()
+}
+
+fn state_priority(state: AgentState) -> u8 {
+    match state {
+        AgentState::Blocked => 0,
+        AgentState::Working => 1,
+        AgentState::Idle => 2,
+        AgentState::Inactive => 3,
+        AgentState::Done => 4,
+        AgentState::Unknown => 5,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use boomux::protocol::{AgentAuthority, ShellRunSnapshot};
+
+    fn workspace(id: &str, agent_ids: &[&str]) -> WorkspaceSnapshot {
+        let shell = boomux::protocol::ShellSnapshot {
+            id: "shell".into(),
+            workspace_id: id.into(),
+            name: "agent".into(),
+            cwd: "/tmp/project".into(),
+            command: Vec::new(),
+            status: ShellStatus::Running,
+            run: Some(ShellRunSnapshot {
+                id: "run".into(),
+                generation: 1,
+                started_at_ms: 1,
+                ended_at_ms: None,
+                exit_reason: None,
+                output_revision: 0,
+                environment_has_run_id: true,
+            }),
+            foreground_process: None,
+        };
+        WorkspaceSnapshot {
+            id: id.into(),
+            name: format!("workspace-{id}"),
+            shells: vec![shell],
+            launchers: Vec::new(),
+            agents: agent_ids
+                .iter()
+                .enumerate()
+                .map(|(index, agent_id)| AgentInstanceSnapshot {
+                    id: (*agent_id).into(),
+                    workspace_id: id.into(),
+                    shell_id: "shell".into(),
+                    run_id: "run".into(),
+                    name: format!("Agent {index}"),
+                    integration: "opencode".into(),
+                    external_session_id: Some("external".into()),
+                    started_at_ms: 10 + index as u64,
+                    ended_at_ms: None,
+                    observation: AgentObservationSnapshot {
+                        revision: 1,
+                        state: AgentState::Working,
+                        authority: AgentAuthority::LifecycleIntegration,
+                        evidence: "working".into(),
+                        confidence: 100,
+                        observed_at_ms: 20 + index as u64,
+                    },
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn groups_occurrences_and_resolves_list_id_exactly() {
+        let sessions = project_workspaces(&[workspace("w1", &["a1", "a2"])]);
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].occurrences.len(), 2);
+        assert_eq!(resolve_exact(&sessions, &sessions[0].id), Ok(&sessions[0]));
+        assert_eq!(
+            resolve_exact(&sessions, "external"),
+            Err(ResolveError::NotFound)
+        );
+    }
+
+    #[test]
+    fn ids_are_globally_unique_across_workspaces() {
+        let sessions = project_workspaces(&[workspace("w1", &["a1"]), workspace("w2", &["a2"])]);
+        assert_eq!(sessions.len(), 2);
+        assert_ne!(sessions[0].id, sessions[1].id);
+        assert_eq!(sessions[0].id, "20633f73-82d0-5834-8a27-f11f4c68980d");
+    }
+
+    #[test]
+    fn global_order_is_newest_then_workspace_and_session_id() {
+        let mut older = workspace("w3", &["a2"]);
+        older.agents[0].observation.observed_at_ms = 10;
+        let mut tied_first = workspace("w1", &["a1"]);
+        tied_first.agents[0].observation.observed_at_ms = 30;
+        let mut tied_second = workspace("w2", &["a3"]);
+        tied_second.agents[0].observation.observed_at_ms = 30;
+
+        let sessions = project_workspaces(&[older, tied_second, tied_first]);
+        assert_eq!(
+            sessions
+                .iter()
+                .map(|session| session.workspace_id.as_str())
+                .collect::<Vec<_>>(),
+            ["w1", "w2", "w3"]
+        );
+        assert_eq!(sessions[2].last_at_ms, 10);
+    }
+
+    #[test]
+    fn duplicate_ids_are_rejected_defensively() {
+        let mut sessions = project_workspaces(&[workspace("w1", &["a1"])]);
+        sessions.push(sessions[0].clone());
+        assert_eq!(
+            resolve_exact(&sessions, &sessions[0].id),
+            Err(ResolveError::DuplicateId)
+        );
+    }
+
+    #[test]
+    fn state_priority_matches_dashboard_attention_order() {
+        let states = [
+            AgentState::Blocked,
+            AgentState::Working,
+            AgentState::Idle,
+            AgentState::Inactive,
+            AgentState::Done,
+            AgentState::Unknown,
+        ];
+        assert_eq!(states.map(state_priority), [0, 1, 2, 3, 4, 5]);
+    }
+}

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1382,6 +1382,62 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert_eq!(list["command"], "agent.list");
     assert_eq!(list["data"]["agents"][0]["id"], agent_id);
     assert_eq!(list["data"]["agents"][0]["observation"]["revision"], 1);
+    let session_list = daemon
+        .command()
+        .args(["session", "list", "--workspace", &workspace.id, "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        session_list.status.success(),
+        "{}",
+        String::from_utf8_lossy(&session_list.stderr)
+    );
+    let session_list: serde_json::Value = serde_json::from_slice(&session_list.stdout).unwrap();
+    assert_eq!(session_list["command"], "session.list");
+    let sessions = session_list["data"]["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 2);
+    assert!(
+        sessions
+            .iter()
+            .all(|session| session["workspace_id"] == workspace.id)
+    );
+    let projected = sessions
+        .iter()
+        .find(|session| session["external_session_id"] == "session-1")
+        .unwrap();
+    let session_id = projected["id"].as_str().unwrap();
+    assert_eq!(projected["description"], "runtime-agent");
+    assert_eq!(projected["occurrence_count"], 1);
+
+    let session_inspect = daemon
+        .command()
+        .args(["session", "inspect", session_id, "--json"])
+        .output()
+        .unwrap();
+    assert!(session_inspect.status.success());
+    let session_inspect: serde_json::Value =
+        serde_json::from_slice(&session_inspect.stdout).unwrap();
+    assert_eq!(session_inspect["command"], "session.inspect");
+    assert_eq!(session_inspect["data"]["session"]["id"], session_id);
+    assert_eq!(
+        session_inspect["data"]["session"]["occurrences"][0]["agent_id"],
+        agent_id
+    );
+    assert_eq!(
+        session_inspect["data"]["session"]["occurrences"][0]["shell_id"],
+        shell_id
+    );
+
+    let missing_session = daemon
+        .command()
+        .args(["session", "inspect", "session-1", "--json"])
+        .output()
+        .unwrap();
+    assert!(!missing_session.status.success());
+    let missing_session: serde_json::Value =
+        serde_json::from_slice(&missing_session.stderr).unwrap();
+    assert_eq!(missing_session["command"], "session.inspect");
+    assert_eq!(missing_session["error"]["code"], "not_found");
     let inspect = daemon
         .command()
         .args(["agent", "inspect", &adapter_id])


### PR DESCRIPTION
## Summary
- extract Agent-instance session projection into one shared TUI/CLI implementation
- add protocol-12-gated session list and exact session inspect commands with stable boomux.cli/v1 JSON
- preserve full run-scoped occurrence identity and deterministic opaque UUID v5 session IDs
- advertise projected session discovery through capabilities and the bundled Agent Skill
- document projection semantics, payloads, identity rules, and remaining transcript/tool-reading work

## Validation
- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- installed session list/filter/inspect and capabilities verification against the running daemon