### PR TITLE
feat: verify integration reporting

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -66,6 +66,8 @@ the user explicitly asks. With that authorization, use `boomux integration
 install opencode --json`, `boomux integration install pi --json`, or
 `boomux integration install --all --json`; add `--force` only when the user also
 authorizes replacing a modified asset.
+After the user restarts a host, verify authoritative reporting with `boomux
+integration verify opencode --json` or `boomux integration verify pi --json`.
 
 Use `boomux events --json` for an immediate snapshot and cursor. Poll again with
 `--after CURSOR --wait-ms 30000` to observe later transitions. If

--- a/README.md
+++ b/README.md
@@ -448,7 +448,8 @@ boomux integration verify opencode --shell <shell-id> --wait-ms 30000
 ```
 
 Verification never treats process or terminal evidence as lifecycle proof. When
-several matching host shells are running, pass one exact shell ID.
+several matching host shells are running, Boomux lists each workspace and shell
+name with a ready-to-run command containing the required exact shell ID.
 
 Boomux currently validates its bundled integrations against these host releases:
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ boomux integration list
 boomux integration status [opencode|pi]
 boomux integration install <opencode|pi> [--force]
 boomux integration install --all [--force]
+boomux integration verify <opencode|pi> [--shell <shell-id>] [--wait-ms <milliseconds>]
 boomux daemon status
 boomux daemon restart
 boomux daemon stop
@@ -437,6 +438,17 @@ preserved unless `--force` is supplied, and symlinked or non-regular paths are
 rejected. Successful changes print the required host restart guidance. The
 existing `boomux opencode install` and `boomux pi install` commands remain
 equivalent host-specific shortcuts.
+
+After restarting a host, verify that a running managed shell has authoritative
+lifecycle reporting:
+
+```console
+boomux integration verify opencode
+boomux integration verify opencode --shell <shell-id> --wait-ms 30000
+```
+
+Verification never treats process or terminal evidence as lifecycle proof. When
+several matching host shells are running, pass one exact shell ID.
 
 Boomux currently validates its bundled integrations against these host releases:
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -58,6 +58,7 @@ The following commands support `--json`:
 - `boomux integration status [opencode|pi]`
 - `boomux integration install <opencode|pi>`
 - `boomux integration install --all`
+- `boomux integration verify <opencode|pi>`
 - `boomux daemon status`
 
 JSON mutations are deliberately narrow: only `agent register`, `agent ensure`,
@@ -106,6 +107,9 @@ Command payloads are:
   `replaced`, or `unchanged` results, target paths, and whether a host restart is
   required. Each target is changed atomically; `--all` is not a transaction
   across hosts, but every target is preflighted before the first write.
+- `integration.verify`: `integration`, `verified`, exact `shell_id` and `run_id`,
+  plus the nonempty authoritative `agents` array. Failure uses typed
+  `not_found`, `ambiguous_target`, `run_changed`, or `timeout` errors.
 - `read`: shell/run identity, observed output revision, and rendered output.
 - `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
   bounded event array.

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -214,6 +214,93 @@ pub(crate) struct RuntimeStatus {
     pub(crate) untracked_processes: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct VerificationTarget {
+    pub(crate) shell_id: String,
+    pub(crate) run_id: String,
+}
+
+#[derive(Debug)]
+pub(crate) enum VerificationCheck {
+    Verified {
+        workspace_name: String,
+        agents: Vec<boomux::protocol::AgentInstanceSnapshot>,
+    },
+    Pending,
+    Missing,
+    RunChanged,
+}
+
+pub(crate) fn verification_targets(
+    snapshot: &Snapshot,
+    id: IntegrationId,
+    shell_id: Option<&str>,
+) -> Vec<VerificationTarget> {
+    let executable = id.spec().executable;
+    let mut targets = snapshot
+        .workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.shells)
+        .filter(|shell| {
+            matches!(shell.status, ShellStatus::Running)
+                && shell.foreground_process.as_deref() == Some(executable)
+                && shell_id.is_none_or(|requested| shell.id == requested)
+        })
+        .filter_map(|shell| {
+            shell.run.as_ref().map(|run| VerificationTarget {
+                shell_id: shell.id.clone(),
+                run_id: run.id.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    targets.sort_by(|left, right| left.shell_id.cmp(&right.shell_id));
+    targets
+}
+
+pub(crate) fn check_verification_target(
+    snapshot: &Snapshot,
+    id: IntegrationId,
+    target: &VerificationTarget,
+) -> VerificationCheck {
+    let spec = id.spec();
+    for workspace in &snapshot.workspaces {
+        let Some(shell) = workspace
+            .shells
+            .iter()
+            .find(|shell| shell.id == target.shell_id)
+        else {
+            continue;
+        };
+        if !matches!(shell.status, ShellStatus::Running)
+            || shell.foreground_process.as_deref() != Some(spec.executable)
+        {
+            return VerificationCheck::Missing;
+        }
+        let Some(run) = shell.run.as_ref() else {
+            return VerificationCheck::Missing;
+        };
+        if run.id != target.run_id {
+            return VerificationCheck::RunChanged;
+        }
+        let mut agents = workspace
+            .agents
+            .iter()
+            .filter(|agent| authoritative_agent_matches(agent, spec, shell, run))
+            .cloned()
+            .collect::<Vec<_>>();
+        agents.sort_by(|left, right| left.id.cmp(&right.id));
+        return if agents.is_empty() {
+            VerificationCheck::Pending
+        } else {
+            VerificationCheck::Verified {
+                workspace_name: workspace.name.clone(),
+                agents,
+            }
+        };
+    }
+    VerificationCheck::Missing
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct IntegrationStatus {
     pub(crate) name: &'static str,
@@ -397,17 +484,10 @@ fn inspect_runtime(spec: &IntegrationSpec, snapshot: Option<&Snapshot>) -> Runti
     for (workspace, shell) in running {
         running_processes += 1;
         if shell.run.as_ref().is_some_and(|run| {
-            workspace.agents.iter().any(|agent| {
-                agent.integration == spec.name
-                    && agent.shell_id == shell.id
-                    && agent.run_id == run.id
-                    && agent.ended_at_ms.is_none()
-                    && agent.observation.authority == AgentAuthority::LifecycleIntegration
-                    && !matches!(
-                        agent.observation.state,
-                        AgentState::Inactive | AgentState::Done
-                    )
-            })
+            workspace
+                .agents
+                .iter()
+                .any(|agent| authoritative_agent_matches(agent, spec, shell, run))
         }) {
             tracked_processes += 1;
         }
@@ -426,6 +506,23 @@ fn inspect_runtime(spec: &IntegrationSpec, snapshot: Option<&Snapshot>) -> Runti
         tracked_processes,
         untracked_processes,
     }
+}
+
+fn authoritative_agent_matches(
+    agent: &boomux::protocol::AgentInstanceSnapshot,
+    spec: &IntegrationSpec,
+    shell: &boomux::protocol::ShellSnapshot,
+    run: &boomux::protocol::ShellRunSnapshot,
+) -> bool {
+    agent.integration == spec.name
+        && agent.shell_id == shell.id
+        && agent.run_id == run.id
+        && agent.ended_at_ms.is_none()
+        && agent.observation.authority == AgentAuthority::LifecycleIntegration
+        && !matches!(
+            agent.observation.state,
+            AgentState::Inactive | AgentState::Done
+        )
 }
 
 fn executable_on_path(name: &str, path: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
@@ -1083,9 +1180,27 @@ mod tests {
             workspaces: vec![workspace.clone()],
         };
         assert_eq!(
+            verification_targets(&snapshot, IntegrationId::Opencode, None),
+            [VerificationTarget {
+                shell_id: "s1".into(),
+                run_id: "r1".into(),
+            }]
+        );
+        assert_eq!(
             inspect_runtime(IntegrationId::Opencode.spec(), Some(&snapshot)).state,
             RuntimeState::Reporting
         );
+        assert!(matches!(
+            check_verification_target(
+                &snapshot,
+                IntegrationId::Opencode,
+                &VerificationTarget {
+                    shell_id: "s1".into(),
+                    run_id: "r1".into(),
+                }
+            ),
+            VerificationCheck::Verified { agents, .. } if agents.len() == 1
+        ));
 
         workspace.agents[0].observation.authority = AgentAuthority::ProcessAdapter;
         let snapshot = Snapshot {
@@ -1095,5 +1210,16 @@ mod tests {
             inspect_runtime(IntegrationId::Opencode.spec(), Some(&snapshot)).state,
             RuntimeState::Untracked
         );
+        assert!(matches!(
+            check_verification_target(
+                &snapshot,
+                IntegrationId::Opencode,
+                &VerificationTarget {
+                    shell_id: "s1".into(),
+                    run_id: "r1".into(),
+                }
+            ),
+            VerificationCheck::Pending
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ const JSON_COMMANDS: &[&str] = &[
     "integration.list",
     "integration.status",
     "integration.install",
+    "integration.verify",
     "session.list",
     "session.inspect",
     "session.read",
@@ -584,6 +585,15 @@ enum IntegrationCommands {
         #[arg(long)]
         force: bool,
     },
+    /// Verify authoritative lifecycle reporting in a running host shell
+    Verify {
+        #[arg(value_enum)]
+        integration: integration_management::IntegrationId,
+        #[arg(long, value_name = "ID")]
+        shell: Option<String>,
+        #[arg(long, default_value_t = 30_000)]
+        wait_ms: u32,
+    },
 }
 
 #[derive(Subcommand)]
@@ -859,6 +869,9 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Integration {
             command: IntegrationCommands::Install { .. },
         }) => "integration.install",
+        Some(Commands::Integration {
+            command: IntegrationCommands::Verify { .. },
+        }) => "integration.verify",
         Some(Commands::Daemon {
             command: DaemonCommands::Status,
         }) => "daemon.status",
@@ -912,6 +925,7 @@ fn supports_json(cli: &Cli) -> bool {
             command: IntegrationCommands::List
                 | IntegrationCommands::Status { .. }
                 | IntegrationCommands::Install { .. }
+                | IntegrationCommands::Verify { .. }
         })
     )
 }
@@ -1613,6 +1627,131 @@ fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), B
             };
             install_integrations(&integrations, force, json)
         }
+        IntegrationCommands::Verify {
+            integration,
+            shell,
+            wait_ms,
+        } => verify_integration(integration, shell.as_deref(), wait_ms, json),
+    }
+}
+
+fn verify_integration(
+    integration: integration_management::IntegrationId,
+    shell_id: Option<&str>,
+    wait_ms: u32,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let client = client::connect().map_err(|error| {
+        cli_output::failure(
+            "daemon_unavailable",
+            format!("cannot verify integration without the daemon: {error}"),
+        )
+    })?;
+    let baseline = client.events(None, 1, 0)?;
+    let snapshot = baseline
+        .snapshot
+        .ok_or_else(|| io::Error::other("event baseline omitted its snapshot"))?;
+    let targets = integration_management::verification_targets(&snapshot, integration, shell_id);
+    let spec = integration.spec();
+    let target = match targets.as_slice() {
+        [target] => target.clone(),
+        [] if shell_id.is_some() => {
+            return Err(cli_output::failure(
+                "not_found",
+                format!(
+                    "shell {} is not a running {} host shell",
+                    shell_id.expect("checked above"),
+                    spec.name
+                ),
+            ));
+        }
+        [] => {
+            return Err(cli_output::failure(
+                "not_found",
+                format!("no running {} host shell found", spec.name),
+            ));
+        }
+        _ => {
+            return Err(cli_output::failure(
+                "ambiguous_target",
+                format!(
+                    "multiple running {} host shells found ({}); pass --shell <id>",
+                    spec.name,
+                    targets
+                        .iter()
+                        .map(|target| target.shell_id.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            ));
+        }
+    };
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(u64::from(wait_ms));
+    let mut cursor = baseline.cursor;
+    let mut snapshot = snapshot;
+    loop {
+        match integration_management::check_verification_target(&snapshot, integration, &target) {
+            integration_management::VerificationCheck::Verified {
+                workspace_name,
+                agents,
+            } => {
+                if json {
+                    let agents = agents
+                        .iter()
+                        .map(|agent| cli_output::agent(agent, Some(&workspace_name)))
+                        .collect::<Vec<_>>();
+                    return cli_output::print(
+                        "integration.verify",
+                        serde_json::json!({
+                            "integration": spec.name,
+                            "verified": true,
+                            "shell_id": target.shell_id,
+                            "run_id": target.run_id,
+                            "agents": agents,
+                        }),
+                    );
+                }
+                println!("Verified {} lifecycle reporting", spec.display_name);
+                println!("  {:<12}{}", "Shell", target.shell_id);
+                println!("  {:<12}{}", "Run", target.run_id);
+                println!("  {:<12}{}", "Agents", agents.len());
+                return Ok(());
+            }
+            integration_management::VerificationCheck::Missing => {
+                return Err(cli_output::failure(
+                    "not_found",
+                    format!(
+                        "shell {} is no longer a running {} host shell",
+                        target.shell_id, spec.name
+                    ),
+                ));
+            }
+            integration_management::VerificationCheck::RunChanged => {
+                return Err(cli_output::failure(
+                    "run_changed",
+                    format!("shell {} started a different run", target.shell_id),
+                ));
+            }
+            integration_management::VerificationCheck::Pending => {}
+        }
+        let now = std::time::Instant::now();
+        if wait_ms == 0 || now >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "did not observe lifecycle integration reporting for {} in shell {} within {} ms",
+                    spec.name, target.shell_id, wait_ms
+                ),
+            )
+            .into());
+        }
+        let remaining = deadline.saturating_duration_since(now).as_millis();
+        let chunk_ms = u32::try_from(remaining.min(30_000))
+            .unwrap_or(30_000)
+            .max(1);
+        let batch = client.events(Some(cursor), 1, chunk_ms)?;
+        cursor = batch.cursor;
+        snapshot = client.snapshot()?;
     }
 }
 
@@ -5145,6 +5284,31 @@ mod tests {
         assert!(Cli::try_parse_from(["boomux", "integration", "install", "--all"]).is_ok());
         assert!(Cli::try_parse_from(["boomux", "integration", "install"]).is_err());
         assert!(Cli::try_parse_from(["boomux", "integration", "install", "pi", "--all",]).is_err());
+
+        let verify = Cli::try_parse_from([
+            "boomux",
+            "integration",
+            "verify",
+            "opencode",
+            "--shell",
+            "s1",
+            "--wait-ms",
+            "0",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            verify.command,
+            Some(Commands::Integration {
+                command: IntegrationCommands::Verify {
+                    integration: integration_management::IntegrationId::Opencode,
+                    shell: Some(ref shell),
+                    wait_ms: 0,
+                }
+            }) if shell == "s1"
+        ));
+        assert_eq!(command_name(&verify), "integration.verify");
+        assert!(supports_json(&verify));
     }
 
     #[test]
@@ -5307,6 +5471,7 @@ mod tests {
             "integration.list",
             "integration.status",
             "integration.install",
+            "integration.verify",
         ] {
             assert!(JSON_COMMANDS.contains(&command));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1674,15 +1674,7 @@ fn verify_integration(
         _ => {
             return Err(cli_output::failure(
                 "ambiguous_target",
-                format!(
-                    "multiple running {} host shells found ({}); pass --shell <id>",
-                    spec.name,
-                    targets
-                        .iter()
-                        .map(|target| target.shell_id.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ),
+                format_ambiguous_verification_targets(&snapshot, integration, &targets),
             ));
         }
     };
@@ -1753,6 +1745,47 @@ fn verify_integration(
         cursor = batch.cursor;
         snapshot = client.snapshot()?;
     }
+}
+
+fn format_ambiguous_verification_targets(
+    snapshot: &Snapshot,
+    integration: integration_management::IntegrationId,
+    targets: &[integration_management::VerificationTarget],
+) -> String {
+    let spec = integration.spec();
+    let mut choices = targets
+        .iter()
+        .filter_map(|target| {
+            snapshot.workspaces.iter().find_map(|workspace| {
+                workspace
+                    .shells
+                    .iter()
+                    .find(|shell| shell.id == target.shell_id)
+                    .map(|shell| {
+                        (
+                            workspace.name.as_str(),
+                            shell.name.as_str(),
+                            target.shell_id.as_str(),
+                        )
+                    })
+            })
+        })
+        .collect::<Vec<_>>();
+    choices.sort_unstable();
+
+    let mut output = format!(
+        "multiple running {} host shells found\n\nChoose a shell:",
+        spec.display_name
+    );
+    for (workspace, shell, shell_id) in choices {
+        write!(
+            output,
+            "\n  {workspace} / {shell}\n    boomux integration verify {} --shell {shell_id}",
+            spec.name
+        )
+        .expect("writing to a string cannot fail");
+    }
+    output
 }
 
 fn list_integrations(json: bool) -> Result<(), Box<dyn Error>> {
@@ -5309,6 +5342,42 @@ mod tests {
         ));
         assert_eq!(command_name(&verify), "integration.verify");
         assert!(supports_json(&verify));
+    }
+
+    #[test]
+    fn ambiguous_verification_lists_named_shell_commands() {
+        let snapshot = Snapshot {
+            workspaces: vec![
+                workspace("w2", "Zeta", vec![shell("s2", "w2", "backend")]),
+                workspace("w1", "Alpha", vec![shell("s1", "w1", "frontend")]),
+            ],
+        };
+        let targets = vec![
+            integration_management::VerificationTarget {
+                shell_id: "s2".into(),
+                run_id: "r2".into(),
+            },
+            integration_management::VerificationTarget {
+                shell_id: "s1".into(),
+                run_id: "r1".into(),
+            },
+        ];
+
+        assert_eq!(
+            format_ambiguous_verification_targets(
+                &snapshot,
+                integration_management::IntegrationId::Opencode,
+                &targets,
+            ),
+            concat!(
+                "multiple running OpenCode host shells found\n\n",
+                "Choose a shell:\n",
+                "  Alpha / frontend\n",
+                "    boomux integration verify opencode --shell s1\n",
+                "  Zeta / backend\n",
+                "    boomux integration verify opencode --shell s2",
+            )
+        );
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -359,15 +359,13 @@ fn native_daemon_recovers_reproducible_metadata_after_restart() {
     let shell = workspace.shells.first().unwrap();
     let workspace_id = workspace.id.clone();
     let shell_id = shell.id.clone();
-    let mut first = daemon
-        .client
-        .attach(&shell_id, false, profile())
-        .unwrap()
-        .stream;
-    assert!(contains(
-        &read_until(&mut first, b"restored-command"),
-        b"restored-command"
-    ));
+    let mut first = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    if !contains(&first.reconstruction, b"restored-command") {
+        first
+            .reconstruction
+            .extend(read_until(&mut first.stream, b"restored-command"));
+    }
+    assert!(contains(&first.reconstruction, b"restored-command"));
     let first_run = daemon
         .client
         .get_shell(&shell_id)
@@ -409,15 +407,13 @@ fn native_daemon_recovers_reproducible_metadata_after_restart() {
     assert_eq!(restored.shells[0].name, "restored-renamed");
     assert_eq!(restored.shells[0].status, ShellStatus::Pending);
     assert!(restored.shells[0].run.is_none());
-    let mut second = daemon
-        .client
-        .attach(&shell_id, false, profile())
-        .unwrap()
-        .stream;
-    assert!(contains(
-        &read_until(&mut second, b"restored-command"),
-        b"restored-command"
-    ));
+    let mut second = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    if !contains(&second.reconstruction, b"restored-command") {
+        second
+            .reconstruction
+            .extend(read_until(&mut second.stream, b"restored-command"));
+    }
+    assert!(contains(&second.reconstruction, b"restored-command"));
     let second_run = daemon
         .client
         .get_shell(&shell_id)

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -2956,6 +2956,7 @@ fn native_daemon_lifecycle() {
         "integration.list",
         "integration.status",
         "integration.install",
+        "integration.verify",
     ] {
         assert!(json_commands.iter().any(|current| current == command));
     }


### PR DESCRIPTION
## Summary
- add `boomux integration verify` for OpenCode and Pi
- select exact running host shells and require lifecycle-integration authority
- support bounded event-backed waiting and typed JSON failures

## Testing
- `cargo test --all-targets --locked`
- `cargo clippy --all-targets --locked -- -D warnings`