### PR TITLE
feat(tui): add scrollable shell previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ also counted as a shell or command.
 
 The selected kind receives a read-only preview. Workspaces show retained Agent
 state and their highest-priority attention item. Shells show run metadata plus a
-bounded terminal-output viewport, fetched only when the selected shell's output
-revision changes. The viewport retains its position while scrolled and follows
-new output again after `End`. Commands show exact argv and run metadata without
+bounded 16-row terminal-output viewport, fetched only when the selected shell's
+output revision changes. The viewport is hidden when it cannot fit without
+crowding the item table, retains its position while scrolled, and follows new
+output again after `End`. Commands show exact argv and run metadata without
 terminal output. Commands and launchers preserve argument boundaries in their
 previews. Launchers explicitly show that their detached output and invocation
 history are not retained.

--- a/README.md
+++ b/README.md
@@ -94,12 +94,13 @@ item actions. Counts are exclusive by visible presentation: an agent row is not
 also counted as a shell or command.
 
 The selected kind receives a read-only preview. Workspaces show retained Agent
-state and their highest-priority attention item. Shells and commands show run
-metadata plus a bounded terminal-output tail, fetched only when the selected
-shell's output revision changes. The output viewport retains its position while
-scrolled and follows new output again after `End`. Commands and launchers
-preserve argument boundaries in their previews. Launchers explicitly show that
-their detached output and invocation history are not retained.
+state and their highest-priority attention item. Shells show run metadata plus a
+bounded terminal-output viewport, fetched only when the selected shell's output
+revision changes. The viewport retains its position while scrolled and follows
+new output again after `End`. Commands show exact argv and run metadata without
+terminal output. Commands and launchers preserve argument boundaries in their
+previews. Launchers explicitly show that their detached output and invocation
+history are not retained.
 
 When an active Agent instance is bound to a shell's current run, that shell row
 morphs into an agent row instead of adding a duplicate item. It keeps the

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Dashboard controls:
 - In the primary Workspaces view, `h`, `l`, and the left/right arrows switch
   between the workspace and item tables.
 - `j`, `k`, and the arrow keys navigate.
+- `PageUp` and `PageDown` scroll a selected shell or command preview. `Home`
+  jumps to the oldest retained preview row and `End` resumes following output.
 - `Enter` restores a workspace, opens a shell, or invokes a launcher.
 - `a` creates an empty workspace or adds a shell, depending on the focused
   table in the Workspaces view. New dashboard shells start in the directory
@@ -94,9 +96,10 @@ also counted as a shell or command.
 The selected kind receives a read-only preview. Workspaces show retained Agent
 state and their highest-priority attention item. Shells and commands show run
 metadata plus a bounded terminal-output tail, fetched only when the selected
-shell's output revision changes. Commands and launchers preserve argument
-boundaries in their previews. Launchers explicitly show that their detached
-output and invocation history are not retained.
+shell's output revision changes. The output viewport retains its position while
+scrolled and follows new output again after `End`. Commands and launchers
+preserve argument boundaries in their previews. Launchers explicitly show that
+their detached output and invocation history are not retained.
 
 When an active Agent instance is bound to a shell's current run, that shell row
 morphs into an agent row instead of adding a duplicate item. It keeps the

--- a/README.md
+++ b/README.md
@@ -526,9 +526,9 @@ See [`docs/live-pty-handoff.md`](docs/live-pty-handoff.md) for the handoff desig
 ## Development
 
 ```console
+cargo run
 cargo run -- .
 cargo run -- . --new
-cargo run -- ui
 cargo run -- doctor
 cargo test
 cargo clippy --all-targets -- -D warnings

--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ state and their highest-priority attention item. Shells show run metadata plus a
 bounded 16-row terminal-output viewport, fetched only when the selected shell's
 output revision changes. The viewport is hidden when it cannot fit without
 crowding the item table, retains its position while scrolled, and follows new
-output again after `End`. Commands show exact argv and run metadata without
-terminal output. Commands and launchers preserve argument boundaries in their
-previews. Launchers explicitly show that their detached output and invocation
-history are not retained.
+output again after `End`. Leading `❯` or `>` shell prompt indicators render as
+`$` in the preview without changing the underlying terminal. Commands show exact
+argv and run metadata without terminal output. Commands and launchers preserve
+argument boundaries in their previews. Launchers explicitly show that their
+detached output and invocation history are not retained.
 
 When an active Agent instance is bound to a shell's current run, that shell row
 morphs into an agent row instead of adding a duplicate item. It keeps the

--- a/README.md
+++ b/README.md
@@ -98,11 +98,10 @@ state and their highest-priority attention item. Shells show run metadata plus a
 bounded 16-row terminal-output viewport, fetched only when the selected shell's
 output revision changes. The viewport is hidden when it cannot fit without
 crowding the item table, retains its position while scrolled, and follows new
-output again after `End`. Leading `❯` or `>` shell prompt indicators render as
-`$` in the preview without changing the underlying terminal. Commands show exact
-argv and run metadata without terminal output. Commands and launchers preserve
-argument boundaries in their previews. Launchers explicitly show that their
-detached output and invocation history are not retained.
+output again after `End`. Commands show exact argv and run metadata without
+terminal output. Commands and launchers preserve argument boundaries in their
+previews. Launchers explicitly show that their detached output and invocation
+history are not retained.
 
 When an active Agent instance is bound to a shell's current run, that shell row
 morphs into an agent row instead of adding a duplicate item. It keeps the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,11 +152,12 @@ Agent presentation takes precedence when the current run has an active Agent or
 an exact `opencode` or `pi` foreground hint.
 
 Selected-kind previews remain read-only. Workspace, launcher, and run metadata
-come from the polled snapshot. Shell and command output uses a bounded plain-text
-read only when the selected shell, run ID, or output revision changes. Its
-viewport follows the tail by default and preserves the viewed rows when new
-output arrives while scrolled. Launcher previews never imply retained invocation
-state because launcher processes remain ephemeral.
+come from the polled snapshot. Shell output uses a bounded plain-text read only
+when the selected shell, run ID, or output revision changes. Its viewport follows
+the tail by default and preserves the viewed rows when new output arrives while
+scrolled. Command previews expose argv and run metadata without reading terminal
+output. Launcher previews never imply retained invocation state because launcher
+processes remain ephemeral.
 
 Agent sessions are a client-side projection, not a sixth durable daemon
 identity. The projection groups stored Agent instances by workspace,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,8 +157,6 @@ when the selected shell, run ID, or output revision changes. Its viewport follow
 the tail by default and preserves the viewed rows when new output arrives while
 scrolled. The dashboard omits a contextual preview rather than rendering a
 partial panel when the full preview and a usable item table cannot both fit.
-As a presentation-only heuristic, a leading standalone `❯` or `>` prompt token
-is normalized to `$`; this does not claim semantic command boundaries.
 Command previews expose argv and run metadata without reading terminal output.
 Launcher previews never imply retained invocation state because launcher
 processes remain ephemeral.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,8 +155,10 @@ Selected-kind previews remain read-only. Workspace, launcher, and run metadata
 come from the polled snapshot. Shell output uses a bounded plain-text read only
 when the selected shell, run ID, or output revision changes. Its viewport follows
 the tail by default and preserves the viewed rows when new output arrives while
-scrolled. Command previews expose argv and run metadata without reading terminal
-output. Launcher previews never imply retained invocation state because launcher
+scrolled. The dashboard omits a contextual preview rather than rendering a
+partial panel when the full preview and a usable item table cannot both fit.
+Command previews expose argv and run metadata without reading terminal output.
+Launcher previews never imply retained invocation state because launcher
 processes remain ephemeral.
 
 Agent sessions are a client-side projection, not a sixth durable daemon

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,6 +157,8 @@ when the selected shell, run ID, or output revision changes. Its viewport follow
 the tail by default and preserves the viewed rows when new output arrives while
 scrolled. The dashboard omits a contextual preview rather than rendering a
 partial panel when the full preview and a usable item table cannot both fit.
+As a presentation-only heuristic, a leading standalone `❯` or `>` prompt token
+is normalized to `$`; this does not claim semantic command boundaries.
 Command previews expose argv and run metadata without reading terminal output.
 Launcher previews never imply retained invocation state because launcher
 processes remain ephemeral.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,9 +153,10 @@ an exact `opencode` or `pi` foreground hint.
 
 Selected-kind previews remain read-only. Workspace, launcher, and run metadata
 come from the polled snapshot. Shell and command output uses a bounded plain-text
-read only when the selected shell, run ID, or output revision changes. Launcher
-previews never imply retained invocation state because launcher processes remain
-ephemeral.
+read only when the selected shell, run ID, or output revision changes. Its
+viewport follows the tail by default and preserves the viewed rows when new
+output arrives while scrolled. Launcher previews never imply retained invocation
+state because launcher processes remain ephemeral.
 
 Agent sessions are a client-side projection, not a sixth durable daemon
 identity. The projection groups stored Agent instances by workspace,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1059,7 +1059,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 let bytes = client
                     .read_shell(shell_id, READ_BYTES)
                     .map_err(|error| error.to_string())?;
-                Ok(recent_lines(&String::from_utf8_lossy(&bytes), 12))
+                Ok(recent_lines(&String::from_utf8_lossy(&bytes), 500))
             },
         },
     )?;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -23,6 +23,8 @@ const GREEN: Color = Color::Green;
 const YELLOW: Color = Color::Yellow;
 const RED: Color = Color::Red;
 const REFRESH_INTERVAL: Duration = Duration::from_millis(250);
+const TERMINAL_PREVIEW_ROWS: usize = 8;
+const TERMINAL_PREVIEW_SCROLL_STEP: usize = 5;
 
 pub(crate) struct WorkspaceView {
     pub(crate) id: String,
@@ -236,6 +238,7 @@ struct TerminalPreviewState {
     run_id: Option<String>,
     output_revision: u64,
     output: Result<String, String>,
+    scroll_from_bottom: usize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -851,12 +854,85 @@ impl App {
         }) {
             return;
         }
+        let output = on_preview(&shell_id);
+        let scroll_from_bottom = self
+            .terminal_preview
+            .as_ref()
+            .filter(|preview| {
+                preview.shell_id == shell_id
+                    && preview.run_id == run_id
+                    && preview.scroll_from_bottom > 0
+            })
+            .map_or(0, |preview| {
+                let previous_count = preview
+                    .output
+                    .as_deref()
+                    .ok()
+                    .map_or(0, |output| terminal_output_lines(output).len());
+                let next_count = output
+                    .as_deref()
+                    .ok()
+                    .map_or(0, |output| terminal_output_lines(output).len());
+                preview
+                    .scroll_from_bottom
+                    .saturating_add(next_count.saturating_sub(previous_count))
+            });
         self.terminal_preview = Some(TerminalPreviewState {
-            output: on_preview(&shell_id),
+            output,
             shell_id,
             run_id,
             output_revision,
+            scroll_from_bottom,
         });
+    }
+
+    fn scroll_terminal_preview_up(&mut self) {
+        let Some(preview) = self.terminal_preview.as_mut() else {
+            return;
+        };
+        let line_count = preview
+            .output
+            .as_deref()
+            .ok()
+            .map_or(0, |output| terminal_output_lines(output).len());
+        let max_scroll = line_count.saturating_sub(TERMINAL_PREVIEW_ROWS);
+        preview.scroll_from_bottom = preview
+            .scroll_from_bottom
+            .saturating_add(TERMINAL_PREVIEW_SCROLL_STEP)
+            .min(max_scroll);
+    }
+
+    fn scroll_terminal_preview_down(&mut self) {
+        let Some(preview) = self.terminal_preview.as_mut() else {
+            return;
+        };
+        preview.scroll_from_bottom = preview
+            .scroll_from_bottom
+            .saturating_sub(TERMINAL_PREVIEW_SCROLL_STEP);
+    }
+
+    fn scroll_terminal_preview_to_start(&mut self) {
+        let Some(preview) = self.terminal_preview.as_mut() else {
+            return;
+        };
+        let line_count = preview
+            .output
+            .as_deref()
+            .ok()
+            .map_or(0, |output| terminal_output_lines(output).len());
+        preview.scroll_from_bottom = line_count.saturating_sub(TERMINAL_PREVIEW_ROWS);
+    }
+
+    fn scroll_terminal_preview_to_end(&mut self) {
+        if let Some(preview) = self.terminal_preview.as_mut() {
+            preview.scroll_from_bottom = 0;
+        }
+    }
+
+    fn terminal_preview_is_available(&self) -> bool {
+        self.terminal_preview
+            .as_ref()
+            .is_some_and(|preview| preview.output.is_ok())
     }
 
     fn replace_workspaces(&mut self, workspaces: Vec<WorkspaceView>) {
@@ -1076,6 +1152,10 @@ where
             KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
             KeyCode::Down | KeyCode::Char('j') => app.next(),
             KeyCode::Up | KeyCode::Char('k') => app.previous(),
+            KeyCode::PageUp => app.scroll_terminal_preview_up(),
+            KeyCode::PageDown => app.scroll_terminal_preview_down(),
+            KeyCode::Home => app.scroll_terminal_preview_to_start(),
+            KeyCode::End => app.scroll_terminal_preview_to_end(),
             KeyCode::Enter => {
                 let dispatched = if app.primary_tab != PrimaryTab::Workspaces {
                     app.open_selected_item(&mut actions.on_open)
@@ -1827,22 +1907,33 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
         Span::styled("  branch ", Style::new().fg(SUBTEXT)),
         Span::raw(terminal.branch.clone()),
     ]));
-    let run = terminal.run.as_ref().map_or_else(
-        || format!("{}  no run yet", terminal.status),
+    let run_detail = terminal.run.as_ref().map_or_else(
+        || "no run yet".to_owned(),
         |run| {
-            let result = run.exit_reason.as_deref().unwrap_or(&terminal.status);
+            let outcome = run
+                .exit_reason
+                .as_deref()
+                .map_or_else(String::new, |reason| format!("{reason}  "));
             let timing = run.ended_at_ms.map_or_else(
                 || format!("started {}", compact_recency(run.started_at_ms)),
                 |ended| format!("ended {}", compact_recency(ended)),
             );
             format!(
-                "{result}  run {} generation {}  {timing}",
+                "{outcome}run {}  generation {}  {timing}",
                 short_id(&run.id),
                 run.generation
             )
         },
     );
-    lines.push(Line::from(Span::styled(run, Style::new().fg(SUBTEXT))));
+    lines.push(Line::from(vec![
+        Span::styled(
+            terminal.status.clone(),
+            Style::new()
+                .fg(status_color(&terminal.status))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("  {run_detail}"), Style::new().fg(SUBTEXT)),
+    ]));
 
     if let Some(preview) = app
         .terminal_preview
@@ -1850,27 +1941,42 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
         .filter(|preview| preview.shell_id == terminal.id)
     {
         match &preview.output {
-            Ok(output) if output.trim().is_empty() => lines.push(Line::from(Span::styled(
-                "No terminal output",
-                Style::new().fg(SUBTEXT),
-            ))),
+            Ok(output) if output.trim().is_empty() => lines.push(Line::from(vec![
+                Span::styled(" Output ", Style::new().fg(BASE).bg(BLUE)),
+                Span::styled(" no terminal output", Style::new().fg(SUBTEXT)),
+            ])),
             Ok(output) => {
+                let viewport =
+                    terminal_viewport(output, TERMINAL_PREVIEW_ROWS, preview.scroll_from_bottom);
                 lines.push(Line::from(vec![
+                    Span::styled(" Output ", Style::new().fg(BASE).bg(BLUE)),
                     Span::styled(
-                        "Terminal tail",
-                        Style::new().fg(BLUE).add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        format!("  revision {}", preview.output_revision),
+                        format!(
+                            " {}-{} / {}  revision {}  ",
+                            viewport.start + 1,
+                            viewport.end,
+                            viewport.total,
+                            preview.output_revision
+                        ),
                         Style::new().fg(SUBTEXT),
                     ),
+                    Span::styled(
+                        if viewport.following {
+                            "FOLLOW"
+                        } else {
+                            "SCROLLED"
+                        },
+                        Style::new()
+                            .fg(if viewport.following { GREEN } else { YELLOW })
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 ]));
-                lines.extend(terminal_tail_lines(output, 5).into_iter().map(|line| {
-                    Line::from(vec![
-                        Span::styled("| ", Style::new().fg(OVERLAY)),
-                        Span::raw(line),
-                    ])
-                }));
+                lines.extend(
+                    viewport
+                        .lines
+                        .into_iter()
+                        .map(|line| Line::from(Span::raw(format!(" {line}")))),
+                );
             }
             Err(error) => lines.push(Line::from(Span::styled(
                 format!("Output unavailable: {error}"),
@@ -1880,16 +1986,24 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
     }
     Some(ContextualPreview {
         title: if is_command {
-            format!(" Command preview: {} ", terminal.name)
+            format!(" Command: {} ", terminal.name)
         } else {
-            format!(" Shell preview: {} ", terminal.name)
+            format!(" Shell: {} ", terminal.name)
         },
         content_height: lines.len() as u16,
         content: PreviewContent::Lines(lines),
     })
 }
 
-fn terminal_tail_lines(output: &str, limit: usize) -> Vec<String> {
+struct TerminalViewport {
+    lines: Vec<String>,
+    start: usize,
+    end: usize,
+    total: usize,
+    following: bool,
+}
+
+fn terminal_output_lines(output: &str) -> Vec<String> {
     let mut lines: Vec<_> = output
         .lines()
         .map(|line| line.trim_end().to_owned())
@@ -1904,10 +2018,23 @@ fn terminal_tail_lines(output: &str, limit: usize) -> Vec<String> {
         .map_or(first, |last| last + 1);
     lines.drain(end..);
     lines.drain(..first);
-    if lines.len() > limit {
-        lines.drain(..lines.len() - limit);
-    }
     lines
+}
+
+fn terminal_viewport(output: &str, height: usize, scroll_from_bottom: usize) -> TerminalViewport {
+    let lines = terminal_output_lines(output);
+    let total = lines.len();
+    let latest_start = total.saturating_sub(height);
+    let scroll_from_bottom = scroll_from_bottom.min(latest_start);
+    let start = latest_start - scroll_from_bottom;
+    let end = (start + height).min(total);
+    TerminalViewport {
+        lines: lines[start..end].to_vec(),
+        start,
+        end,
+        total,
+        following: scroll_from_bottom == 0,
+    }
 }
 
 fn format_argv(argv: &[String]) -> String {
@@ -2254,6 +2381,14 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 Style::new().fg(SUBTEXT),
             ),
         ]);
+        if app.terminal_preview_is_available() {
+            spans.extend([
+                Span::styled("pgup/dn", Style::new().fg(TEAL)),
+                Span::styled(" output  ", Style::new().fg(SUBTEXT)),
+                Span::styled("home/end", Style::new().fg(TEAL)),
+                Span::styled(" oldest/follow  ", Style::new().fg(SUBTEXT)),
+            ]);
+        }
         spans.extend([
             Span::styled("r", Style::new().fg(BLUE)),
             Span::styled(" refresh  ", Style::new().fg(SUBTEXT)),
@@ -3642,7 +3777,7 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        assert!(shell_text.contains("Shell preview"));
+        assert!(shell_text.contains("Shell: agent"));
         assert!(shell_text.contains("/tmp/boomux"));
         assert!(!shell_text.contains("OpenCode session"));
 
@@ -3695,7 +3830,7 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect();
 
-        assert!(text.contains("Command preview"));
+        assert!(text.contains("Command: format"));
         assert!(text.contains("[\"printf\", \"a b\", \"\"]"));
     }
 
@@ -3747,20 +3882,75 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        assert!(text.contains("Terminal tail"));
+        assert!(text.contains("Output"));
         assert!(text.contains("revision 5"));
+        assert!(text.contains("FOLLOW"));
         assert!(text.contains("latest"));
+        assert!(text.contains("pgup/dn"));
     }
 
     #[test]
-    fn terminal_tail_trims_edge_blanks_and_keeps_the_latest_rows() {
+    fn terminal_viewport_trims_edges_and_scrolls_from_the_tail() {
         let output = "\nold\n\nrecent one  \nrecent two\n\n";
 
         assert_eq!(
-            terminal_tail_lines(output, 3),
-            ["", "recent one", "recent two"]
+            terminal_output_lines(output),
+            ["old", "", "recent one", "recent two"]
         );
-        assert!(terminal_tail_lines("\n \n", 5).is_empty());
+        assert!(terminal_output_lines("\n \n").is_empty());
+
+        let following = terminal_viewport(output, 3, 0);
+        assert_eq!(following.lines, ["", "recent one", "recent two"]);
+        assert_eq!((following.start, following.end, following.total), (1, 4, 4));
+        assert!(following.following);
+
+        let scrolled = terminal_viewport(output, 2, 2);
+        assert_eq!(scrolled.lines, ["old", ""]);
+        assert!(!scrolled.following);
+    }
+
+    #[test]
+    fn terminal_preview_scroll_controls_preserve_position_as_output_arrives() {
+        let mut app = app();
+        focus_items(&mut app);
+        let WorkspaceItemView::Shell(shell) = &mut app.workspaces[0].items[0] else {
+            unreachable!();
+        };
+        shell.run = Some(TerminalRunView {
+            id: "run-1".into(),
+            generation: 1,
+            started_at_ms: current_time_ms(),
+            ended_at_ms: None,
+            exit_reason: None,
+            output_revision: 1,
+        });
+        let output = |count: usize| {
+            (1..=count)
+                .map(|line| format!("line {line}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        app.refresh_terminal_preview(&mut |_| Ok(output(20)));
+        app.scroll_terminal_preview_up();
+        assert_eq!(app.terminal_preview.as_ref().unwrap().scroll_from_bottom, 5);
+        app.scroll_terminal_preview_to_start();
+        assert_eq!(
+            app.terminal_preview.as_ref().unwrap().scroll_from_bottom,
+            12
+        );
+        app.scroll_terminal_preview_down();
+        assert_eq!(app.terminal_preview.as_ref().unwrap().scroll_from_bottom, 7);
+
+        let WorkspaceItemView::Shell(shell) = &mut app.workspaces[0].items[0] else {
+            unreachable!();
+        };
+        shell.run.as_mut().unwrap().output_revision = 2;
+        app.refresh_terminal_preview(&mut |_| Ok(output(22)));
+        assert_eq!(app.terminal_preview.as_ref().unwrap().scroll_from_bottom, 9);
+
+        app.scroll_terminal_preview_to_end();
+        assert_eq!(app.terminal_preview.as_ref().unwrap().scroll_from_bottom, 0);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -834,12 +834,14 @@ impl App {
             None
         } else {
             self.selected_item().and_then(|item| match item {
-                WorkspaceItemView::Shell(shell) => Some((
+                WorkspaceItemView::Shell(shell) if shell.command.is_empty() => Some((
                     shell.id.clone(),
                     shell.run.as_ref().map(|run| run.id.clone()),
                     shell.run.as_ref().map_or(0, |run| run.output_revision),
                 )),
-                WorkspaceItemView::AgentShell(_) | WorkspaceItemView::Launcher(_) => None,
+                WorkspaceItemView::Shell(_)
+                | WorkspaceItemView::AgentShell(_)
+                | WorkspaceItemView::Launcher(_) => None,
             })
         };
         let Some((shell_id, run_id, output_revision)) = selected else {
@@ -1938,7 +1940,7 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
     if let Some(preview) = app
         .terminal_preview
         .as_ref()
-        .filter(|preview| preview.shell_id == terminal.id)
+        .filter(|preview| !is_command && preview.shell_id == terminal.id)
     {
         match &preview.output {
             Ok(output) if output.trim().is_empty() => lines.push(Line::from(vec![
@@ -3818,6 +3820,11 @@ mod tests {
         command.argv = vec!["printf".into(), "a b".into(), String::new()];
         let mut app = App::new(vec![workspace], project_context());
         app.select_tab(PrimaryTab::Commands);
+        let reads = std::cell::Cell::new(0);
+        app.refresh_terminal_preview(&mut |_| {
+            reads.set(reads.get() + 1);
+            Ok("command output".into())
+        });
 
         backend_terminal
             .draw(|frame| render(frame, &mut app))
@@ -3832,6 +3839,10 @@ mod tests {
 
         assert!(text.contains("Command: format"));
         assert!(text.contains("[\"printf\", \"a b\", \"\"]"));
+        assert!(!text.contains(" Output "));
+        assert!(!text.contains("pgup/dn"));
+        assert_eq!(reads.get(), 0);
+        assert!(app.terminal_preview.is_none());
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -23,8 +23,9 @@ const GREEN: Color = Color::Green;
 const YELLOW: Color = Color::Yellow;
 const RED: Color = Color::Red;
 const REFRESH_INTERVAL: Duration = Duration::from_millis(250);
-const TERMINAL_PREVIEW_ROWS: usize = 8;
-const TERMINAL_PREVIEW_SCROLL_STEP: usize = 5;
+const TERMINAL_PREVIEW_ROWS: usize = 16;
+const TERMINAL_PREVIEW_SCROLL_STEP: usize = 12;
+const PREVIEW_RESERVED_ITEM_HEIGHT: u16 = 6;
 
 pub(crate) struct WorkspaceView {
     pub(crate) id: String,
@@ -1549,13 +1550,15 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
         .title(title)
         .border_style(Style::new().fg(TEAL));
     let inner = block.inner(area);
-    let contextual_panel = (inner.height >= 9)
-        .then(|| selected_item_preview(app))
-        .flatten();
+    let contextual_panel = selected_item_preview(app).filter(|panel| {
+        inner.height
+            >= panel
+                .content_height
+                .saturating_add(2)
+                .saturating_add(PREVIEW_RESERVED_ITEM_HEIGHT)
+    });
     let (items_inner, preview_area) = contextual_panel.as_ref().map_or((inner, None), |panel| {
-        let panel_height = (panel.content_height + 2)
-            .min(inner.height.saturating_sub(6))
-            .max(3);
+        let panel_height = panel.content_height + 2;
         let [items_area, preview_area] =
             Layout::vertical([Constraint::Fill(1), Constraint::Length(panel_height)]).areas(inner);
         (items_area, Some(preview_area))
@@ -1685,13 +1688,18 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         },
     ));
     let inner = block.inner(area);
-    let contextual_panel = (app.focus == Focus::Items && inner.height >= 9)
+    let contextual_panel = (app.focus == Focus::Items)
         .then(|| selected_item_preview(app))
-        .flatten();
+        .flatten()
+        .filter(|panel| {
+            inner.height
+                >= panel
+                    .content_height
+                    .saturating_add(2)
+                    .saturating_add(PREVIEW_RESERVED_ITEM_HEIGHT)
+        });
     let (items_inner, preview_area) = contextual_panel.as_ref().map_or((inner, None), |panel| {
-        let panel_height = (panel.content_height + 2)
-            .min(inner.height.saturating_sub(6))
-            .max(3);
+        let panel_height = panel.content_height + 2;
         let [items_area, preview_area] =
             Layout::vertical([Constraint::Fill(1), Constraint::Length(panel_height)]).areas(inner);
         (items_area, Some(preview_area))
@@ -1992,7 +2000,11 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
         } else {
             format!(" Shell: {} ", terminal.name)
         },
-        content_height: lines.len() as u16,
+        content_height: if is_command {
+            lines.len() as u16
+        } else {
+            (TERMINAL_PREVIEW_ROWS + 3) as u16
+        },
         content: PreviewContent::Lines(lines),
     })
 }
@@ -3942,26 +3954,83 @@ mod tests {
                 .join("\n")
         };
 
-        app.refresh_terminal_preview(&mut |_| Ok(output(20)));
+        app.refresh_terminal_preview(&mut |_| Ok(output(40)));
         app.scroll_terminal_preview_up();
-        assert_eq!(app.terminal_preview.as_ref().unwrap().scroll_from_bottom, 5);
-        app.scroll_terminal_preview_to_start();
         assert_eq!(
             app.terminal_preview.as_ref().unwrap().scroll_from_bottom,
             12
         );
+        app.scroll_terminal_preview_to_start();
+        assert_eq!(
+            app.terminal_preview.as_ref().unwrap().scroll_from_bottom,
+            24
+        );
         app.scroll_terminal_preview_down();
-        assert_eq!(app.terminal_preview.as_ref().unwrap().scroll_from_bottom, 7);
+        assert_eq!(
+            app.terminal_preview.as_ref().unwrap().scroll_from_bottom,
+            12
+        );
 
         let WorkspaceItemView::Shell(shell) = &mut app.workspaces[0].items[0] else {
             unreachable!();
         };
         shell.run.as_mut().unwrap().output_revision = 2;
-        app.refresh_terminal_preview(&mut |_| Ok(output(22)));
-        assert_eq!(app.terminal_preview.as_ref().unwrap().scroll_from_bottom, 9);
+        app.refresh_terminal_preview(&mut |_| Ok(output(42)));
+        assert_eq!(
+            app.terminal_preview.as_ref().unwrap().scroll_from_bottom,
+            14
+        );
 
         app.scroll_terminal_preview_to_end();
         assert_eq!(app.terminal_preview.as_ref().unwrap().scroll_from_bottom, 0);
+    }
+
+    #[test]
+    fn shell_preview_uses_sixteen_rows_or_hides_when_height_is_insufficient() {
+        let mut app = app();
+        focus_items(&mut app);
+        let WorkspaceItemView::Shell(shell) = &mut app.workspaces[0].items[0] else {
+            unreachable!();
+        };
+        shell.run = Some(TerminalRunView {
+            id: "run-1".into(),
+            generation: 1,
+            started_at_ms: current_time_ms(),
+            ended_at_ms: None,
+            exit_reason: None,
+            output_revision: 1,
+        });
+        let output = (1..=30)
+            .map(|line| format!("viewport line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        app.refresh_terminal_preview(&mut |_| Ok(output.clone()));
+
+        let mut wide = Terminal::new(TestBackend::new(180, 40)).unwrap();
+        wide.draw(|frame| render(frame, &mut app)).unwrap();
+        let wide_text: String = wide
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(wide_text.contains("Shell: agent"));
+        assert!(wide_text.contains("viewport line 15"));
+        assert!(wide_text.contains("viewport line 30"));
+        assert!(!wide_text.contains("viewport line 14"));
+
+        let mut short = Terminal::new(TestBackend::new(180, 24)).unwrap();
+        short.draw(|frame| render(frame, &mut app)).unwrap();
+        let short_text: String = short
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(!short_text.contains("Shell: agent"));
+        assert!(short_text.contains("Items: boomux"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2020,7 +2020,7 @@ struct TerminalViewport {
 fn terminal_output_lines(output: &str) -> Vec<String> {
     let mut lines: Vec<_> = output
         .lines()
-        .map(|line| normalize_shell_prompt_indicator(line.trim_end()))
+        .map(|line| line.trim_end().to_owned())
         .collect();
     let first = lines
         .iter()
@@ -2033,19 +2033,6 @@ fn terminal_output_lines(output: &str) -> Vec<String> {
     lines.drain(end..);
     lines.drain(..first);
     lines
-}
-
-fn normalize_shell_prompt_indicator(line: &str) -> String {
-    let content = line.trim_start();
-    let indentation = &line[..line.len() - content.len()];
-    for indicator in ["❯", ">"] {
-        if let Some(rest) = content.strip_prefix(indicator)
-            && rest.chars().next().is_none_or(char::is_whitespace)
-        {
-            return format!("{indentation}${rest}");
-        }
-    }
-    line.to_owned()
 }
 
 fn terminal_viewport(output: &str, height: usize, scroll_from_bottom: usize) -> TerminalViewport {
@@ -3943,24 +3930,6 @@ mod tests {
         let scrolled = terminal_viewport(output, 2, 2);
         assert_eq!(scrolled.lines, ["old", ""]);
         assert!(!scrolled.following);
-    }
-
-    #[test]
-    fn shell_preview_normalizes_only_leading_prompt_chevrons() {
-        assert_eq!(
-            normalize_shell_prompt_indicator("❯ cargo test"),
-            "$ cargo test"
-        );
-        assert_eq!(
-            normalize_shell_prompt_indicator("  > cargo test"),
-            "  $ cargo test"
-        );
-        assert_eq!(normalize_shell_prompt_indicator("❯"), "$");
-        assert_eq!(normalize_shell_prompt_indicator(">="), ">=");
-        assert_eq!(
-            normalize_shell_prompt_indicator("result > expected"),
-            "result > expected"
-        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2020,7 +2020,7 @@ struct TerminalViewport {
 fn terminal_output_lines(output: &str) -> Vec<String> {
     let mut lines: Vec<_> = output
         .lines()
-        .map(|line| line.trim_end().to_owned())
+        .map(|line| normalize_shell_prompt_indicator(line.trim_end()))
         .collect();
     let first = lines
         .iter()
@@ -2033,6 +2033,19 @@ fn terminal_output_lines(output: &str) -> Vec<String> {
     lines.drain(end..);
     lines.drain(..first);
     lines
+}
+
+fn normalize_shell_prompt_indicator(line: &str) -> String {
+    let content = line.trim_start();
+    let indentation = &line[..line.len() - content.len()];
+    for indicator in ["❯", ">"] {
+        if let Some(rest) = content.strip_prefix(indicator)
+            && rest.chars().next().is_none_or(char::is_whitespace)
+        {
+            return format!("{indentation}${rest}");
+        }
+    }
+    line.to_owned()
 }
 
 fn terminal_viewport(output: &str, height: usize, scroll_from_bottom: usize) -> TerminalViewport {
@@ -3930,6 +3943,24 @@ mod tests {
         let scrolled = terminal_viewport(output, 2, 2);
         assert_eq!(scrolled.lines, ["old", ""]);
         assert!(!scrolled.following);
+    }
+
+    #[test]
+    fn shell_preview_normalizes_only_leading_prompt_chevrons() {
+        assert_eq!(
+            normalize_shell_prompt_indicator("❯ cargo test"),
+            "$ cargo test"
+        );
+        assert_eq!(
+            normalize_shell_prompt_indicator("  > cargo test"),
+            "  $ cargo test"
+        );
+        assert_eq!(normalize_shell_prompt_indicator("❯"), "$");
+        assert_eq!(normalize_shell_prompt_indicator(">="), ">=");
+        assert_eq!(
+            normalize_shell_prompt_indicator("result > expected"),
+            "result > expected"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the fixed five-line shell tail with a 16-row read-only viewport over up to 500 recent rows
- hide contextual previews when the full panel and a usable item table cannot both fit
- add PageUp/PageDown scrolling, Home for the oldest retained row, and End to resume following
- preserve the viewed rows when shell output arrives while the viewport is scrolled
- show visible line range, output revision, and explicit FOLLOW/SCROLLED state
- keep command previews focused on exact argv and run metadata without reading or rendering terminal output
- simplify shell and command preview titles and status presentation

## Validation
- `cargo test` (321 tests)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- responsive coverage verifies the 16-row viewport at tall sizes and complete hiding at short sizes
- installed prototype to `~/.local/bin/boomux` for live evaluation

## Prototype notes
The shell viewport remains plain-text and read-only. It intentionally does not alter prompt text, attach as a PTY controller, or claim semantic prompt/input/output boundaries.