### PR TITLE
feat(notifications): add sound delivery

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -124,6 +124,12 @@ change an observation revision, or contain lifecycle evidence. Always inspect
 the durable queue before acting; do not infer queue state or delivery from a
 desktop notification.
 
+Optional notification sounds are also a best-effort signal for those committed
+transitions. Test configured desktop and sound channels without changing Agent
+state using `boomux notification test blocked` or `boomux notification test
+completed`. Configuration is sampled at daemon startup, so restart the daemon
+after changing notification settings.
+
 Discover projected session metadata with:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -425,15 +425,31 @@ max_depth = 3
 enabled = false
 blocked = true
 completed = true
+
+[notifications.sound]
+enabled = false
+blocked = "message-new-instant"
+completed = "complete"
 ```
 
-Notifications are disabled by default and require `notify-send` plus a desktop
-notification service. The daemon samples this configuration at startup; run
-`boomux daemon restart` after changing it. `boomux doctor` reports whether the
-configured command and a plausible desktop bus environment are present. Bodies
-contain only the sanitized Agent, workspace, and shell names, never evidence,
-working directories, command arguments, external session IDs, or transcript
-content.
+Desktop and sound delivery are independently disabled by default. Desktop
+delivery uses `notify-send` and a desktop notification service. Sound delivery
+uses `canberra-gtk-play`; `blocked` and `completed` are freedesktop sound event
+IDs passed as exact arguments, not shell commands. Both channels share the
+top-level category filters.
+
+Test the configured channels without creating an Agent transition:
+
+```console
+boomux notification test blocked
+boomux notification test completed
+```
+
+The daemon samples notification configuration at startup; run `boomux daemon
+restart` after changing it. `boomux doctor` diagnoses desktop and sound delivery
+separately. Desktop bodies contain only the sanitized Agent, workspace, and shell
+names, never evidence, working directories, command arguments, external session
+IDs, or transcript content.
 
 Directory discovery scans only configured project roots, recognizes ordinary
 and linked Git worktrees, and stops descending after finding a repository. The

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -468,20 +468,24 @@ outstanding items so upgrading does not reinterpret historical work as unseen.
 The CLI projects these records into a deterministic blocked-first queue and
 reports fixed lifecycle-state and attention counts per workspace.
 
-Opt-in desktop notifications are a daemon-owned projection of committed Agent
-state transitions, not durable queue state. A transition from any other state
-into `blocked` or `done` schedules one asynchronous `notify-send` attempt after
-persistence and event publication locks are released. Same-state evidence or
-confidence revisions do not notify, and restored state is not replayed. A daemon
-handoff reloads configuration for the replacement, just like a cold daemon
-start. Delivery uses one worker and a bounded, non-blocking queue. It is
-at-most-once and fail-open: queue saturation, a missing command, desktop-bus
-failure, timeout, or non-zero exit neither retries nor changes the successful
-Agent mutation.
+Opt-in desktop and sound notifications are a daemon-owned projection of committed
+Agent state transitions, not durable queue state. A transition from any other
+state into `blocked` or `done` schedules one asynchronous delivery request after
+persistence and event publication locks are released. Enabled desktop delivery
+invokes `notify-send`; enabled sound delivery invokes `canberra-gtk-play` with a
+configured freedesktop event ID. Same-state evidence or confidence revisions do
+not notify, and restored state is not replayed. A daemon handoff reloads
+configuration for the replacement, just like a cold daemon start. Both channels
+share one worker and a bounded, non-blocking queue. Delivery is at-most-once and
+fail-open: queue saturation, a missing command, desktop-bus or audio failure,
+timeout, or non-zero exit neither retries nor changes the successful Agent
+mutation.
 Notification payloads include only sanitized Agent, workspace, and shell names;
 if retained Agent context outlives a removed shell, the shell is identified as
 removed rather than suppressing the transition. Notifications never acknowledge
 attention, advance an observation revision, or publish lifecycle events.
+`notification test` exercises the same configured delivery commands directly
+without fabricating or persisting an Agent transition.
 
 ### Transition Coordinator
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -30,6 +30,9 @@ notification delivery; it does not imply notifications are enabled or that
 `notify-send` and a desktop notification service are available. Configuration is
 sampled when the daemon starts and is intentionally outside the JSON capability
 contract.
+The `sound_notifications` feature similarly advertises optional direct sound
+delivery through `canberra-gtk-play`. `boomux notification test` is a human-facing
+delivery diagnostic and does not support `--json`.
 
 The following commands support `--json`:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -125,8 +125,8 @@ eternal process.
    persistent attention queue for blocked and completed work.
 4. [Complete] Add revision-aware `agent wait` so scripts can await durable state
    transitions without polling human output.
-5. [Complete] Add deduplicated notifications for blocked and completed
-   transitions after the attention and wait semantics are established.
+5. [Complete] Add deduplicated desktop and sound notifications for blocked and
+   completed transitions after the attention and wait semantics are established.
 6. [Complete] Add explicit cross-harness transcript and tool inspection so Pi can read an OpenCode
    session and OpenCode can read a Pi session. Do not treat bounded rendered
    terminal output as the full session: host adapters must expose canonical

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,15 @@ struct RawNotificationsConfig {
     enabled: Option<bool>,
     blocked: Option<bool>,
     completed: Option<bool>,
+    sound: Option<RawNotificationSoundConfig>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawNotificationSoundConfig {
+    enabled: Option<bool>,
+    blocked: Option<String>,
+    completed: Option<String>,
 }
 
 #[derive(Debug)]
@@ -37,7 +46,7 @@ pub(crate) struct Config {
     pub(crate) terminal: Option<String>,
     pub(crate) projects: ProjectsConfig,
     pub(crate) path: Option<PathBuf>,
-    pub(crate) notifications: boomux::daemon::NotificationSettings,
+    pub(crate) notifications: boomux::daemon::NotificationDeliverySettings,
 }
 
 #[derive(Debug)]
@@ -63,7 +72,7 @@ pub(crate) fn load() -> Result<Config, Box<dyn Error>> {
 }
 
 pub(crate) fn load_notification_settings()
--> Result<boomux::daemon::NotificationSettings, Box<dyn Error>> {
+-> Result<boomux::daemon::NotificationDeliverySettings, Box<dyn Error>> {
     let (raw, _) = load_raw()?;
     Ok(resolve_notifications(raw.notifications))
 }
@@ -136,6 +145,18 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
         if next_notifications.completed.is_some() {
             notifications.completed = next_notifications.completed;
         }
+        if let Some(next_sound) = next_notifications.sound {
+            let sound = notifications.sound.get_or_insert_default();
+            if next_sound.enabled.is_some() {
+                sound.enabled = next_sound.enabled;
+            }
+            if next_sound.blocked.is_some() {
+                sound.blocked = next_sound.blocked;
+            }
+            if next_sound.completed.is_some() {
+                sound.completed = next_sound.completed;
+            }
+        }
     }
 }
 
@@ -173,12 +194,23 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
 
 fn resolve_notifications(
     raw: Option<RawNotificationsConfig>,
-) -> boomux::daemon::NotificationSettings {
+) -> boomux::daemon::NotificationDeliverySettings {
     let raw = raw.unwrap_or_default();
-    boomux::daemon::NotificationSettings {
-        enabled: raw.enabled.unwrap_or(false),
-        blocked: raw.blocked.unwrap_or(true),
-        completed: raw.completed.unwrap_or(true),
+    boomux::daemon::NotificationDeliverySettings {
+        desktop: boomux::daemon::NotificationSettings {
+            enabled: raw.enabled.unwrap_or(false),
+            blocked: raw.blocked.unwrap_or(true),
+            completed: raw.completed.unwrap_or(true),
+        },
+        sound: raw.sound.map_or_else(Default::default, |sound| {
+            boomux::daemon::NotificationSoundSettings {
+                enabled: sound.enabled.unwrap_or(false),
+                blocked: sound
+                    .blocked
+                    .unwrap_or_else(|| "message-new-instant".into()),
+                completed: sound.completed.unwrap_or_else(|| "complete".into()),
+            }
+        }),
     }
 }
 
@@ -318,15 +350,19 @@ mod tests {
     fn notification_settings_default_and_parse() {
         assert_eq!(
             resolve_notifications(None),
-            boomux::daemon::NotificationSettings::default()
+            boomux::daemon::NotificationDeliverySettings::default()
         );
-        let raw: RawConfig =
-            toml::from_str("[notifications]\nenabled = true\nblocked = false\ncompleted = false")
-                .unwrap();
+        let raw: RawConfig = toml::from_str(
+            "[notifications]\nenabled = true\nblocked = false\ncompleted = false\n[notifications.sound]\nenabled = true\nblocked = \"dialog-warning\"",
+        )
+        .unwrap();
         let settings = resolve_notifications(raw.notifications);
-        assert!(settings.enabled);
-        assert!(!settings.blocked);
-        assert!(!settings.completed);
+        assert!(settings.desktop.enabled);
+        assert!(!settings.desktop.blocked);
+        assert!(!settings.desktop.completed);
+        assert!(settings.sound.enabled);
+        assert_eq!(settings.sound.blocked, "dialog-warning");
+        assert_eq!(settings.sound.completed, "complete");
     }
 
     #[test]
@@ -334,16 +370,26 @@ mod tests {
         let mut base: RawConfig =
             toml::from_str("[notifications]\nenabled = true\nblocked = false\ncompleted = false")
                 .unwrap();
-        let next = toml::from_str("[notifications]\ncompleted = true").unwrap();
+        let next = toml::from_str(
+            "[notifications]\ncompleted = true\n[notifications.sound]\nenabled = true\ncompleted = \"service-login\"",
+        )
+        .unwrap();
         merge(&mut base, next);
 
         let settings = resolve_notifications(base.notifications);
         assert_eq!(
             settings,
-            boomux::daemon::NotificationSettings {
-                enabled: true,
-                blocked: false,
-                completed: true,
+            boomux::daemon::NotificationDeliverySettings {
+                desktop: boomux::daemon::NotificationSettings {
+                    enabled: true,
+                    blocked: false,
+                    completed: true,
+                },
+                sound: boomux::daemon::NotificationSoundSettings {
+                    enabled: true,
+                    blocked: "message-new-instant".into(),
+                    completed: "service-login".into(),
+                },
             }
         );
     }
@@ -351,6 +397,7 @@ mod tests {
     #[test]
     fn rejects_unknown_notification_settings() {
         assert!(toml::from_str::<RawConfig>("[notifications]\nunknown = true").is_err());
+        assert!(toml::from_str::<RawConfig>("[notifications.sound]\nunknown = true").is_err());
     }
 
     #[test]
@@ -360,6 +407,6 @@ mod tests {
         )
         .unwrap();
         assert!(resolve(raw.clone(), None).is_err());
-        assert!(resolve_notifications(raw.notifications).enabled);
+        assert!(resolve_notifications(raw.notifications).desktop.enabled);
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 use crate::client;
 use crate::desktop_notifications::{
     DesktopNotificationSink, DisabledNotificationSink, NotificationReason, NotificationRequest,
-    NotificationSink, category_enabled,
+    NotificationSink, category_enabled, test_delivery,
 };
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
@@ -69,6 +69,48 @@ pub struct NotificationSettings {
     pub completed: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NotificationSoundSettings {
+    pub enabled: bool,
+    pub blocked: String,
+    pub completed: String,
+}
+
+impl Default for NotificationSoundSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            blocked: "message-new-instant".into(),
+            completed: "complete".into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct NotificationDeliverySettings {
+    pub desktop: NotificationSettings,
+    pub sound: NotificationSoundSettings,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotificationTestReason {
+    Blocked,
+    Completed,
+}
+
+pub fn test_notification_delivery(
+    settings: &NotificationDeliverySettings,
+    reason: NotificationTestReason,
+) -> io::Result<()> {
+    test_delivery(
+        settings,
+        match reason {
+            NotificationTestReason::Blocked => NotificationReason::Blocked,
+            NotificationTestReason::Completed => NotificationReason::Completed,
+        },
+    )
+}
+
 impl Default for NotificationSettings {
     fn default() -> Self {
         Self {
@@ -86,6 +128,19 @@ pub fn receive_handoff(channel: i32) -> io::Result<()> {
 pub fn receive_handoff_with_notifications(
     channel: i32,
     notification_settings: NotificationSettings,
+) -> io::Result<()> {
+    receive_handoff_with_notification_delivery(
+        channel,
+        NotificationDeliverySettings {
+            desktop: notification_settings,
+            ..Default::default()
+        },
+    )
+}
+
+pub fn receive_handoff_with_notification_delivery(
+    channel: i32,
+    notification_settings: NotificationDeliverySettings,
 ) -> io::Result<()> {
     match handoff::receive_bootstrap(channel)? {
         handoff::Bootstrap::Aborted => Ok(()),
@@ -122,6 +177,15 @@ pub fn run() -> io::Result<()> {
 }
 
 pub fn run_with_notifications(notification_settings: NotificationSettings) -> io::Result<()> {
+    run_with_notification_delivery(NotificationDeliverySettings {
+        desktop: notification_settings,
+        ..Default::default()
+    })
+}
+
+pub fn run_with_notification_delivery(
+    notification_settings: NotificationDeliverySettings,
+) -> io::Result<()> {
     let socket_path = client::socket_path()?;
     let runtime_dir = socket_path
         .parent()
@@ -162,11 +226,11 @@ fn run_daemon(
     store: StateStore,
     transferred: TransferredState,
     committed: Option<&mut UnixStream>,
-    notification_settings: NotificationSettings,
+    notification_settings: NotificationDeliverySettings,
 ) -> io::Result<()> {
     let mut registry = Registry::restore(store, committed.is_some(), transferred.events)?;
-    registry.notification_settings = notification_settings;
-    registry.notification_sink = Arc::new(DesktopNotificationSink::new());
+    registry.notification_settings = notification_settings.clone();
+    registry.notification_sink = Arc::new(DesktopNotificationSink::new(notification_settings));
     let registry = Arc::new(registry);
     let gated_readers = registry.import_handoff(transferred.runtimes, transferred.exited)?;
     if let Some(channel) = committed {
@@ -951,7 +1015,7 @@ struct Registry {
     persist_lock: Mutex<()>,
     stopping: AtomicBool,
     persistence_dirty: AtomicBool,
-    notification_settings: NotificationSettings,
+    notification_settings: NotificationDeliverySettings,
     notification_sink: Arc<dyn NotificationSink>,
 }
 
@@ -1092,7 +1156,7 @@ impl Default for Registry {
             persist_lock: Mutex::new(()),
             stopping: AtomicBool::new(false),
             persistence_dirty: AtomicBool::new(false),
-            notification_settings: NotificationSettings::default(),
+            notification_settings: NotificationDeliverySettings::default(),
             notification_sink: Arc::new(DisabledNotificationSink),
         }
     }
@@ -2110,7 +2174,7 @@ impl Registry {
             persist_lock: Mutex::new(()),
             stopping: AtomicBool::new(false),
             persistence_dirty: AtomicBool::new(false),
-            notification_settings: NotificationSettings::default(),
+            notification_settings: NotificationDeliverySettings::default(),
             notification_sink: Arc::new(DisabledNotificationSink),
         };
         if recovered_interrupted_run {
@@ -2394,7 +2458,7 @@ impl Registry {
             {
                 continue;
             }
-            if !category_enabled(self.notification_settings, reason)
+            if !category_enabled(&self.notification_settings, reason)
                 || !seen.insert((agent.id.as_str(), agent.observation.revision, reason))
             {
                 continue;
@@ -5335,7 +5399,10 @@ mod tests {
     ) -> (Registry, Arc<RecordingNotificationSink>) {
         let sink = Arc::new(RecordingNotificationSink::default());
         let registry = Registry {
-            notification_settings: settings,
+            notification_settings: NotificationDeliverySettings {
+                desktop: settings,
+                ..Default::default()
+            },
             notification_sink: sink.clone(),
             ..Registry::default()
         };
@@ -6386,10 +6453,13 @@ mod tests {
         )
         .unwrap();
         let sink = Arc::new(RecordingNotificationSink::default());
-        registry.notification_settings = NotificationSettings {
-            enabled: true,
-            blocked: true,
-            completed: true,
+        registry.notification_settings = NotificationDeliverySettings {
+            desktop: NotificationSettings {
+                enabled: true,
+                blocked: true,
+                completed: true,
+            },
+            ..Default::default()
         };
         registry.notification_sink = sink.clone();
         let (workspace, shell, _runtime) = running_shell(&registry);

--- a/src/desktop_notifications.rs
+++ b/src/desktop_notifications.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -5,7 +6,7 @@ use std::sync::mpsc::{SyncSender, sync_channel};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use crate::daemon::NotificationSettings;
+use crate::daemon::NotificationDeliverySettings;
 
 const MAX_CONTEXT_BYTES: usize = 120;
 const NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(2);
@@ -38,7 +39,7 @@ pub(crate) struct DesktopNotificationSink {
 pub(crate) struct DisabledNotificationSink;
 
 impl DesktopNotificationSink {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(settings: NotificationDeliverySettings) -> Self {
         let (sender, receiver) = sync_channel(NOTIFICATION_QUEUE_CAPACITY);
         let stopping = Arc::new(AtomicBool::new(false));
         let worker_stopping = stopping.clone();
@@ -48,7 +49,7 @@ impl DesktopNotificationSink {
                 while let Ok(request) = receiver.recv()
                     && !worker_stopping.load(Ordering::Acquire)
                 {
-                    deliver(request, &worker_stopping);
+                    deliver(request, &settings, &worker_stopping);
                 }
             })
             .ok();
@@ -82,41 +83,123 @@ impl NotificationSink for DesktopNotificationSink {
     }
 }
 
-fn deliver(request: NotificationRequest, stopping: &AtomicBool) {
-    let argv = notify_send_argv(&request);
-    if let Ok(mut child) = Command::new(&argv[0])
+fn deliver(
+    request: NotificationRequest,
+    settings: &NotificationDeliverySettings,
+    stopping: &AtomicBool,
+) {
+    if settings.desktop.enabled {
+        let _ = run_bounded(notify_send_argv(&request), stopping);
+    }
+    if settings.sound.enabled && !stopping.load(Ordering::Acquire) {
+        let _ = run_bounded(sound_argv(settings, request.reason), stopping);
+    }
+}
+
+fn run_bounded(argv: Vec<String>, stopping: &AtomicBool) -> io::Result<()> {
+    if stopping.load(Ordering::Acquire) {
+        return Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "notification delivery stopped",
+        ));
+    }
+    let mut child = Command::new(&argv[0])
         .args(&argv[1..])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .spawn()
-    {
-        let deadline = Instant::now() + NOTIFICATION_TIMEOUT;
-        loop {
-            match child.try_wait() {
-                Ok(Some(_)) => break,
-                Ok(None) if stopping.load(Ordering::Acquire) || Instant::now() >= deadline => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    break;
-                }
-                Ok(None) => thread::sleep(Duration::from_millis(10)),
-                Err(_) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    break;
-                }
+        .spawn()?;
+    let deadline = Instant::now() + NOTIFICATION_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => return Ok(()),
+            Ok(Some(status)) => {
+                return Err(io::Error::other(format!(
+                    "{} exited with {status}",
+                    argv[0]
+                )));
+            }
+            Ok(None) if stopping.load(Ordering::Acquire) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "notification delivery stopped",
+                ));
+            }
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("{} timed out", argv[0]),
+                ));
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(10)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
             }
         }
     }
 }
 
-pub(crate) fn category_enabled(settings: NotificationSettings, reason: NotificationReason) -> bool {
-    settings.enabled
+pub(crate) fn test_delivery(
+    settings: &NotificationDeliverySettings,
+    reason: NotificationReason,
+) -> io::Result<()> {
+    if !category_enabled(settings, reason) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "the requested notification category has no enabled delivery channel",
+        ));
+    }
+    let request = NotificationRequest {
+        reason,
+        agent: "Test Agent".into(),
+        workspace: "test-workspace".into(),
+        shell: "test-shell".into(),
+    };
+    let stopping = AtomicBool::new(false);
+    let mut first_error = None;
+    if settings.desktop.enabled
+        && let Err(error) = run_bounded(notify_send_argv(&request), &stopping)
+    {
+        first_error = Some(error);
+    }
+    if settings.sound.enabled
+        && let Err(error) = run_bounded(sound_argv(settings, reason), &stopping)
+        && first_error.is_none()
+    {
+        first_error = Some(error);
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
+pub(crate) fn category_enabled(
+    settings: &NotificationDeliverySettings,
+    reason: NotificationReason,
+) -> bool {
+    (settings.desktop.enabled || settings.sound.enabled)
         && match reason {
-            NotificationReason::Blocked => settings.blocked,
-            NotificationReason::Completed => settings.completed,
+            NotificationReason::Blocked => settings.desktop.blocked,
+            NotificationReason::Completed => settings.desktop.completed,
         }
+}
+
+fn sound_argv(settings: &NotificationDeliverySettings, reason: NotificationReason) -> Vec<String> {
+    let event = match reason {
+        NotificationReason::Blocked => &settings.sound.blocked,
+        NotificationReason::Completed => &settings.sound.completed,
+    };
+    vec![
+        "canberra-gtk-play".into(),
+        "--id".into(),
+        event.clone(),
+        "--description".into(),
+        "Boomux Agent notification".into(),
+    ]
 }
 
 fn notify_send_argv(request: &NotificationRequest) -> Vec<String> {
@@ -228,16 +311,60 @@ mod tests {
 
     #[test]
     fn category_filtering_requires_global_and_category_flags() {
-        let enabled = NotificationSettings {
-            enabled: true,
-            blocked: true,
-            completed: false,
+        let enabled = NotificationDeliverySettings {
+            desktop: crate::daemon::NotificationSettings {
+                enabled: true,
+                blocked: true,
+                completed: false,
+            },
+            ..Default::default()
         };
-        assert!(category_enabled(enabled, NotificationReason::Blocked));
-        assert!(!category_enabled(enabled, NotificationReason::Completed));
+        assert!(category_enabled(&enabled, NotificationReason::Blocked));
+        assert!(!category_enabled(&enabled, NotificationReason::Completed));
         assert!(!category_enabled(
-            NotificationSettings::default(),
+            &NotificationDeliverySettings::default(),
             NotificationReason::Blocked
         ));
+
+        let sound_only = NotificationDeliverySettings {
+            sound: crate::daemon::NotificationSoundSettings {
+                enabled: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(category_enabled(&sound_only, NotificationReason::Blocked));
+    }
+
+    #[test]
+    fn builds_exact_sound_arguments_for_each_reason() {
+        let settings = NotificationDeliverySettings {
+            sound: crate::daemon::NotificationSoundSettings {
+                enabled: true,
+                blocked: "dialog-warning".into(),
+                completed: "complete".into(),
+            },
+            ..Default::default()
+        };
+        assert_eq!(
+            sound_argv(&settings, NotificationReason::Blocked),
+            [
+                "canberra-gtk-play",
+                "--id",
+                "dialog-warning",
+                "--description",
+                "Boomux Agent notification",
+            ]
+        );
+        assert_eq!(
+            sound_argv(&settings, NotificationReason::Completed),
+            [
+                "canberra-gtk-play",
+                "--id",
+                "complete",
+                "--description",
+                "Boomux Agent notification",
+            ]
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "revision_aware_agent_wait",
     "persistent_agent_attention",
     "desktop_notifications",
+    "sound_notifications",
     "integration_management",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
@@ -247,6 +248,11 @@ enum Commands {
     Attention {
         #[command(subcommand)]
         command: AttentionCommands,
+    },
+    /// Test configured desktop and sound notification delivery
+    Notification {
+        #[command(subcommand)]
+        command: NotificationCommands,
     },
     /// Discover projected agent sessions
     Session {
@@ -441,6 +447,30 @@ enum AttentionCommands {
         #[arg(long)]
         observation_revision: u64,
     },
+}
+
+#[derive(Subcommand)]
+enum NotificationCommands {
+    /// Deliver a test notification through every configured channel
+    Test {
+        #[arg(value_enum)]
+        reason: CliNotificationReason,
+    },
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum CliNotificationReason {
+    Blocked,
+    Completed,
+}
+
+impl From<CliNotificationReason> for daemon::NotificationTestReason {
+    fn from(reason: CliNotificationReason) -> Self {
+        match reason {
+            CliNotificationReason::Blocked => Self::Blocked,
+            CliNotificationReason::Completed => Self::Completed,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -719,13 +749,13 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Daemon {
             command: DaemonCommands::Run,
         }) => {
-            daemon::run_with_notifications(config::load_notification_settings()?)?;
+            daemon::run_with_notification_delivery(config::load_notification_settings()?)?;
             return Ok(CliExit::Success);
         }
         Some(Commands::Daemon {
             command: DaemonCommands::ReceiveHandoff { channel },
         }) => {
-            daemon::receive_handoff_with_notifications(
+            daemon::receive_handoff_with_notification_delivery(
                 *channel,
                 config::load_notification_settings()?,
             )?;
@@ -797,6 +827,9 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         }) => return supervise_agent(arguments).map(CliExit::Child),
         Some(Commands::Agent { command }) => agent_command(command, cli.json),
         Some(Commands::Attention { command }) => attention_command(command, cli.json),
+        Some(Commands::Notification {
+            command: NotificationCommands::Test { reason },
+        }) => test_notification(reason),
         Some(Commands::Session { command }) => session_command(command, cli.json),
         Some(Commands::Integration { command }) => integration_command(command, cli.json),
         Some(Commands::Skill {
@@ -874,6 +907,9 @@ fn command_name(cli: &Cli) -> &'static str {
         Some(Commands::Attention {
             command: AttentionCommands::Acknowledge { .. },
         }) => "attention.acknowledge",
+        Some(Commands::Notification {
+            command: NotificationCommands::Test { .. },
+        }) => "notification.test",
         Some(Commands::Session {
             command: SessionCommands::List { .. },
         }) => "session.list",
@@ -4030,7 +4066,7 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 }
             }
             match notification_diagnostic(
-                config.notifications,
+                &config.notifications,
                 executable_on_path("notify-send"),
                 plausible_desktop_bus(),
             ) {
@@ -4049,6 +4085,25 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 NotificationDiagnostic::MissingDesktopBus => {
                     healthy = false;
                     eprintln!("err notifications: no plausible desktop bus is available");
+                }
+            }
+            match sound_notification_diagnostic(
+                &config.notifications,
+                executable_on_path("canberra-gtk-play"),
+            ) {
+                SoundNotificationDiagnostic::Disabled => {
+                    println!("ok  notification sound: disabled (sampled at daemon start)");
+                }
+                SoundNotificationDiagnostic::Ready => {
+                    println!(
+                        "ok  notification sound: canberra-gtk-play is executable; restart daemon after changes"
+                    );
+                }
+                SoundNotificationDiagnostic::MissingExecutable => {
+                    healthy = false;
+                    eprintln!(
+                        "err notification sound: canberra-gtk-play is not executable on PATH"
+                    );
                 }
             }
         }
@@ -4135,12 +4190,19 @@ enum NotificationDiagnostic {
     MissingDesktopBus,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum SoundNotificationDiagnostic {
+    Disabled,
+    Ready,
+    MissingExecutable,
+}
+
 fn notification_diagnostic(
-    settings: daemon::NotificationSettings,
+    settings: &daemon::NotificationDeliverySettings,
     executable: bool,
     desktop_bus: bool,
 ) -> NotificationDiagnostic {
-    if !settings.enabled {
+    if !settings.desktop.enabled {
         NotificationDiagnostic::Disabled
     } else if !executable {
         NotificationDiagnostic::MissingExecutable
@@ -4149,6 +4211,30 @@ fn notification_diagnostic(
     } else {
         NotificationDiagnostic::Ready
     }
+}
+
+fn sound_notification_diagnostic(
+    settings: &daemon::NotificationDeliverySettings,
+    executable: bool,
+) -> SoundNotificationDiagnostic {
+    if !settings.sound.enabled {
+        SoundNotificationDiagnostic::Disabled
+    } else if !executable {
+        SoundNotificationDiagnostic::MissingExecutable
+    } else {
+        SoundNotificationDiagnostic::Ready
+    }
+}
+
+fn test_notification(reason: CliNotificationReason) -> Result<(), Box<dyn Error>> {
+    let settings = config::load_notification_settings()?;
+    daemon::test_notification_delivery(&settings, reason.into())?;
+    let reason = match reason {
+        CliNotificationReason::Blocked => "blocked",
+        CliNotificationReason::Completed => "completed",
+    };
+    println!("Delivered test {reason} notification");
+    Ok(())
 }
 
 fn executable_on_path(name: &str) -> bool {
@@ -4663,6 +4749,23 @@ mod tests {
             sanitize_table_cell("approval\tneeded\nnow\u{7}"),
             "approval needed now "
         );
+    }
+
+    #[test]
+    fn parses_notification_test_commands_without_json_support() {
+        let blocked = Cli::try_parse_from(["boomux", "notification", "test", "blocked"]).unwrap();
+        assert_eq!(command_name(&blocked), "notification.test");
+        assert!(!supports_json(&blocked));
+        assert!(matches!(
+            blocked.command,
+            Some(Commands::Notification {
+                command: NotificationCommands::Test {
+                    reason: CliNotificationReason::Blocked
+                }
+            })
+        ));
+
+        assert!(Cli::try_parse_from(["boomux", "notification", "test", "unknown"]).is_err());
     }
 
     #[test]
@@ -5851,6 +5954,7 @@ mod tests {
             "protocol_16",
             "persistent_agent_attention",
             "desktop_notifications",
+            "sound_notifications",
             "integration_management",
         ] {
             assert!(INTEGRATION_FEATURES.contains(&feature));
@@ -5876,26 +5980,49 @@ mod tests {
 
     #[test]
     fn notification_doctor_diagnostic_is_deterministic() {
-        let disabled = daemon::NotificationSettings::default();
+        let disabled = daemon::NotificationDeliverySettings::default();
         assert_eq!(
-            notification_diagnostic(disabled, false, false),
+            notification_diagnostic(&disabled, false, false),
             NotificationDiagnostic::Disabled
         );
-        let enabled = daemon::NotificationSettings {
-            enabled: true,
+        let enabled = daemon::NotificationDeliverySettings {
+            desktop: daemon::NotificationSettings {
+                enabled: true,
+                ..Default::default()
+            },
             ..disabled
         };
         assert_eq!(
-            notification_diagnostic(enabled, false, true),
+            notification_diagnostic(&enabled, false, true),
             NotificationDiagnostic::MissingExecutable
         );
         assert_eq!(
-            notification_diagnostic(enabled, true, false),
+            notification_diagnostic(&enabled, true, false),
             NotificationDiagnostic::MissingDesktopBus
         );
         assert_eq!(
-            notification_diagnostic(enabled, true, true),
+            notification_diagnostic(&enabled, true, true),
             NotificationDiagnostic::Ready
+        );
+
+        assert_eq!(
+            sound_notification_diagnostic(&enabled, false),
+            SoundNotificationDiagnostic::Disabled
+        );
+        let sound_enabled = daemon::NotificationDeliverySettings {
+            sound: daemon::NotificationSoundSettings {
+                enabled: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(
+            sound_notification_diagnostic(&sound_enabled, false),
+            SoundNotificationDiagnostic::MissingExecutable
+        );
+        assert_eq!(
+            sound_notification_diagnostic(&sound_enabled, true),
+            SoundNotificationDiagnostic::Ready
         );
     }
 

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -62,7 +62,7 @@ impl TestDaemon {
         }
     }
 
-    fn start_with_notifications() -> (Self, PathBuf, PathBuf) {
+    fn start_with_notifications() -> (Self, PathBuf, PathBuf, PathBuf) {
         let executable = PathBuf::from(env!("CARGO_BIN_EXE_boomux"));
         let runtime_dir = std::env::temp_dir().join(format!(
             "boomux-integration-{}-{}",
@@ -73,17 +73,25 @@ impl TestDaemon {
         let bin_dir = runtime_dir.join("bin");
         fs::create_dir(&bin_dir).unwrap();
         let notify_send = bin_dir.join("notify-send");
+        let sound_player = bin_dir.join("canberra-gtk-play");
         let capture = runtime_dir.join("notifications");
+        let sound_capture = runtime_dir.join("sounds");
         fs::write(
             &notify_send,
             "#!/bin/sh\nif [ -f \"$BOOMUX_NOTIFICATION_HANG\" ]; then\n  printf '%s\\n' \"$$\" > \"$BOOMUX_NOTIFICATION_PID\"\n  exec sleep 10\nfi\nprintf '%s\\0' \"$@\" >> \"$BOOMUX_NOTIFICATION_CAPTURE\"\n",
         )
         .unwrap();
         fs::set_permissions(&notify_send, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::write(
+            &sound_player,
+            "#!/bin/sh\nprintf '%s\\0' \"$@\" >> \"$BOOMUX_SOUND_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&sound_player, fs::Permissions::from_mode(0o755)).unwrap();
         let config = runtime_dir.join("config.toml");
         fs::write(
             &config,
-            "[notifications]\nenabled = true\nblocked = true\ncompleted = true\n",
+            "[notifications]\nenabled = true\nblocked = true\ncompleted = true\n[notifications.sound]\nenabled = true\n",
         )
         .unwrap();
         let mut paths = vec![bin_dir];
@@ -97,6 +105,7 @@ impl TestDaemon {
             .env("XDG_STATE_HOME", runtime_dir.join("state"))
             .env("BOOMUX_CONFIG", &config)
             .env("BOOMUX_NOTIFICATION_CAPTURE", &capture)
+            .env("BOOMUX_SOUND_CAPTURE", &sound_capture)
             .env(
                 "BOOMUX_NOTIFICATION_HANG",
                 runtime_dir.join("notification-hang"),
@@ -124,6 +133,7 @@ impl TestDaemon {
             },
             capture,
             notify_send,
+            sound_capture,
         )
     }
 
@@ -1145,7 +1155,7 @@ fn daemon_events_and_revision_reads_survive_handoff() {
 
 #[test]
 fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
-    let (daemon, capture, notify_send) = TestDaemon::start_with_notifications();
+    let (daemon, capture, notify_send, sound_capture) = TestDaemon::start_with_notifications();
     let workspace = daemon
         .client
         .create_workspace(
@@ -1178,6 +1188,10 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
         || captured_notification_count(&capture) == 1,
         "blocked notification was not delivered",
     );
+    wait_until(
+        || captured_notification_count(&sound_capture) == 1,
+        "blocked notification sound was not delivered",
+    );
     let captured = fs::read(&capture).unwrap();
     assert!(
         !captured
@@ -1205,6 +1219,7 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
         .unwrap();
     thread::sleep(Duration::from_millis(100));
     assert_eq!(captured_notification_count(&capture), 1);
+    assert_eq!(captured_notification_count(&sound_capture), 1);
 
     for (state, evidence, expected) in [
         (AgentState::Working, "resumed", 1),
@@ -1227,6 +1242,10 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
         wait_until(
             || captured_notification_count(&capture) == expected,
             "notification transition was not delivered",
+        );
+        wait_until(
+            || captured_notification_count(&sound_capture) == expected,
+            "notification transition sound was not delivered",
         );
     }
 
@@ -1260,6 +1279,11 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
         .trim()
         .parse()
         .unwrap();
+    fs::write(
+        daemon.runtime_dir.join("config.toml"),
+        "[notifications]\nenabled = true\nblocked = true\ncompleted = true\n[notifications.sound]\nenabled = true\nblocked = \"dialog-warning\"\n",
+    )
+    .unwrap();
     drop(attachment.stream);
     let restart = daemon
         .command()
@@ -1300,8 +1324,20 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
         || captured_notification_count(&capture) == 4,
         "notifications stopped after daemon handoff",
     );
+    wait_until(
+        || captured_notification_count(&sound_capture) == 4,
+        "notification sounds stopped after daemon handoff",
+    );
+    assert!(
+        fs::read(&sound_capture)
+            .unwrap()
+            .windows(b"dialog-warning".len())
+            .any(|value| value == b"dialog-warning"),
+        "daemon handoff did not resample sound configuration"
+    );
 
     fs::remove_file(notify_send).unwrap();
+    let sound_count = captured_notification_count(&sound_capture);
     daemon
         .client
         .register_agent(
@@ -1322,6 +1358,88 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
         .unwrap();
     thread::sleep(Duration::from_millis(100));
     assert_eq!(captured_notification_count(&capture), 4);
+    wait_until(
+        || captured_notification_count(&sound_capture) == sound_count + 1,
+        "sound did not survive desktop notification failure",
+    );
+}
+
+#[test]
+fn notification_test_command_plays_the_configured_sound() {
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_boomux"));
+    let directory = std::env::temp_dir().join(format!(
+        "boomux-sound-test-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = directory.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let player = bin.join("canberra-gtk-play");
+    let capture = directory.join("sound-arguments");
+    fs::write(
+        &player,
+        "#!/bin/sh\nprintf '%s\\0' \"$@\" >> \"$BOOMUX_SOUND_CAPTURE\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&player, fs::Permissions::from_mode(0o755)).unwrap();
+    let config = directory.join("config.toml");
+    fs::write(
+        &config,
+        "[notifications]\nenabled = false\nblocked = true\ncompleted = true\n[notifications.sound]\nenabled = true\nblocked = \"dialog-warning\"\ncompleted = \"complete\"\n",
+    )
+    .unwrap();
+    let mut paths = vec![bin];
+    if let Some(path) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&path));
+    }
+    let path = std::env::join_paths(paths).unwrap();
+
+    for reason in ["blocked", "completed"] {
+        let output = Command::new(&executable)
+            .args(["notification", "test", reason])
+            .env("BOOMUX_CONFIG", &config)
+            .env("BOOMUX_SOUND_CAPTURE", &capture)
+            .env("PATH", &path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(String::from_utf8_lossy(&output.stdout).contains(reason));
+    }
+
+    let arguments = fs::read(&capture)
+        .unwrap()
+        .split(|byte| *byte == 0)
+        .filter(|argument| !argument.is_empty())
+        .map(|argument| String::from_utf8(argument.to_vec()).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        arguments,
+        [
+            "--id",
+            "dialog-warning",
+            "--description",
+            "Boomux Agent notification",
+            "--id",
+            "complete",
+            "--description",
+            "Boomux Agent notification",
+        ]
+    );
+
+    fs::write(&player, "#!/bin/sh\nexit 7\n").unwrap();
+    let failed = Command::new(&executable)
+        .args(["notification", "test", "blocked"])
+        .env("BOOMUX_CONFIG", &config)
+        .env("PATH", &path)
+        .output()
+        .unwrap();
+    assert!(!failed.status.success());
+    assert!(String::from_utf8_lossy(&failed.stderr).contains("canberra-gtk-play exited"));
+    fs::remove_dir_all(directory).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add opt-in direct blocked and completed sounds through `canberra-gtk-play`
- keep desktop and sound channels independent while sharing category filters and transition deduplication
- add `boomux notification test blocked|completed` and separate doctor diagnostics
- preserve the existing public desktop notification API and handoff semantics

## Validation
- cargo check --all-targets --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --locked
- bun test integrations/opencode/boomux.test.js
- bun test integrations/pi/boomux.test.js
- live blocked and completed sound tests with the installed build