### PR TITLE
Add stable transcript pagination

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -100,6 +100,7 @@ boomux session list --json
 boomux session list --workspace "<workspace-name-or-id>" --json
 boomux session inspect "<exact-session-id>" --json
 boomux session read "<exact-session-id>" --limit 100 --max-bytes 1048576 --json
+boomux session read "<exact-session-id>" --before "<next-cursor>" --limit 100 --max-bytes 1048576 --json
 ```
 
 Use the exact opaque session ID returned by `session list`. Never guess or
@@ -114,6 +115,10 @@ follow its active branch. Inspect `truncated`, `truncated_by`, and per-entry
 redact host content, so use it only when the user's request authorizes reading
 that exact session. Protocol-13 sessions retain a `source_cwd` for transcript
 lookup after shell removal; this does not preserve deleted harness data itself.
+When `has_more` is true, prepend older pages by passing the exact opaque
+`next_cursor` as `--before`; bounds may change between requests. Discard the
+cursor and start a fresh read on `cursor_expired`. Do not decode, edit, or reuse
+a cursor for another projected session.
 
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,9 +104,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "boomux"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "clap",
  "crossterm",
  "libc",
@@ -109,6 +125,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "sha2",
  "toml",
  "uuid",
  "vt100",
@@ -217,6 +234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +273,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -309,6 +345,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -393,6 +439,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -956,6 +1012,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1288,12 @@ dependencies = [
  "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vt100"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
 libc = "0.2"
@@ -12,6 +13,7 @@ portable-pty = "0.9"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm", "layout-cache"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 toml = "0.9"
 uuid = { version = "1", features = ["v4", "v5"] }
 vt100 = "=0.16.2"

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ boomux attention list [--workspace <name-or-id>]
 boomux attention acknowledge <agent-id> --observation-revision <revision>
 boomux session list [--workspace <name-or-id>]
 boomux session inspect <session-id>
-boomux session read <session-id> [--limit <entries>] [--max-bytes <bytes>]
+boomux session read <session-id> [--before <cursor>] [--limit <entries>] [--max-bytes <bytes>]
 boomux daemon status
 boomux daemon restart
 boomux daemon stop
@@ -251,6 +251,10 @@ scrollback. It returns the newest bounded suffix of messages, reasoning, and too
 activity in chronological order. Pi reads only the current leaf branch and
 combines tool calls with their results. Boomux does not redact host content;
 `--limit` and `--max-bytes` explicitly bound the response and report truncation.
+When `has_more` is true, pass the opaque `next_cursor` back through `--before`
+to read older entries. Cursors preserve the initial normalized snapshot across
+appends that leave its normalized prefix unchanged, and expire if existing
+entries, the active Pi branch, source context, or adapter normalization changes.
 Transcript hosts are registered behind one adapter contract, so future harnesses
 such as Claude Code or Codex can supply canonical lookup and normalization while
 reusing exact Boomux identity, bounds, errors, and output semantics. Discover the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -385,11 +385,25 @@ limits, marks partial entries and truncation causes, caps canonical source input
 at 16 MiB, and times out OpenCode export. Unsupported hosts and unavailable,
 invalid, or oversized sources return stable typed errors.
 
+Older-page reads use a stateless opaque cursor bound to the projected session,
+adapter normalization revision, retained source context, initial normalized
+entry count, and a SHA-256 fingerprint of that baseline. Each continuation
+re-reads the bounded canonical source. Appends that leave the normalized
+baseline prefix unchanged are ignored for the established sequence, while
+baseline mutation, removal, reordering, Pi branch changes, source-context
+changes, or normalization changes expire the cursor.
+Page selection and byte clipping remain shared and advance by whole normalized
+entries; cursors create no daemon identity, persistence, or retained state.
+Cursor data is untrusted consistency metadata rather than authorization; exact
+projected-session resolution and canonical source access remain the security
+boundary.
+
 The transcript layer is an adapter registry keyed by the Agent integration
 name. An adapter receives only the canonical external session ID and retained
 working directory and returns host-neutral transcript entries. Exact projected
-session resolution, access preconditions, newest-suffix selection, byte and
-entry bounds, truncation, typed errors, human output, and `boomux.cli/v1` JSON
+session resolution, access preconditions, newest-suffix pagination, byte and
+entry bounds, cursor validation, truncation, typed errors, human output, and
+`boomux.cli/v1` JSON
 remain shared. Adding Claude Code, Codex, or another harness therefore requires
 one canonical source adapter and one registry entry, not another CLI path.
 `boomux capabilities --json` derives `session_transcript_integrations` from this

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -195,8 +195,9 @@ leaf parent chain and excludes abandoned branches. Tool-result messages are
 combined with their tool calls.
 
 The transcript contains `session_id`, `integration`, `external_session_id`,
-`entries`, `returned_entries`, `total_entries`, `content_bytes`, `truncated`, and
-`truncated_by`. Entries are a newest suffix returned in chronological order.
+`entries`, `returned_entries`, `total_entries`, `content_bytes`, `truncated`,
+`truncated_by`, `has_more`, and `next_cursor`. Entries are a newest suffix
+returned in chronological order.
 Their `type` is `message`, `reasoning`, or `tool`; common fields are `source_id`,
 `timestamp_ms`, and `truncated`. Message and reasoning entries add `role` and
 `text`. Tool entries add `tool_name`, `tool_call_id`, `status`, `input`, and
@@ -210,6 +211,18 @@ bytes in returned text, input, and output fields. `truncated_by` contains `limit
 and/or `max_bytes`; a partially clipped entry also has `truncated: true`. Boomux
 does not redact canonical host content. Raw host source inspection is separately
 capped at 16 MiB.
+
+When `has_more` is true, `next_cursor` is a non-null opaque string for
+`session read --before <cursor>`; otherwise it is JSON `null`. Continuation moves
+toward older logical entries, and bounds may change between requests. The cursor
+binds the projected session, adapter normalization, retained source context, and
+initial normalized transcript. Entries appended after the first page are ignored
+only when the normalized baseline remains an exact prefix. Existing-entry edits,
+tool-result updates, removals, reordering, Pi branch changes, source-context
+changes, and adapter-normalization changes return
+`cursor_expired`; callers discard the cursor and request a fresh newest page.
+Malformed, oversized, or cross-session cursors return `invalid_argument`.
+Pagination remains client-side and does not create daemon cursor state.
 
 `read` returns `shell_id`, `run_id`, `output_revision`, `changed`, `status`, and
 `output`. Output is a JSON string containing the same bounded plain rendered text

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -130,8 +130,9 @@ eternal process.
    capabilities, and an explicit access policy. Boomux trusts the harness as the
    content boundary and does not apply another redaction pass. Host-specific
    canonical lookup and normalization live behind a shared adapter registry so
-   future Claude Code, Codex, and other harness support reuses the same identity,
-   bounds, errors, and output contract.
+    future Claude Code, Codex, and other harness support reuses the same identity,
+    bounds, errors, and output contract. Opaque stateless cursors page toward
+    older entries while expiring on baseline or source-context changes.
 7. [Complete] Add contextual, categorized Agent Session browsing to selected agent rows in
    the Boomux UI. Keep inactive and completed workspace sessions visible without
    adding duplicate shell rows, grouped by active and recent time windows with

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "process_adapters",
     "projected_agent_sessions",
     "canonical_session_transcripts",
+    "transcript_pagination",
     "durable_session_source_context",
     "revision_aware_agent_wait",
     "persistent_agent_attention",
@@ -431,6 +432,8 @@ enum SessionCommands {
     /// Read canonical messages and tool activity by exact opaque ID
     Read {
         session_id: String,
+        #[arg(long)]
+        before: Option<String>,
         #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u16).range(1..=1000))]
         limit: u16,
         #[arg(long, default_value_t = 1024 * 1024, value_parser = clap::value_parser!(u32).range(1..=4 * 1024 * 1024))]
@@ -2109,6 +2112,7 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
         }
         SessionCommands::Read {
             session_id,
+            before,
             limit,
             max_bytes,
         } => {
@@ -2127,8 +2131,13 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
                     ));
                 }
             };
-            let transcript = session_transcript::read(session, limit.into(), max_bytes as usize)
-                .map_err(|error| cli_output::failure(error.code, error.to_string()))?;
+            let transcript = session_transcript::read(
+                session,
+                before.as_deref(),
+                limit.into(),
+                max_bytes as usize,
+            )
+            .map_err(|error| cli_output::failure(error.code, error.to_string()))?;
             if json {
                 return cli_output::print(
                     "session.read",
@@ -2253,6 +2262,11 @@ fn print_transcript(transcript: &session_transcript::Transcript) {
         transcript.returned_entries, transcript.total_entries
     );
     println!("CONTENT BYTES\t{}", transcript.content_bytes);
+    println!("HAS MORE\t{}", transcript.has_more);
+    println!(
+        "NEXT CURSOR\t{}",
+        transcript.next_cursor.as_deref().unwrap_or("-")
+    );
     println!(
         "TRUNCATED\t{}",
         if transcript.truncated {
@@ -3789,6 +3803,8 @@ mod tests {
             "session",
             "read",
             "opaque",
+            "--before",
+            "v1.cursor",
             "--limit",
             "25",
             "--max-bytes",
@@ -3803,10 +3819,11 @@ mod tests {
             Some(Commands::Session {
                 command: SessionCommands::Read {
                     session_id,
+                    before: Some(before),
                     limit: 25,
                     max_bytes: 4096,
                 }
-            }) if session_id == "opaque"
+            }) if session_id == "opaque" && before == "v1.cursor"
         ));
         assert!(
             Cli::try_parse_from(["boomux", "session", "read", "opaque", "--limit", "0"]).is_err()
@@ -4685,6 +4702,7 @@ mod tests {
             "opencode_lifecycle_plugin",
             "pi_lifecycle_extension",
             "canonical_session_transcripts",
+            "transcript_pagination",
             "protocol_15",
             "persistent_agent_attention",
         ] {

--- a/src/session_transcript.rs
+++ b/src/session_transcript.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fs::OpenOptions;
 use std::io::{self, Read};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -9,8 +10,11 @@ use std::sync::mpsc::{self, TryRecvError};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use serde::Serialize;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::host_session_titles::{
     PiEnvironment, PiSessionFileError, normalize_absolute, pi_session_file,
@@ -19,9 +23,13 @@ use crate::session_projection::SessionProjection;
 
 const SOURCE_LIMIT_BYTES: u64 = 16 * 1024 * 1024;
 const OPENCODE_TIMEOUT: Duration = Duration::from_secs(30);
+const CURSOR_PREFIX: &str = "v1.";
+const CURSOR_MAX_BYTES: usize = 4096;
 
 trait TranscriptAdapter: Sync {
     fn integration(&self) -> &'static str;
+
+    fn normalization_revision(&self) -> u32;
 
     fn read(&self, request: TranscriptRequest<'_>)
     -> Result<Vec<TranscriptEntry>, TranscriptError>;
@@ -97,14 +105,39 @@ pub(crate) struct Transcript {
     pub(crate) content_bytes: usize,
     pub(crate) truncated: bool,
     pub(crate) truncated_by: Vec<&'static str>,
+    pub(crate) has_more: bool,
+    pub(crate) next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Cursor {
+    v: u32,
+    n: u32,
+    s: String,
+    i: String,
+    x: String,
+    c: u64,
+    h: String,
+    e: u64,
+}
+
+struct PageBounds {
+    normalization_revision: u32,
+    source_fingerprint: String,
+    baseline_count: usize,
+    baseline_fingerprint: String,
+    end: usize,
+    limit: usize,
+    max_bytes: usize,
 }
 
 pub(crate) fn read(
     session: &SessionProjection,
+    before: Option<&str>,
     limit: usize,
     max_bytes: usize,
 ) -> Result<Transcript, TranscriptError> {
-    read_with_adapters(session, limit, max_bytes, ADAPTERS)
+    read_with_adapters(session, before, limit, max_bytes, ADAPTERS)
 }
 
 pub(crate) fn supported_integrations() -> Vec<&'static str> {
@@ -116,6 +149,7 @@ pub(crate) fn supported_integrations() -> Vec<&'static str> {
 
 fn read_with_adapters(
     session: &SessionProjection,
+    before: Option<&str>,
     limit: usize,
     max_bytes: usize,
     adapters: &[&dyn TranscriptAdapter],
@@ -150,22 +184,66 @@ fn read_with_adapters(
                 ),
             )
         })?;
+    let source_fingerprint =
+        source_context_fingerprint(&session.integration, external_session_id, directory)?;
+    let cursor = before.map(decode_cursor).transpose()?;
+    if let Some(cursor) = cursor.as_ref() {
+        if cursor.s != session.id || cursor.i != session.integration {
+            return Err(invalid_cursor("cursor belongs to a different session"));
+        }
+        if cursor.n != adapter.normalization_revision() || cursor.x != source_fingerprint {
+            return Err(expired_cursor());
+        }
+        if cursor.e > cursor.c {
+            return Err(invalid_cursor("cursor entry index is out of range"));
+        }
+    }
     let entries = adapter.read(TranscriptRequest {
         directory,
         external_session_id,
     })?;
+    let (baseline_count, baseline_fingerprint, end) = if let Some(cursor) = cursor {
+        let baseline_count = usize::try_from(cursor.c)
+            .map_err(|_| invalid_cursor("cursor entry count is out of range"))?;
+        let end = usize::try_from(cursor.e)
+            .map_err(|_| invalid_cursor("cursor entry index is out of range"))?;
+        if entries.len() < baseline_count
+            || normalized_prefix_fingerprint(&entries[..baseline_count]) != cursor.h
+        {
+            return Err(expired_cursor());
+        }
+        (baseline_count, cursor.h, end)
+    } else {
+        let baseline_count = entries.len();
+        (
+            baseline_count,
+            normalized_prefix_fingerprint(&entries),
+            baseline_count,
+        )
+    };
     Ok(bound_entries(
         session,
         external_session_id,
         entries,
-        limit,
-        max_bytes,
+        PageBounds {
+            normalization_revision: adapter.normalization_revision(),
+            source_fingerprint,
+            baseline_count,
+            baseline_fingerprint,
+            end,
+            limit,
+            max_bytes,
+        },
     ))
 }
 
 impl TranscriptAdapter for OpenCodeAdapter {
     fn integration(&self) -> &'static str {
         "opencode"
+    }
+
+    fn normalization_revision(&self) -> u32 {
+        1
     }
 
     fn read(
@@ -180,6 +258,10 @@ impl TranscriptAdapter for OpenCodeAdapter {
 impl TranscriptAdapter for PiAdapter {
     fn integration(&self) -> &'static str {
         "pi"
+    }
+
+    fn normalization_revision(&self) -> u32 {
+        1
     }
 
     fn read(
@@ -734,40 +816,132 @@ fn value_text(value: &Value) -> String {
         .map_or_else(|| compact_json(value), str::to_owned)
 }
 
+fn source_context_fingerprint(
+    integration: &str,
+    external_session_id: &str,
+    directory: &Path,
+) -> Result<String, TranscriptError> {
+    let directory = normalize_absolute(directory).ok_or_else(|| {
+        TranscriptError::new(
+            "session_source_unavailable",
+            "session retained working directory is not absolute",
+        )
+    })?;
+    Ok(hash_fields([
+        integration.as_bytes(),
+        external_session_id.as_bytes(),
+        directory.as_os_str().as_bytes(),
+    ]))
+}
+
+fn normalized_prefix_fingerprint(entries: &[TranscriptEntry]) -> String {
+    let mut hasher = Sha256::new();
+    for entry in entries {
+        let serialized = serde_json::to_vec(entry).expect("transcript entries serialize");
+        hash_field(&mut hasher, &serialized);
+    }
+    URL_SAFE_NO_PAD.encode(hasher.finalize())
+}
+
+fn hash_fields<'a>(fields: impl IntoIterator<Item = &'a [u8]>) -> String {
+    let mut hasher = Sha256::new();
+    for field in fields {
+        hash_field(&mut hasher, field);
+    }
+    URL_SAFE_NO_PAD.encode(hasher.finalize())
+}
+
+fn hash_field(hasher: &mut Sha256, field: &[u8]) {
+    hasher.update((field.len() as u64).to_be_bytes());
+    hasher.update(field);
+}
+
+fn decode_cursor(encoded: &str) -> Result<Cursor, TranscriptError> {
+    if encoded.len() > CURSOR_MAX_BYTES {
+        return Err(invalid_cursor("cursor is too long"));
+    }
+    let payload = encoded
+        .strip_prefix(CURSOR_PREFIX)
+        .ok_or_else(|| invalid_cursor("cursor has an unknown schema"))?;
+    let bytes = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| invalid_cursor("cursor is malformed"))?;
+    let cursor: Cursor =
+        serde_json::from_slice(&bytes).map_err(|_| invalid_cursor("cursor is malformed"))?;
+    if cursor.v != 1 {
+        return Err(invalid_cursor("cursor has an unknown schema"));
+    }
+    Ok(cursor)
+}
+
+fn encode_cursor(cursor: &Cursor) -> String {
+    let payload = serde_json::to_vec(cursor).expect("cursor serializes");
+    format!("{CURSOR_PREFIX}{}", URL_SAFE_NO_PAD.encode(payload))
+}
+
+fn invalid_cursor(message: &'static str) -> TranscriptError {
+    TranscriptError::new("invalid_argument", message)
+}
+
+fn expired_cursor() -> TranscriptError {
+    TranscriptError::new("cursor_expired", "transcript cursor has expired")
+}
+
 fn bound_entries(
     session: &SessionProjection,
     external_session_id: &str,
     entries: Vec<TranscriptEntry>,
-    limit: usize,
-    max_bytes: usize,
+    page: PageBounds,
 ) -> Transcript {
-    let total_entries = entries.len();
-    let entry_start = total_entries.saturating_sub(limit);
+    let PageBounds {
+        normalization_revision,
+        source_fingerprint,
+        baseline_count,
+        baseline_fingerprint,
+        end,
+        limit,
+        max_bytes,
+    } = page;
+    let total_entries = baseline_count;
+    let entry_start = end.saturating_sub(limit);
     let limit_truncated = entry_start > 0;
-    let selected = entries.into_iter().skip(entry_start).collect::<Vec<_>>();
+    let selected = entries
+        .into_iter()
+        .take(end)
+        .skip(entry_start)
+        .enumerate()
+        .map(|(offset, entry)| (entry_start + offset, entry))
+        .collect::<Vec<_>>();
     let selected_entries = selected.len();
     let mut remaining = max_bytes;
     let mut bounded = Vec::new();
     let mut byte_truncated = false;
-    for mut entry in selected.into_iter().rev() {
+    let mut oldest_index = end;
+    for (index, mut entry) in selected.into_iter().rev() {
         let bytes = entry.content_bytes();
         if bytes > remaining {
             byte_truncated = true;
-            if remaining == 0 {
+            if remaining == 0 && !bounded.is_empty() {
                 break;
             }
             entry.truncate_to(remaining);
-            bounded.push(entry);
+            oldest_index = index;
+            bounded.push((index, entry));
             break;
         }
         remaining -= bytes;
-        bounded.push(entry);
+        oldest_index = index;
+        bounded.push((index, entry));
     }
     if bounded.len() < selected_entries {
         byte_truncated = true;
     }
     bounded.reverse();
-    let content_bytes = bounded.iter().map(TranscriptEntry::content_bytes).sum();
+    let entries = bounded
+        .into_iter()
+        .map(|(_, entry)| entry)
+        .collect::<Vec<_>>();
+    let content_bytes = entries.iter().map(TranscriptEntry::content_bytes).sum();
     let mut truncated_by = Vec::new();
     if limit_truncated {
         truncated_by.push("limit");
@@ -775,16 +949,32 @@ fn bound_entries(
     if byte_truncated {
         truncated_by.push("max_bytes");
     }
+    let next_end = oldest_index;
+    let has_more = next_end > 0;
+    let next_cursor = has_more.then(|| {
+        encode_cursor(&Cursor {
+            v: 1,
+            n: normalization_revision,
+            s: session.id.clone(),
+            i: session.integration.clone(),
+            x: source_fingerprint,
+            c: baseline_count as u64,
+            h: baseline_fingerprint,
+            e: next_end as u64,
+        })
+    });
     Transcript {
         session_id: session.id.clone(),
         integration: session.integration.clone(),
         external_session_id: external_session_id.to_owned(),
-        returned_entries: bounded.len(),
+        returned_entries: entries.len(),
         total_entries,
         content_bytes,
-        entries: bounded,
+        entries,
         truncated: !truncated_by.is_empty(),
         truncated_by,
+        has_more,
+        next_cursor,
     }
 }
 
@@ -827,6 +1017,8 @@ fn truncate_utf8(value: &mut String, max_bytes: usize) {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     use boomux::protocol::{AgentAuthority, AgentObservationSnapshot, AgentState};
 
@@ -838,6 +1030,10 @@ mod tests {
     impl TranscriptAdapter for FutureHarnessAdapter {
         fn integration(&self) -> &'static str {
             "future-harness"
+        }
+
+        fn normalization_revision(&self) -> u32 {
+            1
         }
 
         fn read(
@@ -854,6 +1050,59 @@ mod tests {
                 "adapter output",
             )])
         }
+    }
+
+    struct MutableAdapter {
+        entries: Mutex<Vec<TranscriptEntry>>,
+        revision: AtomicU32,
+    }
+
+    impl MutableAdapter {
+        fn new(entries: Vec<TranscriptEntry>) -> Self {
+            Self {
+                entries: Mutex::new(entries),
+                revision: AtomicU32::new(1),
+            }
+        }
+    }
+
+    impl TranscriptAdapter for MutableAdapter {
+        fn integration(&self) -> &'static str {
+            "mutable"
+        }
+
+        fn normalization_revision(&self) -> u32 {
+            self.revision.load(Ordering::Relaxed)
+        }
+
+        fn read(
+            &self,
+            _request: TranscriptRequest<'_>,
+        ) -> Result<Vec<TranscriptEntry>, TranscriptError> {
+            Ok(self.entries.lock().unwrap().clone())
+        }
+    }
+
+    fn entries(ids: &[&str]) -> Vec<TranscriptEntry> {
+        ids.iter()
+            .map(|id| message_entry("message", Some((*id).into()), None, Some("user"), id))
+            .collect()
+    }
+
+    fn read_mutable(
+        session: &SessionProjection,
+        adapter: &MutableAdapter,
+        before: Option<&str>,
+        limit: usize,
+        max_bytes: usize,
+    ) -> Result<Transcript, TranscriptError> {
+        read_with_adapters(
+            session,
+            before,
+            limit,
+            max_bytes,
+            &[adapter as &dyn TranscriptAdapter],
+        )
     }
 
     fn session(integration: &str) -> SessionProjection {
@@ -963,7 +1212,20 @@ mod tests {
             ),
         ];
 
-        let transcript = bound_entries(&session("pi"), "external", entries, 2, 8);
+        let transcript = bound_entries(
+            &session("pi"),
+            "external",
+            entries,
+            PageBounds {
+                normalization_revision: 1,
+                source_fingerprint: "source".into(),
+                baseline_count: 3,
+                baseline_fingerprint: "baseline".into(),
+                end: 3,
+                limit: 2,
+                max_bytes: 8,
+            },
+        );
 
         assert_eq!(transcript.total_entries, 3);
         assert_eq!(transcript.returned_entries, 1);
@@ -978,6 +1240,7 @@ mod tests {
         let adapter = FutureHarnessAdapter;
         let transcript = read_with_adapters(
             &session("future-harness"),
+            None,
             10,
             7,
             &[&adapter as &dyn TranscriptAdapter],
@@ -987,6 +1250,243 @@ mod tests {
         assert_eq!(transcript.integration, "future-harness");
         assert_eq!(transcript.entries[0].text.as_deref(), Some("adapter"));
         assert_eq!(transcript.truncated_by, ["max_bytes"]);
+    }
+
+    #[test]
+    fn cursor_roundtrips_and_rejects_bad_representations() {
+        let cursor = Cursor {
+            v: 1,
+            n: 2,
+            s: "session".into(),
+            i: "integration".into(),
+            x: "source".into(),
+            c: 10,
+            h: "baseline".into(),
+            e: 4,
+        };
+        let encoded = encode_cursor(&cursor);
+        let decoded = decode_cursor(&encoded).unwrap();
+        assert_eq!(decoded.s, "session");
+        assert_eq!(decoded.e, 4);
+
+        for bad in ["garbage", "v1.not-base64", "v2.e30"] {
+            assert_eq!(decode_cursor(bad).unwrap_err().code, "invalid_argument");
+        }
+        let unknown =
+            URL_SAFE_NO_PAD.encode(br#"{"v":2,"n":1,"s":"s","i":"i","x":"x","c":0,"h":"h","e":0}"#);
+        assert_eq!(
+            decode_cursor(&format!("v1.{unknown}")).unwrap_err().code,
+            "invalid_argument"
+        );
+        assert_eq!(
+            decode_cursor(&"x".repeat(CURSOR_MAX_BYTES + 1))
+                .unwrap_err()
+                .code,
+            "invalid_argument"
+        );
+    }
+
+    #[test]
+    fn paginates_exactly_in_chronological_pages_with_changed_bounds() {
+        let adapter = MutableAdapter::new(entries(&["1", "2", "3", "4", "5"]));
+        let session = session("mutable");
+
+        let first = read_mutable(&session, &adapter, None, 2, usize::MAX).unwrap();
+        assert_eq!(source_ids(&first), ["4", "5"]);
+        assert_eq!(first.total_entries, 5);
+        assert_eq!(first.truncated_by, ["limit"]);
+
+        let second = read_mutable(
+            &session,
+            &adapter,
+            first.next_cursor.as_deref(),
+            1,
+            usize::MAX,
+        )
+        .unwrap();
+        assert_eq!(source_ids(&second), ["3"]);
+        assert_eq!(second.total_entries, 5);
+        assert_eq!(second.truncated_by, ["limit"]);
+
+        let third = read_mutable(
+            &session,
+            &adapter,
+            second.next_cursor.as_deref(),
+            10,
+            usize::MAX,
+        )
+        .unwrap();
+        assert_eq!(source_ids(&third), ["1", "2"]);
+        assert!(!third.has_more);
+        assert!(third.next_cursor.is_none());
+        assert!(third.truncated_by.is_empty());
+    }
+
+    #[test]
+    fn append_is_ignored_but_prefix_mutation_or_removal_expires_cursor() {
+        let adapter = MutableAdapter::new(entries(&["1", "2", "3"]));
+        let session = session("mutable");
+        let first = read_mutable(&session, &adapter, None, 1, usize::MAX).unwrap();
+        let cursor = first.next_cursor.unwrap();
+
+        adapter
+            .entries
+            .lock()
+            .unwrap()
+            .push(entries(&["4"]).remove(0));
+        let continued = read_mutable(&session, &adapter, Some(&cursor), 10, usize::MAX).unwrap();
+        assert_eq!(source_ids(&continued), ["1", "2"]);
+        assert_eq!(continued.total_entries, 3);
+
+        adapter.entries.lock().unwrap()[0].text = Some("changed".into());
+        assert_eq!(
+            read_mutable(&session, &adapter, Some(&cursor), 10, usize::MAX)
+                .unwrap_err()
+                .code,
+            "cursor_expired"
+        );
+        *adapter.entries.lock().unwrap() = entries(&["1", "2"]);
+        assert_eq!(
+            read_mutable(&session, &adapter, Some(&cursor), 10, usize::MAX)
+                .unwrap_err()
+                .code,
+            "cursor_expired"
+        );
+    }
+
+    #[test]
+    fn pi_tool_results_and_branch_changes_expire_the_baseline() {
+        let pending = br#"{"type":"session","version":3,"id":"external","cwd":"/repo"}
+{"type":"message","id":"user","parentId":null,"message":{"role":"user","content":"start","timestamp":1}}
+{"type":"message","id":"call","parentId":"user","message":{"role":"assistant","content":[{"type":"toolCall","id":"tc1","name":"read","arguments":{"path":"a"}}],"timestamp":2}}
+"#;
+        let completed = br#"{"type":"session","version":3,"id":"external","cwd":"/repo"}
+{"type":"message","id":"user","parentId":null,"message":{"role":"user","content":"start","timestamp":1}}
+{"type":"message","id":"call","parentId":"user","message":{"role":"assistant","content":[{"type":"toolCall","id":"tc1","name":"read","arguments":{"path":"a"}}],"timestamp":2}}
+{"type":"message","id":"result","parentId":"call","message":{"role":"toolResult","toolCallId":"tc1","content":"data","isError":false,"timestamp":3}}
+"#;
+        let adapter =
+            MutableAdapter::new(parse_pi(pending, "external", Path::new("/repo")).unwrap());
+        let session = session("mutable");
+        let first = read_mutable(&session, &adapter, None, 1, usize::MAX).unwrap();
+        let cursor = first.next_cursor.unwrap();
+        *adapter.entries.lock().unwrap() =
+            parse_pi(completed, "external", Path::new("/repo")).unwrap();
+        assert_eq!(
+            read_mutable(&session, &adapter, Some(&cursor), 1, usize::MAX)
+                .unwrap_err()
+                .code,
+            "cursor_expired"
+        );
+
+        *adapter.entries.lock().unwrap() = entries(&["root", "old-leaf"]);
+        let first = read_mutable(&session, &adapter, None, 1, usize::MAX).unwrap();
+        *adapter.entries.lock().unwrap() = entries(&["root", "new-leaf"]);
+        assert_eq!(
+            read_mutable(
+                &session,
+                &adapter,
+                first.next_cursor.as_deref(),
+                1,
+                usize::MAX,
+            )
+            .unwrap_err()
+            .code,
+            "cursor_expired"
+        );
+    }
+
+    #[test]
+    fn cursor_rejects_wrong_identity_and_expires_for_source_or_normalization() {
+        let adapter = MutableAdapter::new(entries(&["1", "2"]));
+        let original = session("mutable");
+        let first = read_mutable(&original, &adapter, None, 1, usize::MAX).unwrap();
+        let cursor = first.next_cursor.unwrap();
+
+        let mut out_of_range = decode_cursor(&cursor).unwrap();
+        out_of_range.e = out_of_range.c + 1;
+        assert_eq!(
+            read_mutable(
+                &original,
+                &adapter,
+                Some(&encode_cursor(&out_of_range)),
+                1,
+                usize::MAX,
+            )
+            .unwrap_err()
+            .code,
+            "invalid_argument"
+        );
+
+        let mut wrong = original.clone();
+        wrong.id = "other".into();
+        assert_eq!(
+            read_mutable(&wrong, &adapter, Some(&cursor), 1, usize::MAX)
+                .unwrap_err()
+                .code,
+            "invalid_argument"
+        );
+
+        let mut moved = original.clone();
+        moved.occurrences[0].source_cwd = Some(PathBuf::from("/other"));
+        assert_eq!(
+            read_mutable(&moved, &adapter, Some(&cursor), 1, usize::MAX)
+                .unwrap_err()
+                .code,
+            "cursor_expired"
+        );
+
+        adapter.revision.store(2, Ordering::Relaxed);
+        assert_eq!(
+            read_mutable(&original, &adapter, Some(&cursor), 1, usize::MAX)
+                .unwrap_err()
+                .code,
+            "cursor_expired"
+        );
+    }
+
+    #[test]
+    fn byte_clipping_consumes_a_logical_entry_even_at_zero_utf8_bytes() {
+        let adapter = MutableAdapter::new(vec![
+            message_entry("message", Some("old".into()), None, Some("user"), "old"),
+            message_entry("message", Some("emoji".into()), None, Some("user"), "😀"),
+        ]);
+        let session = session("mutable");
+
+        let first = read_mutable(&session, &adapter, None, 10, 1).unwrap();
+        assert_eq!(source_ids(&first), ["emoji"]);
+        assert_eq!(first.entries[0].text.as_deref(), Some(""));
+        assert_eq!(first.content_bytes, 0);
+        assert_eq!(first.truncated_by, ["max_bytes"]);
+
+        let second = read_mutable(
+            &session,
+            &adapter,
+            first.next_cursor.as_deref(),
+            10,
+            usize::MAX,
+        )
+        .unwrap();
+        assert_eq!(source_ids(&second), ["old"]);
+        assert!(!second.has_more);
+    }
+
+    #[test]
+    fn empty_source_has_no_cursor() {
+        let adapter = MutableAdapter::new(Vec::new());
+        let transcript = read_mutable(&session("mutable"), &adapter, None, 10, 10).unwrap();
+        assert_eq!(transcript.total_entries, 0);
+        assert_eq!(transcript.returned_entries, 0);
+        assert!(!transcript.has_more);
+        assert!(transcript.next_cursor.is_none());
+    }
+
+    fn source_ids(transcript: &Transcript) -> Vec<&str> {
+        transcript
+            .entries
+            .iter()
+            .map(|entry| entry.source_id.as_deref().unwrap())
+            .collect()
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1617,7 +1617,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
             "read",
             pi_session_id,
             "--limit",
-            "10",
+            "1",
             "--max-bytes",
             "4096",
             "--json",
@@ -1633,18 +1633,95 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     let pi_read: serde_json::Value = serde_json::from_slice(&pi_read.stdout).unwrap();
     assert_eq!(pi_read["command"], "session.read");
     assert_eq!(pi_read["data"]["transcript"]["total_entries"], 2);
+    assert_eq!(pi_read["data"]["transcript"]["returned_entries"], 1);
+    assert_eq!(pi_read["data"]["transcript"]["has_more"], true);
+    let next_cursor = pi_read["data"]["transcript"]["next_cursor"]
+        .as_str()
+        .unwrap()
+        .to_owned();
     assert_eq!(
         pi_read["data"]["transcript"]["entries"][0]["text"],
-        "inspect this"
+        serde_json::Value::Null
     );
     assert_eq!(
-        pi_read["data"]["transcript"]["entries"][1]["tool_name"],
-        "read"
-    );
-    assert_eq!(
-        pi_read["data"]["transcript"]["entries"][1]["output"],
+        pi_read["data"]["transcript"]["entries"][0]["output"],
         "fixture output"
     );
+    writeln!(
+        OpenOptions::new()
+            .append(true)
+            .open(pi_directory.join("pi-session.jsonl"))
+            .unwrap(),
+        "{{\"type\":\"message\",\"id\":\"later\",\"parentId\":\"result\",\"timestamp\":\"x\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"text\",\"text\":\"appended later\"}}],\"timestamp\":13}}}}"
+    )
+    .unwrap();
+    let older = daemon
+        .command()
+        .args([
+            "session",
+            "read",
+            pi_session_id,
+            "--before",
+            &next_cursor,
+            "--limit",
+            "1",
+            "--max-bytes",
+            "4096",
+            "--json",
+        ])
+        .env("PI_CODING_AGENT_SESSION_DIR", &pi_directory)
+        .output()
+        .unwrap();
+    assert!(older.status.success());
+    let older: serde_json::Value = serde_json::from_slice(&older.stdout).unwrap();
+    assert_eq!(older["data"]["transcript"]["total_entries"], 2);
+    assert_eq!(older["data"]["transcript"]["has_more"], false);
+    assert!(older["data"]["transcript"]["next_cursor"].is_null());
+    assert_eq!(
+        older["data"]["transcript"]["entries"][0]["text"],
+        "inspect this"
+    );
+    let malformed_cursor = daemon
+        .command()
+        .args([
+            "session",
+            "read",
+            pi_session_id,
+            "--before",
+            "not-a-cursor",
+            "--json",
+        ])
+        .env("PI_CODING_AGENT_SESSION_DIR", &pi_directory)
+        .output()
+        .unwrap();
+    assert!(!malformed_cursor.status.success());
+    let malformed_cursor: serde_json::Value =
+        serde_json::from_slice(&malformed_cursor.stderr).unwrap();
+    assert_eq!(malformed_cursor["command"], "session.read");
+    assert_eq!(malformed_cursor["error"]["code"], "invalid_argument");
+
+    let pi_path = pi_directory.join("pi-session.jsonl");
+    let changed = fs::read_to_string(&pi_path)
+        .unwrap()
+        .replace("inspect this", "changed baseline");
+    fs::write(&pi_path, changed).unwrap();
+    let expired_cursor = daemon
+        .command()
+        .args([
+            "session",
+            "read",
+            pi_session_id,
+            "--before",
+            &next_cursor,
+            "--json",
+        ])
+        .env("PI_CODING_AGENT_SESSION_DIR", &pi_directory)
+        .output()
+        .unwrap();
+    assert!(!expired_cursor.status.success());
+    let expired_cursor: serde_json::Value = serde_json::from_slice(&expired_cursor.stderr).unwrap();
+    assert_eq!(expired_cursor["command"], "session.read");
+    assert_eq!(expired_cursor["error"]["code"], "cursor_expired");
 
     let missing_session = daemon
         .command()
@@ -2406,6 +2483,7 @@ fn native_daemon_lifecycle() {
         "opencode_lifecycle_plugin",
         "process_adapters",
         "persistent_agent_attention",
+        "transcript_pagination",
     ] {
         assert!(features.iter().any(|current| current == feature));
     }


### PR DESCRIPTION
## Summary
- add opaque stateless transcript cursors and `session read --before`
- preserve a normalized baseline across prefix-stable appends and expire on mutation, branch, source, or adapter changes
- expose additive `has_more` and `next_cursor` fields with shared entry/byte bounds
- cover multi-page, byte-clipping, Pi branch/tool-result, malformed, expired, and binary append cases

## Verification
- cargo test
- bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check