### PR TITLE
Record lifecycle integration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,9 @@ These versions are compatibility test points, not runtime pins. Older or newer
 releases may work when their plugin APIs remain compatible, but are not claimed
 as supported until validated. `boomux capabilities --json` exposes the same
 matrix under `integration_hosts`.
+The scope and evidence behind each test point, including transitions that still
+require an authenticated disposable provider, are recorded in
+[`docs/lifecycle-validation.md`](docs/lifecycle-validation.md).
 
 ## OpenCode Integration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -298,6 +298,12 @@ identity and lifecycle reports against a managed shell run. The same workflow
 will expose status, validated host versions, actionable diagnostics, repair, and
 uninstall. Individual host installers remain the underlying safe primitives.
 
+Observed host compatibility and provider-dependent gaps are recorded in
+[`lifecycle-validation.md`](lifecycle-validation.md). Focused unit fixtures
+exercise only the host fields and ordering Boomux consumes; the record
+deliberately distinguishes those tests from transitions observed in real
+managed sessions.
+
 ### OpenCode Lifecycle Plugin
 
 The bundled plugin is validated against `opencode-ai` `1.18.15`. This is a

--- a/docs/lifecycle-validation.md
+++ b/docs/lifecycle-validation.md
@@ -1,0 +1,76 @@
+# Lifecycle Integration Validation
+
+This record separates observed host behavior from reducer fixtures and intended
+semantics. Host compatibility is not inferred from process names, terminal
+output, or database recency.
+
+## 2026-08-07
+
+The repository and installed integration assets were byte-for-byte identical.
+The host CLIs reported OpenCode `1.18.15` and Pi `0.84.1`. Validation used the
+installed release Boomux binary at protocol 15 and state schema 6.
+
+### OpenCode
+
+The following disposable managed runs used
+`opencode/deepseek-v4-flash-free`. Agent observations had
+`lifecycle_integration` authority and confidence 100.
+
+| Scenario | Shell/run evidence | Agent evidence | Result |
+| --- | --- | --- | --- |
+| Work and idle | Shell `0113d70a`, run `830b24c2` exited 0 after printing `lifecycle-ok` | Agent `716734d9`, root `ses_02180f6c0ffehnVUiPzdTt5Qp2`, revision 3 `idle` after revision 2 `working` | Validated |
+| Root/subagent aggregation | Shell `8a4b8e0f`, run `989d0c7b` visibly completed one General subagent | Exactly one Agent `8134c688` for root `ses_021803c16ffevmmRw3Ea5I1pG4`, revision 11 `idle`; no child Agent was registered | Validated |
+| Permission blocker and resolution | Shell `2789827d`, run `b04e9380` used `permission.bash=ask`; noninteractive OpenCode rejected the request | Agent `5491e94a` raised revision 6 `blocked` with `OpenCode awaiting permission (1 pending)`, then revision 7 `working` with `OpenCode permission resolved` | Validated |
+| Same-run session reacquisition | Shell `2a0402d2`, run `b564cd1e` invoked two OpenCode processes against one root session | One Agent `d320a1b2` for root `ses_0217c811affeKaEmOvJkW5NFMZ` advanced to revision 6; no duplicate Agent was created | Validated |
+| Graceful daemon replacement | Existing interactive shell `4d587b46`, run `f4d92e18`, and Agent `91c24709` survived replacement into protocol 15 unchanged | Exact shell, run, external session, Agent ID, revision 3, and idle observation were preserved | Validated |
+
+The blocked observation also raised protocol-15 durable attention. Its later
+working observation did not erase the item, and the queue exposed the raising
+revision separately from the current revision.
+
+OpenCode does not expose foreground selection as an inactivity event. Switching
+the UI therefore routes later events to their canonical roots but does not imply
+that a switched-away root is inactive. A disposable `opencode session delete`
+invoked from a separate CLI process did not provide a meaningful same-process
+root-deletion event, so permanent `done` remains fixture-validated only. A
+controlled live `session.error` also remains unvalidated.
+
+### Pi
+
+Pi had no authenticated model (`pi auth check --provider google` and
+`pi auth check --provider openai` returned `not_ready`, and the UI reported no
+available models). A disposable protocol-15 managed run still validated host
+startup and shutdown behavior:
+
+| Scenario | Shell/run evidence | Agent evidence | Result |
+| --- | --- | --- | --- |
+| Startup and shutdown | Shell `9194408f`, run `29057624` loaded the refactored checked-in Pi 0.84.1 asset with canonical project session `boomux-lifecycle-refactor` and exited after the expected missing-key error | Agent `17da9996` advanced from revision 1 `idle` to revision 2 `inactive` on `session_shutdown` | Validated |
+| Graceful daemon replacement | Existing Pi shell `01542817`, run `595d27ee`, and Agent `a142f597` survived replacement into protocol 15 unchanged | Exact shell, run, external session, Agent ID, revision 1, and idle observation were preserved | Validated |
+
+The Pi 0.84.1 installed declarations and runtime implementation define and await
+`session_start`, `agent_start`, `agent_end`, `agent_settled`, and
+`session_shutdown`; reload and session replacement send shutdown before start.
+One focused unit test routes the documented ordering through the handlers using
+only fields Boomux consumes. Separate lifecycle tests verify same-session reuse,
+old-session inactivity, new-session identity, settled terminal errors, and quit
+inactivity. These are implementation tests, not host conformance tests.
+
+Model-driven `working -> idle`, final provider-error blocking, interactive
+`/reload`, and `/resume` remain unvalidated against a live provider. They must
+not be represented as live guarantees until an authenticated disposable model
+is available.
+
+### Automated Coverage
+
+The validation run was followed by:
+
+```console
+bun test integrations/opencode/boomux.test.js
+bun test integrations/pi/boomux.test.js
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Reducer tests remain compatibility evidence, not substitutes for the live cases
+listed above. Future host-version bumps should append a dated record rather than
+silently reusing this one.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -105,7 +105,7 @@ eternal process.
 
 ### Near-Term Priorities
 
-1. Validate the OpenCode and Pi lifecycle integrations during normal work before
+1. [Partially validated; see `lifecycle-validation.md`] Validate the OpenCode and Pi lifecycle integrations during normal work before
    expanding the observation model. Confirm reload identity, session switching,
    root/subagent aggregation where available, blocked prompts, idle transitions,
    explicit completion semantics, and graceful daemon replacement against real

--- a/integrations/opencode/boomux.test.js
+++ b/integrations/opencode/boomux.test.js
@@ -165,6 +165,54 @@ describe("event mapping and reducer", () => {
 });
 
 describe("root aggregation", () => {
+  test("maps OpenCode 1.18.15 fields consumed for child permissions", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: { session: { get: async () => {} } },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return calls.length === 1 ? successfulEnsure() : { data: {} };
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    await lifecycle.enqueue(
+      event("session.created", { info: { id: "child", parentID: "root" } }),
+    );
+    await lifecycle.enqueue(
+      event("session.status", {
+        sessionID: "child",
+        status: { type: "busy" },
+      }),
+    );
+    await lifecycle.enqueue(
+      event("permission.asked", {
+        id: "permission-1",
+        sessionID: "child",
+        permission: "bash",
+      }),
+    );
+    await lifecycle.enqueue(
+      event("permission.replied", {
+        requestID: "permission-1",
+        sessionID: "child",
+        reply: "reject",
+      }),
+    );
+    await lifecycle.enqueue(event("session.idle", { sessionID: "child" }));
+    await lifecycle.enqueue(event("session.idle", { sessionID: "root" }));
+
+    expect(calls.map((argv) => argv[argv.indexOf("--state") + 1])).toEqual([
+      "working",
+      "blocked",
+      "working",
+      "idle",
+    ]);
+    expect(calls[0]).toContain("root");
+    expect(calls.every((argv) => !argv.includes("child"))).toBe(true);
+  });
+
   test("resolves unknown nested ancestry through the client", async () => {
     const calls = [];
     const sessions = {

--- a/integrations/pi/boomux.js
+++ b/integrations/pi/boomux.js
@@ -298,12 +298,7 @@ function currentSessionID(ctx) {
   return text(ctx?.sessionManager?.getSessionId?.());
 }
 
-export default function BoomuxPiExtension(pi) {
-  const lifecycle = createLifecycle({
-    env: globalThis.process?.env ?? {},
-    run: createProcessRunner(),
-  });
-  if (!lifecycle) return;
+function registerLifecycleHandlers(pi, lifecycle) {
   const outcomes = createOutcomeTracker();
 
   const report = (ctx, state, evidence) =>
@@ -335,6 +330,15 @@ export default function BoomuxPiExtension(pi) {
   });
 }
 
+export default function BoomuxPiExtension(pi) {
+  const lifecycle = createLifecycle({
+    env: globalThis.process?.env ?? {},
+    run: createProcessRunner(),
+  });
+  if (!lifecycle) return;
+  registerLifecycleHandlers(pi, lifecycle);
+}
+
 export const __internal = Object.freeze({
   agentErrorEvidence,
   boundedEvidence,
@@ -343,4 +347,5 @@ export const __internal = Object.freeze({
   createProcessRunner,
   ensureArgv,
   reportArgv,
+  registerLifecycleHandlers,
 });

--- a/integrations/pi/boomux.test.js
+++ b/integrations/pi/boomux.test.js
@@ -124,6 +124,71 @@ describe("Pi lifecycle", () => {
     expect(calls.every((argv) => argv.includes("--json"))).toBe(true);
   });
 
+  test("maps the Pi 0.84.1 hook ordering consumed by Boomux", async () => {
+    const handlers = new Map();
+    const calls = [];
+    const lifecycle = {
+      enqueue: async (...values) => calls.push(values),
+    };
+    __internal.registerLifecycleHandlers(
+      { on: (event, handler) => handlers.set(event, handler) },
+      lifecycle,
+    );
+    const first = context("session-1");
+    const second = context("session-2");
+
+    await handlers.get("session_start")(
+      { type: "session_start", reason: "startup" },
+      first,
+    );
+    await handlers.get("agent_start")({ type: "agent_start" }, first);
+    handlers.get("agent_end")(
+      {
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            stopReason: "error",
+            errorMessage: "provider unavailable",
+          },
+        ],
+      },
+      first,
+    );
+    await handlers.get("agent_settled")({ type: "agent_settled" }, first);
+    await handlers.get("session_shutdown")(
+      { type: "session_shutdown", reason: "reload" },
+      first,
+    );
+    await handlers.get("session_start")(
+      { type: "session_start", reason: "reload" },
+      first,
+    );
+    await handlers.get("session_shutdown")(
+      { type: "session_shutdown", reason: "resume" },
+      first,
+    );
+    await handlers.get("session_start")(
+      { type: "session_start", reason: "resume" },
+      second,
+    );
+    await handlers.get("session_shutdown")(
+      { type: "session_shutdown", reason: "quit" },
+      second,
+    );
+
+    expect(calls).toEqual([
+      ["session-1", "idle", "Pi session idle"],
+      ["session-1", "working", "Pi agent working"],
+      ["session-1", "blocked", "Pi error: provider unavailable"],
+      ["session-1", "inactive", "Pi session inactive", 2],
+      ["session-1", "idle", "Pi session idle"],
+      ["session-1", "inactive", "Pi session inactive", 2],
+      ["session-2", "idle", "Pi session idle"],
+      ["session-2", "inactive", "Pi session inactive", 2],
+    ]);
+  });
+
   test("ensures a new identity when Pi switches sessions", async () => {
     const calls = [];
     let next = 0;


### PR DESCRIPTION
## Summary
- record dated real-session validation for OpenCode 1.18.15, Pi 0.84.1, and protocol-15 daemon replacement
- distinguish observed transitions from consumed-field unit fixtures and provider-dependent gaps
- exercise OpenCode child permission routing and Pi reload/resume hook ordering
- extract Pi handler registration as a behavior-preserving test seam

## Verification
- bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check