### PR TITLE
feat: safely uninstall integrations

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -67,6 +67,9 @@ install opencode --json`, `boomux integration install pi --json`, or
 `boomux integration install --all --json`; add `--force` only when the user also
 authorizes replacing a modified asset. Use `--dry-run` first when the user wants
 to inspect exact target paths and planned actions without changing files.
+Use `boomux integration uninstall <name> --json` only when the user explicitly
+asks to remove an integration; add `--force` only with authorization to remove a
+modified asset.
 After the user restarts a host, verify authoritative reporting with `boomux
 integration verify opencode --json` or `boomux integration verify pi --json`.
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ boomux integration list
 boomux integration status [opencode|pi]
 boomux integration install <opencode|pi> [--force] [--dry-run]
 boomux integration install --all [--force] [--dry-run]
+boomux integration uninstall <opencode|pi> [--force]
+boomux integration uninstall --all [--force]
 boomux integration verify <opencode|pi> [--shell <shell-id>] [--wait-ms <milliseconds>]
 boomux daemon status
 boomux daemon restart
@@ -441,6 +443,12 @@ without creating directories or changing files. Successful changes print the
 required host restart guidance. The
 existing `boomux opencode install` and `boomux pi install` commands remain
 equivalent host-specific shortcuts.
+
+Remove one integration or all bundled integrations with `boomux integration
+uninstall opencode` or `boomux integration uninstall --all`. Uninstall removes
+only the bundled asset file and leaves host configuration and directories in
+place. Missing assets are accepted. Modified assets require `--force`, while
+symlinked and non-regular paths are always rejected.
 
 After restarting a host, verify that a running managed shell has authoritative
 lifecycle reporting:

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -58,14 +58,16 @@ The following commands support `--json`:
 - `boomux integration status [opencode|pi]`
 - `boomux integration install <opencode|pi>`
 - `boomux integration install --all`
+- `boomux integration uninstall <opencode|pi>`
+- `boomux integration uninstall --all`
 - `boomux integration verify <opencode|pi>`
 - `boomux daemon status`
 
 JSON mutations are deliberately narrow: only `agent register`, `agent ensure`,
-`agent report`, `attention acknowledge`, and `integration install` support the
-contract. Other mutation commands retain human output. Passing `--json` to an
-unsupported command fails with `invalid_argument` before performing the
-operation.
+`agent report`, `attention acknowledge`, `integration install`, and
+`integration uninstall` support the contract. Other mutation commands retain
+human output. Passing `--json` to an unsupported command fails with
+`invalid_argument` before performing the operation.
 
 Command payloads are:
 
@@ -110,6 +112,9 @@ Command payloads are:
   `restart_required`. Each target is changed atomically; `--all` is not a
   transaction across hosts, but every target is preflighted before the first
   write.
+- `integration.uninstall`: an `integrations` array containing `removed` or
+  `not_installed` results, target paths, and whether a host restart is required.
+  Every target is preflighted before the first removal.
 - `integration.verify`: `integration`, `verified`, exact `shell_id` and `run_id`,
   plus the nonempty authoritative `agents` array. Failure uses typed
   `not_found`, `ambiguous_target`, `run_changed`, or `timeout` errors.
@@ -152,6 +157,11 @@ Install preview entries contain `name`, `current_state`, `action`, `path`, and
 `restart_required`. Current state is `missing`, `current`, or `modified`; action
 is `install`, `replace`, or `unchanged`. Preview performs the same path and
 replacement validation as installation but does not create or modify anything.
+
+Uninstall entries contain `name`, `result`, `path`, and `restart_required`.
+Result is `removed` or `not_installed`. Only the bundled asset file is removed;
+directories and unrelated host configuration are retained. Modified content
+requires `--force`, while unsafe paths fail before any removal.
 
 ## Shell Data
 

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -676,6 +676,23 @@ pub(crate) struct InstallPlan {
     pub(crate) restart_required: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum UninstallOutcome {
+    Removed,
+    NotInstalled,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct UninstallResult {
+    #[serde(skip)]
+    pub(crate) integration: IntegrationId,
+    pub(crate) name: &'static str,
+    pub(crate) result: UninstallOutcome,
+    pub(crate) path: String,
+    pub(crate) restart_required: bool,
+}
+
 pub(crate) fn install(
     id: IntegrationId,
     environment: &Environment,
@@ -716,6 +733,48 @@ pub(crate) fn plan_install(
         action,
         path: target.path.display().to_string(),
         restart_required: action != InstallAction::Unchanged,
+    })
+}
+
+pub(crate) fn preflight_uninstall(
+    id: IntegrationId,
+    environment: &Environment,
+    force: bool,
+) -> Result<(), Box<dyn Error>> {
+    let spec = id.spec();
+    let target = install_target(id, environment)?;
+    validate_existing_directory_chain(&target.directory)?;
+    if inspect_existing_asset(&target.path, spec.content)? == ExistingAsset::Modified && !force {
+        return Err(modified_uninstall_error(&target.path).into());
+    }
+    Ok(())
+}
+
+pub(crate) fn uninstall(
+    id: IntegrationId,
+    environment: &Environment,
+    force: bool,
+) -> Result<UninstallResult, Box<dyn Error>> {
+    let spec = id.spec();
+    let target = install_target(id, environment)?;
+    validate_existing_directory_chain(&target.directory)?;
+    let existing = inspect_existing_asset(&target.path, spec.content)?;
+    let result = match existing {
+        ExistingAsset::Missing => UninstallOutcome::NotInstalled,
+        ExistingAsset::Modified if !force => {
+            return Err(modified_uninstall_error(&target.path).into());
+        }
+        ExistingAsset::Current | ExistingAsset::Modified => {
+            fs::remove_file(&target.path)?;
+            UninstallOutcome::Removed
+        }
+    };
+    Ok(UninstallResult {
+        integration: id,
+        name: spec.name,
+        result,
+        path: target.path.display().to_string(),
+        restart_required: result == UninstallOutcome::Removed,
     })
 }
 
@@ -968,6 +1027,16 @@ fn existing_asset_error(path: &Path) -> io::Error {
     )
 }
 
+fn modified_uninstall_error(path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        format!(
+            "{} contains modified content; rerun with --force to remove it",
+            path.display()
+        ),
+    )
+}
+
 fn write_asset_atomically(directory: &Path, path: &Path, content: &str) -> io::Result<()> {
     let temporary = directory.join(format!(".boomux-install-{}.tmp", Uuid::new_v4()));
     let result = (|| {
@@ -1138,6 +1207,36 @@ mod tests {
         assert_eq!(replacement.current_state, AssetState::Modified);
         assert_eq!(replacement.action, InstallAction::Replace);
         assert_eq!(fs::read_to_string(installed.path).unwrap(), "custom");
+    }
+
+    #[test]
+    fn uninstall_is_idempotent_and_protects_modified_assets() {
+        let home = TestDirectory::new("uninstall");
+        let environment = environment(&home.0);
+        let installed = install(IntegrationId::Pi, &environment, false).unwrap();
+        let directory = Path::new(&installed.path).parent().unwrap().to_owned();
+
+        let removed = uninstall(IntegrationId::Pi, &environment, false).unwrap();
+        assert_eq!(removed.result, UninstallOutcome::Removed);
+        assert!(removed.restart_required);
+        assert!(!Path::new(&removed.path).exists());
+        assert!(directory.is_dir());
+
+        let missing = uninstall(IntegrationId::Pi, &environment, false).unwrap();
+        assert_eq!(missing.result, UninstallOutcome::NotInstalled);
+        assert!(!missing.restart_required);
+
+        install(IntegrationId::Pi, &environment, false).unwrap();
+        fs::write(&installed.path, "custom").unwrap();
+        assert!(preflight_uninstall(IntegrationId::Pi, &environment, false).is_err());
+        assert!(uninstall(IntegrationId::Pi, &environment, false).is_err());
+        assert_eq!(fs::read_to_string(&installed.path).unwrap(), "custom");
+        assert_eq!(
+            uninstall(IntegrationId::Pi, &environment, true)
+                .unwrap()
+                .result,
+            UninstallOutcome::Removed
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ const JSON_COMMANDS: &[&str] = &[
     "integration.list",
     "integration.status",
     "integration.install",
+    "integration.uninstall",
     "integration.verify",
     "session.list",
     "session.inspect",
@@ -587,6 +588,15 @@ enum IntegrationCommands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Remove one integration or every bundled integration
+    Uninstall {
+        #[arg(value_enum, required_unless_present = "all", conflicts_with = "all")]
+        integration: Option<integration_management::IntegrationId>,
+        #[arg(long, conflicts_with = "integration")]
+        all: bool,
+        #[arg(long)]
+        force: bool,
+    },
     /// Verify authoritative lifecycle reporting in a running host shell
     Verify {
         #[arg(value_enum)]
@@ -872,6 +882,9 @@ fn command_name(cli: &Cli) -> &'static str {
             command: IntegrationCommands::Install { .. },
         }) => "integration.install",
         Some(Commands::Integration {
+            command: IntegrationCommands::Uninstall { .. },
+        }) => "integration.uninstall",
+        Some(Commands::Integration {
             command: IntegrationCommands::Verify { .. },
         }) => "integration.verify",
         Some(Commands::Daemon {
@@ -927,6 +940,7 @@ fn supports_json(cli: &Cli) -> bool {
             command: IntegrationCommands::List
                 | IntegrationCommands::Status { .. }
                 | IntegrationCommands::Install { .. }
+                | IntegrationCommands::Uninstall { .. }
                 | IntegrationCommands::Verify { .. }
         })
     )
@@ -1630,6 +1644,23 @@ fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), B
             };
             install_integrations(&integrations, force, dry_run, json)
         }
+        IntegrationCommands::Uninstall {
+            integration,
+            all,
+            force,
+        } => {
+            let integrations = if all {
+                integration_management::IntegrationId::ALL.to_vec()
+            } else {
+                vec![integration.ok_or_else(|| {
+                    cli_output::failure(
+                        "invalid_argument",
+                        "integration uninstall requires a name or --all",
+                    )
+                })?]
+            };
+            uninstall_integrations(&integrations, force, json)
+        }
         IntegrationCommands::Verify {
             integration,
             shell,
@@ -2025,6 +2056,45 @@ fn print_integration_install_results(results: &[integration_management::InstallR
             println!("{}", spec.reload_message);
         }
     }
+}
+
+fn uninstall_integrations(
+    integrations: &[integration_management::IntegrationId],
+    force: bool,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let environment = integration_management::Environment::from_process();
+    for integration in integrations {
+        integration_management::preflight_uninstall(*integration, &environment, force)?;
+    }
+    let results = integrations
+        .iter()
+        .copied()
+        .map(|integration| integration_management::uninstall(integration, &environment, force))
+        .collect::<Result<Vec<_>, _>>()?;
+    if json {
+        return cli_output::print(
+            "integration.uninstall",
+            serde_json::json!({ "integrations": results }),
+        );
+    }
+    for result in &results {
+        let spec = result.integration.spec();
+        match result.result {
+            integration_management::UninstallOutcome::Removed => println!(
+                "Removed Boomux {} {} from {}",
+                spec.display_name, spec.asset_name, result.path
+            ),
+            integration_management::UninstallOutcome::NotInstalled => println!(
+                "Boomux {} {} is not installed at {}",
+                spec.display_name, spec.asset_name, result.path
+            ),
+        }
+        if result.restart_required {
+            println!("{}", spec.reload_message);
+        }
+    }
+    Ok(())
 }
 
 fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
@@ -5375,6 +5445,28 @@ mod tests {
         ));
         assert!(supports_json(&preview));
 
+        let uninstall = Cli::try_parse_from([
+            "boomux",
+            "integration",
+            "uninstall",
+            "opencode",
+            "--force",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            uninstall.command,
+            Some(Commands::Integration {
+                command: IntegrationCommands::Uninstall {
+                    integration: Some(integration_management::IntegrationId::Opencode),
+                    all: false,
+                    force: true,
+                }
+            })
+        ));
+        assert_eq!(command_name(&uninstall), "integration.uninstall");
+        assert!(supports_json(&uninstall));
+
         assert!(Cli::try_parse_from(["boomux", "integration", "install", "--all"]).is_ok());
         assert!(Cli::try_parse_from(["boomux", "integration", "install"]).is_err());
         assert!(Cli::try_parse_from(["boomux", "integration", "install", "pi", "--all",]).is_err());
@@ -5601,6 +5693,7 @@ mod tests {
             "integration.list",
             "integration.status",
             "integration.install",
+            "integration.uninstall",
             "integration.verify",
         ] {
             assert!(JSON_COMMANDS.contains(&command));

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -2892,6 +2892,42 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     assert_eq!(refused["command"], "integration.install");
     assert_eq!(refused["error"]["code"], "already_exists");
 
+    let uninstall_refused = command()
+        .args(["integration", "uninstall", "--all", "--json"])
+        .output()
+        .unwrap();
+    assert!(!uninstall_refused.status.success());
+    assert!(config.join("opencode/plugins/boomux.js").is_file());
+    assert_eq!(
+        fs::read_to_string(pi.join("extensions/boomux.js")).unwrap(),
+        "custom extension"
+    );
+
+    let uninstalled = command()
+        .args(["integration", "uninstall", "--all", "--force", "--json"])
+        .output()
+        .unwrap();
+    assert!(uninstalled.status.success());
+    let uninstalled: serde_json::Value = serde_json::from_slice(&uninstalled.stdout).unwrap();
+    assert_eq!(uninstalled["command"], "integration.uninstall");
+    for integration in uninstalled["data"]["integrations"].as_array().unwrap() {
+        assert_eq!(integration["result"], "removed");
+        assert_eq!(integration["restart_required"], true);
+    }
+    assert!(!config.join("opencode/plugins/boomux.js").exists());
+    assert!(!pi.join("extensions/boomux.js").exists());
+    assert!(config.join("opencode/plugins").is_dir());
+    assert!(pi.join("extensions").is_dir());
+
+    let absent = command()
+        .args(["integration", "uninstall", "pi", "--json"])
+        .output()
+        .unwrap();
+    assert!(absent.status.success());
+    let absent: serde_json::Value = serde_json::from_slice(&absent.stdout).unwrap();
+    assert_eq!(absent["data"]["integrations"][0]["result"], "not_installed");
+    assert_eq!(absent["data"]["integrations"][0]["restart_required"], false);
+
     let invalid_environment = Command::new(env!("CARGO_BIN_EXE_boomux"))
         .args(["integration", "install", "opencode", "--json"])
         .env_remove("HOME")


### PR DESCRIPTION
## Summary
- add safe, idempotent integration uninstall commands
- preflight all selected targets before removal
- preserve directories and require explicit force for modified assets

## Testing
- `cargo test --all-targets --locked`
- `cargo clippy --all-targets --locked -- -D warnings`