### PR TITLE
Add durable agent attention queue

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -78,6 +78,21 @@ the returned newer revision. `revision_ahead` means the caller's context is
 invalid and must be reacquired. `daemon_stopping` means reconnect and retry.
 Duplicate or lower-authority reports do not satisfy a wait.
 
+Inspect outstanding blocked and completed work with:
+
+```console
+boomux attention list --json
+boomux attention list --workspace "<workspace-name-or-id>" --json
+boomux attention acknowledge "<exact-agent-id>" --observation-revision <revision> --json
+```
+
+The queue is durable and ordered blocked before completed, then newest first.
+Use the exact Agent ID and raising observation revision returned by `attention
+list`; never acknowledge by name or by a later lifecycle revision. A stale
+revision fails with `revision_ahead`, while an already empty item returns
+`changed: false`. Acknowledgment does not advance lifecycle state or satisfy an
+`agent wait`.
+
 Discover projected session metadata with:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ boomux agent register <name> --integration <integration> [--external-session-id 
 boomux agent ensure <name> --integration <integration> --external-session-id <id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
 boomux agent supervise <name> --integration <integration> --external-session-id <canonical-root-id> [--shell-id <shell-id>] [--run-id <run-id>] -- <command>...
 boomux agent report <agent-id> [--shell-id <shell-id>] [--run-id <run-id>] --state <state> --authority <authority> --evidence <evidence> --confidence <0-100>
+boomux attention list [--workspace <name-or-id>]
+boomux attention acknowledge <agent-id> --observation-revision <revision>
 boomux session list [--workspace <name-or-id>]
 boomux session inspect <session-id>
 boomux session read <session-id> [--limit <entries>] [--max-bytes <bytes>]
@@ -215,7 +217,12 @@ completes the instance permanently. Retrying the exact completion is an
 idempotent success; a different later report is rejected. Completed instances
 remain inspectable across daemon restart. Protocol 14 adds `agent wait`: callers
 supply the last observed revision and can block until a newer durable observation
-is accepted without polling. Boomux does not yet provide terminal heuristics,
+is accepted without polling. Protocol 15 records accepted blocked and completed
+observations in a durable, blocked-first attention queue. Each item retains the
+exact raising evidence, authority, confidence, revision, and timestamp until it
+is conditionally acknowledged; later working or idle activity does not erase
+unseen work. Workspace output includes fixed Agent state counts and the
+outstanding attention count. Boomux does not yet provide terminal heuristics,
 agent reads, or agent control.
 
 `boomux session list` and `boomux session inspect` project durable Agent

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -404,6 +404,16 @@ duplicate and lower-authority reports do not advance the revision. Waiters are
 not persisted and reconnect with the same durable revision after daemon
 replacement.
 
+Protocol 15 adds one durable outstanding attention item per Agent. Accepted
+`blocked` and `done` observations capture their reason and full raising
+observation; unrelated later states preserve the item until acknowledgment, and
+a newer qualifying observation supersedes it. Acknowledgment is conditional on
+the captured observation revision, idempotent once empty, and does not mutate
+the lifecycle revision used by `agent wait`. Version-5 state migrates with no
+outstanding items so upgrading does not reinterpret historical work as unseen.
+The CLI projects these records into a deterministic blocked-first queue and
+reports fixed lifecycle-state and attention counts per workspace.
+
 ### Transition Coordinator
 
 The daemon serializes observable runtime transitions through one coordinator. A
@@ -431,9 +441,9 @@ not persisted per chunk, but output revision mutation and `output_changed`
 publication cross the coordinator together. A non-blocking terminal lock keeps
 output processing from holding global locks while waiting on terminal snapshots.
 
-Agent registration, ensure, and reports use the same durable mutation coordinator.
-Persistence and `agent_registered`, `agent_state_changed`, or
-`agent_completed` publication therefore share the normal ordering boundary and
+Agent registration, ensure, reports, and attention acknowledgment use the same durable mutation coordinator.
+Persistence and `agent_registered`, `agent_state_changed`, `agent_completed`, or
+`agent_attention_acknowledged` publication therefore share the normal ordering boundary and
 baseline snapshots include the exact coordinated cut.
 
 ## Runtime Semantics
@@ -452,7 +462,7 @@ to the complete registry and removes the runtime socket.
 The daemon atomically writes reproducible registry metadata to
 `$XDG_STATE_HOME/boomux/state.json`, falling back to
 `~/.local/state/boomux/state.json`. Workspace, launcher, shell, and agent IDs;
-names and grouping; working directories; argument vectors; agent observations;
+ names and grouping; working directories; argument vectors; agent observations and attention;
 and last terminal profiles survive restart. The last run record also preserves
 its identity and outcome. Recovered
 shells are pending: Boomux does not claim that arbitrary
@@ -475,5 +485,5 @@ as pending.
 
 Future agent runtime work is tracked in [`roadmap.md`](roadmap.md). The explicit
 process-adapter supervisor is only a foundation; automatic and
-integration-specific adapters, terminal heuristics, aggregation, waits,
+ integration-specific adapters, terminal heuristics,
 notifications, and control remain future work.

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -44,14 +44,16 @@ The following commands support `--json`:
 - `boomux agent register`
 - `boomux agent ensure`
 - `boomux agent report`
+- `boomux attention list`
+- `boomux attention acknowledge`
 - `boomux session list`
 - `boomux session inspect`
 - `boomux session read`
 - `boomux daemon status`
 
 JSON mutations are deliberately narrow: only `agent register`, `agent ensure`,
-and `agent report` support the contract. Other mutation commands retain human
-output. Passing `--json` to an unsupported command fails with
+`agent report`, and `attention acknowledge` support the contract. Other mutation
+commands retain human output. Passing `--json` to an unsupported command fails with
 `invalid_argument` before performing the operation.
 
 Command payloads are:
@@ -61,7 +63,8 @@ Command payloads are:
 - `list`: a `shells` array.
 - `shells`: workspace identity plus a `shells` array.
 - `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`,
-  `launcher_count`, and `agent_count`.
+  `launcher_count`, `agent_count`, fixed `agent_state_counts`, and
+  `attention_count`.
 - `workspace.inspect`: one `workspace` object containing `id`, `name`, and
   `shells`, `launchers`, and `agents` arrays.
 - `shell.inspect`: one `shell` object.
@@ -73,6 +76,9 @@ Command payloads are:
   conditional read.
 - `agent.register`, `agent.ensure`, and `agent.report`: one resulting `agent`
   object. The command field identifies the specific mutation.
+- `attention.list`: an `attention` array ordered blocked before completed, then
+  newest observation first; `--workspace` limits it to one workspace.
+- `attention.acknowledge`: `changed` plus the resulting `agent` object.
 - `session.list`: a globally newest-first `sessions` array, optionally limited
   by exact workspace name or ID.
 - `session.inspect`: one projected `session` object selected only by exact
@@ -100,7 +106,7 @@ and `command`. `command` is the exact executable-and-arguments array.
 
 Agent objects include stable fields `id`, `workspace_id`, `workspace_name`,
 `shell_id`, `run_id`, `name`, `integration`, `external_session_id`,
-`started_at_ms`, `ended_at_ms`, and `observation`. The observation contains
+`started_at_ms`, `ended_at_ms`, `attention`, and `observation`. The observation contains
 `revision`, `state`, `authority`, `evidence`, `confidence`, and
 `observed_at_ms`. Missing optional values are JSON `null`.
 
@@ -116,6 +122,19 @@ the unchanged snapshot. Equal-authority changed reports update the observation.
 `done` is terminal and has a non-null `ended_at_ms`; an exact completion retry is
 an unchanged success, while conflicting later reports fail. Completed records
 remain durable and inspectable.
+
+Protocol 15 raises one durable outstanding attention item for every accepted
+`blocked` or `done` observation. The item records `reason` (`blocked` or
+`completed`) and a copy of the exact raising observation, so later working or
+idle reports do not erase an unseen blocker. A newer blocked observation or
+terminal completion replaces the older item. Existing records migrated from an
+older daemon start acknowledged and do not flood the queue.
+
+`attention acknowledge <agent-id> --observation-revision <revision>` removes
+only the item raised by that exact revision. A different outstanding revision
+fails with `revision_ahead`; an already empty item is an idempotent unchanged
+success. Acknowledgment does not alter the Agent lifecycle observation or
+satisfy `agent wait`.
 
 `agent.ensure` requires `--external-session-id` and protocol 10. Its identity key
 is `integration`, `external_session_id`, `shell_id`, and `run_id`. When that key

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -12,6 +12,10 @@ snapshots and Agent events; protocol-12 clients receive the same records without
 that additive source context. Protocol 14 adds revision-conditional Agent reads
 that reuse the event condition variable for wakeups without consuming or
 depending on the retained global event cursor.
+Protocol 15 adds durable blocked/completed attention and conditional
+acknowledgment. Protocol-14 clients receive Agent snapshots without attention
+and do not receive acknowledgment events, while cursors still advance across
+those filtered events.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns
@@ -47,7 +51,8 @@ The event vocabulary is:
 - `shell_created`, `shell_renamed`, `shell_closed`
 - `launcher_created`, `launcher_renamed`, `launcher_removed`
 - `run_started`, `output_changed`, `run_exited`
-- `agent_registered`, `agent_state_changed`, `agent_completed`
+- `agent_registered`, `agent_state_changed`, `agent_completed`,
+  `agent_attention_acknowledged`
 - `handoff_completed`
 
 Output events carry run identity and the latest output revision, not raw PTY
@@ -67,6 +72,12 @@ successful no-ops with no event. Equal-authority reports with changed content
 are updates and emit the normal state-change or completion event. Retrying the
 exact accepted `done` report is idempotent and emits no second completion event;
 other reports against a completed instance are rejected.
+
+Accepted blocked and completed observations also carry an outstanding attention
+item in their Agent snapshot. `agent_attention_acknowledged` contains the full
+resulting Agent snapshot after the item is removed. The acknowledgment is
+conditional on its raising observation revision, persists before publication,
+and does not increment the lifecycle observation revision.
 
 Protocol-8 and older event clients do not receive protocol-9 agent snapshots or
 agent events. Filtering does not rewrite the journal: their returned cursor

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,7 +117,7 @@ eternal process.
    canonical identity plus lifecycle reporting end to end. Include status,
    version compatibility, diagnostics, repair, and uninstall paths so stronger
    guarantees do not require users to manage plugin files manually.
-3. Aggregate agent states into workspace counts and add an explainable,
+3. [Complete] Aggregate agent states into workspace counts and add an explainable,
    persistent attention queue for blocked and completed work.
 4. [Complete] Add revision-aware `agent wait` so scripts can await durable state
    transitions without polling human output.

--- a/src/agent_attention_projection.rs
+++ b/src/agent_attention_projection.rs
@@ -1,0 +1,254 @@
+use std::cmp::Ordering;
+
+use boomux::protocol::{
+    AgentAttentionReason, AgentAttentionSnapshot, AgentInstanceSnapshot, AgentState,
+    WorkspaceSnapshot,
+};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct AgentStateCounts {
+    pub(crate) unknown: usize,
+    pub(crate) working: usize,
+    pub(crate) blocked: usize,
+    pub(crate) idle: usize,
+    pub(crate) inactive: usize,
+    pub(crate) done: usize,
+}
+
+impl AgentStateCounts {
+    fn add(&mut self, state: AgentState) {
+        match state {
+            AgentState::Unknown => self.unknown += 1,
+            AgentState::Working => self.working += 1,
+            AgentState::Blocked => self.blocked += 1,
+            AgentState::Idle => self.idle += 1,
+            AgentState::Inactive => self.inactive += 1,
+            AgentState::Done => self.done += 1,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct WorkspaceAgentSummary {
+    pub(crate) states: AgentStateCounts,
+    pub(crate) attention_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AttentionItem {
+    pub(crate) workspace_id: String,
+    pub(crate) workspace_name: String,
+    pub(crate) agent: AgentInstanceSnapshot,
+    pub(crate) attention: AgentAttentionSnapshot,
+    pub(crate) observation_is_current: bool,
+    pub(crate) shell_is_retained: bool,
+}
+
+pub(crate) fn summarize_workspace(workspace: &WorkspaceSnapshot) -> WorkspaceAgentSummary {
+    let mut summary = WorkspaceAgentSummary::default();
+    for agent in &workspace.agents {
+        summary.states.add(agent.observation.state);
+        summary.attention_count += usize::from(agent.attention.is_some());
+    }
+    summary
+}
+
+pub(crate) fn project_attention(workspaces: &[WorkspaceSnapshot]) -> Vec<AttentionItem> {
+    let mut items = workspaces
+        .iter()
+        .flat_map(|workspace| {
+            workspace.agents.iter().filter_map(|agent| {
+                let attention = agent.attention.clone()?;
+                let shell_is_retained = workspace
+                    .shells
+                    .iter()
+                    .any(|shell| shell.id == agent.shell_id);
+                Some(AttentionItem {
+                    workspace_id: workspace.id.clone(),
+                    workspace_name: workspace.name.clone(),
+                    observation_is_current: agent.observation.revision
+                        == attention.observation.revision,
+                    shell_is_retained,
+                    agent: agent.clone(),
+                    attention,
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    items.sort_by(compare_attention);
+    items
+}
+
+fn compare_attention(left: &AttentionItem, right: &AttentionItem) -> Ordering {
+    attention_rank(left.attention.reason)
+        .cmp(&attention_rank(right.attention.reason))
+        .then_with(|| {
+            right
+                .attention
+                .observation
+                .observed_at_ms
+                .cmp(&left.attention.observation.observed_at_ms)
+        })
+        .then_with(|| left.workspace_id.cmp(&right.workspace_id))
+        .then_with(|| left.agent.id.cmp(&right.agent.id))
+}
+
+fn attention_rank(reason: AgentAttentionReason) -> u8 {
+    match reason {
+        AgentAttentionReason::Blocked => 0,
+        AgentAttentionReason::Completed => 1,
+    }
+}
+
+pub(crate) fn attention_reason(reason: AgentAttentionReason) -> &'static str {
+    match reason {
+        AgentAttentionReason::Blocked => "blocked",
+        AgentAttentionReason::Completed => "completed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use boomux::protocol::{
+        AgentAuthority, AgentObservationSnapshot, ShellRunSnapshot, ShellStatus,
+        WorkspaceLauncherSnapshot,
+    };
+    use std::path::PathBuf;
+
+    fn agent(
+        id: &str,
+        state: AgentState,
+        attention: Option<(AgentAttentionReason, u64)>,
+    ) -> AgentInstanceSnapshot {
+        let observation = AgentObservationSnapshot {
+            revision: 3,
+            state,
+            authority: AgentAuthority::LifecycleIntegration,
+            evidence: "current".into(),
+            confidence: 100,
+            observed_at_ms: 30,
+        };
+        AgentInstanceSnapshot {
+            id: id.into(),
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            name: id.into(),
+            integration: "test".into(),
+            external_session_id: Some(id.into()),
+            cwd: Some(PathBuf::from("/tmp")),
+            started_at_ms: 1,
+            ended_at_ms: (state == AgentState::Done).then_some(30),
+            attention: attention.map(|(reason, revision)| AgentAttentionSnapshot {
+                reason,
+                observation: AgentObservationSnapshot {
+                    revision,
+                    state: match reason {
+                        AgentAttentionReason::Blocked => AgentState::Blocked,
+                        AgentAttentionReason::Completed => AgentState::Done,
+                    },
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "needs attention".into(),
+                    confidence: 100,
+                    observed_at_ms: revision * 10,
+                },
+            }),
+            observation,
+        }
+    }
+
+    fn workspace(agents: Vec<AgentInstanceSnapshot>) -> WorkspaceSnapshot {
+        WorkspaceSnapshot {
+            id: "w1".into(),
+            name: "project".into(),
+            shells: vec![boomux::protocol::ShellSnapshot {
+                id: "s1".into(),
+                workspace_id: "w1".into(),
+                name: "shell".into(),
+                cwd: PathBuf::from("/tmp"),
+                command: Vec::new(),
+                status: ShellStatus::Running,
+                run: Some(ShellRunSnapshot {
+                    id: "r1".into(),
+                    generation: 1,
+                    started_at_ms: 1,
+                    ended_at_ms: None,
+                    exit_reason: None,
+                    output_revision: 0,
+                    environment_has_run_id: true,
+                }),
+                foreground_process: None,
+            }],
+            launchers: Vec::<WorkspaceLauncherSnapshot>::new(),
+            agents,
+        }
+    }
+
+    #[test]
+    fn counts_every_retained_agent_state_and_outstanding_item() {
+        let states = [
+            AgentState::Unknown,
+            AgentState::Working,
+            AgentState::Blocked,
+            AgentState::Idle,
+            AgentState::Inactive,
+            AgentState::Done,
+        ];
+        let agents = states
+            .into_iter()
+            .enumerate()
+            .map(|(index, state)| {
+                agent(
+                    &format!("a{index}"),
+                    state,
+                    (index == 2).then_some((AgentAttentionReason::Blocked, 3)),
+                )
+            })
+            .collect();
+        let summary = summarize_workspace(&workspace(agents));
+        assert_eq!(
+            summary.states,
+            AgentStateCounts {
+                unknown: 1,
+                working: 1,
+                blocked: 1,
+                idle: 1,
+                inactive: 1,
+                done: 1
+            }
+        );
+        assert_eq!(summary.attention_count, 1);
+    }
+
+    #[test]
+    fn queue_is_blocked_first_newest_first_and_explains_stale_observations() {
+        let items = project_attention(&[workspace(vec![
+            agent(
+                "completed",
+                AgentState::Done,
+                Some((AgentAttentionReason::Completed, 3)),
+            ),
+            agent(
+                "old-blocker",
+                AgentState::Working,
+                Some((AgentAttentionReason::Blocked, 2)),
+            ),
+            agent(
+                "new-blocker",
+                AgentState::Blocked,
+                Some((AgentAttentionReason::Blocked, 3)),
+            ),
+        ])]);
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.agent.id.as_str())
+                .collect::<Vec<_>>(),
+            ["new-blocker", "old-blocker", "completed"]
+        );
+        assert!(items[0].observation_is_current);
+        assert!(!items[1].observation_is_current);
+        assert!(items.iter().all(|item| item.shell_is_retained));
+    }
+}

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -5,10 +5,12 @@ use serde::Serialize;
 
 use boomux::client::RemoteError;
 use boomux::protocol::{
-    AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot, AgentState, ErrorCode,
-    ShellRunExitReason, ShellSnapshot, ShellStatus, WorkspaceLauncherSnapshot,
+    AgentAttentionReason, AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot,
+    AgentState, ErrorCode, ShellRunExitReason, ShellSnapshot, ShellStatus,
+    WorkspaceLauncherSnapshot,
 };
 
+use crate::agent_attention_projection::AgentStateCounts;
 use crate::session_projection::{SessionOccurrence, SessionProjection};
 
 pub(crate) const SCHEMA: &str = "boomux.cli/v1";
@@ -81,6 +83,8 @@ pub(crate) struct WorkspaceSummary {
     pub(crate) shell_count: usize,
     pub(crate) launcher_count: usize,
     pub(crate) agent_count: usize,
+    pub(crate) agent_state_counts: AgentStateCounts,
+    pub(crate) attention_count: usize,
 }
 
 #[derive(Serialize)]
@@ -105,7 +109,14 @@ pub(crate) struct AgentData {
     pub(crate) external_session_id: Option<String>,
     pub(crate) started_at_ms: u64,
     pub(crate) ended_at_ms: Option<u64>,
+    pub(crate) attention: Option<AgentAttentionData>,
     pub(crate) observation: AgentObservationData,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AgentAttentionData {
+    reason: &'static str,
+    observation: AgentObservationData,
 }
 
 #[derive(Serialize)]
@@ -257,6 +268,13 @@ pub(crate) fn agent(agent: &AgentInstanceSnapshot, workspace_name: Option<&str>)
         external_session_id: agent.external_session_id.clone(),
         started_at_ms: agent.started_at_ms,
         ended_at_ms: agent.ended_at_ms,
+        attention: agent
+            .attention
+            .as_ref()
+            .map(|attention| AgentAttentionData {
+                reason: agent_attention_reason(attention.reason),
+                observation: agent_observation(&attention.observation),
+            }),
         observation: agent_observation(&agent.observation),
     }
 }
@@ -324,6 +342,13 @@ pub(crate) fn agent_state(state: AgentState) -> &'static str {
         AgentState::Idle => "idle",
         AgentState::Inactive => "inactive",
         AgentState::Done => "done",
+    }
+}
+
+pub(crate) fn agent_attention_reason(reason: AgentAttentionReason) -> &'static str {
+    match reason {
+        AgentAttentionReason::Blocked => "blocked",
+        AgentAttentionReason::Completed => "completed",
     }
 }
 
@@ -419,6 +444,17 @@ mod tests {
                 cwd: Some("/tmp/project".into()),
                 started_at_ms: 10,
                 ended_at_ms: None,
+                attention: Some(boomux::protocol::AgentAttentionSnapshot {
+                    reason: AgentAttentionReason::Blocked,
+                    observation: AgentObservationSnapshot {
+                        revision: 1,
+                        state: AgentState::Blocked,
+                        authority: AgentAuthority::LifecycleIntegration,
+                        evidence: "approval needed".into(),
+                        confidence: 100,
+                        observed_at_ms: 10,
+                    },
+                }),
                 observation: AgentObservationSnapshot {
                     revision: 2,
                     state: AgentState::Working,
@@ -436,6 +472,8 @@ mod tests {
         assert_eq!(value["observation"]["state"], "working");
         assert_eq!(value["observation"]["authority"], "lifecycle_integration");
         assert_eq!(value["observation"]["confidence"], 95);
+        assert_eq!(value["attention"]["reason"], "blocked");
+        assert_eq!(value["attention"]["observation"]["revision"], 1);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -60,6 +60,12 @@ pub struct AgentWait {
 }
 
 #[derive(Debug)]
+pub struct AgentAttentionAcknowledgement {
+    pub agent: AgentInstanceSnapshot,
+    pub changed: bool,
+}
+
+#[derive(Debug)]
 pub struct RemoteError {
     pub code: Option<ErrorCode>,
     pub message: String,
@@ -458,6 +464,22 @@ impl Client {
         }
     }
 
+    pub fn acknowledge_agent_attention(
+        &self,
+        agent_id: impl Into<String>,
+        observation_revision: u64,
+    ) -> io::Result<AgentAttentionAcknowledgement> {
+        match self.request(Request::AcknowledgeAgentAttention {
+            agent_id: agent_id.into(),
+            observation_revision,
+        })? {
+            Response::AgentAttentionAcknowledged { agent, changed } => {
+                Ok(AgentAttentionAcknowledgement { agent, changed })
+            }
+            other => unexpected(other),
+        }
+    }
+
     pub fn read_shell(&self, shell_id: impl Into<String>, max_bytes: usize) -> io::Result<Vec<u8>> {
         match self.request(Request::ReadShell {
             shell_id: shell_id.into(),
@@ -653,6 +675,7 @@ impl Client {
 
 fn request_minimum_version(request: &Request) -> u32 {
     match request {
+        Request::AcknowledgeAgentAttention { .. } => 15,
         Request::WaitAgent { .. } => 14,
         Request::RegisterAgent { spec, .. } | Request::EnsureAgent { spec, .. }
             if spec.report.state == protocol::AgentState::Inactive =>
@@ -855,12 +878,39 @@ mod tests {
     }
 
     #[test]
+    fn agent_attention_acknowledgment_requires_protocol_fifteen() {
+        assert_eq!(
+            request_minimum_version(&Request::AcknowledgeAgentAttention {
+                agent_id: "a1".into(),
+                observation_revision: 2,
+            }),
+            15
+        );
+    }
+
+    #[test]
     fn direct_client_negotiates_before_sending_agent_wait() {
         let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 15);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    14,
+                    Response::Error {
+                        message: "protocol 15 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 14);
@@ -959,6 +1009,22 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 15);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    14,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 14);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,11 +23,11 @@ use crate::client;
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::protocol::{
-    self, AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot, AgentRegistrationSpec,
-    AgentReport, AgentState, AttachFrame, DaemonEvent, DaemonEventKind, Envelope, ErrorCode,
-    EventCursor, Request, Response, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec,
-    ShellStatus, Snapshot, TerminalProfile, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
-    WorkspaceSnapshot,
+    self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
+    AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame,
+    DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, Request, Response,
+    ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
+    TerminalProfile, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::state_store::{
     PersistedAgentInstance, PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
@@ -683,6 +683,17 @@ fn handle_connection(
             ),
         );
     }
+    if response_version < 15 && matches!(request.message, Request::AcknowledgeAgentAttention { .. })
+    {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "agent attention acknowledgment requires daemon protocol 15",
+            ),
+        );
+    }
 
     if let Request::Attach {
         shell_id,
@@ -790,6 +801,17 @@ fn handle_connection(
 
 fn response_for_version(response: Response, version: u32) -> Response {
     let mut response = response;
+    if version < 15 {
+        remove_agent_attention(&mut response);
+        if let Response::Events { events, .. } = &mut response {
+            events.retain(|event| {
+                !matches!(
+                    event.kind,
+                    DaemonEventKind::AgentAttentionAcknowledged { .. }
+                )
+            });
+        }
+    }
     if version < 13 {
         remove_agent_cwds(&mut response);
     }
@@ -850,6 +872,10 @@ fn remove_agent_cwds(response: &mut Response) {
     visit_response_agents(response, &mut |agent| agent.cwd = None);
 }
 
+fn remove_agent_attention(response: &mut Response) {
+    visit_response_agents(response, &mut |agent| agent.attention = None);
+}
+
 fn downgrade_inactive_agent_states(response: &mut Response) {
     visit_response_agents(response, &mut |agent| {
         if agent.observation.state == AgentState::Inactive {
@@ -875,7 +901,9 @@ fn visit_response_agents(
                 visitor(agent);
             }
         }
-        Response::Agent { agent } | Response::AgentWait { agent, .. } => visitor(agent),
+        Response::Agent { agent }
+        | Response::AgentWait { agent, .. }
+        | Response::AgentAttentionAcknowledged { agent, .. } => visitor(agent),
         Response::Events {
             snapshot, events, ..
         } => {
@@ -890,7 +918,8 @@ fn visit_response_agents(
                 match &mut event.kind {
                     DaemonEventKind::AgentRegistered { agent, .. }
                     | DaemonEventKind::AgentStateChanged { agent, .. }
-                    | DaemonEventKind::AgentCompleted { agent, .. } => visitor(agent),
+                    | DaemonEventKind::AgentCompleted { agent, .. }
+                    | DaemonEventKind::AgentAttentionAcknowledged { agent, .. } => visitor(agent),
                     _ => {}
                 }
             }
@@ -1128,6 +1157,7 @@ struct AgentInstance {
 struct AgentInstanceState {
     ended_at_ms: Option<u64>,
     observation: AgentObservationSnapshot,
+    attention: Option<AgentAttentionSnapshot>,
 }
 
 struct WorkspaceLauncher {
@@ -1672,6 +1702,27 @@ impl Registry {
                 after_revision,
                 wait_ms,
             } => self.wait_agent(&agent_id, after_revision, wait_ms),
+            Request::AcknowledgeAgentAttention {
+                agent_id,
+                observation_revision,
+            } => self.durable_mutation_outcome(|| {
+                let (agent, changed) =
+                    self.acknowledge_agent_attention(&agent_id, observation_revision)?;
+                if !changed {
+                    return Ok(DurableMutation::Unchanged(
+                        Response::AgentAttentionAcknowledged { agent, changed },
+                    ));
+                }
+                let event = DaemonEventKind::AgentAttentionAcknowledged {
+                    workspace_id: agent.workspace_id.clone(),
+                    shell_id: agent.shell_id.clone(),
+                    agent: agent.clone(),
+                };
+                Ok(DurableMutation::Changed(
+                    Response::AgentAttentionAcknowledged { agent, changed },
+                    vec![event],
+                ))
+            }),
             Request::CreateWorkspace { name, shells } => self.durable_mutation(|| {
                 let workspace = self.create_workspace(name, shells)?;
                 let events = workspace_created_events(&workspace);
@@ -3003,8 +3054,13 @@ impl Registry {
                     confidence: spec.report.confidence,
                     observed_at_ms: started_at_ms,
                 },
+                attention: None,
             }),
         });
+        {
+            let mut state = lock(&agent.state)?;
+            state.attention = attention_for_observation(&state.observation);
+        }
         let snapshot = agent.snapshot()?;
         let mut state = lock(&self.state)?;
         let Some(current_shell) = state.shells.get(shell_id) else {
@@ -3129,11 +3185,39 @@ impl Registry {
             confidence: report.confidence,
             observed_at_ms,
         };
+        if let Some(attention) = attention_for_observation(&state.observation) {
+            state.attention = Some(attention);
+        }
         if completed {
             state.ended_at_ms = Some(observed_at_ms);
         }
         drop(state);
         Ok((agent.snapshot()?, true, completed))
+    }
+
+    fn acknowledge_agent_attention(
+        &self,
+        agent_id: &str,
+        observation_revision: u64,
+    ) -> io::Result<(AgentInstanceSnapshot, bool)> {
+        let agent = self.agent(agent_id)?;
+        let mut state = lock(&agent.state)?;
+        let Some(attention) = &state.attention else {
+            drop(state);
+            return Ok((agent.snapshot()?, false));
+        };
+        if attention.observation.revision != observation_revision {
+            return Err(coded_error(
+                ErrorCode::RevisionAhead,
+                format!(
+                    "agent attention observation revision is {}; acknowledgment supplied {}",
+                    attention.observation.revision, observation_revision
+                ),
+            ));
+        }
+        state.attention = None;
+        drop(state);
+        Ok((agent.snapshot()?, true))
     }
 
     fn rename_launcher(&self, launcher_id: &str, name: String) -> io::Result<()> {
@@ -3692,6 +3776,7 @@ impl AgentInstance {
             state: Mutex::new(AgentInstanceState {
                 ended_at_ms: saved.ended_at_ms,
                 observation: saved.observation,
+                attention: saved.attention,
             }),
         }
     }
@@ -3710,6 +3795,7 @@ impl AgentInstance {
             started_at_ms: self.started_at_ms,
             ended_at_ms: state.ended_at_ms,
             observation: state.observation.clone(),
+            attention: state.attention.clone(),
         })
     }
 
@@ -3726,6 +3812,7 @@ impl AgentInstance {
             started_at_ms: snapshot.started_at_ms,
             ended_at_ms: snapshot.ended_at_ms,
             observation: snapshot.observation,
+            attention: snapshot.attention,
         })
     }
 }
@@ -4957,6 +5044,20 @@ fn observation_matches_report(
         && observation.confidence == report.confidence
 }
 
+fn attention_for_observation(
+    observation: &AgentObservationSnapshot,
+) -> Option<AgentAttentionSnapshot> {
+    let reason = match observation.state {
+        AgentState::Blocked => AgentAttentionReason::Blocked,
+        AgentState::Done => AgentAttentionReason::Completed,
+        _ => return None,
+    };
+    Some(AgentAttentionSnapshot {
+        reason,
+        observation: observation.clone(),
+    })
+}
+
 fn agent_authority_rank(authority: AgentAuthority) -> u8 {
     match authority {
         AgentAuthority::LifecycleIntegration => 3,
@@ -5004,6 +5105,40 @@ fn validate_persisted_agent(agent: &PersistedAgentInstance) -> io::Result<()> {
             io::ErrorKind::InvalidData,
             "Boomux state contains an invalid agent observation",
         ));
+    }
+    if let Some(attention) = &agent.attention {
+        validate_agent_report(&AgentReport {
+            state: attention.observation.state,
+            authority: attention.observation.authority,
+            evidence: attention.observation.evidence.clone(),
+            confidence: attention.observation.confidence,
+        })
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        let expected_reason = match attention.observation.state {
+            AgentState::Blocked => AgentAttentionReason::Blocked,
+            AgentState::Done => AgentAttentionReason::Completed,
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Boomux state contains attention for a non-attention agent state",
+                ));
+            }
+        };
+        if attention.reason != expected_reason
+            || attention.observation.revision == 0
+            || attention.observation.revision > agent.observation.revision
+            || attention.observation.observed_at_ms < agent.started_at_ms
+            || attention.observation.observed_at_ms > agent.observation.observed_at_ms
+            || (attention.observation.revision == agent.observation.revision
+                && attention.observation != agent.observation)
+            || (attention.reason == AgentAttentionReason::Completed
+                && attention.observation != agent.observation)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Boomux state contains invalid agent attention",
+            ));
+        }
     }
     Ok(())
 }
@@ -5468,6 +5603,14 @@ mod tests {
         };
         assert_eq!(agent.observation.revision, 2);
         assert_eq!(agent.observation.state, AgentState::Done);
+        assert_eq!(
+            agent.attention.as_ref().map(|attention| attention.reason),
+            Some(AgentAttentionReason::Completed)
+        );
+        assert_eq!(
+            agent.attention.as_ref().unwrap().observation,
+            agent.observation
+        );
         assert_eq!(agent.ended_at_ms, Some(agent.observation.observed_at_ms));
         assert_eq!(
             registry.snapshot().unwrap().workspaces[0].agents,
@@ -5799,6 +5942,179 @@ mod tests {
         let restored = registry.agent(&agent.id).unwrap().snapshot().unwrap();
         assert_eq!(restored.observation.revision, 1);
         assert_eq!(restored.observation.state, AgentState::Working);
+        assert!(restored.attention.is_none());
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn agent_attention_is_raised_preserved_and_superseded_by_completion() {
+        let registry = Registry::default();
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let registered = registry
+            .register_agent(&shell.id, &run_id, agent_spec(AgentState::Blocked))
+            .unwrap();
+        let registered_id = registered.id.clone();
+        let blocked = registered.attention.clone().unwrap();
+        assert_eq!(blocked.reason, AgentAttentionReason::Blocked);
+        assert_eq!(blocked.observation, registered.observation);
+
+        let (unchanged, changed, _) = registry
+            .report_agent(
+                &registered_id,
+                &run_id,
+                agent_report(
+                    AgentState::Working,
+                    AgentAuthority::TerminalHeuristic,
+                    "weak working",
+                ),
+            )
+            .unwrap();
+        assert!(!changed);
+        assert_eq!(unchanged.attention.as_ref(), Some(&blocked));
+
+        let (idle, changed, _) = registry
+            .report_agent(&registered_id, &run_id, agent_spec(AgentState::Idle).report)
+            .unwrap();
+        assert!(changed);
+        assert_eq!(idle.attention.as_ref(), Some(&blocked));
+
+        let duplicate = agent_spec(AgentState::Idle).report;
+        let (idle_again, changed, _) = registry.report_agent(&idle.id, &run_id, duplicate).unwrap();
+        assert!(!changed);
+        assert_eq!(idle_again.attention.as_ref(), Some(&blocked));
+
+        let (done, changed, completed) = registry
+            .report_agent(&idle.id, &run_id, agent_spec(AgentState::Done).report)
+            .unwrap();
+        assert!(changed && completed);
+        let attention = done.attention.unwrap();
+        assert_eq!(attention.reason, AgentAttentionReason::Completed);
+        assert_eq!(attention.observation, done.observation);
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn failed_attention_acknowledgment_persistence_restores_attention() {
+        let directory = env::temp_dir().join(format!("boomux-attention-{}", Uuid::new_v4()));
+        let state_directory = directory.join("state");
+        let registry = Registry::restore(
+            StateStore::at(state_directory.join("state.json")),
+            false,
+            None,
+        )
+        .unwrap();
+        let (_workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let Response::Agent { agent } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id,
+                spec: agent_spec(AgentState::Blocked),
+            })
+            .unwrap()
+        else {
+            panic!("expected registered agent");
+        };
+        let event_id = lock(&registry.events.state).unwrap().latest_id;
+        fs::remove_dir_all(&state_directory).unwrap();
+        fs::write(&state_directory, b"not a directory").unwrap();
+
+        let error = registry
+            .dispatch(Request::AcknowledgeAgentAttention {
+                agent_id: agent.id.clone(),
+                observation_revision: agent.observation.revision,
+            })
+            .unwrap_err();
+
+        assert_eq!(error_code(&error), ErrorCode::PersistenceFailed);
+        assert!(
+            registry
+                .agent(&agent.id)
+                .unwrap()
+                .snapshot()
+                .unwrap()
+                .attention
+                .is_some()
+        );
+        assert_eq!(lock(&registry.events.state).unwrap().latest_id, event_id);
+        shell.kill().unwrap();
+        drop(registry);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn agent_attention_acknowledgment_is_conditional_idempotent_and_rollback_safe() {
+        let registry = Registry::default();
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let agent = registry
+            .register_agent(&shell.id, &run_id, agent_spec(AgentState::Blocked))
+            .unwrap();
+        let revision = agent.observation.revision;
+
+        let mismatch = registry.acknowledge_agent_attention(&agent.id, revision + 1);
+        assert_eq!(error_code(&mismatch.unwrap_err()), ErrorCode::RevisionAhead);
+        assert!(
+            registry
+                .agent(&agent.id)
+                .unwrap()
+                .snapshot()
+                .unwrap()
+                .attention
+                .is_some()
+        );
+
+        let result: io::Result<()> = registry.durable_mutation(|| {
+            registry.acknowledge_agent_attention(&agent.id, revision)?;
+            Err(io::Error::other("force rollback"))
+        });
+        assert!(result.is_err());
+        assert!(
+            registry
+                .agent(&agent.id)
+                .unwrap()
+                .snapshot()
+                .unwrap()
+                .attention
+                .is_some()
+        );
+
+        let event_id = lock(&registry.events.state).unwrap().latest_id;
+        let Response::AgentAttentionAcknowledged { agent, changed } = registry
+            .dispatch(Request::AcknowledgeAgentAttention {
+                agent_id: agent.id.clone(),
+                observation_revision: revision,
+            })
+            .unwrap()
+        else {
+            panic!("expected attention acknowledgment");
+        };
+        assert!(changed);
+        assert!(agent.attention.is_none());
+        assert_eq!(agent.observation.revision, revision);
+        assert_eq!(
+            lock(&registry.events.state).unwrap().latest_id,
+            event_id + 1
+        );
+
+        let Response::AgentAttentionAcknowledged { agent, changed } = registry
+            .dispatch(Request::AcknowledgeAgentAttention {
+                agent_id: agent.id,
+                observation_revision: revision + 100,
+            })
+            .unwrap()
+        else {
+            panic!("expected idempotent acknowledgment");
+        };
+        assert!(!changed);
+        assert_eq!(agent.observation.revision, revision);
+        assert_eq!(
+            lock(&registry.events.state).unwrap().latest_id,
+            event_id + 1
+        );
         shell.kill().unwrap();
         registry.close_workspace(&workspace.id).unwrap();
     }
@@ -6011,6 +6327,7 @@ mod tests {
                 confidence: 90,
                 observed_at_ms: 1,
             },
+            attention: None,
         };
         let workspace = WorkspaceSnapshot {
             id: "w1".into(),
@@ -6091,6 +6408,7 @@ mod tests {
                 confidence: 100,
                 observed_at_ms: 2,
             },
+            attention: None,
         };
 
         let Response::Agent { agent: downgraded } = response_for_version(
@@ -6185,6 +6503,74 @@ mod tests {
             panic!("expected agent state event");
         };
         assert_eq!(agent.observation.state, AgentState::Unknown);
+    }
+
+    #[test]
+    fn protocol_fourteen_omits_attention_and_filters_acknowledgment_events() {
+        let observation = AgentObservationSnapshot {
+            revision: 2,
+            state: AgentState::Blocked,
+            authority: AgentAuthority::LifecycleIntegration,
+            evidence: "blocked".into(),
+            confidence: 100,
+            observed_at_ms: 2,
+        };
+        let agent = AgentInstanceSnapshot {
+            id: "a1".into(),
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            name: "agent".into(),
+            integration: "test".into(),
+            external_session_id: None,
+            cwd: None,
+            started_at_ms: 1,
+            ended_at_ms: None,
+            observation: observation.clone(),
+            attention: Some(AgentAttentionSnapshot {
+                reason: AgentAttentionReason::Blocked,
+                observation,
+            }),
+        };
+        let cursor = EventCursor {
+            stream_id: "stream".into(),
+            event_id: 2,
+        };
+        let response = Response::Events {
+            stream_id: "stream".into(),
+            cursor: cursor.clone(),
+            snapshot: Some(Snapshot {
+                workspaces: vec![WorkspaceSnapshot {
+                    id: "w1".into(),
+                    name: "workspace".into(),
+                    shells: Vec::new(),
+                    launchers: Vec::new(),
+                    agents: vec![agent.clone()],
+                }],
+            }),
+            events: vec![DaemonEvent {
+                id: 2,
+                at_ms: 3,
+                kind: DaemonEventKind::AgentAttentionAcknowledged {
+                    workspace_id: "w1".into(),
+                    shell_id: "s1".into(),
+                    agent,
+                },
+            }],
+        };
+
+        let Response::Events {
+            cursor: filtered_cursor,
+            snapshot: Some(snapshot),
+            events,
+            ..
+        } = response_for_version(response, 14)
+        else {
+            panic!("expected events response");
+        };
+        assert_eq!(filtered_cursor, cursor);
+        assert!(events.is_empty());
+        assert!(snapshot.workspaces[0].agents[0].attention.is_none());
     }
 
     #[test]
@@ -6510,5 +6896,64 @@ mod tests {
 
         registry.close_workspace(&workspace.id).unwrap();
         assert!(registry.snapshot().unwrap().workspaces.is_empty());
+    }
+
+    #[test]
+    fn persisted_attention_rejects_impossible_observation_history() {
+        let persisted = |attention: AgentAttentionSnapshot| PersistedAgentInstance {
+            id: Uuid::new_v4().to_string(),
+            shell_id: Uuid::new_v4().to_string(),
+            run_id: Uuid::new_v4().to_string(),
+            name: "agent".into(),
+            integration: "test".into(),
+            external_session_id: Some("session".into()),
+            cwd: Some(env::temp_dir()),
+            started_at_ms: 10,
+            ended_at_ms: None,
+            observation: AgentObservationSnapshot {
+                revision: 2,
+                state: AgentState::Working,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "working".into(),
+                confidence: 100,
+                observed_at_ms: 20,
+            },
+            attention: Some(attention),
+        };
+        let completed = AgentAttentionSnapshot {
+            reason: AgentAttentionReason::Completed,
+            observation: AgentObservationSnapshot {
+                revision: 1,
+                state: AgentState::Done,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "done".into(),
+                confidence: 100,
+                observed_at_ms: 15,
+            },
+        };
+        assert_eq!(
+            validate_persisted_agent(&persisted(completed))
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        let mismatched_current = AgentAttentionSnapshot {
+            reason: AgentAttentionReason::Blocked,
+            observation: AgentObservationSnapshot {
+                revision: 2,
+                state: AgentState::Blocked,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "different revision contents".into(),
+                confidence: 100,
+                observed_at_ms: 20,
+            },
+        };
+        assert_eq!(
+            validate_persisted_agent(&persisted(mismatched_current))
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use boomux::protocol::{
 };
 use boomux::{attach, client, daemon, protocol};
 
+mod agent_attention_projection;
 mod cli_output;
 mod config;
 mod git;
@@ -52,6 +53,8 @@ const JSON_COMMANDS: &[&str] = &[
     "agent.ensure",
     "agent.report",
     "agent.wait",
+    "attention.list",
+    "attention.acknowledge",
     "session.list",
     "session.inspect",
     "session.read",
@@ -73,6 +76,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "protocol_12",
     "protocol_13",
     "protocol_14",
+    "protocol_15",
     "restartable_exited_shells",
     "inactive_agent_state",
     "idempotent_agent_ensure",
@@ -84,6 +88,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "canonical_session_transcripts",
     "durable_session_source_context",
     "revision_aware_agent_wait",
+    "persistent_agent_attention",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -217,6 +222,11 @@ enum Commands {
     Agent {
         #[command(subcommand)]
         command: AgentCommands,
+    },
+    /// Inspect and acknowledge blocked or completed Agent work
+    Attention {
+        #[command(subcommand)]
+        command: AttentionCommands,
     },
     /// Discover projected agent sessions
     Session {
@@ -390,6 +400,21 @@ enum AgentCommands {
         evidence: String,
         #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
         confidence: u8,
+    },
+}
+
+#[derive(Subcommand)]
+enum AttentionCommands {
+    /// List outstanding attention in priority order
+    List {
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+    /// Acknowledge one exact attention-raising observation
+    Acknowledge {
+        agent_id: String,
+        #[arg(long)]
+        observation_revision: u64,
     },
 }
 
@@ -683,6 +708,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             command: AgentCommands::Supervise(arguments),
         }) => return supervise_agent(arguments).map(CliExit::Child),
         Some(Commands::Agent { command }) => agent_command(command, cli.json),
+        Some(Commands::Attention { command }) => attention_command(command, cli.json),
         Some(Commands::Session { command }) => session_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
@@ -753,6 +779,12 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Agent {
             command: AgentCommands::Report { .. },
         }) => "agent.report",
+        Some(Commands::Attention {
+            command: AttentionCommands::List { .. },
+        }) => "attention.list",
+        Some(Commands::Attention {
+            command: AttentionCommands::Acknowledge { .. },
+        }) => "attention.acknowledge",
         Some(Commands::Session {
             command: SessionCommands::List { .. },
         }) => "session.list",
@@ -805,6 +837,8 @@ fn supports_json(cli: &Cli) -> bool {
                 | AgentCommands::Report { .. }
         }) | Some(Commands::Daemon {
             command: DaemonCommands::Status
+        }) | Some(Commands::Attention {
+            command: AttentionCommands::List { .. } | AttentionCommands::Acknowledge { .. }
         }) | Some(Commands::Session {
             command: SessionCommands::List { .. }
                 | SessionCommands::Inspect { .. }
@@ -1024,6 +1058,7 @@ fn dashboard_views(
         .iter()
         .map(|workspace| {
             let sessions = workspace_session_views(workspace);
+            let agent_summary = agent_attention_projection::summarize_workspace(workspace);
             let shells = workspace.shells.iter().map(|shell| {
                 let git = git_cache.inspect(&shell.cwd);
                 let shell_view = tui::TerminalView {
@@ -1107,6 +1142,8 @@ fn dashboard_views(
                 name: workspace.name.clone(),
                 items: shells.chain(launchers).collect(),
                 sessions,
+                agent_state_counts: agent_summary.states,
+                attention_count: agent_summary.attention_count,
             }
         })
         .collect()
@@ -1440,12 +1477,17 @@ fn workspace_command(
             if json {
                 let workspaces = workspaces
                     .iter()
-                    .map(|workspace| cli_output::WorkspaceSummary {
-                        id: workspace.id.clone(),
-                        name: workspace.name.clone(),
-                        shell_count: workspace.shells.len(),
-                        launcher_count: workspace.launchers.len(),
-                        agent_count: workspace.agents.len(),
+                    .map(|workspace| {
+                        let summary = agent_attention_projection::summarize_workspace(workspace);
+                        cli_output::WorkspaceSummary {
+                            id: workspace.id.clone(),
+                            name: workspace.name.clone(),
+                            shell_count: workspace.shells.len(),
+                            launcher_count: workspace.launchers.len(),
+                            agent_count: workspace.agents.len(),
+                            agent_state_counts: summary.states,
+                            attention_count: summary.attention_count,
+                        }
                     })
                     .collect::<Vec<_>>();
                 return cli_output::print(
@@ -1453,15 +1495,19 @@ fn workspace_command(
                     serde_json::json!({ "workspaces": workspaces }),
                 );
             }
-            println!("NAME\tWORKSPACE ID\tSHELLS\tLAUNCHERS\tAGENTS");
+            println!("NAME\tWORKSPACE ID\tSHELLS\tLAUNCHERS\tAGENTS\tBLOCKED\tDONE\tATTENTION");
             for workspace in workspaces {
+                let summary = agent_attention_projection::summarize_workspace(&workspace);
                 println!(
-                    "{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
                     workspace.name,
                     workspace.id,
                     workspace.shells.len(),
                     workspace.launchers.len(),
-                    workspace.agents.len()
+                    workspace.agents.len(),
+                    summary.states.blocked,
+                    summary.states.done,
+                    summary.attention_count,
                 );
             }
         }
@@ -1485,6 +1531,7 @@ fn workspace_command(
         WorkspaceCommands::Inspect { target } => {
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
+            let agent_summary = agent_attention_projection::summarize_workspace(workspace);
             if json {
                 let shells = workspace
                     .shells
@@ -1504,6 +1551,8 @@ fn workspace_command(
                             "agents": workspace.agents.iter()
                                 .map(|agent| cli_output::agent(agent, Some(&workspace.name)))
                                 .collect::<Vec<_>>(),
+                            "agent_state_counts": agent_summary.states,
+                            "attention_count": agent_summary.attention_count,
                         }
                     }),
                 );
@@ -1513,6 +1562,9 @@ fn workspace_command(
             println!("SHELLS\t{}", workspace.shells.len());
             println!("LAUNCHERS\t{}", workspace.launchers.len());
             println!("AGENTS\t{}", workspace.agents.len());
+            println!("BLOCKED AGENTS\t{}", agent_summary.states.blocked);
+            println!("COMPLETED AGENTS\t{}", agent_summary.states.done);
+            println!("ATTENTION\t{}", agent_summary.attention_count);
             if !workspace.shells.is_empty() {
                 println!("\nNAME\tSHELL ID\tRUN ID\tSTATUS\tCWD");
                 for shell in &workspace.shells {
@@ -1895,6 +1947,93 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
     Ok(())
 }
 
+fn attention_command(command: AttentionCommands, json: bool) -> Result<(), Box<dyn Error>> {
+    let client = client::connect_or_start()?;
+    validate_attention_protocol(client.protocol_version()?)?;
+    match command {
+        AttentionCommands::List { workspace } => {
+            let snapshot = client.snapshot()?;
+            let workspace_id = workspace
+                .as_deref()
+                .map(|target| resolve_workspace_target(&snapshot.workspaces, target))
+                .transpose()?
+                .map(|workspace| workspace.id.as_str());
+            let items = agent_attention_projection::project_attention(&snapshot.workspaces)
+                .into_iter()
+                .filter(|item| workspace_id.is_none_or(|id| item.workspace_id == id))
+                .collect::<Vec<_>>();
+            if json {
+                let attention = items
+                    .iter()
+                    .map(|item| {
+                        serde_json::json!({
+                            "workspace_id": item.workspace_id,
+                            "workspace_name": item.workspace_name,
+                            "reason": agent_attention_projection::attention_reason(item.attention.reason),
+                            "observation": {
+                                "revision": item.attention.observation.revision,
+                                "state": cli_output::agent_state(item.attention.observation.state),
+                                "authority": cli_output::agent_authority(item.attention.observation.authority),
+                                "evidence": item.attention.observation.evidence,
+                                "confidence": item.attention.observation.confidence,
+                                "observed_at_ms": item.attention.observation.observed_at_ms,
+                            },
+                            "observation_is_current": item.observation_is_current,
+                            "shell_is_retained": item.shell_is_retained,
+                            "agent": cli_output::agent(&item.agent, Some(&item.workspace_name)),
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                return cli_output::print(
+                    "attention.list",
+                    serde_json::json!({ "attention": attention }),
+                );
+            }
+            println!(
+                "WORKSPACE\tREASON\tAGENT\tAGENT ID\tREVISION\tCURRENT\tSHELL\tAUTHORITY\tEVIDENCE"
+            );
+            for item in items {
+                println!(
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    sanitize_table_cell(&item.workspace_name),
+                    agent_attention_projection::attention_reason(item.attention.reason),
+                    sanitize_table_cell(&item.agent.name),
+                    item.agent.id,
+                    item.attention.observation.revision,
+                    item.observation_is_current,
+                    if item.shell_is_retained {
+                        "retained"
+                    } else {
+                        "removed"
+                    },
+                    cli_output::agent_authority(item.attention.observation.authority),
+                    sanitize_table_cell(&item.attention.observation.evidence),
+                );
+            }
+        }
+        AttentionCommands::Acknowledge {
+            agent_id,
+            observation_revision,
+        } => {
+            let acknowledged =
+                client.acknowledge_agent_attention(agent_id, observation_revision)?;
+            if json {
+                return cli_output::print(
+                    "attention.acknowledge",
+                    serde_json::json!({
+                        "changed": acknowledged.changed,
+                        "agent": cli_output::agent(&acknowledged.agent, None),
+                    }),
+                );
+            }
+            println!("CHANGED\t{}", acknowledged.changed);
+            println!("AGENT ID\t{}", acknowledged.agent.id);
+            println!("OBSERVATION REVISION\t{observation_revision}");
+        }
+    }
+    Ok(())
+}
+
 fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     validate_session_protocol(client.protocol_version()?)?;
@@ -2000,6 +2139,28 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
         }
     }
     Ok(())
+}
+
+fn validate_attention_protocol(negotiated: u32) -> Result<(), Box<dyn Error>> {
+    (negotiated >= 15).then_some(()).ok_or_else(|| {
+        cli_output::failure(
+            "unsupported_version",
+            format!("Agent attention requires daemon protocol 15; negotiated {negotiated}"),
+        )
+    })
+}
+
+fn sanitize_table_cell(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect()
 }
 
 fn validate_session_protocol(negotiated: u32) -> Result<(), Box<dyn Error>> {
@@ -3149,6 +3310,7 @@ mod tests {
             cwd: Some("/tmp/project".into()),
             started_at_ms: 10,
             ended_at_ms: None,
+            attention: None,
             observation: protocol::AgentObservationSnapshot {
                 revision: 1,
                 state: AgentState::Working,
@@ -3552,6 +3714,38 @@ mod tests {
     }
 
     #[test]
+    fn parses_attention_queue_commands_and_json_support() {
+        let list = Cli::try_parse_from([
+            "boomux",
+            "attention",
+            "list",
+            "--workspace",
+            "project",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(command_name(&list), "attention.list");
+        assert!(supports_json(&list));
+
+        let acknowledge = Cli::try_parse_from([
+            "boomux",
+            "attention",
+            "acknowledge",
+            "a1",
+            "--observation-revision",
+            "7",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(command_name(&acknowledge), "attention.acknowledge");
+        assert!(supports_json(&acknowledge));
+        assert_eq!(
+            sanitize_table_cell("approval\tneeded\nnow\u{7}"),
+            "approval needed now "
+        );
+    }
+
+    #[test]
     fn child_exit_outcomes_map_to_unix_cli_codes() {
         assert_eq!(
             CliExit::Child(process_adapter::ProcessExit::Code(23)).code(),
@@ -3817,6 +4011,8 @@ mod tests {
             id: "w1".into(),
             name: "project".into(),
             items: Vec::new(),
+            agent_state_counts: agent_attention_projection::AgentStateCounts::default(),
+            attention_count: 0,
             sessions: vec![tui::AgentSessionView {
                 id: "session".into(),
                 label: "opencode".into(),
@@ -4472,6 +4668,8 @@ mod tests {
             "agent.ensure",
             "agent.report",
             "agent.wait",
+            "attention.list",
+            "attention.acknowledge",
         ] {
             assert!(JSON_COMMANDS.contains(&command));
         }
@@ -4487,6 +4685,8 @@ mod tests {
             "opencode_lifecycle_plugin",
             "pi_lifecycle_extension",
             "canonical_session_transcripts",
+            "protocol_15",
+            "persistent_agent_attention",
         ] {
             assert!(INTEGRATION_FEATURES.contains(&feature));
         }
@@ -4496,7 +4696,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 14);
+        assert_eq!(protocol::PROTOCOL_VERSION, 15);
     }
 
     #[test]

--- a/src/process_adapter.rs
+++ b/src/process_adapter.rs
@@ -350,6 +350,7 @@ mod tests {
             cwd: Some("/tmp/project".into()),
             started_at_ms: 1,
             ended_at_ms: completed.then_some(2),
+            attention: None,
             observation: AgentObservationSnapshot {
                 revision: 1,
                 state: AgentState::Working,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 14;
+pub const PROTOCOL_VERSION: u32 = 15;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -90,6 +90,19 @@ pub struct AgentObservationSnapshot {
     pub observed_at_ms: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentAttentionReason {
+    Blocked,
+    Completed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentAttentionSnapshot {
+    pub reason: AgentAttentionReason,
+    pub observation: AgentObservationSnapshot,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentInstanceSnapshot {
     pub id: String,
@@ -104,6 +117,8 @@ pub struct AgentInstanceSnapshot {
     pub started_at_ms: u64,
     pub ended_at_ms: Option<u64>,
     pub observation: AgentObservationSnapshot,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention: Option<AgentAttentionSnapshot>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -271,6 +286,11 @@ pub enum DaemonEventKind {
         shell_id: String,
         agent: AgentInstanceSnapshot,
     },
+    AgentAttentionAcknowledged {
+        workspace_id: String,
+        shell_id: String,
+        agent: AgentInstanceSnapshot,
+    },
     HandoffCompleted,
 }
 
@@ -357,6 +377,10 @@ pub enum Request {
         run_id: String,
         report: AgentReport,
     },
+    AcknowledgeAgentAttention {
+        agent_id: String,
+        observation_revision: u64,
+    },
     ReadShell {
         shell_id: String,
         max_bytes: usize,
@@ -432,6 +456,10 @@ pub enum Response {
         agent: AgentInstanceSnapshot,
     },
     AgentWait {
+        agent: AgentInstanceSnapshot,
+        changed: bool,
+    },
+    AgentAttentionAcknowledged {
         agent: AgentInstanceSnapshot,
         changed: bool,
     },
@@ -740,6 +768,7 @@ mod tests {
                 confidence: report.confidence,
                 observed_at_ms: 11,
             },
+            attention: None,
         };
         let event = DaemonEventKind::AgentStateChanged {
             workspace_id: "w1".into(),
@@ -755,8 +784,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_fourteen_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 14);
+    fn protocol_version_is_fifteen_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 15);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -791,6 +820,7 @@ mod tests {
                     confidence: 100,
                     observed_at_ms: 2,
                 },
+                attention: None,
             },
             changed: true,
         };
@@ -826,7 +856,80 @@ mod tests {
         .unwrap();
 
         assert!(agent.cwd.is_none());
+        assert!(agent.attention.is_none());
         assert!(serde_json::to_value(agent).unwrap().get("cwd").is_none());
+    }
+
+    #[test]
+    fn agent_attention_messages_use_snake_case_and_omit_absent_attention() {
+        let observation = AgentObservationSnapshot {
+            revision: 3,
+            state: AgentState::Blocked,
+            authority: AgentAuthority::LifecycleIntegration,
+            evidence: "needs input".into(),
+            confidence: 100,
+            observed_at_ms: 4,
+        };
+        let attention = AgentAttentionSnapshot {
+            reason: AgentAttentionReason::Blocked,
+            observation: observation.clone(),
+        };
+        let encoded = serde_json::to_value(&attention).unwrap();
+        assert_eq!(encoded["reason"], "blocked");
+        assert_eq!(
+            serde_json::to_value(AgentAttentionReason::Completed).unwrap(),
+            "completed"
+        );
+
+        let request = Request::AcknowledgeAgentAttention {
+            agent_id: "a1".into(),
+            observation_revision: 3,
+        };
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["request"],
+            "acknowledge_agent_attention"
+        );
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(request.clone()).unwrap())
+                .unwrap(),
+            request
+        );
+
+        let mut agent: AgentInstanceSnapshot = serde_json::from_value(serde_json::json!({
+            "id": "a1", "workspace_id": "w1", "shell_id": "s1", "run_id": "r1",
+            "name": "agent", "integration": "test", "external_session_id": null,
+            "started_at_ms": 1, "ended_at_ms": null, "observation": observation
+        }))
+        .unwrap();
+        assert!(agent.attention.is_none());
+        assert!(
+            serde_json::to_value(&agent)
+                .unwrap()
+                .get("attention")
+                .is_none()
+        );
+        agent.attention = Some(attention);
+        assert_eq!(
+            serde_json::to_value(&agent).unwrap()["attention"]["reason"],
+            "blocked"
+        );
+        let response = Response::AgentAttentionAcknowledged {
+            agent: agent.clone(),
+            changed: true,
+        };
+        assert_eq!(
+            serde_json::to_value(response).unwrap()["response"],
+            "agent_attention_acknowledged"
+        );
+        let event = DaemonEventKind::AgentAttentionAcknowledged {
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            agent,
+        };
+        assert_eq!(
+            serde_json::to_value(event).unwrap()["event"],
+            "agent_attention_acknowledged"
+        );
     }
 
     #[test]

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -261,6 +261,7 @@ mod tests {
                     cwd: Some("/tmp/project".into()),
                     started_at_ms: 10 + index as u64,
                     ended_at_ms: None,
+                    attention: None,
                     observation: AgentObservationSnapshot {
                         revision: 1,
                         state: AgentState::Working,

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -9,10 +9,13 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::protocol::{AgentObservationSnapshot, ShellRunExitReason, TerminalProfile};
+use crate::protocol::{
+    AgentAttentionSnapshot, AgentObservationSnapshot, ShellRunExitReason, TerminalProfile,
+};
 
-const STATE_VERSION: u32 = 5;
-const PREVIOUS_STATE_VERSION: u32 = 4;
+const STATE_VERSION: u32 = 6;
+const PREVIOUS_STATE_VERSION: u32 = 5;
+const VERSION_FOUR_STATE_VERSION: u32 = 4;
 const VERSION_THREE_STATE_VERSION: u32 = 3;
 const VERSION_TWO_STATE_VERSION: u32 = 2;
 const LEGACY_STATE_VERSION: u32 = 1;
@@ -57,6 +60,7 @@ pub(crate) struct PersistedAgentInstance {
     pub(crate) started_at_ms: u64,
     pub(crate) ended_at_ms: Option<u64>,
     pub(crate) observation: AgentObservationSnapshot,
+    pub(crate) attention: Option<AgentAttentionSnapshot>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -116,6 +120,38 @@ struct PreviousPersistedWorkspace {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PreviousPersistedAgentInstance {
+    id: String,
+    shell_id: String,
+    run_id: String,
+    name: String,
+    integration: String,
+    external_session_id: Option<String>,
+    cwd: Option<PathBuf>,
+    started_at_ms: u64,
+    ended_at_ms: Option<u64>,
+    observation: AgentObservationSnapshot,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionFourPersistedState {
+    version: u32,
+    workspaces: Vec<VersionFourPersistedWorkspace>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionFourPersistedWorkspace {
+    id: String,
+    name: String,
+    shells: Vec<PersistedShell>,
+    launchers: Vec<PersistedWorkspaceLauncher>,
+    agents: Vec<VersionFourPersistedAgentInstance>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionFourPersistedAgentInstance {
     id: String,
     shell_id: String,
     run_id: String,
@@ -283,6 +319,12 @@ impl StateStore {
                 self.save(&state)?;
                 state
             }
+            VERSION_FOUR_STATE_VERSION => {
+                let previous: VersionFourPersistedState = parse_state(&bytes, &self.path)?;
+                let state = migrate_version_four_state(previous);
+                self.save(&state)?;
+                state
+            }
             VERSION_THREE_STATE_VERSION => {
                 let previous: VersionThreePersistedState = parse_state(&bytes, &self.path)?;
                 let state = migrate_version_three_state(previous);
@@ -399,6 +441,40 @@ fn migrate_previous_state(previous: PreviousPersistedState) -> PersistedState {
         workspaces: previous
             .workspaces
             .into_iter()
+            .map(|workspace| PersistedWorkspace {
+                id: workspace.id,
+                name: workspace.name,
+                shells: workspace.shells,
+                launchers: workspace.launchers,
+                agents: workspace
+                    .agents
+                    .into_iter()
+                    .map(|agent| PersistedAgentInstance {
+                        cwd: agent.cwd,
+                        id: agent.id,
+                        shell_id: agent.shell_id,
+                        run_id: agent.run_id,
+                        name: agent.name,
+                        integration: agent.integration,
+                        external_session_id: agent.external_session_id,
+                        started_at_ms: agent.started_at_ms,
+                        ended_at_ms: agent.ended_at_ms,
+                        observation: agent.observation,
+                        attention: None,
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }
+}
+
+fn migrate_version_four_state(previous: VersionFourPersistedState) -> PersistedState {
+    debug_assert_eq!(previous.version, VERSION_FOUR_STATE_VERSION);
+    PersistedState {
+        version: STATE_VERSION,
+        workspaces: previous
+            .workspaces
+            .into_iter()
             .map(|workspace| {
                 let shell_cwds = workspace
                     .shells
@@ -424,6 +500,7 @@ fn migrate_previous_state(previous: PreviousPersistedState) -> PersistedState {
                             started_at_ms: agent.started_at_ms,
                             ended_at_ms: agent.ended_at_ms,
                             observation: agent.observation,
+                            attention: None,
                         })
                         .collect(),
                 }
@@ -560,6 +637,7 @@ mod tests {
                             confidence: 90,
                             observed_at_ms: 11,
                         },
+                        attention: None,
                     },
                     PersistedAgentInstance {
                         id: "agent-2".into(),
@@ -579,6 +657,17 @@ mod tests {
                             confidence: 100,
                             observed_at_ms: 30,
                         },
+                        attention: Some(AgentAttentionSnapshot {
+                            reason: crate::protocol::AgentAttentionReason::Completed,
+                            observation: AgentObservationSnapshot {
+                                revision: 3,
+                                state: AgentState::Done,
+                                authority: AgentAuthority::DaemonLifecycle,
+                                evidence: "run exited".into(),
+                                confidence: 100,
+                                observed_at_ms: 30,
+                            },
+                        }),
                     },
                 ],
             }],
@@ -608,6 +697,13 @@ mod tests {
         assert_eq!(
             restored.workspaces[0].agents[1].observation.state,
             AgentState::Done
+        );
+        assert_eq!(
+            restored.workspaces[0].agents[1]
+                .attention
+                .as_ref()
+                .map(|attention| attention.reason),
+            Some(crate::protocol::AgentAttentionReason::Completed)
         );
         assert_eq!(
             fs::metadata(directory.join("boomux/state.json"))
@@ -685,7 +781,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 5")
+                .contains("\"version\": 6")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
         assert!(migrated.workspaces[0].agents.is_empty());
@@ -735,7 +831,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 5")
+                .contains("\"version\": 6")
         );
         assert!(migrated.workspaces[0].agents.is_empty());
         fs::remove_dir_all(directory).unwrap();
@@ -773,7 +869,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 5")
+                .contains("\"version\": 6")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -849,8 +945,43 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 5")
+                .contains("\"version\": 6")
         );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_five_agents_without_historical_attention() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            br#"{
+  "version": 5,
+  "workspaces": [{
+    "id": "w1", "name": "version-five", "shells": [], "launchers": [],
+    "agents": [{
+      "id": "a1", "shell_id": "s1", "run_id": "r1", "name": "agent",
+      "integration": "test", "external_session_id": null, "cwd": "/tmp/project",
+      "started_at_ms": 1, "ended_at_ms": 3,
+      "observation": {
+        "revision": 2, "state": "done", "authority": "lifecycle_integration",
+        "evidence": "completed before upgrade", "confidence": 100, "observed_at_ms": 3
+      }
+    }]
+  }]
+}"#,
+        )
+        .unwrap();
+        let store = StateStore::at(path.clone());
+
+        let migrated = store.load().unwrap().unwrap();
+
+        assert!(migrated.workspaces[0].agents[0].attention.is_none());
+        let saved = fs::read_to_string(&path).unwrap();
+        assert!(saved.contains("\"version\": 6"));
+        assert!(saved.contains("\"attention\": null"));
         fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,6 +11,8 @@ use ratatui::widgets::{
     Block, Cell, Clear, List, ListItem, ListState, Paragraph, Row, Table, TableState,
 };
 
+use crate::agent_attention_projection::AgentStateCounts;
+
 const BASE: Color = Color::Reset;
 const OVERLAY: Color = Color::DarkGray;
 const TEXT: Color = Color::Reset;
@@ -27,6 +29,8 @@ pub(crate) struct WorkspaceView {
     pub(crate) name: String,
     pub(crate) items: Vec<WorkspaceItemView>,
     pub(crate) sessions: Vec<AgentSessionView>,
+    pub(crate) agent_state_counts: AgentStateCounts,
+    pub(crate) attention_count: usize,
 }
 
 pub(crate) struct AgentSessionView {
@@ -1483,20 +1487,26 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
             Cell::from(workspace.command_count().to_string()),
             Cell::from(workspace.launcher_count().to_string()),
             Cell::from(workspace.agent_count().to_string()),
+            Cell::from(workspace.agent_state_counts.blocked.to_string()),
+            Cell::from(workspace.agent_state_counts.done.to_string()),
+            Cell::from(workspace.attention_count.to_string()),
         ])
     });
     let table = Table::new(
         rows,
         [
             Constraint::Min(8),
-            Constraint::Length(6),
-            Constraint::Length(4),
-            Constraint::Length(4),
-            Constraint::Length(6),
+            Constraint::Length(2),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Length(1),
         ],
     )
     .header(
-        Row::new(["NAME", "SHELLS", "CMDS", "LNCH", "AGENTS"])
+        Row::new(["NAME", "SH", "CMD", "LCH", "AG", "BLK", "DN", "!"])
             .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)),
     )
     .column_spacing(1)
@@ -2408,6 +2418,8 @@ mod tests {
                 command: String::new(),
             })],
             sessions: Vec::new(),
+            agent_state_counts: AgentStateCounts::default(),
+            attention_count: 0,
         }
     }
 
@@ -2656,6 +2668,9 @@ mod tests {
             launcher_view("launcher-1", "editor"),
         ];
         mixed.sessions.push(session("durable-1", "working"));
+        mixed.agent_state_counts.blocked = 1;
+        mixed.agent_state_counts.done = 1;
+        mixed.attention_count = 2;
         let mut app = App::new(vec![mixed], project_context());
 
         terminal_backend
@@ -2678,7 +2693,9 @@ mod tests {
         assert!(text.contains("SHELLS 1"));
         assert!(text.contains("COMMANDS 1"));
         assert!(!text.contains("active agents"));
-        assert!(text.contains("SHELLS CMDS LNCH AGENTS"));
+        for header in ["SH", "CMD", "LCH", "AG", "BLK", "DN", "!"] {
+            assert!(text.contains(header), "missing {header}");
+        }
         let workspace_tab = text.find("WORKSPACES 1").expect("workspace tab");
         let aggregate_label = text.find("ALL:").expect("aggregate label");
         let agent_tab = text.find("AGENTS 1").expect("agent tab");

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1314,6 +1314,10 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert_eq!(done.observation.state, AgentState::Done);
     assert_eq!(done.ended_at_ms, Some(done.observation.observed_at_ms));
     assert_eq!(
+        done.attention.as_ref().map(|attention| attention.reason),
+        Some(protocol::AgentAttentionReason::Completed)
+    );
+    assert_eq!(
         daemon
             .client
             .report_agent(&adapter_id, &run_id, completion)
@@ -1333,6 +1337,77 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
             .count(),
         1
     );
+    let attention = daemon
+        .command()
+        .args(["attention", "list", "--workspace", &workspace.id, "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        attention.status.success(),
+        "{}",
+        String::from_utf8_lossy(&attention.stderr)
+    );
+    let attention: serde_json::Value = serde_json::from_slice(&attention.stdout).unwrap();
+    assert_eq!(attention["command"], "attention.list");
+    assert_eq!(attention["data"]["attention"][0]["agent"]["id"], adapter_id);
+    assert_eq!(attention["data"]["attention"][0]["reason"], "completed");
+    assert_eq!(
+        attention["data"]["attention"][0]["observation"]["revision"],
+        3
+    );
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    assert_eq!(
+        daemon
+            .client
+            .get_agent(&adapter_id)
+            .unwrap()
+            .attention
+            .as_ref()
+            .map(|attention| attention.observation.revision),
+        Some(3)
+    );
+    let acknowledgment_cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let acknowledgment = daemon
+        .command()
+        .args([
+            "attention",
+            "acknowledge",
+            &adapter_id,
+            "--observation-revision",
+            "3",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(acknowledgment.status.success());
+    let acknowledgment: serde_json::Value = serde_json::from_slice(&acknowledgment.stdout).unwrap();
+    assert_eq!(acknowledgment["command"], "attention.acknowledge");
+    assert_eq!(acknowledgment["data"]["changed"], true);
+    assert!(acknowledgment["data"]["agent"]["attention"].is_null());
+    assert!(
+        daemon
+            .client
+            .events(Some(acknowledgment_cursor), 256, 0)
+            .unwrap()
+            .events
+            .iter()
+            .any(|event| matches!(
+                &event.kind,
+                protocol::DaemonEventKind::AgentAttentionAcknowledged { agent, .. }
+                    if agent.id == adapter_id && agent.attention.is_none()
+            ))
+    );
+    let repeated = daemon
+        .client
+        .acknowledge_agent_attention(&adapter_id, 3)
+        .unwrap();
+    assert!(!repeated.changed);
     let error = daemon
         .client
         .report_agent(
@@ -2282,7 +2357,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 14);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 15);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -2310,6 +2385,8 @@ fn native_daemon_lifecycle() {
         "agent.ensure",
         "agent.report",
         "agent.wait",
+        "attention.list",
+        "attention.acknowledge",
     ] {
         assert!(json_commands.iter().any(|current| current == command));
     }
@@ -2320,6 +2397,7 @@ fn native_daemon_lifecycle() {
         "protocol_12",
         "protocol_13",
         "protocol_14",
+        "protocol_15",
         "inactive_agent_state",
         "protocol_11",
         "restartable_exited_shells",
@@ -2327,6 +2405,7 @@ fn native_daemon_lifecycle() {
         "agent_authority_precedence",
         "opencode_lifecycle_plugin",
         "process_adapters",
+        "persistent_agent_attention",
     ] {
         assert!(features.iter().any(|current| current == feature));
     }
@@ -2337,7 +2416,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 14"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 15"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- persist explainable blocked and completed attention with protocol 15 and state schema 6
- add conditional acknowledgment, compatibility filtering, and deterministic blocked-first queue projection
- expose workspace lifecycle/attention counts in stable JSON and the dashboard
- add attention CLI commands, documentation, migration coverage, and binary restart validation

## Verification
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check