### PR TITLE
feat(tui): follow focused terminals

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -373,16 +373,20 @@ The dashboard has workspace, Agent, launcher, shell, and command views. `/` or
 restores the selected workspace or opens the selected entry, and `x` followed
 by `y` confirms close or removal. Shell previews are bounded and read-only.
 Restoring a workspace has the same launcher, takeover, restart, and
-partial-success behavior as `workspace open`.
+partial-success behavior as `workspace open`. By default, a newly focused
+managed terminal selects its owning workspace and shell or Agent row once;
+manual navigation remains until another focus change.
 
 ## Configuration
 
 Boomux reads `$XDG_CONFIG_HOME/boomux/config.toml`, falling back to
 `~/.config/boomux/config.toml`. `BOOMUX_CONFIG` points to an additional
 field-level override loaded last. Configuration controls terminal selection,
-project discovery roots and depth, and desktop and sound notifications. Unknown
-fields are rejected. Project roots provide dashboard workspace-name suggestions
-only; they do not bind a workspace to a directory.
+project discovery roots and depth, dashboard focus following, and desktop and
+sound notifications. Unknown fields are rejected. Project roots provide
+dashboard workspace-name suggestions only; they do not bind a workspace to a
+directory. Set `[dashboard] follow_focused_terminal = false` to disable the
+default focus-following behavior.
 
 ## Manage Workspaces
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ terminal = "Alacritty.desktop"
 roots = ["~/Projects", "~/Work"]
 max_depth = 3
 
+[dashboard]
+follow_focused_terminal = true
+
 [notifications]
 enabled = false
 blocked = true
@@ -239,6 +242,11 @@ completed = "complete"
 
 Project roots provide workspace-name suggestions in the dashboard. Selecting a
 suggestion does not bind the workspace to that path.
+
+The dashboard follows the most recently focused Boomux terminal by default,
+selecting its workspace and shell or Agent row. Manual dashboard navigation is
+preserved until another managed terminal gains focus. Set
+`dashboard.follow_focused_terminal` to `false` to disable this behavior.
 
 Desktop and sound notifications are independently disabled by default. Desktop
 delivery requires `notify-send` and a desktop notification service. Sound

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,9 +110,15 @@ an ungrouped shell.
 ### Attachment
 
 `src/attach.rs` runs inside the selected terminal emulator. It enables raw mode,
-reports dimensions, and copies bytes in both directions without interpreting
-keys or transforming live PTY output. An RAII guard restores terminal mode when
-the attachment exits.
+reports dimensions, and copies bytes in both directions without transforming
+live PTY output. Protocol-18 attachments also enable xterm focus reporting and
+recognize focus-gained input. Physical focus events are forwarded to the PTY
+only while the child has requested focus mode; otherwise they are consumed so
+ordinary shells do not receive synthetic escape input. Child mode changes are
+tracked across output chunks and reconstruction while Boomux keeps physical
+reporting enabled. Each focus gain is also reported through the
+controller-authorized attach stream. RAII cleanup restores terminal and
+focus-reporting modes when the attachment exits.
 
 The daemon keeps a bounded output queue per active controller. A slow client
 drops output rather than blocking the PTY reader and child process.
@@ -150,6 +156,16 @@ dashboard presents an empty vector as `shell` and a non-empty vector as
 durable shell model. Command rows show the stored argv in their detail column.
 Agent presentation takes precedence when the current run has an active Agent or
 an exact `opencode` or `pi` foreground hint.
+
+The daemon retains the latest controller-authorized terminal focus gain as
+ephemeral workspace, shell, run, and monotonic revision metadata. With
+`dashboard.follow_focused_terminal` enabled (the default), the dashboard uses a
+new revision as a one-shot selection trigger and resolves both shell and Agent
+rows by durable shell ID. Repeated snapshot refreshes do not enforce the
+selection, so manual navigation remains usable until another terminal focus
+gain. Focus changes are deferred while an overlay or close confirmation is
+active. The setting is dashboard-local and disabling it does not stop focus
+reporting by attachments.
 
 Selected-kind previews remain read-only. Workspace, launcher, and run metadata
 come from the polled snapshot. Shell output uses a bounded plain-text read only
@@ -473,6 +489,13 @@ the lifecycle revision used by `agent wait`. Version-5 state migrates with no
 outstanding items so upgrading does not reinterpret historical work as unseen.
 The CLI projects these records into a deterministic blocked-first queue and
 reports fixed lifecycle-state and attention counts per workspace.
+
+Protocol 18 adds native-attachment focus reports and an optional focused
+terminal snapshot. The state is non-durable, is accepted only from the current
+controller for the current shell run, and uses a monotonic revision so clients
+can distinguish a later refocus of the same shell. Protocol-17 responses omit
+the additive field. Graceful handoff transfers a still-current focus target;
+cold daemon recovery clears it.
 
 Opt-in desktop and sound notifications are a daemon-owned projection of committed
 Agent state transitions, not durable queue state. A transition from any other

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -15,7 +15,9 @@ depending on the retained global event cursor.
 Protocol 15 adds durable blocked/completed attention and conditional
 acknowledgment. Protocol-14 clients receive Agent snapshots without attention
 and do not receive acknowledgment events, while cursors still advance across
-those filtered events.
+those filtered events. Protocol 18 adds the latest non-durable focused terminal
+and its monotonic revision to baseline snapshots. It does not add an event type;
+protocol-17 clients receive the same baseline without that field.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -30,6 +30,8 @@ The private handoff channel will carry a versioned manifest followed by Unix
   and sanitized VT state
 - Exited-shell run identity, exit status, output revision, terminal profile, and
   sanitized final VT state without process descriptors
+- The latest non-durable focused-terminal revision and workspace/shell/run
+  identity, when it still refers to a transferred runtime
 
 The PTY master is full duplex, so reader and writer duplicates do not need to be
 transferred separately. The replacement cannot inherit Unix parenthood; process
@@ -59,7 +61,9 @@ opening a PTY or starting a process.
 Handoff version 4 also transfers the event stream UUID, high-water mark, and
 bounded retained events. The replacement publishes `handoff_completed` before
 resuming readers, so output revisions remain ordered after the ownership
-boundary.
+boundary. The optional focused-terminal snapshot crosses the same graceful
+handoff so dashboard following does not forget the last focused managed window;
+ordinary cold recovery does not restore it.
 
 ## Delivery Slices
 

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -2,18 +2,102 @@ use std::env;
 use std::io::{self, Read, Write};
 use std::os::fd::AsRawFd;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crossterm::terminal;
 
 use crate::client;
 use crate::protocol::{AttachFrame, TerminalProfile};
+use crate::terminal_focus::FocusMode;
 
 const POLL_INTERVAL_MS: i32 = 100;
+const ESCAPE_DISAMBIGUATION_MS: i32 = 10;
 const RECONNECT_ATTEMPTS: usize = 600;
 const RECONNECT_DELAY: Duration = Duration::from_millis(25);
+const ENABLE_FOCUS_REPORTING: &[u8] = b"\x1b[?1004h";
+const DISABLE_FOCUS_REPORTING: &[u8] = b"\x1b[?1004l";
 
 struct RawMode;
+
+const FOCUS_GAINED: &[u8] = b"\x1b[I";
+const FOCUS_LOST: &[u8] = b"\x1b[O";
+
+#[derive(Default)]
+struct FocusTracking {
+    enabled: bool,
+    child_mode: FocusMode,
+    input: FocusInput,
+}
+
+#[derive(Default)]
+struct FocusInput {
+    pending: Vec<u8>,
+    pending_since: Option<Instant>,
+}
+
+impl FocusInput {
+    fn process(&mut self, bytes: &[u8], forward_focus: bool) -> (Vec<u8>, usize) {
+        let mut combined = std::mem::take(&mut self.pending);
+        self.pending_since = None;
+        combined.extend_from_slice(bytes);
+        let mut forwarded = Vec::with_capacity(combined.len());
+        let mut gained = 0;
+        let mut offset = 0;
+        while offset < combined.len() {
+            let remaining = &combined[offset..];
+            if remaining.starts_with(FOCUS_GAINED) {
+                gained += 1;
+                if forward_focus {
+                    forwarded.extend_from_slice(FOCUS_GAINED);
+                }
+                offset += FOCUS_GAINED.len();
+            } else if remaining.starts_with(FOCUS_LOST) {
+                if forward_focus {
+                    forwarded.extend_from_slice(FOCUS_LOST);
+                }
+                offset += FOCUS_LOST.len();
+            } else if remaining.len() < FOCUS_GAINED.len()
+                && (FOCUS_GAINED.starts_with(remaining) || FOCUS_LOST.starts_with(remaining))
+            {
+                self.pending.extend_from_slice(remaining);
+                self.pending_since = Some(Instant::now());
+                break;
+            } else {
+                forwarded.push(combined[offset]);
+                offset += 1;
+            }
+        }
+        (forwarded, gained)
+    }
+
+    fn flush_pending(&mut self) -> Vec<u8> {
+        self.pending_since = None;
+        std::mem::take(&mut self.pending)
+    }
+
+    fn poll_timeout(&self) -> i32 {
+        let Some(since) = self.pending_since else {
+            return POLL_INTERVAL_MS;
+        };
+        let remaining =
+            Duration::from_millis(ESCAPE_DISAMBIGUATION_MS as u64).saturating_sub(since.elapsed());
+        remaining.as_millis().min(POLL_INTERVAL_MS as u128) as i32
+    }
+
+    fn pending_expired(&self) -> bool {
+        self.pending_since.is_some_and(|since| {
+            since.elapsed() >= Duration::from_millis(ESCAPE_DISAMBIGUATION_MS as u64)
+        })
+    }
+}
+
+impl FocusTracking {
+    fn reset(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        self.child_mode = FocusMode::default();
+        self.input.flush_pending();
+    }
+}
 
 impl RawMode {
     fn enter() -> io::Result<Self> {
@@ -42,27 +126,61 @@ pub fn run(shell_id: &str, takeover: bool, restart_exited: bool) -> io::Result<(
     let mut stdin = io::stdin().lock();
     let mut stdout = io::stdout().lock();
     let mut input = [0; 16 * 1024];
+    let mut focus_reporting = false;
+    let mut focus = FocusTracking::default();
 
-    loop {
-        if let Some(warning) = attachment.warning.take() {
-            eprintln!("boomux: warning: {warning}");
-        }
-        stdout.write_all(&attachment.reconstruction)?;
-        stdout.flush()?;
-        let mut stream = attachment.stream;
+    let result = (|| {
+        loop {
+            let report_focus = attachment.protocol_version >= 18;
+            if report_focus != focus_reporting {
+                stdout.write_all(if report_focus {
+                    ENABLE_FOCUS_REPORTING
+                } else {
+                    DISABLE_FOCUS_REPORTING
+                })?;
+                stdout.flush()?;
+                focus_reporting = report_focus;
+            }
+            if let Some(warning) = attachment.warning.take() {
+                eprintln!("boomux: warning: {warning}");
+            }
+            focus.reset(report_focus);
+            stdout.write_all(&attachment.reconstruction)?;
+            if focus.enabled && focus.child_mode.process(&attachment.reconstruction) {
+                stdout.write_all(ENABLE_FOCUS_REPORTING)?;
+            }
+            stdout.flush()?;
+            let mut stream = attachment.stream;
 
-        if !pump_attachment(&mut stream, &mut stdin, &mut stdout, &mut input, &mut size)? {
-            return Ok(());
+            if !pump_attachment(
+                &mut stream,
+                &mut stdin,
+                &mut stdout,
+                &mut input,
+                &mut size,
+                &mut focus,
+            )? {
+                return Ok(());
+            }
+            if let Ok((rows, cols, pixel_width, pixel_height)) = dimensions() {
+                size = (rows, cols, pixel_width, pixel_height);
+                profile.rows = rows;
+                profile.cols = cols;
+                profile.pixel_width = pixel_width;
+                profile.pixel_height = pixel_height;
+            }
+            attachment = reconnect(&client, shell_id, takeover, &profile)?;
         }
-        if let Ok((rows, cols, pixel_width, pixel_height)) = dimensions() {
-            size = (rows, cols, pixel_width, pixel_height);
-            profile.rows = rows;
-            profile.cols = cols;
-            profile.pixel_width = pixel_width;
-            profile.pixel_height = pixel_height;
+    })();
+    if focus_reporting {
+        let disable_result = stdout
+            .write_all(DISABLE_FOCUS_REPORTING)
+            .and_then(|()| stdout.flush());
+        if result.is_ok() {
+            disable_result?;
         }
-        attachment = reconnect(&client, shell_id, takeover, &profile)?;
     }
+    result
 }
 
 fn reconnect(
@@ -106,6 +224,7 @@ fn pump_attachment(
     stdout: &mut impl Write,
     input: &mut [u8],
     size: &mut (u16, u16, u16, u16),
+    focus: &mut FocusTracking,
 ) -> io::Result<bool> {
     loop {
         let mut descriptors = [
@@ -121,11 +240,16 @@ fn pump_attachment(
             },
         ];
         // Both descriptors remain valid for the duration of this call.
+        let timeout = if focus.enabled {
+            focus.input.poll_timeout()
+        } else {
+            POLL_INTERVAL_MS
+        };
         let ready = unsafe {
             libc::poll(
                 descriptors.as_mut_ptr(),
                 descriptors.len() as libc::nfds_t,
-                POLL_INTERVAL_MS,
+                timeout,
             )
         };
         if ready < 0 {
@@ -139,10 +263,17 @@ fn pump_attachment(
             match AttachFrame::read_from(stream) {
                 Ok(AttachFrame::Output(bytes)) => {
                     stdout.write_all(&bytes)?;
+                    if focus.enabled && focus.child_mode.process(&bytes) {
+                        stdout.write_all(ENABLE_FOCUS_REPORTING)?;
+                    }
                     stdout.flush()?;
                 }
                 Ok(AttachFrame::Detached) => return Ok(false),
                 Ok(AttachFrame::Reconnect) => {
+                    let pending = focus.input.flush_pending();
+                    if !pending.is_empty() {
+                        AttachFrame::Input(pending).write_to(stream)?;
+                    }
                     let _ = AttachFrame::ReconnectAck.write_to(stream);
                     return Ok(true);
                 }
@@ -159,10 +290,32 @@ fn pump_attachment(
         if descriptors[0].revents & libc::POLLIN != 0 {
             let count = stdin.read(input)?;
             if count == 0 {
+                let pending = focus.input.flush_pending();
+                if !pending.is_empty() {
+                    AttachFrame::Input(pending).write_to(stream)?;
+                }
                 AttachFrame::Detached.write_to(stream)?;
                 return Ok(false);
             }
-            AttachFrame::Input(input[..count].to_vec()).write_to(stream)?;
+            if focus.enabled {
+                let (forwarded, gained) = focus
+                    .input
+                    .process(&input[..count], focus.child_mode.enabled());
+                if !forwarded.is_empty() {
+                    AttachFrame::Input(forwarded).write_to(stream)?;
+                }
+                for _ in 0..gained {
+                    AttachFrame::FocusGained.write_to(stream)?;
+                }
+            } else {
+                AttachFrame::Input(input[..count].to_vec()).write_to(stream)?;
+            }
+        }
+        if focus.input.pending_expired() {
+            let pending = focus.input.flush_pending();
+            if !pending.is_empty() {
+                AttachFrame::Input(pending).write_to(stream)?;
+            }
         }
 
         if let Ok(new_size) = dimensions()
@@ -253,11 +406,104 @@ mod tests {
             &mut stdout,
             &mut input,
             &mut size,
+            &mut FocusTracking::default(),
         )
         .unwrap();
 
         sender.join().unwrap();
         assert!(reconnect);
         assert_eq!(stdout, b"before-reconnect");
+    }
+
+    #[test]
+    fn focus_input_detects_split_reports_without_forwarding_to_an_unsubscribed_child() {
+        let mut input = FocusInput::default();
+
+        assert_eq!(input.process(b"text\x1b[", false), (b"text".to_vec(), 0));
+        assert_eq!(input.process(b"I\x1b[I", false), (Vec::new(), 2));
+        assert_eq!(input.process(b"\x1b[x", false), (b"\x1b[x".to_vec(), 0));
+    }
+
+    #[test]
+    fn protocol_eighteen_forwards_input_before_focus_frames() {
+        let (mut daemon, mut attachment) = UnixStream::pair().unwrap();
+        let (mut fake_stdin, mut stdin_writer) = UnixStream::pair().unwrap();
+        let sender = thread::spawn(move || {
+            assert_eq!(
+                AttachFrame::read_from(&mut daemon).unwrap(),
+                AttachFrame::Input(b"a".to_vec())
+            );
+            assert_eq!(
+                AttachFrame::read_from(&mut daemon).unwrap(),
+                AttachFrame::FocusGained
+            );
+            assert_eq!(
+                AttachFrame::read_from(&mut daemon).unwrap(),
+                AttachFrame::FocusGained
+            );
+            AttachFrame::Detached.write_to(&mut daemon).unwrap();
+        });
+        stdin_writer.write_all(b"a\x1b[I\x1b[I").unwrap();
+        let mut stdout = Vec::new();
+        let mut input = [0; 128];
+        let mut size = (24, 80, 0, 0);
+
+        let reconnect = pump_attachment(
+            &mut attachment,
+            &mut fake_stdin,
+            &mut stdout,
+            &mut input,
+            &mut size,
+            &mut FocusTracking {
+                enabled: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        sender.join().unwrap();
+        assert!(!reconnect);
+    }
+
+    #[test]
+    fn focus_input_is_forwarded_when_the_child_subscribed() {
+        let mut input = FocusInput::default();
+
+        assert_eq!(
+            input.process(b"before\x1b[I\x1b[Oafter", true),
+            (b"before\x1b[I\x1b[Oafter".to_vec(), 1)
+        );
+    }
+
+    #[test]
+    fn attachment_reenables_focus_after_child_disables_it() {
+        let (mut daemon, mut attachment) = UnixStream::pair().unwrap();
+        let (mut fake_stdin, _stdin_writer) = UnixStream::pair().unwrap();
+        let sender = thread::spawn(move || {
+            AttachFrame::Output(b"before\x1b[?1004;2004lafter".to_vec())
+                .write_to(&mut daemon)
+                .unwrap();
+            AttachFrame::Detached.write_to(&mut daemon).unwrap();
+        });
+        let mut stdout = Vec::new();
+        let mut input = [0; 128];
+        let mut size = (24, 80, 0, 0);
+
+        let reconnect = pump_attachment(
+            &mut attachment,
+            &mut fake_stdin,
+            &mut stdout,
+            &mut input,
+            &mut size,
+            &mut FocusTracking {
+                enabled: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        sender.join().unwrap();
+        assert!(!reconnect);
+        assert_eq!(stdout, b"before\x1b[?1004;2004lafter\x1b[?1004h");
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,6 +33,7 @@ pub struct Client {
 #[derive(Debug)]
 pub struct Attachment {
     pub stream: UnixStream,
+    pub protocol_version: u32,
     pub token: String,
     pub reconstruction: Vec<u8>,
     pub warning: Option<String>,
@@ -186,10 +187,10 @@ impl Client {
     }
 
     pub fn request(&self, request: Request) -> io::Result<Response> {
-        self.send(request).map(|(_, response)| response)
+        self.send(request).map(|(_, _, response)| response)
     }
 
-    fn send(&self, request: Request) -> io::Result<(UnixStream, Response)> {
+    fn send(&self, request: Request) -> io::Result<(UnixStream, u32, Response)> {
         let mut version = self.protocol_version.load(Ordering::Acquire);
         if version < request.minimum_protocol_version() {
             self.probe_latest()?;
@@ -202,6 +203,7 @@ impl Client {
             }
         }
         match self.send_with_version(request.clone(), version) {
+            Ok((stream, response)) => Ok((stream, version, response)),
             Err(error)
                 if version > protocol::MIN_PROTOCOL_VERSION && is_protocol_rejection(&error) =>
             {
@@ -214,8 +216,9 @@ impl Client {
                     ));
                 }
                 self.send_with_version(request, negotiated)
+                    .map(|(stream, response)| (stream, negotiated, response))
             }
-            result => result,
+            Err(error) => Err(error),
         }
     }
 
@@ -699,7 +702,7 @@ impl Client {
         profile: TerminalProfile,
         environment: Option<UnixEnvironment>,
     ) -> io::Result<Attachment> {
-        let (stream, response) = self.send(Request::Attach {
+        let (stream, protocol_version, response) = self.send(Request::Attach {
             shell_id,
             takeover,
             restart_exited,
@@ -713,6 +716,7 @@ impl Client {
                 warning,
             } => Ok(Attachment {
                 stream,
+                protocol_version,
                 token,
                 reconstruction,
                 warning,
@@ -837,6 +841,22 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 18);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    17,
+                    Response::Error {
+                        message: "protocol 18 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 17);
             assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
@@ -932,7 +952,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 17);
+            assert_eq!(request.version, 18);
             let Request::Attach {
                 environment: Some(environment),
                 ..
@@ -949,7 +969,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    17,
+                    18,
                     Response::Attached {
                         token: "token".into(),
                         reconstruction: Vec::new(),
@@ -971,12 +991,100 @@ mod tests {
     }
 
     #[test]
+    fn attachment_preserves_the_version_used_for_its_handshake() {
+        let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 18);
+            assert!(matches!(request.message, Request::Attach { .. }));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    18,
+                    Response::Error {
+                        message: "protocol 18 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 18);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    18,
+                    Response::Error {
+                        message: "protocol 18 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 17);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(&mut stream, &Envelope::with_version(17, Response::Pong))
+                .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 17);
+            assert!(matches!(request.message, Request::Attach { .. }));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    17,
+                    Response::Attached {
+                        token: "token".into(),
+                        reconstruction: Vec::new(),
+                        warning: None,
+                    },
+                ),
+            )
+            .unwrap();
+        });
+        let client = Client::from_socket_path(socket);
+
+        let attachment = client.attach("s1", false, test_profile()).unwrap();
+
+        assert_eq!(attachment.protocol_version, 17);
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
     fn negotiates_protocol_seven_without_losing_version_seven_requests() {
         let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 18);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    17,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 17);

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ struct RawConfig {
     terminal: Option<String>,
     projects: Option<RawProjectsConfig>,
     notifications: Option<RawNotificationsConfig>,
+    dashboard: Option<RawDashboardConfig>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -41,18 +42,30 @@ struct RawNotificationSoundConfig {
     completed: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawDashboardConfig {
+    follow_focused_terminal: Option<bool>,
+}
+
 #[derive(Debug)]
 pub(crate) struct Config {
     pub(crate) terminal: Option<String>,
     pub(crate) projects: ProjectsConfig,
     pub(crate) path: Option<PathBuf>,
     pub(crate) notifications: boomux::daemon::NotificationDeliverySettings,
+    pub(crate) dashboard: DashboardConfig,
 }
 
 #[derive(Debug)]
 pub(crate) struct ProjectsConfig {
     pub(crate) roots: Vec<PathBuf>,
     pub(crate) max_depth: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct DashboardConfig {
+    pub(crate) follow_focused_terminal: bool,
 }
 
 #[derive(Debug)]
@@ -158,6 +171,12 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
             }
         }
     }
+    if let Some(next_dashboard) = next.dashboard {
+        let dashboard = base.dashboard.get_or_insert_default();
+        if next_dashboard.follow_focused_terminal.is_some() {
+            dashboard.follow_focused_terminal = next_dashboard.follow_focused_terminal;
+        }
+    }
 }
 
 fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Error>> {
@@ -189,6 +208,13 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
         projects: ProjectsConfig { roots, max_depth },
         path,
         notifications: resolve_notifications(raw.notifications),
+        dashboard: DashboardConfig {
+            follow_focused_terminal: raw
+                .dashboard
+                .unwrap_or_default()
+                .follow_focused_terminal
+                .unwrap_or(true),
+        },
     })
 }
 
@@ -266,6 +292,33 @@ mod tests {
         let config = resolve(raw, None).expect("resolved config");
 
         assert_eq!(config.terminal.as_deref(), Some("Alacritty.desktop"));
+    }
+
+    #[test]
+    fn dashboard_follows_focused_terminals_by_default_and_can_be_disabled() {
+        let default = resolve(RawConfig::default(), None).expect("resolved default config");
+        assert!(default.dashboard.follow_focused_terminal);
+
+        let raw: RawConfig =
+            toml::from_str("[dashboard]\nfollow_focused_terminal = false").expect("valid config");
+        let config = resolve(raw, None).expect("resolved config");
+        assert!(!config.dashboard.follow_focused_terminal);
+    }
+
+    #[test]
+    fn dashboard_setting_merges_independently() {
+        let mut base: RawConfig = toml::from_str(
+            "[dashboard]\nfollow_focused_terminal = false\n[projects]\nmax_depth = 2",
+        )
+        .expect("valid base");
+        let next: RawConfig =
+            toml::from_str("[dashboard]\nfollow_focused_terminal = true").expect("valid override");
+
+        merge(&mut base, next);
+        let config = resolve(base, None).expect("resolved config");
+        assert!(config.dashboard.follow_focused_terminal);
+        assert_eq!(config.projects.max_depth, 2);
+        assert!(toml::from_str::<RawConfig>("[dashboard]\nunknown = true").is_err());
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -30,10 +30,10 @@ use crate::handoff;
 use crate::protocol::{
     self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
     AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame,
-    DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, NotificationDeliveryConfig,
-    Request, Response, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus,
-    Snapshot, TerminalProfile, UnixEnvironment, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
-    WorkspaceSnapshot,
+    DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot,
+    NotificationDeliveryConfig, Request, Response, ShellRunExitReason, ShellRunSnapshot,
+    ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalProfile, UnixEnvironment,
+    WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::state_store::{
     PersistedAgentInstance, PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
@@ -183,6 +183,7 @@ pub fn receive_handoff_with_notification_delivery(
             exited,
             event_stream,
             notifications,
+            focused_terminal,
         } => {
             let store = StateStore::from_transferred_lock(state_lock)?;
             let socket_path = client::socket_path()?;
@@ -195,6 +196,7 @@ pub fn receive_handoff_with_notification_delivery(
                     runtimes,
                     exited,
                     events: Some(event_stream),
+                    focused_terminal: focused_terminal.map(|focused| *focused),
                 },
                 Some(&mut channel),
                 notifications
@@ -250,6 +252,7 @@ struct TransferredState {
     runtimes: Vec<handoff::TransferredRuntime>,
     exited: Vec<handoff::TransferredExited>,
     events: Option<handoff::EventStreamManifest>,
+    focused_terminal: Option<FocusedTerminalSnapshot>,
 }
 
 fn run_daemon(
@@ -266,6 +269,7 @@ fn run_daemon(
     registry.notification_sink = Arc::new(DesktopNotificationSink::new(notification_settings));
     let registry = Arc::new(registry);
     let gated_readers = registry.import_handoff(transferred.runtimes, transferred.exited)?;
+    registry.import_focused_terminal(transferred.focused_terminal)?;
     if let Some(channel) = committed {
         {
             let _transition = lock(&registry.transitions)?;
@@ -559,6 +563,7 @@ fn launch_replacement(
             registry.events.changed.notify_all();
         }
         let state_lock = registry.state_lock_descriptor()?;
+        let focused_terminal = registry.focused_terminal_for_handoff()?;
         launch_replacement_process(
             listener.as_fd(),
             daemon_lock.as_fd(),
@@ -566,7 +571,10 @@ fn launch_replacement(
             &transfers,
             &exited,
             &event_stream,
-            notification_settings,
+            ReplacementOptions {
+                focused_terminal,
+                notification_settings,
+            },
         )
     })();
     if result.is_err() {
@@ -578,6 +586,11 @@ fn launch_replacement(
     result
 }
 
+struct ReplacementOptions {
+    focused_terminal: Option<FocusedTerminalSnapshot>,
+    notification_settings: Option<NotificationDeliverySettings>,
+}
+
 fn launch_replacement_process(
     listener: BorrowedFd<'_>,
     runtime_lock: BorrowedFd<'_>,
@@ -585,8 +598,12 @@ fn launch_replacement_process(
     runtimes: &[OutgoingRuntime],
     exited: &[OutgoingExited],
     event_stream: &handoff::EventStreamManifest,
-    notification_settings: Option<NotificationDeliverySettings>,
+    options: ReplacementOptions,
 ) -> io::Result<()> {
+    let ReplacementOptions {
+        focused_terminal,
+        notification_settings,
+    } = options;
     let (mut channel, child_channel) = UnixStream::pair()?;
     let child_channel_fd = child_channel.as_raw_fd();
     let mut command = Command::new(replacement_executable()?);
@@ -628,6 +645,7 @@ fn launch_replacement_process(
                 exited: exited.iter().map(|shell| shell.manifest.clone()).collect(),
                 event_stream: event_stream.clone(),
                 notifications: notification_settings.map(Into::into),
+                focused_terminal,
             },
         )?;
         send_descriptor(&channel, listener, handoff::LISTENER_MARKER)?;
@@ -883,6 +901,9 @@ fn unsupported_request_message(request: &Request, minimum_version: u32) -> Strin
 
 fn response_for_version(response: Response, version: u32) -> Response {
     let mut response = response;
+    if version < 18 {
+        remove_focused_terminal(&mut response);
+    }
     if version < 15 {
         remove_agent_attention(&mut response);
         if let Response::Events { events, .. } = &mut response {
@@ -947,6 +968,17 @@ fn response_for_version(response: Response, version: u32) -> Response {
             }
         }
         response => response,
+    }
+}
+
+fn remove_focused_terminal(response: &mut Response) {
+    match response {
+        Response::Snapshot { snapshot } => snapshot.focused_terminal = None,
+        Response::Events {
+            snapshot: Some(snapshot),
+            ..
+        } => snapshot.focused_terminal = None,
+        _ => {}
     }
 }
 
@@ -1064,6 +1096,7 @@ fn coded_error(code: ErrorCode, message: impl Into<String>) -> io::Error {
 
 struct Registry {
     state: Mutex<RegistryState>,
+    focus: Mutex<FocusState>,
     store: Option<StateStore>,
     events: EventLog,
     transitions: Mutex<TransitionState>,
@@ -1073,6 +1106,12 @@ struct Registry {
     persistence_dirty: AtomicBool,
     notification_settings: NotificationDeliverySettings,
     notification_sink: Arc<dyn NotificationSink>,
+}
+
+#[derive(Default)]
+struct FocusState {
+    revision: u64,
+    focused_terminal: Option<FocusedTerminalSnapshot>,
 }
 
 enum DurableMutation<T> {
@@ -1205,6 +1244,7 @@ impl Default for Registry {
     fn default() -> Self {
         Self {
             state: Mutex::new(RegistryState::default()),
+            focus: Mutex::new(FocusState::default()),
             store: None,
             events: EventLog::new(),
             transitions: Mutex::new(TransitionState::default()),
@@ -2225,6 +2265,7 @@ impl Registry {
         }
         let registry = Self {
             state: Mutex::new(state),
+            focus: Mutex::new(FocusState::default()),
             store: Some(store),
             events: EventLog::from_transfer(transferred_events),
             transitions: Mutex::new(TransitionState::default()),
@@ -2929,7 +2970,112 @@ impl Registry {
                 .into_iter()
                 .map(|workspace| workspace.snapshot(self))
                 .collect::<io::Result<_>>()?,
+            focused_terminal: self.focused_terminal()?,
         })
+    }
+
+    fn focused_terminal(&self) -> io::Result<Option<FocusedTerminalSnapshot>> {
+        let focused = lock(&self.focus)?.focused_terminal.clone();
+        let Some(focused) = focused else {
+            return Ok(None);
+        };
+        Ok(self.focus_target_is_current(&focused)?.then_some(focused))
+    }
+
+    fn focused_terminal_for_handoff(&self) -> io::Result<Option<FocusedTerminalSnapshot>> {
+        Ok(lock(&self.focus)?.focused_terminal.clone())
+    }
+
+    fn focus_target_is_current(&self, focused: &FocusedTerminalSnapshot) -> io::Result<bool> {
+        let state = lock(&self.state)?;
+        let Some(shell) = state.shells.get(&focused.shell_id) else {
+            return Ok(false);
+        };
+        if shell.workspace_id != focused.workspace_id {
+            return Ok(false);
+        }
+        let lifecycle = lock(&shell.lifecycle)?;
+        let current_run_id = match &*lifecycle {
+            ShellLifecycle::Running { run, .. } | ShellLifecycle::Exited { run, .. } => &run.id,
+            ShellLifecycle::Pending | ShellLifecycle::Closed => return Ok(false),
+        };
+        Ok(current_run_id == &focused.run_id)
+    }
+
+    fn record_focus_gained(
+        &self,
+        protocol_version: u32,
+        shell: &Arc<Shell>,
+        run: &Arc<ShellRun>,
+        runtime: &Arc<ShellRuntime>,
+    ) -> io::Result<()> {
+        if protocol_version < 18 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "focus frames require daemon protocol 18",
+            ));
+        }
+        let state = lock(&self.state)?;
+        if !state
+            .shells
+            .get(&shell.id)
+            .is_some_and(|current| Arc::ptr_eq(current, shell))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "focus frame targets a stale shell",
+            ));
+        }
+        let lifecycle = lock(&shell.lifecycle)?;
+        let ShellLifecycle::Running {
+            run: current_run,
+            runtime: current_runtime,
+            ..
+        } = &*lifecycle
+        else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "focus frame targets a shell that is not running",
+            ));
+        };
+        if !Arc::ptr_eq(current_run, run) || !Arc::ptr_eq(current_runtime, runtime) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "focus frame targets a stale shell run",
+            ));
+        }
+        let mut focus = lock(&self.focus)?;
+        let revision = focus
+            .revision
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("focused terminal revision exhausted"))?;
+        focus.revision = revision;
+        focus.focused_terminal = Some(FocusedTerminalSnapshot {
+            revision,
+            workspace_id: shell.workspace_id.clone(),
+            shell_id: shell.id.clone(),
+            run_id: current_run.id.clone(),
+        });
+        Ok(())
+    }
+
+    fn import_focused_terminal(
+        &self,
+        focused_terminal: Option<FocusedTerminalSnapshot>,
+    ) -> io::Result<()> {
+        let Some(focused_terminal) = focused_terminal else {
+            return Ok(());
+        };
+        if focused_terminal.revision == 0 {
+            return Ok(());
+        }
+        let current = self.focus_target_is_current(&focused_terminal)?;
+        let mut focus = lock(&self.focus)?;
+        if focused_terminal.revision >= focus.revision {
+            focus.revision = focused_terminal.revision;
+            focus.focused_terminal = current.then_some(focused_terminal);
+        }
+        Ok(())
     }
 
     fn shutdown(&self) -> io::Result<()> {
@@ -4626,7 +4772,7 @@ fn handle_attach(
     } else {
         false
     };
-    let (runtime, terminal, startup_profile, running, started) = {
+    let (attached_run, runtime, terminal, startup_profile, running, started) = {
         let mut lifecycle = lock(&shell.lifecycle)?;
         let mut started = false;
         if !registry.contains_shell(&shell)? {
@@ -4703,8 +4849,11 @@ fn handle_attach(
         }
         match &*lifecycle {
             ShellLifecycle::Running {
-                profile, runtime, ..
+                profile,
+                run,
+                runtime,
             } => (
+                Some(Arc::clone(run)),
                 Some(Arc::clone(runtime)),
                 Arc::clone(&runtime.terminal),
                 profile.clone(),
@@ -4713,7 +4862,14 @@ fn handle_attach(
             ),
             ShellLifecycle::Exited {
                 profile, terminal, ..
-            } => (None, Arc::clone(terminal), profile.clone(), false, started),
+            } => (
+                None,
+                None,
+                Arc::clone(terminal),
+                profile.clone(),
+                false,
+                started,
+            ),
             ShellLifecycle::Pending => unreachable!(),
             ShellLifecycle::Closed => {
                 return send_response(
@@ -4787,6 +4943,7 @@ fn handle_attach(
         return AttachFrame::Detached.write_to(&mut stream);
     }
     drop(mutation);
+    let attached_run = attached_run.expect("running shell has a run");
     let runtime = runtime.expect("running shell has a runtime");
     let control = lock(&runtime.control)?;
     if !registry.contains_shell(&shell)? {
@@ -4948,6 +5105,9 @@ fn handle_attach(
             AttachFrame::Detached => {
                 drop(control);
                 break;
+            }
+            AttachFrame::FocusGained => {
+                registry.record_focus_gained(response_version, &shell, &attached_run, &runtime)
             }
             AttachFrame::Output(_) | AttachFrame::Reconnect | AttachFrame::ReconnectAck => {
                 Err(io::Error::new(
@@ -5559,6 +5719,68 @@ mod tests {
                 .workspaces
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn focus_reports_require_protocol_eighteen_and_increment_revision() {
+        let registry = Registry::default();
+        let (_workspace, shell, runtime) = running_shell(&registry);
+        let run = match &*lock(&shell.lifecycle).unwrap() {
+            ShellLifecycle::Running { run, .. } => Arc::clone(run),
+            _ => panic!("expected running shell"),
+        };
+
+        assert!(
+            registry
+                .record_focus_gained(17, &shell, &run, &runtime)
+                .is_err()
+        );
+        assert!(registry.snapshot().unwrap().focused_terminal.is_none());
+
+        registry
+            .record_focus_gained(18, &shell, &run, &runtime)
+            .unwrap();
+        registry
+            .record_focus_gained(18, &shell, &run, &runtime)
+            .unwrap();
+
+        let focused = registry.snapshot().unwrap().focused_terminal.unwrap();
+        assert_eq!(focused.revision, 2);
+        assert_eq!(focused.workspace_id, shell.workspace_id);
+        assert_eq!(focused.shell_id, shell.id);
+        let lifecycle = lock(&shell.lifecycle).unwrap();
+        let ShellLifecycle::Running { run, .. } = &*lifecycle else {
+            panic!("expected running shell");
+        };
+        assert_eq!(focused.run_id, run.id);
+        drop(lifecycle);
+
+        *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
+            profile: profile(),
+            run: Arc::new(ShellRun::new(2)),
+            runtime: Arc::clone(&runtime),
+        };
+        assert!(registry.snapshot().unwrap().focused_terminal.is_none());
+
+        lock(&registry.state).unwrap().shells.remove(&shell.id);
+        assert!(registry.snapshot().unwrap().focused_terminal.is_none());
+    }
+
+    #[test]
+    fn stale_handoff_focus_target_is_not_imported() {
+        let registry = Registry::default();
+
+        registry
+            .import_focused_terminal(Some(FocusedTerminalSnapshot {
+                revision: 9,
+                workspace_id: "missing-workspace".into(),
+                shell_id: "missing-shell".into(),
+                run_id: "missing-run".into(),
+            }))
+            .unwrap();
+
+        assert!(registry.snapshot().unwrap().focused_terminal.is_none());
+        assert_eq!(lock(&registry.focus).unwrap().revision, 9);
     }
 
     #[test]
@@ -6960,6 +7182,7 @@ mod tests {
             },
             snapshot: Some(Snapshot {
                 workspaces: vec![workspace],
+                focused_terminal: None,
             }),
             events: vec![
                 DaemonEvent {
@@ -7001,6 +7224,26 @@ mod tests {
         let encoded =
             serde_json::to_value(response_for_version(Response::Snapshot { snapshot }, 8)).unwrap();
         assert!(encoded["snapshot"]["workspaces"][0].get("agents").is_none());
+    }
+
+    #[test]
+    fn protocol_seventeen_responses_hide_focused_terminal() {
+        let response = Response::Snapshot {
+            snapshot: Snapshot {
+                workspaces: Vec::new(),
+                focused_terminal: Some(FocusedTerminalSnapshot {
+                    revision: 1,
+                    workspace_id: "w1".into(),
+                    shell_id: "s1".into(),
+                    run_id: "r1".into(),
+                }),
+            },
+        };
+
+        let Response::Snapshot { snapshot } = response_for_version(response, 17) else {
+            panic!("expected snapshot response");
+        };
+        assert!(snapshot.focused_terminal.is_none());
     }
 
     #[test]
@@ -7095,6 +7338,7 @@ mod tests {
                 },
                 snapshot: Some(Snapshot {
                     workspaces: vec![workspace],
+                    focused_terminal: None,
                 }),
                 events: vec![DaemonEvent {
                     id: 1,
@@ -7163,6 +7407,7 @@ mod tests {
                     launchers: Vec::new(),
                     agents: vec![agent.clone()],
                 }],
+                focused_terminal: None,
             }),
             events: vec![DaemonEvent {
                 id: 2,

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::client;
 use crate::fd_transfer::receive_descriptor;
-use crate::protocol::{self, DaemonEvent, NotificationDeliveryConfig, TerminalProfile};
+use crate::protocol::{
+    self, DaemonEvent, FocusedTerminalSnapshot, NotificationDeliveryConfig, TerminalProfile,
+};
 use crate::state_store;
 
 const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
@@ -35,6 +37,8 @@ pub(crate) struct Manifest {
     pub(crate) event_stream: EventStreamManifest,
     #[serde(default)]
     pub(crate) notifications: Option<NotificationDeliveryConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) focused_terminal: Option<FocusedTerminalSnapshot>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -87,6 +91,7 @@ pub(crate) enum Bootstrap {
         exited: Vec<TransferredExited>,
         event_stream: EventStreamManifest,
         notifications: Option<NotificationDeliveryConfig>,
+        focused_terminal: Option<Box<FocusedTerminalSnapshot>>,
     },
 }
 
@@ -106,6 +111,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
     validate_manifest(&manifest)?;
     let event_stream = manifest.event_stream.clone();
     let notifications = manifest.notifications.clone();
+    let focused_terminal = manifest.focused_terminal.clone().map(Box::new);
     let listener = receive_descriptor(&channel, LISTENER_MARKER)?;
     let runtime_lock = receive_descriptor(&channel, RUNTIME_LOCK_MARKER)?;
     let state_lock = receive_descriptor(&channel, STATE_LOCK_MARKER)?;
@@ -174,6 +180,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             exited,
             event_stream,
             notifications,
+            focused_terminal,
         }),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -385,4 +392,52 @@ fn validate_lock(descriptor: &OwnedFd, path: &Path) -> io::Result<()> {
         return Err(io::Error::last_os_error());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event_stream() -> EventStreamManifest {
+        EventStreamManifest {
+            stream_id: uuid::Uuid::new_v4().to_string(),
+            latest_id: 0,
+            events: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn old_manifest_defaults_focused_terminal() {
+        let manifest: Manifest = serde_json::from_value(serde_json::json!({
+            "runtimes": [],
+            "exited": [],
+            "event_stream": event_stream(),
+            "notifications": null
+        }))
+        .unwrap();
+
+        assert!(manifest.focused_terminal.is_none());
+    }
+
+    #[test]
+    fn manifest_round_trips_focused_terminal() {
+        let focused_terminal = FocusedTerminalSnapshot {
+            revision: 4,
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+            run_id: "r1".into(),
+        };
+        let manifest = Manifest {
+            runtimes: Vec::new(),
+            exited: Vec::new(),
+            event_stream: event_stream(),
+            notifications: None,
+            focused_terminal: Some(focused_terminal.clone()),
+        };
+
+        let decoded: Manifest =
+            serde_json::from_value(serde_json::to_value(manifest).unwrap()).unwrap();
+
+        assert_eq!(decoded.focused_terminal, Some(focused_terminal));
+    }
 }

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -1303,6 +1303,7 @@ mod tests {
         };
         let snapshot = Snapshot {
             workspaces: vec![workspace.clone()],
+            focused_terminal: None,
         };
         assert_eq!(
             inspect_runtime(IntegrationId::Opencode.spec(), Some(&snapshot)).state,
@@ -1332,6 +1333,7 @@ mod tests {
         });
         let snapshot = Snapshot {
             workspaces: vec![workspace.clone()],
+            focused_terminal: None,
         };
         assert_eq!(
             verification_targets(&snapshot, IntegrationId::Opencode, None),
@@ -1359,6 +1361,7 @@ mod tests {
         workspace.agents[0].observation.authority = AgentAuthority::ProcessAdapter;
         let snapshot = Snapshot {
             workspaces: vec![workspace],
+            focused_terminal: None,
         };
         assert_eq!(
             inspect_runtime(IntegrationId::Opencode.spec(), Some(&snapshot)).state,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@ mod fd_transfer;
 mod handoff;
 pub mod protocol;
 mod state_store;
+mod terminal_focus;
 mod terminal_state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,8 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "protocol_15",
     "protocol_16",
     "protocol_17",
+    "protocol_18",
+    "focused_terminal_following",
     "restartable_exited_shells",
     "inactive_agent_state",
     "idempotent_agent_ensure",
@@ -1047,11 +1049,9 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let mut git_cache = git::Cache::default();
     let mut title_cache = host_session_titles::Cache::default();
-    let mut views = dashboard_views_with_catalog(
-        &client.snapshot()?.workspaces,
-        &mut git_cache,
-        &mut title_cache,
-    );
+    let snapshot = client.snapshot()?;
+    let mut views =
+        dashboard_views_with_catalog(&snapshot.workspaces, &mut git_cache, &mut title_cache);
     enrich_session_titles(&mut views, &mut title_cache);
     let config = config::load()?;
     let terminal = terminal_override
@@ -1076,7 +1076,11 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     };
 
     tui::run(
-        views,
+        tui::DashboardState {
+            workspaces: views,
+            focused_terminal: snapshot.focused_terminal.map(focused_terminal_view),
+        },
+        config.dashboard.follow_focused_terminal,
         project_context,
         tui::Actions {
             on_restore: |workspace_id: &str| {
@@ -1184,7 +1188,10 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     &mut title_cache,
                 );
                 enrich_session_titles(&mut views, &mut title_cache);
-                Ok(views)
+                Ok(tui::DashboardState {
+                    workspaces: views,
+                    focused_terminal: snapshot.focused_terminal.map(focused_terminal_view),
+                })
             },
             on_terminal_preview: |shell_id: &str| {
                 let bytes = client
@@ -1195,6 +1202,14 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
         },
     )?;
     Ok(())
+}
+
+fn focused_terminal_view(focused: protocol::FocusedTerminalSnapshot) -> tui::FocusedTerminalView {
+    tui::FocusedTerminalView {
+        revision: focused.revision,
+        workspace_id: focused.workspace_id,
+        shell_id: focused.shell_id,
+    }
 }
 
 fn dispatch_dashboard_open<S, L>(
@@ -4877,6 +4892,7 @@ mod tests {
 
         let value = json_snapshot(Snapshot {
             workspaces: vec![project],
+            focused_terminal: None,
         })
         .unwrap();
 
@@ -4893,6 +4909,7 @@ mod tests {
         project.launchers.push(launcher("l1", "w1", "editor"));
         let snapshot = Snapshot {
             workspaces: vec![workspace("w2", "w1", vec![]), project],
+            focused_terminal: None,
         };
 
         assert_eq!(
@@ -4939,6 +4956,7 @@ mod tests {
                 workspace("w1", "one", vec![shell("s1", "w1", "tests")]),
                 workspace("w2", "two", vec![shell("s2", "w2", "tests")]),
             ],
+            focused_terminal: None,
         };
         assert_eq!(
             resolve_shell_target(&snapshot, None, "s2").unwrap().id,
@@ -5740,6 +5758,7 @@ mod tests {
                 workspace("w2", "Zeta", vec![shell("s2", "w2", "backend")]),
                 workspace("w1", "Alpha", vec![shell("s1", "w1", "frontend")]),
             ],
+            focused_terminal: None,
         };
         let targets = vec![
             integration_management::VerificationTarget {
@@ -5977,7 +5996,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 17);
+        assert_eq!(protocol::PROTOCOL_VERSION, 18);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 17;
+pub const PROTOCOL_VERSION: u32 = 18;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -31,6 +31,16 @@ impl<T> Envelope<T> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Snapshot {
     pub workspaces: Vec<WorkspaceSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub focused_terminal: Option<FocusedTerminalSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FocusedTerminalSnapshot {
+    pub revision: u64,
+    pub workspace_id: String,
+    pub shell_id: String,
+    pub run_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -599,6 +609,7 @@ pub enum AttachFrame {
     Detached,
     Reconnect,
     ReconnectAck,
+    FocusGained,
 }
 
 impl AttachFrame {
@@ -608,6 +619,7 @@ impl AttachFrame {
     const DETACHED: u8 = 4;
     const RECONNECT: u8 = 5;
     const RECONNECT_ACK: u8 = 6;
+    const FOCUS_GAINED: u8 = 7;
 
     pub fn write_to(&self, writer: &mut impl Write) -> io::Result<()> {
         let (kind, payload): (u8, &[u8]) = match self {
@@ -629,6 +641,7 @@ impl AttachFrame {
             Self::Detached => (Self::DETACHED, &[]),
             Self::Reconnect => (Self::RECONNECT, &[]),
             Self::ReconnectAck => (Self::RECONNECT_ACK, &[]),
+            Self::FocusGained => (Self::FOCUS_GAINED, &[]),
         };
         if payload.len() > MAX_ATTACH_FRAME {
             return Err(io::Error::new(
@@ -667,6 +680,7 @@ impl AttachFrame {
             Self::DETACHED if payload.is_empty() => Ok(Self::Detached),
             Self::RECONNECT if payload.is_empty() => Ok(Self::Reconnect),
             Self::RECONNECT_ACK if payload.is_empty() => Ok(Self::ReconnectAck),
+            Self::FOCUS_GAINED if payload.is_empty() => Ok(Self::FocusGained),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "invalid attach frame",
@@ -911,9 +925,16 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_seventeen_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 17);
+    fn protocol_version_is_eighteen_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 18);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
+    }
+
+    #[test]
+    fn old_snapshot_defaults_focused_terminal() {
+        let snapshot: Snapshot = serde_json::from_str(r#"{"workspaces":[]}"#).unwrap();
+
+        assert_eq!(snapshot.focused_terminal, None);
     }
 
     #[test]
@@ -1368,6 +1389,7 @@ mod tests {
             AttachFrame::Detached,
             AttachFrame::Reconnect,
             AttachFrame::ReconnectAck,
+            AttachFrame::FocusGained,
         ];
         for frame in frames {
             let mut bytes = Vec::new();
@@ -1377,6 +1399,9 @@ mod tests {
                 frame
             );
         }
+        let mut bytes = Vec::new();
+        AttachFrame::FocusGained.write_to(&mut bytes).unwrap();
+        assert_eq!(bytes, [7, 0, 0, 0, 0]);
     }
 
     #[test]

--- a/src/terminal_focus.rs
+++ b/src/terminal_focus.rs
@@ -1,0 +1,88 @@
+const ENABLE_FOCUS_REPORTING: &[u8] = b"\x1b[?1004h";
+
+#[derive(Default)]
+pub(crate) struct FocusMode {
+    enabled: bool,
+    state: ParseState,
+    parameters: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Default)]
+enum ParseState {
+    #[default]
+    Normal,
+    Escape,
+    Csi,
+    Private,
+}
+
+impl FocusMode {
+    pub(crate) fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub(crate) fn process(&mut self, bytes: &[u8]) -> bool {
+        let mut disabled = false;
+        for byte in bytes {
+            self.state = match self.state {
+                ParseState::Normal if *byte == 0x1b => ParseState::Escape,
+                ParseState::Normal => ParseState::Normal,
+                ParseState::Escape if *byte == b'[' => ParseState::Csi,
+                ParseState::Escape if *byte == 0x1b => ParseState::Escape,
+                ParseState::Escape => ParseState::Normal,
+                ParseState::Csi if *byte == b'?' => {
+                    self.parameters.clear();
+                    ParseState::Private
+                }
+                ParseState::Csi if *byte == 0x1b => ParseState::Escape,
+                ParseState::Csi => ParseState::Normal,
+                ParseState::Private if byte.is_ascii_digit() || *byte == b';' => {
+                    if self.parameters.len() < 128 {
+                        self.parameters.push(*byte);
+                        ParseState::Private
+                    } else {
+                        ParseState::Normal
+                    }
+                }
+                ParseState::Private if matches!(*byte, b'h' | b'l') => {
+                    if self
+                        .parameters
+                        .split(|parameter| *parameter == b';')
+                        .any(|parameter| parameter == b"1004")
+                    {
+                        self.enabled = *byte == b'h';
+                        disabled |= !self.enabled;
+                    }
+                    ParseState::Normal
+                }
+                ParseState::Private if *byte == 0x1b => ParseState::Escape,
+                ParseState::Private => ParseState::Normal,
+            };
+        }
+        disabled
+    }
+
+    pub(crate) fn restore_sequence(&self) -> &'static [u8] {
+        if self.enabled {
+            ENABLE_FOCUS_REPORTING
+        } else {
+            &[]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracks_split_and_combined_focus_mode_changes() {
+        let mut mode = FocusMode::default();
+
+        assert!(!mode.process(b"\x1b[?10"));
+        assert!(!mode.process(b"04;2004h"));
+        assert!(mode.enabled());
+        assert!(mode.process(b"\x1b[?1004;2004l"));
+        assert!(!mode.enabled());
+    }
+}

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -1,9 +1,12 @@
+use crate::terminal_focus::FocusMode;
+
 const SCROLLBACK_ROWS: usize = 2_000;
 const MAX_RECONSTRUCTION_BYTES: usize = 1024 * 1024;
 
 pub(crate) struct TerminalState {
     parser: vt100::Parser,
     primary_before_alternate: Option<vt100::Screen>,
+    focus_mode: FocusMode,
 }
 
 impl TerminalState {
@@ -12,10 +15,12 @@ impl TerminalState {
         Self {
             parser,
             primary_before_alternate: None,
+            focus_mode: FocusMode::default(),
         }
     }
 
     pub(crate) fn process(&mut self, bytes: &[u8]) {
+        self.focus_mode.process(bytes);
         let was_alternate = self.parser.screen().alternate_screen();
         if !was_alternate && let Some(offset) = alternate_screen_start(bytes) {
             self.parser.process(&bytes[..offset]);
@@ -51,6 +56,7 @@ impl TerminalState {
             output.extend(screen.contents_formatted());
         }
         output.extend(screen.input_mode_formatted());
+        output.extend(self.focus_mode.restore_sequence());
         if output.len() <= MAX_RECONSTRUCTION_BYTES {
             return output;
         }
@@ -60,9 +66,13 @@ impl TerminalState {
             fallback.extend_from_slice(b"\x1b[?1049h\x1b[H\x1b[2J");
         }
         let suffix = state_suffix(screen);
-        let text_limit = MAX_RECONSTRUCTION_BYTES.saturating_sub(suffix.len());
+        let focus_mode = self.focus_mode.restore_sequence();
+        let text_limit = MAX_RECONSTRUCTION_BYTES
+            .saturating_sub(suffix.len())
+            .saturating_sub(focus_mode.len());
         append_terminal_text_bounded(&mut fallback, &screen.contents(), text_limit);
         fallback.extend(suffix);
+        fallback.extend(focus_mode);
         fallback
     }
 
@@ -171,6 +181,21 @@ mod tests {
         assert!(!reconstruction.windows(2).any(|bytes| bytes == b"\x1b]"));
         assert!(!String::from_utf8_lossy(&reconstruction).contains("Y2xpcGJvYXJk"));
         assert_eq!(state.plain_text(), "beforeafter");
+    }
+
+    #[test]
+    fn reconstruction_restores_child_focus_mode() {
+        let mut state = TerminalState::new(4, 40);
+        state.process(b"\x1b[?1004h");
+        assert!(state.reconstruction().ends_with(b"\x1b[?1004h"));
+
+        state.process(b"\x1b[?1004;2004l");
+        assert!(
+            !state
+                .reconstruction()
+                .windows(8)
+                .any(|bytes| bytes == b"\x1b[?1004h")
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -37,6 +37,18 @@ pub(crate) struct WorkspaceView {
     pub(crate) attention: Vec<WorkspaceAttentionView>,
 }
 
+pub(crate) struct DashboardState {
+    pub(crate) workspaces: Vec<WorkspaceView>,
+    pub(crate) focused_terminal: Option<FocusedTerminalView>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FocusedTerminalView {
+    pub(crate) revision: u64,
+    pub(crate) workspace_id: String,
+    pub(crate) shell_id: String,
+}
+
 pub(crate) struct WorkspaceAttentionView {
     pub(crate) shell_id: String,
     pub(crate) agent_name: String,
@@ -267,6 +279,8 @@ struct App {
     pending_close: Option<PendingClose>,
     project_context: ProjectContext,
     terminal_preview: Option<TerminalPreviewState>,
+    follow_focused_terminal: bool,
+    observed_focus_revision: Option<u64>,
 }
 
 struct TerminalPreviewState {
@@ -863,7 +877,54 @@ impl App {
             pending_close: None,
             project_context,
             terminal_preview: None,
+            follow_focused_terminal: false,
+            observed_focus_revision: None,
         }
+    }
+
+    fn enable_focus_following(&mut self, focused_terminal: Option<&FocusedTerminalView>) {
+        self.follow_focused_terminal = true;
+        self.apply_focused_terminal(focused_terminal);
+    }
+
+    fn apply_focused_terminal(&mut self, focused_terminal: Option<&FocusedTerminalView>) {
+        if !self.follow_focused_terminal {
+            return;
+        }
+        let Some(focused) = focused_terminal else {
+            self.observed_focus_revision = None;
+            return;
+        };
+        if self
+            .observed_focus_revision
+            .is_some_and(|revision| revision >= focused.revision)
+        {
+            return;
+        }
+        if !matches!(self.mode, Mode::Normal) || self.pending_close.is_some() {
+            return;
+        }
+        let Some(workspace_index) = self
+            .workspaces
+            .iter()
+            .position(|workspace| workspace.id == focused.workspace_id)
+        else {
+            return;
+        };
+        let Some(item_index) = self.workspaces[workspace_index]
+            .items
+            .iter()
+            .position(|item| {
+                !matches!(item, WorkspaceItemView::Launcher(_)) && item.id() == focused.shell_id
+            })
+        else {
+            return;
+        };
+        self.observed_focus_revision = Some(focused.revision);
+        self.select_tab(PrimaryTab::Workspaces);
+        self.workspace_state.select(Some(workspace_index));
+        self.item_state.select(Some(item_index));
+        self.set_focus(Focus::Items);
     }
 
     fn selected_index(&self) -> Option<usize> {
@@ -1247,10 +1308,13 @@ impl App {
 
     fn refresh<F>(&mut self, on_refresh: &mut F)
     where
-        F: FnMut() -> Result<Vec<WorkspaceView>, String>,
+        F: FnMut() -> Result<DashboardState, String>,
     {
         match on_refresh() {
-            Ok(workspaces) => self.replace_workspaces(workspaces),
+            Ok(state) => {
+                self.replace_workspaces(state.workspaces);
+                self.apply_focused_terminal(state.focused_terminal.as_ref());
+            }
             Err(text) => self.message = Some(Message { text, error: true }),
         }
     }
@@ -1485,7 +1549,8 @@ fn item_pending_close(item: &WorkspaceItemView) -> PendingClose {
 }
 
 pub(crate) fn run<R, O, C, W, N, E, F, P>(
-    workspaces: Vec<WorkspaceView>,
+    state: DashboardState,
+    follow_focused_terminal: bool,
     project_context: ProjectContext,
     actions: Actions<R, O, C, W, N, E, F, P>,
 ) -> io::Result<()>
@@ -1496,15 +1561,15 @@ where
     W: FnMut(&str) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
-    F: FnMut() -> Result<Vec<WorkspaceView>, String>,
+    F: FnMut() -> Result<DashboardState, String>,
     P: FnMut(&str) -> Result<String, String>,
 {
     let mut terminal = ratatui::init();
-    let result = run_loop(
-        &mut terminal,
-        App::new(workspaces, project_context),
-        actions,
-    );
+    let mut app = App::new(state.workspaces, project_context);
+    if follow_focused_terminal {
+        app.enable_focus_following(state.focused_terminal.as_ref());
+    }
+    let result = run_loop(&mut terminal, app, actions);
     ratatui::restore();
     result
 }
@@ -1521,7 +1586,7 @@ where
     W: FnMut(&str) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
-    F: FnMut() -> Result<Vec<WorkspaceView>, String>,
+    F: FnMut() -> Result<DashboardState, String>,
     P: FnMut(&str) -> Result<String, String>,
 {
     let mut last_refresh = Instant::now();
@@ -1656,7 +1721,7 @@ where
     W: FnMut(&str) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
-    F: FnMut() -> Result<Vec<WorkspaceView>, String>,
+    F: FnMut() -> Result<DashboardState, String>,
     P: FnMut(&str) -> Result<String, String>,
 {
     match command {
@@ -3205,6 +3270,14 @@ mod tests {
         }
     }
 
+    fn set_shell_id(workspace: &mut WorkspaceView, shell_id: &str) {
+        match &mut workspace.items[0] {
+            WorkspaceItemView::Shell(shell) => shell.id = shell_id.into(),
+            WorkspaceItemView::AgentShell(agent) => agent.shell.id = shell_id.into(),
+            WorkspaceItemView::Launcher(_) => panic!("expected shell item"),
+        }
+    }
+
     fn agent() -> AgentView {
         AgentView {
             state: "working".into(),
@@ -3269,8 +3342,125 @@ mod tests {
         Ok(String::new())
     }
 
-    fn empty_refresh() -> Result<Vec<WorkspaceView>, String> {
-        Ok(Vec::new())
+    fn empty_refresh() -> Result<DashboardState, String> {
+        Ok(DashboardState {
+            workspaces: Vec::new(),
+            focused_terminal: None,
+        })
+    }
+
+    #[test]
+    fn focus_following_selects_shell_once_per_revision() {
+        let mut one = workspace("w1", "one");
+        set_shell_id(&mut one, "s1");
+        let mut two = workspace("w2", "two");
+        two.items[0] = WorkspaceItemView::AgentShell(agent_shell());
+        set_shell_id(&mut two, "s2");
+        let mut app = App::new(vec![one, two], project_context());
+        let focused = FocusedTerminalView {
+            revision: 1,
+            workspace_id: "w2".into(),
+            shell_id: "s2".into(),
+        };
+
+        app.enable_focus_following(Some(&focused));
+        assert_eq!(
+            app.selected().map(|workspace| workspace.id.as_str()),
+            Some("w2")
+        );
+        assert_eq!(app.selected_item().map(WorkspaceItemView::id), Some("s2"));
+        assert_eq!(app.focus, Focus::Items);
+
+        app.set_focus(Focus::Workspaces);
+        app.previous();
+        assert_eq!(
+            app.selected().map(|workspace| workspace.id.as_str()),
+            Some("w1")
+        );
+        app.apply_focused_terminal(Some(&focused));
+        assert_eq!(
+            app.selected().map(|workspace| workspace.id.as_str()),
+            Some("w1")
+        );
+
+        app.apply_focused_terminal(Some(&FocusedTerminalView {
+            revision: 2,
+            ..focused.clone()
+        }));
+        assert_eq!(
+            app.selected().map(|workspace| workspace.id.as_str()),
+            Some("w2")
+        );
+
+        app.apply_focused_terminal(None);
+        app.apply_focused_terminal(Some(&FocusedTerminalView {
+            revision: 1,
+            workspace_id: "w1".into(),
+            shell_id: "s1".into(),
+        }));
+        assert_eq!(
+            app.selected().map(|workspace| workspace.id.as_str()),
+            Some("w1")
+        );
+    }
+
+    #[test]
+    fn focus_following_can_be_disabled_and_defers_during_overlays() {
+        let mut one = workspace("w1", "one");
+        set_shell_id(&mut one, "s1");
+        let mut two = workspace("w2", "two");
+        set_shell_id(&mut two, "s2");
+        let focused = FocusedTerminalView {
+            revision: 1,
+            workspace_id: "w2".into(),
+            shell_id: "s2".into(),
+        };
+        let mut disabled = App::new(vec![one, two], project_context());
+        disabled.apply_focused_terminal(Some(&focused));
+        assert_eq!(
+            disabled.selected().map(|workspace| workspace.id.as_str()),
+            Some("w1")
+        );
+
+        disabled.enable_focus_following(None);
+        disabled.mode = Mode::Help;
+        disabled.apply_focused_terminal(Some(&focused));
+        assert_eq!(
+            disabled.selected().map(|workspace| workspace.id.as_str()),
+            Some("w1")
+        );
+        assert_eq!(disabled.observed_focus_revision, None);
+        disabled.mode = Mode::Normal;
+        disabled.apply_focused_terminal(Some(&focused));
+        assert_eq!(
+            disabled.selected().map(|workspace| workspace.id.as_str()),
+            Some("w2")
+        );
+    }
+
+    #[test]
+    fn unresolved_focus_revision_is_retried_after_projection_refresh() {
+        let mut one = workspace("w1", "one");
+        set_shell_id(&mut one, "s1");
+        let focused = FocusedTerminalView {
+            revision: 1,
+            workspace_id: "w2".into(),
+            shell_id: "s2".into(),
+        };
+        let mut app = App::new(vec![one], project_context());
+        app.enable_focus_following(Some(&focused));
+        assert_eq!(app.observed_focus_revision, None);
+
+        let mut two = workspace("w2", "two");
+        set_shell_id(&mut two, "s2");
+        app.replace_workspaces(vec![workspace("w1", "one"), two]);
+        app.apply_focused_terminal(Some(&focused));
+
+        assert_eq!(app.observed_focus_revision, Some(1));
+        assert_eq!(
+            app.selected().map(|workspace| workspace.id.as_str()),
+            Some("w2")
+        );
     }
 
     fn hinted_agent_shell() -> AgentShellView {

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -349,6 +349,98 @@ fn replacement_bootstrap_receives_listener_and_lock_ownership() {
 }
 
 #[test]
+fn focused_attachment_is_exposed_in_daemon_snapshots() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "focused-terminal",
+            vec![ShellSpec::login("shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    assert_eq!(attachment.protocol_version, 18);
+
+    AttachFrame::FocusGained
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .snapshot()
+                .unwrap()
+                .focused_terminal
+                .is_some_and(|focused| {
+                    focused.revision == 1
+                        && focused.workspace_id == workspace.id
+                        && focused.shell_id == shell_id
+                })
+        },
+        "daemon did not expose the focused attachment",
+    );
+
+    AttachFrame::FocusGained
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .snapshot()
+                .unwrap()
+                .focused_terminal
+                .is_some_and(|focused| focused.revision == 2)
+        },
+        "repeated focus did not advance the revision",
+    );
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    acknowledge_reconnect(&mut attachment.stream);
+    let restart = restart.wait_with_output().unwrap();
+    assert!(
+        restart.status.success(),
+        "daemon restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    wait_until(
+        || {
+            daemon
+                .client
+                .snapshot()
+                .unwrap()
+                .focused_terminal
+                .is_some_and(|focused| focused.revision == 2 && focused.shell_id == shell_id)
+        },
+        "graceful handoff did not retain focused terminal state",
+    );
+    let mut reattached = wait_for_attach_with_profile(&daemon.client, &shell_id, profile());
+    AttachFrame::FocusGained
+        .write_to(&mut reattached.stream)
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .snapshot()
+                .unwrap()
+                .focused_terminal
+                .is_some_and(|focused| focused.revision == 3)
+        },
+        "focus revision did not continue after graceful handoff",
+    );
+    drop(reattached);
+    drop(attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn native_daemon_recovers_reproducible_metadata_after_restart() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon
@@ -3121,7 +3213,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 17);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 18);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -3168,6 +3260,8 @@ fn native_daemon_lifecycle() {
         "protocol_15",
         "protocol_16",
         "protocol_17",
+        "protocol_18",
+        "focused_terminal_following",
         "inactive_agent_state",
         "protocol_11",
         "restartable_exited_shells",
@@ -3188,7 +3282,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 17"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 18"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])
@@ -3908,6 +4002,7 @@ fn attach_with_environment(
             token,
             reconstruction,
             warning,
+            protocol_version: 16,
         },
         response => panic!("unexpected attach response: {response:?}"),
     }


### PR DESCRIPTION
## Summary
- follow the most recently focused Boomux terminal in the dashboard by default
- add protocol 18 focus reporting with controller authorization and graceful handoff continuity
- multiplex physical terminal focus mode so ordinary shells do not receive synthetic focus escapes
- add `[dashboard] follow_focused_terminal = false` to disable automatic selection

Manual dashboard navigation remains selected until another managed terminal gains focus. Shell and Agent presentations resolve through the same durable shell ID.

## Verification
- `cargo test` (362 tests)
- `bun test integrations` (29 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- deployed release binary and daemon locally; focus following validated across managed terminal windows