### PR TITLE
Fix CLI lifecycle edge cases

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4942,10 +4942,12 @@ fn term_mismatch_warning(started: Option<&str>, attached: Option<&str>) -> Optio
 }
 
 fn validate_name(name: &str) -> io::Result<()> {
-    if name.trim().is_empty() || name.len() > MAX_NAME_BYTES {
+    if name.trim().is_empty() || name.len() > MAX_NAME_BYTES || name.chars().any(char::is_control) {
         Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("name must be nonempty and at most {MAX_NAME_BYTES} bytes"),
+            format!(
+                "name must be nonempty, contain no control characters, and be at most {MAX_NAME_BYTES} bytes"
+            ),
         ))
     } else {
         Ok(())
@@ -5579,6 +5581,11 @@ mod tests {
             io::ErrorKind::InvalidInput
         );
         assert!(validate_persisted_name(&long_name).is_ok());
+        assert_eq!(
+            validate_name("real\nforged\trow").unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert!(validate_persisted_name("real\nlegacy row").is_ok());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::error::Error;
+use std::ffi::OsString;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::{self, Write};
@@ -587,7 +588,7 @@ impl CliExit {
 }
 
 fn main() -> ExitCode {
-    let json_requested = env::args_os().any(|argument| argument == "--json");
+    let json_requested = requests_json(env::args_os().skip(1));
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
         Err(error) => {
@@ -626,6 +627,13 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+fn requests_json(arguments: impl IntoIterator<Item = OsString>) -> bool {
+    arguments
+        .into_iter()
+        .take_while(|argument| argument != "--")
+        .any(|argument| argument == "--json")
 }
 
 fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
@@ -1237,25 +1245,32 @@ fn open_directory(
         .map(str::to_owned);
     let client = client::connect_or_start()?;
     let snapshot = client.snapshot()?;
-    let (shell, workspace_name) = if let Some(name) = requested_name {
-        let shell = if let Some(workspace) = find_workspace(&snapshot.workspaces, &name) {
-            let shell_name = unique_shell_name("shell", &workspace.shells);
-            client.create_shell(
-                &workspace.id,
-                shell_spec(shell_name, &directory, startup_command),
-            )?
-        } else {
-            client
-                .create_workspace(
-                    &name,
-                    vec![shell_spec("shell-1", &directory, startup_command)],
-                )?
-                .shells
-                .into_iter()
-                .next()
-                .ok_or("new workspace has no shell")?
-        };
-        (shell, name)
+    let (shell, workspace_name, created_workspace) = if let Some(name) = requested_name {
+        let (shell, created_workspace) =
+            if let Some(workspace) = find_workspace(&snapshot.workspaces, &name) {
+                let shell_name = unique_shell_name("shell", &workspace.shells);
+                (
+                    client.create_shell(
+                        &workspace.id,
+                        shell_spec(shell_name, &directory, startup_command),
+                    )?,
+                    false,
+                )
+            } else {
+                (
+                    client
+                        .create_workspace(
+                            &name,
+                            vec![shell_spec("shell-1", &directory, startup_command)],
+                        )?
+                        .shells
+                        .into_iter()
+                        .next()
+                        .ok_or("new workspace has no shell")?,
+                    true,
+                )
+            };
+        (shell, name, created_workspace)
     } else {
         let shell = client.create_shell_with_workspace(shell_spec(
             "shell-1",
@@ -1263,10 +1278,10 @@ fn open_directory(
             startup_command,
         ))?;
         let workspace_name = client.get_workspace(&shell.workspace_id)?.name;
-        (shell, workspace_name)
+        (shell, workspace_name, true)
     };
 
-    if open_in_new_window {
+    let open_result = if open_in_new_window {
         open_terminal(
             &shell.id,
             &format!("{workspace_name} - {}", shell.name),
@@ -1275,7 +1290,22 @@ fn open_directory(
         )
     } else {
         Ok(attach::run(&shell.id, true, false)?)
+    };
+    if let Err(open_error) = open_result {
+        let rollback = if created_workspace {
+            client.close_workspace(&shell.workspace_id)
+        } else {
+            client.close_shell(&shell.id)
+        };
+        if let Err(rollback_error) = rollback {
+            return Err(format!(
+                "{open_error}; additionally could not roll back failed launch: {rollback_error}"
+            )
+            .into());
+        }
+        return Err(open_error);
     }
+    Ok(())
 }
 
 fn shell_spec(name: impl Into<String>, cwd: &Path, command: &[String]) -> ShellSpec {
@@ -1333,7 +1363,8 @@ fn resolve_workspace_target<'a>(
 ) -> Result<&'a WorkspaceSnapshot, Box<dyn Error>> {
     workspaces
         .iter()
-        .find(|workspace| workspace.id == target || workspace.name == target)
+        .find(|workspace| workspace.id == target)
+        .or_else(|| workspaces.iter().find(|workspace| workspace.name == target))
         .ok_or_else(|| cli_output::failure("not_found", format!("workspace not found: {target}")))
 }
 
@@ -1509,7 +1540,7 @@ fn workspace_command(
                 let summary = agent_attention_projection::summarize_workspace(&workspace);
                 println!(
                     "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-                    workspace.name,
+                    sanitize_table_cell(&workspace.name),
                     workspace.id,
                     workspace.shells.len(),
                     workspace.launchers.len(),
@@ -1876,11 +1907,12 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
         } => {
             let waited = client.wait_agent(agent_id, after_revision, wait_ms)?;
             if json {
+                let workspace = client.get_workspace(&waited.agent.workspace_id)?;
                 return cli_output::print(
                     "agent.wait",
                     serde_json::json!({
                         "changed": waited.changed,
-                        "agent": cli_output::agent(&waited.agent, None),
+                        "agent": cli_output::agent(&waited.agent, Some(&workspace.name)),
                     }),
                 );
             }
@@ -1938,10 +1970,11 @@ fn agent_command(command: AgentCommands, json: bool) -> Result<(), Box<dyn Error
                 },
             )?;
             if json {
+                let workspace = client.get_workspace(&agent.workspace_id)?;
                 return cli_output::print(
                     "agent.report",
                     serde_json::json!({
-                        "agent": cli_output::agent(&agent, None),
+                        "agent": cli_output::agent(&agent, Some(&workspace.name)),
                     }),
                 );
             }
@@ -2027,11 +2060,12 @@ fn attention_command(command: AttentionCommands, json: bool) -> Result<(), Box<d
             let acknowledged =
                 client.acknowledge_agent_attention(agent_id, observation_revision)?;
             if json {
+                let workspace = client.get_workspace(&acknowledged.agent.workspace_id)?;
                 return cli_output::print(
                     "attention.acknowledge",
                     serde_json::json!({
                         "changed": acknowledged.changed,
-                        "agent": cli_output::agent(&acknowledged.agent, None),
+                        "agent": cli_output::agent(&acknowledged.agent, Some(&workspace.name)),
                     }),
                 );
             }
@@ -2366,6 +2400,7 @@ fn register_or_ensure_agent(
         client.register_agent(shell_id, run_id, spec)?
     };
     if json {
+        let workspace = client.get_workspace(&agent.workspace_id)?;
         return cli_output::print(
             if ensure {
                 "agent.ensure"
@@ -2373,7 +2408,7 @@ fn register_or_ensure_agent(
                 "agent.register"
             },
             serde_json::json!({
-                "agent": cli_output::agent(&agent, None),
+                "agent": cli_output::agent(&agent, Some(&workspace.name)),
             }),
         );
     }
@@ -3522,6 +3557,16 @@ mod tests {
     }
 
     #[test]
+    fn detects_json_only_before_the_command_separator() {
+        assert!(requests_json(
+            ["workspace", "list", "--json"].map(OsString::from)
+        ));
+        assert!(!requests_json(
+            [".", "--", "/bin/echo", "--json"].map(OsString::from)
+        ));
+    }
+
+    #[test]
     fn parses_workspace_and_shell_lifecycle_commands() {
         assert!(matches!(
             Cli::try_parse_from(["boomux", "workspace", "create", "project"])
@@ -3951,7 +3996,7 @@ mod tests {
         let mut project = workspace("w1", "project", vec![shell("s1", "w1", "tests")]);
         project.launchers.push(launcher("l1", "w1", "editor"));
         let snapshot = Snapshot {
-            workspaces: vec![project],
+            workspaces: vec![workspace("w2", "w1", vec![]), project],
         };
 
         assert_eq!(
@@ -3959,6 +4004,12 @@ mod tests {
                 .unwrap()
                 .id,
             "w1"
+        );
+        assert_eq!(
+            resolve_workspace_target(&snapshot.workspaces, "w1")
+                .unwrap()
+                .name,
+            "project"
         );
         assert_eq!(
             resolve_cli_shell(&snapshot, "tests", Some("project"))

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1331,6 +1331,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert_eq!(ensure["data"]["agent"]["shell_id"], shell_id);
     assert_eq!(ensure["data"]["agent"]["run_id"], run_id);
     assert_eq!(ensure["data"]["agent"]["external_session_id"], "session-1");
+    assert_eq!(ensure["data"]["agent"]["workspace_name"], "agent-runtime");
     assert_eq!(ensure["data"]["agent"]["observation"]["revision"], 1);
 
     let repeated = ensure_agent(&daemon);
@@ -1436,6 +1437,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     let register: serde_json::Value = serde_json::from_slice(&register.stdout).unwrap();
     assert_eq!(register["schema"], "boomux.cli/v1");
     assert_eq!(register["command"], "agent.register");
+    assert_eq!(register["data"]["agent"]["workspace_name"], "agent-runtime");
     assert_eq!(register["data"]["agent"]["observation"]["revision"], 1);
     let adapter_id = register["data"]["agent"]["id"].as_str().unwrap().to_owned();
 
@@ -1484,6 +1486,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     let report: serde_json::Value = serde_json::from_slice(&report.stdout).unwrap();
     assert_eq!(report["schema"], "boomux.cli/v1");
     assert_eq!(report["command"], "agent.report");
+    assert_eq!(report["data"]["agent"]["workspace_name"], "agent-runtime");
     assert_eq!(report["data"]["agent"]["observation"]["revision"], 2);
     assert_eq!(
         report["data"]["agent"]["observation"]["authority"],
@@ -1499,6 +1502,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert_eq!(waited["command"], "agent.wait");
     assert_eq!(waited["data"]["changed"], true);
     assert_eq!(waited["data"]["agent"]["id"], adapter_id);
+    assert_eq!(waited["data"]["agent"]["workspace_name"], "agent-runtime");
     assert_eq!(waited["data"]["agent"]["observation"]["revision"], 2);
     let duplicate = daemon
         .client
@@ -1635,6 +1639,10 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     let acknowledgment: serde_json::Value = serde_json::from_slice(&acknowledgment.stdout).unwrap();
     assert_eq!(acknowledgment["command"], "attention.acknowledge");
     assert_eq!(acknowledgment["data"]["changed"], true);
+    assert_eq!(
+        acknowledgment["data"]["agent"]["workspace_name"],
+        "agent-runtime"
+    );
     assert!(acknowledgment["data"]["agent"]["attention"].is_null());
     assert!(
         daemon
@@ -2665,6 +2673,44 @@ fn workspace_launchers_persist_emit_events_and_open_without_shells() {
             .all(|current| current.id != workspace.id)
     );
     daemon.stop_with_cli();
+}
+
+#[test]
+fn failed_implicit_terminal_launch_rolls_back_created_state() {
+    let daemon = TestDaemon::start();
+    let project = daemon.runtime_dir.join("project");
+    fs::create_dir(&project).unwrap();
+
+    let generated = daemon
+        .command()
+        .arg(&project)
+        .arg("--new")
+        .env("PATH", "")
+        .output()
+        .unwrap();
+    assert!(!generated.status.success());
+    assert!(daemon.client.snapshot().unwrap().workspaces.is_empty());
+
+    let workspace = daemon
+        .client
+        .create_workspace("existing", Vec::new())
+        .unwrap();
+    let existing = daemon
+        .command()
+        .arg(&project)
+        .args(["--name", "existing", "--new"])
+        .env("PATH", "")
+        .output()
+        .unwrap();
+    assert!(!existing.status.success());
+    assert!(
+        daemon
+            .client
+            .get_workspace(&workspace.id)
+            .unwrap()
+            .shells
+            .is_empty()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make exact workspace IDs take precedence over colliding names
- roll back shells and workspaces when implicit terminal launch fails
- reject control characters in new names and sanitize legacy workspace table output
- include workspace names consistently in Agent JSON responses
- ignore child `--json` arguments after the command separator

## Verification
- `cargo test --all-targets`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`