### PR TITLE
feat: guide integration setup

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -70,6 +70,10 @@ to inspect exact target paths and planned actions without changing files.
 Use `boomux integration uninstall <name> --json` only when the user explicitly
 asks to remove an integration; add `--force` only with authorization to remove a
 modified asset.
+For an interactive end-to-end workflow, use `boomux integration setup <name>`.
+It inspects current state, previews the target action, confirms mutation, and
+prints restart and verification guidance. Do not pass `--yes` unless the user
+has authorized installation, or `--force` unless they authorized replacement.
 After the user restarts a host, verify authoritative reporting with `boomux
 integration verify opencode --json` or `boomux integration verify pi --json`.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ boomux integration install <opencode|pi> [--force] [--dry-run]
 boomux integration install --all [--force] [--dry-run]
 boomux integration uninstall <opencode|pi> [--force]
 boomux integration uninstall --all [--force]
+boomux integration setup <opencode|pi> [--yes] [--force]
 boomux integration verify <opencode|pi> [--shell <shell-id>] [--wait-ms <milliseconds>]
 boomux daemon status
 boomux daemon restart
@@ -449,6 +450,12 @@ uninstall opencode` or `boomux integration uninstall --all`. Uninstall removes
 only the bundled asset file and leaves host configuration and directories in
 place. Missing assets are accepted. Modified assets require `--force`, while
 symlinked and non-regular paths are always rejected.
+
+For an end-to-end guided path, run `boomux integration setup opencode` or
+`boomux integration setup pi`. Setup displays host, asset, and runtime status,
+previews the exact installation action, asks before changing files, and prints
+the restart and verification command. `--yes` accepts a missing-asset install
+without prompting; automated replacement requires both `--yes` and `--force`.
 
 After restarting a host, verify that a running managed shell has authoritative
 lifecycle reporting:

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -69,6 +69,12 @@ JSON mutations are deliberately narrow: only `agent register`, `agent ensure`,
 human output. Passing `--json` to an unsupported command fails with
 `invalid_argument` before performing the operation.
 
+`boomux integration setup <opencode|pi>` is intentionally human-oriented and
+does not support `--json`. It composes status inspection, an exact install
+preview, confirmation, installation when needed, and restart/verification
+guidance. `--yes` skips confirmation for automation; replacing modified content
+also requires `--force`.
+
 Command payloads are:
 
 - `capabilities`: CLI/protocol versions, integration host compatibility, plus

--- a/src/main.rs
+++ b/src/main.rs
@@ -597,6 +597,17 @@ enum IntegrationCommands {
         #[arg(long)]
         force: bool,
     },
+    /// Inspect, install, and explain verification for one integration
+    Setup {
+        #[arg(value_enum)]
+        integration: integration_management::IntegrationId,
+        /// Accept the proposed installation without prompting
+        #[arg(long)]
+        yes: bool,
+        /// Allow replacement of a modified integration asset
+        #[arg(long)]
+        force: bool,
+    },
     /// Verify authoritative lifecycle reporting in a running host shell
     Verify {
         #[arg(value_enum)]
@@ -884,6 +895,9 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Integration {
             command: IntegrationCommands::Uninstall { .. },
         }) => "integration.uninstall",
+        Some(Commands::Integration {
+            command: IntegrationCommands::Setup { .. },
+        }) => "integration.setup",
         Some(Commands::Integration {
             command: IntegrationCommands::Verify { .. },
         }) => "integration.verify",
@@ -1661,6 +1675,11 @@ fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), B
             };
             uninstall_integrations(&integrations, force, json)
         }
+        IntegrationCommands::Setup {
+            integration,
+            yes,
+            force,
+        } => setup_integration(integration, yes, force),
         IntegrationCommands::Verify {
             integration,
             shell,
@@ -2095,6 +2114,102 @@ fn uninstall_integrations(
         }
     }
     Ok(())
+}
+
+fn setup_integration(
+    integration: integration_management::IntegrationId,
+    yes: bool,
+    force: bool,
+) -> Result<(), Box<dyn Error>> {
+    let environment = integration_management::Environment::from_process();
+    let snapshot = client::connect().and_then(|client| client.snapshot()).ok();
+    let status = integration_management::inspect(integration, &environment, snapshot.as_ref());
+    print!(
+        "{}",
+        format_integration_statuses(std::slice::from_ref(&status))
+    );
+
+    let spec = integration.spec();
+    if status.asset.state == integration_management::AssetState::Current {
+        print_setup_next_step(integration, status.runtime.state);
+        return Ok(());
+    }
+    if status.asset.state == integration_management::AssetState::Unavailable {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            status
+                .asset
+                .error
+                .unwrap_or_else(|| "integration asset could not be inspected".into()),
+        )
+        .into());
+    }
+
+    let replacing = status.asset.state == integration_management::AssetState::Modified;
+    let plan = integration_management::plan_install(integration, &environment, replacing || force)?;
+    let action = match plan.action {
+        integration_management::InstallAction::Install => "install",
+        integration_management::InstallAction::Replace => "replace",
+        integration_management::InstallAction::Unchanged => "leave unchanged",
+    };
+    println!("Plan: {action} Boomux {} at {}", spec.asset_name, plan.path);
+
+    if yes && replacing && !force {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--yes requires --force to replace a modified integration asset",
+        )
+        .into());
+    }
+    if !yes {
+        let prompt = if replacing {
+            "Replace the modified asset?"
+        } else {
+            "Install this integration?"
+        };
+        if !confirm_setup(prompt)? {
+            println!("No changes made.");
+            return Ok(());
+        }
+    }
+
+    let result = integration_management::install(integration, &environment, replacing || force)?;
+    print_integration_install_results(&[result]);
+    println!(
+        "After restarting {}, run: boomux integration verify {}",
+        spec.display_name, spec.name
+    );
+    Ok(())
+}
+
+fn confirm_setup(prompt: &str) -> io::Result<bool> {
+    print!("{prompt} [y/N] ");
+    std::io::Write::flush(&mut io::stdout())?;
+    let mut response = String::new();
+    io::stdin().read_line(&mut response)?;
+    Ok(is_setup_confirmation(&response))
+}
+
+fn is_setup_confirmation(response: &str) -> bool {
+    matches!(response.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+fn print_setup_next_step(
+    integration: integration_management::IntegrationId,
+    runtime: integration_management::RuntimeState,
+) {
+    let spec = integration.spec();
+    if runtime == integration_management::RuntimeState::Reporting {
+        println!(
+            "Boomux lifecycle reporting is ready for {}.",
+            spec.display_name
+        );
+    } else {
+        println!(
+            "The asset is current. Restart {}, open it in a Boomux-managed shell, then run: boomux integration verify {}",
+            spec.display_name, spec.name
+        );
+    }
 }
 
 fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
@@ -5467,6 +5582,22 @@ mod tests {
         assert_eq!(command_name(&uninstall), "integration.uninstall");
         assert!(supports_json(&uninstall));
 
+        let setup =
+            Cli::try_parse_from(["boomux", "integration", "setup", "pi", "--yes", "--force"])
+                .unwrap();
+        assert!(matches!(
+            setup.command,
+            Some(Commands::Integration {
+                command: IntegrationCommands::Setup {
+                    integration: integration_management::IntegrationId::Pi,
+                    yes: true,
+                    force: true,
+                }
+            })
+        ));
+        assert_eq!(command_name(&setup), "integration.setup");
+        assert!(!supports_json(&setup));
+
         assert!(Cli::try_parse_from(["boomux", "integration", "install", "--all"]).is_ok());
         assert!(Cli::try_parse_from(["boomux", "integration", "install"]).is_err());
         assert!(Cli::try_parse_from(["boomux", "integration", "install", "pi", "--all",]).is_err());
@@ -5531,6 +5662,14 @@ mod tests {
                 "    boomux integration verify opencode --shell s2",
             )
         );
+    }
+
+    #[test]
+    fn setup_confirmation_requires_an_explicit_yes() {
+        assert!(is_setup_confirmation("y\n"));
+        assert!(is_setup_confirmation(" YES "));
+        assert!(!is_setup_confirmation(""));
+        assert!(!is_setup_confirmation("no"));
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -2928,6 +2928,50 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     assert_eq!(absent["data"]["integrations"][0]["result"], "not_installed");
     assert_eq!(absent["data"]["integrations"][0]["restart_required"], false);
 
+    let mut declined = command();
+    declined
+        .args(["integration", "setup", "pi"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped());
+    let mut declined = declined.spawn().unwrap();
+    declined.stdin.take().unwrap().write_all(b"n\n").unwrap();
+    let declined = declined.wait_with_output().unwrap();
+    assert!(declined.status.success());
+    assert!(String::from_utf8_lossy(&declined.stdout).contains("No changes made."));
+    assert!(!pi.join("extensions/boomux.js").exists());
+
+    let setup = command()
+        .args(["integration", "setup", "pi", "--yes"])
+        .output()
+        .unwrap();
+    assert!(setup.status.success());
+    let setup_output = String::from_utf8_lossy(&setup.stdout);
+    assert!(setup_output.contains("Plan: install"));
+    assert!(setup_output.contains("boomux integration verify pi"));
+    assert!(pi.join("extensions/boomux.js").is_file());
+
+    fs::write(pi.join("extensions/boomux.js"), "custom extension").unwrap();
+    let setup_refused = command()
+        .args(["integration", "setup", "pi", "--yes"])
+        .output()
+        .unwrap();
+    assert!(!setup_refused.status.success());
+    assert_eq!(
+        fs::read_to_string(pi.join("extensions/boomux.js")).unwrap(),
+        "custom extension"
+    );
+
+    let setup_replaced = command()
+        .args(["integration", "setup", "pi", "--yes", "--force"])
+        .output()
+        .unwrap();
+    assert!(setup_replaced.status.success());
+    assert!(String::from_utf8_lossy(&setup_replaced.stdout).contains("Plan: replace"));
+    assert_ne!(
+        fs::read_to_string(pi.join("extensions/boomux.js")).unwrap(),
+        "custom extension"
+    );
+
     let invalid_environment = Command::new(env!("CARGO_BIN_EXE_boomux"))
         .args(["integration", "install", "opencode", "--json"])
         .env_remove("HOME")


### PR DESCRIPTION
## Summary
- add guided setup for OpenCode and Pi integrations
- show status and exact install plan before confirmation
- provide safe automation flags plus restart and verification guidance

## Testing
- `cargo test --all-targets --locked`
- `cargo clippy --all-targets --locked -- -D warnings`