### PR TITLE
Persist session transcript source context

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -90,7 +90,8 @@ messages, reasoning, and tool activity, not terminal scrollback. Pi results
 follow its active branch. Inspect `truncated`, `truncated_by`, and per-entry
 `truncated` before deciding whether to request larger bounds. Boomux does not
 redact host content, so use it only when the user's request authorizes reading
-that exact session.
+that exact session. Protocol-13 sessions retain a `source_cwd` for transcript
+lookup after shell removal; this does not preserve deleted harness data itself.
 
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ never guess one from an external session ID, description, shell, or Agent ID.
 Session projection is client-side metadata over daemon protocol 12 snapshots,
 not another persisted daemon entity.
 
+Protocol 13 captures each Agent instance's working directory from its exact
+bound shell at registration. Projected occurrences expose this as `source_cwd`,
+so canonical transcript lookup can survive shell removal and daemon restart.
+The underlying directory and harness transcript data must still exist.
+
 `session read` loads canonical host data for OpenCode and Pi, never terminal
 scrollback. It returns the newest bounded suffix of messages, reasoning, and tool
 activity in chronological order. Pi reads only the current leaf branch and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,8 +161,12 @@ enrich labels asynchronously from bounded host catalogs; CLI descriptions remain
 the latest stored Agent registration name and do not invoke host adapters.
 
 Session list/inspect requires a negotiated protocol-12 snapshot because the
-projection depends on that complete Agent state model. It adds no protocol
-request, wire field, persistence record, event, or protocol-version bump.
+projection depends on that complete Agent state model. Protocol 13 adds an
+optional Agent `cwd` snapshot field, captured authoritatively from the bound
+shell during registration and persisted with the Agent. Projection exposes it as
+`source_cwd` separately from retained-shell metadata, allowing transcript lookup
+after shell removal without claiming that the shell remains openable. Protocol
+12 remains usable while a matching shell is retained.
 
 An active Agent instance bound to a shell's exact current run decorates that
 shell as an agent-shell row rather than adding a second item. The row retains
@@ -276,6 +280,24 @@ OpenCode should not be wrapped merely to obtain process evidence when the
 lifecycle plugin is available; that plugin resolves root ancestry and reports
 the stronger lifecycle evidence described below.
 
+### Integration Setup Policy
+
+Boomux prefers authoritative harness integrations over process or rendered-screen
+inference for canonical session identity and lifecycle state. This preserves the
+distinction between direct harness evidence, process existence, and terminal
+heuristics instead of making convenient setup silently weaken session semantics.
+Process adapters and any future screen detectors remain explicitly lower
+authority and cannot substitute for integration evidence.
+
+The resulting installation cost must be handled as a product workflow rather
+than left as manual plugin-file management. A future unified setup command will
+discover supported installed harnesses, describe the access and guarantees each
+integration provides, preview configuration changes, require consent, install
+or update atomically, identify required harness reloads, and verify canonical
+identity and lifecycle reports against a managed shell run. The same workflow
+will expose status, validated host versions, actionable diagnostics, repair, and
+uninstall. Individual host installers remain the underlying safe primitives.
+
 ### OpenCode Lifecycle Plugin
 
 The bundled plugin is validated against `opencode-ai` `1.18.15`. This is a
@@ -343,6 +365,12 @@ from its project-scoped JSONL file with no-follow regular-file checks. Pi's
 append-only tree is reduced to the latest leaf's parent chain so abandoned
 branches are not presented as the active transcript.
 
+Transcript lookup uses the newest occurrence `source_cwd`. For protocol-13 Agent
+records this directory survives shell removal and cold daemon restart; migrated
+protocol-12-era records recover it from a retained shell where possible. The
+source directory is a locator rather than copied transcript storage, so removing
+the directory or harness data still makes the transcript unavailable.
+
 Adapters normalize host text, reasoning, tool calls, inputs, results, status,
 source identity, and timestamps. Boomux does not redact this content because
 the harness is the content trust boundary. Reads remain explicit and bounded:
@@ -363,7 +391,9 @@ registry so integrations can discover support without hard-coded host lists.
 
 Protocol 12 adds `inactive`. Protocol-9 through protocol-11 clients receive that
 observation as `unknown`, while protocol-12 clients can distinguish a resumable
-session that is not currently active from permanent `done` completion.
+session that is not currently active from permanent `done` completion. Protocol
+13 adds durable Agent working-directory context; older clients receive Agent
+snapshots without that additive field.
 
 ### Transition Coordinator
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -131,9 +131,12 @@ title. Missing optional values are JSON `null`.
 
 Inspect includes all summary fields plus ordered `occurrences`. Each occurrence
 contains `agent_id`, the original `shell_id` even if that shell was removed,
-`retained_shell_name`, `retained_shell_cwd`, `run_id`, `started_at_ms`,
-`ended_at_ms`, `is_current`, and the full stable Agent `observation` shape.
-Retained shell fields are null after shell removal. State and authority use the
+`retained_shell_name`, `retained_shell_cwd`, `source_cwd`, `run_id`,
+`started_at_ms`, `ended_at_ms`, `is_current`, and the full stable Agent
+`observation` shape. Retained shell fields are null after shell removal.
+`source_cwd` is the registration-time Agent working directory under protocol 13
+and can remain available for canonical transcript lookup. Protocol-12 snapshots
+fall back to a currently retained shell directory. State and authority use the
 same spellings documented for Agent observations.
 
 Projection groups Agent instances only when workspace, integration, and external

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -7,7 +7,9 @@ adds idempotent agent ensure without adding an event type. Protocol 11 adds an
 explicit exited-shell restart; the subsequent attachment emits the existing
 `run_started` event for the new generation. Protocol 12 adds resumable
 `inactive` Agent observations; older Agent-capable clients receive them as
-`unknown`.
+`unknown`. Protocol 13 adds the registration-time Agent working directory to
+snapshots and Agent events; protocol-12 clients receive the same records without
+that additive source context.
 
 ## Cursors
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -99,6 +99,9 @@ eternal process.
    process start/exit evidence, and fails open when Boomux reporting fails.
 4. [Complete] Project run-scoped Agent instances into globally discoverable
    session metadata with stable list/inspect JSON and human CLI commands.
+5. [Complete] Capture and persist each Agent's registration-time working
+   directory so canonical transcript lookup survives shell removal and cold
+   daemon restart while retained-shell metadata remains semantically accurate.
 
 ### Near-Term Priorities
 
@@ -107,13 +110,20 @@ eternal process.
    root/subagent aggregation where available, blocked prompts, idle transitions,
    explicit completion semantics, and graceful daemon replacement against real
    sessions.
-2. Aggregate agent states into workspace counts and add an explainable,
+2. Build a first-class integration setup workflow that discovers supported
+   installed harnesses, explains why authoritative lifecycle access is required,
+   previews and obtains consent for configuration changes, installs or updates
+   each integration safely, prompts for required harness reloads, and verifies
+   canonical identity plus lifecycle reporting end to end. Include status,
+   version compatibility, diagnostics, repair, and uninstall paths so stronger
+   guarantees do not require users to manage plugin files manually.
+3. Aggregate agent states into workspace counts and add an explainable,
    persistent attention queue for blocked and completed work.
-3. Add revision-aware `agent wait` so scripts can await durable state
+4. Add revision-aware `agent wait` so scripts can await durable state
    transitions without polling human output.
-4. Add deduplicated notifications for blocked and completed transitions after
+5. Add deduplicated notifications for blocked and completed transitions after
    the attention and wait semantics are established.
-5. [Complete] Add explicit cross-harness transcript and tool inspection so Pi can read an OpenCode
+6. [Complete] Add explicit cross-harness transcript and tool inspection so Pi can read an OpenCode
    session and OpenCode can read a Pi session. Do not treat bounded rendered
    terminal output as the full session: host adapters must expose canonical
    session identity, bounded messages and tool activity, versioned
@@ -122,14 +132,14 @@ eternal process.
    canonical lookup and normalization live behind a shared adapter registry so
    future Claude Code, Codex, and other harness support reuses the same identity,
    bounds, errors, and output contract.
-6. [Complete] Add contextual, categorized Agent Session browsing to selected agent rows in
+7. [Complete] Add contextual, categorized Agent Session browsing to selected agent rows in
    the Boomux UI. Keep inactive and completed workspace sessions visible without
    adding duplicate shell rows, grouped by active and recent time windows with
    integration, canonical identity, associated shell and run, lifecycle state,
    and timestamps. Bounded asynchronous host catalog adapters provide OpenCode
    generated titles and Pi names or first-user-message summaries; future adapters
-    also provide canonical transcripts and tool activity through bounded,
-    versioned CLI output.
+   also provide canonical transcripts and tool activity through bounded,
+   versioned CLI output.
 
 ### Deferred Agent Work
 
@@ -139,6 +149,8 @@ eternal process.
   safe fallback.
 - Defer terminal-screen heuristics until real usage demonstrates a visibility
   gap that lifecycle integrations and explicit process evidence do not cover.
+  Heuristics must remain lower-authority, visibly identified observations rather
+  than silently replacing setup for canonical identity and lifecycle evidence.
 - Defer guarded prompts and common responses until run-scoped leases,
   user-controller precedence, idempotency, and audit events are defined.
 - Defer hooks, tests, focus actions, and other automatic reactions until waits,

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -146,6 +146,7 @@ pub(crate) struct SessionOccurrenceData {
     pub(crate) shell_id: String,
     pub(crate) retained_shell_name: Option<String>,
     pub(crate) retained_shell_cwd: Option<String>,
+    pub(crate) source_cwd: Option<String>,
     pub(crate) run_id: String,
     pub(crate) started_at_ms: u64,
     pub(crate) ended_at_ms: Option<u64>,
@@ -292,6 +293,10 @@ fn session_occurrence(occurrence: &SessionOccurrence) -> SessionOccurrenceData {
             .retained_shell_cwd
             .as_ref()
             .map(|cwd| cwd.display().to_string()),
+        source_cwd: occurrence
+            .source_cwd
+            .as_ref()
+            .map(|cwd| cwd.display().to_string()),
         run_id: occurrence.run_id.clone(),
         started_at_ms: occurrence.started_at_ms,
         ended_at_ms: occurrence.ended_at_ms,
@@ -411,6 +416,7 @@ mod tests {
                 name: "opencode".into(),
                 integration: "plugin".into(),
                 external_session_id: Some("external-1".into()),
+                cwd: Some("/tmp/project".into()),
                 started_at_ms: 10,
                 ended_at_ms: None,
                 observation: AgentObservationSnapshot {
@@ -462,6 +468,7 @@ mod tests {
                 is_current: false,
                 retained_shell_name: None,
                 retained_shell_cwd: None,
+                source_cwd: Some("/tmp/project".into()),
             }],
         });
 
@@ -469,6 +476,7 @@ mod tests {
         assert!(value["external_session_id"].is_null());
         assert!(value["occurrences"][0]["retained_shell_name"].is_null());
         assert!(value["occurrences"][0]["retained_shell_cwd"].is_null());
+        assert_eq!(value["occurrences"][0]["source_cwd"], "/tmp/project");
         assert!(value["occurrences"][0]["ended_at_ms"].is_null());
         assert_eq!(value["occurrences"][0]["shell_id"], "removed-shell");
         assert_eq!(value["occurrences"][0]["observation"]["state"], "inactive");

--- a/src/client.rs
+++ b/src/client.rs
@@ -881,6 +881,22 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 13);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    12,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 12);
             assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
@@ -888,7 +904,7 @@ mod tests {
                 &Envelope::with_version(
                     11,
                     Response::Error {
-                        message: "expected an older protocol".into(),
+                        message: "expected protocol 7".into(),
                         code: Some(ErrorCode::UnsupportedVersion),
                     },
                 ),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -780,6 +780,9 @@ fn handle_connection(
 
 fn response_for_version(response: Response, version: u32) -> Response {
     let mut response = response;
+    if version < 13 {
+        remove_agent_cwds(&mut response);
+    }
     if version < 12 {
         downgrade_inactive_agent_states(&mut response);
     }
@@ -833,34 +836,43 @@ fn response_for_version(response: Response, version: u32) -> Response {
     }
 }
 
+fn remove_agent_cwds(response: &mut Response) {
+    visit_response_agents(response, &mut |agent| agent.cwd = None);
+}
+
 fn downgrade_inactive_agent_states(response: &mut Response) {
-    fn downgrade(agent: &mut AgentInstanceSnapshot) {
+    visit_response_agents(response, &mut |agent| {
         if agent.observation.state == AgentState::Inactive {
             agent.observation.state = AgentState::Unknown;
         }
-    }
+    });
+}
 
+fn visit_response_agents(
+    response: &mut Response,
+    visitor: &mut impl FnMut(&mut AgentInstanceSnapshot),
+) {
     match response {
         Response::Snapshot { snapshot } => {
             for workspace in &mut snapshot.workspaces {
                 for agent in &mut workspace.agents {
-                    downgrade(agent);
+                    visitor(agent);
                 }
             }
         }
         Response::Workspace { workspace } => {
             for agent in &mut workspace.agents {
-                downgrade(agent);
+                visitor(agent);
             }
         }
-        Response::Agent { agent } => downgrade(agent),
+        Response::Agent { agent } => visitor(agent),
         Response::Events {
             snapshot, events, ..
         } => {
             if let Some(snapshot) = snapshot {
                 for workspace in &mut snapshot.workspaces {
                     for agent in &mut workspace.agents {
-                        downgrade(agent);
+                        visitor(agent);
                     }
                 }
             }
@@ -868,7 +880,7 @@ fn downgrade_inactive_agent_states(response: &mut Response) {
                 match &mut event.kind {
                     DaemonEventKind::AgentRegistered { agent, .. }
                     | DaemonEventKind::AgentStateChanged { agent, .. }
-                    | DaemonEventKind::AgentCompleted { agent, .. } => downgrade(agent),
+                    | DaemonEventKind::AgentCompleted { agent, .. } => visitor(agent),
                     _ => {}
                 }
             }
@@ -1097,6 +1109,7 @@ struct AgentInstance {
     name: String,
     integration: String,
     external_session_id: Option<String>,
+    cwd: Option<PathBuf>,
     started_at_ms: u64,
     state: Mutex<AgentInstanceState>,
 }
@@ -2963,6 +2976,7 @@ impl Registry {
             name: spec.name,
             integration: spec.integration,
             external_session_id: spec.external_session_id,
+            cwd: Some(shell.cwd.clone()),
             started_at_ms,
             state: Mutex::new(AgentInstanceState {
                 ended_at_ms,
@@ -3609,6 +3623,7 @@ impl AgentInstance {
             name: saved.name,
             integration: saved.integration,
             external_session_id: saved.external_session_id,
+            cwd: saved.cwd,
             started_at_ms: saved.started_at_ms,
             state: Mutex::new(AgentInstanceState {
                 ended_at_ms: saved.ended_at_ms,
@@ -3627,6 +3642,7 @@ impl AgentInstance {
             name: self.name.clone(),
             integration: self.integration.clone(),
             external_session_id: self.external_session_id.clone(),
+            cwd: self.cwd.clone(),
             started_at_ms: self.started_at_ms,
             ended_at_ms: state.ended_at_ms,
             observation: state.observation.clone(),
@@ -3642,6 +3658,7 @@ impl AgentInstance {
             name: snapshot.name,
             integration: snapshot.integration,
             external_session_id: snapshot.external_session_id,
+            cwd: snapshot.cwd,
             started_at_ms: snapshot.started_at_ms,
             ended_at_ms: snapshot.ended_at_ms,
             observation: snapshot.observation,
@@ -4909,6 +4926,9 @@ fn validate_persisted_agent(agent: &PersistedAgentInstance) -> io::Result<()> {
         },
     })
     .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    if let Some(cwd) = &agent.cwd {
+        validate_persisted_cwd(cwd)?;
+    }
     if agent.observation.revision == 0
         || agent.observation.observed_at_ms < agent.started_at_ms
         || agent
@@ -5356,6 +5376,7 @@ mod tests {
         else {
             panic!("expected registered agent");
         };
+        assert_eq!(agent.cwd.as_deref(), Some(shell.cwd.as_path()));
         assert_eq!(agent.observation.revision, 1);
         assert!(agent.ended_at_ms.is_none());
         assert_eq!(
@@ -5803,6 +5824,7 @@ mod tests {
             name: "agent".into(),
             integration: "test".into(),
             external_session_id: None,
+            cwd: Some("/tmp/project".into()),
             started_at_ms: 1,
             ended_at_ms: None,
             observation: AgentObservationSnapshot {
@@ -5873,7 +5895,7 @@ mod tests {
     }
 
     #[test]
-    fn protocol_eleven_responses_downgrade_inactive_agent_state() {
+    fn older_protocol_responses_downgrade_agent_fields() {
         let agent = AgentInstanceSnapshot {
             id: "a1".into(),
             workspace_id: "w1".into(),
@@ -5882,6 +5904,7 @@ mod tests {
             name: "pi".into(),
             integration: "pi".into(),
             external_session_id: Some("session-1".into()),
+            cwd: Some("/tmp/project".into()),
             started_at_ms: 1,
             ended_at_ms: None,
             observation: AgentObservationSnapshot {
@@ -5903,6 +5926,7 @@ mod tests {
             panic!("expected agent response");
         };
         assert_eq!(downgraded.observation.state, AgentState::Unknown);
+        assert!(downgraded.cwd.is_none());
 
         let Response::Agent { agent: current } = response_for_version(
             Response::Agent {
@@ -5913,6 +5937,17 @@ mod tests {
             panic!("expected agent response");
         };
         assert_eq!(current.observation.state, AgentState::Inactive);
+        assert!(current.cwd.is_none());
+
+        let Response::Agent { agent: current } = response_for_version(
+            Response::Agent {
+                agent: agent.clone(),
+            },
+            13,
+        ) else {
+            panic!("expected agent response");
+        };
+        assert_eq!(current.cwd.as_deref(), Some(Path::new("/tmp/project")));
 
         let workspace = WorkspaceSnapshot {
             id: "w1".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "protocol_10",
     "protocol_11",
     "protocol_12",
+    "protocol_13",
     "restartable_exited_shells",
     "inactive_agent_state",
     "idempotent_agent_ensure",
@@ -79,6 +80,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "process_adapters",
     "projected_agent_sessions",
     "canonical_session_transcripts",
+    "durable_session_source_context",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -1108,7 +1110,7 @@ fn workspace_session_views(workspace: &WorkspaceSnapshot) -> Vec<tui::AgentSessi
                         .as_ref()
                         .map(|_| occurrence.shell_id),
                     shell_name: occurrence.retained_shell_name,
-                    directory: occurrence.retained_shell_cwd,
+                    directory: occurrence.source_cwd,
                 })
                 .collect();
             tui::AgentSessionView {
@@ -2006,6 +2008,13 @@ fn print_session(session: &session_projection::SessionProjection) {
             "RETAINED SHELL CWD\t{}",
             occurrence
                 .retained_shell_cwd
+                .as_ref()
+                .map_or_else(|| "-".into(), |cwd| cwd.display().to_string())
+        );
+        println!(
+            "SOURCE CWD\t{}",
+            occurrence
+                .source_cwd
                 .as_ref()
                 .map_or_else(|| "-".into(), |cwd| cwd.display().to_string())
         );
@@ -3099,6 +3108,7 @@ mod tests {
             name: "OpenCode".into(),
             integration: "opencode".into(),
             external_session_id: Some("external-1".into()),
+            cwd: Some("/tmp/project".into()),
             started_at_ms: 10,
             ended_at_ms: None,
             observation: protocol::AgentObservationSnapshot {
@@ -4419,7 +4429,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 12);
+        assert_eq!(protocol::PROTOCOL_VERSION, 13);
     }
 
     #[test]

--- a/src/process_adapter.rs
+++ b/src/process_adapter.rs
@@ -347,6 +347,7 @@ mod tests {
             name: "agent".into(),
             integration: "test".into(),
             external_session_id: Some("session-1".into()),
+            cwd: Some("/tmp/project".into()),
             started_at_ms: 1,
             ended_at_ms: completed.then_some(2),
             observation: AgentObservationSnapshot {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 12;
+pub const PROTOCOL_VERSION: u32 = 13;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -99,6 +99,8 @@ pub struct AgentInstanceSnapshot {
     pub name: String,
     pub integration: String,
     pub external_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<PathBuf>,
     pub started_at_ms: u64,
     pub ended_at_ms: Option<u64>,
     pub observation: AgentObservationSnapshot,
@@ -717,6 +719,7 @@ mod tests {
             name: "opencode".into(),
             integration: "opencode-plugin".into(),
             external_session_id: Some("external-1".into()),
+            cwd: Some("/tmp/project".into()),
             started_at_ms: 10,
             ended_at_ms: None,
             observation: AgentObservationSnapshot {
@@ -742,9 +745,36 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_twelve_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 12);
+    fn protocol_version_is_thirteen_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 13);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
+    }
+
+    #[test]
+    fn agent_snapshot_defaults_cwd_omitted_by_old_daemons() {
+        let agent: AgentInstanceSnapshot = serde_json::from_value(serde_json::json!({
+            "id": "a1",
+            "workspace_id": "w1",
+            "shell_id": "s1",
+            "run_id": "r1",
+            "name": "agent",
+            "integration": "test",
+            "external_session_id": "external",
+            "started_at_ms": 1,
+            "ended_at_ms": null,
+            "observation": {
+                "revision": 1,
+                "state": "working",
+                "authority": "lifecycle_integration",
+                "evidence": "working",
+                "confidence": 100,
+                "observed_at_ms": 1
+            }
+        }))
+        .unwrap();
+
+        assert!(agent.cwd.is_none());
+        assert!(serde_json::to_value(agent).unwrap().get("cwd").is_none());
     }
 
     #[test]

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -37,6 +37,7 @@ pub(crate) struct SessionOccurrence {
     pub(crate) is_current: bool,
     pub(crate) retained_shell_name: Option<String>,
     pub(crate) retained_shell_cwd: Option<PathBuf>,
+    pub(crate) source_cwd: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -155,6 +156,10 @@ fn project_workspace(workspace: &WorkspaceSnapshot) -> Vec<SessionProjection> {
                         is_current: occurrence_is_current(workspace, agent),
                         retained_shell_name: retained_shell.map(|shell| shell.name.clone()),
                         retained_shell_cwd: retained_shell.map(|shell| shell.cwd.clone()),
+                        source_cwd: agent
+                            .cwd
+                            .clone()
+                            .or_else(|| retained_shell.map(|shell| shell.cwd.clone())),
                     }
                 })
                 .collect();
@@ -213,6 +218,8 @@ fn state_priority(state: AgentState) -> u8 {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
     use boomux::protocol::{AgentAuthority, ShellRunSnapshot};
 
@@ -251,6 +258,7 @@ mod tests {
                     name: format!("Agent {index}"),
                     integration: "opencode".into(),
                     external_session_id: Some("external".into()),
+                    cwd: Some("/tmp/project".into()),
                     started_at_ms: 10 + index as u64,
                     ended_at_ms: None,
                     observation: AgentObservationSnapshot {
@@ -327,5 +335,35 @@ mod tests {
             AgentState::Unknown,
         ];
         assert_eq!(states.map(state_priority), [0, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn source_cwd_survives_shell_removal_without_making_occurrence_current() {
+        let mut workspace = workspace("w1", &["a1"]);
+        workspace.shells.clear();
+
+        let sessions = project_workspaces(&[workspace]);
+        let occurrence = &sessions[0].occurrences[0];
+
+        assert!(!occurrence.is_current);
+        assert!(occurrence.retained_shell_name.is_none());
+        assert!(occurrence.retained_shell_cwd.is_none());
+        assert_eq!(
+            occurrence.source_cwd.as_deref(),
+            Some(Path::new("/tmp/project"))
+        );
+    }
+
+    #[test]
+    fn retained_shell_cwd_is_a_compatibility_fallback_for_old_daemons() {
+        let mut workspace = workspace("w1", &["a1"]);
+        workspace.agents[0].cwd = None;
+
+        let sessions = project_workspaces(&[workspace]);
+
+        assert_eq!(
+            sessions[0].occurrences[0].source_cwd.as_deref(),
+            Some(Path::new("/tmp/project"))
+        );
     }
 }

--- a/src/session_transcript.rs
+++ b/src/session_transcript.rs
@@ -130,7 +130,7 @@ fn read_with_adapters(
         .occurrences
         .iter()
         .rev()
-        .find_map(|occurrence| occurrence.retained_shell_cwd.as_deref())
+        .find_map(|occurrence| occurrence.source_cwd.as_deref())
         .ok_or_else(|| {
             TranscriptError::new(
                 "session_source_unavailable",
@@ -885,6 +885,7 @@ mod tests {
                 is_current: true,
                 retained_shell_name: Some("agent".into()),
                 retained_shell_cwd: Some(PathBuf::from("/repo")),
+                source_cwd: Some(PathBuf::from("/repo")),
             }],
         }
     }

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -11,8 +11,9 @@ use uuid::Uuid;
 
 use crate::protocol::{AgentObservationSnapshot, ShellRunExitReason, TerminalProfile};
 
-const STATE_VERSION: u32 = 4;
-const PREVIOUS_STATE_VERSION: u32 = 3;
+const STATE_VERSION: u32 = 5;
+const PREVIOUS_STATE_VERSION: u32 = 4;
+const VERSION_THREE_STATE_VERSION: u32 = 3;
 const VERSION_TWO_STATE_VERSION: u32 = 2;
 const LEGACY_STATE_VERSION: u32 = 1;
 const MAX_STATE_BYTES: u64 = 8 * 1024 * 1024;
@@ -52,6 +53,7 @@ pub(crate) struct PersistedAgentInstance {
     pub(crate) name: String,
     pub(crate) integration: String,
     pub(crate) external_session_id: Option<String>,
+    pub(crate) cwd: Option<PathBuf>,
     pub(crate) started_at_ms: u64,
     pub(crate) ended_at_ms: Option<u64>,
     pub(crate) observation: AgentObservationSnapshot,
@@ -104,6 +106,37 @@ struct PreviousPersistedState {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PreviousPersistedWorkspace {
+    id: String,
+    name: String,
+    shells: Vec<PersistedShell>,
+    launchers: Vec<PersistedWorkspaceLauncher>,
+    agents: Vec<PreviousPersistedAgentInstance>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PreviousPersistedAgentInstance {
+    id: String,
+    shell_id: String,
+    run_id: String,
+    name: String,
+    integration: String,
+    external_session_id: Option<String>,
+    started_at_ms: u64,
+    ended_at_ms: Option<u64>,
+    observation: AgentObservationSnapshot,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionThreePersistedState {
+    version: u32,
+    workspaces: Vec<VersionThreePersistedWorkspace>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionThreePersistedWorkspace {
     id: String,
     name: String,
     shells: Vec<PersistedShell>,
@@ -250,6 +283,12 @@ impl StateStore {
                 self.save(&state)?;
                 state
             }
+            VERSION_THREE_STATE_VERSION => {
+                let previous: VersionThreePersistedState = parse_state(&bytes, &self.path)?;
+                let state = migrate_version_three_state(previous);
+                self.save(&state)?;
+                state
+            }
             VERSION_TWO_STATE_VERSION => {
                 let previous: VersionTwoPersistedState = parse_state(&bytes, &self.path)?;
                 let state = migrate_version_two_state(previous);
@@ -355,6 +394,46 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
 
 fn migrate_previous_state(previous: PreviousPersistedState) -> PersistedState {
     debug_assert_eq!(previous.version, PREVIOUS_STATE_VERSION);
+    PersistedState {
+        version: STATE_VERSION,
+        workspaces: previous
+            .workspaces
+            .into_iter()
+            .map(|workspace| {
+                let shell_cwds = workspace
+                    .shells
+                    .iter()
+                    .map(|shell| (shell.id.clone(), shell.cwd.clone()))
+                    .collect::<std::collections::HashMap<_, _>>();
+                PersistedWorkspace {
+                    id: workspace.id,
+                    name: workspace.name,
+                    shells: workspace.shells,
+                    launchers: workspace.launchers,
+                    agents: workspace
+                        .agents
+                        .into_iter()
+                        .map(|agent| PersistedAgentInstance {
+                            cwd: shell_cwds.get(&agent.shell_id).cloned(),
+                            id: agent.id,
+                            shell_id: agent.shell_id,
+                            run_id: agent.run_id,
+                            name: agent.name,
+                            integration: agent.integration,
+                            external_session_id: agent.external_session_id,
+                            started_at_ms: agent.started_at_ms,
+                            ended_at_ms: agent.ended_at_ms,
+                            observation: agent.observation,
+                        })
+                        .collect(),
+                }
+            })
+            .collect(),
+    }
+}
+
+fn migrate_version_three_state(previous: VersionThreePersistedState) -> PersistedState {
+    debug_assert_eq!(previous.version, VERSION_THREE_STATE_VERSION);
     PersistedState {
         version: STATE_VERSION,
         workspaces: previous
@@ -470,6 +549,7 @@ mod tests {
                         name: "first".into(),
                         integration: "test".into(),
                         external_session_id: Some("external-1".into()),
+                        cwd: Some("/tmp/project".into()),
                         started_at_ms: 10,
                         ended_at_ms: None,
                         observation: AgentObservationSnapshot {
@@ -488,6 +568,7 @@ mod tests {
                         name: "second".into(),
                         integration: "adapter".into(),
                         external_session_id: None,
+                        cwd: None,
                         started_at_ms: 20,
                         ended_at_ms: Some(30),
                         observation: AgentObservationSnapshot {
@@ -604,7 +685,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 4")
+                .contains("\"version\": 5")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
         assert!(migrated.workspaces[0].agents.is_empty());
@@ -654,7 +735,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 4")
+                .contains("\"version\": 5")
         );
         assert!(migrated.workspaces[0].agents.is_empty());
         fs::remove_dir_all(directory).unwrap();
@@ -692,7 +773,83 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 4")
+                .contains("\"version\": 5")
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_four_agent_cwds_from_retained_shells() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            br#"{
+  "version": 4,
+  "workspaces": [{
+    "id": "w1",
+    "name": "version-four",
+    "shells": [{
+      "id": "s1",
+      "name": "agent",
+      "cwd": "/tmp/project",
+      "command": [],
+      "last_run": null
+    }],
+    "launchers": [],
+    "agents": [{
+      "id": "a1",
+      "shell_id": "s1",
+      "run_id": "r1",
+      "name": "pi",
+      "integration": "pi",
+      "external_session_id": "external-1",
+      "started_at_ms": 1,
+      "ended_at_ms": null,
+      "observation": {
+        "revision": 1,
+        "state": "inactive",
+        "authority": "lifecycle_integration",
+        "evidence": "inactive",
+        "confidence": 100,
+        "observed_at_ms": 2
+      }
+    }, {
+      "id": "a2",
+      "shell_id": "removed",
+      "run_id": "r2",
+      "name": "old",
+      "integration": "pi",
+      "external_session_id": "external-2",
+      "started_at_ms": 1,
+      "ended_at_ms": null,
+      "observation": {
+        "revision": 1,
+        "state": "inactive",
+        "authority": "lifecycle_integration",
+        "evidence": "inactive",
+        "confidence": 100,
+        "observed_at_ms": 2
+      }
+    }]
+  }]
+}"#,
+        )
+        .unwrap();
+        let store = StateStore::at(path.clone());
+
+        let migrated = store.load().unwrap().unwrap();
+
+        assert_eq!(
+            migrated.workspaces[0].agents[0].cwd.as_deref(),
+            Some(Path::new("/tmp/project"))
+        );
+        assert!(migrated.workspaces[0].agents[1].cwd.is_none());
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("\"version\": 5")
         );
         fs::remove_dir_all(directory).unwrap();
     }

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1652,6 +1652,98 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
 }
 
 #[test]
+fn session_source_context_survives_shell_removal_and_cold_restart() {
+    let mut daemon = TestDaemon::start();
+    let project = daemon.runtime_dir.join("durable-source-project");
+    fs::create_dir(&project).unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "durable-source",
+            vec![ShellSpec::login("agent", project.clone())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+    let agent = daemon
+        .client
+        .ensure_agent(
+            &shell_id,
+            &run_id,
+            AgentRegistrationSpec {
+                name: "pi".into(),
+                integration: "pi".into(),
+                external_session_id: Some("durable-pi-session".into()),
+                report: AgentReport {
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "fixture idle".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    assert_eq!(agent.cwd.as_deref(), Some(project.as_path()));
+
+    let pi_directory = daemon.runtime_dir.join("durable-pi-sessions");
+    fs::create_dir(&pi_directory).unwrap();
+    fs::write(
+        pi_directory.join("custom.jsonl"),
+        format!(
+            "{{\"type\":\"session\",\"version\":3,\"id\":\"durable-pi-session\",\"cwd\":\"{}\"}}\n\
+             {{\"type\":\"message\",\"id\":\"user\",\"parentId\":null,\"timestamp\":\"x\",\"message\":{{\"role\":\"user\",\"content\":\"survives cleanup\",\"timestamp\":10}}}}\n\
+             {{\"type\":\"message\",\"id\":\"assistant\",\"parentId\":\"user\",\"timestamp\":\"x\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"text\",\"text\":\"still readable\"}}],\"timestamp\":11}}}}\n",
+            project.display()
+        ),
+    )
+    .unwrap();
+
+    daemon.client.close_shell(&shell_id).unwrap();
+    drop(attachment);
+    assert!(daemon.client.get_shell(&shell_id).is_err());
+    daemon.stop_with_cli();
+    daemon.restart();
+
+    let sessions = daemon
+        .command()
+        .args(["session", "list", "--workspace", &workspace.id, "--json"])
+        .output()
+        .unwrap();
+    assert!(sessions.status.success());
+    let sessions: serde_json::Value = serde_json::from_slice(&sessions.stdout).unwrap();
+    let session_id = sessions["data"]["sessions"][0]["id"].as_str().unwrap();
+    let inspect = daemon
+        .command()
+        .args(["session", "inspect", session_id, "--json"])
+        .output()
+        .unwrap();
+    assert!(inspect.status.success());
+    let inspect: serde_json::Value = serde_json::from_slice(&inspect.stdout).unwrap();
+    let occurrence = &inspect["data"]["session"]["occurrences"][0];
+    assert!(occurrence["retained_shell_name"].is_null());
+    assert!(occurrence["retained_shell_cwd"].is_null());
+    assert_eq!(occurrence["source_cwd"], project.display().to_string());
+
+    let read = daemon
+        .command()
+        .args(["session", "read", session_id, "--json"])
+        .env("PI_CODING_AGENT_SESSION_DIR", &pi_directory)
+        .output()
+        .unwrap();
+    assert!(
+        read.status.success(),
+        "{}",
+        String::from_utf8_lossy(&read.stderr)
+    );
+    let read: serde_json::Value = serde_json::from_slice(&read.stdout).unwrap();
+    assert_eq!(
+        read["data"]["transcript"]["entries"][1]["text"],
+        "still readable"
+    );
+}
+
+#[test]
 fn explicit_process_supervisor_preserves_child_io_exit_and_agent_authority() {
     let daemon = TestDaemon::start();
     let workspace = daemon
@@ -2133,7 +2225,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 12);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 13);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -2163,6 +2255,7 @@ fn native_daemon_lifecycle() {
         "revision_aware_reads",
         "protocol_10",
         "protocol_12",
+        "protocol_13",
         "inactive_agent_state",
         "protocol_11",
         "restartable_exited_shells",
@@ -2180,7 +2273,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 12"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 13"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- capture each Agent working directory authoritatively from its bound shell and persist it through state schema 5
- add protocol-13 source context with protocol-12 downgrade compatibility and version-4 state migration
- expose projected `source_cwd` separately from retained-shell metadata so canonical transcript reads survive shell removal and cold restart
- document the stronger-integration setup policy and roadmap workflow

## Validation
- `cargo test` (267 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`
- binary-level Pi transcript read after shell removal and cold daemon restart