### PR TITLE
Add revision-aware agent waits

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -65,11 +65,18 @@ Discover and inspect durable agent instances with:
 boomux agent list --json
 boomux agent list --workspace "<workspace-name-or-id>" --json
 boomux agent inspect "<exact-agent-id>" --json
+boomux agent wait "<exact-agent-id>" --after-revision <revision> --wait-ms 30000 --json
 ```
 
 Agent lookup is by exact agent ID. Never infer an agent ID or run ID from a
 name, shell status, terminal text, a recently seen row, or an external session
 ID.
+
+Use `agent wait` after inspecting an exact Agent and retaining its observation
+revision. If `changed` is false, repeat with the same revision; if true, retain
+the returned newer revision. `revision_ahead` means the caller's context is
+invalid and must be reacquired. `daemon_stopping` means reconnect and retry.
+Duplicate or lower-authority reports do not satisfy a wait.
 
 Discover projected session metadata with:
 
@@ -144,7 +151,7 @@ while conflicting later reports are rejected.
 
 If `register`, `ensure`, or `report` returns `run_changed`, stop reporting for that
 instance and reacquire exact lifecycle context. Do not guess the replacement
-run. Boomux does not yet provide terminal heuristics, agent wait/read commands,
+run. Boomux does not yet provide terminal heuristics, agent read commands,
 notifications, or control.
 
 ## Supervise An Explicit Process

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ boomux launcher rename <launcher-name-or-id> <new-name> [--workspace <name-or-id
 boomux launcher remove <launcher-name-or-id> [--workspace <name-or-id>]
 boomux agent list [--workspace <name-or-id>]
 boomux agent inspect <agent-id>
+boomux agent wait <agent-id> --after-revision <revision> [--wait-ms <milliseconds>]
 boomux agent register <name> --integration <integration> [--external-session-id <id>] [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux agent ensure <name> --integration <integration> --external-session-id <id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux agent supervise <name> --integration <integration> --external-session-id <canonical-root-id> [--shell-id <shell-id>] [--run-id <run-id>] -- <command>...
@@ -212,8 +213,10 @@ its revision. `daemon-lifecycle` exists in snapshots but is reserved for daemon
 observations and cannot be supplied to public mutation commands. A `done` report
 completes the instance permanently. Retrying the exact completion is an
 idempotent success; a different later report is rejected. Completed instances
-remain inspectable across daemon restart. Boomux does not yet provide terminal
-heuristics, agent waits, agent reads, or agent control.
+remain inspectable across daemon restart. Protocol 14 adds `agent wait`: callers
+supply the last observed revision and can block until a newer durable observation
+is accepted without polling. Boomux does not yet provide terminal heuristics,
+agent reads, or agent control.
 
 `boomux session list` and `boomux session inspect` project durable Agent
 instances into workspace session history. Instances are grouped within one

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -395,6 +395,15 @@ session that is not currently active from permanent `done` completion. Protocol
 13 adds durable Agent working-directory context; older clients receive Agent
 snapshots without that additive field.
 
+Protocol 14 adds an exact revision-conditional Agent read. `agent wait` holds the
+event coordination boundary while sampling the durable Agent observation, then
+uses the event condition variable only as a wake-up signal. Accepted reports are
+persisted before publication, so a waiter sees either the old revision or the
+complete committed replacement. Unrelated events cause harmless rechecks;
+duplicate and lower-authority reports do not advance the revision. Waiters are
+not persisted and reconnect with the same durable revision after daemon
+replacement.
+
 ### Transition Coordinator
 
 The daemon serializes observable runtime transitions through one coordinator. A

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -40,6 +40,7 @@ The following commands support `--json`:
 - `boomux launcher inspect`
 - `boomux agent list`
 - `boomux agent inspect`
+- `boomux agent wait`
 - `boomux agent register`
 - `boomux agent ensure`
 - `boomux agent report`
@@ -68,6 +69,8 @@ Command payloads are:
 - `launcher.inspect`: one `launcher` object.
 - `agent.list`: an `agents` array, optionally limited by `--workspace`.
 - `agent.inspect`: one `agent` object selected by exact agent ID.
+- `agent.wait`: `changed` plus one exact `agent` object after a revision-aware
+  conditional read.
 - `agent.register`, `agent.ensure`, and `agent.report`: one resulting `agent`
   object. The command field identifies the specific mutation.
 - `session.list`: a globally newest-first `sessions` array, optionally limited
@@ -120,6 +123,16 @@ already identifies a unique record, ensure returns the stored snapshot without
 applying the supplied name or report. This is the intended identity-recovery
 path after an integration reload. Otherwise it creates the record with the same
 shape and validation as `agent.register`.
+
+`agent.wait` requires protocol 14, an exact Agent ID, and
+`--after-revision`. A current revision greater than the supplied revision returns
+immediately with `changed: true`; an equal revision waits for at most `--wait-ms`
+and returns `changed: false` on timeout. Revision zero therefore returns any
+existing Agent immediately. A supplied future revision fails with
+`revision_ahead`. A terminal `done` observation at the equal revision returns
+unchanged immediately. Inactive sessions remain resumable and may advance later.
+No-op ensure calls, duplicate reports, and lower-authority reports do not advance
+the revision or satisfy a wait.
 
 ## Session Data
 

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -9,7 +9,15 @@ explicit exited-shell restart; the subsequent attachment emits the existing
 `inactive` Agent observations; older Agent-capable clients receive them as
 `unknown`. Protocol 13 adds the registration-time Agent working directory to
 snapshots and Agent events; protocol-12 clients receive the same records without
-that additive source context.
+that additive source context. Protocol 14 adds revision-conditional Agent reads
+that reuse the event condition variable for wakeups without consuming or
+depending on the retained global event cursor.
+
+`boomux agent wait <id> --after-revision <revision>` is the preferred way to
+await one Agent. It returns on a newer accepted durable observation, returns
+unchanged on timeout, rejects future revisions, and wakes with
+`daemon_stopping` during replacement. Callers reconnect and repeat with the same
+revision; no waiter state is persisted.
 
 ## Cursors
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -119,7 +119,7 @@ eternal process.
    guarantees do not require users to manage plugin files manually.
 3. Aggregate agent states into workspace counts and add an explainable,
    persistent attention queue for blocked and completed work.
-4. Add revision-aware `agent wait` so scripts can await durable state
+4. [Complete] Add revision-aware `agent wait` so scripts can await durable state
    transitions without polling human output.
 5. Add deduplicated notifications for blocked and completed transitions after
    the attention and wait semantics are established.

--- a/src/client.rs
+++ b/src/client.rs
@@ -54,6 +54,12 @@ pub struct EventBatch {
 }
 
 #[derive(Debug)]
+pub struct AgentWait {
+    pub agent: AgentInstanceSnapshot,
+    pub changed: bool,
+}
+
+#[derive(Debug)]
 pub struct RemoteError {
     pub code: Option<ErrorCode>,
     pub message: String,
@@ -430,6 +436,28 @@ impl Client {
         }
     }
 
+    pub fn wait_agent(
+        &self,
+        agent_id: impl Into<String>,
+        after_revision: u64,
+        wait_ms: u32,
+    ) -> io::Result<AgentWait> {
+        if self.protocol_version()? < 14 {
+            return Err(remote_error(
+                ErrorCode::UnsupportedVersion,
+                "daemon does not support Agent wait",
+            ));
+        }
+        match self.request(Request::WaitAgent {
+            agent_id: agent_id.into(),
+            after_revision,
+            wait_ms,
+        })? {
+            Response::AgentWait { agent, changed } => Ok(AgentWait { agent, changed }),
+            other => unexpected(other),
+        }
+    }
+
     pub fn read_shell(&self, shell_id: impl Into<String>, max_bytes: usize) -> io::Result<Vec<u8>> {
         match self.request(Request::ReadShell {
             shell_id: shell_id.into(),
@@ -625,6 +653,7 @@ impl Client {
 
 fn request_minimum_version(request: &Request) -> u32 {
     match request {
+        Request::WaitAgent { .. } => 14,
         Request::RegisterAgent { spec, .. } | Request::EnsureAgent { spec, .. }
             if spec.report.state == protocol::AgentState::Inactive =>
         {
@@ -814,6 +843,57 @@ mod tests {
     }
 
     #[test]
+    fn agent_wait_requires_protocol_fourteen() {
+        assert_eq!(
+            request_minimum_version(&Request::WaitAgent {
+                agent_id: "a1".into(),
+                after_revision: 1,
+                wait_ms: 30_000,
+            }),
+            14
+        );
+    }
+
+    #[test]
+    fn direct_client_negotiates_before_sending_agent_wait() {
+        let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 14);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    13,
+                    Response::Error {
+                        message: "protocol 14 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 13);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(&mut stream, &Envelope::with_version(13, Response::Pong))
+                .unwrap();
+        });
+        let client = Client::from_socket_path(socket);
+
+        let error = client.wait_agent("a1", 1, 0).unwrap_err();
+
+        assert_eq!(remote_code(&error), Some(ErrorCode::UnsupportedVersion));
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
     fn restart_shell_requires_protocol_eleven() {
         assert_eq!(
             request_minimum_version(&Request::RestartShell {
@@ -879,6 +959,22 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 14);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    13,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 13);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -673,6 +673,16 @@ fn handle_connection(
             ),
         );
     }
+    if response_version < 14 && matches!(request.message, Request::WaitAgent { .. }) {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "agent wait requires daemon protocol 14",
+            ),
+        );
+    }
 
     if let Request::Attach {
         shell_id,
@@ -865,7 +875,7 @@ fn visit_response_agents(
                 visitor(agent);
             }
         }
-        Response::Agent { agent } => visitor(agent),
+        Response::Agent { agent } | Response::AgentWait { agent, .. } => visitor(agent),
         Response::Events {
             snapshot, events, ..
         } => {
@@ -1657,6 +1667,11 @@ impl Registry {
             Request::GetAgent { agent_id } => Ok(Response::Agent {
                 agent: self.agent(&agent_id)?.snapshot()?,
             }),
+            Request::WaitAgent {
+                agent_id,
+                after_revision,
+                wait_ms,
+            } => self.wait_agent(&agent_id, after_revision, wait_ms),
             Request::CreateWorkspace { name, shells } => self.durable_mutation(|| {
                 let workspace = self.create_workspace(name, shells)?;
                 let events = workspace_created_events(&workspace);
@@ -3221,6 +3236,55 @@ impl Registry {
         Ok(tail_utf8(&text, max_bytes.min(MAX_SHELL_READ_BYTES))
             .as_bytes()
             .to_vec())
+    }
+
+    fn wait_agent(
+        &self,
+        agent_id: &str,
+        after_revision: u64,
+        wait_ms: u32,
+    ) -> io::Result<Response> {
+        let deadline =
+            Instant::now() + Duration::from_millis(u64::from(wait_ms)).min(MAX_EVENT_WAIT);
+        let mut events = lock(&self.events.state)?;
+        loop {
+            if self.stopping.load(Ordering::Acquire) {
+                return Err(coded_error(
+                    ErrorCode::DaemonStopping,
+                    "Boomux daemon is stopping",
+                ));
+            }
+            let agent = self.agent(agent_id)?.snapshot()?;
+            let revision = agent.observation.revision;
+            if after_revision < revision {
+                return Ok(Response::AgentWait {
+                    agent,
+                    changed: true,
+                });
+            }
+            if after_revision > revision {
+                return Err(coded_error(
+                    ErrorCode::RevisionAhead,
+                    "requested Agent revision is ahead of the current observation",
+                ));
+            }
+            if agent.observation.state == AgentState::Done
+                || wait_ms == 0
+                || Instant::now() >= deadline
+            {
+                return Ok(Response::AgentWait {
+                    agent,
+                    changed: false,
+                });
+            }
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            let (next, _) = self
+                .events
+                .changed
+                .wait_timeout(events, timeout)
+                .map_err(|_| io::Error::other("event wait lock poisoned"))?;
+            events = next;
+        }
     }
 
     fn read_shell_at(
@@ -5735,6 +5799,118 @@ mod tests {
         let restored = registry.agent(&agent.id).unwrap().snapshot().unwrap();
         assert_eq!(restored.observation.revision, 1);
         assert_eq!(restored.observation.state, AgentState::Working);
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn agent_wait_is_revision_conditional_and_wakes_after_durable_change() {
+        let registry = Arc::new(Registry::default());
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let Response::Agent { agent } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected registered agent");
+        };
+
+        let Response::AgentWait { changed, .. } = registry.wait_agent(&agent.id, 0, 0).unwrap()
+        else {
+            panic!("expected immediate Agent wait");
+        };
+        assert!(changed);
+        let Response::AgentWait { changed, .. } = registry.wait_agent(&agent.id, 1, 0).unwrap()
+        else {
+            panic!("expected unchanged Agent wait");
+        };
+        assert!(!changed);
+        assert_eq!(
+            error_code(&registry.wait_agent(&agent.id, 2, 0).unwrap_err()),
+            ErrorCode::RevisionAhead
+        );
+
+        let waiting_registry = Arc::clone(&registry);
+        let waiting_agent_id = agent.id.clone();
+        let waiter =
+            thread::spawn(move || waiting_registry.wait_agent(&waiting_agent_id, 1, 2_000));
+        thread::sleep(Duration::from_millis(20));
+        let Response::Agent { agent: blocked } = registry
+            .dispatch(Request::ReportAgent {
+                agent_id: agent.id.clone(),
+                run_id: run_id.clone(),
+                report: agent_spec(AgentState::Blocked).report,
+            })
+            .unwrap()
+        else {
+            panic!("expected changed Agent");
+        };
+        let Response::AgentWait {
+            agent: waited,
+            changed,
+        } = waiter.join().unwrap().unwrap()
+        else {
+            panic!("expected changed Agent wait");
+        };
+        assert!(changed);
+        assert_eq!(waited, blocked);
+        assert_eq!(waited.observation.revision, 2);
+
+        let Response::Agent { agent: done } = registry
+            .dispatch(Request::ReportAgent {
+                agent_id: agent.id.clone(),
+                run_id,
+                report: agent_spec(AgentState::Done).report,
+            })
+            .unwrap()
+        else {
+            panic!("expected completed Agent");
+        };
+        let start = Instant::now();
+        let Response::AgentWait { changed, .. } = registry
+            .wait_agent(&done.id, done.observation.revision, 2_000)
+            .unwrap()
+        else {
+            panic!("expected terminal Agent wait");
+        };
+        assert!(!changed);
+        assert!(start.elapsed() < Duration::from_secs(1));
+
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn agent_wait_wakes_with_daemon_stopping_before_registry_cleanup() {
+        let registry = Arc::new(Registry::default());
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let Response::Agent { agent } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id,
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected registered agent");
+        };
+        let waiting_registry = Arc::clone(&registry);
+        let waiter = thread::spawn(move || waiting_registry.wait_agent(&agent.id, 1, 2_000));
+        thread::sleep(Duration::from_millis(20));
+
+        registry.stopping.store(true, Ordering::Release);
+        registry.events.notify();
+
+        assert_eq!(
+            error_code(&waiter.join().unwrap().unwrap_err()),
+            ErrorCode::DaemonStopping
+        );
+        registry.stopping.store(false, Ordering::Release);
         shell.kill().unwrap();
         registry.close_workspace(&workspace.id).unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ const JSON_COMMANDS: &[&str] = &[
     "agent.register",
     "agent.ensure",
     "agent.report",
+    "agent.wait",
     "session.list",
     "session.inspect",
     "session.read",
@@ -71,6 +72,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "protocol_11",
     "protocol_12",
     "protocol_13",
+    "protocol_14",
     "restartable_exited_shells",
     "inactive_agent_state",
     "idempotent_agent_ensure",
@@ -81,6 +83,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "projected_agent_sessions",
     "canonical_session_transcripts",
     "durable_session_source_context",
+    "revision_aware_agent_wait",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -358,6 +361,14 @@ enum AgentCommands {
     /// Show an agent instance by exact ID
     #[command(alias = "get")]
     Inspect { agent_id: String },
+    /// Wait for an exact Agent observation revision to advance
+    Wait {
+        agent_id: String,
+        #[arg(long)]
+        after_revision: u64,
+        #[arg(long, default_value_t = 30_000)]
+        wait_ms: u32,
+    },
     /// Register an agent instance for a shell run
     Register(AgentRegistrationArgs),
     /// Ensure an idempotent agent instance for a shell run
@@ -728,6 +739,9 @@ fn command_name(cli: &Cli) -> &'static str {
             command: AgentCommands::Inspect { .. },
         }) => "agent.inspect",
         Some(Commands::Agent {
+            command: AgentCommands::Wait { .. },
+        }) => "agent.wait",
+        Some(Commands::Agent {
             command: AgentCommands::Register(..),
         }) => "agent.register",
         Some(Commands::Agent {
@@ -785,6 +799,7 @@ fn supports_json(cli: &Cli) -> bool {
         }) | Some(Commands::Agent {
             command: AgentCommands::List { .. }
                 | AgentCommands::Inspect { .. }
+                | AgentCommands::Wait { .. }
                 | AgentCommands::Register(..)
                 | AgentCommands::Ensure(..)
                 | AgentCommands::Report { .. }
@@ -1792,6 +1807,29 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
                 );
             }
             print_agent(&agent, &workspace.name);
+        }
+        AgentCommands::Wait {
+            agent_id,
+            after_revision,
+            wait_ms,
+        } => {
+            let waited = client.wait_agent(agent_id, after_revision, wait_ms)?;
+            if json {
+                return cli_output::print(
+                    "agent.wait",
+                    serde_json::json!({
+                        "changed": waited.changed,
+                        "agent": cli_output::agent(&waited.agent, None),
+                    }),
+                );
+            }
+            println!("CHANGED\t{}", waited.changed);
+            println!("ID\t{}", waited.agent.id);
+            println!(
+                "STATE\t{}",
+                cli_output::agent_state(waited.agent.observation.state)
+            );
+            println!("REVISION\t{}", waited.agent.observation.revision);
         }
         AgentCommands::Register(arguments) => {
             register_or_ensure_agent(&client, arguments, json, false)?;
@@ -3377,6 +3415,30 @@ mod tests {
         let cli = Cli::try_parse_from([
             "boomux",
             "agent",
+            "wait",
+            "a1",
+            "--after-revision",
+            "3",
+            "--wait-ms",
+            "5000",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(command_name(&cli), "agent.wait");
+        assert!(supports_json(&cli));
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Agent {
+                command: AgentCommands::Wait {
+                    agent_id,
+                    after_revision: 3,
+                    wait_ms: 5000,
+                }
+            }) if agent_id == "a1"
+        ));
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "agent",
             "report",
             "a1",
             "--state",
@@ -4405,7 +4467,12 @@ mod tests {
 
     #[test]
     fn capabilities_advertise_phase_two_agent_integration_surface() {
-        for command in ["agent.register", "agent.ensure", "agent.report"] {
+        for command in [
+            "agent.register",
+            "agent.ensure",
+            "agent.report",
+            "agent.wait",
+        ] {
             assert!(JSON_COMMANDS.contains(&command));
         }
         for command in ["session.list", "session.inspect", "session.read"] {
@@ -4429,7 +4496,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 13);
+        assert_eq!(protocol::PROTOCOL_VERSION, 14);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 13;
+pub const PROTOCOL_VERSION: u32 = 14;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -323,6 +323,12 @@ pub enum Request {
     GetAgent {
         agent_id: String,
     },
+    WaitAgent {
+        agent_id: String,
+        after_revision: u64,
+        #[serde(default)]
+        wait_ms: u32,
+    },
     CreateWorkspace {
         name: String,
         shells: Vec<ShellSpec>,
@@ -424,6 +430,10 @@ pub enum Response {
     },
     Agent {
         agent: AgentInstanceSnapshot,
+    },
+    AgentWait {
+        agent: AgentInstanceSnapshot,
+        changed: bool,
     },
     Output {
         bytes: Vec<u8>,
@@ -745,9 +755,51 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_thirteen_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 13);
+    fn protocol_version_is_fourteen_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 14);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
+    }
+
+    #[test]
+    fn agent_wait_messages_round_trip() {
+        let request = Request::WaitAgent {
+            agent_id: "a1".into(),
+            after_revision: 3,
+            wait_ms: 30_000,
+        };
+        let encoded = serde_json::to_value(&request).unwrap();
+        assert_eq!(encoded["request"], "wait_agent");
+        assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
+
+        let response = Response::AgentWait {
+            agent: AgentInstanceSnapshot {
+                id: "a1".into(),
+                workspace_id: "w1".into(),
+                shell_id: "s1".into(),
+                run_id: "r1".into(),
+                name: "agent".into(),
+                integration: "test".into(),
+                external_session_id: Some("external".into()),
+                cwd: Some("/tmp/project".into()),
+                started_at_ms: 1,
+                ended_at_ms: None,
+                observation: AgentObservationSnapshot {
+                    revision: 4,
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "idle".into(),
+                    confidence: 100,
+                    observed_at_ms: 2,
+                },
+            },
+            changed: true,
+        };
+        let encoded = serde_json::to_value(&response).unwrap();
+        assert_eq!(encoded["response"], "agent_wait");
+        assert_eq!(
+            serde_json::from_value::<Response>(encoded).unwrap(),
+            response
+        );
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1193,6 +1193,20 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert_eq!(register["data"]["agent"]["observation"]["revision"], 1);
     let adapter_id = register["data"]["agent"]["id"].as_str().unwrap().to_owned();
 
+    let mut wait_command = daemon.command();
+    wait_command.args([
+        "agent",
+        "wait",
+        &adapter_id,
+        "--after-revision",
+        "1",
+        "--wait-ms",
+        "5000",
+        "--json",
+    ]);
+    let wait = thread::spawn(move || wait_command.output().unwrap());
+    thread::sleep(Duration::from_millis(50));
+
     let report_cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
     let report = daemon
         .command()
@@ -1229,6 +1243,17 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
         report["data"]["agent"]["observation"]["authority"],
         "process_adapter"
     );
+    let waited = wait.join().unwrap();
+    assert!(
+        waited.status.success(),
+        "{}",
+        String::from_utf8_lossy(&waited.stderr)
+    );
+    let waited: serde_json::Value = serde_json::from_slice(&waited.stdout).unwrap();
+    assert_eq!(waited["command"], "agent.wait");
+    assert_eq!(waited["data"]["changed"], true);
+    assert_eq!(waited["data"]["agent"]["id"], adapter_id);
+    assert_eq!(waited["data"]["agent"]["observation"]["revision"], 2);
     let duplicate = daemon
         .client
         .report_agent(
@@ -1243,6 +1268,23 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
         )
         .unwrap();
     assert_eq!(duplicate.observation.revision, 2);
+    let unchanged = daemon
+        .command()
+        .args([
+            "agent",
+            "wait",
+            &adapter_id,
+            "--after-revision",
+            "2",
+            "--wait-ms",
+            "10",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(unchanged.status.success());
+    let unchanged: serde_json::Value = serde_json::from_slice(&unchanged.stdout).unwrap();
+    assert_eq!(unchanged["data"]["changed"], false);
     let report_events = daemon.client.events(Some(report_cursor), 256, 0).unwrap();
     assert_eq!(
         report_events
@@ -1566,6 +1608,21 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
                 shell_id: shell_id.clone(),
                 run_id: run_id.clone(),
                 spec: registration.clone(),
+            },
+        ),
+        protocol::Response::Error {
+            code: Some(ErrorCode::UnsupportedVersion),
+            ..
+        }
+    ));
+    assert!(matches!(
+        versioned_request(
+            &daemon.client,
+            13,
+            protocol::Request::WaitAgent {
+                agent_id: agent_id.clone(),
+                after_revision: 1,
+                wait_ms: 0,
             },
         ),
         protocol::Response::Error {
@@ -2225,7 +2282,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 13);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 14);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -2247,7 +2304,13 @@ fn native_daemon_lifecycle() {
         "@earendil-works/pi-coding-agent"
     );
     let json_commands = capabilities["data"]["json_commands"].as_array().unwrap();
-    for command in ["events", "agent.register", "agent.ensure", "agent.report"] {
+    for command in [
+        "events",
+        "agent.register",
+        "agent.ensure",
+        "agent.report",
+        "agent.wait",
+    ] {
         assert!(json_commands.iter().any(|current| current == command));
     }
     let features = capabilities["data"]["features"].as_array().unwrap();
@@ -2256,6 +2319,7 @@ fn native_daemon_lifecycle() {
         "protocol_10",
         "protocol_12",
         "protocol_13",
+        "protocol_14",
         "inactive_agent_state",
         "protocol_11",
         "restartable_exited_shells",
@@ -2273,7 +2337,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 13"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 14"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- add protocol 14 conditional Agent reads keyed by observation revision
- expose agent wait through the typed client, CLI, and stable JSON command
- document synchronization semantics and cover wake, timeout, completion, shutdown, and compatibility paths

## Verification
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check