### PR TITLE
fix(notifications): deliver agent completion alerts

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -167,9 +167,11 @@ revision fails with `revision_ahead`, while an already empty item returns
 `agent wait`.
 
 Desktop and sound notifications, when the user opts in, are best-effort signals
-for new transitions into blocked or done. They do not acknowledge attention,
-change an observation revision, or contain lifecycle evidence. Always inspect
-the durable queue before acting; do not infer queue state or delivery from a
+for new transitions into blocked or done, and for working Agents becoming idle
+after completing a unit of work. Idle completion notifications do not create
+durable completed attention. Notifications do not acknowledge attention, change
+an observation revision, or contain lifecycle evidence. Always inspect the
+durable queue before acting; do not infer queue state or delivery from a
 notification.
 
 Desktop and sound delivery are independently disabled by default. Desktop uses
@@ -199,7 +201,9 @@ boomux notification test completed
 
 These commands are human-only, do not support `--json`, and fail when the
 requested category has no enabled channel. Runtime delivery uses the daemon's
-startup-sampled configuration until `boomux daemon restart`.
+startup-sampled configuration until `boomux daemon restart`. Restart applies
+the invoking client's resolved notification settings, even when the old daemon
+inherited a different config environment.
 
 Session discovery is not limited to daemon metadata. It may execute the
 PATH-resolved OpenCode CLI and inspect host catalogs in workspace-derived

--- a/README.md
+++ b/README.md
@@ -244,7 +244,9 @@ Desktop and sound notifications are independently disabled by default. Desktop
 delivery requires `notify-send` and a desktop notification service. Sound
 delivery requires `canberra-gtk-play`; its `blocked` and `completed` values are
 freedesktop sound event IDs, not shell commands. Both channels use the top-level
-category filters.
+category filters. A completed notification is sent when an Agent finishes a
+unit of work and becomes idle, as well as when the Agent reaches its terminal
+done state.
 
 Test every configured, enabled channel with:
 
@@ -253,8 +255,10 @@ boomux notification test blocked
 boomux notification test completed
 ```
 
-The daemon reads notification configuration at startup; run `boomux daemon
-restart` after changing it. `boomux doctor` diagnoses both delivery channels.
+The daemon reads notification configuration at startup. `boomux daemon restart`
+applies the invoking client's resolved notification settings to the replacement
+daemon, even when the old daemon inherited a different config environment.
+`boomux doctor` diagnoses both delivery channels.
 
 Managed shells expose `BOOMUX_WORKSPACE_ID`, `BOOMUX_WORKSPACE`,
 `BOOMUX_SHELL_ID`, `BOOMUX_SHELL_NAME`, and `BOOMUX_RUN_ID` for scripts and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -470,22 +470,30 @@ reports fixed lifecycle-state and attention counts per workspace.
 
 Opt-in desktop and sound notifications are a daemon-owned projection of committed
 Agent state transitions, not durable queue state. A transition from any other
-state into `blocked` or `done` schedules one asynchronous delivery request after
-persistence and event publication locks are released. Enabled desktop delivery
-invokes `notify-send`; enabled sound delivery invokes `canberra-gtk-play` with a
-configured freedesktop event ID. Same-state evidence or confidence revisions do
-not notify, and restored state is not replayed. A daemon handoff reloads
-configuration for the replacement, just like a cold daemon start. Both channels
-share one worker and a bounded, non-blocking queue. Delivery is at-most-once and
-fail-open: queue saturation, a missing command, desktop-bus or audio failure,
-timeout, or non-zero exit neither retries nor changes the successful Agent
-mutation.
+state into `blocked` or `done`, or from `working` into `idle`, schedules one
+asynchronous delivery request after persistence and event publication locks are
+released. The `working` to `idle` signal represents a completed unit of work but
+does not create durable completed attention or make the Agent terminal. Enabled
+desktop delivery invokes `notify-send`; enabled sound delivery invokes
+`canberra-gtk-play` with a configured freedesktop event ID. Same-state evidence
+or confidence revisions do not notify, and restored state is not replayed. Both
+channels share one worker and a bounded, non-blocking queue. Delivery is
+at-most-once and fail-open: queue saturation, a missing command, desktop-bus or
+audio failure, timeout, or non-zero exit neither retries nor changes the
+successful Agent mutation.
 Notification payloads include only sanitized Agent, workspace, and shell names;
 if retained Agent context outlives a removed shell, the shell is identified as
 removed rather than suppressing the transition. Notifications never acknowledge
 attention, advance an observation revision, or publish lifecycle events.
 `notification test` exercises the same configured delivery commands directly
 without fabricating or persisting an Agent transition.
+
+Protocol 17 lets a restart request carry the invoking client's resolved
+notification settings through the handoff manifest. This prevents a long-lived
+daemon's inherited `XDG_CONFIG_HOME` or `BOOMUX_CONFIG` from overriding the
+configuration intentionally selected by the restart caller. A protocol-16
+daemon is first upgraded with a compatibility handoff, followed by a protocol-17
+handoff that applies the settings.
 
 ### Transition Coordinator
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,9 +15,9 @@ use std::time::Duration;
 
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, DaemonEvent, Envelope,
-    ErrorCode, EventCursor, Request, Response, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
-    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
-    WorkspaceLauncherSpec, WorkspaceSnapshot,
+    ErrorCode, EventCursor, NotificationDeliveryConfig, Request, Response, ShellSnapshot,
+    ShellSpec, ShellStatus, Snapshot, TerminalProfile, UnixEnvironment, UnixEnvironmentVariable,
+    WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -286,7 +286,21 @@ impl Client {
     }
 
     pub fn restart(&self) -> io::Result<()> {
-        expect_ok(self.request(Request::Restart)?, Response::Ok)?;
+        self.restart_request(Request::Restart)
+    }
+
+    pub fn restart_with_notification_config(
+        &self,
+        notifications: NotificationDeliveryConfig,
+    ) -> io::Result<()> {
+        if self.protocol_version()? < 17 {
+            self.restart_request(Request::Restart)?;
+        }
+        self.restart_request(Request::RestartWithNotificationConfig { notifications })
+    }
+
+    fn restart_request(&self, request: Request) -> io::Result<()> {
+        expect_ok(self.request(request)?, Response::Ok)?;
         let mut last_error = None;
         for _ in 0..CONNECT_ATTEMPTS {
             match self.ping() {
@@ -823,6 +837,22 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 17);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    16,
+                    Response::Error {
+                        message: "protocol 17 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 16);
             assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
@@ -902,7 +932,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 16);
+            assert_eq!(request.version, 17);
             let Request::Attach {
                 environment: Some(environment),
                 ..
@@ -919,7 +949,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    16,
+                    17,
                     Response::Attached {
                         token: "token".into(),
                         reconstruction: Vec::new(),
@@ -947,6 +977,22 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 17);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    16,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 16);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -30,9 +30,9 @@ use crate::handoff;
 use crate::protocol::{
     self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
     AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame,
-    DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, Request, Response,
-    ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
-    TerminalProfile, UnixEnvironment, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
+    DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, NotificationDeliveryConfig,
+    Request, Response, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus,
+    Snapshot, TerminalProfile, UnixEnvironment, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
     WorkspaceSnapshot,
 };
 use crate::state_store::{
@@ -82,6 +82,36 @@ impl Default for NotificationSoundSettings {
             enabled: false,
             blocked: "message-new-instant".into(),
             completed: "complete".into(),
+        }
+    }
+}
+
+impl From<NotificationDeliveryConfig> for NotificationDeliverySettings {
+    fn from(config: NotificationDeliveryConfig) -> Self {
+        Self {
+            desktop: NotificationSettings {
+                enabled: config.desktop_enabled,
+                blocked: config.blocked,
+                completed: config.completed,
+            },
+            sound: NotificationSoundSettings {
+                enabled: config.sound_enabled,
+                blocked: config.blocked_sound,
+                completed: config.completed_sound,
+            },
+        }
+    }
+}
+
+impl From<NotificationDeliverySettings> for NotificationDeliveryConfig {
+    fn from(settings: NotificationDeliverySettings) -> Self {
+        Self {
+            desktop_enabled: settings.desktop.enabled,
+            sound_enabled: settings.sound.enabled,
+            blocked: settings.desktop.blocked,
+            completed: settings.desktop.completed,
+            blocked_sound: settings.sound.blocked,
+            completed_sound: settings.sound.completed,
         }
     }
 }
@@ -152,6 +182,7 @@ pub fn receive_handoff_with_notification_delivery(
             runtimes,
             exited,
             event_stream,
+            notifications,
         } => {
             let store = StateStore::from_transferred_lock(state_lock)?;
             let socket_path = client::socket_path()?;
@@ -166,7 +197,9 @@ pub fn receive_handoff_with_notification_delivery(
                     events: Some(event_stream),
                 },
                 Some(&mut channel),
-                notification_settings,
+                notifications
+                    .map(Into::into)
+                    .unwrap_or(notification_settings),
             )
         }
     }
@@ -291,7 +324,12 @@ fn run_daemon(
         }
         match restart_receiver.try_recv() {
             Ok(request) => {
-                let result = launch_replacement(&listener, &daemon_lock, &registry);
+                let result = launch_replacement(
+                    &listener,
+                    &daemon_lock,
+                    &registry,
+                    request.notification_settings,
+                );
                 if result.is_ok() {
                     handed_off = true;
                     shutdown.store(true, Ordering::Release);
@@ -342,6 +380,7 @@ fn run_daemon(
 
 struct RestartRequest {
     reply: SyncSender<io::Result<()>>,
+    notification_settings: Option<NotificationDeliverySettings>,
 }
 
 #[derive(Debug)]
@@ -442,6 +481,7 @@ fn launch_replacement(
     listener: &UnixListener,
     daemon_lock: &File,
     registry: &Registry,
+    notification_settings: Option<NotificationDeliverySettings>,
 ) -> io::Result<()> {
     let _mutation = lock(&registry.mutation_lock)?;
     registry.ensure_running()?;
@@ -526,6 +566,7 @@ fn launch_replacement(
             &transfers,
             &exited,
             &event_stream,
+            notification_settings,
         )
     })();
     if result.is_err() {
@@ -544,6 +585,7 @@ fn launch_replacement_process(
     runtimes: &[OutgoingRuntime],
     exited: &[OutgoingExited],
     event_stream: &handoff::EventStreamManifest,
+    notification_settings: Option<NotificationDeliverySettings>,
 ) -> io::Result<()> {
     let (mut channel, child_channel) = UnixStream::pair()?;
     let child_channel_fd = child_channel.as_raw_fd();
@@ -585,6 +627,7 @@ fn launch_replacement_process(
                     .collect(),
                 exited: exited.iter().map(|shell| shell.manifest.clone()).collect(),
                 event_stream: event_stream.clone(),
+                notifications: notification_settings.map(Into::into),
             },
         )?;
         send_descriptor(&channel, listener, handoff::LISTENER_MARKER)?;
@@ -753,7 +796,14 @@ fn handle_connection(
             }
         };
     }
-    if matches!(request.message, Request::Restart) {
+    let restart_notification_settings = match &request.message {
+        Request::Restart => Some(None),
+        Request::RestartWithNotificationConfig { notifications } => {
+            Some(Some(notifications.clone().into()))
+        }
+        _ => None,
+    };
+    if let Some(notification_settings) = restart_notification_settings {
         if transition
             .compare_exchange(
                 TRANSITION_IDLE,
@@ -770,7 +820,13 @@ fn handle_connection(
             );
         }
         let (reply, response) = mpsc::sync_channel(1);
-        if restart_sender.send(RestartRequest { reply }).is_err() {
+        if restart_sender
+            .send(RestartRequest {
+                reply,
+                notification_settings,
+            })
+            .is_err()
+        {
             transition.store(TRANSITION_IDLE, Ordering::Release);
             return Err(io::Error::other("daemon restart coordinator stopped"));
         }
@@ -1710,7 +1766,9 @@ impl Registry {
     fn dispatch(&self, request: Request) -> io::Result<Response> {
         match request {
             Request::Ping => Ok(Response::Pong),
-            Request::Restart => unreachable!("restart is handled before dispatch"),
+            Request::Restart | Request::RestartWithNotificationConfig { .. } => {
+                unreachable!("restart is handled before dispatch")
+            }
             Request::Shutdown => unreachable!("shutdown is handled before dispatch"),
             Request::Snapshot => Ok(Response::Snapshot {
                 snapshot: self.snapshot()?,
@@ -2438,26 +2496,37 @@ impl Registry {
                 } => (workspace_id, shell_id, agent),
                 _ => continue,
             };
-            let Some(attention) = agent.attention.as_ref() else {
-                continue;
-            };
-            if attention.observation.revision != agent.observation.revision {
+            let previous_state = previous
+                .agent_states
+                .get(&agent.id)
+                .map(|state| state.observation.state);
+            if previous_state == Some(agent.observation.state) {
                 continue;
             }
-            let reason = match (attention.reason, agent.observation.state) {
-                (AgentAttentionReason::Blocked, AgentState::Blocked) => NotificationReason::Blocked,
-                (AgentAttentionReason::Completed, AgentState::Done) => {
+            let current_attention = agent
+                .attention
+                .as_ref()
+                .filter(|attention| attention.observation.revision == agent.observation.revision);
+            let reason = match agent.observation.state {
+                AgentState::Blocked
+                    if current_attention.is_some_and(|attention| {
+                        attention.reason == AgentAttentionReason::Blocked
+                    }) =>
+                {
+                    NotificationReason::Blocked
+                }
+                AgentState::Done
+                    if current_attention.is_some_and(|attention| {
+                        attention.reason == AgentAttentionReason::Completed
+                    }) =>
+                {
+                    NotificationReason::Completed
+                }
+                AgentState::Idle if previous_state == Some(AgentState::Working) => {
                     NotificationReason::Completed
                 }
                 _ => continue,
             };
-            if previous
-                .agent_states
-                .get(&agent.id)
-                .is_some_and(|state| state.observation.state == agent.observation.state)
-            {
-                continue;
-            }
             if !category_enabled(&self.notification_settings, reason)
                 || !seen.insert((agent.id.as_str(), agent.observation.revision, reason))
             {
@@ -6381,6 +6450,46 @@ mod tests {
         assert_eq!(requests[0].shell, "agent-shell");
         drop(requests);
 
+        shell.kill().unwrap();
+        registry.close_workspace(&workspace.id).unwrap();
+    }
+
+    #[test]
+    fn working_to_idle_notifies_without_completed_attention() {
+        let (registry, sink) = notification_registry(NotificationSettings {
+            enabled: true,
+            blocked: true,
+            completed: true,
+        });
+        let (workspace, shell, _runtime) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let Response::Agent { agent } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec: agent_spec(AgentState::Working),
+            })
+            .unwrap()
+        else {
+            panic!("expected working agent");
+        };
+
+        let Response::Agent { agent } = registry
+            .dispatch(Request::ReportAgent {
+                agent_id: agent.id,
+                run_id,
+                report: agent_spec(AgentState::Idle).report,
+            })
+            .unwrap()
+        else {
+            panic!("expected idle agent");
+        };
+
+        assert!(agent.attention.is_none());
+        let requests = sink.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].reason, NotificationReason::Completed);
+        drop(requests);
         shell.kill().unwrap();
         registry.close_workspace(&workspace.id).unwrap();
     }

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::client;
 use crate::fd_transfer::receive_descriptor;
-use crate::protocol::{self, DaemonEvent, TerminalProfile};
+use crate::protocol::{self, DaemonEvent, NotificationDeliveryConfig, TerminalProfile};
 use crate::state_store;
 
 const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
@@ -33,6 +33,8 @@ pub(crate) struct Manifest {
     pub(crate) runtimes: Vec<RuntimeManifest>,
     pub(crate) exited: Vec<ExitedManifest>,
     pub(crate) event_stream: EventStreamManifest,
+    #[serde(default)]
+    pub(crate) notifications: Option<NotificationDeliveryConfig>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -84,6 +86,7 @@ pub(crate) enum Bootstrap {
         runtimes: Vec<TransferredRuntime>,
         exited: Vec<TransferredExited>,
         event_stream: EventStreamManifest,
+        notifications: Option<NotificationDeliveryConfig>,
     },
 }
 
@@ -102,6 +105,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
     let manifest: Manifest = protocol::read_message(&mut channel)?;
     validate_manifest(&manifest)?;
     let event_stream = manifest.event_stream.clone();
+    let notifications = manifest.notifications.clone();
     let listener = receive_descriptor(&channel, LISTENER_MARKER)?;
     let runtime_lock = receive_descriptor(&channel, RUNTIME_LOCK_MARKER)?;
     let state_lock = receive_descriptor(&channel, STATE_LOCK_MARKER)?;
@@ -169,6 +173,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             runtimes,
             exited,
             event_stream,
+            notifications,
         }),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "protocol_14",
     "protocol_15",
     "protocol_16",
+    "protocol_17",
     "restartable_exited_shells",
     "inactive_agent_state",
     "idempotent_agent_ensure",
@@ -1016,7 +1017,8 @@ fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Err
             client.socket_path().display()
         ),
         DaemonCommands::Restart => {
-            client.restart()?;
+            client
+                .restart_with_notification_config(config::load_notification_settings()?.into())?;
             println!("Restarted Boomux daemon");
         }
         DaemonCommands::Stop => {
@@ -5975,7 +5977,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 16);
+        assert_eq!(protocol::PROTOCOL_VERSION, 17);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 16;
+pub const PROTOCOL_VERSION: u32 = 17;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -329,6 +329,16 @@ pub struct UnixEnvironmentVariable {
     pub value: Vec<u8>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationDeliveryConfig {
+    pub desktop_enabled: bool,
+    pub sound_enabled: bool,
+    pub blocked: bool,
+    pub completed: bool,
+    pub blocked_sound: String,
+    pub completed_sound: String,
+}
+
 impl std::fmt::Debug for UnixEnvironmentVariable {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("UnixEnvironmentVariable(<redacted>)")
@@ -358,6 +368,9 @@ impl ShellSpec {
 pub enum Request {
     Ping,
     Restart,
+    RestartWithNotificationConfig {
+        notifications: NotificationDeliveryConfig,
+    },
     Shutdown,
     Snapshot,
     GetWorkspace {
@@ -470,6 +483,7 @@ pub enum Request {
 impl Request {
     pub fn minimum_protocol_version(&self) -> u32 {
         match self {
+            Self::RestartWithNotificationConfig { .. } => 17,
             Self::Attach {
                 environment: Some(_),
                 ..
@@ -897,14 +911,27 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_sixteen_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 16);
+    fn protocol_version_is_seventeen_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 17);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
     #[test]
     fn request_minimum_protocol_versions_cover_all_groups() {
         let groups = vec![
+            (
+                17,
+                vec![Request::RestartWithNotificationConfig {
+                    notifications: NotificationDeliveryConfig {
+                        desktop_enabled: true,
+                        sound_enabled: true,
+                        blocked: true,
+                        completed: true,
+                        blocked_sound: "dialog-warning".into(),
+                        completed_sound: "complete".into(),
+                    },
+                }],
+            ),
             (
                 6,
                 vec![

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -1223,8 +1223,10 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
 
     for (state, evidence, expected) in [
         (AgentState::Working, "resumed", 1),
-        (AgentState::Blocked, "blocked again", 2),
-        (AgentState::Done, "completed", 3),
+        (AgentState::Idle, "turn completed", 2),
+        (AgentState::Working, "next turn", 2),
+        (AgentState::Blocked, "blocked again", 3),
+        (AgentState::Done, "completed", 4),
     ] {
         daemon
             .client
@@ -1279,14 +1281,16 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
         .trim()
         .parse()
         .unwrap();
+    let replacement_config = daemon.runtime_dir.join("replacement-config.toml");
     fs::write(
-        daemon.runtime_dir.join("config.toml"),
+        &replacement_config,
         "[notifications]\nenabled = true\nblocked = true\ncompleted = true\n[notifications.sound]\nenabled = true\nblocked = \"dialog-warning\"\n",
     )
     .unwrap();
     drop(attachment.stream);
     let restart = daemon
         .command()
+        .env("BOOMUX_CONFIG", replacement_config)
         .args(["daemon", "restart"])
         .output()
         .unwrap();
@@ -1301,7 +1305,7 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
     );
     fs::remove_file(hang).unwrap();
     thread::sleep(Duration::from_millis(100));
-    assert_eq!(captured_notification_count(&capture), 3);
+    assert_eq!(captured_notification_count(&capture), 4);
     daemon
         .client
         .register_agent(
@@ -1321,11 +1325,11 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
         )
         .unwrap();
     wait_until(
-        || captured_notification_count(&capture) == 4,
+        || captured_notification_count(&capture) == 5,
         "notifications stopped after daemon handoff",
     );
     wait_until(
-        || captured_notification_count(&sound_capture) == 4,
+        || captured_notification_count(&sound_capture) == 5,
         "notification sounds stopped after daemon handoff",
     );
     assert!(
@@ -1357,7 +1361,7 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
         )
         .unwrap();
     thread::sleep(Duration::from_millis(100));
-    assert_eq!(captured_notification_count(&capture), 4);
+    assert_eq!(captured_notification_count(&capture), 5);
     wait_until(
         || captured_notification_count(&sound_capture) == sound_count + 1,
         "sound did not survive desktop notification failure",
@@ -3117,7 +3121,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 16);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 17);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -3163,6 +3167,7 @@ fn native_daemon_lifecycle() {
         "protocol_14",
         "protocol_15",
         "protocol_16",
+        "protocol_17",
         "inactive_agent_state",
         "protocol_11",
         "restartable_exited_shells",
@@ -3183,7 +3188,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 16"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 17"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- send completed desktop and sound notifications when an Agent transitions from working to idle
- keep idle reusable and nonterminal without creating durable completed attention
- carry the restart caller's resolved notification settings through protocol-17 daemon handoff
- upgrade protocol-16 daemons compatibly before applying transferred settings

## Testing
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`
- live protocol-16 to protocol-17 daemon upgrade and repeated configured restart