### PR TITLE
ci: stabilize native backend checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       RUSTUP_TOOLCHAIN: stable
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install Rust toolchain
         run: rustup toolchain install stable --profile minimal --component rustfmt,clippy
@@ -32,15 +32,18 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
-      - name: Run Rust tests
-        run: cargo test --all-targets --locked
+      - name: Run Rust unit tests
+        run: cargo test --lib --bins --locked
+
+      - name: Run native backend tests
+        run: cargo test --test native_backend --locked -- --test-threads=1
 
   integrations:
     name: Integrations
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2


### PR DESCRIPTION
## Summary
- run process-heavy native backend tests serially to avoid daemon contention on shared runners
- keep unit tests parallel in a separate step
- update Checkout to the Node 24-compatible v5 action

## Failure addressed
The post-merge CI run for #49 timed out waiting for `restored-command` in `native_daemon_recovers_reproducible_metadata_after_restart` while 20 daemon integration tests ran concurrently.

## Local verification
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`