### PR TITLE
feat: improve shell identity and dashboard previews

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -112,8 +112,9 @@ boomux session read "<exact-session-id>" --before "<next-cursor>" --limit 100 --
 Use the exact opaque session ID returned by `session list`. Never guess or
 resolve it from an external session ID, description, shell ID, or Agent ID.
 Session state is marked current only when an occurrence is active on the current
-run of a running retained shell; otherwise it is last-known. `description` is
-the latest stored Boomux Agent registration name, not a host-enriched title.
+run of a running retained shell; otherwise it is last-known. Catalog-only
+OpenCode history has state `unknown`, no fabricated occurrence, and a sanitized
+host title. Registered-session descriptions remain durable Agent names.
 `session read` returns the newest bounded suffix of canonical OpenCode or Pi
 messages, reasoning, and tool activity, not terminal scrollback. Pi results
 follow its active branch. Inspect `truncated`, `truncated_by`, and per-entry
@@ -407,6 +408,11 @@ BOOMUX_SHELL_ID
 BOOMUX_SHELL_NAME
 BOOMUX_RUN_ID
 ```
+
+Protocol 16 starts pending and exited shell runs with the attaching client's
+ephemeral Unix environment. Boomux does not persist or project that payload;
+terminal-profile and `BOOMUX_*` identity values are authoritative. Reattaching
+does not alter an already-running process environment.
 
 Detached launcher invocations inherit the invoking client's environment and
 receive `BOOMUX_WORKSPACE_ID`, `BOOMUX_WORKSPACE`, `BOOMUX_LAUNCHER_ID`, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Repository Workflow
+
+## Commits
+
+- Use Conventional Commits for every commit: `type(scope): description` or
+  `type: description`.
+- Use `feat` for user-visible capabilities, `fix` for user-visible corrections,
+  and `perf` for performance improvements. Use `docs`, `test`, `refactor`,
+  `build`, `ci`, or `chore` when the change is not release-note material.
+- Mark breaking changes with `!` after the type or scope and explain them in a
+  `BREAKING CHANGE:` footer.
+- Keep the description imperative, lowercase, and concise.
+
+## Pull Requests And Releases
+
+- Use a Conventional Commit title for every PR. The title must describe the
+  release impact of the complete PR, for example `feat: add workspace previews`
+  or `fix(agent): preserve lifecycle registration`.
+- Squash-merge PRs into `main` so the conventional PR title becomes the
+  main-branch commit consumed by Release Please.
+- Before merging, update the PR title if its release type or scope changed.
+- If a PR contains existing non-conventional commits, add a Release Please
+  commit override to the PR body and squash-merge it:
+
+  ```text
+  BEGIN_COMMIT_OVERRIDE
+  feat: describe the complete release-visible change
+  END_COMMIT_OVERRIDE
+  ```
+
+- `feat` produces a minor release, `fix` and `perf` produce a patch release, and
+  a breaking change produces a major release under the default Release Please
+  versioning strategy.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,9 @@ external integration authority.
 
 Inactive means a resumable external session is not currently active. It remains durable and can
 return to idle or working, but does not decorate a dashboard shell. Done is permanent completion.
+A foreground process hint is not an Agent Instance and is presented as Untracked, never Idle.
+Catalog-only OpenCode history is a client-side projected session with Unknown state and no
+fabricated Agent occurrence.
 
 ## Process Adapter
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ When an active Agent instance is bound to a shell's current run, that shell row
 morphs into an agent row instead of adding a duplicate item. It keeps the
 shell's name, ID, directory, and open, rename, and close actions while showing the
 Agent's lifecycle state and evidence. The Agents view stays focused on those
-current presentations. The Sessions view independently retains Boomux-observed
-active and historical sessions, grouped by activity window with workspace,
+current presentations. A process-only foreground hint is labeled `untracked`,
+never `idle`, until its lifecycle integration registers. The Sessions view
+combines Boomux-observed sessions with bounded OpenCode catalog history, grouped by activity window with workspace,
 integration, state, host-provided description, associated shell, recency, and
 canonical identity. A foreground `opencode` or `pi` process also supplies a
 presentation-only agent hint while the lifecycle integration establishes a
@@ -235,13 +236,15 @@ blocked Agent does not generate another notification until the Agent first
 leaves that state.
 
 `boomux session list` and `boomux session inspect` project durable Agent
-instances into workspace session history. Instances are grouped within one
+instances and bounded OpenCode root-session catalogs into workspace session
+history. Instances are grouped within one
 workspace and integration by external session ID; records without one remain
 isolated. A session is current only while at least one occurrence is active on
 the exact current run of a running retained shell. Otherwise its state is
 explicitly last-known. The CLI `description` is the latest stored Boomux Agent
-registration name. The dashboard may separately enrich its display title from
-bounded host catalogs; the CLI never synchronously calls those adapters.
+registration name. Catalog-only records use the sanitized OpenCode title, have
+state `unknown`, contain no fabricated occurrence, and remain available for
+canonical transcript reads while their source directory and host data exist.
 
 Projected session IDs are deterministic, globally unique UUIDs, but are opaque.
 Obtain an ID from `session list` and pass that exact value to `session inspect`
@@ -351,6 +354,12 @@ BOOMUX_SHELL_NAME
 BOOMUX_RUN_ID
 ```
 
+When an attachment starts a pending or exited shell run, protocol 16 forwards
+that attachment client's Unix environment directly to the child. Boomux does
+not persist it or expose it in snapshots or events. Terminal-profile values and
+the authoritative `BOOMUX_*` identity variables override conflicting client
+values. Later attachments never mutate a running process environment.
+
 Workspace launcher invocations instead receive `BOOMUX_WORKSPACE_ID`,
 `BOOMUX_WORKSPACE`, `BOOMUX_LAUNCHER_ID`, and `BOOMUX_LAUNCHER_NAME`. They
 inherit the invoking client's desktop environment, while shell/run context is
@@ -422,7 +431,9 @@ does not edit `opencode.json` or other plugins. An identical file is left
 unchanged. Different content requires `--force`, and detected symlinked or
 non-regular path components and targets are rejected even with `--force`. Because OpenCode
 loads config-time plugins at startup, quit and restart OpenCode after installing
-or replacing the plugin.
+or replacing the plugin. The installer prints this requirement, and `boomux
+doctor` reports a foreground OpenCode process without lifecycle registration as
+untracked instead of presenting it as idle.
 
 Inside a Boomux-managed shell, the plugin groups each root OpenCode session and
 all child/subagent sessions into one durable agent instance keyed by the root

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ untracked instead of presenting it as idle.
 
 Inside a Boomux-managed shell, the plugin groups each root OpenCode session and
 all child/subagent sessions into one durable agent instance keyed by the root
-session ID. OpenCode status, chat, tool, compaction, permission/question, error,
+session ID. OpenCode creation, status, chat, tool, compaction, permission/question, error,
 idle, and deletion events produce explainable `working`, `blocked`, `idle`, and
 `done` observations. Child activity contributes to the root; only root idle can
 make it idle, and only explicit deletion of the root reports `done`. Process or

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Boomux
 
-<p align="center">
-  <img src="assets/dashboard-workspaces.png" alt="Boomux workspace dashboard with global agent, session, launcher, shell, and command views" width="100%">
-</p>
-
 > [!WARNING]
 > Boomux is an early proof of concept. Commands, storage, and session behavior
 > may change without migration support.
@@ -73,13 +69,12 @@ boomux ui
 
 Dashboard controls:
 
-- `Tab` and `Shift-Tab` cycle the Workspaces, Agents, Sessions, Launchers,
-  Shells, and Commands views. Number keys `1` through `6` select them directly.
+- `Tab` and `Shift-Tab` cycle the Workspaces, Agents, Launchers, Shells, and
+  Commands views. Number keys `1` through `5` select them directly.
 - In the primary Workspaces view, `h`, `l`, and the left/right arrows switch
   between the workspace and item tables.
 - `j`, `k`, and the arrow keys navigate.
-- `Enter` restores a workspace, opens a shell, invokes a launcher, or opens the
-  newest still-existing shell associated with a selected session.
+- `Enter` restores a workspace, opens a shell, or invokes a launcher.
 - `a` creates an empty workspace or adds a shell, depending on the focused
   table in the Workspaces view. New dashboard shells start in the directory
   where the dashboard was launched.
@@ -95,6 +90,13 @@ configured launchers in a `KIND` column. The secondary `ALL:` views aggregate
 each kind across every workspace while retaining the owning workspace and exact
 item actions. Counts are exclusive by visible presentation: an agent row is not
 also counted as a shell or command.
+
+The selected kind receives a read-only preview. Workspaces show retained Agent
+state and their highest-priority attention item. Shells and commands show run
+metadata plus a bounded terminal-output tail, fetched only when the selected
+shell's output revision changes. Commands and launchers preserve argument
+boundaries in their previews. Launchers explicitly show that their detached
+output and invocation history are not retained.
 
 When an active Agent instance is bound to a shell's current run, that shell row
 morphs into an agent row instead of adding a duplicate item. It keeps the

--- a/README.md
+++ b/README.md
@@ -101,16 +101,10 @@ morphs into an agent row instead of adding a duplicate item. It keeps the
 shell's name, ID, directory, and open, rename, and close actions while showing the
 Agent's lifecycle state and evidence. The Agents view stays focused on those
 current presentations. A process-only foreground hint is labeled `untracked`,
-never `idle`, until its lifecycle integration registers. The Sessions view
-combines Boomux-observed sessions with bounded OpenCode catalog history, grouped by activity window with workspace,
-integration, state, host-provided description, associated shell, recency, and
-canonical identity. A foreground `opencode` or `pi` process also supplies a
-presentation-only agent hint while the lifecycle integration establishes a
-durable Agent session.
-
-<p align="center">
-  <img src="assets/dashboard-sessions.png" alt="Boomux global session history grouped by activity window" width="100%">
-</p>
+never `idle`, until its lifecycle integration registers. A selected durable
+Agent may show its one matching canonical session; untracked hints never receive
+directory-wide history. Full Boomux-observed and bounded OpenCode catalog
+history remains available through the session CLI.
 
 Closing a terminal window only disconnects its attachment. The Boomux daemon
 retains the PTY and child process until the shell exits, the workspace is

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Agent's lifecycle state and evidence. The Agents view stays focused on those
 current presentations. A process-only foreground hint is labeled `untracked`,
 never `idle`, until its lifecycle integration registers. A selected durable
 Agent may show its one matching canonical session; untracked hints never receive
-directory-wide history. Full Boomux-observed and bounded OpenCode catalog
+directory-wide history. The preview prefers the active match and otherwise uses
+the latest match. Full Boomux-observed and bounded OpenCode catalog
 history remains available through the session CLI.
 
 Closing a terminal window only disconnects its attachment. The Boomux daemon

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,12 @@ durable shell model. Command rows show the stored argv in their detail column.
 Agent presentation takes precedence when the current run has an active Agent or
 an exact `opencode` or `pi` foreground hint.
 
+Selected-kind previews remain read-only. Workspace, launcher, and run metadata
+come from the polled snapshot. Shell and command output uses a bounded plain-text
+read only when the selected shell, run ID, or output revision changes. Launcher
+previews never imply retained invocation state because launcher processes remain
+ephemeral.
+
 Agent sessions are a client-side projection, not a sixth durable daemon
 identity. The projection groups stored Agent instances by workspace,
 integration, and external session ID, while isolating instances without an
@@ -162,8 +168,9 @@ consumers. Bounded OpenCode root-session catalogs add historical, `unknown`
 sessions without fabricating Agent occurrences and merge with a later durable
 registration under the same stable ID. Catalog records associate to each
 workspace that references their exact normalized directory. The dashboard maps
-retained shells to openable run views and discovers catalogs asynchronously;
-session CLI listing performs the same bounded discovery synchronously.
+the active or latest exact match into a durable Agent's contextual preview and
+discovers catalogs asynchronously; session CLI listing performs the same bounded
+discovery synchronously. Sessions are not a dashboard kind.
 Title enrichment has its own adapter registry. The shared layer owns asynchronous
 cache, refresh, deduplication, sanitization, and fallback policy; OpenCode and Pi
 modules own host command execution and title extraction. Neutral host source

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ persistence across attachment disconnects, naming, grouping, and orchestration.
 `src/main.rs` owns the CLI, project-name suggestions, dashboard actions, shell
 name resolution, and conversion from daemon snapshots into TUI view models.
 `src/session_projection.rs` is the shared binary projection used by the CLI and
-dashboard to derive session history from one daemon snapshot.
+dashboard to combine one daemon snapshot with bounded host session catalogs.
 
 ### Protocol
 
@@ -97,8 +97,10 @@ them; a failed spawn kills the staged children. Workspace names are checked for
 global uniqueness at publication while the registry is locked.
 
 Shell creation records metadata without immediately starting a process. The
-first attachment supplies `TERM`, `COLORTERM`, terminal program identity, and
-cell/pixel dimensions; the daemon then creates the PTY and child. Failed startup
+first attachment supplies its ephemeral Unix environment, `TERM`, `COLORTERM`,
+terminal program identity, and cell/pixel dimensions; the daemon then creates
+the PTY and child. The environment is validated, never persisted or projected,
+and is overridden by authoritative terminal-profile and Boomux identity values. Failed startup
 leaves the shell pending and retryable. Shell creation may omit a workspace ID.
 The daemon then selects the lowest
 available `workspace-N` name and publishes the generated workspace and shell as
@@ -156,9 +158,12 @@ external ID. It retains original shell/run identity and observations even when a
 shell no longer exists. UUID v5 IDs use a fixed namespace and a versioned,
 length-prefixed encoding of workspace ID, integration, and the external-or-agent
 grouping identity. IDs are globally unique and deterministic but opaque to
-consumers. The dashboard maps retained shells to openable run views and may
-enrich labels asynchronously from bounded host catalogs; CLI descriptions remain
-the latest stored Agent registration name and do not invoke host adapters.
+consumers. Bounded OpenCode root-session catalogs add historical, `unknown`
+sessions without fabricating Agent occurrences and merge with a later durable
+registration under the same stable ID. Catalog records associate to each
+workspace that references their exact normalized directory. The dashboard maps
+retained shells to openable run views and discovers catalogs asynchronously;
+session CLI listing performs the same bounded discovery synchronously.
 Title enrichment has its own adapter registry. The shared layer owns asynchronous
 cache, refresh, deduplication, sanitization, and fallback policy; OpenCode and Pi
 modules own host command execution and title extraction. Neutral host source
@@ -184,8 +189,10 @@ remain available through CLI inspection but do not occupy dashboard rows. A
 running shell snapshot may also expose its PTY foreground process name. The
 dashboard recognizes exact `opencode` and `pi` as presentation-only agent-shell hints
 before a canonical Agent session exists; this hint creates no AgentInstance,
-durable state observation, persistence, or events. It displays `idle` until
-lifecycle data exists, then yields to that authoritative observation.
+durable state observation, persistence, or events. It displays `untracked` until
+lifecycle data exists, then yields to that authoritative observation. `doctor`
+checks installed integration assets and reports a running untracked host with
+explicit install or restart guidance.
 
 ### Agent Skill
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -162,11 +162,13 @@ the revision or satisfy a wait.
 
 Session summaries contain `id`, `workspace_id`, `workspace_name`, `description`,
 `integration`, `external_session_id`, `state`, `state_is_current`,
-`started_at_ms`, `last_at_ms`, and `occurrence_count`. `description` is the
-latest stored Boomux Agent registration name, never a synchronously fetched host
-title. Missing optional values are JSON `null`.
+`started_at_ms`, `last_at_ms`, and `occurrence_count`. Registered-session
+`description` is the latest stored Boomux Agent registration name. Catalog-only
+OpenCode sessions use the sanitized host title, state `unknown`, and zero
+occurrences. Missing optional values are JSON `null`.
 
-Inspect includes all summary fields plus ordered `occurrences`. Each occurrence
+Inspect includes all summary fields, session-level `source_cwd`, and ordered
+`occurrences`. Each occurrence
 contains `agent_id`, the original `shell_id` even if that shell was removed,
 `retained_shell_name`, `retained_shell_cwd`, `source_cwd`, `run_id`,
 `started_at_ms`, `ended_at_ms`, `is_current`, and the full stable Agent
@@ -178,6 +180,9 @@ same spellings documented for Agent observations.
 
 Projection groups Agent instances only when workspace, integration, and external
 session ID match. An Agent without an external session ID forms its own session.
+Bounded OpenCode catalogs add root sessions to workspaces that reference the
+same normalized directory. A matching durable Agent merges into the same stable
+ID and supplies authoritative lifecycle state and occurrences.
 Current state is selected from occurrences that are incomplete, non-inactive,
 and bound to the current run of a running retained shell; otherwise state is the
 latest stored observation and `state_is_current` is false. List order is newest

--- a/docs/native-terminal-follow-up.md
+++ b/docs/native-terminal-follow-up.md
@@ -52,7 +52,8 @@ create pending shell with explicit working directory
   -> daemon starts the child with the reported environment
 ```
 
-The attachment explicitly supplies these variables:
+Protocol 16 supplies the attachment client's complete Unix environment
+ephemerally, including these terminal-profile variables:
 
 ```text
 TERM
@@ -61,8 +62,11 @@ TERM_PROGRAM
 TERM_PROGRAM_VERSION
 ```
 
-Missing values remain unset rather than inheriting the daemon's terminal
-environment. A later attachment does not mutate a running child and receives a
+The daemon validates names and values, clears its own inherited environment,
+then applies the client environment. It overrides terminal-profile fields and
+`BOOMUX_*` identity fields authoritatively. The payload is not persisted,
+included in snapshots, events, or handoff state. Missing values remain unset.
+A later attachment does not mutate a running child and receives a
 warning when its `TERM` differs from the startup profile.
 
 This can affect terminfo selection, true-color detection, keyboard protocols,
@@ -105,8 +109,9 @@ struct TerminalProfile {
 }
 ```
 
-Do not forward the attachment client's complete environment. Validate lengths,
-reject control characters, and send only known terminal capability fields.
+Forward the attachment client's environment only in the startup request that
+can create a new run. Preserve Unix bytes, reject invalid names, duplicates, and
+NUL bytes, redact the payload from debug output, and never persist it.
 
 Read cell and pixel dimensions from `TIOCGWINSZ` on Unix. Pixel dimensions may
 legitimately remain zero when the emulator or kernel does not report them.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -133,11 +133,11 @@ eternal process.
     future Claude Code, Codex, and other harness support reuses the same identity,
     bounds, errors, and output contract. Opaque stateless cursors page toward
     older entries while expiring on baseline or source-context changes.
-7. [Complete] Add contextual, categorized Agent Session browsing to selected agent rows in
-   the Boomux UI. Keep inactive and completed workspace sessions visible without
-   adding duplicate shell rows, grouped by active and recent time windows with
-   integration, canonical identity, associated shell and run, lifecycle state,
-   and timestamps. Bounded host catalogs also project pre-registration OpenCode
+7. [Complete] Add canonical Agent Session context to selected durable Agent rows
+   in the Boomux UI without attaching directory-wide history to untracked
+   process hints. Keep full inactive and completed workspace history available
+   through the session CLI with integration, canonical identity, associated
+   shell and run, lifecycle state, and timestamps. Bounded host catalogs also project pre-registration OpenCode
    root-session history without fabricated Agent occurrences, while asynchronous
    adapters provide OpenCode generated titles and Pi names or first-user-message summaries; future adapters
    also provide canonical transcripts and tool activity through bounded,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,8 +36,8 @@ commitments.
 - [x] Make the Ratatui dashboard the default interface and remove the external
   picker dependency.
 - [x] Run an explicit one-off command when creating a shell from a path.
-- [x] Start pending shells on first attachment using its terminal environment,
-  cell dimensions, and pixel dimensions.
+- [x] Start pending shells on first attachment using its ephemeral full Unix
+  environment, cell dimensions, and pixel dimensions without persisting it.
 - [x] Expose workspace and shell create, inspect, rename, and close operations
   through explicit CLI command groups.
 - [x] Reconstruct reconnect state with a shadow VT parser and expose plain
@@ -137,8 +137,9 @@ eternal process.
    the Boomux UI. Keep inactive and completed workspace sessions visible without
    adding duplicate shell rows, grouped by active and recent time windows with
    integration, canonical identity, associated shell and run, lifecycle state,
-   and timestamps. Bounded asynchronous host catalog adapters provide OpenCode
-   generated titles and Pi names or first-user-message summaries; future adapters
+   and timestamps. Bounded host catalogs also project pre-registration OpenCode
+   root-session history without fabricated Agent occurrences, while asynchronous
+   adapters provide OpenCode generated titles and Pi names or first-user-message summaries; future adapters
    also provide canonical transcripts and tool activity through bounded,
    versioned CLI output.
 8. [Complete] Separate OpenCode and Pi title and transcript adapters from shared

--- a/integrations/opencode/boomux.js
+++ b/integrations/opencode/boomux.js
@@ -56,6 +56,14 @@ function classifyEvent(event) {
   const id = sessionID(event);
   if (!type || !id) return undefined;
 
+  if (type === "session.created") {
+    return {
+      kind: "idle",
+      sessionID: id,
+      evidence: "OpenCode root session created",
+    };
+  }
+
   if (type === "session.status") {
     const kind = statusKind(properties.status);
     if (

--- a/integrations/opencode/boomux.test.js
+++ b/integrations/opencode/boomux.test.js
@@ -42,6 +42,13 @@ function successfulEnsure(
 describe("event mapping and reducer", () => {
   test("maps structural status, chat, tool, compaction, waits, and errors", () => {
     expect(
+      classifyEvent(event("session.created", { info: { id: "root" } })),
+    ).toEqual({
+      kind: "idle",
+      sessionID: "root",
+      evidence: "OpenCode root session created",
+    });
+    expect(
       classifyEvent(
         event("session.status", { sessionID: "s", status: { type: "retry" } }),
       ).kind,
@@ -180,6 +187,8 @@ describe("root aggregation", () => {
     await lifecycle.enqueue(
       event("session.created", { info: { id: "child", parentID: "root" } }),
     );
+    expect(calls[0]).toContain("root");
+    calls.length = 0;
     await lifecycle.enqueue(
       event("session.status", {
         sessionID: "child",
@@ -209,7 +218,6 @@ describe("root aggregation", () => {
       "working",
       "idle",
     ]);
-    expect(calls[0]).toContain("root");
     expect(calls.every((argv) => !argv.includes("child"))).toBe(true);
   });
 
@@ -265,6 +273,7 @@ describe("root aggregation", () => {
     await lifecycle.enqueue(
       event("session.created", { info: { id: "child", parentID: "root" } }),
     );
+    calls.length = 0;
     await lifecycle.enqueue(
       event("session.deleted", { info: { id: "child", parentID: "root" } }),
     );
@@ -294,6 +303,7 @@ describe("root aggregation", () => {
     await lifecycle.enqueue(
       event("session.created", { info: { id: "child", parentID: "root" } }),
     );
+    calls.length = 0;
 
     await lifecycle.enqueue(
       event("permission.asked", { sessionID: "child", id: "permission-1" }),
@@ -331,6 +341,7 @@ describe("root aggregation", () => {
       log: () => {},
     });
     await lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    calls.length = 0;
     for (const id of ["first", "second"]) {
       await lifecycle.enqueue(
         event("session.created", { info: { id, parentID: "root" } }),
@@ -369,6 +380,7 @@ describe("root aggregation", () => {
     await lifecycle.enqueue(
       event("session.created", { info: { id: "child", parentID: "root" } }),
     );
+    calls.length = 0;
 
     await lifecycle.enqueue(
       event("session.error", {

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -37,11 +37,7 @@ pub fn run(shell_id: &str, takeover: bool, restart_exited: bool) -> io::Result<(
         profile.pixel_height,
     );
     let client = client::connect_or_start()?;
-    let mut attachment = if restart_exited {
-        client.attach_restarting(shell_id, takeover, profile.clone())?
-    } else {
-        client.attach(shell_id, takeover, profile.clone())?
-    };
+    let mut attachment = attach_once(&client, shell_id, takeover, restart_exited, &profile)?;
     let _raw_mode = RawMode::enter()?;
     let mut stdin = io::stdin().lock();
     let mut stdout = io::stdout().lock();
@@ -77,13 +73,31 @@ fn reconnect(
 ) -> io::Result<client::Attachment> {
     let mut last_error = None;
     for _ in 0..RECONNECT_ATTEMPTS {
-        match client.attach(shell_id, takeover, profile.clone()) {
+        match attach_once(client, shell_id, takeover, false, profile) {
             Ok(attachment) => return Ok(attachment),
             Err(error) => last_error = Some(error),
         }
         thread::sleep(RECONNECT_DELAY);
     }
     Err(last_error.unwrap_or_else(|| io::Error::other("daemon attachment did not reconnect")))
+}
+
+fn attach_once(
+    client: &client::Client,
+    shell_id: &str,
+    takeover: bool,
+    restart_exited: bool,
+    profile: &TerminalProfile,
+) -> io::Result<client::Attachment> {
+    let transfers_environment = client.protocol_version()? >= 16;
+    match (restart_exited, transfers_environment) {
+        (true, true) => {
+            client.attach_restarting_with_client_environment(shell_id, takeover, profile.clone())
+        }
+        (true, false) => client.attach_restarting(shell_id, takeover, profile.clone()),
+        (false, true) => client.attach_with_client_environment(shell_id, takeover, profile.clone()),
+        (false, false) => client.attach(shell_id, takeover, profile.clone()),
+    }
 }
 
 fn pump_attachment(

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -148,6 +148,7 @@ pub(crate) struct SessionSummaryData {
 pub(crate) struct SessionData {
     #[serde(flatten)]
     pub(crate) summary: SessionSummaryData,
+    pub(crate) source_cwd: Option<String>,
     pub(crate) occurrences: Vec<SessionOccurrenceData>,
 }
 
@@ -298,6 +299,10 @@ pub(crate) fn session_summary(session: &SessionProjection) -> SessionSummaryData
 pub(crate) fn session(session: &SessionProjection) -> SessionData {
     SessionData {
         summary: session_summary(session),
+        source_cwd: session
+            .source_cwd
+            .as_ref()
+            .map(|cwd| cwd.display().to_string()),
         occurrences: session.occurrences.iter().map(session_occurrence).collect(),
     }
 }
@@ -489,6 +494,7 @@ mod tests {
             state_is_current: false,
             started_at_ms: 10,
             last_at_ms: 11,
+            source_cwd: Some("/tmp/project".into()),
             occurrences: vec![SessionOccurrence {
                 agent_id: "a1".into(),
                 shell_id: "removed-shell".into(),
@@ -512,6 +518,7 @@ mod tests {
 
         let value = serde_json::to_value(data).unwrap();
         assert!(value["external_session_id"].is_null());
+        assert_eq!(value["source_cwd"], "/tmp/project");
         assert!(value["occurrences"][0]["retained_shell_name"].is_null());
         assert!(value["occurrences"][0]["retained_shell_cwd"].is_null());
         assert_eq!(value["occurrences"][0]["source_cwd"], "/tmp/project");

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::fs::OpenOptions;
 use std::io;
 use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -15,7 +16,8 @@ use std::time::Duration;
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, DaemonEvent, Envelope,
     ErrorCode, EventCursor, Request, Response, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
-    TerminalProfile, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
+    WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -632,7 +634,22 @@ impl Client {
         takeover: bool,
         profile: TerminalProfile,
     ) -> io::Result<Attachment> {
-        self.attach_with_restart(shell_id.into(), takeover, false, profile)
+        self.attach_with_restart(shell_id.into(), takeover, false, profile, None)
+    }
+
+    pub fn attach_with_client_environment(
+        &self,
+        shell_id: impl Into<String>,
+        takeover: bool,
+        profile: TerminalProfile,
+    ) -> io::Result<Attachment> {
+        self.attach_with_restart(
+            shell_id.into(),
+            takeover,
+            false,
+            profile,
+            Some(current_environment()),
+        )
     }
 
     pub fn attach_restarting(
@@ -641,7 +658,22 @@ impl Client {
         takeover: bool,
         profile: TerminalProfile,
     ) -> io::Result<Attachment> {
-        self.attach_with_restart(shell_id.into(), takeover, true, profile)
+        self.attach_with_restart(shell_id.into(), takeover, true, profile, None)
+    }
+
+    pub fn attach_restarting_with_client_environment(
+        &self,
+        shell_id: impl Into<String>,
+        takeover: bool,
+        profile: TerminalProfile,
+    ) -> io::Result<Attachment> {
+        self.attach_with_restart(
+            shell_id.into(),
+            takeover,
+            true,
+            profile,
+            Some(current_environment()),
+        )
     }
 
     fn attach_with_restart(
@@ -650,12 +682,14 @@ impl Client {
         takeover: bool,
         restart_exited: bool,
         profile: TerminalProfile,
+        environment: Option<UnixEnvironment>,
     ) -> io::Result<Attachment> {
         let (stream, response) = self.send(Request::Attach {
             shell_id,
             takeover,
             restart_exited,
             profile,
+            environment,
         })?;
         match response {
             Response::Attached {
@@ -673,8 +707,23 @@ impl Client {
     }
 }
 
+fn current_environment() -> UnixEnvironment {
+    UnixEnvironment {
+        variables: env::vars_os()
+            .map(|(name, value)| UnixEnvironmentVariable {
+                name: name.as_os_str().as_bytes().to_vec(),
+                value: value.as_os_str().as_bytes().to_vec(),
+            })
+            .collect(),
+    }
+}
+
 fn request_minimum_version(request: &Request) -> u32 {
     match request {
+        Request::Attach {
+            environment: Some(_),
+            ..
+        } => 16,
         Request::AcknowledgeAgentAttention { .. } => 15,
         Request::WaitAgent { .. } => 14,
         Request::RegisterAgent { spec, .. } | Request::EnsureAgent { spec, .. }
@@ -780,6 +829,19 @@ mod tests {
     use std::os::unix::net::UnixListener;
 
     use uuid::Uuid;
+
+    fn test_profile() -> TerminalProfile {
+        TerminalProfile {
+            term: None,
+            colorterm: None,
+            term_program: None,
+            term_program_version: None,
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
 
     #[test]
     fn launcher_requests_require_protocol_eight() {
@@ -897,6 +959,22 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 16);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    15,
+                    Response::Error {
+                        message: "protocol 16 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 15);
             assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
@@ -971,6 +1049,7 @@ mod tests {
                 takeover: false,
                 restart_exited: true,
                 profile: profile.clone(),
+                environment: None,
             }),
             11
         );
@@ -980,9 +1059,90 @@ mod tests {
                 takeover: false,
                 restart_exited: false,
                 profile,
+                environment: None,
             }),
             protocol::MIN_PROTOCOL_VERSION
         );
+    }
+
+    #[test]
+    fn attach_environment_requires_protocol_sixteen() {
+        assert_eq!(
+            request_minimum_version(&Request::Attach {
+                shell_id: "s1".into(),
+                takeover: false,
+                restart_exited: false,
+                profile: TerminalProfile {
+                    term: None,
+                    colorterm: None,
+                    term_program: None,
+                    term_program_version: None,
+                    rows: 24,
+                    cols: 80,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                },
+                environment: Some(UnixEnvironment {
+                    variables: Vec::new(),
+                }),
+            }),
+            16
+        );
+    }
+
+    #[test]
+    fn attach_captures_the_full_unix_environment() {
+        let expected: std::collections::HashMap<Vec<u8>, Vec<u8>> = env::vars_os()
+            .map(|(name, value)| {
+                (
+                    name.as_os_str().as_bytes().to_vec(),
+                    value.as_os_str().as_bytes().to_vec(),
+                )
+            })
+            .collect();
+        let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 16);
+            let Request::Attach {
+                environment: Some(environment),
+                ..
+            } = request.message
+            else {
+                panic!("attach did not include an environment");
+            };
+            let actual: std::collections::HashMap<Vec<u8>, Vec<u8>> = environment
+                .variables
+                .into_iter()
+                .map(|variable| (variable.name, variable.value))
+                .collect();
+            assert_eq!(actual, expected);
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    16,
+                    Response::Attached {
+                        token: "token".into(),
+                        reconstruction: Vec::new(),
+                        warning: None,
+                    },
+                ),
+            )
+            .unwrap();
+        });
+        let client = Client::from_socket_path(socket);
+
+        let attachment = client
+            .attach_with_client_environment("s1", false, test_profile())
+            .unwrap();
+
+        assert_eq!(attachment.token, "token");
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
@@ -1009,6 +1169,22 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 16);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    15,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 15);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -575,6 +575,14 @@ fn select_replacement_executable(current: PathBuf, argument_zero: Option<PathBuf
     if current.exists() {
         return current;
     }
+    if let Some(installed) = current
+        .to_str()
+        .and_then(|path| path.strip_suffix(" (deleted)"))
+        .map(PathBuf::from)
+        .filter(|path| path.exists())
+    {
+        return installed;
+    }
     if let Some(argument_zero) = argument_zero
         && argument_zero.is_absolute()
         && argument_zero.exists()
@@ -4175,6 +4183,17 @@ fn create_pending_shell(workspace_id: &str, spec: ShellSpec) -> io::Result<Arc<S
     }))
 }
 
+fn initial_terminal_state(
+    rows: u16,
+    cols: u16,
+    workspace_name: &str,
+    shell_name: &str,
+) -> TerminalState {
+    let mut terminal = TerminalState::new(rows, cols);
+    terminal.process(format!("\x1b[2mBoomux: {workspace_name}/{shell_name}\x1b[0m\r\n").as_bytes());
+    terminal
+}
+
 fn spawn_runtime(
     shell: &Arc<Shell>,
     run: &ShellRun,
@@ -4226,12 +4245,14 @@ fn spawn_runtime(
     drop(pty.slave);
     drop(pty.master);
 
+    let terminal = initial_terminal_state(profile.rows, profile.cols, workspace_name, shell_name);
+
     Ok((
         Arc::new(ShellRuntime {
             control: Mutex::new(()),
             master: Mutex::new(master),
             process: Mutex::new(ManagedProcess::Owned(child)),
-            terminal: Arc::new(Mutex::new(TerminalState::new(profile.rows, profile.cols))),
+            terminal: Arc::new(Mutex::new(terminal)),
             controller: Mutex::new(None),
             reader: Mutex::new(None),
         }),
@@ -5340,6 +5361,13 @@ mod tests {
         }
     }
 
+    #[test]
+    fn new_shell_terminal_starts_with_its_workspace_and_shell_name() {
+        let terminal = initial_terminal_state(24, 80, "project", "build");
+
+        assert!(terminal.plain_text().contains("Boomux: project/build"));
+    }
+
     fn agent_spec(state: AgentState) -> AgentRegistrationSpec {
         AgentRegistrationSpec {
             name: "test-agent".into(),
@@ -5399,7 +5427,7 @@ mod tests {
     }
 
     #[test]
-    fn replacement_uses_absolute_argument_zero_after_binary_replacement() {
+    fn replacement_finds_new_binary_after_binary_replacement() {
         let directory = env::temp_dir().join(format!("boomux-replacement-{}", Uuid::new_v4()));
         let installed = directory.join("boomux");
         fs::create_dir_all(&directory).unwrap();
@@ -5408,7 +5436,7 @@ mod tests {
         assert_eq!(
             select_replacement_executable(
                 directory.join("boomux (deleted)"),
-                Some(installed.clone())
+                Some(PathBuf::from("boomux"))
             ),
             installed
         );

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
@@ -31,7 +32,8 @@ use crate::protocol::{
     AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame,
     DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, Request, Response,
     ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
-    TerminalProfile, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    TerminalProfile, UnixEnvironment, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
+    WorkspaceSnapshot,
 };
 use crate::state_store::{
     PersistedAgentInstance, PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
@@ -736,12 +738,31 @@ fn handle_connection(
             ),
         );
     }
+    if response_version < 16
+        && matches!(
+            request.message,
+            Request::Attach {
+                environment: Some(_),
+                ..
+            }
+        )
+    {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "client environment requires daemon protocol 16",
+            ),
+        );
+    }
 
     if let Request::Attach {
         shell_id,
         takeover,
         restart_exited,
         profile,
+        environment,
     } = request.message
     {
         return handle_attach(
@@ -749,9 +770,12 @@ fn handle_connection(
             response_version,
             &registry,
             &shell_id,
-            takeover,
-            restart_exited,
-            profile,
+            AttachRequestOptions {
+                takeover,
+                restart_exited,
+                profile,
+                environment,
+            },
         );
     }
     if matches!(request.message, Request::Shutdown) {
@@ -4200,6 +4224,7 @@ fn spawn_runtime(
     workspace_name: &str,
     shell_name: &str,
     profile: &TerminalProfile,
+    environment: Option<&UnixEnvironment>,
 ) -> io::Result<(Arc<ShellRuntime>, PtyReader)> {
     let pty = native_pty_system()
         .openpty(PtySize {
@@ -4212,14 +4237,38 @@ fn spawn_runtime(
     let master = PtyMaster::duplicate(pty.master.as_ref())?;
     let reader = master.try_clone_reader()?;
 
+    let client_shell = environment
+        .and_then(|environment| {
+            environment
+                .variables
+                .iter()
+                .find(|variable| variable.name == b"SHELL")
+                .map(|variable| std::ffi::OsString::from_vec(variable.value.clone()))
+        })
+        .or_else(|| {
+            environment
+                .is_none()
+                .then(|| env::var_os("SHELL"))
+                .flatten()
+        })
+        .unwrap_or_else(|| "/bin/sh".into());
     let mut command = if shell.command.is_empty() {
-        CommandBuilder::new(env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into()))
+        CommandBuilder::new(client_shell)
     } else {
         let mut command = CommandBuilder::new(&shell.command[0]);
         command.args(&shell.command[1..]);
         command
     };
     command.cwd(&shell.cwd);
+    if let Some(environment) = environment {
+        command.env_clear();
+        for variable in &environment.variables {
+            command.env(
+                std::ffi::OsString::from_vec(variable.name.clone()),
+                std::ffi::OsString::from_vec(variable.value.clone()),
+            );
+        }
+    }
     for name in ["TERM", "COLORTERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION"] {
         command.env_remove(name);
     }
@@ -4449,16 +4498,36 @@ fn tail_utf8(text: &str, max_bytes: usize) -> &str {
     &text[start..]
 }
 
+struct AttachRequestOptions {
+    takeover: bool,
+    restart_exited: bool,
+    profile: TerminalProfile,
+    environment: Option<UnixEnvironment>,
+}
+
 fn handle_attach(
     mut stream: UnixStream,
     response_version: u32,
     registry: &Arc<Registry>,
     shell_id: &str,
-    takeover: bool,
-    restart_exited: bool,
-    profile: TerminalProfile,
+    options: AttachRequestOptions,
 ) -> io::Result<()> {
+    let AttachRequestOptions {
+        takeover,
+        restart_exited,
+        profile,
+        environment,
+    } = options;
     if let Err(error) = validate_terminal_profile(&profile) {
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(ErrorCode::InvalidArgument, error.to_string()),
+        );
+    }
+    if let Some(environment) = &environment
+        && let Err(error) = validate_unix_environment(environment)
+    {
         return send_response(
             &mut stream,
             response_version,
@@ -4543,20 +4612,26 @@ fn handle_attach(
                     .ok_or_else(|| io::Error::other("shell run generation exhausted"))
             })?;
             let run = Arc::new(ShellRun::new(generation));
-            let (runtime, reader) =
-                match spawn_runtime(&shell, &run, &workspace_name, &shell_name, &profile) {
-                    Ok(runtime) => runtime,
-                    Err(error) => {
-                        return send_response(
-                            &mut stream,
-                            response_version,
-                            error_response(
-                                ErrorCode::ShellStartFailed,
-                                format!("could not start shell: {error}"),
-                            ),
-                        );
-                    }
-                };
+            let (runtime, reader) = match spawn_runtime(
+                &shell,
+                &run,
+                &workspace_name,
+                &shell_name,
+                &profile,
+                environment.as_ref(),
+            ) {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    return send_response(
+                        &mut stream,
+                        response_version,
+                        error_response(
+                            ErrorCode::ShellStartFailed,
+                            format!("could not start shell: {error}"),
+                        ),
+                    );
+                }
+            };
             *lifecycle = ShellLifecycle::Running {
                 profile: profile.clone(),
                 run: Arc::clone(&run),
@@ -4931,6 +5006,29 @@ fn validate_terminal_profile(profile: &TerminalProfile) -> io::Result<()> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "terminal profile contains an invalid environment value",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_unix_environment(environment: &UnixEnvironment) -> io::Result<()> {
+    let mut names = HashSet::new();
+    for variable in &environment.variables {
+        if variable.name.is_empty()
+            || variable.name.contains(&0)
+            || variable.name.contains(&b'=')
+            || !names.insert(variable.name.as_slice())
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "client environment contains an invalid variable name",
+            ));
+        }
+        if variable.value.contains(&0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "client environment contains an invalid variable value",
             ));
         }
     }
@@ -5405,7 +5503,7 @@ mod tests {
         let shell = registry.shell(&workspace.shells[0].id).unwrap();
         let run = Arc::new(ShellRun::new(1));
         let (runtime, _reader) =
-            spawn_runtime(&shell, &run, "agents", "agent-shell", &profile()).unwrap();
+            spawn_runtime(&shell, &run, "agents", "agent-shell", &profile(), None).unwrap();
         *lock(&shell.last_run).unwrap() = Some(run.persisted(profile()).unwrap());
         *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
             profile: profile(),
@@ -5599,6 +5697,35 @@ mod tests {
         let mut invalid = profile();
         invalid.term = Some("x".repeat(MAX_TERMINAL_ENV_VALUE + 1));
         assert!(validate_terminal_profile(&invalid).is_err());
+    }
+
+    #[test]
+    fn validates_unix_environment_without_echoing_payload() {
+        let invalid_name = UnixEnvironment {
+            variables: vec![protocol::UnixEnvironmentVariable {
+                name: b"SECRET=NAME".to_vec(),
+                value: b"secret-value".to_vec(),
+            }],
+        };
+        let error = validate_unix_environment(&invalid_name).unwrap_err();
+        assert!(!error.to_string().contains("SECRET"));
+        assert!(!error.to_string().contains("secret-value"));
+
+        let invalid_value = UnixEnvironment {
+            variables: vec![protocol::UnixEnvironmentVariable {
+                name: b"VALID_NAME".to_vec(),
+                value: b"secret\0value".to_vec(),
+            }],
+        };
+        assert!(validate_unix_environment(&invalid_value).is_err());
+
+        let bytes = UnixEnvironment {
+            variables: vec![protocol::UnixEnvironmentVariable {
+                name: b"NON_UTF8".to_vec(),
+                value: vec![0xff, 0xfe],
+            }],
+        };
+        assert!(validate_unix_environment(&bytes).is_ok());
     }
 
     #[test]
@@ -7065,8 +7192,15 @@ mod tests {
         .unwrap();
         let terminal_profile = profile();
         let run = Arc::new(ShellRun::new(1));
-        let (runtime, reader) =
-            spawn_runtime(&shell, &run, "workspace", "pause-test", &terminal_profile).unwrap();
+        let (runtime, reader) = spawn_runtime(
+            &shell,
+            &run,
+            "workspace",
+            "pause-test",
+            &terminal_profile,
+            None,
+        )
+        .unwrap();
         *lock(&shell.last_run).unwrap() = Some(run.persisted(terminal_profile.clone()).unwrap());
         *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
             profile: terminal_profile,
@@ -7129,8 +7263,15 @@ mod tests {
         let shell = registry.shell(&workspace.shells[0].id).unwrap();
         let terminal_profile = profile();
         let run = Arc::new(ShellRun::new(1));
-        let (runtime, reader) =
-            spawn_runtime(&shell, &run, "exit-race", "short-lived", &terminal_profile).unwrap();
+        let (runtime, reader) = spawn_runtime(
+            &shell,
+            &run,
+            "exit-race",
+            "short-lived",
+            &terminal_profile,
+            None,
+        )
+        .unwrap();
         *lock(&shell.last_run).unwrap() = Some(run.persisted(terminal_profile.clone()).unwrap());
         *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
             profile: terminal_profile,

--- a/src/host_session_titles.rs
+++ b/src/host_session_titles.rs
@@ -15,7 +15,7 @@ use crate::host_session_source::pi::{
 };
 #[cfg(test)]
 use opencode::{
-    MAX_STDOUT_BYTES as MAX_OPENCODE_STDOUT_BYTES, parse_titles as parse_opencode_titles,
+    MAX_STDOUT_BYTES as MAX_OPENCODE_STDOUT_BYTES, parse_catalog as parse_opencode_catalog,
 };
 #[cfg(test)]
 use pi::{inspect as inspect_pi, parse_session as parse_pi_session};
@@ -26,7 +26,23 @@ const MAX_SESSIONS: usize = 100;
 const MAX_TITLE_CHARS: usize = 160;
 
 type Titles = HashMap<String, String>;
-type Inspector = dyn Fn(&str, &Path) -> Option<Titles> + Send + Sync;
+type Inspector = dyn Fn(&str, &Path) -> Option<Inspection> + Send + Sync;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct HostSession {
+    pub(crate) integration: String,
+    pub(crate) root_id: String,
+    pub(crate) title: String,
+    pub(crate) directory: PathBuf,
+    pub(crate) created_at_ms: u64,
+    pub(crate) updated_at_ms: u64,
+}
+
+#[derive(Clone, Debug)]
+struct Inspection {
+    titles: Titles,
+    catalog: Vec<HostSession>,
+}
 
 trait TitleAdapter: Sync {
     fn integration(&self) -> &'static str;
@@ -42,16 +58,16 @@ struct CacheKey {
     directory: PathBuf,
 }
 
-struct CachedTitles {
-    value: Option<Titles>,
+struct CachedInspection {
+    value: Option<Inspection>,
     inspected_at: Instant,
 }
 
 pub(crate) struct Cache {
-    entries: HashMap<CacheKey, CachedTitles>,
+    entries: HashMap<CacheKey, CachedInspection>,
     pending: HashSet<CacheKey>,
     requests: Sender<CacheKey>,
-    results: Receiver<(CacheKey, Option<Titles>)>,
+    results: Receiver<(CacheKey, Option<Inspection>)>,
 }
 
 impl Default for Cache {
@@ -86,11 +102,40 @@ impl Cache {
         directory: &Path,
         external_session_id: &str,
     ) -> Option<String> {
+        self.refresh(integration, directory);
+        let key = CacheKey {
+            integration: integration.to_owned(),
+            directory: directory.to_owned(),
+        };
+        self.entries
+            .get(&key)
+            .and_then(|cached| cached.value.as_ref())
+            .and_then(|inspection| inspection.titles.get(external_session_id))
+            .cloned()
+    }
+
+    pub(crate) fn catalog(
+        &mut self,
+        integration: &str,
+        directory: &Path,
+    ) -> Option<Vec<HostSession>> {
+        self.refresh(integration, directory);
+        let key = CacheKey {
+            integration: integration.to_owned(),
+            directory: directory.to_owned(),
+        };
+        self.entries
+            .get(&key)
+            .and_then(|cached| cached.value.as_ref())
+            .map(|inspection| inspection.catalog.clone())
+    }
+
+    fn refresh(&mut self, integration: &str, directory: &Path) {
         for (key, value) in self.results.try_iter() {
             self.pending.remove(&key);
             self.entries.insert(
                 key,
-                CachedTitles {
+                CachedInspection {
                     value,
                     inspected_at: Instant::now(),
                 },
@@ -98,7 +143,7 @@ impl Cache {
         }
 
         if !is_supported(integration) {
-            return None;
+            return;
         }
 
         let key = CacheKey {
@@ -114,14 +159,8 @@ impl Cache {
                 }
         });
         if !fresh && !self.pending.contains(&key) && self.requests.send(key.clone()).is_ok() {
-            self.pending.insert(key.clone());
+            self.pending.insert(key);
         }
-
-        self.entries
-            .get(&key)
-            .and_then(|cached| cached.value.as_ref())
-            .and_then(|titles| titles.get(external_session_id))
-            .cloned()
     }
 }
 
@@ -131,11 +170,22 @@ fn is_supported(integration: &str) -> bool {
         .any(|adapter| adapter.integration() == integration)
 }
 
-fn inspect(integration: &str, directory: &Path) -> Option<Titles> {
+fn inspect(integration: &str, directory: &Path) -> Option<Inspection> {
+    if integration == "opencode" {
+        return opencode::inspect_catalog(directory);
+    }
     ADAPTERS
         .iter()
         .find(|adapter| adapter.integration() == integration)?
         .inspect(directory)
+        .map(|titles| Inspection {
+            titles,
+            catalog: Vec::new(),
+        })
+}
+
+pub(crate) fn catalog(directory: &Path) -> Option<Vec<HostSession>> {
+    opencode::inspect_catalog(directory).map(|inspection| inspection.catalog)
 }
 
 fn sanitize_title(title: &str) -> Option<String> {
@@ -201,7 +251,7 @@ mod tests {
 
     #[test]
     fn parses_opencode_catalog_by_canonical_session_id() {
-        let titles = parse_opencode_titles(
+        let inspection = parse_opencode_catalog(
             br#"[
                 {"id":"ses_one","title":"Review cache","updated":2,"created":1,"directory":"/repo"},
                 {"id":"ses_two","title":"Implement panel","updated":4,"created":3,"directory":"/repo"}
@@ -210,13 +260,17 @@ mod tests {
         .expect("valid catalog");
 
         assert_eq!(
-            titles.get("ses_one").map(String::as_str),
+            inspection.titles.get("ses_one").map(String::as_str),
             Some("Review cache")
         );
         assert_eq!(
-            titles.get("ses_two").map(String::as_str),
+            inspection.titles.get("ses_two").map(String::as_str),
             Some("Implement panel")
         );
+        assert_eq!(inspection.catalog[0].root_id, "ses_one");
+        assert_eq!(inspection.catalog[0].directory, Path::new("/repo"));
+        assert_eq!(inspection.catalog[0].created_at_ms, 1);
+        assert_eq!(inspection.catalog[0].updated_at_ms, 2);
     }
 
     #[test]
@@ -235,10 +289,49 @@ mod tests {
 
     #[test]
     fn malformed_and_oversized_opencode_catalogs_fail_open() {
-        assert!(parse_opencode_titles(b"not json").is_none());
+        assert!(parse_opencode_catalog(b"not json").is_none());
         assert!(
-            parse_opencode_titles(&vec![b'x'; MAX_OPENCODE_STDOUT_BYTES as usize + 1]).is_none()
+            parse_opencode_catalog(&vec![b'x'; MAX_OPENCODE_STDOUT_BYTES as usize + 1]).is_none()
         );
+    }
+
+    #[test]
+    fn opencode_catalog_normalizes_absolute_directories_and_skips_invalid_records() {
+        let inspection = parse_opencode_catalog(
+            br#"[
+                {"id":"normalized","title":"Title","updated":20,"created":10,"directory":"/repo/./src/.."},
+                {"id":"relative","title":"Ignored","updated":2,"created":1,"directory":"repo"},
+                {"id":"empty-title","title":"  ","updated":2,"created":1,"directory":"/repo"}
+            ]"#,
+        )
+        .expect("valid catalog");
+
+        assert_eq!(inspection.catalog.len(), 1);
+        assert_eq!(inspection.catalog[0].directory, Path::new("/repo"));
+        assert_eq!(inspection.catalog[0].integration, "opencode");
+        assert_eq!(inspection.titles.len(), 1);
+    }
+
+    #[test]
+    fn opencode_catalog_is_bounded_to_the_requested_session_limit() {
+        let sessions = (0..MAX_SESSIONS + 1)
+            .map(|index| {
+                serde_json::json!({
+                    "id": format!("session-{index}"),
+                    "title": format!("Title {index}"),
+                    "updated": index + 1,
+                    "created": index,
+                    "directory": "/repo",
+                })
+            })
+            .collect::<Vec<_>>();
+        let output = serde_json::to_vec(&sessions).expect("serialize catalog");
+
+        let inspection = parse_opencode_catalog(&output).expect("valid catalog");
+
+        assert_eq!(inspection.catalog.len(), MAX_SESSIONS);
+        assert!(inspection.titles.contains_key("session-99"));
+        assert!(!inspection.titles.contains_key("session-100"));
     }
 
     #[test]
@@ -509,10 +602,24 @@ mod tests {
                 .expect("calls lock")
                 .push((integration.to_owned(), directory.to_owned()));
             let _ = finished_sender.send(integration.to_owned());
-            Some(HashMap::from([(
-                format!("{integration}-id"),
-                format!("{integration} title"),
-            )]))
+            let catalog = (integration == "opencode")
+                .then(|| HostSession {
+                    integration: integration.to_owned(),
+                    root_id: format!("{integration}-id"),
+                    title: format!("{integration} title"),
+                    directory: directory.to_owned(),
+                    created_at_ms: 1,
+                    updated_at_ms: 2,
+                })
+                .into_iter()
+                .collect();
+            Some(Inspection {
+                titles: HashMap::from([(
+                    format!("{integration}-id"),
+                    format!("{integration} title"),
+                )]),
+                catalog,
+            })
         }));
 
         assert_eq!(
@@ -545,6 +652,19 @@ mod tests {
             thread::yield_now();
         }
         assert_eq!(calls.lock().expect("calls lock").len(), 2);
+        assert_eq!(
+            cache
+                .catalog("opencode", Path::new("/repo"))
+                .expect("cached catalog")[0]
+                .root_id,
+            "opencode-id"
+        );
+        assert!(
+            cache
+                .catalog("pi", Path::new("/repo"))
+                .expect("cached catalog")
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src/host_session_titles/opencode.rs
+++ b/src/host_session_titles/opencode.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -6,7 +5,8 @@ use std::sync::mpsc::{self, TryRecvError};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use super::{MAX_SESSIONS, TitleAdapter, Titles, sanitize_title};
+use super::{HostSession, Inspection, MAX_SESSIONS, TitleAdapter, sanitize_title};
+use crate::host_session_source::normalize_absolute;
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(15);
 pub(super) const MAX_STDOUT_BYTES: u64 = 1024 * 1024;
@@ -20,15 +20,19 @@ impl TitleAdapter for OpenCodeAdapter {
         "opencode"
     }
 
-    fn inspect(&self, directory: &Path) -> Option<Titles> {
-        let stdout = run(directory)?;
-        parse_titles(&stdout)
+    fn inspect(&self, directory: &Path) -> Option<super::Titles> {
+        inspect_catalog(directory).map(|inspection| inspection.titles)
     }
+}
+
+pub(super) fn inspect_catalog(directory: &Path) -> Option<Inspection> {
+    let stdout = run(directory)?;
+    parse_catalog(&stdout)
 }
 
 fn run(directory: &Path) -> Option<Vec<u8>> {
     let mut child = Command::new("opencode")
-        .args(["session", "list", "--format", "json", "-n", "100"])
+        .args(["--pure", "session", "list", "--format", "json", "-n", "100"])
         .current_dir(directory)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -89,27 +93,39 @@ fn run(directory: &Path) -> Option<Vec<u8>> {
 struct OpenCodeSession {
     id: String,
     title: String,
-    #[serde(rename = "updated")]
-    _updated: serde_json::Value,
-    #[serde(rename = "created")]
-    _created: serde_json::Value,
-    #[serde(rename = "directory")]
-    _directory: String,
+    updated: u64,
+    created: u64,
+    directory: String,
 }
 
-pub(super) fn parse_titles(output: &[u8]) -> Option<Titles> {
+pub(super) fn parse_catalog(output: &[u8]) -> Option<Inspection> {
     if output.len() as u64 > MAX_STDOUT_BYTES {
         return None;
     }
     let sessions: Vec<OpenCodeSession> = serde_json::from_slice(output).ok()?;
-    let mut titles = HashMap::new();
+    let mut catalog = Vec::new();
     for session in sessions.into_iter().take(MAX_SESSIONS) {
         if session.id.is_empty() {
             continue;
         }
-        if let Some(title) = sanitize_title(&session.title) {
-            titles.insert(session.id, title);
-        }
+        let Some(title) = sanitize_title(&session.title) else {
+            continue;
+        };
+        let Some(directory) = normalize_absolute(Path::new(&session.directory)) else {
+            continue;
+        };
+        catalog.push(HostSession {
+            integration: "opencode".into(),
+            root_id: session.id,
+            title,
+            directory,
+            created_at_ms: session.created,
+            updated_at_ms: session.updated,
+        });
     }
-    Some(titles)
+    let titles = catalog
+        .iter()
+        .map(|session| (session.root_id.clone(), session.title.clone()))
+        .collect();
+    Some(Inspection { titles, catalog })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1166,20 +1166,17 @@ fn dashboard_views_from_sessions(
                             id: agent.id.clone(),
                             state: cli_output::agent_state(agent.observation.state).into(),
                             integration: agent.integration.clone(),
+                            external_session_id: agent.external_session_id.clone(),
                             authority: cli_output::agent_authority(agent.observation.authority)
                                 .into(),
                             confidence: agent.observation.confidence,
                             evidence: agent.observation.evidence.clone(),
                         }),
-                        hinted_integration: None,
                     }),
-                    (None, Some(integration @ ("opencode" | "pi")))
-                        if !suppress_foreground_hint =>
-                    {
+                    (None, Some("opencode" | "pi")) if !suppress_foreground_hint => {
                         tui::WorkspaceItemView::AgentShell(tui::AgentShellView {
                             shell: shell_view,
                             agent: None,
-                            hinted_integration: Some(integration.to_owned()),
                         })
                     }
                     (None, _) => tui::WorkspaceItemView::Shell(shell_view),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1059,7 +1059,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 let bytes = client
                     .read_shell(shell_id, READ_BYTES)
                     .map_err(|error| error.to_string())?;
-                Ok(recent_lines(&String::from_utf8_lossy(&bytes), 3))
+                Ok(recent_lines(&String::from_utf8_lossy(&bytes), 12))
             },
         },
     )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1055,6 +1055,12 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 enrich_session_titles(&mut views, &mut title_cache);
                 Ok(views)
             },
+            on_terminal_preview: |shell_id: &str| {
+                let bytes = client
+                    .read_shell(shell_id, READ_BYTES)
+                    .map_err(|error| error.to_string())?;
+                Ok(recent_lines(&String::from_utf8_lossy(&bytes), 3))
+            },
         },
     )?;
     Ok(())
@@ -1111,6 +1117,18 @@ fn dashboard_views_from_sessions(
                     .filter(|session| session.workspace_id == workspace.id),
             );
             let agent_summary = agent_attention_projection::summarize_workspace(workspace);
+            let attention =
+                agent_attention_projection::project_attention(std::slice::from_ref(workspace))
+                    .into_iter()
+                    .next()
+                    .map(|item| tui::WorkspaceAttentionView {
+                        agent_name: item.agent.name,
+                        reason: agent_attention_projection::attention_reason(item.attention.reason)
+                            .into(),
+                        evidence: item.attention.observation.evidence,
+                        observed_at_ms: item.attention.observation.observed_at_ms,
+                        observation_is_current: item.observation_is_current,
+                    });
             let shells = workspace.shells.iter().map(|shell| {
                 let git = git_cache.inspect(&shell.cwd);
                 let shell_view = tui::TerminalView {
@@ -1120,6 +1138,15 @@ fn dashboard_views_from_sessions(
                     directory: shell.cwd.display().to_string(),
                     branch: git.branch,
                     command: shell.command.join(" "),
+                    argv: shell.command.clone(),
+                    run: shell.run.as_ref().map(|run| tui::TerminalRunView {
+                        id: run.id.clone(),
+                        generation: run.generation,
+                        started_at_ms: run.started_at_ms,
+                        ended_at_ms: run.ended_at_ms,
+                        exit_reason: run.exit_reason.as_ref().map(shell_exit_reason),
+                        output_revision: run.output_revision,
+                    }),
                 };
                 let agent = matches!(shell.status, ShellStatus::Running)
                     .then(|| {
@@ -1188,6 +1215,7 @@ fn dashboard_views_from_sessions(
                     name: launcher.name.clone(),
                     directory: launcher.cwd.display().to_string(),
                     command: launcher.command.join(" "),
+                    argv: launcher.command.clone(),
                 })
             });
             tui::WorkspaceView {
@@ -1197,6 +1225,7 @@ fn dashboard_views_from_sessions(
                 sessions,
                 agent_state_counts: agent_summary.states,
                 attention_count: agent_summary.attention_count,
+                attention,
             }
         })
         .collect()
@@ -1212,10 +1241,6 @@ fn workspace_session_views<'a>(
                 .occurrences
                 .iter()
                 .map(|occurrence| tui::AgentSessionRunView {
-                    shell_id: occurrence
-                        .retained_shell_name
-                        .as_ref()
-                        .map(|_| occurrence.shell_id.clone()),
                     shell_name: occurrence.retained_shell_name.clone(),
                     directory: occurrence.source_cwd.clone(),
                 })
@@ -4339,8 +4364,6 @@ mod tests {
         assert_eq!(session.state, "blocked");
         assert!(session.state_is_current);
         assert_eq!(session.runs.len(), 2);
-        assert_eq!(session.runs[0].shell_id.as_deref(), Some("s1"));
-        assert_eq!(session.runs[1].shell_id.as_deref(), Some("s2"));
         assert_eq!(session.runs[0].shell_name.as_deref(), Some("build"));
         assert_eq!(session.runs[1].shell_name.as_deref(), Some("review"));
         assert_eq!(
@@ -4373,6 +4396,7 @@ mod tests {
             items: Vec::new(),
             agent_state_counts: agent_attention_projection::AgentStateCounts::default(),
             attention_count: 0,
+            attention: None,
             sessions: vec![tui::AgentSessionView {
                 id: "session".into(),
                 label: "opencode".into(),
@@ -4384,12 +4408,10 @@ mod tests {
                 source_cwd: Some("/tmp/project".into()),
                 runs: vec![
                     tui::AgentSessionRunView {
-                        shell_id: Some("old-shell-id".into()),
                         shell_name: Some("old-shell".into()),
                         directory: Some("/tmp/project".into()),
                     },
                     tui::AgentSessionRunView {
-                        shell_id: None,
                         shell_name: None,
                         directory: None,
                     },
@@ -4544,6 +4566,7 @@ mod tests {
         };
         assert_eq!(launcher.name, "editor");
         assert_eq!(launcher.command, "zeditor .");
+        assert_eq!(launcher.argv, ["zeditor", "."]);
         assert_eq!(launcher.directory, "/tmp/project");
     }
 
@@ -4560,6 +4583,10 @@ mod tests {
         };
         assert_eq!(command.name, "clock");
         assert_eq!(command.command, "watch -n 1 date");
+        assert_eq!(command.argv, ["watch", "-n", "1", "date"]);
+        let run = command.run.as_ref().expect("current run metadata");
+        assert_eq!(run.id, "r1");
+        assert_eq!(run.generation, 1);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::env;
 use std::error::Error;
 use std::ffi::OsString;
@@ -39,6 +40,7 @@ const BOOMUX_OPENCODE_PLUGIN: &str = include_str!("../integrations/opencode/boom
 const BOOMUX_PI_EXTENSION: &str = include_str!("../integrations/pi/boomux.js");
 const VALIDATED_OPENCODE_VERSION: &str = "1.18.15";
 const VALIDATED_PI_VERSION: &str = "0.84.1";
+const MAX_HOST_CATALOG_DIRECTORIES: usize = 8;
 const JSON_COMMANDS: &[&str] = &[
     "capabilities",
     "list",
@@ -80,6 +82,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "protocol_13",
     "protocol_14",
     "protocol_15",
+    "protocol_16",
     "restartable_exited_shells",
     "inactive_agent_state",
     "idempotent_agent_ensure",
@@ -913,7 +916,11 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let mut git_cache = git::Cache::default();
     let mut title_cache = host_session_titles::Cache::default();
-    let mut views = dashboard_views(&client.snapshot()?.workspaces, &mut git_cache);
+    let mut views = dashboard_views_with_catalog(
+        &client.snapshot()?.workspaces,
+        &mut git_cache,
+        &mut title_cache,
+    );
     enrich_session_titles(&mut views, &mut title_cache);
     let config = config::load()?;
     let terminal = terminal_override
@@ -1040,7 +1047,11 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             },
             on_refresh: || {
                 let snapshot = client.snapshot().map_err(|error| error.to_string())?;
-                let mut views = dashboard_views(&snapshot.workspaces, &mut git_cache);
+                let mut views = dashboard_views_with_catalog(
+                    &snapshot.workspaces,
+                    &mut git_cache,
+                    &mut title_cache,
+                );
                 enrich_session_titles(&mut views, &mut title_cache);
                 Ok(views)
             },
@@ -1067,14 +1078,38 @@ where
     }
 }
 
+#[cfg(test)]
 fn dashboard_views(
     workspaces: &[WorkspaceSnapshot],
     git_cache: &mut git::Cache,
 ) -> Vec<tui::WorkspaceView> {
+    let sessions = session_projection::project_workspaces(workspaces);
+    dashboard_views_from_sessions(workspaces, git_cache, &sessions)
+}
+
+fn dashboard_views_with_catalog(
+    workspaces: &[WorkspaceSnapshot],
+    git_cache: &mut git::Cache,
+    title_cache: &mut host_session_titles::Cache,
+) -> Vec<tui::WorkspaceView> {
+    let catalog = cached_host_catalog(workspaces, title_cache);
+    let sessions = session_projection::project_workspaces_with_catalog(workspaces, Some(&catalog));
+    dashboard_views_from_sessions(workspaces, git_cache, &sessions)
+}
+
+fn dashboard_views_from_sessions(
+    workspaces: &[WorkspaceSnapshot],
+    git_cache: &mut git::Cache,
+    sessions: &[session_projection::SessionProjection],
+) -> Vec<tui::WorkspaceView> {
     workspaces
         .iter()
         .map(|workspace| {
-            let sessions = workspace_session_views(workspace);
+            let sessions = workspace_session_views(
+                sessions
+                    .iter()
+                    .filter(|session| session.workspace_id == workspace.id),
+            );
             let agent_summary = agent_attention_projection::summarize_workspace(workspace);
             let shells = workspace.shells.iter().map(|shell| {
                 let git = git_cache.inspect(&shell.cwd);
@@ -1136,11 +1171,15 @@ fn dashboard_views(
                             confidence: agent.observation.confidence,
                             evidence: agent.observation.evidence.clone(),
                         }),
+                        hinted_integration: None,
                     }),
-                    (None, Some("opencode" | "pi")) if !suppress_foreground_hint => {
+                    (None, Some(integration @ ("opencode" | "pi")))
+                        if !suppress_foreground_hint =>
+                    {
                         tui::WorkspaceItemView::AgentShell(tui::AgentShellView {
                             shell: shell_view,
                             agent: None,
+                            hinted_integration: Some(integration.to_owned()),
                         })
                     }
                     (None, _) => tui::WorkspaceItemView::Shell(shell_view),
@@ -1166,34 +1205,92 @@ fn dashboard_views(
         .collect()
 }
 
-fn workspace_session_views(workspace: &WorkspaceSnapshot) -> Vec<tui::AgentSessionView> {
-    session_projection::project_workspaces(std::slice::from_ref(workspace))
+fn workspace_session_views<'a>(
+    sessions: impl IntoIterator<Item = &'a session_projection::SessionProjection>,
+) -> Vec<tui::AgentSessionView> {
+    sessions
         .into_iter()
         .map(|session| {
             let runs = session
                 .occurrences
-                .into_iter()
+                .iter()
                 .map(|occurrence| tui::AgentSessionRunView {
                     shell_id: occurrence
                         .retained_shell_name
                         .as_ref()
-                        .map(|_| occurrence.shell_id),
-                    shell_name: occurrence.retained_shell_name,
-                    directory: occurrence.source_cwd,
+                        .map(|_| occurrence.shell_id.clone()),
+                    shell_name: occurrence.retained_shell_name.clone(),
+                    directory: occurrence.source_cwd.clone(),
                 })
                 .collect();
             tui::AgentSessionView {
-                id: session.id,
-                label: session.description,
-                integration: session.integration,
-                external_session_id: session.external_session_id,
+                id: session.id.clone(),
+                label: session.description.clone(),
+                integration: session.integration.clone(),
+                external_session_id: session.external_session_id.clone(),
                 state: cli_output::agent_state(session.state).into(),
                 state_is_current: session.state_is_current,
                 last_at_ms: session.last_at_ms,
+                source_cwd: session.source_cwd.clone(),
                 runs,
             }
         })
         .collect()
+}
+
+fn workspace_source_directories(workspaces: &[WorkspaceSnapshot]) -> BTreeSet<PathBuf> {
+    workspaces
+        .iter()
+        .flat_map(|workspace| {
+            workspace
+                .shells
+                .iter()
+                .map(|shell| shell.cwd.clone())
+                .chain(
+                    workspace
+                        .launchers
+                        .iter()
+                        .map(|launcher| launcher.cwd.clone()),
+                )
+                .chain(
+                    workspace
+                        .agents
+                        .iter()
+                        .filter_map(|agent| agent.cwd.clone()),
+                )
+        })
+        .collect()
+}
+
+fn cached_host_catalog(
+    workspaces: &[WorkspaceSnapshot],
+    cache: &mut host_session_titles::Cache,
+) -> Vec<host_session_titles::HostSession> {
+    workspace_source_directories(workspaces)
+        .into_iter()
+        .take(MAX_HOST_CATALOG_DIRECTORIES)
+        .filter_map(|directory| cache.catalog("opencode", &directory))
+        .flatten()
+        .collect()
+}
+
+fn discover_host_catalog(
+    workspaces: &[WorkspaceSnapshot],
+) -> Vec<host_session_titles::HostSession> {
+    let directories = workspace_source_directories(workspaces)
+        .into_iter()
+        .take(MAX_HOST_CATALOG_DIRECTORIES)
+        .collect::<Vec<_>>();
+    thread::scope(|scope| {
+        directories
+            .into_iter()
+            .map(|directory| scope.spawn(move || host_session_titles::catalog(&directory)))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .filter_map(|handle| handle.join().ok().flatten())
+            .flatten()
+            .collect()
+    })
 }
 
 fn enrich_session_titles(
@@ -1221,6 +1318,7 @@ where
             .iter()
             .rev()
             .find_map(|run| run.directory.as_deref())
+            .or(session.source_cwd.as_deref())
         else {
             continue;
         };
@@ -2081,14 +2179,19 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
     let client = client::connect_or_start()?;
     validate_session_protocol(client.protocol_version()?)?;
     let snapshot = client.snapshot()?;
-    let sessions = session_projection::project_snapshot(&snapshot);
     match command {
         SessionCommands::List { workspace } => {
-            let workspace_id = workspace
+            let selected_workspace = workspace
                 .as_deref()
                 .map(|target| resolve_workspace_target(&snapshot.workspaces, target))
-                .transpose()?
-                .map(|workspace| workspace.id.as_str());
+                .transpose()?;
+            let catalog = selected_workspace.map_or_else(
+                || discover_host_catalog(&snapshot.workspaces),
+                |workspace| discover_host_catalog(std::slice::from_ref(workspace)),
+            );
+            let sessions =
+                session_projection::project_snapshot_with_catalog(&snapshot, Some(&catalog));
+            let workspace_id = selected_workspace.map(|workspace| workspace.id.as_str());
             let sessions = sessions
                 .iter()
                 .filter(|session| {
@@ -2127,6 +2230,9 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
             }
         }
         SessionCommands::Inspect { session_id } => {
+            let catalog = discover_host_catalog(&snapshot.workspaces);
+            let sessions =
+                session_projection::project_snapshot_with_catalog(&snapshot, Some(&catalog));
             let session = match session_projection::resolve_exact(&sessions, &session_id) {
                 Ok(session) => session,
                 Err(session_projection::ResolveError::NotFound) => {
@@ -2156,6 +2262,9 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
             limit,
             max_bytes,
         } => {
+            let catalog = discover_host_catalog(&snapshot.workspaces);
+            let sessions =
+                session_projection::project_snapshot_with_catalog(&snapshot, Some(&catalog));
             let session = match session_projection::resolve_exact(&sessions, &session_id) {
                 Ok(session) => session,
                 Err(session_projection::ResolveError::NotFound) => {
@@ -2242,6 +2351,13 @@ fn print_session(session: &session_projection::SessionProjection) {
     );
     println!("STARTED AT MS\t{}", session.started_at_ms);
     println!("LAST ACTIVITY MS\t{}", session.last_at_ms);
+    println!(
+        "SOURCE CWD\t{}",
+        session
+            .source_cwd
+            .as_ref()
+            .map_or_else(|| "-".into(), |cwd| cwd.display().to_string())
+    );
     println!("OCCURRENCES\t{}", session.occurrences.len());
     for (index, occurrence) in session.occurrences.iter().enumerate() {
         println!();
@@ -3101,6 +3217,7 @@ fn install_opencode_at(config_root: &Path, force: bool) -> Result<(), Box<dyn Er
         );
     } else {
         println!("Installed Boomux OpenCode plugin at {}", path.display());
+        println!("Restart any running OpenCode process to activate the plugin");
     }
     Ok(())
 }
@@ -3145,6 +3262,7 @@ fn install_pi_at(config_root: &Path, force: bool) -> Result<(), Box<dyn Error>> 
         );
     } else {
         println!("Installed Boomux Pi extension at {}", path.display());
+        println!("Restart any running Pi process to activate the extension");
     }
     Ok(())
 }
@@ -3252,17 +3370,28 @@ fn legacy_skill_install_path(home: &Path) -> PathBuf {
 
 fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     let mut healthy = true;
-    match client::connect_or_start() {
-        Ok(client) => println!(
-            "ok  daemon: protocol {} ({})",
-            protocol::PROTOCOL_VERSION,
-            client.socket_path().display()
-        ),
+    let daemon_snapshot = match client::connect_or_start() {
+        Ok(client) => {
+            println!(
+                "ok  daemon: protocol {} ({})",
+                client.protocol_version()?,
+                client.socket_path().display()
+            );
+            match client.snapshot() {
+                Ok(snapshot) => Some(snapshot),
+                Err(error) => {
+                    healthy = false;
+                    eprintln!("err daemon snapshot: {error}");
+                    None
+                }
+            }
+        }
         Err(error) => {
             healthy = false;
             eprintln!("err daemon: {error}");
+            None
         }
-    }
+    };
     for command in ["git"] {
         match Command::new(command).arg("--version").output() {
             Ok(output) if output.status.success() => {
@@ -3333,10 +3462,106 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             eprintln!("err config: {error}");
         }
     }
+    if let Some(snapshot) = daemon_snapshot.as_ref() {
+        healthy &= print_integration_diagnostic(
+            "opencode",
+            "plugin",
+            opencode_config_root(env::var_os("XDG_CONFIG_HOME"), env::var_os("HOME"))
+                .map(|root| opencode_install_path(&root)),
+            BOOMUX_OPENCODE_PLUGIN,
+            snapshot,
+        );
+        healthy &= print_integration_diagnostic(
+            "pi",
+            "extension",
+            pi_config_root(env::var_os("PI_CODING_AGENT_DIR"), env::var_os("HOME"))
+                .map(|root| pi_install_path(&root)),
+            BOOMUX_PI_EXTENSION,
+            snapshot,
+        );
+    }
     if healthy {
         Ok(())
     } else {
         Err("one or more dependency or configuration checks failed".into())
+    }
+}
+
+fn print_integration_diagnostic(
+    integration: &str,
+    asset_name: &str,
+    path: Result<PathBuf, Box<dyn Error>>,
+    expected: &str,
+    snapshot: &Snapshot,
+) -> bool {
+    let running = snapshot.workspaces.iter().flat_map(|workspace| {
+        workspace.shells.iter().filter_map(move |shell| {
+            (matches!(shell.status, ShellStatus::Running)
+                && shell.foreground_process.as_deref() == Some(integration))
+            .then_some((workspace, shell))
+        })
+    });
+    let running = running.collect::<Vec<_>>();
+    let untracked = running
+        .iter()
+        .filter(|(workspace, shell)| {
+            !shell.run.as_ref().is_some_and(|run| {
+                workspace.agents.iter().any(|agent| {
+                    agent.integration == integration
+                        && agent.shell_id == shell.id
+                        && agent.run_id == run.id
+                        && agent.ended_at_ms.is_none()
+                        && !matches!(
+                            agent.observation.state,
+                            AgentState::Inactive | AgentState::Done
+                        )
+                })
+            })
+        })
+        .count();
+    let path = match path {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("err {integration} integration: cannot resolve {asset_name} path: {error}");
+            return false;
+        }
+    };
+    let state = match read_regular_file(&path) {
+        Ok(None) => "missing",
+        Ok(Some(contents)) if contents == expected.as_bytes() => "current",
+        Ok(Some(_)) => "stale",
+        Err(error) => {
+            eprintln!(
+                "err {integration} integration: invalid {asset_name} at {}: {error}",
+                path.display()
+            );
+            return false;
+        }
+    };
+    if running.is_empty() {
+        println!(
+            "ok  {integration} integration: {asset_name} {state} at {}",
+            path.display()
+        );
+        return true;
+    }
+    if state != "current" {
+        eprintln!(
+            "err {integration} integration: {asset_name} {state} at {}; run boomux {integration} install{}",
+            path.display(),
+            if state == "stale" { " --force" } else { "" }
+        );
+        return false;
+    }
+    if untracked == 0 {
+        println!("ok  {integration} integration: lifecycle registration active");
+        true
+    } else {
+        eprintln!(
+            "err {integration} integration: {untracked} foreground process(es) are untracked; restart {integration} and verify it loads {}",
+            path.display()
+        );
+        false
     }
 }
 
@@ -4159,6 +4384,7 @@ mod tests {
                 state: "inactive".into(),
                 state_is_current: false,
                 last_at_ms: 30,
+                source_cwd: Some("/tmp/project".into()),
                 runs: vec![
                     tui::AgentSessionRunView {
                         shell_id: Some("old-shell-id".into()),
@@ -4257,12 +4483,14 @@ mod tests {
         let mut first = agent("agent-z", "w1", "s1");
         first.started_at_ms = 10;
         workspace.agents = vec![first.clone()];
-        let initial_id = workspace_session_views(&workspace)[0].id.clone();
+        let initial = session_projection::project_workspaces(std::slice::from_ref(&workspace));
+        let initial_id = workspace_session_views(&initial)[0].id.clone();
 
         let mut added = agent("agent-a", "w1", "s1");
         added.started_at_ms = 10;
         workspace.agents.push(added);
-        let sessions = workspace_session_views(&workspace);
+        let projected = session_projection::project_workspaces(std::slice::from_ref(&workspace));
+        let sessions = workspace_session_views(&projected);
 
         assert_eq!(sessions[0].id, initial_id);
         assert_eq!(sessions[0].runs.len(), 2);
@@ -4348,7 +4576,7 @@ mod tests {
         let views = dashboard_views(&[workspace], &mut git::Cache::default());
 
         assert_eq!(views[0].items.len(), 2);
-        let tui::WorkspaceItemView::AgentShell(tui::AgentShellView { shell, agent }) =
+        let tui::WorkspaceItemView::AgentShell(tui::AgentShellView { shell, agent, .. }) =
             &views[0].items[0]
         else {
             panic!("expected agent-shell item");
@@ -4825,6 +5053,7 @@ mod tests {
             "canonical_session_transcripts",
             "transcript_pagination",
             "protocol_15",
+            "protocol_16",
             "persistent_agent_attention",
             "desktop_notifications",
         ] {
@@ -4836,7 +5065,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 15);
+        assert_eq!(protocol::PROTOCOL_VERSION, 16);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 15;
+pub const PROTOCOL_VERSION: u32 = 16;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -306,6 +306,35 @@ pub struct TerminalProfile {
     pub pixel_height: u16,
 }
 
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnixEnvironment {
+    pub variables: Vec<UnixEnvironmentVariable>,
+}
+
+impl std::fmt::Debug for UnixEnvironment {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("UnixEnvironment")
+            .field(
+                "variables",
+                &format_args!("<redacted: {}>", self.variables.len()),
+            )
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnixEnvironmentVariable {
+    pub name: Vec<u8>,
+    pub value: Vec<u8>,
+}
+
+impl std::fmt::Debug for UnixEnvironmentVariable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("UnixEnvironmentVariable(<redacted>)")
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShellSpec {
     pub name: String,
@@ -433,6 +462,8 @@ pub enum Request {
         #[serde(default)]
         restart_exited: bool,
         profile: TerminalProfile,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        environment: Option<UnixEnvironment>,
     },
 }
 
@@ -644,6 +675,12 @@ mod tests {
                 pixel_width: 800,
                 pixel_height: 600,
             },
+            environment: Some(UnixEnvironment {
+                variables: vec![UnixEnvironmentVariable {
+                    name: b"NON_UTF8".to_vec(),
+                    value: vec![0xff, 0xfe],
+                }],
+            }),
         });
         let mut bytes = Vec::new();
         write_message(&mut bytes, &value).unwrap();
@@ -784,9 +821,33 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_fifteen_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 15);
+    fn protocol_version_is_sixteen_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 16);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
+    }
+
+    #[test]
+    fn attach_environment_is_optional_and_debug_is_redacted() {
+        let legacy = r#"{"request":"attach","shell_id":"s1","takeover":false,"profile":{"term":null,"colorterm":null,"term_program":null,"term_program_version":null,"rows":24,"cols":80,"pixel_width":0,"pixel_height":0}}"#;
+        let request: Request = serde_json::from_str(legacy).unwrap();
+        assert!(matches!(
+            request,
+            Request::Attach {
+                environment: None,
+                ..
+            }
+        ));
+
+        let environment = UnixEnvironment {
+            variables: vec![UnixEnvironmentVariable {
+                name: b"SECRET_NAME".to_vec(),
+                value: b"secret-value".to_vec(),
+            }],
+        };
+        let debug = format!("{environment:?}");
+        assert!(!debug.contains("SECRET_NAME"));
+        assert!(!debug.contains("secret-value"));
+        assert!(debug.contains("redacted"));
     }
 
     #[test]

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -1,5 +1,5 @@
-use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 
 use uuid::Uuid;
 
@@ -7,6 +7,9 @@ use boomux::protocol::{
     AgentInstanceSnapshot, AgentObservationSnapshot, AgentState, ShellStatus, Snapshot,
     WorkspaceSnapshot,
 };
+
+use crate::host_session_source::normalize_absolute;
+use crate::host_session_titles::HostSession;
 
 // Frozen namespace for opaque boomux projected-session IDs.
 const SESSION_ID_NAMESPACE: Uuid = Uuid::from_u128(0x8ea7578e_7532_5d53_91f6_1d210f960b48);
@@ -23,6 +26,7 @@ pub(crate) struct SessionProjection {
     pub(crate) state_is_current: bool,
     pub(crate) started_at_ms: u64,
     pub(crate) last_at_ms: u64,
+    pub(crate) source_cwd: Option<PathBuf>,
     pub(crate) occurrences: Vec<SessionOccurrence>,
 }
 
@@ -46,15 +50,29 @@ pub(crate) enum ResolveError {
     DuplicateId,
 }
 
-pub(crate) fn project_snapshot(snapshot: &Snapshot) -> Vec<SessionProjection> {
-    project_workspaces(&snapshot.workspaces)
+#[cfg(test)]
+pub(crate) fn project_workspaces(workspaces: &[WorkspaceSnapshot]) -> Vec<SessionProjection> {
+    project_workspaces_with_catalog(workspaces, None)
 }
 
-pub(crate) fn project_workspaces(workspaces: &[WorkspaceSnapshot]) -> Vec<SessionProjection> {
+pub(crate) fn project_snapshot_with_catalog(
+    snapshot: &Snapshot,
+    catalog: Option<&[HostSession]>,
+) -> Vec<SessionProjection> {
+    project_workspaces_with_catalog(&snapshot.workspaces, catalog)
+}
+
+pub(crate) fn project_workspaces_with_catalog(
+    workspaces: &[WorkspaceSnapshot],
+    catalog: Option<&[HostSession]>,
+) -> Vec<SessionProjection> {
     let mut sessions = workspaces
         .iter()
         .flat_map(project_workspace)
         .collect::<Vec<_>>();
+    if let Some(catalog) = catalog {
+        merge_catalog(workspaces, &mut sessions, catalog);
+    }
     sessions.sort_by(|left, right| {
         right
             .last_at_ms
@@ -142,7 +160,7 @@ fn project_workspace(workspace: &WorkspaceSnapshot) -> Vec<SessionProjection> {
                 })
                 .max()
                 .unwrap_or(first.started_at_ms);
-            let occurrences = agents
+            let occurrences: Vec<SessionOccurrence> = agents
                 .into_iter()
                 .map(|agent| {
                     let retained_shell = shells.get(agent.shell_id.as_str()).copied();
@@ -163,6 +181,7 @@ fn project_workspace(workspace: &WorkspaceSnapshot) -> Vec<SessionProjection> {
                     }
                 })
                 .collect();
+            let source_cwd = agents_source_cwd(&occurrences);
 
             SessionProjection {
                 id: stable_session_id(&workspace.id, &integration, &identity),
@@ -175,10 +194,102 @@ fn project_workspace(workspace: &WorkspaceSnapshot) -> Vec<SessionProjection> {
                 state_is_current,
                 started_at_ms: first.started_at_ms,
                 last_at_ms,
+                source_cwd,
                 occurrences,
             }
         })
         .collect()
+}
+
+fn agents_source_cwd(occurrences: &[SessionOccurrence]) -> Option<PathBuf> {
+    occurrences
+        .iter()
+        .rev()
+        .find_map(|occurrence| occurrence.source_cwd.clone())
+}
+
+fn merge_catalog(
+    workspaces: &[WorkspaceSnapshot],
+    sessions: &mut Vec<SessionProjection>,
+    catalog: &[HostSession],
+) {
+    let workspace_directories = workspaces
+        .iter()
+        .map(|workspace| (workspace.id.as_str(), workspace_directories(workspace)))
+        .collect::<Vec<_>>();
+
+    for record in catalog {
+        let Some(record_directory) = normalize_absolute(&record.directory) else {
+            continue;
+        };
+        let matching_workspaces = workspace_directories
+            .iter()
+            .filter(|(_, directories)| directories.contains(&record_directory))
+            .map(|(workspace_id, _)| *workspace_id)
+            .collect::<Vec<_>>();
+        if matching_workspaces.is_empty() {
+            continue;
+        }
+        for workspace_id in matching_workspaces {
+            let Some(workspace) = workspaces
+                .iter()
+                .find(|workspace| workspace.id == workspace_id)
+            else {
+                continue;
+            };
+            let identity = format!("external:{}", record.root_id);
+            if let Some(session) = sessions.iter_mut().find(|session| {
+                session.workspace_id == workspace.id
+                    && session.integration == record.integration
+                    && session.external_session_id.as_deref() == Some(record.root_id.as_str())
+            }) {
+                if session.source_cwd.is_none() {
+                    session.source_cwd = Some(record_directory.clone());
+                }
+                continue;
+            }
+
+            sessions.push(SessionProjection {
+                id: stable_session_id(&workspace.id, &record.integration, &identity),
+                workspace_id: workspace.id.clone(),
+                workspace_name: workspace.name.clone(),
+                integration: record.integration.clone(),
+                external_session_id: Some(record.root_id.clone()),
+                description: record.title.clone(),
+                state: AgentState::Unknown,
+                state_is_current: false,
+                started_at_ms: record.created_at_ms,
+                last_at_ms: record.updated_at_ms,
+                source_cwd: Some(record_directory.clone()),
+                occurrences: Vec::new(),
+            });
+        }
+    }
+}
+
+fn workspace_directories(workspace: &WorkspaceSnapshot) -> BTreeSet<PathBuf> {
+    workspace
+        .shells
+        .iter()
+        .map(|shell| shell.cwd.as_path())
+        .chain(
+            workspace
+                .launchers
+                .iter()
+                .map(|launcher| launcher.cwd.as_path()),
+        )
+        .chain(
+            workspace
+                .agents
+                .iter()
+                .filter_map(|agent| agent.cwd.as_deref()),
+        )
+        .filter_map(normalized_directory)
+        .collect()
+}
+
+fn normalized_directory(directory: &Path) -> Option<PathBuf> {
+    normalize_absolute(directory)
 }
 
 fn occurrence_is_current(workspace: &WorkspaceSnapshot, agent: &AgentInstanceSnapshot) -> bool {
@@ -222,6 +333,17 @@ mod tests {
 
     use super::*;
     use boomux::protocol::{AgentAuthority, ShellRunSnapshot};
+
+    fn catalog_session(id: &str, directory: &str) -> HostSession {
+        HostSession {
+            integration: "opencode".into(),
+            root_id: id.into(),
+            title: format!("Catalog {id}"),
+            directory: PathBuf::from(directory),
+            created_at_ms: 5,
+            updated_at_ms: 50,
+        }
+    }
 
     fn workspace(id: &str, agent_ids: &[&str]) -> WorkspaceSnapshot {
         let shell = boomux::protocol::ShellSnapshot {
@@ -364,6 +486,139 @@ mod tests {
 
         assert_eq!(
             sessions[0].occurrences[0].source_cwd.as_deref(),
+            Some(Path::new("/tmp/project"))
+        );
+        assert_eq!(
+            sessions[0].source_cwd.as_deref(),
+            Some(Path::new("/tmp/project"))
+        );
+    }
+
+    #[test]
+    fn catalog_only_session_requires_one_exact_normalized_workspace_match() {
+        let mut matching = workspace("w1", &[]);
+        matching.shells[0].cwd = "/tmp/project/./src/..".into();
+        let mut unmatched = workspace("w2", &[]);
+        unmatched.shells[0].cwd = "/other/project".into();
+        let catalog = [catalog_session("catalog-only", "/tmp/project")];
+
+        let sessions = project_workspaces_with_catalog(&[matching, unmatched], Some(&catalog));
+
+        assert_eq!(sessions.len(), 1);
+        let session = &sessions[0];
+        assert_eq!(session.workspace_id, "w1");
+        assert_eq!(session.external_session_id.as_deref(), Some("catalog-only"));
+        assert_eq!(session.description, "Catalog catalog-only");
+        assert_eq!(session.state, AgentState::Unknown);
+        assert!(!session.state_is_current);
+        assert!(session.occurrences.is_empty());
+        assert_eq!(
+            session.source_cwd.as_deref(),
+            Some(Path::new("/tmp/project"))
+        );
+        assert_eq!(session.started_at_ms, 5);
+        assert_eq!(session.last_at_ms, 50);
+    }
+
+    #[test]
+    fn catalog_association_uses_launcher_and_agent_cwds() {
+        let mut launcher_match = workspace("launcher", &[]);
+        launcher_match.shells.clear();
+        launcher_match
+            .launchers
+            .push(boomux::protocol::WorkspaceLauncherSnapshot {
+                id: "launcher".into(),
+                workspace_id: "launcher".into(),
+                name: "build".into(),
+                command: vec!["make".into()],
+                cwd: "/launcher/repo".into(),
+            });
+        let mut agent_match = workspace("agent", &["a1"]);
+        agent_match.shells.clear();
+        agent_match.agents[0].cwd = Some("/agent/repo".into());
+        let catalog = [
+            catalog_session("from-launcher", "/launcher/repo"),
+            catalog_session("from-agent", "/agent/repo"),
+        ];
+
+        let sessions =
+            project_workspaces_with_catalog(&[launcher_match, agent_match], Some(&catalog));
+
+        assert_eq!(sessions.len(), 3);
+        assert!(sessions.iter().any(|session| {
+            session.workspace_id == "launcher"
+                && session.external_session_id.as_deref() == Some("from-launcher")
+        }));
+        assert!(sessions.iter().any(|session| {
+            session.workspace_id == "agent"
+                && session.external_session_id.as_deref() == Some("from-agent")
+        }));
+    }
+
+    #[test]
+    fn shared_catalog_directories_project_into_each_matching_workspace() {
+        let first = workspace("w1", &[]);
+        let second = workspace("w2", &[]);
+        let catalog = [
+            catalog_session("ambiguous", "/tmp/project"),
+            catalog_session("unmatched", "/elsewhere"),
+        ];
+
+        let sessions = project_workspaces_with_catalog(&[first, second], Some(&catalog));
+        assert_eq!(sessions.len(), 2);
+        assert!(
+            sessions
+                .iter()
+                .all(|session| { session.external_session_id.as_deref() == Some("ambiguous") })
+        );
+    }
+
+    #[test]
+    fn catalog_merges_durable_identity_and_keeps_stable_id_and_durable_source() {
+        let durable = workspace("w1", &["a1"]);
+        let durable_only = project_workspaces(std::slice::from_ref(&durable));
+        let mut record = catalog_session("external", "/tmp/project");
+        record.created_at_ms = 1;
+        record.updated_at_ms = 100;
+
+        let merged = project_workspaces_with_catalog(&[durable], Some(&[record]));
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].id, durable_only[0].id);
+        assert_eq!(merged[0].description, durable_only[0].description);
+        assert_eq!(merged[0].state, AgentState::Working);
+        assert!(merged[0].state_is_current);
+        assert_eq!(merged[0].occurrences.len(), 1);
+        assert_eq!(merged[0].source_cwd, durable_only[0].source_cwd);
+        assert_eq!(merged[0].started_at_ms, durable_only[0].started_at_ms);
+        assert_eq!(merged[0].last_at_ms, durable_only[0].last_at_ms);
+    }
+
+    #[test]
+    fn catalog_directory_is_the_fallback_when_durable_source_is_missing() {
+        let mut durable = workspace("w1", &["a1"]);
+        durable.shells.clear();
+        durable.agents[0].cwd = None;
+        durable
+            .launchers
+            .push(boomux::protocol::WorkspaceLauncherSnapshot {
+                id: "launcher".into(),
+                workspace_id: "w1".into(),
+                name: "agent".into(),
+                command: vec!["opencode".into()],
+                cwd: "/tmp/project".into(),
+            });
+
+        let merged = project_workspaces_with_catalog(
+            &[durable],
+            Some(&[catalog_session("external", "/tmp/project")]),
+        );
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].occurrences.len(), 1);
+        assert!(merged[0].occurrences[0].source_cwd.is_none());
+        assert_eq!(
+            merged[0].source_cwd.as_deref(),
             Some(Path::new("/tmp/project"))
         );
     }

--- a/src/session_transcript.rs
+++ b/src/session_transcript.rs
@@ -152,17 +152,12 @@ fn read_with_adapters(
             "session has no canonical external session ID",
         )
     })?;
-    let directory = session
-        .occurrences
-        .iter()
-        .rev()
-        .find_map(|occurrence| occurrence.source_cwd.as_deref())
-        .ok_or_else(|| {
-            TranscriptError::new(
-                "session_source_unavailable",
-                "session has no retained working directory for host lookup",
-            )
-        })?;
+    let directory = session.source_cwd.as_deref().ok_or_else(|| {
+        TranscriptError::new(
+            "session_source_unavailable",
+            "session has no retained working directory for host lookup",
+        )
+    })?;
 
     let adapter = adapters
         .iter()
@@ -562,6 +557,7 @@ mod tests {
             state_is_current: true,
             started_at_ms: 1,
             last_at_ms: 2,
+            source_cwd: Some(PathBuf::from("/repo")),
             occurrences: vec![SessionOccurrence {
                 agent_id: "agent".into(),
                 shell_id: "shell".into(),
@@ -695,6 +691,27 @@ mod tests {
         assert_eq!(transcript.integration, "future-harness");
         assert_eq!(transcript.entries[0].text.as_deref(), Some("adapter"));
         assert_eq!(transcript.truncated_by, ["max_bytes"]);
+    }
+
+    #[test]
+    fn session_level_source_reads_without_occurrences() {
+        let adapter = FutureHarnessAdapter;
+        let mut catalog_only = session("future-harness");
+        catalog_only.occurrences.clear();
+
+        let transcript = read_with_adapters(
+            &catalog_only,
+            None,
+            10,
+            usize::MAX,
+            &[&adapter as &dyn TranscriptAdapter],
+        )
+        .unwrap();
+
+        assert_eq!(
+            transcript.entries[0].text.as_deref(),
+            Some("adapter output")
+        );
     }
 
     #[test]
@@ -873,7 +890,7 @@ mod tests {
         );
 
         let mut moved = original.clone();
-        moved.occurrences[0].source_cwd = Some(PathBuf::from("/other"));
+        moved.source_cwd = Some(PathBuf::from("/other"));
         assert_eq!(
             read_mutable(&moved, &adapter, Some(&cursor), 1, usize::MAX)
                 .unwrap_err()

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::error::Error;
 use std::ffi::OsString;
 use std::fs;
+use std::io;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{self, Command, Stdio};
@@ -45,7 +46,7 @@ pub(crate) fn open(
         .arg(r"--print-cmd=\0")
         .arg(format!("--title={title}"))
         .arg("--")
-        .arg(env::current_exe()?)
+        .arg(attachment_executable()?)
         .args(["__attach", shell_id, "--restart-exited"]);
     if takeover {
         resolver.arg("--takeover");
@@ -80,6 +81,22 @@ pub(crate) fn open(
         .spawn()
         .map_err(|error| format!("could not launch {selected}: {error}"))?;
     Ok(())
+}
+
+fn attachment_executable() -> io::Result<PathBuf> {
+    Ok(select_attachment_executable(env::current_exe()?))
+}
+
+fn select_attachment_executable(current: PathBuf) -> PathBuf {
+    if current.exists() {
+        return current;
+    }
+    current
+        .to_str()
+        .and_then(|path| path.strip_suffix(" (deleted)"))
+        .map(PathBuf::from)
+        .filter(|path| path.exists())
+        .unwrap_or(current)
 }
 
 fn selected_with_preference(
@@ -203,6 +220,16 @@ mod tests {
             ["alacritty", "-e", "boomux", "__attach"]
                 .map(OsStr::new)
                 .map(OsStr::to_owned)
+        );
+    }
+
+    #[test]
+    fn attachment_finds_installed_binary_after_replacement() {
+        let installed = PathBuf::from("/bin/sh");
+
+        assert_eq!(
+            select_attachment_executable(PathBuf::from("/bin/sh (deleted)")),
+            installed
         );
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -61,7 +61,6 @@ pub(crate) enum WorkspaceItemView {
 pub(crate) struct AgentShellView {
     pub(crate) shell: TerminalView,
     pub(crate) agent: Option<AgentView>,
-    pub(crate) hinted_integration: Option<String>,
 }
 
 impl AgentShellView {
@@ -70,19 +69,13 @@ impl AgentShellView {
             .as_ref()
             .map_or("untracked", |agent| agent.state.as_str())
     }
-
-    fn integration(&self) -> Option<&str> {
-        self.agent
-            .as_ref()
-            .map(|agent| agent.integration.as_str())
-            .or(self.hinted_integration.as_deref())
-    }
 }
 
 pub(crate) struct AgentView {
     pub(crate) id: String,
     pub(crate) state: String,
     pub(crate) integration: String,
+    pub(crate) external_session_id: Option<String>,
     pub(crate) authority: String,
     pub(crate) confidence: u8,
     pub(crate) evidence: String,
@@ -238,10 +231,9 @@ enum PrimaryTab {
 }
 
 impl PrimaryTab {
-    const ALL: [Self; 6] = [
+    const ALL: [Self; 5] = [
         Self::Workspaces,
         Self::Agents,
-        Self::Sessions,
         Self::Launchers,
         Self::Shells,
         Self::Commands,
@@ -1975,12 +1967,16 @@ fn contextual_session_panel(app: &App) -> Option<ContextualSessionPanel> {
     let WorkspaceItemView::AgentShell(agent_shell) = app.selected_item()? else {
         return None;
     };
-    let integration = agent_shell.integration()?;
+    let agent = agent_shell.agent.as_ref()?;
+    let external_session_id = agent.external_session_id.as_deref()?;
     let workspace = app.selected_item_workspace()?;
     let sessions: Vec<_> = workspace
         .sessions
         .iter()
-        .filter(|session| session.integration == integration)
+        .filter(|session| {
+            session.integration == agent.integration
+                && session.external_session_id.as_deref() == Some(external_session_id)
+        })
         .collect();
     if sessions.is_empty() {
         return None;
@@ -2056,7 +2052,7 @@ fn contextual_session_panel(app: &App) -> Option<ContextualSessionPanel> {
         content_height += categorized_count * 2;
     }
     Some(ContextualSessionPanel {
-        title: format!(" {} sessions ", integration_display_name(integration)),
+        title: format!(" {} session ", integration_display_name(&agent.integration)),
         rows,
         content_height,
     })
@@ -2292,7 +2288,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             let line = Line::from(vec![
                 Span::styled(" j/k", Style::new().fg(TEAL)),
                 Span::styled(
-                    " navigate  tab/shift-tab views  1-6 select view  ",
+                    " navigate  tab/shift-tab views  1-5 select view  ",
                     Style::new().fg(SUBTEXT),
                 ),
                 Span::styled("enter", Style::new().fg(GREEN)),
@@ -2312,7 +2308,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 if app.primary_tab == PrimaryTab::Workspaces {
                     " navigate  tab/shift-tab views  h/l panes  "
                 } else {
-                    " navigate  tab/shift-tab views  1-6 select view  "
+                    " navigate  tab/shift-tab views  1-5 select view  "
                 },
                 Style::new().fg(SUBTEXT),
             ),
@@ -2443,6 +2439,7 @@ mod tests {
             id: "agent-1".into(),
             state: "working".into(),
             integration: "opencode".into(),
+            external_session_id: Some("external-active".into()),
             authority: "lifecycle_integration".into(),
             confidence: 95,
             evidence: "tool call in progress".into(),
@@ -2460,7 +2457,6 @@ mod tests {
                 command: String::new(),
             },
             agent: Some(agent()),
-            hinted_integration: None,
         }
     }
 
@@ -2497,7 +2493,6 @@ mod tests {
                 command: String::new(),
             },
             agent: None,
-            hinted_integration: Some("opencode".into()),
         }
     }
 
@@ -2596,11 +2591,7 @@ mod tests {
         app.cycle_tab(false);
         assert_eq!(app.primary_tab, PrimaryTab::Agents);
         app.cycle_tab(false);
-        assert_eq!(app.primary_tab, PrimaryTab::Sessions);
-        app.cycle_tab(false);
         assert_eq!(app.primary_tab, PrimaryTab::Launchers);
-        app.cycle_tab(true);
-        assert_eq!(app.primary_tab, PrimaryTab::Sessions);
         app.cycle_tab(true);
         assert_eq!(app.primary_tab, PrimaryTab::Agents);
         app.cycle_tab(true);
@@ -2611,11 +2602,11 @@ mod tests {
     #[test]
     fn numeric_shortcuts_match_primary_tab_order() {
         assert_eq!(
-            ('1'..='6').filter_map(shortcut_tab).collect::<Vec<_>>(),
+            ('1'..='5').filter_map(shortcut_tab).collect::<Vec<_>>(),
             PrimaryTab::ALL
         );
         assert_eq!(shortcut_tab('0'), None);
-        assert_eq!(shortcut_tab('7'), None);
+        assert_eq!(shortcut_tab('6'), None);
     }
 
     #[test]
@@ -2707,7 +2698,7 @@ mod tests {
 
         assert!(text.contains("WORKSPACES 1"));
         assert!(text.contains("AGENTS 1"));
-        assert!(text.contains("SESSIONS 1"));
+        assert!(!text.contains("SESSIONS"));
         assert!(text.contains("LAUNCHERS 1"));
         assert!(text.contains("SHELLS 1"));
         assert!(text.contains("COMMANDS 1"));
@@ -2737,7 +2728,6 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect();
         assert!(agent_text.contains("AGENTS (1)"));
-        assert!(!agent_text.contains("| 1 SESSIONS"));
     }
 
     #[test]
@@ -3416,6 +3406,7 @@ mod tests {
         let mut agent_shell = hinted_agent_shell();
         agent_shell.shell.name = "keepname".into();
         app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell);
+        app.workspaces[0].sessions = vec![session("active", "working")];
         focus_items(&mut app);
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
@@ -3436,6 +3427,7 @@ mod tests {
         assert!(!lines.iter().any(|line| line.contains("opencode")));
         assert!(lines.iter().any(|line| line.contains("untracked")));
         assert!(!lines.iter().any(|line| line.contains("idle")));
+        assert!(!lines.iter().any(|line| line.contains("OpenCode session")));
     }
 
     #[test]
@@ -3481,7 +3473,7 @@ mod tests {
     }
 
     #[test]
-    fn selected_durable_agent_renders_filtered_categorized_sessions() {
+    fn selected_durable_agent_renders_only_its_canonical_session() {
         let backend = TestBackend::new(180, 34);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = app();
@@ -3519,15 +3511,12 @@ mod tests {
             .collect();
         let text = lines.join("\n");
 
-        assert!(text.contains("OpenCode sessions"));
+        assert!(text.contains("OpenCode session"));
         assert!(text.contains("ACTIVE"));
-        assert!(text.contains("LAST 24 HOURS"));
-        assert!(text.contains("LAST 7 DAYS"));
-        assert!(text.contains("OLDER"));
         assert!(text.contains("Current work"));
-        assert!(text.contains("Recent review"));
-        assert!(text.contains("Dormant review"));
-        assert!(text.contains("Finished build"));
+        assert!(!text.contains("Recent review"));
+        assert!(!text.contains("Dormant review"));
+        assert!(!text.contains("Finished build"));
         assert!(!text.contains("Pi session must be filtered"));
         assert!(text.contains("Items: boomux (1)"));
         assert!(lines.iter().any(|line| {
@@ -3884,6 +3873,7 @@ mod tests {
         let mut two = workspace("w2", "two");
         two.items = vec![WorkspaceItemView::AgentShell(agent_shell())];
         let mut right = session("right", "working");
+        right.external_session_id = Some("external-active".into());
         right.label = "Owning workspace session".into();
         two.sessions.push(right);
         let mut app = App::new(vec![one, two], project_context());

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1926,13 +1926,6 @@ enum SessionCategory {
 }
 
 impl SessionCategory {
-    const ALL: [Self; 4] = [
-        Self::Active,
-        Self::Last24Hours,
-        Self::Last7Days,
-        Self::Older,
-    ];
-
     fn label(self) -> &'static str {
         match self {
             Self::Active => "ACTIVE",
@@ -1970,91 +1963,68 @@ fn contextual_session_panel(app: &App) -> Option<ContextualSessionPanel> {
     let agent = agent_shell.agent.as_ref()?;
     let external_session_id = agent.external_session_id.as_deref()?;
     let workspace = app.selected_item_workspace()?;
-    let sessions: Vec<_> = workspace
+    let session = workspace
         .sessions
         .iter()
         .filter(|session| {
             session.integration == agent.integration
                 && session.external_session_id.as_deref() == Some(external_session_id)
         })
-        .collect();
-    if sessions.is_empty() {
-        return None;
-    }
-    let now_ms = current_time_ms();
-    let mut rows = Vec::new();
-    let mut content_height = 0;
-    for category in SessionCategory::ALL {
-        let categorized: Vec<_> = sessions
-            .iter()
-            .copied()
-            .filter(|session| session_category(session, now_ms) == category)
-            .collect();
-        if categorized.is_empty() {
-            continue;
-        }
-        let categorized_count = categorized.len() as u16;
-        rows.push(
-            Row::new([
-                Cell::from(""),
-                Cell::from(category.label()),
-                Cell::from(""),
-                Cell::from(""),
-            ])
-            .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)),
-        );
-        content_height += 1;
-        rows.extend(categorized.into_iter().map(|session| {
-            let label = best_session_label(session);
-            let external_identity = session
-                .external_session_id
-                .as_deref()
-                .map(short_id)
-                .unwrap_or_else(|| short_id(&session.id));
-            let shell = session
-                .runs
-                .last()
-                .and_then(|run| run.shell_name.as_deref())
-                .unwrap_or(if session.runs.is_empty() {
-                    "catalog only"
-                } else {
-                    "removed shell"
-                });
-            let occurrences = session.runs.len();
-            let currency = if session.state_is_current {
-                "current"
-            } else {
-                "last known"
-            };
-            Row::new([
-                Cell::from(Span::styled(
-                    session_state_symbol(&session.state),
-                    Style::new().fg(session_state_color(&session.state)),
+        .max_by(|left, right| {
+            left.state_is_current
+                .cmp(&right.state_is_current)
+                .then_with(|| left.last_at_ms.cmp(&right.last_at_ms))
+                .then_with(|| left.id.cmp(&right.id))
+        })?;
+    let label = best_session_label(session);
+    let external_identity = session
+        .external_session_id
+        .as_deref()
+        .map(short_id)
+        .unwrap_or_else(|| short_id(&session.id));
+    let shell = session
+        .runs
+        .last()
+        .and_then(|run| run.shell_name.as_deref())
+        .unwrap_or(if session.runs.is_empty() {
+            "catalog only"
+        } else {
+            "removed shell"
+        });
+    let occurrences = session.runs.len();
+    let currency = if session.state_is_current {
+        "current"
+    } else {
+        "last known"
+    };
+    let rows = vec![
+        Row::new([
+            Cell::from(Span::styled(
+                session_state_symbol(&session.state),
+                Style::new().fg(session_state_color(&session.state)),
+            )),
+            Cell::from(vec![
+                Line::from(Span::styled(
+                    label,
+                    Style::new().add_modifier(Modifier::BOLD),
                 )),
-                Cell::from(vec![
-                    Line::from(Span::styled(
-                        label,
-                        Style::new().add_modifier(Modifier::BOLD),
-                    )),
-                    Line::from(Span::styled(
-                        format!(
-                            "{shell}  {external_identity}  {occurrences} occurrence{}  {currency}",
-                            if occurrences == 1 { "" } else { "s" }
-                        ),
-                        Style::new().fg(SUBTEXT),
-                    )),
-                ]),
-                Cell::from(session.state.clone()),
-                Cell::from(compact_recency(session.last_at_ms)),
-            ])
-            .height(2)
-        }));
-        content_height += categorized_count * 2;
-    }
+                Line::from(Span::styled(
+                    format!(
+                        "{shell}  {external_identity}  {occurrences} occurrence{}  {currency}",
+                        if occurrences == 1 { "" } else { "s" }
+                    ),
+                    Style::new().fg(SUBTEXT),
+                )),
+            ]),
+            Cell::from(session.state.clone()),
+            Cell::from(compact_recency(session.last_at_ms)),
+        ])
+        .height(2),
+    ];
     Some(ContextualSessionPanel {
         title: format!(" {} session ", integration_display_name(&agent.integration)),
         rows,
-        content_height,
+        content_height: 2,
     })
 }
 
@@ -3485,8 +3455,9 @@ mod tests {
         active.last_at_ms = now;
         let mut recent = session("recent", "inactive");
         recent.label = "Recent review".into();
+        recent.external_session_id = Some("external-active".into());
         recent.state_is_current = false;
-        recent.last_at_ms = now - 2 * 60 * 60 * 1_000;
+        recent.last_at_ms = now + 1;
         let mut week = session("week", "done");
         week.label = "Finished build".into();
         week.state_is_current = false;
@@ -3512,7 +3483,6 @@ mod tests {
         let text = lines.join("\n");
 
         assert!(text.contains("OpenCode session"));
-        assert!(text.contains("ACTIVE"));
         assert!(text.contains("Current work"));
         assert!(!text.contains("Recent review"));
         assert!(!text.contains("Dormant review"));
@@ -3531,6 +3501,18 @@ mod tests {
         assert!(!text.contains("first "));
         assert!(!text.contains("observed "));
         assert!(!text.contains("tool call in progress"));
+
+        app.workspaces[0].sessions[0].state_is_current = false;
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let latest_text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(latest_text.contains("Recent review"));
+        assert!(!latest_text.contains("Current work"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -41,6 +41,7 @@ pub(crate) struct AgentSessionView {
     pub(crate) state: String,
     pub(crate) state_is_current: bool,
     pub(crate) last_at_ms: u64,
+    pub(crate) source_cwd: Option<PathBuf>,
     pub(crate) runs: Vec<AgentSessionRunView>,
 }
 
@@ -60,13 +61,21 @@ pub(crate) enum WorkspaceItemView {
 pub(crate) struct AgentShellView {
     pub(crate) shell: TerminalView,
     pub(crate) agent: Option<AgentView>,
+    pub(crate) hinted_integration: Option<String>,
 }
 
 impl AgentShellView {
     fn status(&self) -> &str {
         self.agent
             .as_ref()
-            .map_or("idle", |agent| agent.state.as_str())
+            .map_or("untracked", |agent| agent.state.as_str())
+    }
+
+    fn integration(&self) -> Option<&str> {
+        self.agent
+            .as_ref()
+            .map(|agent| agent.integration.as_str())
+            .or(self.hinted_integration.as_deref())
     }
 }
 
@@ -1674,7 +1683,11 @@ fn render_global_sessions(frame: &mut Frame, area: Rect, app: &mut App) {
         };
         let latest_shell = latest_existing_session_run(session)
             .and_then(|run| run.shell_name.as_deref())
-            .unwrap_or("removed shell");
+            .unwrap_or(if session.runs.is_empty() {
+                "catalog only"
+            } else {
+                "removed shell"
+            });
         let identity = session
             .external_session_id
             .as_deref()
@@ -1962,12 +1975,12 @@ fn contextual_session_panel(app: &App) -> Option<ContextualSessionPanel> {
     let WorkspaceItemView::AgentShell(agent_shell) = app.selected_item()? else {
         return None;
     };
-    let agent = agent_shell.agent.as_ref()?;
+    let integration = agent_shell.integration()?;
     let workspace = app.selected_item_workspace()?;
     let sessions: Vec<_> = workspace
         .sessions
         .iter()
-        .filter(|session| session.integration == agent.integration)
+        .filter(|session| session.integration == integration)
         .collect();
     if sessions.is_empty() {
         return None;
@@ -2006,7 +2019,11 @@ fn contextual_session_panel(app: &App) -> Option<ContextualSessionPanel> {
                 .runs
                 .last()
                 .and_then(|run| run.shell_name.as_deref())
-                .unwrap_or("removed shell");
+                .unwrap_or(if session.runs.is_empty() {
+                    "catalog only"
+                } else {
+                    "removed shell"
+                });
             let occurrences = session.runs.len();
             let currency = if session.state_is_current {
                 "current"
@@ -2039,10 +2056,7 @@ fn contextual_session_panel(app: &App) -> Option<ContextualSessionPanel> {
         content_height += categorized_count * 2;
     }
     Some(ContextualSessionPanel {
-        title: format!(
-            " {} sessions ",
-            integration_display_name(&agent.integration)
-        ),
+        title: format!(" {} sessions ", integration_display_name(integration)),
         rows,
         content_height,
     })
@@ -2368,7 +2382,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
 
 fn status_color(status: &str) -> Color {
     match status {
-        "pending" => YELLOW,
+        "pending" | "untracked" => YELLOW,
         "exited" => SUBTEXT,
         _ => TEAL,
     }
@@ -2446,6 +2460,7 @@ mod tests {
                 command: String::new(),
             },
             agent: Some(agent()),
+            hinted_integration: None,
         }
     }
 
@@ -2458,6 +2473,7 @@ mod tests {
             state: state.into(),
             state_is_current: true,
             last_at_ms: 30,
+            source_cwd: Some("/tmp/boomux".into()),
             runs: vec![AgentSessionRunView {
                 shell_id: Some("term_1".into()),
                 shell_name: Some("agent".into()),
@@ -2481,6 +2497,7 @@ mod tests {
                 command: String::new(),
             },
             agent: None,
+            hinted_integration: Some("opencode".into()),
         }
     }
 
@@ -3417,7 +3434,8 @@ mod tests {
         assert!(lines.iter().any(|line| line.contains("foreground process")));
         assert!(lines.iter().any(|line| line.contains("keepname")));
         assert!(!lines.iter().any(|line| line.contains("opencode")));
-        assert!(lines.iter().any(|line| line.contains("idle")));
+        assert!(lines.iter().any(|line| line.contains("untracked")));
+        assert!(!lines.iter().any(|line| line.contains("idle")));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -593,6 +593,7 @@ impl App {
     fn select_tab(&mut self, tab: PrimaryTab) {
         self.primary_tab = tab;
         if tab == PrimaryTab::Workspaces {
+            self.focus = Focus::Workspaces;
             return;
         }
         self.focus = Focus::Items;
@@ -2587,6 +2588,7 @@ mod tests {
         assert_eq!(app.primary_tab, PrimaryTab::Agents);
         app.cycle_tab(true);
         assert_eq!(app.primary_tab, PrimaryTab::Workspaces);
+        assert_eq!(app.focus, Focus::Workspaces);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -31,6 +31,15 @@ pub(crate) struct WorkspaceView {
     pub(crate) sessions: Vec<AgentSessionView>,
     pub(crate) agent_state_counts: AgentStateCounts,
     pub(crate) attention_count: usize,
+    pub(crate) attention: Option<WorkspaceAttentionView>,
+}
+
+pub(crate) struct WorkspaceAttentionView {
+    pub(crate) agent_name: String,
+    pub(crate) reason: String,
+    pub(crate) evidence: String,
+    pub(crate) observed_at_ms: u64,
+    pub(crate) observation_is_current: bool,
 }
 
 pub(crate) struct AgentSessionView {
@@ -46,7 +55,6 @@ pub(crate) struct AgentSessionView {
 }
 
 pub(crate) struct AgentSessionRunView {
-    pub(crate) shell_id: Option<String>,
     pub(crate) shell_name: Option<String>,
     pub(crate) directory: Option<PathBuf>,
 }
@@ -86,6 +94,7 @@ pub(crate) struct LauncherView {
     pub(crate) name: String,
     pub(crate) directory: String,
     pub(crate) command: String,
+    pub(crate) argv: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -110,6 +119,17 @@ pub(crate) struct TerminalView {
     pub(crate) directory: String,
     pub(crate) branch: String,
     pub(crate) command: String,
+    pub(crate) argv: Vec<String>,
+    pub(crate) run: Option<TerminalRunView>,
+}
+
+pub(crate) struct TerminalRunView {
+    pub(crate) id: String,
+    pub(crate) generation: u64,
+    pub(crate) started_at_ms: u64,
+    pub(crate) ended_at_ms: Option<u64>,
+    pub(crate) exit_reason: Option<String>,
+    pub(crate) output_revision: u64,
 }
 
 impl TerminalView {
@@ -159,10 +179,6 @@ impl WorkspaceView {
             .count()
     }
 
-    fn session_count(&self) -> usize {
-        self.sessions.len()
-    }
-
     fn process_count(&self) -> usize {
         self.items
             .iter()
@@ -190,7 +206,7 @@ impl WorkspaceItemView {
     }
 }
 
-pub(crate) struct Actions<R, O, C, W, N, E, F> {
+pub(crate) struct Actions<R, O, C, W, N, E, F, P> {
     pub(crate) on_restore: R,
     pub(crate) on_open: O,
     pub(crate) on_close: C,
@@ -198,6 +214,7 @@ pub(crate) struct Actions<R, O, C, W, N, E, F> {
     pub(crate) on_create_shell: N,
     pub(crate) on_rename: E,
     pub(crate) on_refresh: F,
+    pub(crate) on_terminal_preview: P,
 }
 
 struct App {
@@ -205,13 +222,20 @@ struct App {
     workspace_state: TableState,
     item_state: TableState,
     global_state: TableState,
-    session_state: TableState,
     primary_tab: PrimaryTab,
     focus: Focus,
     mode: Mode,
     message: Option<Message>,
     pending_close: Option<PendingClose>,
     project_context: ProjectContext,
+    terminal_preview: Option<TerminalPreviewState>,
+}
+
+struct TerminalPreviewState {
+    shell_id: String,
+    run_id: Option<String>,
+    output_revision: u64,
+    output: Result<String, String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -224,7 +248,6 @@ enum Focus {
 enum PrimaryTab {
     Workspaces,
     Agents,
-    Sessions,
     Launchers,
     Shells,
     Commands,
@@ -243,7 +266,6 @@ impl PrimaryTab {
         match self {
             Self::Workspaces => None,
             Self::Agents => Some(ItemKind::Agent),
-            Self::Sessions => None,
             Self::Launchers => Some(ItemKind::Launcher),
             Self::Shells => Some(ItemKind::Shell),
             Self::Commands => Some(ItemKind::Command),
@@ -254,7 +276,6 @@ impl PrimaryTab {
         match self {
             Self::Workspaces => "WORKSPACES",
             Self::Agents => "AGENTS",
-            Self::Sessions => "SESSIONS",
             Self::Launchers => "LAUNCHERS",
             Self::Shells => "SHELLS",
             Self::Commands => "COMMANDS",
@@ -273,12 +294,6 @@ struct ItemIdentity {
     workspace_id: String,
     item_id: String,
     launcher: bool,
-}
-
-#[derive(Clone)]
-struct SessionIdentity {
-    workspace_id: String,
-    session_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -464,13 +479,13 @@ impl App {
             workspace_state,
             item_state,
             global_state: TableState::default(),
-            session_state: TableState::default(),
             primary_tab: PrimaryTab::Workspaces,
             focus: Focus::Workspaces,
             mode: Mode::Normal,
             message: None,
             pending_close: None,
             project_context,
+            terminal_preview: None,
         }
     }
 
@@ -519,67 +534,6 @@ impl App {
             .nth(ordinal)
     }
 
-    fn global_session_locations(&self) -> Vec<(usize, usize)> {
-        let now_ms = current_time_ms();
-        let mut locations: Vec<_> = self
-            .workspaces
-            .iter()
-            .enumerate()
-            .flat_map(|(workspace_index, workspace)| {
-                workspace
-                    .sessions
-                    .iter()
-                    .enumerate()
-                    .map(move |(session_index, session)| {
-                        (
-                            workspace_index,
-                            session_index,
-                            session_category(session, now_ms),
-                        )
-                    })
-            })
-            .collect();
-        locations.sort_by(
-            |(left_workspace, left_session, left_category),
-             (right_workspace, right_session, right_category)| {
-                let left = &self.workspaces[*left_workspace].sessions[*left_session];
-                let right = &self.workspaces[*right_workspace].sessions[*right_session];
-                session_category_order(*left_category)
-                    .cmp(&session_category_order(*right_category))
-                    .then_with(|| right.last_at_ms.cmp(&left.last_at_ms))
-                    .then_with(|| {
-                        self.workspaces[*left_workspace]
-                            .id
-                            .cmp(&self.workspaces[*right_workspace].id)
-                    })
-                    .then_with(|| left.id.cmp(&right.id))
-            },
-        );
-        locations
-            .into_iter()
-            .map(|(workspace, session, _)| (workspace, session))
-            .collect()
-    }
-
-    fn global_session_location(&self, ordinal: usize) -> Option<(usize, usize)> {
-        self.global_session_locations().get(ordinal).copied()
-    }
-
-    fn selected_session(&self) -> Option<(&WorkspaceView, &AgentSessionView)> {
-        let (workspace, session) = self.global_session_location(self.session_state.selected()?)?;
-        Some((
-            self.workspaces.get(workspace)?,
-            self.workspaces.get(workspace)?.sessions.get(session)?,
-        ))
-    }
-
-    fn global_session_count(&self) -> usize {
-        self.workspaces
-            .iter()
-            .map(WorkspaceView::session_count)
-            .sum()
-    }
-
     fn global_item_count(&self) -> usize {
         let Some(kind) = self.primary_tab.kind() else {
             return 0;
@@ -598,13 +552,8 @@ impl App {
             return;
         }
         self.focus = Focus::Items;
-        if tab == PrimaryTab::Sessions {
-            self.session_state
-                .select((self.global_session_count() > 0).then_some(0));
-        } else {
-            self.global_state
-                .select((self.global_item_count() > 0).then_some(0));
-        }
+        self.global_state
+            .select((self.global_item_count() > 0).then_some(0));
         self.message = None;
     }
 
@@ -623,20 +572,13 @@ impl App {
 
     fn next(&mut self) {
         if self.primary_tab != PrimaryTab::Workspaces {
-            let sessions = self.primary_tab == PrimaryTab::Sessions;
-            let item_count = if sessions {
-                self.global_session_count()
-            } else {
-                self.global_item_count()
-            };
+            let item_count = self.global_item_count();
             if item_count > 0 {
-                let state = if sessions {
-                    &mut self.session_state
-                } else {
-                    &mut self.global_state
-                };
-                let next = state.selected().map_or(0, |index| (index + 1) % item_count);
-                state.select(Some(next));
+                let next = self
+                    .global_state
+                    .selected()
+                    .map_or(0, |index| (index + 1) % item_count);
+                self.global_state.select(Some(next));
             }
             self.message = None;
             return;
@@ -669,26 +611,16 @@ impl App {
 
     fn previous(&mut self) {
         if self.primary_tab != PrimaryTab::Workspaces {
-            let sessions = self.primary_tab == PrimaryTab::Sessions;
-            let item_count = if sessions {
-                self.global_session_count()
-            } else {
-                self.global_item_count()
-            };
+            let item_count = self.global_item_count();
             if item_count > 0 {
-                let state = if sessions {
-                    &mut self.session_state
-                } else {
-                    &mut self.global_state
-                };
-                let previous = state.selected().map_or(0, |index| {
+                let previous = self.global_state.selected().map_or(0, |index| {
                     if index == 0 {
                         item_count - 1
                     } else {
                         index - 1
                     }
                 });
-                state.select(Some(previous));
+                self.global_state.select(Some(previous));
             }
             self.message = None;
             return;
@@ -753,9 +685,6 @@ impl App {
     }
 
     fn request_rename(&mut self) {
-        if self.primary_tab == PrimaryTab::Sessions {
-            return;
-        }
         let target = if self.primary_tab != PrimaryTab::Workspaces {
             self.selected_item().map(item_rename_target)
         } else {
@@ -854,25 +783,7 @@ impl App {
         true
     }
 
-    fn open_selected_session<F>(&mut self, on_open: &mut F) -> bool
-    where
-        F: FnMut(&OpenTarget) -> Result<String, String>,
-    {
-        let Some(shell_id) = self.selected_session().and_then(|(_, session)| {
-            latest_existing_session_run(session)
-                .and_then(|run| run.shell_id.as_deref())
-                .map(str::to_owned)
-        }) else {
-            return false;
-        };
-        self.message = Some(Message::from_result(on_open(&OpenTarget::Shell(shell_id))));
-        true
-    }
-
     fn request_close(&mut self) {
-        if self.primary_tab == PrimaryTab::Sessions {
-            return;
-        }
         self.pending_close = if self.primary_tab != PrimaryTab::Workspaces {
             self.selected_item().map(item_pending_close)
         } else {
@@ -912,11 +823,46 @@ impl App {
         }
     }
 
+    fn refresh_terminal_preview<P>(&mut self, on_preview: &mut P)
+    where
+        P: FnMut(&str) -> Result<String, String>,
+    {
+        let selected = if self.primary_tab == PrimaryTab::Workspaces && self.focus != Focus::Items {
+            None
+        } else {
+            self.selected_item().and_then(|item| match item {
+                WorkspaceItemView::Shell(shell) => Some((
+                    shell.id.clone(),
+                    shell.run.as_ref().map(|run| run.id.clone()),
+                    shell.run.as_ref().map_or(0, |run| run.output_revision),
+                )),
+                WorkspaceItemView::AgentShell(_) | WorkspaceItemView::Launcher(_) => None,
+            })
+        };
+        let Some((shell_id, run_id, output_revision)) = selected else {
+            self.terminal_preview = None;
+            return;
+        };
+        if self.terminal_preview.as_ref().is_some_and(|preview| {
+            preview.shell_id == shell_id
+                && preview.run_id == run_id
+                && preview.output_revision == output_revision
+                && preview.output.is_ok()
+        }) {
+            return;
+        }
+        self.terminal_preview = Some(TerminalPreviewState {
+            output: on_preview(&shell_id),
+            shell_id,
+            run_id,
+            output_revision,
+        });
+    }
+
     fn replace_workspaces(&mut self, workspaces: Vec<WorkspaceView>) {
         let selected_id = self.selected().map(|workspace| workspace.id.clone());
         let selected_item = self.workspace_item_identity();
         let selected_global_item = self.global_item_identity();
-        let selected_global_session = self.global_session_identity();
         let previous_index = self.selected_index().unwrap_or(0);
         let selected_index = selected_id
             .and_then(|id| workspaces.iter().position(|workspace| workspace.id == id))
@@ -935,12 +881,7 @@ impl App {
                 .or_else(|| (!workspace.items.is_empty()).then_some(0))
         });
         self.item_state.select(item_index);
-        if self.primary_tab == PrimaryTab::Sessions {
-            let session_index = selected_global_session
-                .and_then(|target| self.global_session_position(&target))
-                .or_else(|| (self.global_session_count() > 0).then_some(0));
-            self.session_state.select(session_index);
-        } else if self.primary_tab != PrimaryTab::Workspaces {
+        if self.primary_tab != PrimaryTab::Workspaces {
             let global_index = selected_global_item
                 .and_then(|target| self.global_item_position(&target))
                 .or_else(|| (self.global_item_count() > 0).then_some(0));
@@ -958,10 +899,7 @@ impl App {
     }
 
     fn global_item_identity(&self) -> Option<ItemIdentity> {
-        if matches!(
-            self.primary_tab,
-            PrimaryTab::Workspaces | PrimaryTab::Sessions
-        ) {
+        if self.primary_tab == PrimaryTab::Workspaces {
             return None;
         }
         let (workspace, item) = self.selected_item_location()?;
@@ -969,26 +907,6 @@ impl App {
             &self.workspaces[workspace],
             &self.workspaces[workspace].items[item],
         ))
-    }
-
-    fn global_session_identity(&self) -> Option<SessionIdentity> {
-        if self.primary_tab != PrimaryTab::Sessions {
-            return None;
-        }
-        let (workspace, session) = self.global_session_location(self.session_state.selected()?)?;
-        Some(SessionIdentity {
-            workspace_id: self.workspaces[workspace].id.clone(),
-            session_id: self.workspaces[workspace].sessions[session].id.clone(),
-        })
-    }
-
-    fn global_session_position(&self, identity: &SessionIdentity) -> Option<usize> {
-        self.global_session_locations()
-            .iter()
-            .position(|(workspace, session)| {
-                self.workspaces[*workspace].id == identity.workspace_id
-                    && self.workspaces[*workspace].sessions[*session].id == identity.session_id
-            })
     }
 
     fn global_item_position(&self, identity: &ItemIdentity) -> Option<usize> {
@@ -1059,10 +977,10 @@ fn item_pending_close(item: &WorkspaceItemView) -> PendingClose {
     }
 }
 
-pub(crate) fn run<R, O, C, W, N, E, F>(
+pub(crate) fn run<R, O, C, W, N, E, F, P>(
     workspaces: Vec<WorkspaceView>,
     project_context: ProjectContext,
-    actions: Actions<R, O, C, W, N, E, F>,
+    actions: Actions<R, O, C, W, N, E, F, P>,
 ) -> io::Result<()>
 where
     R: FnMut(&str) -> Result<String, String>,
@@ -1072,6 +990,7 @@ where
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
+    P: FnMut(&str) -> Result<String, String>,
 {
     let mut terminal = ratatui::init();
     let result = run_loop(
@@ -1083,10 +1002,10 @@ where
     result
 }
 
-fn run_loop<R, O, C, W, N, E, F>(
+fn run_loop<R, O, C, W, N, E, F, P>(
     terminal: &mut ratatui::DefaultTerminal,
     mut app: App,
-    mut actions: Actions<R, O, C, W, N, E, F>,
+    mut actions: Actions<R, O, C, W, N, E, F, P>,
 ) -> io::Result<()>
 where
     R: FnMut(&str) -> Result<String, String>,
@@ -1096,6 +1015,7 @@ where
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
     F: FnMut() -> Result<Vec<WorkspaceView>, String>,
+    P: FnMut(&str) -> Result<String, String>,
 {
     let mut last_refresh = Instant::now();
     loop {
@@ -1103,6 +1023,7 @@ where
             app.refresh(&mut actions.on_refresh);
             last_refresh = Instant::now();
         }
+        app.refresh_terminal_preview(&mut actions.on_terminal_preview);
         terminal.draw(|frame| render(frame, &mut app))?;
 
         if !event::poll(Duration::from_millis(250))? {
@@ -1156,9 +1077,7 @@ where
             KeyCode::Down | KeyCode::Char('j') => app.next(),
             KeyCode::Up | KeyCode::Char('k') => app.previous(),
             KeyCode::Enter => {
-                let dispatched = if app.primary_tab == PrimaryTab::Sessions {
-                    app.open_selected_session(&mut actions.on_open)
-                } else if app.primary_tab != PrimaryTab::Workspaces {
+                let dispatched = if app.primary_tab != PrimaryTab::Workspaces {
                     app.open_selected_item(&mut actions.on_open)
                 } else {
                     match app.focus {
@@ -1299,9 +1218,7 @@ fn render(frame: &mut Frame, app: &mut App) {
     .areas(area);
 
     render_tabs(frame, tabs_area, app);
-    if app.primary_tab == PrimaryTab::Sessions {
-        render_global_sessions(frame, dashboard_area, app);
-    } else if app.primary_tab != PrimaryTab::Workspaces {
+    if app.primary_tab != PrimaryTab::Workspaces {
         render_global_items(frame, dashboard_area, app);
     } else if dashboard_area.width >= 114 {
         let [workspace_area, terminal_area] =
@@ -1447,11 +1364,6 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                     PrimaryTab::Agents => {
                         app.workspaces.iter().map(WorkspaceView::agent_count).sum()
                     }
-                    PrimaryTab::Sessions => app
-                        .workspaces
-                        .iter()
-                        .map(WorkspaceView::session_count)
-                        .sum(),
                     PrimaryTab::Launchers => app
                         .workspaces
                         .iter()
@@ -1482,6 +1394,17 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
+    let preview = (app.focus == Focus::Workspaces && area.height >= 12)
+        .then(|| app.selected().map(workspace_preview))
+        .flatten();
+    let (table_area, preview_area) = preview.as_ref().map_or((area, None), |preview| {
+        let preview_height = (preview.content_height + 2)
+            .min(area.height.saturating_sub(6))
+            .max(3);
+        let [table_area, preview_area] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(preview_height)]).areas(area);
+        (table_area, Some(preview_area))
+    });
     let rows = app.workspaces.iter().map(|workspace| {
         Row::new([
             Cell::from(workspace.name.as_str()),
@@ -1528,7 +1451,10 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
     )
     .highlight_symbol("> ");
 
-    frame.render_stateful_widget(table, area, &mut app.workspace_state);
+    frame.render_stateful_widget(table, table_area, &mut app.workspace_state);
+    if let (Some(preview), Some(preview_area)) = (preview, preview_area) {
+        render_contextual_preview(frame, preview_area, preview);
+    }
 }
 
 fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
@@ -1541,16 +1467,16 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
         .title(title)
         .border_style(Style::new().fg(TEAL));
     let inner = block.inner(area);
-    let contextual_panel = (app.primary_tab == PrimaryTab::Agents && inner.height >= 9)
-        .then(|| contextual_session_panel(app))
+    let contextual_panel = (inner.height >= 9)
+        .then(|| selected_item_preview(app))
         .flatten();
-    let (items_inner, sessions_area) = contextual_panel.as_ref().map_or((inner, None), |panel| {
+    let (items_inner, preview_area) = contextual_panel.as_ref().map_or((inner, None), |panel| {
         let panel_height = (panel.content_height + 2)
             .min(inner.height.saturating_sub(6))
             .max(3);
-        let [items_area, sessions_area] =
+        let [items_area, preview_area] =
             Layout::vertical([Constraint::Fill(1), Constraint::Length(panel_height)]).areas(inner);
-        (items_area, Some(sessions_area))
+        (items_area, Some(preview_area))
     });
     let show_full_ids = items_inner.width >= 150;
     let kind = app.primary_tab.kind().expect("global tab kind");
@@ -1653,129 +1579,9 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
         .highlight_symbol("> ");
     frame.render_widget(block, area);
     frame.render_stateful_widget(table, table_area, &mut app.global_state);
-    if let (Some(panel), Some(panel_area)) = (contextual_panel, sessions_area) {
-        render_contextual_sessions(frame, panel_area, panel);
+    if let (Some(panel), Some(panel_area)) = (contextual_panel, preview_area) {
+        render_contextual_preview(frame, panel_area, panel);
     }
-}
-
-fn render_global_sessions(frame: &mut Frame, area: Rect, app: &mut App) {
-    let now_ms = current_time_ms();
-    let locations = app.global_session_locations();
-    let compact = area.width < 120;
-    let mut previous_category = None;
-    let rows = locations.iter().map(|(workspace_index, session_index)| {
-        let workspace = &app.workspaces[*workspace_index];
-        let session = &workspace.sessions[*session_index];
-        let category = session_category(session, now_ms);
-        let category_label = if previous_category == Some(category) {
-            ""
-        } else {
-            previous_category = Some(category);
-            category.label()
-        };
-        let latest_shell = latest_existing_session_run(session)
-            .and_then(|run| run.shell_name.as_deref())
-            .unwrap_or(if session.runs.is_empty() {
-                "catalog only"
-            } else {
-                "removed shell"
-            });
-        let identity = session
-            .external_session_id
-            .as_deref()
-            .map(short_id)
-            .unwrap_or_else(|| short_id(&session.id));
-        let state = Cell::from(Line::from(vec![
-            Span::styled(
-                session_state_symbol(&session.state),
-                Style::new().fg(session_state_color(&session.state)),
-            ),
-            Span::raw(format!(" {}", session.state)),
-        ]));
-        if compact {
-            Row::new(vec![
-                Cell::from(category_label),
-                Cell::from(workspace.name.clone()),
-                Cell::from(best_session_label(session)),
-                state,
-                Cell::from(latest_shell.to_owned()),
-                Cell::from(compact_recency(session.last_at_ms)),
-            ])
-        } else {
-            Row::new(vec![
-                Cell::from(category_label),
-                Cell::from(workspace.name.clone()),
-                Cell::from(best_session_label(session)),
-                Cell::from(integration_display_name(&session.integration).to_owned()),
-                state,
-                Cell::from(latest_shell.to_owned()),
-                Cell::from(compact_recency(session.last_at_ms)),
-                Cell::from(identity),
-            ])
-        }
-    });
-    let (header, widths) = if compact {
-        (
-            Row::new([
-                "ACTIVITY",
-                "WORKSPACE",
-                "DESCRIPTION",
-                "STATE",
-                "SHELL",
-                "LAST",
-            ]),
-            vec![
-                Constraint::Length(8),
-                Constraint::Length(11),
-                Constraint::Fill(1),
-                Constraint::Length(10),
-                Constraint::Length(13),
-                Constraint::Length(7),
-            ],
-        )
-    } else {
-        (
-            Row::new([
-                "ACTIVITY",
-                "WORKSPACE",
-                "DESCRIPTION",
-                "INTEGRATION",
-                "STATE",
-                "LATEST SHELL",
-                "RECENCY",
-                "ID",
-            ]),
-            vec![
-                Constraint::Length(13),
-                Constraint::Length(16),
-                Constraint::Fill(1),
-                Constraint::Length(10),
-                Constraint::Length(11),
-                Constraint::Length(18),
-                Constraint::Length(9),
-                Constraint::Length(8),
-            ],
-        )
-    };
-    let table = Table::new(rows, widths)
-        .header(header.style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
-        .column_spacing(1)
-        .block(
-            Block::bordered()
-                .title(format!(" SESSIONS ({}) ", locations.len()))
-                .border_style(Style::new().fg(TEAL)),
-        )
-        .row_highlight_style(
-            Style::new()
-                .fg(TEXT)
-                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
-        )
-        .highlight_symbol("> ");
-    frame.render_stateful_widget(table, area, &mut app.session_state);
-}
-
-fn latest_existing_session_run(session: &AgentSessionView) -> Option<&AgentSessionRunView> {
-    session.runs.iter().rev().find(|run| run.shell_id.is_some())
 }
 
 fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
@@ -1797,16 +1603,16 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         },
     ));
     let inner = block.inner(area);
-    let contextual_panel = (inner.height >= 9)
-        .then(|| contextual_session_panel(app))
+    let contextual_panel = (app.focus == Focus::Items && inner.height >= 9)
+        .then(|| selected_item_preview(app))
         .flatten();
-    let (items_inner, sessions_area) = contextual_panel.as_ref().map_or((inner, None), |panel| {
+    let (items_inner, preview_area) = contextual_panel.as_ref().map_or((inner, None), |panel| {
         let panel_height = (panel.content_height + 2)
             .min(inner.height.saturating_sub(6))
             .max(3);
-        let [items_area, sessions_area] =
+        let [items_area, preview_area] =
             Layout::vertical([Constraint::Fill(1), Constraint::Length(panel_height)]).areas(inner);
-        (items_area, Some(sessions_area))
+        (items_area, Some(preview_area))
     });
     let show_full_ids = items_inner.width >= 150;
     let rows: Vec<_> = selected
@@ -1906,60 +1712,185 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         )
         .highlight_symbol("> ");
     frame.render_stateful_widget(table, table_area, &mut app.item_state);
-    if let (Some(panel), Some(panel_area)) = (contextual_panel, sessions_area) {
-        render_contextual_sessions(frame, panel_area, panel);
+    if let (Some(panel), Some(panel_area)) = (contextual_panel, preview_area) {
+        render_contextual_preview(frame, panel_area, panel);
     }
 }
 
-struct ContextualSessionPanel {
+struct ContextualPreview {
     title: String,
-    rows: Vec<Row<'static>>,
+    content: PreviewContent,
     content_height: u16,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SessionCategory {
-    Active,
-    Last24Hours,
-    Last7Days,
-    Older,
+enum PreviewContent {
+    AgentSession(Vec<Row<'static>>),
+    Lines(Vec<Line<'static>>),
 }
 
-impl SessionCategory {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Active => "ACTIVE",
-            Self::Last24Hours => "LAST 24 HOURS",
-            Self::Last7Days => "LAST 7 DAYS",
-            Self::Older => "OLDER",
+fn selected_item_preview(app: &App) -> Option<ContextualPreview> {
+    match app.selected_item()? {
+        WorkspaceItemView::AgentShell(agent) => agent_session_preview(app, agent),
+        WorkspaceItemView::Shell(terminal) => terminal_preview(app, terminal),
+        WorkspaceItemView::Launcher(launcher) => Some(launcher_preview(launcher)),
+    }
+}
+
+fn workspace_preview(workspace: &WorkspaceView) -> ContextualPreview {
+    let counts = workspace.agent_state_counts;
+    let mut lines = vec![
+        Line::from(format!(
+            "{} shell  {} command  {} launcher  {} agent",
+            workspace.shell_count(),
+            workspace.command_count(),
+            workspace.launcher_count(),
+            workspace.agent_count()
+        )),
+        Line::from(Span::styled(
+            format!(
+                "working {}  blocked {}  idle {}  done {}",
+                counts.working, counts.blocked, counts.idle, counts.done
+            ),
+            Style::new().fg(SUBTEXT),
+        )),
+    ];
+    if let Some(attention) = &workspace.attention {
+        let currency = if attention.observation_is_current {
+            "current"
+        } else {
+            "stale"
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{}: {}", attention.reason, attention.agent_name),
+                Style::new().fg(if attention.reason == "blocked" {
+                    RED
+                } else {
+                    BLUE
+                }),
+            ),
+            Span::styled(
+                format!(
+                    "  {}  {}  {currency}",
+                    attention.evidence,
+                    compact_recency(attention.observed_at_ms)
+                ),
+                Style::new().fg(SUBTEXT),
+            ),
+        ]));
+    } else {
+        lines.push(Line::from(Span::styled(
+            "No outstanding attention",
+            Style::new().fg(SUBTEXT),
+        )));
+    }
+    ContextualPreview {
+        title: format!(" {} overview ", workspace.name),
+        content_height: lines.len() as u16,
+        content: PreviewContent::Lines(lines),
+    }
+}
+
+fn launcher_preview(launcher: &LauncherView) -> ContextualPreview {
+    ContextualPreview {
+        title: " Launcher configuration ".into(),
+        content_height: 3,
+        content: PreviewContent::Lines(vec![
+            Line::from(vec![
+                Span::styled("cwd  ", Style::new().fg(SUBTEXT)),
+                Span::raw(launcher.directory.clone()),
+            ]),
+            Line::from(vec![
+                Span::styled("argv ", Style::new().fg(SUBTEXT)),
+                Span::raw(format_argv(&launcher.argv)),
+            ]),
+            Line::from(Span::styled(
+                "Detached invocation; output and run history are not retained",
+                Style::new().fg(SUBTEXT),
+            )),
+        ]),
+    }
+}
+
+fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPreview> {
+    let is_command = !terminal.command.is_empty();
+    let mut lines = Vec::new();
+    if is_command {
+        lines.push(Line::from(vec![
+            Span::styled("argv ", Style::new().fg(SUBTEXT)),
+            Span::raw(format_argv(&terminal.argv)),
+        ]));
+    }
+    lines.push(Line::from(vec![
+        Span::styled("cwd  ", Style::new().fg(SUBTEXT)),
+        Span::raw(terminal.directory.clone()),
+        Span::styled("  branch ", Style::new().fg(SUBTEXT)),
+        Span::raw(terminal.branch.clone()),
+    ]));
+    let run = terminal.run.as_ref().map_or_else(
+        || format!("{}  no run yet", terminal.status),
+        |run| {
+            let result = run.exit_reason.as_deref().unwrap_or(&terminal.status);
+            let timing = run.ended_at_ms.map_or_else(
+                || format!("started {}", compact_recency(run.started_at_ms)),
+                |ended| format!("ended {}", compact_recency(ended)),
+            );
+            format!(
+                "{result}  run {} generation {}  {timing}",
+                short_id(&run.id),
+                run.generation
+            )
+        },
+    );
+    lines.push(Line::from(Span::styled(run, Style::new().fg(SUBTEXT))));
+
+    if let Some(preview) = app
+        .terminal_preview
+        .as_ref()
+        .filter(|preview| preview.shell_id == terminal.id)
+    {
+        match &preview.output {
+            Ok(output) if output.trim().is_empty() => lines.push(Line::from(Span::styled(
+                "No terminal output",
+                Style::new().fg(SUBTEXT),
+            ))),
+            Ok(output) => {
+                lines.push(Line::from(Span::styled(
+                    "Latest terminal output",
+                    Style::new().fg(BLUE).add_modifier(Modifier::BOLD),
+                )));
+                let output_lines: Vec<_> = output.lines().collect();
+                lines.extend(
+                    output_lines
+                        .iter()
+                        .rev()
+                        .take(3)
+                        .rev()
+                        .map(|line| Line::from(Span::raw((*line).to_owned()))),
+                );
+            }
+            Err(error) => lines.push(Line::from(Span::styled(
+                format!("Output unavailable: {error}"),
+                Style::new().fg(YELLOW),
+            ))),
         }
     }
+    Some(ContextualPreview {
+        title: if is_command {
+            " Command preview ".into()
+        } else {
+            " Shell preview ".into()
+        },
+        content_height: lines.len() as u16,
+        content: PreviewContent::Lines(lines),
+    })
 }
 
-fn session_category_order(category: SessionCategory) -> u8 {
-    match category {
-        SessionCategory::Active => 0,
-        SessionCategory::Last24Hours => 1,
-        SessionCategory::Last7Days => 2,
-        SessionCategory::Older => 3,
-    }
+fn format_argv(argv: &[String]) -> String {
+    format!("{argv:?}")
 }
 
-fn session_category(session: &AgentSessionView, now_ms: u64) -> SessionCategory {
-    if session.state_is_current {
-        return SessionCategory::Active;
-    }
-    match now_ms.saturating_sub(session.last_at_ms) {
-        0..=86_400_000 => SessionCategory::Last24Hours,
-        86_400_001..=604_800_000 => SessionCategory::Last7Days,
-        _ => SessionCategory::Older,
-    }
-}
-
-fn contextual_session_panel(app: &App) -> Option<ContextualSessionPanel> {
-    let WorkspaceItemView::AgentShell(agent_shell) = app.selected_item()? else {
-        return None;
-    };
+fn agent_session_preview(app: &App, agent_shell: &AgentShellView) -> Option<ContextualPreview> {
     let agent = agent_shell.agent.as_ref()?;
     let external_session_id = agent.external_session_id.as_deref()?;
     let workspace = app.selected_item_workspace()?;
@@ -2021,11 +1952,36 @@ fn contextual_session_panel(app: &App) -> Option<ContextualSessionPanel> {
         ])
         .height(2),
     ];
-    Some(ContextualSessionPanel {
+    Some(ContextualPreview {
         title: format!(" {} session ", integration_display_name(&agent.integration)),
-        rows,
+        content: PreviewContent::AgentSession(rows),
         content_height: 2,
     })
+}
+
+fn render_contextual_preview(frame: &mut Frame, area: Rect, preview: ContextualPreview) {
+    let block = Block::bordered()
+        .title(preview.title)
+        .border_style(Style::new().fg(OVERLAY));
+    match preview.content {
+        PreviewContent::AgentSession(rows) => {
+            let table = Table::new(
+                rows,
+                [
+                    Constraint::Length(2),
+                    Constraint::Fill(1),
+                    Constraint::Length(10),
+                    Constraint::Length(9),
+                ],
+            )
+            .column_spacing(1)
+            .block(block);
+            frame.render_widget(table, area);
+        }
+        PreviewContent::Lines(lines) => {
+            frame.render_widget(Paragraph::new(lines).block(block), area);
+        }
+    }
 }
 
 fn best_session_label(session: &AgentSessionView) -> String {
@@ -2063,25 +2019,6 @@ fn integration_display_name(integration: &str) -> &str {
         "pi" => "Pi",
         other => other,
     }
-}
-
-fn render_contextual_sessions(frame: &mut Frame, area: Rect, panel: ContextualSessionPanel) {
-    let table = Table::new(
-        panel.rows,
-        [
-            Constraint::Length(2),
-            Constraint::Fill(1),
-            Constraint::Length(10),
-            Constraint::Length(9),
-        ],
-    )
-    .column_spacing(1)
-    .block(
-        Block::bordered()
-            .title(panel.title)
-            .border_style(Style::new().fg(OVERLAY)),
-    );
-    frame.render_widget(table, area);
 }
 
 fn item_detail_lines(item: &WorkspaceItemView) -> Vec<Line<'_>> {
@@ -2244,33 +2181,6 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Style::new().fg(if message.error { RED } else { GREEN }),
         ))
     } else {
-        if app.primary_tab == PrimaryTab::Sessions {
-            let shell_available = app.selected_session().is_some_and(|(_, session)| {
-                session.runs.iter().rev().any(|run| run.shell_id.is_some())
-            });
-            let open_help = if app.session_state.selected().is_none() {
-                " no session selected  "
-            } else if shell_available {
-                " open latest shell  "
-            } else {
-                " unavailable (no shell)  "
-            };
-            let line = Line::from(vec![
-                Span::styled(" j/k", Style::new().fg(TEAL)),
-                Span::styled(
-                    " navigate  tab/shift-tab views  1-5 select view  ",
-                    Style::new().fg(SUBTEXT),
-                ),
-                Span::styled("enter", Style::new().fg(GREEN)),
-                Span::styled(open_help, Style::new().fg(SUBTEXT)),
-                Span::styled("r", Style::new().fg(BLUE)),
-                Span::styled(" refresh  ", Style::new().fg(SUBTEXT)),
-                Span::styled("q", Style::new().fg(RED)),
-                Span::styled(" quit", Style::new().fg(SUBTEXT)),
-            ]);
-            frame.render_widget(Paragraph::new(line), area);
-            return;
-        }
         let launcher_selected = matches!(app.selected_item(), Some(WorkspaceItemView::Launcher(_)));
         let mut spans = vec![
             Span::styled(" j/k", Style::new().fg(TEAL)),
@@ -2397,10 +2307,13 @@ mod tests {
                 directory: "/tmp/boomux".into(),
                 branch: "main".into(),
                 command: String::new(),
+                argv: Vec::new(),
+                run: None,
             })],
             sessions: Vec::new(),
             agent_state_counts: AgentStateCounts::default(),
             attention_count: 0,
+            attention: None,
         }
     }
 
@@ -2425,6 +2338,8 @@ mod tests {
                 directory: "/tmp/boomux".into(),
                 branch: "main".into(),
                 command: String::new(),
+                argv: Vec::new(),
+                run: None,
             },
             agent: Some(agent()),
         }
@@ -2441,7 +2356,6 @@ mod tests {
             last_at_ms: 30,
             source_cwd: Some("/tmp/boomux".into()),
             runs: vec![AgentSessionRunView {
-                shell_id: Some("term_1".into()),
                 shell_name: Some("agent".into()),
                 directory: Some("/tmp/boomux".into()),
             }],
@@ -2461,6 +2375,8 @@ mod tests {
                 directory: "/tmp/boomux".into(),
                 branch: "main".into(),
                 command: String::new(),
+                argv: Vec::new(),
+                run: None,
             },
             agent: None,
         }
@@ -2474,6 +2390,8 @@ mod tests {
             directory: format!("/tmp/{name}"),
             branch: "main".into(),
             command: command.into(),
+            argv: command.split_whitespace().map(str::to_owned).collect(),
+            run: None,
         })
     }
 
@@ -2483,6 +2401,7 @@ mod tests {
             name: name.into(),
             directory: format!("/tmp/{name}"),
             command: format!("run-{name}"),
+            argv: vec![format!("run-{name}")],
         })
     }
 
@@ -2722,6 +2641,7 @@ mod tests {
             name: "editor".into(),
             directory: "/tmp/boomux".into(),
             command: "zeditor .".into(),
+            argv: vec!["zeditor".into(), ".".into()],
         };
         let mut initial = workspace("w1", "boomux");
         initial.items.push(WorkspaceItemView::Launcher(launcher()));
@@ -2741,6 +2661,8 @@ mod tests {
             directory: "/tmp/boomux".into(),
             branch: "main".into(),
             command: String::new(),
+            argv: Vec::new(),
+            run: None,
         }));
         refreshed
             .items
@@ -2776,6 +2698,7 @@ mod tests {
                 name: "editor".into(),
                 directory: "/tmp/boomux".into(),
                 command: "true".into(),
+                argv: vec!["true".into()],
             }),
         );
         app.replace_workspaces(vec![refreshed]);
@@ -2966,6 +2889,7 @@ mod tests {
                 name: "editor".into(),
                 directory: "/tmp/boomux".into(),
                 command: "zeditor .".into(),
+                argv: vec!["zeditor".into(), ".".into()],
             }));
         focus_items(&mut app);
         app.next();
@@ -2992,6 +2916,7 @@ mod tests {
             name: "editor".into(),
             directory: "/tmp/boomux".into(),
             command: "zeditor .".into(),
+            argv: vec!["zeditor".into(), ".".into()],
         };
         let mut app = app();
         app.workspaces[0]
@@ -3258,6 +3183,7 @@ mod tests {
                 name: "editor".into(),
                 directory: "/tmp/boomux".into(),
                 command: "zeditor .".into(),
+                argv: vec!["zeditor".into(), ".".into()],
             }));
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
@@ -3287,6 +3213,7 @@ mod tests {
                 name: format!("launcher-{index}"),
                 directory: "/tmp/boomux".into(),
                 command: format!("command-{index}"),
+                argv: vec![format!("command-{index}")],
             })
         }));
         focus_items(&mut app);
@@ -3411,6 +3338,7 @@ mod tests {
                 name: "editor".into(),
                 directory: "/tmp/boomux".into(),
                 command: "zeditor .".into(),
+                argv: vec!["zeditor".into(), ".".into()],
             }));
 
         focus_items(&mut app);
@@ -3547,208 +3475,6 @@ mod tests {
     }
 
     #[test]
-    fn global_sessions_render_grouped_and_sorted_across_workspaces() {
-        let backend = TestBackend::new(180, 24);
-        let mut terminal = Terminal::new(backend).unwrap();
-        let now = current_time_ms();
-        let mut one = workspace("w1", "one");
-        let mut older_active = session("active-old", "idle");
-        older_active.label = "Active old".into();
-        older_active.last_at_ms = now - 2_000;
-        let mut recent = session("recent", "inactive");
-        recent.label = "Recent session".into();
-        recent.state_is_current = false;
-        recent.last_at_ms = now - 60_000;
-        one.sessions = vec![recent, older_active];
-        let mut two = workspace("w2", "two");
-        let mut newer_active = session("active-new", "working");
-        newer_active.label = "Active new".into();
-        newer_active.last_at_ms = now - 1_000;
-        let mut weekly = session("weekly", "done");
-        weekly.label = "Weekly session".into();
-        weekly.state_is_current = false;
-        weekly.last_at_ms = now - 2 * 86_400_000;
-        two.sessions = vec![weekly, newer_active];
-        let mut app = App::new(vec![one, two], project_context());
-        app.select_tab(PrimaryTab::Sessions);
-
-        let labels: Vec<_> = app
-            .global_session_locations()
-            .into_iter()
-            .map(|(workspace, session)| app.workspaces[workspace].sessions[session].label.as_str())
-            .collect();
-        assert_eq!(
-            labels,
-            [
-                "Active new",
-                "Active old",
-                "Recent session",
-                "Weekly session"
-            ]
-        );
-        terminal.draw(|frame| render(frame, &mut app)).unwrap();
-        let text: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect();
-
-        assert!(text.contains("SESSIONS (4)"));
-        assert!(text.contains("ACTIVITY"));
-        assert!(text.contains("WORKSPACE"));
-        assert!(text.contains("DESCRIPTION"));
-        assert!(text.contains("LATEST SHELL"));
-        assert_eq!(text.matches("ACTIVE").count(), 1);
-        assert_eq!(text.matches("LAST 24 HOURS").count(), 1);
-        assert_eq!(text.matches("LAST 7 DAYS").count(), 1);
-        assert!(text.find("Active new").unwrap() < text.find("Active old").unwrap());
-    }
-
-    #[test]
-    fn narrow_global_sessions_keep_core_context_visible() {
-        let backend = TestBackend::new(100, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
-        let mut workspace = workspace("w1", "project");
-        let mut view = session("session", "idle");
-        view.label = "Review narrow layout".into();
-        workspace.sessions.push(view);
-        let mut app = App::new(vec![workspace], project_context());
-        app.select_tab(PrimaryTab::Sessions);
-
-        terminal.draw(|frame| render(frame, &mut app)).unwrap();
-        let text: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect();
-
-        assert!(text.contains("ACTIVITY"));
-        assert!(text.contains("WORKSPACE"));
-        assert!(text.contains("DESCRIPTION"));
-        assert!(text.contains("STATE"));
-        assert!(text.contains("SHELL"));
-        assert!(text.contains("LAST"));
-        assert!(text.contains("Review narrow layout"));
-        assert!(text.contains("project"));
-        assert!(text.contains("agent"));
-    }
-
-    #[test]
-    fn global_session_navigation_and_refresh_preserve_session_identity() {
-        let mut one = workspace("w1", "one");
-        one.sessions = vec![session("one", "working")];
-        let mut two = workspace("w2", "two");
-        two.sessions = vec![session("two", "working")];
-        let mut app = App::new(vec![one, two], project_context());
-        app.select_tab(PrimaryTab::Sessions);
-        assert_eq!(app.session_state.selected(), Some(0));
-        app.next();
-        assert_eq!(
-            app.selected_session()
-                .map(|(_, session)| session.id.as_str()),
-            Some("two")
-        );
-        app.previous();
-        assert_eq!(
-            app.selected_session()
-                .map(|(_, session)| session.id.as_str()),
-            Some("one")
-        );
-        app.next();
-
-        let mut refreshed_two = workspace("w2", "two");
-        refreshed_two.sessions = vec![session("new", "working"), session("two", "working")];
-        let mut refreshed_one = workspace("w1", "one");
-        refreshed_one.sessions = vec![session("one", "working")];
-        app.replace_workspaces(vec![refreshed_two, refreshed_one]);
-
-        assert_eq!(
-            app.selected_session()
-                .map(|(workspace, _)| workspace.id.as_str()),
-            Some("w2")
-        );
-        assert_eq!(
-            app.selected_session()
-                .map(|(_, session)| session.id.as_str()),
-            Some("two")
-        );
-    }
-
-    #[test]
-    fn session_open_uses_newest_still_existing_shell() {
-        let mut workspace = workspace("w1", "one");
-        let mut view = session("session", "inactive");
-        view.runs = vec![
-            AgentSessionRunView {
-                shell_id: Some("old-shell".into()),
-                shell_name: Some("old".into()),
-                directory: None,
-            },
-            AgentSessionRunView {
-                shell_id: Some("new-shell".into()),
-                shell_name: Some("new".into()),
-                directory: None,
-            },
-            AgentSessionRunView {
-                shell_id: None,
-                shell_name: None,
-                directory: None,
-            },
-        ];
-        workspace.sessions.push(view);
-        let mut app = App::new(vec![workspace], project_context());
-        app.select_tab(PrimaryTab::Sessions);
-        let mut opened = None;
-
-        assert!(app.open_selected_session(&mut |target| {
-            opened = Some(target.clone());
-            Ok(String::new())
-        }));
-        assert_eq!(opened, Some(OpenTarget::Shell("new-shell".into())));
-    }
-
-    #[test]
-    fn unavailable_session_has_no_open_or_mutation_actions() {
-        let backend = TestBackend::new(140, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
-        let mut workspace = workspace("w1", "one");
-        let mut view = session("removed", "inactive");
-        view.runs[0].shell_id = None;
-        view.runs[0].shell_name = None;
-        workspace.sessions.push(view);
-        let mut app = App::new(vec![workspace], project_context());
-        app.select_tab(PrimaryTab::Sessions);
-        let mut opened = false;
-
-        assert!(!app.open_selected_session(&mut |_| {
-            opened = true;
-            Ok(String::new())
-        }));
-        app.request_rename();
-        app.request_close();
-        assert!(!app.request_add(&mut |_| Ok(String::new())));
-        assert!(!opened);
-        assert!(matches!(app.mode, Mode::Normal));
-        assert!(app.pending_close.is_none());
-
-        terminal.draw(|frame| render(frame, &mut app)).unwrap();
-        let text: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect();
-        assert!(text.contains("unavailable (no shell)"), "{text:?}");
-        assert!(!text.contains("rename shell"));
-        assert!(!text.contains("close shell"));
-    }
-
-    #[test]
     fn narrow_global_view_keeps_all_aggregate_columns_visible() {
         let backend = TestBackend::new(80, 20);
         let mut terminal_backend = Terminal::new(backend).unwrap();
@@ -3877,11 +3603,12 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_shell_and_launcher_hide_contextual_sessions() {
+    fn shell_and_launcher_render_kind_previews_without_session_history() {
         let backend = TestBackend::new(180, 34);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = app();
         app.workspaces[0].sessions.push(session("hidden", "done"));
+        focus_items(&mut app);
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
         let shell_text: String = terminal
@@ -3891,7 +3618,9 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        assert!(!shell_text.contains("OpenCode sessions"));
+        assert!(shell_text.contains("Shell preview"));
+        assert!(shell_text.contains("/tmp/boomux"));
+        assert!(!shell_text.contains("OpenCode session"));
 
         app.workspaces[0]
             .items
@@ -3900,6 +3629,7 @@ mod tests {
                 name: "editor".into(),
                 directory: "/tmp/boomux".into(),
                 command: "editor .".into(),
+                argv: vec!["editor".into(), ".".into()],
             }));
         focus_items(&mut app);
         app.next();
@@ -3911,22 +3641,119 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        assert!(!launcher_text.contains("OpenCode sessions"));
+        assert!(launcher_text.contains("Launcher configuration"));
+        assert!(launcher_text.contains("[\"editor\", \".\"]"));
+        assert!(launcher_text.contains("output and run history are not retained"));
+        assert!(!launcher_text.contains("OpenCode session"));
     }
 
     #[test]
-    fn session_categories_are_non_overlapping_at_boundaries() {
-        let now = 1_000_000_000;
-        let mut view = session("category", "idle");
-        view.state_is_current = true;
-        assert_eq!(session_category(&view, now), SessionCategory::Active);
-        view.state_is_current = false;
-        view.last_at_ms = now - 86_400_000;
-        assert_eq!(session_category(&view, now), SessionCategory::Last24Hours);
-        view.last_at_ms -= 1;
-        assert_eq!(session_category(&view, now), SessionCategory::Last7Days);
-        view.last_at_ms = now - 604_800_001;
-        assert_eq!(session_category(&view, now), SessionCategory::Older);
+    fn command_preview_preserves_argument_boundaries() {
+        let backend = TestBackend::new(180, 34);
+        let mut backend_terminal = Terminal::new(backend).unwrap();
+        let mut workspace = workspace("w1", "commands");
+        workspace.items = vec![terminal("command", "format", "printf")];
+        let WorkspaceItemView::Shell(command) = &mut workspace.items[0] else {
+            unreachable!();
+        };
+        command.argv = vec!["printf".into(), "a b".into(), String::new()];
+        let mut app = App::new(vec![workspace], project_context());
+        app.select_tab(PrimaryTab::Commands);
+
+        backend_terminal
+            .draw(|frame| render(frame, &mut app))
+            .unwrap();
+        let text: String = backend_terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(text.contains("Command preview"));
+        assert!(text.contains("[\"printf\", \"a b\", \"\"]"));
+    }
+
+    #[test]
+    fn terminal_output_preview_reads_only_when_selection_or_revision_changes() {
+        let mut app = app();
+        focus_items(&mut app);
+        let WorkspaceItemView::Shell(shell) = &mut app.workspaces[0].items[0] else {
+            unreachable!();
+        };
+        shell.run = Some(TerminalRunView {
+            id: "run-1".into(),
+            generation: 1,
+            started_at_ms: current_time_ms(),
+            ended_at_ms: None,
+            exit_reason: None,
+            output_revision: 4,
+        });
+        let calls = std::cell::Cell::new(0);
+        let mut read = |_: &str| {
+            calls.set(calls.get() + 1);
+            Ok("first\nlatest".into())
+        };
+
+        app.refresh_terminal_preview(&mut read);
+        app.refresh_terminal_preview(&mut read);
+        assert_eq!(calls.get(), 1);
+
+        let WorkspaceItemView::Shell(shell) = &mut app.workspaces[0].items[0] else {
+            unreachable!();
+        };
+        shell.run.as_mut().unwrap().output_revision = 5;
+        app.refresh_terminal_preview(&mut read);
+        assert_eq!(calls.get(), 2);
+        let WorkspaceItemView::Shell(shell) = &mut app.workspaces[0].items[0] else {
+            unreachable!();
+        };
+        shell.run.as_mut().unwrap().id = "run-2".into();
+        app.refresh_terminal_preview(&mut read);
+        assert_eq!(calls.get(), 3);
+
+        let backend = TestBackend::new(180, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("Latest terminal output"));
+        assert!(text.contains("latest"));
+    }
+
+    #[test]
+    fn workspace_preview_surfaces_most_urgent_attention() {
+        let backend = TestBackend::new(140, 34);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut workspace = workspace("w1", "review");
+        workspace.attention = Some(WorkspaceAttentionView {
+            agent_name: "review-agent".into(),
+            reason: "blocked".into(),
+            evidence: "approval required".into(),
+            observed_at_ms: current_time_ms(),
+            observation_is_current: true,
+        });
+        workspace.attention_count = 1;
+        let mut app = App::new(vec![workspace], project_context());
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(text.contains("review overview"));
+        assert!(text.contains("blocked: review-agent"));
+        assert!(text.contains("approval required"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1855,19 +1855,22 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
                 Style::new().fg(SUBTEXT),
             ))),
             Ok(output) => {
-                lines.push(Line::from(Span::styled(
-                    "Latest terminal output",
-                    Style::new().fg(BLUE).add_modifier(Modifier::BOLD),
-                )));
-                let output_lines: Vec<_> = output.lines().collect();
-                lines.extend(
-                    output_lines
-                        .iter()
-                        .rev()
-                        .take(3)
-                        .rev()
-                        .map(|line| Line::from(Span::raw((*line).to_owned()))),
-                );
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        "Terminal tail",
+                        Style::new().fg(BLUE).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        format!("  revision {}", preview.output_revision),
+                        Style::new().fg(SUBTEXT),
+                    ),
+                ]));
+                lines.extend(terminal_tail_lines(output, 5).into_iter().map(|line| {
+                    Line::from(vec![
+                        Span::styled("| ", Style::new().fg(OVERLAY)),
+                        Span::raw(line),
+                    ])
+                }));
             }
             Err(error) => lines.push(Line::from(Span::styled(
                 format!("Output unavailable: {error}"),
@@ -1877,13 +1880,34 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
     }
     Some(ContextualPreview {
         title: if is_command {
-            " Command preview ".into()
+            format!(" Command preview: {} ", terminal.name)
         } else {
-            " Shell preview ".into()
+            format!(" Shell preview: {} ", terminal.name)
         },
         content_height: lines.len() as u16,
         content: PreviewContent::Lines(lines),
     })
+}
+
+fn terminal_tail_lines(output: &str, limit: usize) -> Vec<String> {
+    let mut lines: Vec<_> = output
+        .lines()
+        .map(|line| line.trim_end().to_owned())
+        .collect();
+    let first = lines
+        .iter()
+        .position(|line| !line.is_empty())
+        .unwrap_or(lines.len());
+    let end = lines
+        .iter()
+        .rposition(|line| !line.is_empty())
+        .map_or(first, |last| last + 1);
+    lines.drain(end..);
+    lines.drain(..first);
+    if lines.len() > limit {
+        lines.drain(..lines.len() - limit);
+    }
+    lines
 }
 
 fn format_argv(argv: &[String]) -> String {
@@ -3723,8 +3747,20 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        assert!(text.contains("Latest terminal output"));
+        assert!(text.contains("Terminal tail"));
+        assert!(text.contains("revision 5"));
         assert!(text.contains("latest"));
+    }
+
+    #[test]
+    fn terminal_tail_trims_edge_blanks_and_keeps_the_latest_rows() {
+        let output = "\nold\n\nrecent one  \nrecent two\n\n";
+
+        assert_eq!(
+            terminal_tail_lines(output, 3),
+            ["", "recent one", "recent two"]
+        );
+        assert!(terminal_tail_lines("\n \n", 5).is_empty());
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -12,7 +12,8 @@ use std::time::{Duration, Instant};
 use boomux::client::{Attachment, Client, RemoteError};
 use boomux::protocol::{
     self, AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame, ErrorCode,
-    ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile, WorkspaceLauncherSpec,
+    ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile, UnixEnvironment,
+    UnixEnvironmentVariable, WorkspaceLauncherSpec,
 };
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use uuid::Uuid;
@@ -45,6 +46,7 @@ impl TestDaemon {
             .env("COLORTERM", "daemon-color")
             .env("TERM_PROGRAM", "daemon-program")
             .env("TERM_PROGRAM_VERSION", "daemon-version")
+            .env("BOOMUX_DAEMON_ONLY", "must-not-leak")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -426,6 +428,74 @@ fn native_daemon_recovers_reproducible_metadata_after_restart() {
     assert_eq!(second_run.generation, 2);
     drop(second);
     daemon.stop_with_cli();
+}
+
+#[test]
+fn attach_environment_is_ephemeral_and_authoritative_for_initial_and_restarted_runs() {
+    let daemon = TestDaemon::start();
+    let client_shell = daemon.runtime_dir.join("client-shell");
+    fs::write(
+        &client_shell,
+        "#!/bin/sh\nbytes=$(printf '%s' \"$NON_UTF8\" | /usr/bin/od -An -tx1)\nprintf 'startup=%s|daemon=%s|term=%s|run=%s|bytes=%s\\n' \"$CLIENT_MARKER\" \"${BOOMUX_DAEMON_ONLY-unset}\" \"$TERM\" \"$BOOMUX_RUN_ID\" \"$bytes\"\nexec /bin/sh\n",
+    )
+    .unwrap();
+    fs::set_permissions(&client_shell, fs::Permissions::from_mode(0o755)).unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "ephemeral-environment",
+            vec![ShellSpec::login("shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let first_secret = format!("first-secret-{}", Uuid::new_v4());
+    let mut first = attach_with_environment(
+        &daemon.client,
+        &shell_id,
+        false,
+        environment_for_shell(&client_shell, &first_secret),
+    );
+    let first_output = read_until(&mut first.stream, b"|bytes= ff fe");
+    assert!(contains(&first_output, first_secret.as_bytes()));
+    assert!(contains(&first_output, b"daemon=unset"));
+    assert!(contains(&first_output, b"term=attachment-term"));
+    assert!(!contains(&first_output, b"attacker-run-id"));
+    AttachFrame::Input(b"exit 0\n".to_vec())
+        .write_to(&mut first.stream)
+        .unwrap();
+    drop(first);
+    wait_until(
+        || {
+            matches!(
+                daemon.client.get_shell(&shell_id).unwrap().status,
+                ShellStatus::Exited { .. }
+            )
+        },
+        "first environment shell did not exit",
+    );
+
+    let second_secret = format!("second-secret-{}", Uuid::new_v4());
+    let mut second = attach_with_environment(
+        &daemon.client,
+        &shell_id,
+        true,
+        environment_for_shell(&client_shell, &second_secret),
+    );
+    let second_output = read_until(&mut second.stream, b"|bytes= ff fe");
+    assert!(contains(&second_output, second_secret.as_bytes()));
+    assert!(contains(&second_output, b"daemon=unset"));
+    assert!(contains(&second_output, b"term=attachment-term"));
+    assert!(!contains(&second_output, first_secret.as_bytes()));
+
+    let state = fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap();
+    let snapshot = serde_json::to_vec(&daemon.client.snapshot().unwrap()).unwrap();
+    let events = daemon.client.events(None, 256, 0).unwrap();
+    let events = serde_json::to_vec(&(events.snapshot, events.events)).unwrap();
+    for bytes in [&state, &snapshot, &events] {
+        assert!(!contains(bytes, first_secret.as_bytes()));
+        assert!(!contains(bytes, second_secret.as_bytes()));
+        assert!(!contains(bytes, b"attacker-run-id"));
+    }
 }
 
 #[test]
@@ -2471,6 +2541,7 @@ fn attachment_client_reconnects_across_daemon_restart() {
     command.env("COLORTERM", "truecolor");
     command.env("TERM_PROGRAM", "integration-terminal");
     command.env("TERM_PROGRAM_VERSION", "1.0");
+    command.env("SHELL", "/bin/sh");
     let mut attachment_process = pty.slave.spawn_command(command).unwrap();
     drop(pty.slave);
     let mut reader = pty.master.try_clone_reader().unwrap();
@@ -2726,7 +2797,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 15);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 16);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -2767,6 +2838,7 @@ fn native_daemon_lifecycle() {
         "protocol_13",
         "protocol_14",
         "protocol_15",
+        "protocol_16",
         "inactive_agent_state",
         "protocol_11",
         "restartable_exited_shells",
@@ -2786,7 +2858,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 15"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 16"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])
@@ -3442,6 +3514,72 @@ fn profile() -> TerminalProfile {
         cols: 80,
         pixel_width: 800,
         pixel_height: 600,
+    }
+}
+
+fn environment_for_shell(shell: &std::path::Path, marker: &str) -> UnixEnvironment {
+    UnixEnvironment {
+        variables: vec![
+            UnixEnvironmentVariable {
+                name: b"SHELL".to_vec(),
+                value: shell.as_os_str().as_encoded_bytes().to_vec(),
+            },
+            UnixEnvironmentVariable {
+                name: b"CLIENT_MARKER".to_vec(),
+                value: marker.as_bytes().to_vec(),
+            },
+            UnixEnvironmentVariable {
+                name: b"TERM".to_vec(),
+                value: b"client-supplied-term".to_vec(),
+            },
+            UnixEnvironmentVariable {
+                name: b"BOOMUX_RUN_ID".to_vec(),
+                value: b"attacker-run-id".to_vec(),
+            },
+            UnixEnvironmentVariable {
+                name: b"NON_UTF8".to_vec(),
+                value: vec![0xff, 0xfe],
+            },
+        ],
+    }
+}
+
+fn attach_with_environment(
+    client: &Client,
+    shell_id: &str,
+    restart_exited: bool,
+    environment: UnixEnvironment,
+) -> Attachment {
+    let mut stream = UnixStream::connect(client.socket_path()).unwrap();
+    protocol::write_message(
+        &mut stream,
+        &protocol::Envelope::with_version(
+            16,
+            protocol::Request::Attach {
+                shell_id: shell_id.into(),
+                takeover: false,
+                restart_exited,
+                profile: profile(),
+                environment: Some(environment),
+            },
+        ),
+    )
+    .unwrap();
+    let response: protocol::Envelope<protocol::Response> =
+        protocol::read_message(&mut stream).unwrap();
+    assert_eq!(response.version, 16);
+    match response.message {
+        protocol::Response::Attached {
+            token,
+            reconstruction,
+            warning,
+        } => Attachment {
+            stream,
+            token,
+            reconstruction,
+            warning,
+        },
+        response => panic!("unexpected attach response: {response:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary
- show workspace and shell identity when a managed shell run starts
- preserve attachment launching across in-place binary upgrades and hand off ephemeral client environment for new runs
- harden OpenCode lifecycle registration, integration diagnostics, and catalog-backed session projection
- keep full session history in the CLI while showing only the active or latest exact session for a durable Agent
- add read-only Workspace, Agent, Launcher, Shell, and Command previews and remove Sessions as a dashboard kind
- document the Conventional Commit and squash-merge workflow required by Release Please

## Validation
- `cargo test` (319 tests)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- live protocol 16 daemon handoff
- live selected-shell terminal preview

## Release Please
BEGIN_COMMIT_OVERRIDE
feat: improve shell identity and dashboard previews
END_COMMIT_OVERRIDE