### PR TITLE
perf(opencode): coalesce working activity reports

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -523,9 +523,11 @@ The plugin activates only in a managed shell run. It identifies one agent by the
 root OpenCode session and aggregates child/subagent activity. Work, tool, chat,
 and compaction events map to `working`; outstanding permission/questions and
 errors map to `blocked`; only root idle maps to `idle`; and only explicit root
-session deletion maps to `done`. Child deletion and process exit do not report
-completion. Unmanaged or unavailable Boomux is fail-open. If Boomux returns
-`run_changed`, reporting for that root is disabled rather than redirected.
+session deletion maps to `done`. Repeated working activity is coalesced until a
+meaningful state transition, so tool bursts do not create evidence-only durable
+reports. Child deletion and process exit do not report completion. Unmanaged or
+unavailable Boomux is fail-open. If Boomux returns `run_changed`, reporting for
+that root is disabled rather than redirected.
 
 ## Direct Pi Install Shortcut
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,11 +259,14 @@ exited run remains non-mutating and can replay its retained terminal state.
 External observation authority is ordered lifecycle integration, process
 adapter, then terminal heuristic. Lower-authority reports are successful no-ops.
 At equal authority an exact duplicate is also a no-op, but a changed report is
-accepted, so a source can advance its own state and evidence. Higher-authority
+accepted, so a source can advance its own state and evidence. The exception is a
+same-authority, same-confidence `working` report: evidence-only changes are
+successful no-ops because they do not change lifecycle meaning and would put
+high-frequency tool activity on the durable persistence path. Higher-authority
 reports replace lower-authority observations. `daemon_lifecycle` is a wire and
-snapshot value reserved for daemon-originated observations and is not exposed by
-the public mutation CLI. Exact retries of an accepted `done` report return the
-completed snapshot without another revision, write, or event; conflicting
+snapshot value reserved for daemon-originated observations and is not exposed
+by the public mutation CLI. Exact retries of an accepted `done` report return
+the completed snapshot without another revision, write, or event; conflicting
 reports after completion are rejected.
 
 ### Explicit Process-Adapter Supervisor
@@ -351,14 +354,17 @@ prompts map to `working`; outstanding permission or question requests and
 session errors map to `blocked`; only root idle maps to `idle`. Blockers are
 tracked as a set, and errors remain latched until later work is observed. Only
 explicit root `session.deleted` maps to `done`: child deletion and process or
-shell exit do not complete the instance.
+shell exit do not complete the instance. Once the derived state is `working`,
+later chat, tool, and compaction evidence is coalesced until a meaningful state
+transition occurs. This keeps activity bursts off the CLI and durable fsync path.
 
 On first relevant event, or after plugin reload, the plugin calls `agent ensure`
-and then reports a changed derived observation when the reused durable record
-does not already match. Calls use exact argument vectors, a one-second timeout,
-bounded output, and the stable JSON envelope. Unmanaged sessions are a no-op;
-Boomux or ancestry failures are rate-limited and fail open so OpenCode continues.
-`run_changed` disables all later reports for that tracked root.
+and then reports a changed derived state when the reused durable record does not
+already represent `working`, or when another state or authority differs. Calls
+use exact argument vectors, a one-second timeout, bounded output, and the stable
+JSON envelope. Unmanaged sessions are a no-op; Boomux or ancestry failures are
+rate-limited and fail open so OpenCode continues. `run_changed` disables all
+later reports for that tracked root.
 
 ### Pi Lifecycle Extension
 

--- a/integrations/opencode/boomux.js
+++ b/integrations/opencode/boomux.js
@@ -240,8 +240,12 @@ function reduce(state, action, isRootEvent) {
   }
 
   const bounded = boundedEvidence(evidence);
-  if (next === state.lastState && bounded === state.lastEvidence)
+  if (
+    next === state.lastState &&
+    (next === "working" || bounded === state.lastEvidence)
+  ) {
     return undefined;
+  }
   state.lastEvidence = bounded;
   state.lastState = next;
   return { state: next, evidence: bounded };
@@ -421,6 +425,15 @@ function observationMatches(observation, derived) {
   );
 }
 
+function observationAlreadyWorking(observation, derived) {
+  return (
+    derived.state === "working" &&
+    observation?.state === "working" &&
+    observation?.authority === LIFECYCLE_AUTHORITY &&
+    observation?.confidence === LIFECYCLE_CONFIDENCE
+  );
+}
+
 function rateLimitedLogger(log, now = Date.now) {
   let last = -Infinity;
   let suppressed = 0;
@@ -484,7 +497,12 @@ function createLifecycle({ client, env, run, log = console.error, now }) {
           item.reducer.terminal = true;
           return;
         }
-        if (observationMatches(agent?.observation, derived)) return;
+        if (
+          observationMatches(agent?.observation, derived) ||
+          observationAlreadyWorking(agent?.observation, derived)
+        ) {
+          return;
+        }
       }
       await run(
         reportArgv(

--- a/integrations/opencode/boomux.test.js
+++ b/integrations/opencode/boomux.test.js
@@ -150,7 +150,7 @@ describe("event mapping and reducer", () => {
     ).toBe("working");
   });
 
-  test("updates working evidence and suppresses only exact duplicates", () => {
+  test("suppresses evidence-only updates while already working", () => {
     const state = createReducerState();
     const chat = {
       kind: "working",
@@ -164,9 +164,7 @@ describe("event mapping and reducer", () => {
     };
 
     expect(reduce(state, chat, true).evidence).toBe("OpenCode chat.message");
-    expect(reduce(state, tool, true).evidence).toBe(
-      "OpenCode tool.execute.before",
-    );
+    expect(reduce(state, tool, true)).toBeUndefined();
     expect(reduce(state, tool, true)).toBeUndefined();
   });
 });
@@ -517,7 +515,7 @@ describe("Boomux commands", () => {
     expect(calls[1]).toContain(env.BOOMUX_RUN_ID);
   });
 
-  test("same-state Ensure with different evidence reports immediately", async () => {
+  test("same-state Ensure with different working evidence does not report", async () => {
     const calls = [];
     const lifecycle = createLifecycle({
       client: {
@@ -537,17 +535,33 @@ describe("Boomux commands", () => {
       event("session.status", { sessionID: "root", status: "busy" }),
     );
 
-    expect(calls).toHaveLength(2);
-    expect(calls[1].slice(0, 4)).toEqual([
-      "boomux",
-      "agent",
-      "report",
-      "existing",
-    ]);
-    expect(calls[1][calls[1].indexOf("--state") + 1]).toBe("working");
-    expect(calls[1][calls[1].indexOf("--evidence") + 1]).toBe(
-      "OpenCode session busy",
+    expect(calls).toHaveLength(1);
+  });
+
+  test("coalesces a burst of working activity into one lifecycle command", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: { session: { get: async ({ path }) => ({ data: { id: path.id } }) } },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return successfulEnsure("agent", "working");
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue(
+      event("session.status", { sessionID: "root", status: "busy" }),
     );
+    for (let index = 0; index < 100; index += 1) {
+      await lifecycle.enqueue(
+        event(index % 2 ? "tool.execute.before" : "tool.execute.after", {
+          sessionID: "root",
+        }),
+      );
+    }
+
+    expect(calls).toHaveLength(1);
   });
 
   test("reattached working agent reports the first idle event", async () => {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3347,7 +3347,12 @@ impl Registry {
                 "completed agent instance cannot be reported again",
             ));
         }
+        let repeated_working = state.observation.state == AgentState::Working
+            && report.state == AgentState::Working
+            && state.observation.authority == report.authority
+            && state.observation.confidence == report.confidence;
         if observation_matches_report(&state.observation, &report)
+            || repeated_working
             || agent_authority_rank(report.authority)
                 < agent_authority_rank(state.observation.authority)
         {
@@ -6186,6 +6191,11 @@ mod tests {
                 AgentState::Working,
                 AgentAuthority::ProcessAdapter,
                 "process working",
+            ),
+            agent_report(
+                AgentState::Working,
+                AgentAuthority::ProcessAdapter,
+                "updated working evidence",
             ),
         ] {
             let Response::Agent { agent: unchanged } = registry


### PR DESCRIPTION
## Summary
- coalesce evidence-only OpenCode activity while an agent remains working
- make repeated same-authority and same-confidence working reports daemon-side no-ops
- document the persistence boundary and add a 100-event burst regression

## Verification
- `cargo test`
- `bun test integrations`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- deployed release daemon and plugin locally; a parallel tool burst remained smooth with no lifecycle timeout