### PR TITLE
Add deduplicated agent notifications

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -93,6 +93,12 @@ revision fails with `revision_ahead`, while an already empty item returns
 `changed: false`. Acknowledgment does not advance lifecycle state or satisfy an
 `agent wait`.
 
+Desktop notifications, when the user has opted in, are only a best-effort signal
+for new transitions into blocked or done. They do not acknowledge attention,
+change an observation revision, or contain lifecycle evidence. Always inspect
+the durable queue before acting; do not infer queue state or delivery from a
+desktop notification.
+
 Discover projected session metadata with:
 
 ```console
@@ -171,8 +177,8 @@ while conflicting later reports are rejected.
 
 If `register`, `ensure`, or `report` returns `run_changed`, stop reporting for that
 instance and reacquire exact lifecycle context. Do not guess the replacement
-run. Boomux does not yet provide terminal heuristics, agent read commands,
-notifications, or control.
+run. Boomux does not yet provide terminal heuristics, agent read commands, or
+control.
 
 ## Supervise An Explicit Process
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ unseen work. Workspace output includes fixed Agent state counts and the
 outstanding attention count. Boomux does not yet provide terminal heuristics,
 agent reads, or agent control.
 
+Optional desktop notifications mirror transitions into `blocked` and `done`.
+They do not replace or acknowledge durable attention items. Delivery is an
+asynchronous, at-most-once attempt after the Agent mutation commits, and failures
+never fail the Agent request. A bounded delivery queue prevents notification
+bursts from exhausting daemon resources. Boomux does not replay restored
+attention after a daemon start or handoff, and changed evidence for an already
+blocked Agent does not generate another notification until the Agent first
+leaves that state.
+
 `boomux session list` and `boomux session inspect` project durable Agent
 instances into workspace session history. Instances are grouped within one
 workspace and integration by external session ID; records without one remain
@@ -309,7 +318,19 @@ terminal = "Alacritty.desktop"
 roots = ["~/Projects", "~/Work"]
 max_depth = 3
 
+[notifications]
+enabled = false
+blocked = true
+completed = true
 ```
+
+Notifications are disabled by default and require `notify-send` plus a desktop
+notification service. The daemon samples this configuration at startup; run
+`boomux daemon restart` after changing it. `boomux doctor` reports whether the
+configured command and a plausible desktop bus environment are present. Bodies
+contain only the sanitized Agent, workspace, and shell names, never evidence,
+working directories, command arguments, external session IDs, or transcript
+content.
 
 Directory discovery scans only configured project roots, recognizes ordinary
 and linked Git worktrees, and stops descending after finding a repository. The

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -434,6 +434,21 @@ outstanding items so upgrading does not reinterpret historical work as unseen.
 The CLI projects these records into a deterministic blocked-first queue and
 reports fixed lifecycle-state and attention counts per workspace.
 
+Opt-in desktop notifications are a daemon-owned projection of committed Agent
+state transitions, not durable queue state. A transition from any other state
+into `blocked` or `done` schedules one asynchronous `notify-send` attempt after
+persistence and event publication locks are released. Same-state evidence or
+confidence revisions do not notify, and restored state is not replayed. A daemon
+handoff reloads configuration for the replacement, just like a cold daemon
+start. Delivery uses one worker and a bounded, non-blocking queue. It is
+at-most-once and fail-open: queue saturation, a missing command, desktop-bus
+failure, timeout, or non-zero exit neither retries nor changes the successful
+Agent mutation.
+Notification payloads include only sanitized Agent, workspace, and shell names;
+if retained Agent context outlives a removed shell, the shell is identified as
+removed rather than suppressing the transition. Notifications never acknowledge
+attention, advance an observation revision, or publish lifecycle events.
+
 ### Transition Coordinator
 
 The daemon serializes observable runtime transitions through one coordinator. A
@@ -461,10 +476,14 @@ not persisted per chunk, but output revision mutation and `output_changed`
 publication cross the coordinator together. A non-blocking terminal lock keeps
 output processing from holding global locks while waiting on terminal snapshots.
 
-Agent registration, ensure, reports, and attention acknowledgment use the same durable mutation coordinator.
+Agent registration, ensure, reports, and attention acknowledgment use the same
+durable mutation coordinator.
 Persistence and `agent_registered`, `agent_state_changed`, `agent_completed`, or
-`agent_attention_acknowledged` publication therefore share the normal ordering boundary and
-baseline snapshots include the exact coordinated cut.
+`agent_attention_acknowledged` publication therefore share the normal ordering
+boundary and baseline snapshots include the exact coordinated cut. Notification
+eligibility is derived from the pre-mutation and committed Agent states inside
+this boundary, but sink dispatch occurs only after all coordinator and mutation
+locks are released.
 
 ## Runtime Semantics
 
@@ -506,4 +525,4 @@ as pending.
 Future agent runtime work is tracked in [`roadmap.md`](roadmap.md). The explicit
 process-adapter supervisor is only a foundation; automatic and
  integration-specific adapters, terminal heuristics,
-notifications, and control remain future work.
+and control remain future work.

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -25,6 +25,11 @@ each bundled integration host under `integration_hosts`. Validated versions are
 compatibility test points, not runtime pins or minimum-version guarantees.
 `session_transcript_integrations` lists the integration keys with registered
 canonical transcript adapters.
+The `desktop_notifications` feature means this binary supports daemon-owned
+notification delivery; it does not imply notifications are enabled or that
+`notify-send` and a desktop notification service are available. Configuration is
+sampled when the daemon starts and is intentionally outside the JSON capability
+contract.
 
 The following commands support `--json`:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -121,8 +121,8 @@ eternal process.
    persistent attention queue for blocked and completed work.
 4. [Complete] Add revision-aware `agent wait` so scripts can await durable state
    transitions without polling human output.
-5. Add deduplicated notifications for blocked and completed transitions after
-   the attention and wait semantics are established.
+5. [Complete] Add deduplicated notifications for blocked and completed
+   transitions after the attention and wait semantics are established.
 6. [Complete] Add explicit cross-harness transcript and tool inspection so Pi can read an OpenCode
    session and OpenCode can read a Pi session. Do not treat bounded rendered
    terminal output as the full session: host adapters must expose canonical
@@ -160,6 +160,6 @@ eternal process.
 ## Distribution And Polish
 
 - Add a LazyGit-style interactive keybinding panel.
-- Support configuration for refresh rate and notifications.
+- Support configuration for refresh rate.
 - Package Boomux and its daemon lifecycle for Arch and Omarchy users.
 - Validate compatible `xdg-terminal-exec` versions in `boomux doctor`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,18 +9,27 @@ use serde::Deserialize;
 const DEFAULT_PROJECT_SEARCH_DEPTH: usize = 3;
 const MAX_PROJECT_SEARCH_DEPTH: usize = 10;
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 struct RawConfig {
     terminal: Option<String>,
     projects: Option<RawProjectsConfig>,
+    notifications: Option<RawNotificationsConfig>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 struct RawProjectsConfig {
     roots: Option<Vec<String>>,
     max_depth: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawNotificationsConfig {
+    enabled: Option<bool>,
+    blocked: Option<bool>,
+    completed: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -28,6 +37,7 @@ pub(crate) struct Config {
     pub(crate) terminal: Option<String>,
     pub(crate) projects: ProjectsConfig,
     pub(crate) path: Option<PathBuf>,
+    pub(crate) notifications: boomux::daemon::NotificationSettings,
 }
 
 #[derive(Debug)]
@@ -48,6 +58,17 @@ impl fmt::Display for ConfigError {
 impl Error for ConfigError {}
 
 pub(crate) fn load() -> Result<Config, Box<dyn Error>> {
+    let (raw, loaded_path) = load_raw()?;
+    resolve(raw, loaded_path)
+}
+
+pub(crate) fn load_notification_settings()
+-> Result<boomux::daemon::NotificationSettings, Box<dyn Error>> {
+    let (raw, _) = load_raw()?;
+    Ok(resolve_notifications(raw.notifications))
+}
+
+fn load_raw() -> Result<(RawConfig, Option<PathBuf>), Box<dyn Error>> {
     let global_path = global_config_path();
     let mut raw = RawConfig::default();
     let mut loaded_path = None;
@@ -68,7 +89,7 @@ pub(crate) fn load() -> Result<Config, Box<dyn Error>> {
         loaded_path = Some(path);
     }
 
-    resolve(raw, loaded_path)
+    Ok((raw, loaded_path))
 }
 
 pub(crate) fn global_config_path() -> Option<PathBuf> {
@@ -104,6 +125,18 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
             projects.max_depth = next_projects.max_depth;
         }
     }
+    if let Some(next_notifications) = next.notifications {
+        let notifications = base.notifications.get_or_insert_default();
+        if next_notifications.enabled.is_some() {
+            notifications.enabled = next_notifications.enabled;
+        }
+        if next_notifications.blocked.is_some() {
+            notifications.blocked = next_notifications.blocked;
+        }
+        if next_notifications.completed.is_some() {
+            notifications.completed = next_notifications.completed;
+        }
+    }
 }
 
 fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Error>> {
@@ -134,7 +167,19 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
         terminal,
         projects: ProjectsConfig { roots, max_depth },
         path,
+        notifications: resolve_notifications(raw.notifications),
     })
+}
+
+fn resolve_notifications(
+    raw: Option<RawNotificationsConfig>,
+) -> boomux::daemon::NotificationSettings {
+    let raw = raw.unwrap_or_default();
+    boomux::daemon::NotificationSettings {
+        enabled: raw.enabled.unwrap_or(false),
+        blocked: raw.blocked.unwrap_or(true),
+        completed: raw.completed.unwrap_or(true),
+    }
 }
 
 fn expand_root(root: &str) -> Result<PathBuf, Box<dyn Error>> {
@@ -267,5 +312,54 @@ mod tests {
         .expect("valid TOML");
 
         assert!(resolve(raw, None).is_err());
+    }
+
+    #[test]
+    fn notification_settings_default_and_parse() {
+        assert_eq!(
+            resolve_notifications(None),
+            boomux::daemon::NotificationSettings::default()
+        );
+        let raw: RawConfig =
+            toml::from_str("[notifications]\nenabled = true\nblocked = false\ncompleted = false")
+                .unwrap();
+        let settings = resolve_notifications(raw.notifications);
+        assert!(settings.enabled);
+        assert!(!settings.blocked);
+        assert!(!settings.completed);
+    }
+
+    #[test]
+    fn notification_overrides_merge_per_field() {
+        let mut base: RawConfig =
+            toml::from_str("[notifications]\nenabled = true\nblocked = false\ncompleted = false")
+                .unwrap();
+        let next = toml::from_str("[notifications]\ncompleted = true").unwrap();
+        merge(&mut base, next);
+
+        let settings = resolve_notifications(base.notifications);
+        assert_eq!(
+            settings,
+            boomux::daemon::NotificationSettings {
+                enabled: true,
+                blocked: false,
+                completed: true,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_notification_settings() {
+        assert!(toml::from_str::<RawConfig>("[notifications]\nunknown = true").is_err());
+    }
+
+    #[test]
+    fn notification_resolution_ignores_unrelated_semantic_errors() {
+        let raw: RawConfig = toml::from_str(
+            "terminal = \"invalid\"\n[projects]\nroots = [\"relative\"]\n[notifications]\nenabled = true",
+        )
+        .unwrap();
+        assert!(resolve(raw.clone(), None).is_err());
+        assert!(resolve_notifications(raw.notifications).enabled);
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -20,6 +20,10 @@ use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system}
 use uuid::Uuid;
 
 use crate::client;
+use crate::desktop_notifications::{
+    DesktopNotificationSink, DisabledNotificationSink, NotificationReason, NotificationRequest,
+    NotificationSink, category_enabled,
+};
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::protocol::{
@@ -56,7 +60,31 @@ const TRANSITION_IDLE: u8 = 0;
 const TRANSITION_RESTART: u8 = 1;
 const TRANSITION_SHUTDOWN: u8 = 2;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NotificationSettings {
+    pub enabled: bool,
+    pub blocked: bool,
+    pub completed: bool,
+}
+
+impl Default for NotificationSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            blocked: true,
+            completed: true,
+        }
+    }
+}
+
 pub fn receive_handoff(channel: i32) -> io::Result<()> {
+    receive_handoff_with_notifications(channel, NotificationSettings::default())
+}
+
+pub fn receive_handoff_with_notifications(
+    channel: i32,
+    notification_settings: NotificationSettings,
+) -> io::Result<()> {
     match handoff::receive_bootstrap(channel)? {
         handoff::Bootstrap::Aborted => Ok(()),
         handoff::Bootstrap::Committed {
@@ -81,12 +109,17 @@ pub fn receive_handoff(channel: i32) -> io::Result<()> {
                     events: Some(event_stream),
                 },
                 Some(&mut channel),
+                notification_settings,
             )
         }
     }
 }
 
 pub fn run() -> io::Result<()> {
+    run_with_notifications(NotificationSettings::default())
+}
+
+pub fn run_with_notifications(notification_settings: NotificationSettings) -> io::Result<()> {
     let socket_path = client::socket_path()?;
     let runtime_dir = socket_path
         .parent()
@@ -109,6 +142,7 @@ pub fn run() -> io::Result<()> {
         StateStore::from_environment()?,
         TransferredState::default(),
         None,
+        notification_settings,
     )
 }
 
@@ -126,12 +160,12 @@ fn run_daemon(
     store: StateStore,
     transferred: TransferredState,
     committed: Option<&mut UnixStream>,
+    notification_settings: NotificationSettings,
 ) -> io::Result<()> {
-    let registry = Arc::new(Registry::restore(
-        store,
-        committed.is_some(),
-        transferred.events,
-    )?);
+    let mut registry = Registry::restore(store, committed.is_some(), transferred.events)?;
+    registry.notification_settings = notification_settings;
+    registry.notification_sink = Arc::new(DesktopNotificationSink::new());
+    let registry = Arc::new(registry);
     let gated_readers = registry.import_handoff(transferred.runtimes, transferred.exited)?;
     if let Some(channel) = committed {
         {
@@ -989,6 +1023,8 @@ struct Registry {
     persist_lock: Mutex<()>,
     stopping: AtomicBool,
     persistence_dirty: AtomicBool,
+    notification_settings: NotificationSettings,
+    notification_sink: Arc<dyn NotificationSink>,
 }
 
 enum DurableMutation<T> {
@@ -1128,6 +1164,8 @@ impl Default for Registry {
             persist_lock: Mutex::new(()),
             stopping: AtomicBool::new(false),
             persistence_dirty: AtomicBool::new(false),
+            notification_settings: NotificationSettings::default(),
+            notification_sink: Arc::new(DisabledNotificationSink),
         }
     }
 }
@@ -2144,6 +2182,8 @@ impl Registry {
             persist_lock: Mutex::new(()),
             stopping: AtomicBool::new(false),
             persistence_dirty: AtomicBool::new(false),
+            notification_settings: NotificationSettings::default(),
+            notification_sink: Arc::new(DisabledNotificationSink),
         };
         if recovered_interrupted_run {
             registry.persist()?;
@@ -2338,9 +2378,9 @@ impl Registry {
         &self,
         operation: impl FnOnce() -> io::Result<DurableMutation<T>>,
     ) -> io::Result<T> {
-        let _mutation = lock(&self.mutation_lock)?;
+        let mutation = lock(&self.mutation_lock)?;
         let mut transition = lock(&self.transitions)?;
-        let _persistence = lock(&self.persist_lock)?;
+        let persistence = lock(&self.persist_lock)?;
         let mut events = lock(&self.events.state)?;
         self.ensure_running()?;
         self.flush_pending_locked(&mut transition, &mut events)?;
@@ -2352,12 +2392,18 @@ impl Registry {
                     self.restore_backup(backup)?;
                     return Err(error);
                 }
+                let notifications = self.notification_requests(&kinds, &backup);
                 match self.persist_unlocked().map_err(persistence_error) {
                     Ok(()) => {
                         EventLog::append_batch_locked(&mut events, kinds);
                         drop(events);
                         drop(transition);
+                        drop(persistence);
                         self.events.changed.notify_all();
+                        drop(mutation);
+                        for notification in notifications {
+                            self.notification_sink.notify(notification);
+                        }
                         Ok(value)
                     }
                     Err(error) => {
@@ -2372,6 +2418,85 @@ impl Registry {
                 Err(error)
             }
         }
+    }
+
+    fn notification_requests(
+        &self,
+        kinds: &[DaemonEventKind],
+        previous: &RegistryBackup,
+    ) -> Vec<NotificationRequest> {
+        let mut seen = HashSet::new();
+        let mut requests = Vec::new();
+        for kind in kinds {
+            let (workspace_id, shell_id, agent) = match kind {
+                DaemonEventKind::AgentRegistered {
+                    workspace_id,
+                    shell_id,
+                    agent,
+                }
+                | DaemonEventKind::AgentStateChanged {
+                    workspace_id,
+                    shell_id,
+                    agent,
+                }
+                | DaemonEventKind::AgentCompleted {
+                    workspace_id,
+                    shell_id,
+                    agent,
+                } => (workspace_id, shell_id, agent),
+                _ => continue,
+            };
+            let Some(attention) = agent.attention.as_ref() else {
+                continue;
+            };
+            if attention.observation.revision != agent.observation.revision {
+                continue;
+            }
+            let reason = match (attention.reason, agent.observation.state) {
+                (AgentAttentionReason::Blocked, AgentState::Blocked) => NotificationReason::Blocked,
+                (AgentAttentionReason::Completed, AgentState::Done) => {
+                    NotificationReason::Completed
+                }
+                _ => continue,
+            };
+            if previous
+                .agent_states
+                .get(&agent.id)
+                .is_some_and(|state| state.observation.state == agent.observation.state)
+            {
+                continue;
+            }
+            if !category_enabled(self.notification_settings, reason)
+                || !seen.insert((agent.id.as_str(), agent.observation.revision, reason))
+            {
+                continue;
+            }
+            let (workspace, shell) = self.notification_context(workspace_id, shell_id);
+            requests.push(NotificationRequest {
+                reason,
+                agent: agent.name.clone(),
+                workspace,
+                shell,
+            });
+        }
+        requests
+    }
+
+    fn notification_context(&self, workspace_id: &str, shell_id: &str) -> (String, String) {
+        let Ok(state) = self.state.lock() else {
+            return ("unknown".into(), "removed".into());
+        };
+        let workspace = state
+            .workspaces
+            .get(workspace_id)
+            .and_then(|workspace| workspace.name.lock().ok().map(|name| name.clone()))
+            .unwrap_or_else(|| "unknown".into());
+        let shell = state
+            .shells
+            .get(shell_id)
+            .and_then(|shell| shell.name.lock().ok().map(|name| name.clone()))
+            .unwrap_or_else(|| "removed".into());
+        (workspace, shell)
     }
 
     fn flush_pending_locked(
@@ -5177,6 +5302,29 @@ mod tests {
 
     use crate::protocol::{AgentAuthority, AgentState};
 
+    #[derive(Default)]
+    struct RecordingNotificationSink {
+        requests: Mutex<Vec<NotificationRequest>>,
+    }
+
+    impl NotificationSink for RecordingNotificationSink {
+        fn notify(&self, request: NotificationRequest) {
+            self.requests.lock().unwrap().push(request);
+        }
+    }
+
+    fn notification_registry(
+        settings: NotificationSettings,
+    ) -> (Registry, Arc<RecordingNotificationSink>) {
+        let sink = Arc::new(RecordingNotificationSink::default());
+        let registry = Registry {
+            notification_settings: settings,
+            notification_sink: sink.clone(),
+            ..Registry::default()
+        };
+        (registry, sink)
+    }
+
     fn profile() -> TerminalProfile {
         TerminalProfile {
             term: Some("xterm-256color".into()),
@@ -5994,6 +6142,227 @@ mod tests {
         assert_eq!(attention.observation, done.observation);
         shell.kill().unwrap();
         registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn notifications_are_deduplicated_and_follow_current_attention() {
+        let (registry, sink) = notification_registry(NotificationSettings {
+            enabled: true,
+            blocked: true,
+            completed: true,
+        });
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+
+        let Response::Agent { agent: blocked } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec: agent_spec(AgentState::Blocked),
+            })
+            .unwrap()
+        else {
+            panic!("expected blocked agent");
+        };
+        assert_eq!(sink.requests.lock().unwrap().len(), 1);
+
+        registry
+            .dispatch(Request::ReportAgent {
+                agent_id: blocked.id.clone(),
+                run_id: run_id.clone(),
+                report: agent_spec(AgentState::Blocked).report,
+            })
+            .unwrap();
+        registry
+            .dispatch(Request::ReportAgent {
+                agent_id: blocked.id.clone(),
+                run_id: run_id.clone(),
+                report: agent_report(
+                    AgentState::Blocked,
+                    AgentAuthority::LifecycleIntegration,
+                    "same blocker with updated evidence",
+                ),
+            })
+            .unwrap();
+        registry
+            .dispatch(Request::ReportAgent {
+                agent_id: blocked.id.clone(),
+                run_id: run_id.clone(),
+                report: agent_report(
+                    AgentState::Working,
+                    AgentAuthority::TerminalHeuristic,
+                    "lower authority",
+                ),
+            })
+            .unwrap();
+        assert_eq!(sink.requests.lock().unwrap().len(), 1);
+
+        let Response::Agent { agent: working } = registry
+            .dispatch(Request::ReportAgent {
+                agent_id: blocked.id.clone(),
+                run_id: run_id.clone(),
+                report: agent_spec(AgentState::Working).report,
+            })
+            .unwrap()
+        else {
+            panic!("expected working agent");
+        };
+        assert!(working.attention.is_some());
+        assert_eq!(sink.requests.lock().unwrap().len(), 1);
+
+        let Response::Agent { agent: reblocked } = registry
+            .dispatch(Request::ReportAgent {
+                agent_id: blocked.id.clone(),
+                run_id: run_id.clone(),
+                report: agent_spec(AgentState::Blocked).report,
+            })
+            .unwrap()
+        else {
+            panic!("expected reblocked agent");
+        };
+        assert_eq!(sink.requests.lock().unwrap().len(), 2);
+
+        registry
+            .dispatch(Request::AcknowledgeAgentAttention {
+                agent_id: reblocked.id.clone(),
+                observation_revision: reblocked.observation.revision,
+            })
+            .unwrap();
+        assert_eq!(sink.requests.lock().unwrap().len(), 2);
+
+        registry
+            .dispatch(Request::ReportAgent {
+                agent_id: reblocked.id,
+                run_id: run_id.clone(),
+                report: agent_spec(AgentState::Done).report,
+            })
+            .unwrap();
+        assert_eq!(sink.requests.lock().unwrap().len(), 3);
+
+        registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id,
+                spec: agent_spec(AgentState::Done),
+            })
+            .unwrap();
+        let requests = sink.requests.lock().unwrap();
+        assert_eq!(requests.len(), 4);
+        assert_eq!(requests[0].reason, NotificationReason::Blocked);
+        assert_eq!(requests[1].reason, NotificationReason::Blocked);
+        assert_eq!(requests[2].reason, NotificationReason::Completed);
+        assert_eq!(requests[3].reason, NotificationReason::Completed);
+        assert_eq!(requests[0].workspace, "agents");
+        assert_eq!(requests[0].shell, "agent-shell");
+        drop(requests);
+
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn disabled_notifications_do_not_reach_sink() {
+        let (registry, sink) = notification_registry(NotificationSettings::default());
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id,
+                spec: agent_spec(AgentState::Blocked),
+            })
+            .unwrap();
+        assert!(sink.requests.lock().unwrap().is_empty());
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn retained_agent_notifications_explain_a_removed_shell() {
+        let (registry, sink) = notification_registry(NotificationSettings {
+            enabled: true,
+            blocked: true,
+            completed: true,
+        });
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let Response::Agent { agent } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected working agent");
+        };
+        registry
+            .dispatch(Request::CloseShell {
+                shell_id: shell.id.clone(),
+            })
+            .unwrap();
+        registry
+            .dispatch(Request::ReportAgent {
+                agent_id: agent.id,
+                run_id,
+                report: agent_spec(AgentState::Blocked).report,
+            })
+            .unwrap();
+
+        let requests = sink.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].workspace, "agents");
+        assert_eq!(requests[0].shell, "removed");
+        drop(requests);
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn failed_persistence_does_not_notify() {
+        let directory = env::temp_dir().join(format!("boomux-notification-{}", Uuid::new_v4()));
+        let state_directory = directory.join("state");
+        let mut registry = Registry::restore(
+            StateStore::at(state_directory.join("state.json")),
+            false,
+            None,
+        )
+        .unwrap();
+        let sink = Arc::new(RecordingNotificationSink::default());
+        registry.notification_settings = NotificationSettings {
+            enabled: true,
+            blocked: true,
+            completed: true,
+        };
+        registry.notification_sink = sink.clone();
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let Response::Agent { agent } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected working agent");
+        };
+        fs::remove_dir_all(&state_directory).unwrap();
+        fs::write(&state_directory, b"not a directory").unwrap();
+
+        assert!(
+            registry
+                .dispatch(Request::ReportAgent {
+                    agent_id: agent.id,
+                    run_id,
+                    report: agent_spec(AgentState::Blocked).report,
+                })
+                .is_err()
+        );
+        assert!(sink.requests.lock().unwrap().is_empty());
+        shell.kill().unwrap();
+        let _ = workspace;
+        drop(registry);
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/src/desktop_notifications.rs
+++ b/src/desktop_notifications.rs
@@ -1,0 +1,243 @@
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{SyncSender, sync_channel};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use crate::daemon::NotificationSettings;
+
+const MAX_CONTEXT_BYTES: usize = 120;
+const NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(2);
+const NOTIFICATION_QUEUE_CAPACITY: usize = 32;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum NotificationReason {
+    Blocked,
+    Completed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct NotificationRequest {
+    pub(crate) reason: NotificationReason,
+    pub(crate) agent: String,
+    pub(crate) workspace: String,
+    pub(crate) shell: String,
+}
+
+pub(crate) trait NotificationSink: Send + Sync {
+    fn notify(&self, request: NotificationRequest);
+}
+
+pub(crate) struct DesktopNotificationSink {
+    sender: Option<SyncSender<NotificationRequest>>,
+    stopping: Arc<AtomicBool>,
+    worker: Option<JoinHandle<()>>,
+}
+
+pub(crate) struct DisabledNotificationSink;
+
+impl DesktopNotificationSink {
+    pub(crate) fn new() -> Self {
+        let (sender, receiver) = sync_channel(NOTIFICATION_QUEUE_CAPACITY);
+        let stopping = Arc::new(AtomicBool::new(false));
+        let worker_stopping = stopping.clone();
+        let worker = thread::Builder::new()
+            .name("boomux-notifications".into())
+            .spawn(move || {
+                while let Ok(request) = receiver.recv()
+                    && !worker_stopping.load(Ordering::Acquire)
+                {
+                    deliver(request, &worker_stopping);
+                }
+            })
+            .ok();
+        Self {
+            sender: Some(sender),
+            stopping,
+            worker,
+        }
+    }
+}
+
+impl Drop for DesktopNotificationSink {
+    fn drop(&mut self) {
+        self.stopping.store(true, Ordering::Release);
+        self.sender.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+impl NotificationSink for DisabledNotificationSink {
+    fn notify(&self, _request: NotificationRequest) {}
+}
+
+impl NotificationSink for DesktopNotificationSink {
+    fn notify(&self, request: NotificationRequest) {
+        if let Some(sender) = self.sender.as_ref() {
+            let _ = sender.try_send(request);
+        }
+    }
+}
+
+fn deliver(request: NotificationRequest, stopping: &AtomicBool) {
+    let argv = notify_send_argv(&request);
+    if let Ok(mut child) = Command::new(&argv[0])
+        .args(&argv[1..])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        let deadline = Instant::now() + NOTIFICATION_TIMEOUT;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) if stopping.load(Ordering::Acquire) || Instant::now() >= deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break;
+                }
+                Ok(None) => thread::sleep(Duration::from_millis(10)),
+                Err(_) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break;
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn category_enabled(settings: NotificationSettings, reason: NotificationReason) -> bool {
+    settings.enabled
+        && match reason {
+            NotificationReason::Blocked => settings.blocked,
+            NotificationReason::Completed => settings.completed,
+        }
+}
+
+fn notify_send_argv(request: &NotificationRequest) -> Vec<String> {
+    let reason = match request.reason {
+        NotificationReason::Blocked => "blocked",
+        NotificationReason::Completed => "completed",
+    };
+    vec![
+        "notify-send".into(),
+        "--app-name".into(),
+        "Boomux".into(),
+        format!("Boomux Agent {reason}"),
+        format!(
+            "{} in workspace {}, shell {}. Open Boomux or run `boomux attention list`.",
+            sanitize(&request.agent),
+            sanitize(&request.workspace),
+            sanitize(&request.shell)
+        ),
+    ]
+}
+
+fn sanitize(value: &str) -> String {
+    let value = value
+        .chars()
+        .map(|character| {
+            if character.is_control()
+                || matches!(
+                    character,
+                    '<' | '>' | '&' | '\u{061c}'
+                        | '\u{200b}'..='\u{200f}'
+                        | '\u{202a}'..='\u{202e}'
+                        | '\u{2060}'..='\u{2069}'
+                        | '\u{feff}'
+                )
+            {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let value = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut sanitized = String::new();
+    for character in value.chars() {
+        if sanitized.len() + character.len_utf8() > MAX_CONTEXT_BYTES {
+            break;
+        }
+        sanitized.push(character);
+    }
+    if sanitized.is_empty() {
+        sanitized.push_str("unnamed");
+    }
+    sanitized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> NotificationRequest {
+        NotificationRequest {
+            reason: NotificationReason::Blocked,
+            agent: "OpenCode".into(),
+            workspace: "boomux".into(),
+            shell: "tests".into(),
+        }
+    }
+
+    #[test]
+    fn builds_exact_notify_send_arguments() {
+        assert_eq!(
+            notify_send_argv(&request()),
+            [
+                "notify-send",
+                "--app-name",
+                "Boomux",
+                "Boomux Agent blocked",
+                "OpenCode in workspace boomux, shell tests. Open Boomux or run `boomux attention list`.",
+            ]
+        );
+    }
+
+    #[test]
+    fn sanitizes_and_limits_untrusted_context() {
+        let mut request = request();
+        request.agent = format!(" secret\n\t{}", "x".repeat(200));
+        request.workspace = "<b>spoof</b>\u{061c}\u{202e}".into();
+        let arguments = notify_send_argv(&request);
+        assert!(!arguments[4].contains('\n'));
+        assert!(!arguments[4].contains('\t'));
+        assert!(!arguments[4].contains(&"x".repeat(121)));
+        assert!(!arguments[4].contains(['<', '>', '&', '\u{061c}', '\u{202e}']));
+    }
+
+    #[test]
+    fn body_contains_no_private_agent_fields() {
+        let arguments = notify_send_argv(&request());
+        for private in [
+            "evidence",
+            "cwd",
+            "agent-id",
+            "external-session",
+            "argv",
+            "transcript",
+        ] {
+            assert!(!arguments[4].contains(private));
+        }
+    }
+
+    #[test]
+    fn category_filtering_requires_global_and_category_flags() {
+        let enabled = NotificationSettings {
+            enabled: true,
+            blocked: true,
+            completed: false,
+        };
+        assert!(category_enabled(enabled, NotificationReason::Blocked));
+        assert!(!category_enabled(enabled, NotificationReason::Completed));
+        assert!(!category_enabled(
+            NotificationSettings::default(),
+            NotificationReason::Blocked
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod attach;
 pub mod client;
 pub mod daemon;
+mod desktop_notifications;
 // The replacement-daemon protocol will activate this transport in the next
 // handoff slice; keeping it compiled now prevents the unsafe boundary drifting.
 #[allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::{self, Write};
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
@@ -90,6 +91,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "durable_session_source_context",
     "revision_aware_agent_wait",
     "persistent_agent_attention",
+    "desktop_notifications",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -637,13 +639,16 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Daemon {
             command: DaemonCommands::Run,
         }) => {
-            daemon::run()?;
+            daemon::run_with_notifications(config::load_notification_settings()?)?;
             return Ok(CliExit::Success);
         }
         Some(Commands::Daemon {
             command: DaemonCommands::ReceiveHandoff { channel },
         }) => {
-            daemon::receive_handoff(*channel)?;
+            daemon::receive_handoff_with_notifications(
+                *channel,
+                config::load_notification_settings()?,
+            )?;
             return Ok(CliExit::Success);
         }
         Some(Commands::Attach {
@@ -3264,6 +3269,28 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     eprintln!("err terminal: {error}");
                 }
             }
+            match notification_diagnostic(
+                config.notifications,
+                executable_on_path("notify-send"),
+                plausible_desktop_bus(),
+            ) {
+                NotificationDiagnostic::Disabled => {
+                    println!("ok  notification config: disabled (sampled at daemon start)");
+                }
+                NotificationDiagnostic::Ready => {
+                    println!(
+                        "ok  notification config: notify-send and plausible desktop bus context present; restart daemon after changes"
+                    );
+                }
+                NotificationDiagnostic::MissingExecutable => {
+                    healthy = false;
+                    eprintln!("err notifications: notify-send is not executable on PATH");
+                }
+                NotificationDiagnostic::MissingDesktopBus => {
+                    healthy = false;
+                    eprintln!("err notifications: no plausible desktop bus is available");
+                }
+            }
         }
         Err(error) => {
             healthy = false;
@@ -3275,6 +3302,48 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     } else {
         Err("one or more dependency or configuration checks failed".into())
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum NotificationDiagnostic {
+    Disabled,
+    Ready,
+    MissingExecutable,
+    MissingDesktopBus,
+}
+
+fn notification_diagnostic(
+    settings: daemon::NotificationSettings,
+    executable: bool,
+    desktop_bus: bool,
+) -> NotificationDiagnostic {
+    if !settings.enabled {
+        NotificationDiagnostic::Disabled
+    } else if !executable {
+        NotificationDiagnostic::MissingExecutable
+    } else if !desktop_bus {
+        NotificationDiagnostic::MissingDesktopBus
+    } else {
+        NotificationDiagnostic::Ready
+    }
+}
+
+fn executable_on_path(name: &str) -> bool {
+    env::var_os("PATH").is_some_and(|path| {
+        env::split_paths(&path).any(|directory| {
+            fs::metadata(directory.join(name)).is_ok_and(|metadata| {
+                metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+            })
+        })
+    })
+}
+
+fn plausible_desktop_bus() -> bool {
+    env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some_and(|value| !value.is_empty())
+        || env::var_os("XDG_RUNTIME_DIR").is_some_and(|directory| {
+            let directory = PathBuf::from(directory);
+            directory.is_absolute() && directory.join("bus").exists()
+        })
 }
 
 #[cfg(test)]
@@ -4705,6 +4774,7 @@ mod tests {
             "transcript_pagination",
             "protocol_15",
             "persistent_agent_attention",
+            "desktop_notifications",
         ] {
             assert!(INTEGRATION_FEATURES.contains(&feature));
         }
@@ -4715,6 +4785,31 @@ mod tests {
             ["opencode", "pi"]
         );
         assert_eq!(protocol::PROTOCOL_VERSION, 15);
+    }
+
+    #[test]
+    fn notification_doctor_diagnostic_is_deterministic() {
+        let disabled = daemon::NotificationSettings::default();
+        assert_eq!(
+            notification_diagnostic(disabled, false, false),
+            NotificationDiagnostic::Disabled
+        );
+        let enabled = daemon::NotificationSettings {
+            enabled: true,
+            ..disabled
+        };
+        assert_eq!(
+            notification_diagnostic(enabled, false, true),
+            NotificationDiagnostic::MissingExecutable
+        );
+        assert_eq!(
+            notification_diagnostic(enabled, true, false),
+            NotificationDiagnostic::MissingDesktopBus
+        );
+        assert_eq!(
+            notification_diagnostic(enabled, true, true),
+            NotificationDiagnostic::Ready
+        );
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1,7 +1,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::{self, IoSlice, Read, Write};
 use std::os::fd::{AsRawFd, RawFd};
-use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
@@ -58,6 +58,71 @@ impl TestDaemon {
             child: Some(child),
             client,
         }
+    }
+
+    fn start_with_notifications() -> (Self, PathBuf, PathBuf) {
+        let executable = PathBuf::from(env!("CARGO_BIN_EXE_boomux"));
+        let runtime_dir = std::env::temp_dir().join(format!(
+            "boomux-integration-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        fs::create_dir(&runtime_dir).unwrap();
+        let bin_dir = runtime_dir.join("bin");
+        fs::create_dir(&bin_dir).unwrap();
+        let notify_send = bin_dir.join("notify-send");
+        let capture = runtime_dir.join("notifications");
+        fs::write(
+            &notify_send,
+            "#!/bin/sh\nif [ -f \"$BOOMUX_NOTIFICATION_HANG\" ]; then\n  printf '%s\\n' \"$$\" > \"$BOOMUX_NOTIFICATION_PID\"\n  exec sleep 10\nfi\nprintf '%s\\0' \"$@\" >> \"$BOOMUX_NOTIFICATION_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&notify_send, fs::Permissions::from_mode(0o755)).unwrap();
+        let config = runtime_dir.join("config.toml");
+        fs::write(
+            &config,
+            "[notifications]\nenabled = true\nblocked = true\ncompleted = true\n",
+        )
+        .unwrap();
+        let mut paths = vec![bin_dir];
+        if let Some(path) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&path));
+        }
+        let path = std::env::join_paths(paths).unwrap();
+        let child = Command::new(&executable)
+            .args(["daemon", "run"])
+            .env("XDG_RUNTIME_DIR", &runtime_dir)
+            .env("XDG_STATE_HOME", runtime_dir.join("state"))
+            .env("BOOMUX_CONFIG", &config)
+            .env("BOOMUX_NOTIFICATION_CAPTURE", &capture)
+            .env(
+                "BOOMUX_NOTIFICATION_HANG",
+                runtime_dir.join("notification-hang"),
+            )
+            .env(
+                "BOOMUX_NOTIFICATION_PID",
+                runtime_dir.join("notification-pid"),
+            )
+            .env("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent")
+            .env("PATH", path)
+            .env("SHELL", "/bin/sh")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let client = Client::from_socket_path(runtime_dir.join("boomux/daemon.sock"));
+        wait_until(|| client.ping().is_ok(), "daemon did not accept requests");
+        (
+            Self {
+                executable,
+                runtime_dir,
+                child: Some(child),
+                client,
+            },
+            capture,
+            notify_send,
+        )
     }
 
     fn command(&self) -> Command {
@@ -1010,6 +1075,187 @@ fn daemon_events_and_revision_reads_survive_handoff() {
             .and_then(|error| error.code),
         Some(ErrorCode::DaemonStopping)
     );
+}
+
+#[test]
+fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
+    let (daemon, capture, notify_send) = TestDaemon::start_with_notifications();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "notification-workspace",
+            vec![ShellSpec::login("notification-shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+    let agent = daemon
+        .client
+        .register_agent(
+            &shell_id,
+            &run_id,
+            AgentRegistrationSpec {
+                name: "notification-agent".into(),
+                integration: "native-test".into(),
+                external_session_id: Some("PRIVATE-SESSION".into()),
+                report: AgentReport {
+                    state: AgentState::Blocked,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "PRIVATE-EVIDENCE".into(),
+                    confidence: 90,
+                },
+            },
+        )
+        .unwrap();
+    wait_until(
+        || captured_notification_count(&capture) == 1,
+        "blocked notification was not delivered",
+    );
+    let captured = fs::read(&capture).unwrap();
+    assert!(
+        !captured
+            .windows(b"PRIVATE-EVIDENCE".len())
+            .any(|value| value == b"PRIVATE-EVIDENCE")
+    );
+    assert!(
+        !captured
+            .windows(b"PRIVATE-SESSION".len())
+            .any(|value| value == b"PRIVATE-SESSION")
+    );
+
+    daemon
+        .client
+        .report_agent(
+            &agent.id,
+            &run_id,
+            AgentReport {
+                state: AgentState::Blocked,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "changed blocker evidence".into(),
+                confidence: 95,
+            },
+        )
+        .unwrap();
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(captured_notification_count(&capture), 1);
+
+    for (state, evidence, expected) in [
+        (AgentState::Working, "resumed", 1),
+        (AgentState::Blocked, "blocked again", 2),
+        (AgentState::Done, "completed", 3),
+    ] {
+        daemon
+            .client
+            .report_agent(
+                &agent.id,
+                &run_id,
+                AgentReport {
+                    state,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: evidence.into(),
+                    confidence: 95,
+                },
+            )
+            .unwrap();
+        wait_until(
+            || captured_notification_count(&capture) == expected,
+            "notification transition was not delivered",
+        );
+    }
+
+    let hang = daemon.runtime_dir.join("notification-hang");
+    let notification_pid = daemon.runtime_dir.join("notification-pid");
+    fs::write(&hang, b"").unwrap();
+    daemon
+        .client
+        .register_agent(
+            shell_id.clone(),
+            run_id.clone(),
+            AgentRegistrationSpec {
+                name: "handoff-hanging-agent".into(),
+                integration: "native-test".into(),
+                external_session_id: Some("handoff-hanging-session".into()),
+                report: AgentReport {
+                    state: AgentState::Blocked,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "exercise notifier shutdown".into(),
+                    confidence: 90,
+                },
+            },
+        )
+        .unwrap();
+    wait_until(
+        || notification_pid.is_file(),
+        "fake notifier did not enter its hanging state",
+    );
+    let notification_pid_value = fs::read_to_string(&notification_pid)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    drop(attachment.stream);
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "{}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    wait_until(
+        || !process_exists(notification_pid_value),
+        "daemon handoff did not reap the active notifier",
+    );
+    fs::remove_file(hang).unwrap();
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(captured_notification_count(&capture), 3);
+    daemon
+        .client
+        .register_agent(
+            shell_id.clone(),
+            run_id.clone(),
+            AgentRegistrationSpec {
+                name: "post-handoff-agent".into(),
+                integration: "native-test".into(),
+                external_session_id: Some("post-handoff-session".into()),
+                report: AgentReport {
+                    state: AgentState::Blocked,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "post-handoff blocker".into(),
+                    confidence: 90,
+                },
+            },
+        )
+        .unwrap();
+    wait_until(
+        || captured_notification_count(&capture) == 4,
+        "notifications stopped after daemon handoff",
+    );
+
+    fs::remove_file(notify_send).unwrap();
+    daemon
+        .client
+        .register_agent(
+            shell_id,
+            run_id,
+            AgentRegistrationSpec {
+                name: "missing-notify-send-agent".into(),
+                integration: "native-test".into(),
+                external_session_id: Some("missing-notify-send-session".into()),
+                report: AgentReport {
+                    state: AgentState::Blocked,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "delivery must fail open".into(),
+                    confidence: 90,
+                },
+            },
+        )
+        .unwrap();
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(captured_notification_count(&capture), 4);
 }
 
 #[test]
@@ -3328,4 +3574,16 @@ fn wait_until(mut condition: impl FnMut() -> bool, message: &str) {
         thread::sleep(Duration::from_millis(20));
     }
     panic!("{message}");
+}
+
+fn captured_notification_count(path: &std::path::Path) -> usize {
+    fs::read(path)
+        .map(|contents| {
+            contents
+                .split(|byte| *byte == 0)
+                .filter(|argument| !argument.is_empty())
+                .count()
+                / 4
+        })
+        .unwrap_or(0)
 }


### PR DESCRIPTION
## Summary
- add opt-in daemon-owned desktop notifications for Agent transitions into blocked and done
- dispatch privacy-safe notify-send attempts after durable commit through a bounded, cancellation-safe worker
- add layered configuration, doctor diagnostics, capability discovery, lifecycle/handoff coverage, and documentation

## Semantics
- same-state evidence revisions do not notify, restored state is not replayed, and notification delivery never acknowledges attention or changes Agent revisions
- delivery is asynchronous, at-most-once, and fail-open on queue saturation, missing notify-send, desktop failures, timeout, or non-zero exit

## Verification
- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- bun test integrations/opencode/boomux.test.js
- bun test integrations/pi/boomux.test.js
- git diff --check