### PR TITLE
refactor: centralize compatibility and adapter policies

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -165,7 +165,7 @@ otherwise pass both explicitly. Retain the exact agent ID returned by
 never replace it with a newer run from the durable shell.
 
 Every register, ensure, and report command requires an explicit state (`unknown`, `working`,
-`blocked`, `idle`, or `done`), external authority (`lifecycle-integration`,
+`blocked`, `idle`, `done`, or `inactive`), external authority (`lifecycle-integration`,
 `process-adapter`, or `terminal-heuristic`), nonempty evidence, and confidence
 from 0 through 100. `daemon-lifecycle` is reserved and public mutations reject
 it. Authority precedence is lifecycle integration over process adapter over
@@ -178,8 +178,7 @@ while conflicting later reports are rejected.
 
 If `register`, `ensure`, or `report` returns `run_changed`, stop reporting for that
 instance and reacquire exact lifecycle context. Do not guess the replacement
-run. Boomux does not yet provide terminal heuristics, agent read commands, or
-control.
+run. Boomux does not yet provide terminal heuristics or agent control.
 
 ## Supervise An Explicit Process
 

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ observations in a durable, blocked-first attention queue. Each item retains the
 exact raising evidence, authority, confidence, revision, and timestamp until it
 is conditionally acknowledged; later working or idle activity does not erase
 unseen work. Workspace output includes fixed Agent state counts and the
-outstanding attention count. Boomux does not yet provide terminal heuristics,
-agent reads, or agent control.
+outstanding attention count. Boomux does not yet provide terminal heuristics or
+agent control.
 
 Optional desktop notifications mirror transitions into `blocked` and `done`.
 They do not replace or acknowledge durable attention items. Delivery is an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,12 +175,13 @@ workspace that references their exact normalized directory. The dashboard maps
 the active or latest exact match into a durable Agent's contextual preview and
 discovers catalogs asynchronously; session CLI listing performs the same bounded
 discovery synchronously. Sessions are not a dashboard kind.
-Title enrichment has its own adapter registry. The shared layer owns asynchronous
-cache, refresh, deduplication, sanitization, and fallback policy; OpenCode and Pi
-modules own host command execution and title extraction. Neutral host source
-modules own shared path normalization and secure source discovery. Title support
-remains independent from transcript support so a future harness may implement
-either capability without claiming the other.
+Title enrichment has its own adapter registry. Each adapter declares whether it
+also provides a session catalog. The shared layer owns asynchronous cache,
+refresh, deduplication, sanitization, and fallback policy; OpenCode and Pi modules
+own host command execution and title extraction. Neutral host source modules own
+shared path normalization and secure source discovery. Title and catalog support
+remain independent from transcript support so a future harness may implement
+the relevant capabilities without claiming transcript support.
 
 Session list/inspect requires a negotiated protocol-12 snapshot because the
 projection depends on that complete Agent state model. Protocol 13 adds an

--- a/integrations/pi/boomux.js
+++ b/integrations/pi/boomux.js
@@ -340,12 +340,9 @@ export default function BoomuxPiExtension(pi) {
 }
 
 export const __internal = Object.freeze({
-  agentErrorEvidence,
   boundedEvidence,
   createLifecycle,
   createOutcomeTracker,
   createProcessRunner,
-  ensureArgv,
-  reportArgv,
   registerLifecycleHandlers,
 });

--- a/src/client.rs
+++ b/src/client.rs
@@ -191,10 +191,10 @@ impl Client {
 
     fn send(&self, request: Request) -> io::Result<(UnixStream, Response)> {
         let mut version = self.protocol_version.load(Ordering::Acquire);
-        if version < request_minimum_version(&request) {
+        if version < request.minimum_protocol_version() {
             self.probe_latest()?;
             version = self.protocol_version.load(Ordering::Acquire);
-            if version < request_minimum_version(&request) {
+            if version < request.minimum_protocol_version() {
                 return Err(remote_error(
                     ErrorCode::UnsupportedVersion,
                     "daemon does not support this request",
@@ -207,7 +207,7 @@ impl Client {
             {
                 self.probe_latest()?;
                 let negotiated = self.protocol_version.load(Ordering::Acquire);
-                if negotiated < request_minimum_version(&request) {
+                if negotiated < request.minimum_protocol_version() {
                     return Err(remote_error(
                         ErrorCode::UnsupportedVersion,
                         "daemon does not support this request",
@@ -450,17 +450,18 @@ impl Client {
         after_revision: u64,
         wait_ms: u32,
     ) -> io::Result<AgentWait> {
-        if self.protocol_version()? < 14 {
+        let request = Request::WaitAgent {
+            agent_id: agent_id.into(),
+            after_revision,
+            wait_ms,
+        };
+        if self.protocol_version()? < request.minimum_protocol_version() {
             return Err(remote_error(
                 ErrorCode::UnsupportedVersion,
                 "daemon does not support Agent wait",
             ));
         }
-        match self.request(Request::WaitAgent {
-            agent_id: agent_id.into(),
-            after_revision,
-            wait_ms,
-        })? {
+        match self.request(request)? {
             Response::AgentWait { agent, changed } => Ok(AgentWait { agent, changed }),
             other => unexpected(other),
         }
@@ -718,36 +719,6 @@ fn current_environment() -> UnixEnvironment {
     }
 }
 
-fn request_minimum_version(request: &Request) -> u32 {
-    match request {
-        Request::Attach {
-            environment: Some(_),
-            ..
-        } => 16,
-        Request::AcknowledgeAgentAttention { .. } => 15,
-        Request::WaitAgent { .. } => 14,
-        Request::RegisterAgent { spec, .. } | Request::EnsureAgent { spec, .. }
-            if spec.report.state == protocol::AgentState::Inactive =>
-        {
-            12
-        }
-        Request::ReportAgent { report, .. } if report.state == protocol::AgentState::Inactive => 12,
-        Request::GetLauncher { .. }
-        | Request::CreateLauncher { .. }
-        | Request::RenameLauncher { .. }
-        | Request::RemoveLauncher { .. } => 8,
-        Request::GetAgent { .. } | Request::RegisterAgent { .. } | Request::ReportAgent { .. } => 9,
-        Request::EnsureAgent { .. } => 10,
-        Request::RestartShell { .. }
-        | Request::Attach {
-            restart_exited: true,
-            ..
-        } => 11,
-        Request::ReadShellAt { .. } | Request::Events { .. } => 7,
-        _ => protocol::MIN_PROTOCOL_VERSION,
-    }
-}
-
 fn remote_code(error: &io::Error) -> Option<ErrorCode> {
     error
         .get_ref()
@@ -844,113 +815,6 @@ mod tests {
     }
 
     #[test]
-    fn launcher_requests_require_protocol_eight() {
-        let requests = [
-            Request::GetLauncher {
-                launcher_id: "l1".into(),
-            },
-            Request::CreateLauncher {
-                workspace_id: "w1".into(),
-                spec: WorkspaceLauncherSpec {
-                    name: "editor".into(),
-                    command: vec!["editor".into()],
-                    cwd: "/tmp".into(),
-                },
-            },
-            Request::RenameLauncher {
-                launcher_id: "l1".into(),
-                name: "renamed".into(),
-            },
-            Request::RemoveLauncher {
-                launcher_id: "l1".into(),
-            },
-        ];
-
-        for request in requests {
-            assert_eq!(request_minimum_version(&request), 8);
-        }
-    }
-
-    #[test]
-    fn agent_requests_require_protocol_nine() {
-        let report = AgentReport {
-            state: protocol::AgentState::Idle,
-            authority: protocol::AgentAuthority::TerminalHeuristic,
-            evidence: "prompt visible".into(),
-            confidence: 70,
-        };
-        let requests = [
-            Request::GetAgent {
-                agent_id: "a1".into(),
-            },
-            Request::RegisterAgent {
-                shell_id: "s1".into(),
-                run_id: "r1".into(),
-                spec: AgentRegistrationSpec {
-                    name: "agent".into(),
-                    integration: "test".into(),
-                    external_session_id: None,
-                    report: report.clone(),
-                },
-            },
-            Request::ReportAgent {
-                agent_id: "a1".into(),
-                run_id: "r1".into(),
-                report,
-            },
-        ];
-
-        for request in requests {
-            assert_eq!(request_minimum_version(&request), 9);
-        }
-    }
-
-    #[test]
-    fn ensure_agent_requires_protocol_ten() {
-        assert_eq!(
-            request_minimum_version(&Request::EnsureAgent {
-                shell_id: "s1".into(),
-                run_id: "r1".into(),
-                spec: AgentRegistrationSpec {
-                    name: "agent".into(),
-                    integration: "test".into(),
-                    external_session_id: Some("external-1".into()),
-                    report: AgentReport {
-                        state: protocol::AgentState::Working,
-                        authority: protocol::AgentAuthority::LifecycleIntegration,
-                        evidence: "working".into(),
-                        confidence: 90,
-                    },
-                },
-            }),
-            10
-        );
-    }
-
-    #[test]
-    fn agent_wait_requires_protocol_fourteen() {
-        assert_eq!(
-            request_minimum_version(&Request::WaitAgent {
-                agent_id: "a1".into(),
-                after_revision: 1,
-                wait_ms: 30_000,
-            }),
-            14
-        );
-    }
-
-    #[test]
-    fn agent_attention_acknowledgment_requires_protocol_fifteen() {
-        assert_eq!(
-            request_minimum_version(&Request::AcknowledgeAgentAttention {
-                agent_id: "a1".into(),
-                observation_revision: 2,
-            }),
-            15
-        );
-    }
-
-    #[test]
     fn direct_client_negotiates_before_sending_agent_wait() {
         let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
@@ -1022,75 +886,6 @@ mod tests {
     }
 
     #[test]
-    fn restart_shell_requires_protocol_eleven() {
-        assert_eq!(
-            request_minimum_version(&Request::RestartShell {
-                shell_id: "s1".into(),
-            }),
-            11
-        );
-    }
-
-    #[test]
-    fn restarting_attach_requires_protocol_eleven() {
-        let profile = TerminalProfile {
-            term: None,
-            colorterm: None,
-            term_program: None,
-            term_program_version: None,
-            rows: 24,
-            cols: 80,
-            pixel_width: 0,
-            pixel_height: 0,
-        };
-        assert_eq!(
-            request_minimum_version(&Request::Attach {
-                shell_id: "s1".into(),
-                takeover: false,
-                restart_exited: true,
-                profile: profile.clone(),
-                environment: None,
-            }),
-            11
-        );
-        assert_eq!(
-            request_minimum_version(&Request::Attach {
-                shell_id: "s1".into(),
-                takeover: false,
-                restart_exited: false,
-                profile,
-                environment: None,
-            }),
-            protocol::MIN_PROTOCOL_VERSION
-        );
-    }
-
-    #[test]
-    fn attach_environment_requires_protocol_sixteen() {
-        assert_eq!(
-            request_minimum_version(&Request::Attach {
-                shell_id: "s1".into(),
-                takeover: false,
-                restart_exited: false,
-                profile: TerminalProfile {
-                    term: None,
-                    colorterm: None,
-                    term_program: None,
-                    term_program_version: None,
-                    rows: 24,
-                    cols: 80,
-                    pixel_width: 0,
-                    pixel_height: 0,
-                },
-                environment: Some(UnixEnvironment {
-                    variables: Vec::new(),
-                }),
-            }),
-            16
-        );
-    }
-
-    #[test]
     fn attach_captures_the_full_unix_environment() {
         let expected: std::collections::HashMap<Vec<u8>, Vec<u8>> = env::vars_os()
             .map(|(name, value)| {
@@ -1143,23 +938,6 @@ mod tests {
         assert_eq!(attachment.token, "token");
         server.join().unwrap();
         fs::remove_dir_all(directory).unwrap();
-    }
-
-    #[test]
-    fn inactive_agent_reports_require_protocol_twelve() {
-        assert_eq!(
-            request_minimum_version(&Request::ReportAgent {
-                agent_id: "a1".into(),
-                run_id: "r1".into(),
-                report: AgentReport {
-                    state: protocol::AgentState::Inactive,
-                    authority: protocol::AgentAuthority::LifecycleIntegration,
-                    evidence: "inactive".into(),
-                    confidence: 100,
-                },
-            }),
-            12
-        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -594,17 +594,6 @@ fn select_replacement_executable(current: PathBuf, argument_zero: Option<PathBuf
     current
 }
 
-fn request_requires_protocol_twelve(request: &Request) -> bool {
-    matches!(
-        request,
-        Request::RegisterAgent { spec, .. } | Request::EnsureAgent { spec, .. }
-            if spec.report.state == AgentState::Inactive
-    ) || matches!(
-        request,
-        Request::ReportAgent { report, .. } if report.state == AgentState::Inactive
-    )
-}
-
 fn handle_connection(
     mut stream: UnixStream,
     registry: Arc<Registry>,
@@ -630,129 +619,14 @@ fn handle_connection(
         );
     }
     let response_version = request.version;
-    if response_version < 7
-        && matches!(
-            request.message,
-            Request::ReadShellAt { .. } | Request::Events { .. }
-        )
-    {
+    let minimum_version = request.message.minimum_protocol_version();
+    if response_version < minimum_version {
         return send_response(
             &mut stream,
             response_version,
             error_response(
                 ErrorCode::UnsupportedVersion,
-                "request requires daemon protocol 7",
-            ),
-        );
-    }
-    if response_version < 8
-        && matches!(
-            request.message,
-            Request::GetLauncher { .. }
-                | Request::CreateLauncher { .. }
-                | Request::RenameLauncher { .. }
-                | Request::RemoveLauncher { .. }
-        )
-    {
-        return send_response(
-            &mut stream,
-            response_version,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                "request requires daemon protocol 8",
-            ),
-        );
-    }
-    if response_version < 9
-        && matches!(
-            request.message,
-            Request::GetAgent { .. } | Request::RegisterAgent { .. } | Request::ReportAgent { .. }
-        )
-    {
-        return send_response(
-            &mut stream,
-            response_version,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                "request requires daemon protocol 9",
-            ),
-        );
-    }
-    if response_version < 10 && matches!(request.message, Request::EnsureAgent { .. }) {
-        return send_response(
-            &mut stream,
-            response_version,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                "request requires daemon protocol 10",
-            ),
-        );
-    }
-    if response_version < 11
-        && matches!(
-            request.message,
-            Request::RestartShell { .. }
-                | Request::Attach {
-                    restart_exited: true,
-                    ..
-                }
-        )
-    {
-        return send_response(
-            &mut stream,
-            response_version,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                "request requires daemon protocol 11",
-            ),
-        );
-    }
-    if response_version < 12 && request_requires_protocol_twelve(&request.message) {
-        return send_response(
-            &mut stream,
-            response_version,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                "inactive agent state requires daemon protocol 12",
-            ),
-        );
-    }
-    if response_version < 14 && matches!(request.message, Request::WaitAgent { .. }) {
-        return send_response(
-            &mut stream,
-            response_version,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                "agent wait requires daemon protocol 14",
-            ),
-        );
-    }
-    if response_version < 15 && matches!(request.message, Request::AcknowledgeAgentAttention { .. })
-    {
-        return send_response(
-            &mut stream,
-            response_version,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                "agent attention acknowledgment requires daemon protocol 15",
-            ),
-        );
-    }
-    if response_version < 16
-        && matches!(
-            request.message,
-            Request::Attach {
-                environment: Some(_),
-                ..
-            }
-        )
-    {
-        return send_response(
-            &mut stream,
-            response_version,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                "client environment requires daemon protocol 16",
+                unsupported_request_message(&request.message, minimum_version),
             ),
         );
     }
@@ -863,6 +737,28 @@ fn handle_connection(
         response_version,
         response_for_version(response, response_version),
     )
+}
+
+fn unsupported_request_message(request: &Request, minimum_version: u32) -> String {
+    match request {
+        Request::RegisterAgent { spec, .. } | Request::EnsureAgent { spec, .. }
+            if spec.report.state == AgentState::Inactive =>
+        {
+            "inactive agent state requires daemon protocol 12".into()
+        }
+        Request::ReportAgent { report, .. } if report.state == AgentState::Inactive => {
+            "inactive agent state requires daemon protocol 12".into()
+        }
+        Request::WaitAgent { .. } => "agent wait requires daemon protocol 14".into(),
+        Request::AcknowledgeAgentAttention { .. } => {
+            "agent attention acknowledgment requires daemon protocol 15".into()
+        }
+        Request::Attach {
+            environment: Some(_),
+            ..
+        } => "client environment requires daemon protocol 16".into(),
+        _ => format!("request requires daemon protocol {minimum_version}"),
+    }
 }
 
 fn response_for_version(response: Response, version: u32) -> Response {
@@ -7102,30 +6998,6 @@ mod tests {
         assert_eq!(filtered_cursor, cursor);
         assert!(events.is_empty());
         assert!(snapshot.workspaces[0].agents[0].attention.is_none());
-    }
-
-    #[test]
-    fn inactive_agent_mutations_require_protocol_twelve() {
-        assert!(request_requires_protocol_twelve(&Request::EnsureAgent {
-            shell_id: "s1".into(),
-            run_id: "r1".into(),
-            spec: agent_spec(AgentState::Inactive),
-        }));
-        assert!(request_requires_protocol_twelve(&Request::RegisterAgent {
-            shell_id: "s1".into(),
-            run_id: "r1".into(),
-            spec: agent_spec(AgentState::Inactive),
-        }));
-        assert!(request_requires_protocol_twelve(&Request::ReportAgent {
-            agent_id: "a1".into(),
-            run_id: "r1".into(),
-            report: agent_spec(AgentState::Inactive).report,
-        }));
-        assert!(!request_requires_protocol_twelve(&Request::EnsureAgent {
-            shell_id: "s1".into(),
-            run_id: "r1".into(),
-            spec: agent_spec(AgentState::Idle),
-        }));
     }
 
     #[test]

--- a/src/host_session_titles.rs
+++ b/src/host_session_titles.rs
@@ -47,7 +47,11 @@ struct Inspection {
 trait TitleAdapter: Sync {
     fn integration(&self) -> &'static str;
 
-    fn inspect(&self, directory: &Path) -> Option<Titles>;
+    fn inspect(&self, directory: &Path) -> Option<Inspection>;
+
+    fn provides_catalog(&self) -> bool {
+        false
+    }
 }
 
 static ADAPTERS: &[&dyn TitleAdapter] = &[opencode::ADAPTER, pi::ADAPTER];
@@ -119,6 +123,9 @@ impl Cache {
         integration: &str,
         directory: &Path,
     ) -> Option<Vec<HostSession>> {
+        if !adapter(integration).is_some_and(|adapter| adapter.provides_catalog()) {
+            return None;
+        }
         self.refresh(integration, directory);
         let key = CacheKey {
             integration: integration.to_owned(),
@@ -142,7 +149,7 @@ impl Cache {
             );
         }
 
-        if !is_supported(integration) {
+        if adapter(integration).is_none() {
             return;
         }
 
@@ -164,28 +171,32 @@ impl Cache {
     }
 }
 
-fn is_supported(integration: &str) -> bool {
-    ADAPTERS
-        .iter()
-        .any(|adapter| adapter.integration() == integration)
-}
-
 fn inspect(integration: &str, directory: &Path) -> Option<Inspection> {
-    if integration == "opencode" {
-        return opencode::inspect_catalog(directory);
-    }
-    ADAPTERS
-        .iter()
-        .find(|adapter| adapter.integration() == integration)?
-        .inspect(directory)
-        .map(|titles| Inspection {
-            titles,
-            catalog: Vec::new(),
-        })
+    adapter(integration)?.inspect(directory)
 }
 
-pub(crate) fn catalog(directory: &Path) -> Option<Vec<HostSession>> {
-    opencode::inspect_catalog(directory).map(|inspection| inspection.catalog)
+pub(crate) fn catalog_integrations() -> impl Iterator<Item = &'static str> {
+    ADAPTERS
+        .iter()
+        .filter(|adapter| adapter.provides_catalog())
+        .map(|adapter| adapter.integration())
+}
+
+pub(crate) fn catalog(integration: &str, directory: &Path) -> Option<Vec<HostSession>> {
+    let adapter = adapter(integration)?;
+    if !adapter.provides_catalog() {
+        return None;
+    }
+    adapter
+        .inspect(directory)
+        .map(|inspection| inspection.catalog)
+}
+
+fn adapter(integration: &str) -> Option<&'static dyn TitleAdapter> {
+    ADAPTERS
+        .iter()
+        .copied()
+        .find(|adapter| adapter.integration() == integration)
 }
 
 fn sanitize_title(title: &str) -> Option<String> {
@@ -390,7 +401,9 @@ mod tests {
             ),
         );
 
-        let titles = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+        let inspection = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+        assert!(inspection.catalog.is_empty());
+        let titles = inspection.titles;
 
         assert_eq!(
             titles.get("matching").map(String::as_str),
@@ -490,7 +503,8 @@ mod tests {
             ),
         );
 
-        let titles = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+        let inspection = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+        let titles = inspection.titles;
 
         assert_eq!(
             titles.get("pi-oversized").map(String::as_str),
@@ -524,7 +538,8 @@ mod tests {
             ),
         );
 
-        let titles = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+        let inspection = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+        let titles = inspection.titles;
 
         assert_eq!(titles.len(), 1);
         assert_eq!(titles.get("valid").map(String::as_str), Some("Valid title"));
@@ -550,7 +565,8 @@ mod tests {
                 .expect("set session timestamp");
         }
 
-        let titles = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+        let inspection = inspect_pi(Path::new("/repo"), &test.environment()).expect("catalog");
+        let titles = inspection.titles;
 
         assert_eq!(titles.len(), MAX_SESSIONS);
         assert!(titles.contains_key("pi-100"));
@@ -589,6 +605,13 @@ mod tests {
             pi_session_file(Path::new("/repo"), "external", &test.environment()),
             Ok(exact)
         );
+    }
+
+    #[test]
+    fn adapters_declare_catalog_support() {
+        assert_eq!(catalog_integrations().collect::<Vec<_>>(), ["opencode"]);
+        assert!(catalog("pi", Path::new("/repo")).is_none());
+        assert!(adapter("missing").is_none());
     }
 
     #[test]
@@ -659,12 +682,7 @@ mod tests {
                 .root_id,
             "opencode-id"
         );
-        assert!(
-            cache
-                .catalog("pi", Path::new("/repo"))
-                .expect("cached catalog")
-                .is_empty()
-        );
+        assert!(cache.catalog("pi", Path::new("/repo")).is_none());
     }
 
     #[test]

--- a/src/host_session_titles/opencode.rs
+++ b/src/host_session_titles/opencode.rs
@@ -20,8 +20,12 @@ impl TitleAdapter for OpenCodeAdapter {
         "opencode"
     }
 
-    fn inspect(&self, directory: &Path) -> Option<super::Titles> {
-        inspect_catalog(directory).map(|inspection| inspection.titles)
+    fn inspect(&self, directory: &Path) -> Option<Inspection> {
+        inspect_catalog(directory)
+    }
+
+    fn provides_catalog(&self) -> bool {
+        true
     }
 }
 

--- a/src/host_session_titles/pi.rs
+++ b/src/host_session_titles/pi.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::{MAX_SESSIONS, TitleAdapter, Titles, sanitize_title};
+use super::{Inspection, MAX_SESSIONS, TitleAdapter, sanitize_title};
 use crate::host_session_source::{
     normalize_absolute,
     pi::{Environment, session_catalog},
@@ -16,12 +16,12 @@ impl TitleAdapter for PiAdapter {
         "pi"
     }
 
-    fn inspect(&self, directory: &Path) -> Option<Titles> {
+    fn inspect(&self, directory: &Path) -> Option<Inspection> {
         inspect(directory, &Environment::from_process())
     }
 }
 
-pub(super) fn inspect(directory: &Path, environment: &Environment) -> Option<Titles> {
+pub(super) fn inspect(directory: &Path, environment: &Environment) -> Option<Inspection> {
     let (normalized_directory, prefixes) = session_catalog(directory, environment, MAX_SESSIONS)?;
     let mut titles = HashMap::new();
 
@@ -30,7 +30,10 @@ pub(super) fn inspect(directory: &Path, environment: &Environment) -> Option<Tit
             titles.entry(id).or_insert(title);
         }
     }
-    Some(titles)
+    Some(Inspection {
+        titles,
+        catalog: Vec::new(),
+    })
 }
 
 pub(super) fn parse_session(output: &[u8], requested_directory: &Path) -> Option<(String, String)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,6 @@ pub mod attach;
 pub mod client;
 pub mod daemon;
 mod desktop_notifications;
-// The replacement-daemon protocol will activate this transport in the next
-// handoff slice; keeping it compiled now prevents the unsafe boundary drifting.
-#[allow(dead_code)]
 mod fd_transfer;
 mod handoff;
 pub mod protocol;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1288,12 +1288,18 @@ fn cached_host_catalog(
     workspaces: &[WorkspaceSnapshot],
     cache: &mut host_session_titles::Cache,
 ) -> Vec<host_session_titles::HostSession> {
-    workspace_source_directories(workspaces)
+    let mut catalog = Vec::new();
+    for directory in workspace_source_directories(workspaces)
         .into_iter()
         .take(MAX_HOST_CATALOG_DIRECTORIES)
-        .filter_map(|directory| cache.catalog("opencode", &directory))
-        .flatten()
-        .collect()
+    {
+        for integration in host_session_titles::catalog_integrations() {
+            if let Some(sessions) = cache.catalog(integration, &directory) {
+                catalog.extend(sessions);
+            }
+        }
+    }
+    catalog
 }
 
 fn discover_host_catalog(
@@ -1303,10 +1309,15 @@ fn discover_host_catalog(
         .into_iter()
         .take(MAX_HOST_CATALOG_DIRECTORIES)
         .collect::<Vec<_>>();
+    let requests = directories.into_iter().flat_map(|directory| {
+        host_session_titles::catalog_integrations()
+            .map(move |integration| (integration, directory.clone()))
+    });
     thread::scope(|scope| {
-        directories
-            .into_iter()
-            .map(|directory| scope.spawn(move || host_session_titles::catalog(&directory)))
+        requests
+            .map(|(integration, directory)| {
+                scope.spawn(move || host_session_titles::catalog(integration, &directory))
+            })
             .collect::<Vec<_>>()
             .into_iter()
             .filter_map(|handle| handle.join().ok().flatten())

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -467,6 +467,51 @@ pub enum Request {
     },
 }
 
+impl Request {
+    pub fn minimum_protocol_version(&self) -> u32 {
+        match self {
+            Self::Attach {
+                environment: Some(_),
+                ..
+            } => 16,
+            Self::AcknowledgeAgentAttention { .. } => 15,
+            Self::WaitAgent { .. } => 14,
+            Self::RegisterAgent { spec, .. } | Self::EnsureAgent { spec, .. }
+                if spec.report.state == AgentState::Inactive =>
+            {
+                12
+            }
+            Self::ReportAgent { report, .. } if report.state == AgentState::Inactive => 12,
+            Self::RestartShell { .. }
+            | Self::Attach {
+                restart_exited: true,
+                ..
+            } => 11,
+            Self::EnsureAgent { .. } => 10,
+            Self::GetAgent { .. } | Self::RegisterAgent { .. } | Self::ReportAgent { .. } => 9,
+            Self::GetLauncher { .. }
+            | Self::CreateLauncher { .. }
+            | Self::RenameLauncher { .. }
+            | Self::RemoveLauncher { .. } => 8,
+            Self::ReadShellAt { .. } | Self::Events { .. } => 7,
+            Self::Ping
+            | Self::Restart
+            | Self::Shutdown
+            | Self::Snapshot
+            | Self::GetWorkspace { .. }
+            | Self::GetShell { .. }
+            | Self::CreateWorkspace { .. }
+            | Self::CreateShell { .. }
+            | Self::ReadShell { .. }
+            | Self::RenameWorkspace { .. }
+            | Self::RenameShell { .. }
+            | Self::CloseWorkspace { .. }
+            | Self::CloseShell { .. }
+            | Self::Attach { .. } => MIN_PROTOCOL_VERSION,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "response", rename_all = "snake_case")]
 pub enum Response {
@@ -647,6 +692,37 @@ pub fn read_message<T: DeserializeOwned>(reader: &mut impl Read) -> io::Result<T
 mod tests {
     use super::*;
 
+    fn test_profile() -> TerminalProfile {
+        TerminalProfile {
+            term: None,
+            colorterm: None,
+            term_program: None,
+            term_program_version: None,
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
+
+    fn test_report(state: AgentState) -> AgentReport {
+        AgentReport {
+            state,
+            authority: AgentAuthority::LifecycleIntegration,
+            evidence: "test".into(),
+            confidence: 100,
+        }
+    }
+
+    fn test_registration(state: AgentState) -> AgentRegistrationSpec {
+        AgentRegistrationSpec {
+            name: "agent".into(),
+            integration: "test".into(),
+            external_session_id: None,
+            report: test_report(state),
+        }
+    }
+
     #[derive(Deserialize)]
     struct ProtocolSixShellSnapshot {
         id: String,
@@ -824,6 +900,198 @@ mod tests {
     fn protocol_version_is_sixteen_with_minimum_six() {
         assert_eq!(PROTOCOL_VERSION, 16);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
+    }
+
+    #[test]
+    fn request_minimum_protocol_versions_cover_all_groups() {
+        let groups = vec![
+            (
+                6,
+                vec![
+                    Request::Ping,
+                    Request::Restart,
+                    Request::Shutdown,
+                    Request::Snapshot,
+                    Request::GetWorkspace {
+                        workspace_id: "w1".into(),
+                    },
+                    Request::GetShell {
+                        shell_id: "s1".into(),
+                    },
+                    Request::CreateWorkspace {
+                        name: "workspace".into(),
+                        shells: Vec::new(),
+                    },
+                    Request::CreateShell {
+                        workspace_id: Some("w1".into()),
+                        shell: ShellSpec::login("shell", "/tmp"),
+                    },
+                    Request::ReadShell {
+                        shell_id: "s1".into(),
+                        max_bytes: 1024,
+                    },
+                    Request::RenameWorkspace {
+                        workspace_id: "w1".into(),
+                        name: "renamed".into(),
+                    },
+                    Request::RenameShell {
+                        shell_id: "s1".into(),
+                        name: "renamed".into(),
+                    },
+                    Request::CloseWorkspace {
+                        workspace_id: "w1".into(),
+                    },
+                    Request::CloseShell {
+                        shell_id: "s1".into(),
+                    },
+                    Request::Attach {
+                        shell_id: "s1".into(),
+                        takeover: false,
+                        restart_exited: false,
+                        profile: test_profile(),
+                        environment: None,
+                    },
+                ],
+            ),
+            (
+                7,
+                vec![
+                    Request::ReadShellAt {
+                        shell_id: "s1".into(),
+                        max_bytes: 1024,
+                        run_id: None,
+                        after_revision: None,
+                        wait_ms: 0,
+                    },
+                    Request::Events {
+                        after: None,
+                        limit: 1,
+                        wait_ms: 0,
+                    },
+                ],
+            ),
+            (
+                8,
+                vec![
+                    Request::GetLauncher {
+                        launcher_id: "l1".into(),
+                    },
+                    Request::CreateLauncher {
+                        workspace_id: "w1".into(),
+                        spec: WorkspaceLauncherSpec {
+                            name: "editor".into(),
+                            command: vec!["editor".into()],
+                            cwd: "/tmp".into(),
+                        },
+                    },
+                    Request::RenameLauncher {
+                        launcher_id: "l1".into(),
+                        name: "renamed".into(),
+                    },
+                    Request::RemoveLauncher {
+                        launcher_id: "l1".into(),
+                    },
+                ],
+            ),
+            (
+                9,
+                vec![
+                    Request::GetAgent {
+                        agent_id: "a1".into(),
+                    },
+                    Request::RegisterAgent {
+                        shell_id: "s1".into(),
+                        run_id: "r1".into(),
+                        spec: test_registration(AgentState::Working),
+                    },
+                    Request::ReportAgent {
+                        agent_id: "a1".into(),
+                        run_id: "r1".into(),
+                        report: test_report(AgentState::Idle),
+                    },
+                ],
+            ),
+            (
+                10,
+                vec![Request::EnsureAgent {
+                    shell_id: "s1".into(),
+                    run_id: "r1".into(),
+                    spec: test_registration(AgentState::Working),
+                }],
+            ),
+            (
+                11,
+                vec![
+                    Request::RestartShell {
+                        shell_id: "s1".into(),
+                    },
+                    Request::Attach {
+                        shell_id: "s1".into(),
+                        takeover: false,
+                        restart_exited: true,
+                        profile: test_profile(),
+                        environment: None,
+                    },
+                ],
+            ),
+            (
+                12,
+                vec![
+                    Request::RegisterAgent {
+                        shell_id: "s1".into(),
+                        run_id: "r1".into(),
+                        spec: test_registration(AgentState::Inactive),
+                    },
+                    Request::EnsureAgent {
+                        shell_id: "s1".into(),
+                        run_id: "r1".into(),
+                        spec: test_registration(AgentState::Inactive),
+                    },
+                    Request::ReportAgent {
+                        agent_id: "a1".into(),
+                        run_id: "r1".into(),
+                        report: test_report(AgentState::Inactive),
+                    },
+                ],
+            ),
+            (
+                14,
+                vec![Request::WaitAgent {
+                    agent_id: "a1".into(),
+                    after_revision: 1,
+                    wait_ms: 0,
+                }],
+            ),
+            (
+                15,
+                vec![Request::AcknowledgeAgentAttention {
+                    agent_id: "a1".into(),
+                    observation_revision: 1,
+                }],
+            ),
+            (
+                16,
+                vec![Request::Attach {
+                    shell_id: "s1".into(),
+                    takeover: false,
+                    restart_exited: true,
+                    profile: test_profile(),
+                    environment: Some(UnixEnvironment {
+                        variables: Vec::new(),
+                    }),
+                }],
+            ),
+        ];
+
+        for (expected, requests) in groups {
+            for request in requests {
+                assert_eq!(
+                    request.minimum_protocol_version(),
+                    expected,
+                    "unexpected minimum protocol version for {request:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- centralize exhaustive request protocol requirements in the wire model for both clients and the daemon
- route host title and catalog discovery through adapter-declared capabilities instead of OpenCode-specific branches
- remove obsolete suppressions and Pi test exports, and correct stale documentation

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`
- `git diff --check origin/main...HEAD`