### PR TITLE
feat: preview integration installs

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -65,7 +65,8 @@ not an incompatibility claim. Never install or replace integration files unless
 the user explicitly asks. With that authorization, use `boomux integration
 install opencode --json`, `boomux integration install pi --json`, or
 `boomux integration install --all --json`; add `--force` only when the user also
-authorizes replacing a modified asset.
+authorizes replacing a modified asset. Use `--dry-run` first when the user wants
+to inspect exact target paths and planned actions without changing files.
 After the user restarts a host, verify authoritative reporting with `boomux
 integration verify opencode --json` or `boomux integration verify pi --json`.
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ boomux session inspect <session-id>
 boomux session read <session-id> [--before <cursor>] [--limit <entries>] [--max-bytes <bytes>]
 boomux integration list
 boomux integration status [opencode|pi]
-boomux integration install <opencode|pi> [--force]
-boomux integration install --all [--force]
+boomux integration install <opencode|pi> [--force] [--dry-run]
+boomux integration install --all [--force] [--dry-run]
 boomux integration verify <opencode|pi> [--shell <shell-id>] [--wait-ms <milliseconds>]
 boomux daemon status
 boomux daemon restart
@@ -431,11 +431,14 @@ Install one integration or all bundled integrations with:
 ```console
 boomux integration install opencode
 boomux integration install --all
+boomux integration install --all --dry-run
 ```
 
 Installation is individually atomic and idempotent. A modified target is
 preserved unless `--force` is supplied, and symlinked or non-regular paths are
-rejected. Successful changes print the required host restart guidance. The
+rejected. `--dry-run` reports the current state and exact action for every target
+without creating directories or changing files. Successful changes print the
+required host restart guidance. The
 existing `boomux opencode install` and `boomux pi install` commands remain
 equivalent host-specific shortcuts.
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -103,10 +103,13 @@ Command payloads are:
   mutate integration files. It executes each PATH-resolved host's `--version`
   command with bounded output and runtime; missing or unhealthy integrations are
   represented as data and do not make status fail.
-- `integration.install`: an `integrations` array containing `installed`,
-  `replaced`, or `unchanged` results, target paths, and whether a host restart is
-  required. Each target is changed atomically; `--all` is not a transaction
-  across hosts, but every target is preflighted before the first write.
+- `integration.install`: normally, an `integrations` array containing
+  `installed`, `replaced`, or `unchanged` results, target paths, and whether a
+  host restart is required. With `--dry-run`, `dry_run` is `true` and each entry
+  instead contains `current_state`, the planned `action`, `path`, and
+  `restart_required`. Each target is changed atomically; `--all` is not a
+  transaction across hosts, but every target is preflighted before the first
+  write.
 - `integration.verify`: `integration`, `verified`, exact `shell_id` and `run_id`,
   plus the nonempty authoritative `agents` array. Failure uses typed
   `not_found`, `ambiguous_target`, `run_changed`, or `timeout` errors.
@@ -144,6 +147,11 @@ Install entries contain `name`, `result`, `path`, and `restart_required`.
 Result is `installed`, `replaced`, or `unchanged`. A modified target fails with
 `already_exists` unless `--force` is supplied. Invalid roots or unsafe paths fail
 with `invalid_argument` before mutation.
+
+Install preview entries contain `name`, `current_state`, `action`, `path`, and
+`restart_required`. Current state is `missing`, `current`, or `modified`; action
+is `install`, `replace`, or `unchanged`. Preview performs the same path and
+replacement validation as installation but does not create or modify anything.
 
 ## Shell Data
 

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -657,6 +657,25 @@ pub(crate) struct InstallResult {
     pub(crate) restart_required: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum InstallAction {
+    Install,
+    Replace,
+    Unchanged,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct InstallPlan {
+    #[serde(skip)]
+    pub(crate) integration: IntegrationId,
+    pub(crate) name: &'static str,
+    pub(crate) current_state: AssetState,
+    pub(crate) action: InstallAction,
+    pub(crate) path: String,
+    pub(crate) restart_required: bool,
+}
+
 pub(crate) fn install(
     id: IntegrationId,
     environment: &Environment,
@@ -675,18 +694,29 @@ pub(crate) fn install(
     })
 }
 
-pub(crate) fn preflight_install(
+pub(crate) fn plan_install(
     id: IntegrationId,
     environment: &Environment,
     force: bool,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<InstallPlan, Box<dyn Error>> {
     let spec = id.spec();
     let target = install_target(id, environment)?;
     validate_existing_directory_chain(&target.directory)?;
-    if inspect_existing_asset(&target.path, spec.content)? == ExistingAsset::Modified && !force {
-        return Err(existing_asset_error(&target.path).into());
-    }
-    Ok(())
+    let existing = inspect_existing_asset(&target.path, spec.content)?;
+    let (current_state, action) = match existing {
+        ExistingAsset::Missing => (AssetState::Missing, InstallAction::Install),
+        ExistingAsset::Current => (AssetState::Current, InstallAction::Unchanged),
+        ExistingAsset::Modified if !force => return Err(existing_asset_error(&target.path).into()),
+        ExistingAsset::Modified => (AssetState::Modified, InstallAction::Replace),
+    };
+    Ok(InstallPlan {
+        integration: id,
+        name: spec.name,
+        current_state,
+        action,
+        path: target.path.display().to_string(),
+        restart_required: action != InstallAction::Unchanged,
+    })
 }
 
 #[cfg(test)]
@@ -1083,6 +1113,31 @@ mod tests {
                 .result,
             InstallOutcome::Replaced
         );
+    }
+
+    #[test]
+    fn install_plan_reports_actions_without_mutating_the_target() {
+        let home = TestDirectory::new("install-plan");
+        let environment = environment(&home.0);
+
+        let missing = plan_install(IntegrationId::Opencode, &environment, false).unwrap();
+        assert_eq!(missing.current_state, AssetState::Missing);
+        assert_eq!(missing.action, InstallAction::Install);
+        assert!(missing.restart_required);
+        assert!(!home.0.join(".config").exists());
+
+        let installed = install(IntegrationId::Opencode, &environment, false).unwrap();
+        let current = plan_install(IntegrationId::Opencode, &environment, false).unwrap();
+        assert_eq!(current.current_state, AssetState::Current);
+        assert_eq!(current.action, InstallAction::Unchanged);
+        assert!(!current.restart_required);
+
+        fs::write(&installed.path, "custom").unwrap();
+        assert!(plan_install(IntegrationId::Opencode, &environment, false).is_err());
+        let replacement = plan_install(IntegrationId::Opencode, &environment, true).unwrap();
+        assert_eq!(replacement.current_state, AssetState::Modified);
+        assert_eq!(replacement.action, InstallAction::Replace);
+        assert_eq!(fs::read_to_string(installed.path).unwrap(), "custom");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -584,6 +584,8 @@ enum IntegrationCommands {
         all: bool,
         #[arg(long)]
         force: bool,
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Verify authoritative lifecycle reporting in a running host shell
     Verify {
@@ -1614,6 +1616,7 @@ fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), B
             integration,
             all,
             force,
+            dry_run,
         } => {
             let integrations = if all {
                 integration_management::IntegrationId::ALL.to_vec()
@@ -1625,7 +1628,7 @@ fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), B
                     )
                 })?]
             };
-            install_integrations(&integrations, force, json)
+            install_integrations(&integrations, force, dry_run, json)
         }
         IntegrationCommands::Verify {
             integration,
@@ -1951,11 +1954,40 @@ fn format_recommended_action(action: integration_management::RecommendedAction) 
 fn install_integrations(
     integrations: &[integration_management::IntegrationId],
     force: bool,
+    dry_run: bool,
     json: bool,
 ) -> Result<(), Box<dyn Error>> {
     let environment = integration_management::Environment::from_process();
-    for integration in integrations {
-        integration_management::preflight_install(*integration, &environment, force)?;
+    let plans = integrations
+        .iter()
+        .copied()
+        .map(|integration| integration_management::plan_install(integration, &environment, force))
+        .collect::<Result<Vec<_>, _>>()?;
+    if dry_run {
+        if json {
+            return cli_output::print(
+                "integration.install",
+                serde_json::json!({ "dry_run": true, "integrations": plans }),
+            );
+        }
+        for plan in &plans {
+            let spec = plan.integration.spec();
+            match plan.action {
+                integration_management::InstallAction::Install => println!(
+                    "Would install Boomux {} {} at {}",
+                    spec.display_name, spec.asset_name, plan.path
+                ),
+                integration_management::InstallAction::Replace => println!(
+                    "Would replace Boomux {} {} at {}",
+                    spec.display_name, spec.asset_name, plan.path
+                ),
+                integration_management::InstallAction::Unchanged => println!(
+                    "Boomux {} {} is already installed at {}",
+                    spec.display_name, spec.asset_name, plan.path
+                ),
+            }
+        }
+        return Ok(());
     }
     let results = integrations
         .iter()
@@ -3690,6 +3722,7 @@ fn install_opencode(force: bool) -> Result<(), Box<dyn Error>> {
         &[integration_management::IntegrationId::Opencode],
         force,
         false,
+        false,
     )
 }
 
@@ -3705,7 +3738,12 @@ fn install_opencode_at(config_root: &Path, force: bool) -> Result<(), Box<dyn Er
 }
 
 fn install_pi(force: bool) -> Result<(), Box<dyn Error>> {
-    install_integrations(&[integration_management::IntegrationId::Pi], force, false)
+    install_integrations(
+        &[integration_management::IntegrationId::Pi],
+        force,
+        false,
+        false,
+    )
 }
 
 #[cfg(test)]
@@ -5309,10 +5347,33 @@ mod tests {
                     integration: Some(integration_management::IntegrationId::Opencode),
                     all: false,
                     force: true,
+                    dry_run: false,
                 }
             })
         ));
         assert_eq!(command_name(&install), "integration.install");
+
+        let preview = Cli::try_parse_from([
+            "boomux",
+            "integration",
+            "install",
+            "pi",
+            "--dry-run",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            preview.command,
+            Some(Commands::Integration {
+                command: IntegrationCommands::Install {
+                    integration: Some(integration_management::IntegrationId::Pi),
+                    all: false,
+                    force: false,
+                    dry_run: true,
+                }
+            })
+        ));
+        assert!(supports_json(&preview));
 
         assert!(Cli::try_parse_from(["boomux", "integration", "install", "--all"]).is_ok());
         assert!(Cli::try_parse_from(["boomux", "integration", "install"]).is_err());


### PR DESCRIPTION
## Summary
- add `--dry-run` to unified integration installation
- report current state, exact action, target path, and restart requirement
- validate every target without creating directories or changing files

## Testing
- `cargo test --all-targets --locked`
- `cargo clippy --all-targets --locked -- -D warnings`