### PR TITLE
Add canonical session transcript reads

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -77,6 +77,7 @@ Discover projected session metadata with:
 boomux session list --json
 boomux session list --workspace "<workspace-name-or-id>" --json
 boomux session inspect "<exact-session-id>" --json
+boomux session read "<exact-session-id>" --limit 100 --max-bytes 1048576 --json
 ```
 
 Use the exact opaque session ID returned by `session list`. Never guess or
@@ -84,8 +85,12 @@ resolve it from an external session ID, description, shell ID, or Agent ID.
 Session state is marked current only when an occurrence is active on the current
 run of a running retained shell; otherwise it is last-known. `description` is
 the latest stored Boomux Agent registration name, not a host-enriched title.
-These commands expose metadata only; transcript and tool reading is not yet
-available.
+`session read` returns the newest bounded suffix of canonical OpenCode or Pi
+messages, reasoning, and tool activity, not terminal scrollback. Pi results
+follow its active branch. Inspect `truncated`, `truncated_by`, and per-entry
+`truncated` before deciding whether to request larger bounds. Boomux does not
+redact host content, so use it only when the user's request authorizes reading
+that exact session.
 
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.
@@ -311,7 +316,7 @@ replace different existing content. The installer removes an untouched legacy
 
 ## Install The OpenCode Integration
 
-The bundled plugin is validated against `opencode-ai` `1.18.14`; this is a
+The bundled plugin is validated against `opencode-ai` `1.18.15`; this is a
 compatibility test point rather than a runtime pin.
 
 ```console
@@ -337,7 +342,7 @@ completion. Unmanaged or unavailable Boomux is fail-open. If Boomux returns
 ## Install The Pi Integration
 
 The bundled extension is validated against
-`@earendil-works/pi-coding-agent` `0.83.0`; this is a compatibility test point
+`@earendil-works/pi-coding-agent` `0.84.1`; this is a compatibility test point
 rather than a runtime pin.
 
 ```console

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ boomux agent supervise <name> --integration <integration> --external-session-id 
 boomux agent report <agent-id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux session list [--workspace <name-or-id>]
 boomux session inspect <session-id>
+boomux session read <session-id> [--limit <entries>] [--max-bytes <bytes>]
 boomux daemon status
 boomux daemon restart
 boomux daemon stop
@@ -224,10 +225,22 @@ registration name. The dashboard may separately enrich its display title from
 bounded host catalogs; the CLI never synchronously calls those adapters.
 
 Projected session IDs are deterministic, globally unique UUIDs, but are opaque.
-Obtain an ID from `session list` and pass that exact value to `session inspect`;
+Obtain an ID from `session list` and pass that exact value to `session inspect`
+or `session read`;
 never guess one from an external session ID, description, shell, or Agent ID.
 Session projection is client-side metadata over daemon protocol 12 snapshots,
 not another persisted daemon entity.
+
+`session read` loads canonical host data for OpenCode and Pi, never terminal
+scrollback. It returns the newest bounded suffix of messages, reasoning, and tool
+activity in chronological order. Pi reads only the current leaf branch and
+combines tool calls with their results. Boomux does not redact host content;
+`--limit` and `--max-bytes` explicitly bound the response and report truncation.
+Transcript hosts are registered behind one adapter contract, so future harnesses
+such as Claude Code or Codex can supply canonical lookup and normalization while
+reusing exact Boomux identity, bounds, errors, and output semantics. Discover the
+currently bundled adapters through `session_transcript_integrations` in
+`boomux capabilities --json`.
 
 The first explicit process-adapter supervisor runs one exact argument vector:
 
@@ -258,7 +271,7 @@ understands cursor rewrites and terminal soft wrapping, retains up to 2,000
 scrollback rows per shell, and never returns ANSI control sequences.
 
 Read-only integration commands, including `agent list`, `agent inspect`,
-`session list`, and `session inspect`, accept `--json` and emit the stable
+`session list`, `session inspect`, and `session read` accept `--json` and emit the stable
 `boomux.cli/v1` envelope. Run `boomux capabilities --json` to discover supported
 commands, features, and typed error codes without starting the daemon. See
 [`docs/cli-json.md`](docs/cli-json.md) for the contract.
@@ -343,8 +356,8 @@ Boomux currently validates its bundled integrations against these host releases:
 
 | Integration | Package | Validated version |
 | --- | --- | --- |
-| OpenCode | `opencode-ai` | `1.18.14` |
-| Pi | `@earendil-works/pi-coding-agent` | `0.83.0` |
+| OpenCode | `opencode-ai` | `1.18.15` |
+| Pi | `@earendil-works/pi-coding-agent` | `0.84.1` |
 
 These versions are compatibility test points, not runtime pins. Older or newer
 releases may work when their plugin APIs remain compatible, but are not claimed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -278,7 +278,7 @@ the stronger lifecycle evidence described below.
 
 ### OpenCode Lifecycle Plugin
 
-The bundled plugin is validated against `opencode-ai` `1.18.14`. This is a
+The bundled plugin is validated against `opencode-ai` `1.18.15`. This is a
 compatibility test point rather than a runtime version pin.
 
 `integrations/opencode/boomux.js` is a config-time OpenCode plugin installed by
@@ -310,7 +310,7 @@ Boomux or ancestry failures are rate-limited and fail open so OpenCode continues
 ### Pi Lifecycle Extension
 
 The bundled extension is validated against
-`@earendil-works/pi-coding-agent` `0.83.0`. This is a compatibility test point
+`@earendil-works/pi-coding-agent` `0.84.1`. This is a compatibility test point
 rather than a runtime version pin.
 
 `integrations/pi/boomux.js` is a global Pi extension installed by
@@ -333,6 +333,33 @@ agent ID and ensure the new canonical session identity. Reports are serialized,
 use exact argument vectors and bounded JSON output, and fail open with
 rate-limited diagnostics. Session shutdown makes one bounded retry so a
 transient reporting failure is less likely to leave the old session active.
+
+### Canonical Session Transcripts
+
+`boomux session read` resolves only an exact projected session ID, then uses the
+canonical external ID and a retained occurrence working directory to invoke the
+matching host adapter. OpenCode is read through `opencode export`; Pi is read
+from its project-scoped JSONL file with no-follow regular-file checks. Pi's
+append-only tree is reduced to the latest leaf's parent chain so abandoned
+branches are not presented as the active transcript.
+
+Adapters normalize host text, reasoning, tool calls, inputs, results, status,
+source identity, and timestamps. Boomux does not redact this content because
+the harness is the content trust boundary. Reads remain explicit and bounded:
+the CLI returns a newest chronological suffix with entry and UTF-8 content-byte
+limits, marks partial entries and truncation causes, caps canonical source input
+at 16 MiB, and times out OpenCode export. Unsupported hosts and unavailable,
+invalid, or oversized sources return stable typed errors.
+
+The transcript layer is an adapter registry keyed by the Agent integration
+name. An adapter receives only the canonical external session ID and retained
+working directory and returns host-neutral transcript entries. Exact projected
+session resolution, access preconditions, newest-suffix selection, byte and
+entry bounds, truncation, typed errors, human output, and `boomux.cli/v1` JSON
+remain shared. Adding Claude Code, Codex, or another harness therefore requires
+one canonical source adapter and one registry entry, not another CLI path.
+`boomux capabilities --json` derives `session_transcript_integrations` from this
+registry so integrations can discover support without hard-coded host lists.
 
 Protocol 12 adds `inactive`. Protocol-9 through protocol-11 clients receive that
 observation as `unknown`, while protocol-12 clients can distinguish a resumable

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -23,6 +23,8 @@ the CLI version, daemon protocol version, supported JSON schemas and commands,
 stable error codes, feature names, and the package and validated version for
 each bundled integration host under `integration_hosts`. Validated versions are
 compatibility test points, not runtime pins or minimum-version guarantees.
+`session_transcript_integrations` lists the integration keys with registered
+canonical transcript adapters.
 
 The following commands support `--json`:
 
@@ -43,6 +45,7 @@ The following commands support `--json`:
 - `boomux agent report`
 - `boomux session list`
 - `boomux session inspect`
+- `boomux session read`
 - `boomux daemon status`
 
 JSON mutations are deliberately narrow: only `agent register`, `agent ensure`,
@@ -70,6 +73,8 @@ Command payloads are:
 - `session.list`: a globally newest-first `sessions` array, optionally limited
   by exact workspace name or ID.
 - `session.inspect`: one projected `session` object selected only by exact
+  opaque session ID.
+- `session.read`: one bounded canonical `transcript` selected only by exact
   opaque session ID.
 - `read`: shell/run identity, observed output revision, and rendered output.
 - `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
@@ -144,9 +149,32 @@ versioned, length-prefixed encoding of workspace ID, integration, and grouping
 identity (`external:<id>` or `instance:<agent-id>`). This algorithm is frozen to
 keep emitted IDs stable, not exposed for callers to reproduce or guess. Only an
 exact ID returned by `session.list` resolves; external IDs, descriptions, shell
-IDs, and Agent IDs never resolve through `session.inspect`. Both session commands
-require a negotiated daemon protocol of at least 12 and return
+IDs, and Agent IDs never resolve through `session.inspect` or `session.read`.
+All session commands require a negotiated daemon protocol of at least 12 and return
 `unsupported_version` before projection against an older daemon.
+
+`session.read` supports OpenCode and Pi sessions with a canonical external
+session ID and a retained working directory. It reads OpenCode's export and Pi's
+project JSONL rather than terminal scrollback. Pi projection follows the current
+leaf parent chain and excludes abandoned branches. Tool-result messages are
+combined with their tool calls.
+
+The transcript contains `session_id`, `integration`, `external_session_id`,
+`entries`, `returned_entries`, `total_entries`, `content_bytes`, `truncated`, and
+`truncated_by`. Entries are a newest suffix returned in chronological order.
+Their `type` is `message`, `reasoning`, or `tool`; common fields are `source_id`,
+`timestamp_ms`, and `truncated`. Message and reasoning entries add `role` and
+`text`. Tool entries add `tool_name`, `tool_call_id`, `status`, `input`, and
+`output`; input is compact host JSON encoded as a string. Inapplicable fields are
+omitted except `source_id` and `timestamp_ms`, which are JSON `null` when the host
+does not provide them.
+
+`--limit` defaults to 100 and accepts 1 through 1,000 entries. `--max-bytes`
+defaults to 1 MiB and accepts 1 byte through 4 MiB. `content_bytes` counts UTF-8
+bytes in returned text, input, and output fields. `truncated_by` contains `limit`
+and/or `max_bytes`; a partially clipped entry also has `truncated: true`. Boomux
+does not redact canonical host content. Raw host source inspection is separately
+capped at 16 MiB.
 
 `read` returns `shell_id`, `run_id`, `output_revision`, `changed`, `status`, and
 `output`. Output is a JSON string containing the same bounded plain rendered text

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,20 +113,23 @@ eternal process.
    transitions without polling human output.
 4. Add deduplicated notifications for blocked and completed transitions after
    the attention and wait semantics are established.
-5. Add explicit cross-harness transcript and tool inspection so Pi can read an OpenCode
+5. [Complete] Add explicit cross-harness transcript and tool inspection so Pi can read an OpenCode
    session and OpenCode can read a Pi session. Do not treat bounded rendered
    terminal output as the full session: host adapters must expose canonical
-   session identity, bounded and redacted messages and tool activity, versioned
-   capabilities, and an explicit access policy.
+   session identity, bounded messages and tool activity, versioned
+   capabilities, and an explicit access policy. Boomux trusts the harness as the
+   content boundary and does not apply another redaction pass. Host-specific
+   canonical lookup and normalization live behind a shared adapter registry so
+   future Claude Code, Codex, and other harness support reuses the same identity,
+   bounds, errors, and output contract.
 6. [Complete] Add contextual, categorized Agent Session browsing to selected agent rows in
    the Boomux UI. Keep inactive and completed workspace sessions visible without
    adding duplicate shell rows, grouped by active and recent time windows with
    integration, canonical identity, associated shell and run, lifecycle state,
    and timestamps. Bounded asynchronous host catalog adapters provide OpenCode
    generated titles and Pi names or first-user-message summaries; future adapters
-   may provide transcripts and tool activity. Session metadata discovery is
-   exposed through versioned CLI commands; transcript and tool reading remains
-   future work.
+    also provide canonical transcripts and tool activity through bounded,
+    versioned CLI output.
 
 ### Deferred Agent Work
 

--- a/src/host_session_titles.rs
+++ b/src/host_session_titles.rs
@@ -16,6 +16,8 @@ const COMMAND_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_OPENCODE_STDOUT_BYTES: u64 = 1024 * 1024;
 const MAX_PI_FILE_BYTES: u64 = 256 * 1024;
 const MAX_PI_CATALOG_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_PI_TRANSCRIPT_SCAN_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_PI_TRANSCRIPT_SCAN_FILES: usize = 4096;
 const MAX_SESSIONS: usize = 100;
 const MAX_TITLE_CHARS: usize = 160;
 
@@ -217,14 +219,14 @@ fn parse_opencode_titles(output: &[u8]) -> Option<Titles> {
 }
 
 #[derive(Clone, Debug, Default)]
-struct PiEnvironment {
+pub(crate) struct PiEnvironment {
     coding_agent_dir: Option<OsString>,
     session_dir: Option<OsString>,
     home: Option<OsString>,
 }
 
 impl PiEnvironment {
-    fn from_process() -> Self {
+    pub(crate) fn from_process() -> Self {
         Self {
             coding_agent_dir: std::env::var_os("PI_CODING_AGENT_DIR"),
             session_dir: std::env::var_os("PI_CODING_AGENT_SESSION_DIR"),
@@ -256,7 +258,10 @@ fn inspect_pi(directory: &Path, environment: &PiEnvironment) -> Option<Titles> {
     Some(titles)
 }
 
-fn pi_session_directory(directory: &Path, environment: &PiEnvironment) -> Option<PathBuf> {
+pub(crate) fn pi_session_directory(
+    directory: &Path,
+    environment: &PiEnvironment,
+) -> Option<PathBuf> {
     if let Some(session_directory) = nonempty(environment.session_dir.as_ref()) {
         return expand_home(session_directory, environment.home.as_ref());
     }
@@ -299,7 +304,7 @@ fn pi_encoded_session_directory(directory: &Path) -> String {
     format!("--{encoded}--")
 }
 
-fn normalize_absolute(path: &Path) -> Option<PathBuf> {
+pub(crate) fn normalize_absolute(path: &Path) -> Option<PathBuf> {
     if !path.is_absolute() {
         return None;
     }
@@ -342,6 +347,89 @@ fn pi_catalog_files(directory: &Path) -> Option<Vec<PathBuf>> {
     });
     files.truncate(MAX_SESSIONS);
     Some(files.into_iter().map(|(path, _)| path).collect())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PiSessionFileError {
+    Unavailable,
+    ScanLimit,
+}
+
+pub(crate) fn pi_session_file(
+    directory: &Path,
+    external_session_id: &str,
+    environment: &PiEnvironment,
+) -> Result<PathBuf, PiSessionFileError> {
+    let normalized_directory =
+        normalize_absolute(directory).ok_or(PiSessionFileError::Unavailable)?;
+    let catalog_directory = pi_session_directory(&normalized_directory, environment)
+        .ok_or(PiSessionFileError::Unavailable)?;
+    let mut remaining_bytes = MAX_PI_TRANSCRIPT_SCAN_BYTES;
+    let mut remaining_files = MAX_PI_TRANSCRIPT_SCAN_FILES;
+    for filename_match in [true, false] {
+        let entries =
+            fs::read_dir(&catalog_directory).map_err(|_| PiSessionFileError::Unavailable)?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if pi_session_filename_matches(&path, external_session_id) != filename_match
+                || path
+                    .extension()
+                    .is_none_or(|extension| extension != "jsonl")
+                || !fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_file())
+            {
+                continue;
+            }
+            if remaining_bytes == 0 || remaining_files == 0 {
+                return Err(PiSessionFileError::ScanLimit);
+            }
+            remaining_files -= 1;
+            let Some(prefix) =
+                read_regular_file_prefix(&path, remaining_bytes.min(MAX_PI_FILE_BYTES))
+            else {
+                continue;
+            };
+            remaining_bytes = remaining_bytes.saturating_sub(prefix.scanned_bytes);
+            if pi_header_matches(&prefix.bytes, external_session_id, &normalized_directory) {
+                return Ok(path);
+            }
+        }
+    }
+    Err(PiSessionFileError::Unavailable)
+}
+
+fn pi_header_matches(output: &[u8], external_session_id: &str, directory: &Path) -> bool {
+    let Some(header) = output
+        .split(|byte| *byte == b'\n')
+        .filter_map(|line| serde_json::from_slice::<serde_json::Value>(line).ok())
+        .next()
+    else {
+        return false;
+    };
+    header.get("type").and_then(serde_json::Value::as_str) == Some("session")
+        && header.get("id").and_then(serde_json::Value::as_str) == Some(external_session_id)
+        && header
+            .get("cwd")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|cwd| normalize_absolute(Path::new(cwd)))
+            .is_some_and(|cwd| cwd == directory)
+}
+
+fn pi_session_filename_matches(path: &Path, external_session_id: &str) -> bool {
+    if external_session_id.is_empty()
+        || path
+            .extension()
+            .is_none_or(|extension| extension != "jsonl")
+    {
+        return false;
+    }
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| {
+            stem == external_session_id
+                || stem
+                    .strip_suffix(external_session_id)
+                    .is_some_and(|prefix| prefix.ends_with('_'))
+        })
 }
 
 struct FilePrefix {
@@ -771,6 +859,40 @@ mod tests {
         assert_eq!(titles.len(), MAX_SESSIONS);
         assert!(titles.contains_key("pi-100"));
         assert!(!titles.contains_key("pi-000"));
+    }
+
+    #[test]
+    fn exact_pi_file_lookup_is_not_limited_to_the_newest_catalog_entries() {
+        let test = TestDirectory::new();
+        let exact = test.write(
+            "2026-01-01_external.jsonl",
+            &format!("{}\n", pi_header("external", "/repo")),
+        );
+        for index in 0..MAX_SESSIONS + 1 {
+            test.write(
+                &format!("2026-02-{index:03}_other-{index}.jsonl"),
+                &format!("{}\n", pi_header(&format!("other-{index}"), "/repo")),
+            );
+        }
+
+        assert_eq!(
+            pi_session_file(Path::new("/repo"), "external", &test.environment()),
+            Ok(exact)
+        );
+    }
+
+    #[test]
+    fn exact_pi_file_lookup_accepts_noncanonical_filenames_by_header_identity() {
+        let test = TestDirectory::new();
+        let exact = test.write(
+            "custom.jsonl",
+            &format!("{}\n", pi_header("external", "/repo")),
+        );
+
+        assert_eq!(
+            pi_session_file(Path::new("/repo"), "external", &test.environment()),
+            Ok(exact)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,14 +26,15 @@ mod host_session_titles;
 mod process_adapter;
 mod projects;
 mod session_projection;
+mod session_transcript;
 mod terminal;
 mod tui;
 
 const BOOMUX_SKILL: &str = include_str!("../.agents/skills/boomux/SKILL.md");
 const BOOMUX_OPENCODE_PLUGIN: &str = include_str!("../integrations/opencode/boomux.js");
 const BOOMUX_PI_EXTENSION: &str = include_str!("../integrations/pi/boomux.js");
-const VALIDATED_OPENCODE_VERSION: &str = "1.18.14";
-const VALIDATED_PI_VERSION: &str = "0.83.0";
+const VALIDATED_OPENCODE_VERSION: &str = "1.18.15";
+const VALIDATED_PI_VERSION: &str = "0.84.1";
 const JSON_COMMANDS: &[&str] = &[
     "capabilities",
     "list",
@@ -52,6 +53,7 @@ const JSON_COMMANDS: &[&str] = &[
     "agent.report",
     "session.list",
     "session.inspect",
+    "session.read",
     "daemon.status",
 ];
 const INTEGRATION_FEATURES: &[&str] = &[
@@ -76,6 +78,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "pi_lifecycle_extension",
     "process_adapters",
     "projected_agent_sessions",
+    "canonical_session_transcripts",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -387,6 +390,14 @@ enum SessionCommands {
     /// Show a projected session by exact opaque ID
     #[command(alias = "get")]
     Inspect { session_id: String },
+    /// Read canonical messages and tool activity by exact opaque ID
+    Read {
+        session_id: String,
+        #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u16).range(1..=1000))]
+        limit: u16,
+        #[arg(long, default_value_t = 1024 * 1024, value_parser = clap::value_parser!(u32).range(1..=4 * 1024 * 1024))]
+        max_bytes: u32,
+    },
 }
 
 #[derive(Args)]
@@ -732,6 +743,9 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Session {
             command: SessionCommands::Inspect { .. },
         }) => "session.inspect",
+        Some(Commands::Session {
+            command: SessionCommands::Read { .. },
+        }) => "session.read",
         Some(Commands::Daemon {
             command: DaemonCommands::Status,
         }) => "daemon.status",
@@ -775,7 +789,9 @@ fn supports_json(cli: &Cli) -> bool {
         }) | Some(Commands::Daemon {
             command: DaemonCommands::Status
         }) | Some(Commands::Session {
-            command: SessionCommands::List { .. } | SessionCommands::Inspect { .. }
+            command: SessionCommands::List { .. }
+                | SessionCommands::Inspect { .. }
+                | SessionCommands::Read { .. }
         })
     )
 }
@@ -1319,6 +1335,10 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "revision_ahead",
         "context_required",
         "ambiguous_target",
+        "unsupported_integration",
+        "session_source_unavailable",
+        "session_source_invalid",
+        "session_source_too_large",
         "internal",
         "unknown",
     ];
@@ -1331,6 +1351,7 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
                 "json_schemas": [cli_output::SCHEMA],
                 "json_commands": JSON_COMMANDS,
                 "features": INTEGRATION_FEATURES,
+                "session_transcript_integrations": session_transcript::supported_integrations(),
                 "integration_hosts": {
                     "opencode": {
                         "package": "opencode-ai",
@@ -1350,6 +1371,10 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
     println!("JSON SCHEMAS\t{}", cli_output::SCHEMA);
     println!("JSON COMMANDS\t{}", JSON_COMMANDS.join(","));
     println!("FEATURES\t{}", INTEGRATION_FEATURES.join(","));
+    println!(
+        "SESSION TRANSCRIPT INTEGRATIONS\t{}",
+        session_transcript::supported_integrations().join(",")
+    );
     println!("INTEGRATION HOSTS\topencode={VALIDATED_OPENCODE_VERSION},pi={VALIDATED_PI_VERSION}");
     println!("ERROR CODES\t{}", error_codes.join(","));
     Ok(())
@@ -1903,6 +1928,36 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
             }
             print_session(session);
         }
+        SessionCommands::Read {
+            session_id,
+            limit,
+            max_bytes,
+        } => {
+            let session = match session_projection::resolve_exact(&sessions, &session_id) {
+                Ok(session) => session,
+                Err(session_projection::ResolveError::NotFound) => {
+                    return Err(cli_output::failure(
+                        "not_found",
+                        format!("session not found: {session_id}"),
+                    ));
+                }
+                Err(session_projection::ResolveError::DuplicateId) => {
+                    return Err(cli_output::failure(
+                        "internal",
+                        format!("duplicate projected session ID: {session_id}"),
+                    ));
+                }
+            };
+            let transcript = session_transcript::read(session, limit.into(), max_bytes as usize)
+                .map_err(|error| cli_output::failure(error.code, error.to_string()))?;
+            if json {
+                return cli_output::print(
+                    "session.read",
+                    serde_json::json!({ "transcript": transcript }),
+                );
+            }
+            print_transcript(&transcript);
+        }
     }
     Ok(())
 }
@@ -1978,6 +2033,58 @@ fn print_session(session: &session_projection::SessionProjection) {
             occurrence.observation.confidence
         );
         println!("OBSERVED AT MS\t{}", occurrence.observation.observed_at_ms);
+    }
+}
+
+fn print_transcript(transcript: &session_transcript::Transcript) {
+    println!("SESSION ID\t{}", transcript.session_id);
+    println!("INTEGRATION\t{}", transcript.integration);
+    println!("EXTERNAL SESSION ID\t{}", transcript.external_session_id);
+    println!(
+        "ENTRIES\t{} of {}",
+        transcript.returned_entries, transcript.total_entries
+    );
+    println!("CONTENT BYTES\t{}", transcript.content_bytes);
+    println!(
+        "TRUNCATED\t{}",
+        if transcript.truncated {
+            transcript.truncated_by.join(",")
+        } else {
+            "no".to_owned()
+        }
+    );
+    for entry in &transcript.entries {
+        println!();
+        match entry.kind {
+            "tool" => println!(
+                "TOOL\t{}\t{}",
+                entry.tool_name.as_deref().unwrap_or("unknown"),
+                entry.status.as_deref().unwrap_or("unknown")
+            ),
+            _ => println!(
+                "{}\t{}",
+                entry.kind.to_uppercase(),
+                entry.role.as_deref().unwrap_or("unknown")
+            ),
+        }
+        if let Some(timestamp_ms) = entry.timestamp_ms {
+            println!("TIMESTAMP MS\t{timestamp_ms}");
+        }
+        if let Some(call_id) = entry.tool_call_id.as_deref() {
+            println!("CALL ID\t{call_id}");
+        }
+        if let Some(text) = entry.text.as_deref() {
+            println!("{text}");
+        }
+        if let Some(input) = entry.input.as_deref() {
+            println!("INPUT\t{input}");
+        }
+        if let Some(output) = entry.output.as_deref() {
+            println!("OUTPUT\t{output}");
+        }
+        if entry.truncated {
+            println!("ENTRY TRUNCATED\ttrue");
+        }
     }
 }
 
@@ -3410,6 +3517,34 @@ mod tests {
             Cli::try_parse_from(["boomux", "session", "get", "opaque", "--json"]).unwrap();
         assert_eq!(command_name(&inspect), "session.inspect");
         assert!(supports_json(&inspect));
+
+        let read = Cli::try_parse_from([
+            "boomux",
+            "session",
+            "read",
+            "opaque",
+            "--limit",
+            "25",
+            "--max-bytes",
+            "4096",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(command_name(&read), "session.read");
+        assert!(supports_json(&read));
+        assert!(matches!(
+            read.command,
+            Some(Commands::Session {
+                command: SessionCommands::Read {
+                    session_id,
+                    limit: 25,
+                    max_bytes: 4096,
+                }
+            }) if session_id == "opaque"
+        ));
+        assert!(
+            Cli::try_parse_from(["boomux", "session", "read", "opaque", "--limit", "0"]).is_err()
+        );
     }
 
     #[test]
@@ -4263,7 +4398,7 @@ mod tests {
         for command in ["agent.register", "agent.ensure", "agent.report"] {
             assert!(JSON_COMMANDS.contains(&command));
         }
-        for command in ["session.list", "session.inspect"] {
+        for command in ["session.list", "session.inspect", "session.read"] {
             assert!(JSON_COMMANDS.contains(&command));
         }
         for feature in [
@@ -4274,11 +4409,16 @@ mod tests {
             "agent_authority_precedence",
             "opencode_lifecycle_plugin",
             "pi_lifecycle_extension",
+            "canonical_session_transcripts",
         ] {
             assert!(INTEGRATION_FEATURES.contains(&feature));
         }
-        assert_eq!(VALIDATED_OPENCODE_VERSION, "1.18.14");
-        assert_eq!(VALIDATED_PI_VERSION, "0.83.0");
+        assert_eq!(VALIDATED_OPENCODE_VERSION, "1.18.15");
+        assert_eq!(VALIDATED_PI_VERSION, "0.84.1");
+        assert_eq!(
+            session_transcript::supported_integrations(),
+            ["opencode", "pi"]
+        );
         assert_eq!(protocol::PROTOCOL_VERSION, 12);
     }
 
@@ -4395,6 +4535,7 @@ mod tests {
             "boomux shell close",
             "boomux session list",
             "boomux session inspect",
+            "boomux session read",
             "boomux skill install",
             "boomux opencode install",
             "boomux pi install",

--- a/src/session_transcript.rs
+++ b/src/session_transcript.rs
@@ -1,0 +1,995 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::fs::OpenOptions;
+use std::io::{self, Read};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, TryRecvError};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::host_session_titles::{
+    PiEnvironment, PiSessionFileError, normalize_absolute, pi_session_file,
+};
+use crate::session_projection::SessionProjection;
+
+const SOURCE_LIMIT_BYTES: u64 = 16 * 1024 * 1024;
+const OPENCODE_TIMEOUT: Duration = Duration::from_secs(30);
+
+trait TranscriptAdapter: Sync {
+    fn integration(&self) -> &'static str;
+
+    fn read(&self, request: TranscriptRequest<'_>)
+    -> Result<Vec<TranscriptEntry>, TranscriptError>;
+}
+
+#[derive(Clone, Copy)]
+struct TranscriptRequest<'a> {
+    directory: &'a Path,
+    external_session_id: &'a str,
+}
+
+struct OpenCodeAdapter;
+struct PiAdapter;
+
+static OPENCODE_ADAPTER: OpenCodeAdapter = OpenCodeAdapter;
+static PI_ADAPTER: PiAdapter = PiAdapter;
+static ADAPTERS: &[&dyn TranscriptAdapter] = &[&OPENCODE_ADAPTER, &PI_ADAPTER];
+
+#[derive(Debug)]
+pub(crate) struct TranscriptError {
+    pub(crate) code: &'static str,
+    message: String,
+}
+
+impl TranscriptError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for TranscriptError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for TranscriptError {}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct TranscriptEntry {
+    #[serde(rename = "type")]
+    pub(crate) kind: &'static str,
+    pub(crate) source_id: Option<String>,
+    pub(crate) timestamp_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) input: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) output: Option<String>,
+    pub(crate) truncated: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Transcript {
+    pub(crate) session_id: String,
+    pub(crate) integration: String,
+    pub(crate) external_session_id: String,
+    pub(crate) entries: Vec<TranscriptEntry>,
+    pub(crate) returned_entries: usize,
+    pub(crate) total_entries: usize,
+    pub(crate) content_bytes: usize,
+    pub(crate) truncated: bool,
+    pub(crate) truncated_by: Vec<&'static str>,
+}
+
+pub(crate) fn read(
+    session: &SessionProjection,
+    limit: usize,
+    max_bytes: usize,
+) -> Result<Transcript, TranscriptError> {
+    read_with_adapters(session, limit, max_bytes, ADAPTERS)
+}
+
+pub(crate) fn supported_integrations() -> Vec<&'static str> {
+    ADAPTERS
+        .iter()
+        .map(|adapter| adapter.integration())
+        .collect()
+}
+
+fn read_with_adapters(
+    session: &SessionProjection,
+    limit: usize,
+    max_bytes: usize,
+    adapters: &[&dyn TranscriptAdapter],
+) -> Result<Transcript, TranscriptError> {
+    let external_session_id = session.external_session_id.as_deref().ok_or_else(|| {
+        TranscriptError::new(
+            "session_source_unavailable",
+            "session has no canonical external session ID",
+        )
+    })?;
+    let directory = session
+        .occurrences
+        .iter()
+        .rev()
+        .find_map(|occurrence| occurrence.retained_shell_cwd.as_deref())
+        .ok_or_else(|| {
+            TranscriptError::new(
+                "session_source_unavailable",
+                "session has no retained working directory for host lookup",
+            )
+        })?;
+
+    let adapter = adapters
+        .iter()
+        .find(|adapter| adapter.integration() == session.integration)
+        .ok_or_else(|| {
+            TranscriptError::new(
+                "unsupported_integration",
+                format!(
+                    "session transcript integration is not supported: {}",
+                    session.integration
+                ),
+            )
+        })?;
+    let entries = adapter.read(TranscriptRequest {
+        directory,
+        external_session_id,
+    })?;
+    Ok(bound_entries(
+        session,
+        external_session_id,
+        entries,
+        limit,
+        max_bytes,
+    ))
+}
+
+impl TranscriptAdapter for OpenCodeAdapter {
+    fn integration(&self) -> &'static str {
+        "opencode"
+    }
+
+    fn read(
+        &self,
+        request: TranscriptRequest<'_>,
+    ) -> Result<Vec<TranscriptEntry>, TranscriptError> {
+        let output = run_opencode_export(request.directory, request.external_session_id)?;
+        parse_opencode(&output, request.external_session_id)
+    }
+}
+
+impl TranscriptAdapter for PiAdapter {
+    fn integration(&self) -> &'static str {
+        "pi"
+    }
+
+    fn read(
+        &self,
+        request: TranscriptRequest<'_>,
+    ) -> Result<Vec<TranscriptEntry>, TranscriptError> {
+        read_pi(request.directory, request.external_session_id)
+    }
+}
+
+fn run_opencode_export(
+    directory: &Path,
+    external_session_id: &str,
+) -> Result<Vec<u8>, TranscriptError> {
+    let mut child = Command::new("opencode")
+        .args(["export", external_session_id])
+        .current_dir(directory)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| {
+            TranscriptError::new(
+                "session_source_unavailable",
+                format!("could not start OpenCode export: {error}"),
+            )
+        })?;
+    let mut stdout = child.stdout.take().ok_or_else(|| {
+        TranscriptError::new(
+            "session_source_unavailable",
+            "could not capture OpenCode export",
+        )
+    })?;
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let result = stdout
+            .by_ref()
+            .take(SOURCE_LIMIT_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map(|_| bytes);
+        let _ = sender.send(result);
+    });
+
+    let deadline = Instant::now() + OPENCODE_TIMEOUT;
+    let mut output = None;
+    let mut status = None;
+    loop {
+        if output.is_none() {
+            match receiver.try_recv() {
+                Ok(Ok(bytes)) => output = Some(bytes),
+                Ok(Err(error)) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(TranscriptError::new(
+                        "session_source_unavailable",
+                        format!("could not read OpenCode export: {error}"),
+                    ));
+                }
+                Err(TryRecvError::Disconnected) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(TranscriptError::new(
+                        "session_source_unavailable",
+                        "OpenCode export reader stopped unexpectedly",
+                    ));
+                }
+                Err(TryRecvError::Empty) => {}
+            }
+        }
+        if output
+            .as_ref()
+            .is_some_and(|bytes| bytes.len() as u64 > SOURCE_LIMIT_BYTES)
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(TranscriptError::new(
+                "session_source_too_large",
+                format!("OpenCode export exceeds {SOURCE_LIMIT_BYTES} bytes"),
+            ));
+        }
+        if status.is_none() {
+            status = match child.try_wait() {
+                Ok(status) => status,
+                Err(error) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(TranscriptError::new(
+                        "session_source_unavailable",
+                        format!("could not wait for OpenCode export: {error}"),
+                    ));
+                }
+            };
+        }
+        if let Some(status) = status.as_ref()
+            && let Some(bytes) = output.take()
+        {
+            if status.success() {
+                return Ok(bytes);
+            }
+            return Err(TranscriptError::new(
+                "session_source_unavailable",
+                format!("OpenCode export exited with {status}"),
+            ));
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(TranscriptError::new("timeout", "OpenCode export timed out"));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn parse_opencode(
+    output: &[u8],
+    external_session_id: &str,
+) -> Result<Vec<TranscriptEntry>, TranscriptError> {
+    let document: Value = serde_json::from_slice(output).map_err(|error| {
+        TranscriptError::new(
+            "session_source_invalid",
+            format!("OpenCode export is not valid JSON: {error}"),
+        )
+    })?;
+    if document.pointer("/info/id").and_then(Value::as_str) != Some(external_session_id) {
+        return Err(TranscriptError::new(
+            "session_source_invalid",
+            "OpenCode export session ID does not match the requested session",
+        ));
+    }
+    let messages = document
+        .get("messages")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            TranscriptError::new(
+                "session_source_invalid",
+                "OpenCode export has no messages array",
+            )
+        })?;
+    let mut entries = Vec::new();
+    for message in messages {
+        let role = message.pointer("/info/role").and_then(Value::as_str);
+        let message_time = message
+            .pointer("/info/time/created")
+            .and_then(Value::as_u64);
+        let Some(parts) = message.get("parts").and_then(Value::as_array) else {
+            continue;
+        };
+        for part in parts {
+            let source_id = part.get("id").and_then(Value::as_str).map(str::to_owned);
+            let timestamp_ms = part
+                .pointer("/time/start")
+                .and_then(Value::as_u64)
+                .or(message_time);
+            match part.get("type").and_then(Value::as_str) {
+                Some("text") => {
+                    if let Some(text) = part
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .filter(|text| !text.is_empty())
+                    {
+                        entries.push(message_entry(
+                            "message",
+                            source_id,
+                            timestamp_ms,
+                            role,
+                            text,
+                        ));
+                    }
+                }
+                Some("reasoning") => {
+                    if let Some(text) = part
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .filter(|text| !text.is_empty())
+                    {
+                        entries.push(message_entry(
+                            "reasoning",
+                            source_id,
+                            timestamp_ms,
+                            role,
+                            text,
+                        ));
+                    }
+                }
+                Some("tool") => entries.push(TranscriptEntry {
+                    kind: "tool",
+                    source_id,
+                    timestamp_ms,
+                    role: None,
+                    text: None,
+                    tool_name: part.get("tool").and_then(Value::as_str).map(str::to_owned),
+                    tool_call_id: part
+                        .get("callID")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned),
+                    status: part
+                        .pointer("/state/status")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned),
+                    input: part.pointer("/state/input").map(compact_json),
+                    output: part
+                        .pointer("/state/output")
+                        .or_else(|| part.pointer("/state/error"))
+                        .map(value_text),
+                    truncated: false,
+                }),
+                _ => {}
+            }
+        }
+    }
+    Ok(entries)
+}
+
+fn read_pi(
+    directory: &Path,
+    external_session_id: &str,
+) -> Result<Vec<TranscriptEntry>, TranscriptError> {
+    let environment = PiEnvironment::from_process();
+    let path = pi_session_file(directory, external_session_id, &environment).map_err(|error| {
+        let (code, message) = match error {
+            PiSessionFileError::Unavailable => (
+                "session_source_unavailable",
+                format!("Pi session file not found for {external_session_id}"),
+            ),
+            PiSessionFileError::ScanLimit => (
+                "session_source_too_large",
+                format!("Pi session lookup exceeded its bounded scan for {external_session_id}"),
+            ),
+        };
+        TranscriptError::new(code, message)
+    })?;
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&path)
+        .map_err(|error| source_io_error("open Pi session file", error))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| source_io_error("inspect Pi session file", error))?;
+    if !metadata.file_type().is_file() {
+        return Err(TranscriptError::new(
+            "session_source_unavailable",
+            "Pi session source is not a regular file",
+        ));
+    }
+    if metadata.len() > SOURCE_LIMIT_BYTES {
+        return Err(TranscriptError::new(
+            "session_source_too_large",
+            format!("Pi session file exceeds {SOURCE_LIMIT_BYTES} bytes"),
+        ));
+    }
+    let mut output = Vec::with_capacity(metadata.len() as usize);
+    file.by_ref()
+        .take(SOURCE_LIMIT_BYTES + 1)
+        .read_to_end(&mut output)
+        .map_err(|error| source_io_error("read Pi session file", error))?;
+    if output.len() as u64 > SOURCE_LIMIT_BYTES {
+        return Err(TranscriptError::new(
+            "session_source_too_large",
+            format!("Pi session file exceeds {SOURCE_LIMIT_BYTES} bytes"),
+        ));
+    }
+    parse_pi(&output, external_session_id, directory)
+}
+
+fn source_io_error(action: &str, error: io::Error) -> TranscriptError {
+    TranscriptError::new(
+        "session_source_unavailable",
+        format!("could not {action}: {error}"),
+    )
+}
+
+fn parse_pi(
+    output: &[u8],
+    external_session_id: &str,
+    requested_directory: &Path,
+) -> Result<Vec<TranscriptEntry>, TranscriptError> {
+    let values = output
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(serde_json::from_slice::<Value>)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            TranscriptError::new(
+                "session_source_invalid",
+                format!("Pi session contains invalid JSONL: {error}"),
+            )
+        })?;
+    let header = values
+        .first()
+        .ok_or_else(|| TranscriptError::new("session_source_invalid", "Pi session is empty"))?;
+    let expected_directory = normalize_absolute(requested_directory).ok_or_else(|| {
+        TranscriptError::new(
+            "session_source_invalid",
+            "Pi session working directory is not absolute",
+        )
+    })?;
+    let header_directory = header
+        .get("cwd")
+        .and_then(Value::as_str)
+        .and_then(|cwd| normalize_absolute(Path::new(cwd)));
+    if header.get("type").and_then(Value::as_str) != Some("session")
+        || header.get("id").and_then(Value::as_str) != Some(external_session_id)
+        || header_directory.as_ref() != Some(&expected_directory)
+    {
+        return Err(TranscriptError::new(
+            "session_source_invalid",
+            "Pi session header does not match the requested session",
+        ));
+    }
+
+    let session_entries = &values[1..];
+    let by_id = session_entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| {
+            entry
+                .get("id")
+                .and_then(Value::as_str)
+                .map(|id| (id, index))
+        })
+        .collect::<HashMap<_, _>>();
+    let mut branch = Vec::new();
+    let mut current = session_entries.len().checked_sub(1);
+    while let Some(index) = current {
+        if branch.len() >= session_entries.len() {
+            return Err(TranscriptError::new(
+                "session_source_invalid",
+                "Pi session parent chain contains a cycle",
+            ));
+        }
+        let entry = &session_entries[index];
+        branch.push(entry);
+        current = entry
+            .get("parentId")
+            .and_then(Value::as_str)
+            .and_then(|parent_id| by_id.get(parent_id).copied());
+    }
+    branch.reverse();
+
+    let tool_results = branch
+        .iter()
+        .filter_map(|entry| {
+            let message = entry.get("message")?;
+            if entry.get("type").and_then(Value::as_str) != Some("message")
+                || message.get("role").and_then(Value::as_str) != Some("toolResult")
+            {
+                return None;
+            }
+            Some((message.get("toolCallId")?.as_str()?, message))
+        })
+        .collect::<HashMap<_, _>>();
+    let mut entries = Vec::new();
+    for entry in branch {
+        match entry.get("type").and_then(Value::as_str) {
+            Some("message") => normalize_pi_message(entry, &tool_results, &mut entries),
+            Some("custom_message")
+                if entry.get("display").and_then(Value::as_bool) == Some(true) =>
+            {
+                if let Some(text) = content_text(entry.get("content")) {
+                    entries.push(message_entry(
+                        "message",
+                        string_field(entry, "id"),
+                        None,
+                        Some("custom"),
+                        &text,
+                    ));
+                }
+            }
+            Some("compaction" | "branch_summary") => {
+                if let Some(summary) = entry.get("summary").and_then(Value::as_str) {
+                    entries.push(message_entry(
+                        "message",
+                        string_field(entry, "id"),
+                        None,
+                        Some("summary"),
+                        summary,
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(entries)
+}
+
+fn normalize_pi_message(
+    entry: &Value,
+    tool_results: &HashMap<&str, &Value>,
+    entries: &mut Vec<TranscriptEntry>,
+) {
+    let Some(message) = entry.get("message") else {
+        return;
+    };
+    let role = message.get("role").and_then(Value::as_str);
+    let timestamp_ms = message.get("timestamp").and_then(Value::as_u64);
+    let source_id = string_field(entry, "id");
+    match role {
+        Some("user") => {
+            if let Some(text) = content_text(message.get("content")) {
+                entries.push(message_entry(
+                    "message",
+                    source_id,
+                    timestamp_ms,
+                    role,
+                    &text,
+                ));
+            }
+        }
+        Some("assistant") => {
+            let Some(blocks) = message.get("content").and_then(Value::as_array) else {
+                return;
+            };
+            for block in blocks {
+                match block.get("type").and_then(Value::as_str) {
+                    Some("text") => {
+                        if let Some(text) = block.get("text").and_then(Value::as_str) {
+                            entries.push(message_entry(
+                                "message",
+                                source_id.clone(),
+                                timestamp_ms,
+                                role,
+                                text,
+                            ));
+                        }
+                    }
+                    Some("thinking") => {
+                        if let Some(text) = block.get("thinking").and_then(Value::as_str) {
+                            entries.push(message_entry(
+                                "reasoning",
+                                source_id.clone(),
+                                timestamp_ms,
+                                role,
+                                text,
+                            ));
+                        }
+                    }
+                    Some("toolCall") => {
+                        let call_id = block.get("id").and_then(Value::as_str);
+                        let result = call_id.and_then(|call_id| tool_results.get(call_id).copied());
+                        entries.push(TranscriptEntry {
+                            kind: "tool",
+                            source_id: source_id.clone(),
+                            timestamp_ms,
+                            role: None,
+                            text: None,
+                            tool_name: block.get("name").and_then(Value::as_str).map(str::to_owned),
+                            tool_call_id: call_id.map(str::to_owned),
+                            status: result.map(|result| {
+                                if result.get("isError").and_then(Value::as_bool) == Some(true) {
+                                    "error".to_owned()
+                                } else {
+                                    "completed".to_owned()
+                                }
+                            }),
+                            input: block.get("arguments").map(compact_json),
+                            output: result.and_then(|result| content_text(result.get("content"))),
+                            truncated: false,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Some("bashExecution") => entries.push(TranscriptEntry {
+            kind: "tool",
+            source_id,
+            timestamp_ms,
+            role: None,
+            text: None,
+            tool_name: Some("bash".to_owned()),
+            tool_call_id: None,
+            status: Some(
+                if message.get("cancelled").and_then(Value::as_bool) == Some(true) {
+                    "cancelled".to_owned()
+                } else if message.get("exitCode").and_then(Value::as_i64) == Some(0) {
+                    "completed".to_owned()
+                } else {
+                    "error".to_owned()
+                },
+            ),
+            input: message
+                .get("command")
+                .map(|command| compact_json(&serde_json::json!({ "command": command }))),
+            output: message.get("output").map(value_text),
+            truncated: message.get("truncated").and_then(Value::as_bool) == Some(true),
+        }),
+        Some("custom") if message.get("display").and_then(Value::as_bool) == Some(true) => {
+            if let Some(text) = content_text(message.get("content")) {
+                entries.push(message_entry(
+                    "message",
+                    source_id,
+                    timestamp_ms,
+                    Some("custom"),
+                    &text,
+                ));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn message_entry(
+    kind: &'static str,
+    source_id: Option<String>,
+    timestamp_ms: Option<u64>,
+    role: Option<&str>,
+    text: &str,
+) -> TranscriptEntry {
+    TranscriptEntry {
+        kind,
+        source_id,
+        timestamp_ms,
+        role: role.map(str::to_owned),
+        text: Some(text.to_owned()),
+        tool_name: None,
+        tool_call_id: None,
+        status: None,
+        input: None,
+        output: None,
+        truncated: false,
+    }
+}
+
+fn content_text(content: Option<&Value>) -> Option<String> {
+    let content = content?;
+    if let Some(text) = content.as_str() {
+        return (!text.is_empty()).then(|| text.to_owned());
+    }
+    let text = content
+        .as_array()?
+        .iter()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|block| block.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
+}
+
+fn string_field(value: &Value, field: &str) -> Option<String> {
+    value.get(field).and_then(Value::as_str).map(str::to_owned)
+}
+
+fn compact_json(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "null".to_owned())
+}
+
+fn value_text(value: &Value) -> String {
+    value
+        .as_str()
+        .map_or_else(|| compact_json(value), str::to_owned)
+}
+
+fn bound_entries(
+    session: &SessionProjection,
+    external_session_id: &str,
+    entries: Vec<TranscriptEntry>,
+    limit: usize,
+    max_bytes: usize,
+) -> Transcript {
+    let total_entries = entries.len();
+    let entry_start = total_entries.saturating_sub(limit);
+    let limit_truncated = entry_start > 0;
+    let selected = entries.into_iter().skip(entry_start).collect::<Vec<_>>();
+    let selected_entries = selected.len();
+    let mut remaining = max_bytes;
+    let mut bounded = Vec::new();
+    let mut byte_truncated = false;
+    for mut entry in selected.into_iter().rev() {
+        let bytes = entry.content_bytes();
+        if bytes > remaining {
+            byte_truncated = true;
+            if remaining == 0 {
+                break;
+            }
+            entry.truncate_to(remaining);
+            bounded.push(entry);
+            break;
+        }
+        remaining -= bytes;
+        bounded.push(entry);
+    }
+    if bounded.len() < selected_entries {
+        byte_truncated = true;
+    }
+    bounded.reverse();
+    let content_bytes = bounded.iter().map(TranscriptEntry::content_bytes).sum();
+    let mut truncated_by = Vec::new();
+    if limit_truncated {
+        truncated_by.push("limit");
+    }
+    if byte_truncated {
+        truncated_by.push("max_bytes");
+    }
+    Transcript {
+        session_id: session.id.clone(),
+        integration: session.integration.clone(),
+        external_session_id: external_session_id.to_owned(),
+        returned_entries: bounded.len(),
+        total_entries,
+        content_bytes,
+        entries: bounded,
+        truncated: !truncated_by.is_empty(),
+        truncated_by,
+    }
+}
+
+impl TranscriptEntry {
+    fn content_bytes(&self) -> usize {
+        [&self.text, &self.input, &self.output]
+            .into_iter()
+            .filter_map(|value| value.as_ref())
+            .map(String::len)
+            .sum()
+    }
+
+    fn truncate_to(&mut self, mut remaining: usize) {
+        for value in [&mut self.text, &mut self.input, &mut self.output]
+            .into_iter()
+            .filter_map(Option::as_mut)
+        {
+            if value.len() <= remaining {
+                remaining -= value.len();
+                continue;
+            }
+            truncate_utf8(value, remaining);
+            remaining = 0;
+        }
+        self.truncated = true;
+    }
+}
+
+fn truncate_utf8(value: &mut String, max_bytes: usize) {
+    if value.len() <= max_bytes {
+        return;
+    }
+    let mut boundary = max_bytes;
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    value.truncate(boundary);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use boomux::protocol::{AgentAuthority, AgentObservationSnapshot, AgentState};
+
+    use super::*;
+    use crate::session_projection::SessionOccurrence;
+
+    struct FutureHarnessAdapter;
+
+    impl TranscriptAdapter for FutureHarnessAdapter {
+        fn integration(&self) -> &'static str {
+            "future-harness"
+        }
+
+        fn read(
+            &self,
+            request: TranscriptRequest<'_>,
+        ) -> Result<Vec<TranscriptEntry>, TranscriptError> {
+            assert_eq!(request.directory, Path::new("/repo"));
+            assert_eq!(request.external_session_id, "external");
+            Ok(vec![message_entry(
+                "message",
+                Some("future-1".into()),
+                Some(10),
+                Some("assistant"),
+                "adapter output",
+            )])
+        }
+    }
+
+    fn session(integration: &str) -> SessionProjection {
+        SessionProjection {
+            id: "projected".into(),
+            workspace_id: "workspace".into(),
+            workspace_name: "project".into(),
+            integration: integration.into(),
+            external_session_id: Some("external".into()),
+            description: "Agent".into(),
+            state: AgentState::Idle,
+            state_is_current: true,
+            started_at_ms: 1,
+            last_at_ms: 2,
+            occurrences: vec![SessionOccurrence {
+                agent_id: "agent".into(),
+                shell_id: "shell".into(),
+                run_id: "run".into(),
+                started_at_ms: 1,
+                ended_at_ms: None,
+                observation: AgentObservationSnapshot {
+                    revision: 1,
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "idle".into(),
+                    confidence: 100,
+                    observed_at_ms: 2,
+                },
+                is_current: true,
+                retained_shell_name: Some("agent".into()),
+                retained_shell_cwd: Some(PathBuf::from("/repo")),
+            }],
+        }
+    }
+
+    #[test]
+    fn parses_opencode_text_reasoning_and_completed_tool() {
+        let output = br#"{
+            "info":{"id":"external"},
+            "messages":[
+                {"info":{"role":"user","time":{"created":10}},"parts":[
+                    {"id":"p1","type":"text","text":"hello"}
+                ]},
+                {"info":{"role":"assistant","time":{"created":20}},"parts":[
+                    {"id":"p2","type":"reasoning","text":"consider"},
+                    {"id":"p3","type":"tool","tool":"read","callID":"call-1","state":{"status":"completed","input":{"path":"a"},"output":"contents"}}
+                ]}
+            ]
+        }"#;
+
+        let entries = parse_opencode(output, "external").unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].kind, "message");
+        assert_eq!(entries[0].text.as_deref(), Some("hello"));
+        assert_eq!(entries[1].kind, "reasoning");
+        assert_eq!(entries[2].tool_name.as_deref(), Some("read"));
+        assert_eq!(entries[2].input.as_deref(), Some(r#"{"path":"a"}"#));
+        assert_eq!(entries[2].output.as_deref(), Some("contents"));
+    }
+
+    #[test]
+    fn pi_follows_latest_branch_and_combines_tool_result() {
+        let output = br#"{"type":"session","version":3,"id":"external","cwd":"/repo"}
+{"type":"message","id":"one","parentId":null,"timestamp":"x","message":{"role":"user","content":"start","timestamp":1}}
+{"type":"message","id":"abandoned","parentId":"one","timestamp":"x","message":{"role":"assistant","content":[{"type":"text","text":"old branch"}],"timestamp":2}}
+{"type":"message","id":"call","parentId":"one","timestamp":"x","message":{"role":"assistant","content":[{"type":"thinking","thinking":"plan"},{"type":"toolCall","id":"tc1","name":"read","arguments":{"path":"a"}}],"timestamp":3}}
+{"type":"message","id":"result","parentId":"call","timestamp":"x","message":{"role":"toolResult","toolCallId":"tc1","toolName":"read","content":[{"type":"text","text":"data"}],"isError":false,"timestamp":4}}
+{"type":"message","id":"custom","parentId":"result","timestamp":"x","message":{"role":"custom","customType":"notice","content":"visible notice","display":true,"timestamp":5}}
+"#;
+
+        let entries = parse_pi(output, "external", Path::new("/repo")).unwrap();
+
+        assert_eq!(entries.len(), 4);
+        assert_eq!(entries[0].text.as_deref(), Some("start"));
+        assert_eq!(entries[1].kind, "reasoning");
+        assert_eq!(entries[2].kind, "tool");
+        assert_eq!(entries[2].status.as_deref(), Some("completed"));
+        assert_eq!(entries[2].output.as_deref(), Some("data"));
+        assert_eq!(entries[3].role.as_deref(), Some("custom"));
+        assert_eq!(entries[3].text.as_deref(), Some("visible notice"));
+        assert!(
+            entries
+                .iter()
+                .all(|entry| entry.text.as_deref() != Some("old branch"))
+        );
+    }
+
+    #[test]
+    fn bounds_the_newest_suffix_by_entries_and_utf8_content_bytes() {
+        let entries = vec![
+            message_entry("message", Some("1".into()), None, Some("user"), "old"),
+            message_entry(
+                "message",
+                Some("2".into()),
+                None,
+                Some("assistant"),
+                "middle",
+            ),
+            message_entry(
+                "message",
+                Some("3".into()),
+                None,
+                Some("assistant"),
+                "new-😀",
+            ),
+        ];
+
+        let transcript = bound_entries(&session("pi"), "external", entries, 2, 8);
+
+        assert_eq!(transcript.total_entries, 3);
+        assert_eq!(transcript.returned_entries, 1);
+        assert_eq!(transcript.entries[0].source_id.as_deref(), Some("3"));
+        assert_eq!(transcript.entries[0].text.as_deref(), Some("new-😀"));
+        assert_eq!(transcript.content_bytes, 8);
+        assert_eq!(transcript.truncated_by, ["limit", "max_bytes"]);
+    }
+
+    #[test]
+    fn registered_adapter_uses_the_shared_identity_and_bounding_contract() {
+        let adapter = FutureHarnessAdapter;
+        let transcript = read_with_adapters(
+            &session("future-harness"),
+            10,
+            7,
+            &[&adapter as &dyn TranscriptAdapter],
+        )
+        .unwrap();
+
+        assert_eq!(transcript.integration, "future-harness");
+        assert_eq!(transcript.entries[0].text.as_deref(), Some("adapter"));
+        assert_eq!(transcript.truncated_by, ["max_bytes"]);
+    }
+
+    #[test]
+    fn registry_advertises_every_bundled_adapter() {
+        assert_eq!(supported_integrations(), ["opencode", "pi"]);
+    }
+}

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1428,6 +1428,107 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
         shell_id
     );
 
+    let unsupported_read = daemon
+        .command()
+        .args(["session", "read", session_id, "--json"])
+        .output()
+        .unwrap();
+    assert!(!unsupported_read.status.success());
+    let unsupported_read: serde_json::Value =
+        serde_json::from_slice(&unsupported_read.stderr).unwrap();
+    assert_eq!(unsupported_read["command"], "session.read");
+    assert_eq!(unsupported_read["error"]["code"], "unsupported_integration");
+
+    let pi_ensure = daemon
+        .command()
+        .args([
+            "agent",
+            "ensure",
+            "pi-agent",
+            "--integration",
+            "pi",
+            "--external-session-id",
+            "pi-session",
+            "--shell-id",
+            &shell_id,
+            "--run-id",
+            &run_id,
+            "--state",
+            "idle",
+            "--authority",
+            "lifecycle-integration",
+            "--evidence",
+            "pi fixture",
+            "--confidence",
+            "100",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(pi_ensure.status.success());
+    let pi_directory = daemon.runtime_dir.join("pi-sessions");
+    fs::create_dir(&pi_directory).unwrap();
+    fs::write(
+        pi_directory.join("pi-session.jsonl"),
+        format!(
+            "{{\"type\":\"session\",\"version\":3,\"id\":\"pi-session\",\"cwd\":\"{}\"}}\n\
+             {{\"type\":\"message\",\"id\":\"user\",\"parentId\":null,\"timestamp\":\"x\",\"message\":{{\"role\":\"user\",\"content\":\"inspect this\",\"timestamp\":10}}}}\n\
+             {{\"type\":\"message\",\"id\":\"call\",\"parentId\":\"user\",\"timestamp\":\"x\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"toolCall\",\"id\":\"tc1\",\"name\":\"read\",\"arguments\":{{\"path\":\"README.md\"}}}}],\"timestamp\":11}}}}\n\
+             {{\"type\":\"message\",\"id\":\"result\",\"parentId\":\"call\",\"timestamp\":\"x\",\"message\":{{\"role\":\"toolResult\",\"toolCallId\":\"tc1\",\"toolName\":\"read\",\"content\":[{{\"type\":\"text\",\"text\":\"fixture output\"}}],\"isError\":false,\"timestamp\":12}}}}\n",
+            std::env::temp_dir().display()
+        ),
+    )
+    .unwrap();
+    let pi_sessions = daemon
+        .command()
+        .args(["session", "list", "--json"])
+        .output()
+        .unwrap();
+    let pi_sessions: serde_json::Value = serde_json::from_slice(&pi_sessions.stdout).unwrap();
+    let pi_session_id = pi_sessions["data"]["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["external_session_id"] == "pi-session")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let pi_read = daemon
+        .command()
+        .args([
+            "session",
+            "read",
+            pi_session_id,
+            "--limit",
+            "10",
+            "--max-bytes",
+            "4096",
+            "--json",
+        ])
+        .env("PI_CODING_AGENT_SESSION_DIR", &pi_directory)
+        .output()
+        .unwrap();
+    assert!(
+        pi_read.status.success(),
+        "{}",
+        String::from_utf8_lossy(&pi_read.stderr)
+    );
+    let pi_read: serde_json::Value = serde_json::from_slice(&pi_read.stdout).unwrap();
+    assert_eq!(pi_read["command"], "session.read");
+    assert_eq!(pi_read["data"]["transcript"]["total_entries"], 2);
+    assert_eq!(
+        pi_read["data"]["transcript"]["entries"][0]["text"],
+        "inspect this"
+    );
+    assert_eq!(
+        pi_read["data"]["transcript"]["entries"][1]["tool_name"],
+        "read"
+    );
+    assert_eq!(
+        pi_read["data"]["transcript"]["entries"][1]["output"],
+        "fixture output"
+    );
+
     let missing_session = daemon
         .command()
         .args(["session", "inspect", "session-1", "--json"])
@@ -2034,8 +2135,12 @@ fn native_daemon_lifecycle() {
     assert_eq!(capabilities["command"], "capabilities");
     assert_eq!(capabilities["data"]["daemon_protocol_version"], 12);
     assert_eq!(
+        capabilities["data"]["session_transcript_integrations"],
+        serde_json::json!(["opencode", "pi"])
+    );
+    assert_eq!(
         capabilities["data"]["integration_hosts"]["opencode"]["validated_version"],
-        "1.18.14"
+        "1.18.15"
     );
     assert_eq!(
         capabilities["data"]["integration_hosts"]["opencode"]["package"],
@@ -2043,7 +2148,7 @@ fn native_daemon_lifecycle() {
     );
     assert_eq!(
         capabilities["data"]["integration_hosts"]["pi"]["validated_version"],
-        "0.83.0"
+        "0.84.1"
     );
     assert_eq!(
         capabilities["data"]["integration_hosts"]["pi"]["package"],


### PR DESCRIPTION
## Summary
- add bounded `boomux session read` output for canonical OpenCode and Pi messages, reasoning, and tool activity
- route harness-specific lookup and normalization through a discoverable adapter registry reusable by future Claude Code, Codex, and other integrations
- document the stable JSON contract, trust policy, typed source errors, and updated host validation points

## Validation
- `cargo test` (262 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`
- live OpenCode 1.18.15 export/read with entry and byte truncation
- daemon-level Pi 0.84.1 JSONL active-branch and tool-result round trip

## Pi live note
The existing interactive Pi instance has no configured models and has not persisted a JSONL session, so it cannot provide an additional live transcript without mutating or authenticating that session. The canonical Pi adapter path is covered at binary level with a real daemon projection and JSONL source.