### PR TITLE
feat: add integration management

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -49,8 +49,23 @@ boomux capabilities --json
 ```
 
 Parse `data` on success and `error.code` on a nonzero exit; do not parse human
-tables or `error.message`. JSON mutation support is limited to `agent register`,
-`agent ensure`, and `agent report`.
+tables or `error.message`. JSON mutation support includes explicit Agent reports,
+attention acknowledgment, and integration installation.
+
+Inspect bundled lifecycle integrations with:
+
+```console
+boomux integration list --json
+boomux integration status --json
+boomux integration status opencode --json
+```
+
+Host, asset, and runtime status are independent. `unvalidated` compatibility is
+not an incompatibility claim. Never install or replace integration files unless
+the user explicitly asks. With that authorization, use `boomux integration
+install opencode --json`, `boomux integration install pi --json`, or
+`boomux integration install --all --json`; add `--force` only when the user also
+authorizes replacing a modified asset.
 
 Use `boomux events --json` for an immediate snapshot and cursor. Poll again with
 `--after CURSOR --wait-ms 30000` to observe later transitions. If

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ boomux attention acknowledge <agent-id> --observation-revision <revision>
 boomux session list [--workspace <name-or-id>]
 boomux session inspect <session-id>
 boomux session read <session-id> [--before <cursor>] [--limit <entries>] [--max-bytes <bytes>]
+boomux integration list
+boomux integration status [opencode|pi]
+boomux integration install <opencode|pi> [--force]
+boomux integration install --all [--force]
 boomux daemon status
 boomux daemon restart
 boomux daemon stop
@@ -402,6 +406,37 @@ installation. An untouched legacy `boomux-shells` skill is removed
 automatically; customized legacy content is preserved with a warning.
 
 ## Integration Compatibility
+
+Inspect every bundled host integration from one command group:
+
+```console
+boomux integration list
+boomux integration status
+boomux integration status opencode --json
+```
+
+Status reports host discovery and version compatibility, the installed Boomux
+asset, and current lifecycle reporting independently. Asset state is `missing`,
+`current`, `modified`, or `unavailable`. Runtime state is `not_observable` when
+the daemon cannot be contacted, `not_running` when no matching foreground host
+is present, `reporting` when every matching process has an exact current-run
+Agent registration, and `untracked` otherwise. An `unvalidated` host version is
+not known to be incompatible; it has simply not been recorded as a Boomux test
+point. The `ACTION` column recommends installation, explicit replacement, or a
+host restart without performing it.
+
+Install one integration or all bundled integrations with:
+
+```console
+boomux integration install opencode
+boomux integration install --all
+```
+
+Installation is individually atomic and idempotent. A modified target is
+preserved unless `--force` is supplied, and symlinked or non-regular paths are
+rejected. Successful changes print the required host restart guidance. The
+existing `boomux opencode install` and `boomux pi install` commands remain
+equivalent host-specific shortcuts.
 
 Boomux currently validates its bundled integrations against these host releases:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -314,14 +314,14 @@ heuristics instead of making convenient setup silently weaken session semantics.
 Process adapters and any future screen detectors remain explicitly lower
 authority and cannot substitute for integration evidence.
 
-The resulting installation cost must be handled as a product workflow rather
-than left as manual plugin-file management. A future unified setup command will
-discover supported installed harnesses, describe the access and guarantees each
-integration provides, preview configuration changes, require consent, install
-or update atomically, identify required harness reloads, and verify canonical
-identity and lifecycle reports against a managed shell run. The same workflow
-will expose status, validated host versions, actionable diagnostics, repair, and
-uninstall. Individual host installers remain the underlying safe primitives.
+The resulting installation cost is handled as a product workflow rather than
+left as manual plugin-file management. The unified `integration` commands list
+bundled harnesses, inspect host versions, assets, and current-run lifecycle
+reporting, and install one or all assets with each write atomic and accompanied
+by reload guidance.
+Individual host installers remain equivalent shortcuts over the same registry
+and safe primitives. Guided consent, end-to-end verification, and uninstall
+remain future workflow additions.
 
 Observed host compatibility and provider-dependent gaps are recorded in
 [`lifecycle-validation.md`](lifecycle-validation.md). Focused unit fixtures

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -54,12 +54,17 @@ The following commands support `--json`:
 - `boomux session list`
 - `boomux session inspect`
 - `boomux session read`
+- `boomux integration list`
+- `boomux integration status [opencode|pi]`
+- `boomux integration install <opencode|pi>`
+- `boomux integration install --all`
 - `boomux daemon status`
 
 JSON mutations are deliberately narrow: only `agent register`, `agent ensure`,
-`agent report`, and `attention acknowledge` support the contract. Other mutation
-commands retain human output. Passing `--json` to an unsupported command fails with
-`invalid_argument` before performing the operation.
+`agent report`, `attention acknowledge`, and `integration install` support the
+contract. Other mutation commands retain human output. Passing `--json` to an
+unsupported command fails with `invalid_argument` before performing the
+operation.
 
 Command payloads are:
 
@@ -90,10 +95,51 @@ Command payloads are:
   opaque session ID.
 - `session.read`: one bounded canonical `transcript` selected only by exact
   opaque session ID.
+- `integration.list`: an `integrations` array containing bundled integration
+  names, display names, packages, and validated host versions.
+- `integration.status`: an `integrations` array containing independent `host`,
+  `asset`, and `runtime` status objects. Status does not start the daemon or
+  mutate integration files. It executes each PATH-resolved host's `--version`
+  command with bounded output and runtime; missing or unhealthy integrations are
+  represented as data and do not make status fail.
+- `integration.install`: an `integrations` array containing `installed`,
+  `replaced`, or `unchanged` results, target paths, and whether a host restart is
+  required. Each target is changed atomically; `--all` is not a transaction
+  across hosts, but every target is preflighted before the first write.
 - `read`: shell/run identity, observed output revision, and rendered output.
 - `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
   bounded event array.
 - `daemon.status`: `status`, `protocol_version`, and `socket_path`.
+
+## Integration Data
+
+Integration arrays are ordered `opencode`, then `pi`. List entries contain
+`name`, `display_name`, `package`, and `validated_version`.
+
+Status entries contain those four fields plus `host`, `asset`, `runtime`, and
+`recommended_action`.
+The `host` object contains `state`, `executable`, `version`, `compatibility`, and
+`error`. Host state is `missing`, `available`, or `probe_failed`;
+`compatibility` is `validated`, `unvalidated`, or `unknown`. Paths, versions, and
+errors that are not available are JSON `null`. A validated version is an
+observed compatibility test point, not a version requirement.
+
+The `asset` object contains `state`, `path`, and `error`. Asset state is
+`missing`, `current`, `modified`, or `unavailable`. The `runtime` object contains
+`state`, `running_processes`, `tracked_processes`, and `untracked_processes`.
+Runtime state is `not_observable`, `not_running`, `reporting`, or `untracked`.
+Reporting requires an active exact shell/run Agent observation with
+`lifecycle_integration` authority; process and terminal evidence do not satisfy
+it.
+
+`recommended_action` is `none`, `install`, `replace`, `restart_host`, or
+`inspect_error`. Replacement requires explicit `--force`; the recommendation
+does not authorize a mutation by itself.
+
+Install entries contain `name`, `result`, `path`, and `restart_required`.
+Result is `installed`, `replaced`, or `unchanged`. A modified target fails with
+`already_exists` unless `--force` is supplied. Invalid roots or unsafe paths fail
+with `invalid_argument` before mutation.
 
 ## Shell Data
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -110,13 +110,16 @@ eternal process.
    root/subagent aggregation where available, blocked prompts, idle transitions,
    explicit completion semantics, and graceful daemon replacement against real
    sessions.
-2. Build a first-class integration setup workflow that discovers supported
+2. [In progress] Build a first-class integration setup workflow that discovers supported
    installed harnesses, explains why authoritative lifecycle access is required,
    previews and obtains consent for configuration changes, installs or updates
    each integration safely, prompts for required harness reloads, and verifies
    canonical identity plus lifecycle reporting end to end. Include status,
    version compatibility, diagnostics, repair, and uninstall paths so stronger
    guarantees do not require users to manage plugin files manually.
+   Unified list, status, host-version detection, runtime registration diagnosis,
+   and atomic single/all installation are complete; guided verification,
+   consented previews, repair guidance, and uninstall remain.
 3. [Complete] Aggregate agent states into workspace counts and add an explainable,
    persistent attention queue for blocked and completed work.
 4. [Complete] Add revision-aware `agent wait` so scripts can await durable state

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -1,0 +1,1099 @@
+use std::env;
+use std::error::Error;
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use clap::ValueEnum;
+use serde::Serialize;
+use uuid::Uuid;
+
+use boomux::protocol::{AgentAuthority, AgentState, ShellStatus, Snapshot};
+
+pub(crate) const OPENCODE_ASSET: &str = include_str!("../integrations/opencode/boomux.js");
+pub(crate) const PI_ASSET: &str = include_str!("../integrations/pi/boomux.js");
+
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_VERSION_OUTPUT_BYTES: u64 = 4096;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum IntegrationId {
+    Opencode,
+    Pi,
+}
+
+impl IntegrationId {
+    pub(crate) const ALL: [Self; 2] = [Self::Opencode, Self::Pi];
+
+    pub(crate) const fn spec(self) -> &'static IntegrationSpec {
+        match self {
+            Self::Opencode => &OPENCODE,
+            Self::Pi => &PI,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct IntegrationSpec {
+    pub(crate) id: IntegrationId,
+    pub(crate) name: &'static str,
+    pub(crate) display_name: &'static str,
+    pub(crate) package: &'static str,
+    pub(crate) validated_version: &'static str,
+    pub(crate) asset_name: &'static str,
+    pub(crate) content: &'static str,
+    pub(crate) executable: &'static str,
+    pub(crate) reload_message: &'static str,
+}
+
+const OPENCODE: IntegrationSpec = IntegrationSpec {
+    id: IntegrationId::Opencode,
+    name: "opencode",
+    display_name: "OpenCode",
+    package: "opencode-ai",
+    validated_version: "1.18.15",
+    asset_name: "plugin",
+    content: OPENCODE_ASSET,
+    executable: "opencode",
+    reload_message: "Restart any running OpenCode process to activate the plugin",
+};
+
+const PI: IntegrationSpec = IntegrationSpec {
+    id: IntegrationId::Pi,
+    name: "pi",
+    display_name: "Pi",
+    package: "@earendil-works/pi-coding-agent",
+    validated_version: "0.84.1",
+    asset_name: "extension",
+    content: PI_ASSET,
+    executable: "pi",
+    reload_message: "Restart any running Pi process to activate the extension",
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Environment {
+    home: Option<OsString>,
+    xdg_config_home: Option<OsString>,
+    pi_coding_agent_dir: Option<OsString>,
+    path: Option<OsString>,
+}
+
+impl Environment {
+    pub(crate) fn from_process() -> Self {
+        Self {
+            home: env::var_os("HOME"),
+            xdg_config_home: env::var_os("XDG_CONFIG_HOME"),
+            pi_coding_agent_dir: env::var_os("PI_CODING_AGENT_DIR"),
+            path: env::var_os("PATH"),
+        }
+    }
+
+    #[cfg(test)]
+    fn for_test(
+        home: Option<OsString>,
+        xdg_config_home: Option<OsString>,
+        pi_coding_agent_dir: Option<OsString>,
+        path: Option<OsString>,
+    ) -> Self {
+        Self {
+            home,
+            xdg_config_home,
+            pi_coding_agent_dir,
+            path,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct IntegrationSummary {
+    pub(crate) name: &'static str,
+    pub(crate) display_name: &'static str,
+    pub(crate) package: &'static str,
+    pub(crate) validated_version: &'static str,
+}
+
+impl From<IntegrationId> for IntegrationSummary {
+    fn from(id: IntegrationId) -> Self {
+        let spec = id.spec();
+        Self {
+            name: spec.name,
+            display_name: spec.display_name,
+            package: spec.package,
+            validated_version: spec.validated_version,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AssetState {
+    Missing,
+    Current,
+    Modified,
+    Unavailable,
+}
+
+impl AssetState {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::Current => "current",
+            Self::Modified => "modified",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AssetStatus {
+    pub(crate) state: AssetState,
+    pub(crate) path: Option<String>,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum HostState {
+    NotChecked,
+    Missing,
+    Available,
+    ProbeFailed,
+}
+
+impl HostState {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotChecked => "not_checked",
+            Self::Missing => "missing",
+            Self::Available => "available",
+            Self::ProbeFailed => "probe_failed",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct HostStatus {
+    pub(crate) state: HostState,
+    pub(crate) executable: Option<String>,
+    pub(crate) version: Option<String>,
+    pub(crate) compatibility: &'static str,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RuntimeState {
+    NotObservable,
+    NotRunning,
+    Reporting,
+    Untracked,
+}
+
+impl RuntimeState {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotObservable => "not_observable",
+            Self::NotRunning => "not_running",
+            Self::Reporting => "reporting",
+            Self::Untracked => "untracked",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct RuntimeStatus {
+    pub(crate) state: RuntimeState,
+    pub(crate) running_processes: usize,
+    pub(crate) tracked_processes: usize,
+    pub(crate) untracked_processes: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct IntegrationStatus {
+    pub(crate) name: &'static str,
+    pub(crate) display_name: &'static str,
+    pub(crate) package: &'static str,
+    pub(crate) validated_version: &'static str,
+    pub(crate) host: HostStatus,
+    pub(crate) asset: AssetStatus,
+    pub(crate) runtime: RuntimeStatus,
+    pub(crate) recommended_action: RecommendedAction,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RecommendedAction {
+    None,
+    Install,
+    Replace,
+    RestartHost,
+    InspectError,
+}
+
+pub(crate) fn inspect(
+    id: IntegrationId,
+    environment: &Environment,
+    snapshot: Option<&Snapshot>,
+) -> IntegrationStatus {
+    inspect_with_host_probe(id, environment, snapshot, true)
+}
+
+pub(crate) fn inspect_without_host_probe(
+    id: IntegrationId,
+    environment: &Environment,
+    snapshot: Option<&Snapshot>,
+) -> IntegrationStatus {
+    inspect_with_host_probe(id, environment, snapshot, false)
+}
+
+fn inspect_with_host_probe(
+    id: IntegrationId,
+    environment: &Environment,
+    snapshot: Option<&Snapshot>,
+    probe_host: bool,
+) -> IntegrationStatus {
+    let spec = id.spec();
+    let asset = inspect_asset(spec, environment);
+    let runtime = inspect_runtime(spec, snapshot);
+    let recommended_action = recommended_action(asset.state, runtime.state);
+    IntegrationStatus {
+        name: spec.name,
+        display_name: spec.display_name,
+        package: spec.package,
+        validated_version: spec.validated_version,
+        host: if probe_host {
+            inspect_host(spec, environment)
+        } else {
+            HostStatus {
+                state: HostState::NotChecked,
+                executable: None,
+                version: None,
+                compatibility: "unknown",
+                error: None,
+            }
+        },
+        asset,
+        runtime,
+        recommended_action,
+    }
+}
+
+const fn recommended_action(asset: AssetState, runtime: RuntimeState) -> RecommendedAction {
+    match asset {
+        AssetState::Missing => RecommendedAction::Install,
+        AssetState::Modified => RecommendedAction::Replace,
+        AssetState::Unavailable => RecommendedAction::InspectError,
+        AssetState::Current if matches!(runtime, RuntimeState::Untracked) => {
+            RecommendedAction::RestartHost
+        }
+        AssetState::Current => RecommendedAction::None,
+    }
+}
+
+fn inspect_asset(spec: &IntegrationSpec, environment: &Environment) -> AssetStatus {
+    let path = match install_target(spec.id, environment) {
+        Ok(target) => target.path,
+        Err(error) => {
+            return AssetStatus {
+                state: AssetState::Unavailable,
+                path: None,
+                error: Some(error.to_string()),
+            };
+        }
+    };
+    let path_text = path.display().to_string();
+    let result = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "install path has no parent"))
+        .and_then(validate_existing_directory_chain)
+        .and_then(|()| inspect_existing_asset(&path, spec.content));
+    match result {
+        Ok(ExistingAsset::Missing) => AssetStatus {
+            state: AssetState::Missing,
+            path: Some(path_text),
+            error: None,
+        },
+        Ok(ExistingAsset::Current) => AssetStatus {
+            state: AssetState::Current,
+            path: Some(path_text),
+            error: None,
+        },
+        Ok(ExistingAsset::Modified) => AssetStatus {
+            state: AssetState::Modified,
+            path: Some(path_text),
+            error: None,
+        },
+        Err(error) => AssetStatus {
+            state: AssetState::Unavailable,
+            path: Some(path_text),
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+fn inspect_host(spec: &IntegrationSpec, environment: &Environment) -> HostStatus {
+    let Some(executable) = executable_on_path(spec.executable, environment.path.as_deref()) else {
+        return HostStatus {
+            state: HostState::Missing,
+            executable: None,
+            version: None,
+            compatibility: "unknown",
+            error: None,
+        };
+    };
+    let executable_text = executable.display().to_string();
+    match probe_version(&executable) {
+        Ok(output) => {
+            let version = version_token(&output);
+            let compatibility = if version.as_deref() == Some(spec.validated_version) {
+                "validated"
+            } else if version.is_some() {
+                "unvalidated"
+            } else {
+                "unknown"
+            };
+            HostStatus {
+                state: HostState::Available,
+                executable: Some(executable_text),
+                version,
+                compatibility,
+                error: None,
+            }
+        }
+        Err(error) => HostStatus {
+            state: HostState::ProbeFailed,
+            executable: Some(executable_text),
+            version: None,
+            compatibility: "unknown",
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+fn inspect_runtime(spec: &IntegrationSpec, snapshot: Option<&Snapshot>) -> RuntimeStatus {
+    let Some(snapshot) = snapshot else {
+        return RuntimeStatus {
+            state: RuntimeState::NotObservable,
+            running_processes: 0,
+            tracked_processes: 0,
+            untracked_processes: 0,
+        };
+    };
+    let running = snapshot.workspaces.iter().flat_map(|workspace| {
+        workspace.shells.iter().filter_map(move |shell| {
+            (matches!(shell.status, ShellStatus::Running)
+                && shell.foreground_process.as_deref() == Some(spec.executable))
+            .then_some((workspace, shell))
+        })
+    });
+    let mut running_processes = 0;
+    let mut tracked_processes = 0;
+    for (workspace, shell) in running {
+        running_processes += 1;
+        if shell.run.as_ref().is_some_and(|run| {
+            workspace.agents.iter().any(|agent| {
+                agent.integration == spec.name
+                    && agent.shell_id == shell.id
+                    && agent.run_id == run.id
+                    && agent.ended_at_ms.is_none()
+                    && agent.observation.authority == AgentAuthority::LifecycleIntegration
+                    && !matches!(
+                        agent.observation.state,
+                        AgentState::Inactive | AgentState::Done
+                    )
+            })
+        }) {
+            tracked_processes += 1;
+        }
+    }
+    let untracked_processes = running_processes - tracked_processes;
+    let state = if running_processes == 0 {
+        RuntimeState::NotRunning
+    } else if untracked_processes == 0 {
+        RuntimeState::Reporting
+    } else {
+        RuntimeState::Untracked
+    };
+    RuntimeStatus {
+        state,
+        running_processes,
+        tracked_processes,
+        untracked_processes,
+    }
+}
+
+fn executable_on_path(name: &str, path: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
+    env::split_paths(path?).find_map(|directory| {
+        let candidate = directory.join(name);
+        fs::metadata(&candidate)
+            .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+            .then_some(candidate)
+    })
+}
+
+fn probe_version(executable: &Path) -> io::Result<String> {
+    probe_version_with_timeout(executable, VERSION_PROBE_TIMEOUT)
+}
+
+fn probe_version_with_timeout(executable: &Path, timeout: Duration) -> io::Result<String> {
+    let mut child = Command::new(executable)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("version probe stdout was unavailable"))?;
+    let (output_sender, output_receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut output = Vec::new();
+        let result = stdout
+            .take(MAX_VERSION_OUTPUT_BYTES + 1)
+            .read_to_end(&mut output)
+            .map(|_| output);
+        let _ = output_sender.send(result);
+    });
+    let process_group = i32::try_from(child.id())
+        .map_err(|_| io::Error::other("version probe process ID exceeded i32"))?;
+    let deadline = Instant::now() + timeout;
+    let result = (|| {
+        let mut status = None;
+        let mut output = None;
+        loop {
+            if status.is_none() {
+                status = child.try_wait()?;
+            }
+            if output.is_none() {
+                match output_receiver.try_recv() {
+                    Ok(result) => output = Some(result?),
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        return Err(io::Error::other("version probe reader stopped"));
+                    }
+                }
+            }
+            if output
+                .as_ref()
+                .is_some_and(|output| output.len() > MAX_VERSION_OUTPUT_BYTES as usize)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "version output exceeded 4096 bytes",
+                ));
+            }
+            if let (Some(status), Some(output)) = (status, output.as_ref()) {
+                if !status.success() {
+                    return Err(io::Error::other(format!(
+                        "version probe exited with {status}"
+                    )));
+                }
+                return Ok(String::from_utf8_lossy(output).trim().to_owned());
+            }
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "version probe timed out",
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    })();
+    terminate_process_group(&mut child, process_group);
+    result
+}
+
+fn terminate_process_group(child: &mut std::process::Child, process_group: i32) {
+    // The child creates this process group immediately before exec.
+    unsafe {
+        libc::kill(-process_group, libc::SIGKILL);
+    }
+    let deadline = Instant::now() + Duration::from_millis(100);
+    while Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(_)) | Err(_) => return,
+            Ok(None) => std::thread::sleep(Duration::from_millis(1)),
+        }
+    }
+}
+
+fn version_token(output: &str) -> Option<String> {
+    output.split_whitespace().find_map(|token| {
+        let token = token
+            .trim_matches(|character: char| !character.is_ascii_alphanumeric() && character != '.');
+        let token = token.strip_prefix('v').unwrap_or(token);
+        (token
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_digit())
+            && token.contains('.')
+            && token
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric() || ".+-_".contains(character)))
+        .then(|| token.to_owned())
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum InstallOutcome {
+    Installed,
+    Replaced,
+    Unchanged,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct InstallResult {
+    #[serde(skip)]
+    pub(crate) integration: IntegrationId,
+    pub(crate) name: &'static str,
+    pub(crate) result: InstallOutcome,
+    pub(crate) path: String,
+    pub(crate) restart_required: bool,
+}
+
+pub(crate) fn install(
+    id: IntegrationId,
+    environment: &Environment,
+    force: bool,
+) -> Result<InstallResult, Box<dyn Error>> {
+    let spec = id.spec();
+    let target = install_target(id, environment)?;
+    let directory = ensure_safe_directory(&target.directory)?;
+    let result = install_asset_at(&directory, &target.path, spec.content, force)?;
+    Ok(InstallResult {
+        integration: id,
+        name: spec.name,
+        result,
+        path: target.path.display().to_string(),
+        restart_required: result != InstallOutcome::Unchanged,
+    })
+}
+
+pub(crate) fn preflight_install(
+    id: IntegrationId,
+    environment: &Environment,
+    force: bool,
+) -> Result<(), Box<dyn Error>> {
+    let spec = id.spec();
+    let target = install_target(id, environment)?;
+    validate_existing_directory_chain(&target.directory)?;
+    if inspect_existing_asset(&target.path, spec.content)? == ExistingAsset::Modified && !force {
+        return Err(existing_asset_error(&target.path).into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn install_at(
+    id: IntegrationId,
+    config_root: &Path,
+    force: bool,
+) -> Result<InstallResult, Box<dyn Error>> {
+    require_absolute_root(config_root, config_root_name(id))?;
+    let spec = id.spec();
+    let target = target_at(id, config_root);
+    let directory = ensure_safe_directory(&target.directory)?;
+    let result = install_asset_at(&directory, &target.path, spec.content, force)?;
+    Ok(InstallResult {
+        integration: id,
+        name: spec.name,
+        result,
+        path: target.path.display().to_string(),
+        restart_required: result != InstallOutcome::Unchanged,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn install_path_at(id: IntegrationId, config_root: &Path) -> PathBuf {
+    target_at(id, config_root).path
+}
+
+struct InstallTarget {
+    directory: PathBuf,
+    path: PathBuf,
+}
+
+fn install_target(
+    id: IntegrationId,
+    environment: &Environment,
+) -> Result<InstallTarget, Box<dyn Error>> {
+    let root = config_root(id, environment)?;
+    Ok(target_at(id, &root))
+}
+
+fn config_root(id: IntegrationId, environment: &Environment) -> Result<PathBuf, Box<dyn Error>> {
+    match id {
+        IntegrationId::Opencode => opencode_config_root(
+            environment.xdg_config_home.clone(),
+            environment.home.clone(),
+        ),
+        IntegrationId::Pi => pi_config_root(
+            environment.pi_coding_agent_dir.clone(),
+            environment.home.clone(),
+        ),
+    }
+}
+
+fn target_at(id: IntegrationId, config_root: &Path) -> InstallTarget {
+    match id {
+        IntegrationId::Opencode => InstallTarget {
+            directory: config_root.join("opencode/plugins"),
+            path: config_root.join("opencode/plugins/boomux.js"),
+        },
+        IntegrationId::Pi => InstallTarget {
+            directory: config_root.join("extensions"),
+            path: config_root.join("extensions/boomux.js"),
+        },
+    }
+}
+
+#[cfg(test)]
+const fn config_root_name(id: IntegrationId) -> &'static str {
+    match id {
+        IntegrationId::Opencode => "XDG configuration root",
+        IntegrationId::Pi => "Pi configuration root",
+    }
+}
+
+pub(crate) fn opencode_config_root(
+    xdg_config_home: Option<OsString>,
+    home: Option<OsString>,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let root = match xdg_config_home.filter(|value| !value.is_empty()) {
+        Some(root) => PathBuf::from(root),
+        None => PathBuf::from(home.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "HOME must be set to install the Boomux OpenCode plugin",
+            )
+        })?)
+        .join(".config"),
+    };
+    require_absolute_root(&root, "XDG configuration root")?;
+    Ok(root)
+}
+
+pub(crate) fn pi_config_root(
+    pi_coding_agent_dir: Option<OsString>,
+    home: Option<OsString>,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let home = || -> Result<PathBuf, Box<dyn Error>> {
+        home.clone().map(PathBuf::from).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "HOME must be set to install the Boomux Pi extension",
+            )
+            .into()
+        })
+    };
+    let root = match pi_coding_agent_dir.filter(|value| !value.is_empty()) {
+        Some(root) => {
+            let root = PathBuf::from(root);
+            if let Ok(suffix) = root.strip_prefix("~") {
+                home()?.join(suffix)
+            } else {
+                root
+            }
+        }
+        None => home()?.join(".pi/agent"),
+    };
+    require_absolute_root(&root, "Pi configuration root")?;
+    Ok(root)
+}
+
+pub(crate) fn require_absolute_root(root: &Path, name: &str) -> Result<(), Box<dyn Error>> {
+    if !root.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{name} must be an absolute path"),
+        )
+        .into());
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_safe_directory(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
+    require_absolute_root(path, "install directory")?;
+    let mut directory = PathBuf::new();
+    for component in path.components() {
+        directory.push(component);
+        match fs::symlink_metadata(&directory) {
+            Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
+            Ok(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "install path component is not a regular directory: {}",
+                        directory.display()
+                    ),
+                )
+                .into());
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                fs::create_dir(&directory)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(directory)
+}
+
+fn validate_existing_directory_chain(path: &Path) -> io::Result<()> {
+    require_absolute_root(path, "install directory")
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+    let mut directory = PathBuf::new();
+    for component in path.components() {
+        directory.push(component);
+        match fs::symlink_metadata(&directory) {
+            Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
+            Ok(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "install path component is not a regular directory: {}",
+                        directory.display()
+                    ),
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ExistingAsset {
+    Missing,
+    Current,
+    Modified,
+}
+
+pub(crate) fn regular_file_matches(path: &Path, expected: &str) -> io::Result<Option<bool>> {
+    match inspect_existing_asset(path, expected)? {
+        ExistingAsset::Missing => Ok(None),
+        ExistingAsset::Current => Ok(Some(true)),
+        ExistingAsset::Modified => Ok(Some(false)),
+    }
+}
+
+fn inspect_existing_asset(path: &Path, expected: &str) -> io::Result<ExistingAsset> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => metadata,
+        Ok(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("install path is not a regular file: {}", path.display()),
+            ));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(ExistingAsset::Missing);
+        }
+        Err(error) => return Err(error),
+    };
+    if metadata.len() != expected.len() as u64 {
+        return Ok(ExistingAsset::Modified);
+    }
+    let mut contents = Vec::with_capacity(expected.len() + 1);
+    fs::File::open(path)?
+        .take(expected.len() as u64 + 1)
+        .read_to_end(&mut contents)?;
+    Ok(if contents == expected.as_bytes() {
+        ExistingAsset::Current
+    } else {
+        ExistingAsset::Modified
+    })
+}
+
+pub(crate) fn install_asset_at(
+    directory: &Path,
+    path: &Path,
+    content: &str,
+    force: bool,
+) -> Result<InstallOutcome, Box<dyn Error>> {
+    let existing = inspect_existing_asset(path, content)?;
+    let outcome = match existing {
+        ExistingAsset::Current => return Ok(InstallOutcome::Unchanged),
+        ExistingAsset::Modified if !force => return Err(existing_asset_error(path).into()),
+        ExistingAsset::Modified => InstallOutcome::Replaced,
+        ExistingAsset::Missing => InstallOutcome::Installed,
+    };
+    write_asset_atomically(directory, path, content)?;
+    Ok(outcome)
+}
+
+fn existing_asset_error(path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        format!(
+            "{} already exists; rerun with --force to replace it",
+            path.display()
+        ),
+    )
+}
+
+fn write_asset_atomically(directory: &Path, path: &Path, content: &str) -> io::Result<()> {
+    let temporary = directory.join(format!(".boomux-install-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use boomux::protocol::{
+        AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot, ShellRunSnapshot,
+        ShellSnapshot, WorkspaceSnapshot,
+    };
+
+    use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(name: &str) -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos();
+            let path = env::temp_dir().join(format!(
+                "boomux-integration-{}-{name}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("create test directory");
+            Self(path)
+        }
+
+        fn executable(&self, name: &str, contents: &str) -> PathBuf {
+            let path = self.0.join(name);
+            fs::write(&path, contents).expect("write executable");
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+                .expect("set executable mode");
+            path
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn environment(home: &Path) -> Environment {
+        Environment::for_test(
+            Some(home.as_os_str().to_owned()),
+            None,
+            None,
+            Some(OsString::new()),
+        )
+    }
+
+    #[test]
+    fn descriptors_have_unique_names_and_expected_metadata() {
+        assert_eq!(IntegrationId::Opencode.spec().package, "opencode-ai");
+        assert_eq!(IntegrationId::Pi.spec().validated_version, "0.84.1");
+        assert_ne!(
+            IntegrationId::Opencode.spec().name,
+            IntegrationId::Pi.spec().name
+        );
+    }
+
+    #[test]
+    fn resolves_host_configuration_roots() {
+        assert_eq!(
+            opencode_config_root(Some("/xdg".into()), Some("/home/example".into())).unwrap(),
+            Path::new("/xdg")
+        );
+        assert_eq!(
+            opencode_config_root(Some(OsString::new()), Some("/home/example".into())).unwrap(),
+            Path::new("/home/example/.config")
+        );
+        assert_eq!(
+            pi_config_root(Some("~/.config/pi".into()), Some("/home/example".into())).unwrap(),
+            Path::new("/home/example/.config/pi")
+        );
+        assert!(pi_config_root(Some("relative".into()), None).is_err());
+    }
+
+    #[test]
+    fn status_distinguishes_missing_current_and_modified_assets() {
+        let home = TestDirectory::new("asset-status");
+        let environment = environment(&home.0);
+        let missing = inspect(IntegrationId::Opencode, &environment, None);
+        assert_eq!(missing.asset.state, AssetState::Missing);
+        assert_eq!(missing.recommended_action, RecommendedAction::Install);
+        assert!(!home.0.join(".config").exists());
+
+        install(IntegrationId::Opencode, &environment, false).unwrap();
+        let current = inspect(IntegrationId::Opencode, &environment, None);
+        assert_eq!(current.asset.state, AssetState::Current);
+        assert_eq!(current.recommended_action, RecommendedAction::None);
+
+        fs::write(
+            install_path_at(IntegrationId::Opencode, &home.0.join(".config")),
+            "custom",
+        )
+        .unwrap();
+        let modified = inspect(IntegrationId::Opencode, &environment, None);
+        assert_eq!(modified.asset.state, AssetState::Modified);
+        assert_eq!(modified.recommended_action, RecommendedAction::Replace);
+
+        assert_eq!(
+            recommended_action(AssetState::Current, RuntimeState::Untracked),
+            RecommendedAction::RestartHost
+        );
+    }
+
+    #[test]
+    fn unified_install_is_idempotent_and_requires_force() {
+        let home = TestDirectory::new("install");
+        let environment = environment(&home.0);
+        let installed = install(IntegrationId::Pi, &environment, false).unwrap();
+        assert_eq!(installed.result, InstallOutcome::Installed);
+        assert_eq!(
+            install(IntegrationId::Pi, &environment, false)
+                .unwrap()
+                .result,
+            InstallOutcome::Unchanged
+        );
+        fs::write(&installed.path, "custom").unwrap();
+        assert!(install(IntegrationId::Pi, &environment, false).is_err());
+        assert_eq!(
+            install(IntegrationId::Pi, &environment, true)
+                .unwrap()
+                .result,
+            InstallOutcome::Replaced
+        );
+    }
+
+    #[test]
+    fn version_parser_accepts_common_host_output() {
+        assert_eq!(version_token("1.18.15\n").as_deref(), Some("1.18.15"));
+        assert_eq!(
+            version_token("opencode version v1.18.15").as_deref(),
+            Some("1.18.15")
+        );
+        assert_eq!(version_token("unknown"), None);
+    }
+
+    #[test]
+    fn version_probe_bounds_output_and_runtime() {
+        let directory = TestDirectory::new("version-probe");
+        let oversized = directory.executable(
+            "oversized",
+            "#!/bin/sh\ni=0; while [ $i -lt 5000 ]; do printf x; i=$((i + 1)); done\n",
+        );
+        assert_eq!(
+            probe_version_with_timeout(&oversized, Duration::from_secs(1))
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        let hanging = directory.executable("hanging", "#!/bin/sh\nsleep 10\n");
+        let started = Instant::now();
+        assert_eq!(
+            probe_version_with_timeout(&hanging, Duration::from_millis(50))
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::TimedOut
+        );
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+
+    #[test]
+    fn runtime_status_requires_exact_current_run_registration() {
+        let shell = ShellSnapshot {
+            id: "s1".into(),
+            workspace_id: "w1".into(),
+            name: "shell".into(),
+            cwd: "/repo".into(),
+            command: Vec::new(),
+            status: ShellStatus::Running,
+            run: Some(ShellRunSnapshot {
+                id: "r1".into(),
+                generation: 1,
+                started_at_ms: 1,
+                ended_at_ms: None,
+                exit_reason: None,
+                output_revision: 0,
+                environment_has_run_id: true,
+            }),
+            foreground_process: Some("opencode".into()),
+        };
+        let mut workspace = WorkspaceSnapshot {
+            id: "w1".into(),
+            name: "workspace".into(),
+            shells: vec![shell],
+            launchers: Vec::new(),
+            agents: Vec::new(),
+        };
+        let snapshot = Snapshot {
+            workspaces: vec![workspace.clone()],
+        };
+        assert_eq!(
+            inspect_runtime(IntegrationId::Opencode.spec(), Some(&snapshot)).state,
+            RuntimeState::Untracked
+        );
+
+        workspace.agents.push(AgentInstanceSnapshot {
+            id: "a1".into(),
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+            name: "OpenCode".into(),
+            integration: "opencode".into(),
+            external_session_id: Some("root".into()),
+            cwd: Some("/repo".into()),
+            started_at_ms: 1,
+            ended_at_ms: None,
+            attention: None,
+            observation: AgentObservationSnapshot {
+                revision: 1,
+                state: AgentState::Working,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "working".into(),
+                confidence: 100,
+                observed_at_ms: 1,
+            },
+        });
+        let snapshot = Snapshot {
+            workspaces: vec![workspace.clone()],
+        };
+        assert_eq!(
+            inspect_runtime(IntegrationId::Opencode.spec(), Some(&snapshot)).state,
+            RuntimeState::Reporting
+        );
+
+        workspace.agents[0].observation.authority = AgentAuthority::ProcessAdapter;
+        let snapshot = Snapshot {
+            workspaces: vec![workspace],
+        };
+        assert_eq!(
+            inspect_runtime(IntegrationId::Opencode.spec(), Some(&snapshot)).state,
+            RuntimeState::Untracked
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeSet;
 use std::env;
 use std::error::Error;
 use std::ffi::OsString;
+use std::fmt::Write as _;
 use std::fs;
-use std::fs::OpenOptions;
-use std::io::{self, Write};
+use std::io;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -22,12 +22,18 @@ use boomux::protocol::{
 };
 use boomux::{attach, client, daemon, protocol};
 
+use crate::integration_management::{
+    InstallOutcome, ensure_safe_directory, install_asset_at, regular_file_matches,
+    require_absolute_root,
+};
+
 mod agent_attention_projection;
 mod cli_output;
 mod config;
 mod git;
 mod host_session_source;
 mod host_session_titles;
+mod integration_management;
 mod process_adapter;
 mod projects;
 mod session_projection;
@@ -36,10 +42,10 @@ mod terminal;
 mod tui;
 
 const BOOMUX_SKILL: &str = include_str!("../.agents/skills/boomux/SKILL.md");
-const BOOMUX_OPENCODE_PLUGIN: &str = include_str!("../integrations/opencode/boomux.js");
-const BOOMUX_PI_EXTENSION: &str = include_str!("../integrations/pi/boomux.js");
-const VALIDATED_OPENCODE_VERSION: &str = "1.18.15";
-const VALIDATED_PI_VERSION: &str = "0.84.1";
+#[cfg(test)]
+const BOOMUX_OPENCODE_PLUGIN: &str = integration_management::OPENCODE_ASSET;
+#[cfg(test)]
+const BOOMUX_PI_EXTENSION: &str = integration_management::PI_ASSET;
 const MAX_HOST_CATALOG_DIRECTORIES: usize = 8;
 const JSON_COMMANDS: &[&str] = &[
     "capabilities",
@@ -60,6 +66,9 @@ const JSON_COMMANDS: &[&str] = &[
     "agent.wait",
     "attention.list",
     "attention.acknowledge",
+    "integration.list",
+    "integration.status",
+    "integration.install",
     "session.list",
     "session.inspect",
     "session.read",
@@ -97,6 +106,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "revision_aware_agent_wait",
     "persistent_agent_attention",
     "desktop_notifications",
+    "integration_management",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -240,6 +250,11 @@ enum Commands {
     Session {
         #[command(subcommand)]
         command: SessionCommands,
+    },
+    /// Inspect and install supported harness integrations
+    Integration {
+        #[command(subcommand)]
+        command: IntegrationCommands,
     },
     /// Manage the vendor-neutral Boomux Agent Skill
     Skill {
@@ -552,6 +567,26 @@ enum PiCommands {
 }
 
 #[derive(Subcommand)]
+enum IntegrationCommands {
+    /// List integrations bundled with this Boomux binary
+    List,
+    /// Inspect host, asset, and runtime reporting status
+    Status {
+        #[arg(value_enum)]
+        integration: Option<integration_management::IntegrationId>,
+    },
+    /// Install one integration or every bundled integration
+    Install {
+        #[arg(value_enum, required_unless_present = "all", conflicts_with = "all")]
+        integration: Option<integration_management::IntegrationId>,
+        #[arg(long, conflicts_with = "integration")]
+        all: bool,
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum DaemonCommands {
     /// Start the daemon in the foreground
     #[command(hide = true)]
@@ -730,6 +765,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Agent { command }) => agent_command(command, cli.json),
         Some(Commands::Attention { command }) => attention_command(command, cli.json),
         Some(Commands::Session { command }) => session_command(command, cli.json),
+        Some(Commands::Integration { command }) => integration_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
         }) => install_skill(force),
@@ -814,6 +850,15 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Session {
             command: SessionCommands::Read { .. },
         }) => "session.read",
+        Some(Commands::Integration {
+            command: IntegrationCommands::List,
+        }) => "integration.list",
+        Some(Commands::Integration {
+            command: IntegrationCommands::Status { .. },
+        }) => "integration.status",
+        Some(Commands::Integration {
+            command: IntegrationCommands::Install { .. },
+        }) => "integration.install",
         Some(Commands::Daemon {
             command: DaemonCommands::Status,
         }) => "daemon.status",
@@ -863,6 +908,10 @@ fn supports_json(cli: &Cli) -> bool {
             command: SessionCommands::List { .. }
                 | SessionCommands::Inspect { .. }
                 | SessionCommands::Read { .. }
+        }) | Some(Commands::Integration {
+            command: IntegrationCommands::List
+                | IntegrationCommands::Status { .. }
+                | IntegrationCommands::Install { .. }
         })
     )
 }
@@ -1543,6 +1592,237 @@ fn unique_shell_name(base_name: &str, shells: &[ShellSnapshot]) -> String {
     )
 }
 
+fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), Box<dyn Error>> {
+    match command {
+        IntegrationCommands::List => list_integrations(json),
+        IntegrationCommands::Status { integration } => integration_status(integration, json),
+        IntegrationCommands::Install {
+            integration,
+            all,
+            force,
+        } => {
+            let integrations = if all {
+                integration_management::IntegrationId::ALL.to_vec()
+            } else {
+                vec![integration.ok_or_else(|| {
+                    cli_output::failure(
+                        "invalid_argument",
+                        "integration install requires a name or --all",
+                    )
+                })?]
+            };
+            install_integrations(&integrations, force, json)
+        }
+    }
+}
+
+fn list_integrations(json: bool) -> Result<(), Box<dyn Error>> {
+    let integrations = integration_management::IntegrationId::ALL
+        .into_iter()
+        .map(integration_management::IntegrationSummary::from)
+        .collect::<Vec<_>>();
+    if json {
+        return cli_output::print(
+            "integration.list",
+            serde_json::json!({ "integrations": integrations }),
+        );
+    }
+    print!("{}", format_integration_list(&integrations));
+    Ok(())
+}
+
+fn format_integration_list(integrations: &[integration_management::IntegrationSummary]) -> String {
+    let name_width = integrations
+        .iter()
+        .map(|integration| integration.name.len())
+        .max()
+        .unwrap_or(0)
+        .max("NAME".len());
+    let package_width = integrations
+        .iter()
+        .map(|integration| integration.package.len())
+        .max()
+        .unwrap_or(0)
+        .max("PACKAGE".len());
+    let mut output = String::new();
+    writeln!(
+        output,
+        "{:<name_width$}  {:<package_width$}  VALIDATED VERSION",
+        "NAME", "PACKAGE"
+    )
+    .expect("writing to a string cannot fail");
+    for integration in integrations {
+        writeln!(
+            output,
+            "{:<name_width$}  {:<package_width$}  {}",
+            integration.name, integration.package, integration.validated_version
+        )
+        .expect("writing to a string cannot fail");
+    }
+    output
+}
+
+fn integration_status(
+    integration: Option<integration_management::IntegrationId>,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let environment = integration_management::Environment::from_process();
+    let snapshot = client::connect().and_then(|client| client.snapshot()).ok();
+    let integrations = integration.map_or_else(
+        || integration_management::IntegrationId::ALL.to_vec(),
+        |integration| vec![integration],
+    );
+    let statuses = integrations
+        .into_iter()
+        .map(|integration| {
+            integration_management::inspect(integration, &environment, snapshot.as_ref())
+        })
+        .collect::<Vec<_>>();
+    if json {
+        return cli_output::print(
+            "integration.status",
+            serde_json::json!({ "integrations": statuses }),
+        );
+    }
+    print!("{}", format_integration_statuses(&statuses));
+    for status in &statuses {
+        if let Some(error) = status.host.error.as_deref() {
+            eprintln!("warning: {} host version: {error}", status.name);
+        }
+        if let Some(error) = status.asset.error.as_deref() {
+            eprintln!("warning: {} integration asset: {error}", status.name);
+        }
+    }
+    Ok(())
+}
+
+fn format_integration_statuses(statuses: &[integration_management::IntegrationStatus]) -> String {
+    let mut output = String::new();
+    for (index, status) in statuses.iter().enumerate() {
+        if index > 0 {
+            output.push('\n');
+        }
+        writeln!(output, "{} ({})", status.display_name, status.name)
+            .expect("writing to a string cannot fail");
+        writeln!(output, "  {:<14}{}", "Host", status.host.state.as_str())
+            .expect("writing to a string cannot fail");
+        writeln!(
+            output,
+            "  {:<14}{}",
+            "Executable",
+            status.host.executable.as_deref().unwrap_or("-")
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            output,
+            "  {:<14}{}",
+            "Version",
+            status.host.version.as_deref().unwrap_or("-")
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            output,
+            "  {:<14}{}",
+            "Compatibility", status.host.compatibility
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(output, "  {:<14}{}", "Asset", status.asset.state.as_str())
+            .expect("writing to a string cannot fail");
+        writeln!(
+            output,
+            "  {:<14}{}",
+            "Runtime",
+            format_runtime_status(&status.runtime)
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            output,
+            "  {:<14}{}",
+            "Action",
+            format_recommended_action(status.recommended_action)
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            output,
+            "  {:<14}{}",
+            "Path",
+            sanitize_table_cell(status.asset.path.as_deref().unwrap_or("-"))
+        )
+        .expect("writing to a string cannot fail");
+    }
+    output
+}
+
+fn format_runtime_status(status: &integration_management::RuntimeStatus) -> String {
+    if status.running_processes == 0 {
+        return status.state.as_str().replace('_', " ");
+    }
+    format!(
+        "{} ({} running, {} reporting, {} untracked)",
+        status.state.as_str().replace('_', " "),
+        status.running_processes,
+        status.tracked_processes,
+        status.untracked_processes
+    )
+}
+
+fn format_recommended_action(action: integration_management::RecommendedAction) -> &'static str {
+    match action {
+        integration_management::RecommendedAction::None => "none",
+        integration_management::RecommendedAction::Install => "install integration",
+        integration_management::RecommendedAction::Replace => "replace with --force",
+        integration_management::RecommendedAction::RestartHost => "restart host",
+        integration_management::RecommendedAction::InspectError => "inspect reported error",
+    }
+}
+
+fn install_integrations(
+    integrations: &[integration_management::IntegrationId],
+    force: bool,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let environment = integration_management::Environment::from_process();
+    for integration in integrations {
+        integration_management::preflight_install(*integration, &environment, force)?;
+    }
+    let results = integrations
+        .iter()
+        .copied()
+        .map(|integration| integration_management::install(integration, &environment, force))
+        .collect::<Result<Vec<_>, _>>()?;
+    if json {
+        return cli_output::print(
+            "integration.install",
+            serde_json::json!({ "integrations": results }),
+        );
+    }
+    print_integration_install_results(&results);
+    Ok(())
+}
+
+fn print_integration_install_results(results: &[integration_management::InstallResult]) {
+    for result in results {
+        let spec = result.integration.spec();
+        match result.result {
+            integration_management::InstallOutcome::Unchanged => println!(
+                "Boomux {} {} is already installed at {}",
+                spec.display_name, spec.asset_name, result.path
+            ),
+            integration_management::InstallOutcome::Installed => println!(
+                "Installed Boomux {} {} at {}",
+                spec.display_name, spec.asset_name, result.path
+            ),
+            integration_management::InstallOutcome::Replaced => println!(
+                "Replaced Boomux {} {} at {}",
+                spec.display_name, spec.asset_name, result.path
+            ),
+        }
+        if result.restart_required {
+            println!("{}", spec.reload_message);
+        }
+    }
+}
+
 fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
     let error_codes = [
         "invalid_argument",
@@ -1567,6 +1847,19 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "internal",
         "unknown",
     ];
+    let integration_hosts = integration_management::IntegrationId::ALL
+        .into_iter()
+        .map(|integration| {
+            let spec = integration.spec();
+            (
+                spec.name.to_owned(),
+                serde_json::json!({
+                    "package": spec.package,
+                    "validated_version": spec.validated_version,
+                }),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
     if json {
         return cli_output::print(
             "capabilities",
@@ -1577,16 +1870,7 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
                 "json_commands": JSON_COMMANDS,
                 "features": INTEGRATION_FEATURES,
                 "session_transcript_integrations": session_transcript::supported_integrations(),
-                "integration_hosts": {
-                    "opencode": {
-                        "package": "opencode-ai",
-                        "validated_version": VALIDATED_OPENCODE_VERSION,
-                    },
-                    "pi": {
-                        "package": "@earendil-works/pi-coding-agent",
-                        "validated_version": VALIDATED_PI_VERSION,
-                    },
-                },
+                "integration_hosts": integration_hosts,
                 "error_codes": error_codes,
             }),
         );
@@ -1600,7 +1884,17 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "SESSION TRANSCRIPT INTEGRATIONS\t{}",
         session_transcript::supported_integrations().join(",")
     );
-    println!("INTEGRATION HOSTS\topencode={VALIDATED_OPENCODE_VERSION},pi={VALIDATED_PI_VERSION}");
+    println!(
+        "INTEGRATION HOSTS\t{}",
+        integration_management::IntegrationId::ALL
+            .into_iter()
+            .map(|integration| {
+                let spec = integration.spec();
+                format!("{}={}", spec.name, spec.validated_version)
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    );
     println!("ERROR CODES\t{}", error_codes.join(","));
     Ok(())
 }
@@ -3173,9 +3467,9 @@ fn install_skill_at(home: &Path, force: bool) -> Result<(), Box<dyn Error>> {
     require_absolute_root(home, "HOME")?;
     let directory = ensure_safe_directory(&home.join(".agents/skills/boomux"))?;
     let path = skill_install_path(home);
-    let already_installed = install_asset_at(&directory, &path, BOOMUX_SKILL, force)?;
+    let outcome = install_asset_at(&directory, &path, BOOMUX_SKILL, force)?;
 
-    if already_installed {
+    if outcome == InstallOutcome::Unchanged {
         println!("Boomux skill is already installed at {}", path.display());
     } else {
         println!("Installed Boomux skill at {}", path.display());
@@ -3199,11 +3493,10 @@ fn migrate_legacy_skill(home: &Path) -> Result<(), Box<dyn Error>> {
         Err(error) => return Err(error.into()),
     }
     let path = legacy_skill_install_path(home);
-    if let Some(existing) = read_regular_file(&path)? {
+    if let Some(content_matches) = regular_file_matches(&path, LEGACY_BOOMUX_SHELLS_SKILL)? {
         let entries = fs::read_dir(&directory)?.collect::<Result<Vec<_>, _>>()?;
-        let untouched = existing == LEGACY_BOOMUX_SHELLS_SKILL.as_bytes()
-            && entries.len() == 1
-            && entries[0].file_name() == "SKILL.md";
+        let untouched =
+            content_matches && entries.len() == 1 && entries[0].file_name() == "SKILL.md";
         if untouched {
             fs::remove_file(&path)?;
             if let Some(directory) = path.parent() {
@@ -3221,180 +3514,54 @@ fn migrate_legacy_skill(home: &Path) -> Result<(), Box<dyn Error>> {
 }
 
 fn install_opencode(force: bool) -> Result<(), Box<dyn Error>> {
-    let config_root = opencode_config_root(env::var_os("XDG_CONFIG_HOME"), env::var_os("HOME"))?;
-    install_opencode_at(&config_root, force)
+    install_integrations(
+        &[integration_management::IntegrationId::Opencode],
+        force,
+        false,
+    )
 }
 
-fn opencode_config_root(
-    xdg_config_home: Option<std::ffi::OsString>,
-    home: Option<std::ffi::OsString>,
-) -> Result<PathBuf, Box<dyn Error>> {
-    let root = if let Some(root) = xdg_config_home {
-        PathBuf::from(root)
-    } else {
-        PathBuf::from(home.ok_or("HOME must be set to install the Boomux OpenCode plugin")?)
-            .join(".config")
-    };
-    require_absolute_root(&root, "XDG configuration root")?;
-    Ok(root)
-}
-
+#[cfg(test)]
 fn install_opencode_at(config_root: &Path, force: bool) -> Result<(), Box<dyn Error>> {
-    require_absolute_root(config_root, "XDG configuration root")?;
-    let directory = ensure_safe_directory(&config_root.join("opencode/plugins"))?;
-    let path = opencode_install_path(config_root);
-    if install_asset_at(&directory, &path, BOOMUX_OPENCODE_PLUGIN, force)? {
-        println!(
-            "Boomux OpenCode plugin is already installed at {}",
-            path.display()
-        );
-    } else {
-        println!("Installed Boomux OpenCode plugin at {}", path.display());
-        println!("Restart any running OpenCode process to activate the plugin");
-    }
+    let result = integration_management::install_at(
+        integration_management::IntegrationId::Opencode,
+        config_root,
+        force,
+    )?;
+    print_integration_install_results(&[result]);
     Ok(())
 }
 
 fn install_pi(force: bool) -> Result<(), Box<dyn Error>> {
-    let config_root = pi_config_root(env::var_os("PI_CODING_AGENT_DIR"), env::var_os("HOME"))?;
-    install_pi_at(&config_root, force)
+    install_integrations(&[integration_management::IntegrationId::Pi], force, false)
 }
 
-fn pi_config_root(
-    pi_coding_agent_dir: Option<std::ffi::OsString>,
-    home: Option<std::ffi::OsString>,
-) -> Result<PathBuf, Box<dyn Error>> {
-    let home = || -> Result<PathBuf, Box<dyn Error>> {
-        home.clone()
-            .map(PathBuf::from)
-            .ok_or_else(|| "HOME must be set to install the Boomux Pi extension".into())
-    };
-    let root = match pi_coding_agent_dir.filter(|value| !value.is_empty()) {
-        Some(root) => {
-            let root = PathBuf::from(root);
-            if let Ok(suffix) = root.strip_prefix("~") {
-                home()?.join(suffix)
-            } else {
-                root
-            }
-        }
-        None => home()?.join(".pi/agent"),
-    };
-    require_absolute_root(&root, "Pi configuration root")?;
-    Ok(root)
-}
-
+#[cfg(test)]
 fn install_pi_at(config_root: &Path, force: bool) -> Result<(), Box<dyn Error>> {
-    require_absolute_root(config_root, "Pi configuration root")?;
-    let directory = ensure_safe_directory(&config_root.join("extensions"))?;
-    let path = pi_install_path(config_root);
-    if install_asset_at(&directory, &path, BOOMUX_PI_EXTENSION, force)? {
-        println!(
-            "Boomux Pi extension is already installed at {}",
-            path.display()
-        );
-    } else {
-        println!("Installed Boomux Pi extension at {}", path.display());
-        println!("Restart any running Pi process to activate the extension");
-    }
+    let result = integration_management::install_at(
+        integration_management::IntegrationId::Pi,
+        config_root,
+        force,
+    )?;
+    print_integration_install_results(&[result]);
     Ok(())
-}
-
-fn require_absolute_root(root: &Path, name: &str) -> Result<(), Box<dyn Error>> {
-    if !root.is_absolute() {
-        return Err(format!("{name} must be an absolute path").into());
-    }
-    Ok(())
-}
-
-fn ensure_safe_directory(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
-    require_absolute_root(path, "install directory")?;
-    let mut directory = PathBuf::new();
-    for component in path.components() {
-        directory.push(component);
-        match fs::symlink_metadata(&directory) {
-            Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
-            Ok(_) => {
-                return Err(format!(
-                    "install path component is not a regular directory: {}",
-                    directory.display()
-                )
-                .into());
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                fs::create_dir(&directory)?;
-            }
-            Err(error) => return Err(error.into()),
-        }
-    }
-    Ok(directory)
-}
-
-fn read_regular_file(path: &Path) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {
-            Ok(Some(fs::read(path)?))
-        }
-        Ok(_) => Err(format!("install path is not a regular file: {}", path.display()).into()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error.into()),
-    }
-}
-
-fn install_asset_at(
-    directory: &Path,
-    path: &Path,
-    content: &str,
-    force: bool,
-) -> Result<bool, Box<dyn Error>> {
-    if let Some(existing) = read_regular_file(path)? {
-        if existing == content.as_bytes() {
-            return Ok(true);
-        }
-        if !force {
-            return Err(format!(
-                "{} already exists; rerun with --force to replace it",
-                path.display()
-            )
-            .into());
-        }
-    }
-    write_asset_atomically(directory, path, content)?;
-    Ok(false)
-}
-
-fn write_asset_atomically(
-    directory: &Path,
-    path: &Path,
-    content: &str,
-) -> Result<(), Box<dyn Error>> {
-    let temporary = directory.join(format!(".boomux-install-{}.tmp", Uuid::new_v4()));
-    let result = (|| {
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temporary)?;
-        file.write_all(content.as_bytes())?;
-        file.sync_all()?;
-        fs::rename(&temporary, path)?;
-        Ok::<(), std::io::Error>(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&temporary);
-    }
-    result.map_err(Into::into)
 }
 
 fn skill_install_path(home: &Path) -> PathBuf {
     home.join(".agents/skills/boomux/SKILL.md")
 }
 
+#[cfg(test)]
 fn opencode_install_path(config_root: &Path) -> PathBuf {
-    config_root.join("opencode/plugins/boomux.js")
+    integration_management::install_path_at(
+        integration_management::IntegrationId::Opencode,
+        config_root,
+    )
 }
 
+#[cfg(test)]
 fn pi_install_path(config_root: &Path) -> PathBuf {
-    config_root.join("extensions/boomux.js")
+    integration_management::install_path_at(integration_management::IntegrationId::Pi, config_root)
 }
 
 fn legacy_skill_install_path(home: &Path) -> PathBuf {
@@ -3495,23 +3662,14 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             eprintln!("err config: {error}");
         }
     }
-    if let Some(snapshot) = daemon_snapshot.as_ref() {
-        healthy &= print_integration_diagnostic(
-            "opencode",
-            "plugin",
-            opencode_config_root(env::var_os("XDG_CONFIG_HOME"), env::var_os("HOME"))
-                .map(|root| opencode_install_path(&root)),
-            BOOMUX_OPENCODE_PLUGIN,
-            snapshot,
+    let integration_environment = integration_management::Environment::from_process();
+    for integration in integration_management::IntegrationId::ALL {
+        let status = integration_management::inspect_without_host_probe(
+            integration,
+            &integration_environment,
+            daemon_snapshot.as_ref(),
         );
-        healthy &= print_integration_diagnostic(
-            "pi",
-            "extension",
-            pi_config_root(env::var_os("PI_CODING_AGENT_DIR"), env::var_os("HOME"))
-                .map(|root| pi_install_path(&root)),
-            BOOMUX_PI_EXTENSION,
-            snapshot,
-        );
+        healthy &= print_integration_diagnostic(integration, &status);
     }
     if healthy {
         Ok(())
@@ -3521,78 +3679,54 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
 }
 
 fn print_integration_diagnostic(
-    integration: &str,
-    asset_name: &str,
-    path: Result<PathBuf, Box<dyn Error>>,
-    expected: &str,
-    snapshot: &Snapshot,
+    integration: integration_management::IntegrationId,
+    status: &integration_management::IntegrationStatus,
 ) -> bool {
-    let running = snapshot.workspaces.iter().flat_map(|workspace| {
-        workspace.shells.iter().filter_map(move |shell| {
-            (matches!(shell.status, ShellStatus::Running)
-                && shell.foreground_process.as_deref() == Some(integration))
-            .then_some((workspace, shell))
-        })
-    });
-    let running = running.collect::<Vec<_>>();
-    let untracked = running
-        .iter()
-        .filter(|(workspace, shell)| {
-            !shell.run.as_ref().is_some_and(|run| {
-                workspace.agents.iter().any(|agent| {
-                    agent.integration == integration
-                        && agent.shell_id == shell.id
-                        && agent.run_id == run.id
-                        && agent.ended_at_ms.is_none()
-                        && !matches!(
-                            agent.observation.state,
-                            AgentState::Inactive | AgentState::Done
-                        )
-                })
-            })
-        })
-        .count();
-    let path = match path {
-        Ok(path) => path,
-        Err(error) => {
-            eprintln!("err {integration} integration: cannot resolve {asset_name} path: {error}");
-            return false;
-        }
-    };
-    let state = match read_regular_file(&path) {
-        Ok(None) => "missing",
-        Ok(Some(contents)) if contents == expected.as_bytes() => "current",
-        Ok(Some(_)) => "stale",
-        Err(error) => {
-            eprintln!(
-                "err {integration} integration: invalid {asset_name} at {}: {error}",
-                path.display()
-            );
-            return false;
-        }
-    };
-    if running.is_empty() {
-        println!(
-            "ok  {integration} integration: {asset_name} {state} at {}",
-            path.display()
-        );
-        return true;
-    }
-    if state != "current" {
+    let spec = integration.spec();
+    let path = status.asset.path.as_deref().unwrap_or("unresolved path");
+    if status.asset.state == integration_management::AssetState::Unavailable {
         eprintln!(
-            "err {integration} integration: {asset_name} {state} at {}; run boomux {integration} install{}",
-            path.display(),
-            if state == "stale" { " --force" } else { "" }
+            "err {} integration: cannot inspect {} at {path}: {}",
+            spec.name,
+            spec.asset_name,
+            status.asset.error.as_deref().unwrap_or("unknown error")
         );
         return false;
     }
-    if untracked == 0 {
-        println!("ok  {integration} integration: lifecycle registration active");
+    if status.runtime.running_processes == 0 {
+        println!(
+            "ok  {} integration: {} {} at {path}",
+            spec.name,
+            spec.asset_name,
+            status.asset.state.as_str(),
+        );
+        return true;
+    }
+    if status.asset.state != integration_management::AssetState::Current {
+        eprintln!(
+            "err {} integration: {} {} at {path}; run boomux integration install {}{}",
+            spec.name,
+            spec.asset_name,
+            status.asset.state.as_str(),
+            spec.name,
+            if status.asset.state == integration_management::AssetState::Modified {
+                " --force"
+            } else {
+                ""
+            }
+        );
+        return false;
+    }
+    if status.runtime.untracked_processes == 0 {
+        println!(
+            "ok  {} integration: lifecycle registration active",
+            spec.name
+        );
         true
     } else {
         eprintln!(
-            "err {integration} integration: {untracked} foreground process(es) are untracked; restart {integration} and verify it loads {}",
-            path.display()
+            "err {} integration: {} foreground process(es) are untracked; restart {} and verify it loads {path}",
+            spec.name, status.runtime.untracked_processes, spec.display_name
         );
         false
     }
@@ -3643,6 +3777,7 @@ fn plausible_desktop_bus() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::integration_management::{opencode_config_root, pi_config_root};
 
     fn shell(id: &str, workspace_id: &str, name: &str) -> ShellSnapshot {
         ShellSnapshot {
@@ -3763,6 +3898,9 @@ mod tests {
                 "--json",
             ],
             vec!["boomux", "daemon", "status", "--json"],
+            vec!["boomux", "integration", "list", "--json"],
+            vec!["boomux", "integration", "status", "opencode", "--json"],
+            vec!["boomux", "integration", "install", "pi", "--json"],
         ] {
             let cli = Cli::try_parse_from(arguments).unwrap();
             assert!(cli.json);
@@ -4968,6 +5106,94 @@ mod tests {
     }
 
     #[test]
+    fn parses_unified_integration_management_commands() {
+        let list = Cli::try_parse_from(["boomux", "integration", "list"]).unwrap();
+        assert!(matches!(
+            list.command,
+            Some(Commands::Integration {
+                command: IntegrationCommands::List
+            })
+        ));
+        assert_eq!(command_name(&list), "integration.list");
+
+        let status = Cli::try_parse_from(["boomux", "integration", "status", "pi"]).unwrap();
+        assert!(matches!(
+            status.command,
+            Some(Commands::Integration {
+                command: IntegrationCommands::Status {
+                    integration: Some(integration_management::IntegrationId::Pi)
+                }
+            })
+        ));
+        assert_eq!(command_name(&status), "integration.status");
+
+        let install =
+            Cli::try_parse_from(["boomux", "integration", "install", "opencode", "--force"])
+                .unwrap();
+        assert!(matches!(
+            install.command,
+            Some(Commands::Integration {
+                command: IntegrationCommands::Install {
+                    integration: Some(integration_management::IntegrationId::Opencode),
+                    all: false,
+                    force: true,
+                }
+            })
+        ));
+        assert_eq!(command_name(&install), "integration.install");
+
+        assert!(Cli::try_parse_from(["boomux", "integration", "install", "--all"]).is_ok());
+        assert!(Cli::try_parse_from(["boomux", "integration", "install"]).is_err());
+        assert!(Cli::try_parse_from(["boomux", "integration", "install", "pi", "--all",]).is_err());
+    }
+
+    #[test]
+    fn formats_integration_output_without_tab_alignment() {
+        let integrations = integration_management::IntegrationId::ALL
+            .into_iter()
+            .map(integration_management::IntegrationSummary::from)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            format_integration_list(&integrations),
+            "NAME      PACKAGE                          VALIDATED VERSION\n\
+             opencode  opencode-ai                      1.18.15\n\
+             pi        @earendil-works/pi-coding-agent  0.84.1\n"
+        );
+
+        let status = integration_management::IntegrationStatus {
+            name: "opencode",
+            display_name: "OpenCode",
+            package: "opencode-ai",
+            validated_version: "1.18.15",
+            host: integration_management::HostStatus {
+                state: integration_management::HostState::Available,
+                executable: Some("/usr/bin/opencode".into()),
+                version: Some("1.18.15".into()),
+                compatibility: "validated",
+                error: None,
+            },
+            asset: integration_management::AssetStatus {
+                state: integration_management::AssetState::Current,
+                path: Some("/home/test/.config/opencode/plugins/boomux.js".into()),
+                error: None,
+            },
+            runtime: integration_management::RuntimeStatus {
+                state: integration_management::RuntimeState::Untracked,
+                running_processes: 3,
+                tracked_processes: 2,
+                untracked_processes: 1,
+            },
+            recommended_action: integration_management::RecommendedAction::RestartHost,
+        };
+        let output = format_integration_statuses(&[status]);
+        assert!(output.contains("  Host          available\n"));
+        assert!(
+            output.contains("  Runtime       untracked (3 running, 2 reporting, 1 untracked)\n")
+        );
+        assert!(output.contains("  Action        restart host\n"));
+    }
+
+    #[test]
     fn opencode_install_is_idempotent_and_requires_force_for_changes() {
         let config = test_skill_home("opencode-content");
         let plugin = opencode_install_path(&config);
@@ -5077,6 +5303,13 @@ mod tests {
         for command in ["session.list", "session.inspect", "session.read"] {
             assert!(JSON_COMMANDS.contains(&command));
         }
+        for command in [
+            "integration.list",
+            "integration.status",
+            "integration.install",
+        ] {
+            assert!(JSON_COMMANDS.contains(&command));
+        }
         for feature in [
             "protocol_10",
             "protocol_12",
@@ -5091,11 +5324,22 @@ mod tests {
             "protocol_16",
             "persistent_agent_attention",
             "desktop_notifications",
+            "integration_management",
         ] {
             assert!(INTEGRATION_FEATURES.contains(&feature));
         }
-        assert_eq!(VALIDATED_OPENCODE_VERSION, "1.18.15");
-        assert_eq!(VALIDATED_PI_VERSION, "0.84.1");
+        assert_eq!(
+            integration_management::IntegrationId::Opencode
+                .spec()
+                .validated_version,
+            "1.18.15"
+        );
+        assert_eq!(
+            integration_management::IntegrationId::Pi
+                .spec()
+                .validated_version,
+            "0.84.1"
+        );
         assert_eq!(
             session_transcript::supported_integrations(),
             ["opencode", "pi"]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -2785,6 +2785,132 @@ fn failed_implicit_terminal_launch_rolls_back_created_state() {
 }
 
 #[test]
+fn integration_management_reports_and_installs_bundled_hosts() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-integration-management-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = root.join("bin");
+    let config = root.join("config");
+    let pi = root.join("pi");
+    let runtime = root.join("runtime");
+    fs::create_dir_all(&bin).unwrap();
+    fs::create_dir_all(&runtime).unwrap();
+    for (name, version) in [("opencode", "1.18.15"), ("pi", "0.84.1")] {
+        let executable = bin.join(name);
+        fs::write(
+            &executable,
+            format!("#!/bin/sh\nprintf '%s\\n' '{version}'\n"),
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let command = || {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+        command
+            .env("HOME", &root)
+            .env("XDG_CONFIG_HOME", &config)
+            .env("PI_CODING_AGENT_DIR", &pi)
+            .env("XDG_RUNTIME_DIR", &runtime)
+            .env("PATH", &bin);
+        command
+    };
+
+    let listed = command()
+        .args(["integration", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(listed.status.success());
+    let listed: serde_json::Value = serde_json::from_slice(&listed.stdout).unwrap();
+    assert_eq!(listed["schema"], "boomux.cli/v1");
+    assert_eq!(listed["command"], "integration.list");
+    assert_eq!(listed["data"]["integrations"].as_array().unwrap().len(), 2);
+
+    let missing = command()
+        .args(["integration", "status", "--json"])
+        .output()
+        .unwrap();
+    assert!(missing.status.success());
+    let missing: serde_json::Value = serde_json::from_slice(&missing.stdout).unwrap();
+    assert_eq!(missing["command"], "integration.status");
+    for integration in missing["data"]["integrations"].as_array().unwrap() {
+        assert_eq!(integration["host"]["compatibility"], "validated");
+        assert_eq!(integration["asset"]["state"], "missing");
+        assert_eq!(integration["runtime"]["state"], "not_observable");
+        assert_eq!(integration["recommended_action"], "install");
+    }
+    assert!(fs::read_dir(&runtime).unwrap().next().is_none());
+
+    fs::create_dir_all(pi.join("extensions")).unwrap();
+    fs::write(pi.join("extensions/boomux.js"), "custom extension").unwrap();
+    let preflight_refused = command()
+        .args(["integration", "install", "--all", "--json"])
+        .output()
+        .unwrap();
+    assert!(!preflight_refused.status.success());
+    assert!(!config.join("opencode/plugins/boomux.js").exists());
+    fs::remove_file(pi.join("extensions/boomux.js")).unwrap();
+
+    let installed = command()
+        .args(["integration", "install", "--all", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        installed.status.success(),
+        "integration install failed: {}",
+        String::from_utf8_lossy(&installed.stderr)
+    );
+    let installed: serde_json::Value = serde_json::from_slice(&installed.stdout).unwrap();
+    assert_eq!(installed["command"], "integration.install");
+    for integration in installed["data"]["integrations"].as_array().unwrap() {
+        assert_eq!(integration["result"], "installed");
+        assert_eq!(integration["restart_required"], true);
+    }
+    assert!(config.join("opencode/plugins/boomux.js").is_file());
+    assert!(pi.join("extensions/boomux.js").is_file());
+
+    for arguments in [["opencode", "install"], ["pi", "install"]] {
+        let shortcut = command().args(arguments).output().unwrap();
+        assert!(shortcut.status.success());
+        assert!(String::from_utf8_lossy(&shortcut.stdout).contains("already installed"));
+    }
+
+    let current = command()
+        .args(["integration", "status", "pi", "--json"])
+        .output()
+        .unwrap();
+    let current: serde_json::Value = serde_json::from_slice(&current.stdout).unwrap();
+    assert_eq!(
+        current["data"]["integrations"][0]["asset"]["state"],
+        "current"
+    );
+
+    fs::write(pi.join("extensions/boomux.js"), "custom extension").unwrap();
+    let refused = command()
+        .args(["integration", "install", "pi", "--json"])
+        .output()
+        .unwrap();
+    assert!(!refused.status.success());
+    let refused: serde_json::Value = serde_json::from_slice(&refused.stderr).unwrap();
+    assert_eq!(refused["command"], "integration.install");
+    assert_eq!(refused["error"]["code"], "already_exists");
+
+    let invalid_environment = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["integration", "install", "opencode", "--json"])
+        .env_remove("HOME")
+        .env_remove("XDG_CONFIG_HOME")
+        .output()
+        .unwrap();
+    assert!(!invalid_environment.status.success());
+    let invalid_environment: serde_json::Value =
+        serde_json::from_slice(&invalid_environment.stderr).unwrap();
+    assert_eq!(invalid_environment["error"]["code"], "invalid_argument");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn native_daemon_lifecycle() {
     let mut daemon = TestDaemon::start();
 
@@ -2827,6 +2953,9 @@ fn native_daemon_lifecycle() {
         "agent.wait",
         "attention.list",
         "attention.acknowledge",
+        "integration.list",
+        "integration.status",
+        "integration.install",
     ] {
         assert!(json_commands.iter().any(|current| current == command));
     }
@@ -2848,6 +2977,7 @@ fn native_daemon_lifecycle() {
         "process_adapters",
         "persistent_agent_attention",
         "transcript_pagination",
+        "integration_management",
     ] {
         assert!(features.iter().any(|current| current == feature));
     }


### PR DESCRIPTION
## Summary
- add unified `integration list`, `integration status`, and single/all `integration install` commands with human and stable JSON output
- report bounded host-version compatibility, safe asset state, authoritative runtime registration, and recommended next actions
- centralize integration metadata and atomic installer primitives while preserving the existing OpenCode and Pi installer shortcuts
- document the CLI contract and add readable aligned human output

## Safety
- status does not start the daemon or mutate integration files
- version probes enforce process-group, time, and output bounds
- `--all` preflights every target before writing; each write remains individually atomic
- modified, symlinked, and non-regular targets are preserved unless explicitly and safely handled

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`
- `git diff --check`
- manual smoke test of installed `integration list` and `integration status` output