### PR TITLE
fix(workspace): preserve project cwd for new shells

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -4,7 +4,7 @@ description: Inspect and manage Boomux persistent terminal workspaces, launchers
 compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; agent mutation and supervision require exact shell-run context, and supervision requires a caller-supplied canonical external session ID.
 metadata:
   author: boomux
-  version: "8"
+  version: "9"
 ---
 
 # Boomux
@@ -347,11 +347,12 @@ boomux "/path/to/project" --terminal "Alacritty.desktop"
 boomux "/path/to/project" -- command arg1 arg2
 ```
 
-Without `--name`, Boomux creates the next generated workspace. With `--name`, it
-adds a shell to an existing exact-name workspace or creates that workspace. A
-command after `--` is an exact executable and argument vector; shell operators
-such as pipes or redirects work only when explicitly passed through a shell,
-for example `-- /bin/sh -lc 'command | command'`.
+Without `--name`, Boomux creates the next generated workspace and stores the
+selected path as its default cwd. With `--name`, it adds a shell to an existing
+exact-name workspace or creates that workspace with the selected path as its
+default. A command after `--` is an exact executable and argument vector; shell
+operators such as pipes or redirects work only when explicitly passed through a
+shell, for example `-- /bin/sh -lc 'command | command'`.
 
 `--terminal` overrides configured terminal selection and implies `--new` for
 path opening. Selection otherwise follows Boomux configuration and then normal
@@ -383,23 +384,27 @@ Boomux reads `$XDG_CONFIG_HOME/boomux/config.toml`, falling back to
 `~/.config/boomux/config.toml`. `BOOMUX_CONFIG` points to an additional
 field-level override loaded last. Configuration controls terminal selection,
 project discovery roots and depth, dashboard focus following, and desktop and
-sound notifications. Unknown fields are rejected. Project roots provide
-dashboard workspace-name suggestions only; they do not bind a workspace to a
-directory. Set `[dashboard] follow_focused_terminal = false` to disable the
-default focus-following behavior.
+sound notifications. Unknown fields are rejected. Selecting a discovered
+project in the dashboard persists its canonical path as the workspace default
+cwd for later shells. Set `[dashboard] follow_focused_terminal = false` to
+disable the default focus-following behavior.
 
 ## Manage Workspaces
 
 ```console
 boomux workspace list
 boomux workspace create "<name>"
+boomux workspace create "<name>" --cwd "/path/to/project"
 boomux workspace open "<name-or-id>"
 boomux workspace inspect "<name-or-id>"
 boomux workspace rename "<name-or-id>" "<new-name>"
 boomux workspace close "<name-or-id>"
 ```
 
-`workspace create` creates an empty workspace. `workspace close` terminates
+`workspace create` creates an empty workspace. `--cwd` stores an optional
+default used by dashboard shells and `shell create` when no explicit cwd is
+given. The default does not prevent individual shells from using other paths.
+`workspace close` terminates
 every running shell process session and removes the workspace, all shell and
 launcher definitions, retained terminal state, and all durable Agent and
 attention records associated with it. Canonical OpenCode or Pi host data is not
@@ -441,11 +446,13 @@ boomux shell rename "<name-or-id>" "<new-name>" --workspace "<workspace-name-or-
 boomux shell close "<name-or-id>" --workspace "<workspace-name-or-id>"
 ```
 
-`shell create` records a pending shell. `--cwd` defaults to the current
-directory. Omit `--name` to let Boomux generate a unique shell name. A shell
-cannot close itself through the CLI. Closing one shell terminates its process
-session and removes its retained terminal state, but durable Agent records
-remain in the workspace as historical occurrences.
+`shell create` records a pending shell. Without `--cwd`, it uses the workspace
+default when present and otherwise the current directory. An unavailable stored
+default is an error rather than a silent fallback. Omit `--name` to let Boomux
+generate a unique shell name. A shell cannot close itself through the CLI.
+Closing one shell terminates its process session and removes its retained
+terminal state, but durable Agent records remain in the workspace as historical
+occurrences.
 
 The contextual close shorthand is:
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ boomux . --name my-project
 ```
 
 `.` selects the current directory. Boomux creates the workspace and shell, then
-connects the current terminal window to that shell. The workspace is identified
-by its name; it is not permanently bound to the directory.
+connects the current terminal window to that shell. The directory becomes the
+workspace default for shells created without an explicit working directory;
+individual shells can still use other directories.
 
 Start a program, then close the terminal window. The process keeps running. From
 a fresh, regular terminal, open the dashboard:
@@ -116,14 +117,16 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | --- | --- |
 | Create a generated workspace | `boomux .` |
 | Create or add to a named workspace | `boomux . --name feature-x` |
+| Create an empty workspace with a default directory | `boomux workspace create feature-x --cwd .` |
 | Open the new shell in another terminal | `boomux . --name feature-x --new` |
 | Run one command | `boomux . --name feature-x --new -- lazygit` |
 | Choose a terminal | `boomux . --terminal Alacritty.desktop` |
 | Open the dashboard | `boomux` or `boomux ui` |
 | Inspect daemon health | `boomux doctor` |
 
-Without `--name`, Boomux creates the next `workspace-N`. With `--name`, it adds
-a shell to an existing exact-name workspace or creates the workspace.
+Without `--name`, Boomux creates the next `workspace-N` and stores the selected
+path as its default for later shells. With `--name`, it adds a shell to an
+existing exact-name workspace or creates a workspace with that default.
 `--terminal` implies `--new`. Terminal selection uses the CLI override, then
 Boomux configuration, then the normal `xdg-terminal-exec` policy.
 
@@ -240,8 +243,10 @@ blocked = "message-new-instant"
 completed = "complete"
 ```
 
-Project roots provide workspace-name suggestions in the dashboard. Selecting a
-suggestion does not bind the workspace to that path.
+Project roots provide workspace suggestions in the dashboard. Selecting one
+stores its path as the workspace default for shells added later. Free-text and
+legacy workspaces without a default continue to use the directory where the
+dashboard was opened. An explicit shell cwd always takes precedence.
 
 The dashboard follows the most recently focused Boomux terminal by default,
 selecting its workspace and shell or Agent row. Manual dashboard navigation is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,8 +36,9 @@ frames for input, output, resize, and detach events.
 
 The domain has five durable identities:
 
-- A workspace is a globally named shell container with a UUID. It has no path
-  or working directory.
+- A workspace is a globally named shell container with a UUID and an optional
+  default working directory for newly created shells. The default is creation
+  behavior, not workspace identity; individual shells may use other paths.
 - A shell is a durable process slot with a name, startup command, explicit
   working directory, and workspace ID.
 - A shell run identifies one process incarnation beneath that durable shell. It
@@ -76,7 +77,8 @@ is restricted to the current user and the socket mode is `0600`.
 
 The daemon supports:
 
-- Empty or explicitly populated workspace creation
+- Empty or explicitly populated workspace creation with an optional shell cwd
+  default
 - Atomic shell creation with an implicit `workspace-N` container when no
   workspace is selected
 - Additional shell creation
@@ -145,10 +147,11 @@ window has spawned, preserving retained output when terminal preparation fails.
 `src/tui.rs` remains a control plane. It receives backend-neutral view models
 and callback functions rather than opening sockets itself. One daemon snapshot
 contains each workspace, its launchers, and its shells, avoiding races between separate list
-operations. Configured project roots provide workspace-name suggestions only.
-Git information is collected independently from shell directories and cached;
-empty or mixed-directory workspaces have no workspace-level directory or Git
-identity.
+operations. Configured project roots provide workspace suggestions; selecting
+one persists its canonical path as the workspace's default cwd. Git information
+is still collected independently from shell directories and cached. A default
+cwd does not create workspace-level Git identity, and mixed-directory
+workspaces remain valid.
 
 Shell snapshots include their additive stored startup argument vector. The
 dashboard presents an empty vector as `shell` and a non-empty vector as

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -87,8 +87,8 @@ Command payloads are:
 - `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`,
   `launcher_count`, `agent_count`, fixed `agent_state_counts`, and
   `attention_count`.
-- `workspace.inspect`: one `workspace` object containing `id`, `name`, and
-  `shells`, `launchers`, and `agents` arrays.
+- `workspace.inspect`: one `workspace` object containing `id`, `name`, nullable
+  `default_cwd`, and `shells`, `launchers`, and `agents` arrays.
 - `shell.inspect`: one `shell` object.
 - `launcher.list`: workspace identity plus a `launchers` array.
 - `launcher.inspect`: one `launcher` object.

--- a/docs/native-terminal-follow-up.md
+++ b/docs/native-terminal-follow-up.md
@@ -34,10 +34,11 @@ consistently in Ghostty, Alacritty, Kitty, and other XDG terminal emulators.
 The current backend reconstructs text VT state but does not claim graphics
 restoration. Running processes survive acknowledged graceful daemon restart;
 an unexpected daemon exit falls back to reproducible metadata recovery.
-Workspace metadata contains only a UUID and name; working directories belong
-exclusively to shells. Dashboard project discovery supplies name suggestions
-and does not persist project paths. A shell request without a selected workspace
-atomically creates the next available `workspace-N` container.
+Workspace metadata contains a UUID, name, and optional default working directory
+for newly created shells. Every shell still stores its own authoritative cwd,
+so mixed-directory workspaces remain valid. Dashboard project discovery persists
+the selected project path as that default. A shell request without a selected
+workspace atomically creates the next available `workspace-N` container.
 
 ## Current Creation Sequence
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,8 +10,9 @@ commitments.
   dashboard.
 - [x] Restore a whole workspace into native terminal windows or open only one
   selected terminal.
-- [x] Create empty named workspaces from free text or searchable project-name
-  suggestions grouped by configured roots, without associating project paths.
+- [x] Create empty named workspaces from free text or searchable project
+  suggestions grouped by configured roots, persisting a selected project's path
+  as the default cwd for later shells.
 - [x] Assign shells created without a workspace to the next available
   `workspace-N` container.
 - [x] Load layered TOML configuration from the XDG config directory and an

--- a/src/agent_attention_projection.rs
+++ b/src/agent_attention_projection.rs
@@ -162,6 +162,7 @@ mod tests {
         WorkspaceSnapshot {
             id: "w1".into(),
             name: "project".into(),
+            default_cwd: None,
             shells: vec![boomux::protocol::ShellSnapshot {
                 id: "s1".into(),
                 workspace_id: "w1".into(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -366,8 +366,18 @@ impl Client {
         name: impl Into<String>,
         shells: Vec<ShellSpec>,
     ) -> io::Result<WorkspaceSnapshot> {
+        self.create_workspace_with_default_cwd(name, None, shells)
+    }
+
+    pub fn create_workspace_with_default_cwd(
+        &self,
+        name: impl Into<String>,
+        default_cwd: Option<PathBuf>,
+        shells: Vec<ShellSpec>,
+    ) -> io::Result<WorkspaceSnapshot> {
         match self.request(Request::CreateWorkspace {
             name: name.into(),
+            default_cwd,
             shells,
         })? {
             Response::Workspace { workspace } => Ok(workspace),
@@ -841,6 +851,22 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 19);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    18,
+                    Response::Error {
+                        message: "protocol 19 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 18);
             assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
@@ -952,7 +978,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 18);
+            assert_eq!(request.version, 19);
             let Request::Attach {
                 environment: Some(environment),
                 ..
@@ -969,7 +995,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    18,
+                    19,
                     Response::Attached {
                         token: "token".into(),
                         reconstruction: Vec::new(),
@@ -999,14 +1025,30 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 18);
+            assert_eq!(request.version, 19);
             assert!(matches!(request.message, Request::Attach { .. }));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    19,
+                    Response::Error {
+                        message: "protocol 19 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 19);
+            assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
                     18,
                     Response::Error {
-                        message: "protocol 18 unsupported".into(),
+                        message: "protocol 19 unsupported".into(),
                         code: Some(ErrorCode::UnsupportedVersion),
                     },
                 ),
@@ -1020,7 +1062,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    18,
+                    17,
                     Response::Error {
                         message: "protocol 18 unsupported".into(),
                         code: Some(ErrorCode::UnsupportedVersion),
@@ -1069,6 +1111,22 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 19);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    18,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 18);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -283,6 +283,9 @@ fn run_daemon(
             handoff::ABORT => return Ok(()),
             handoff::FINALIZE => {
                 socket_cleanup.arm();
+                if registry.persistence_dirty.load(Ordering::Acquire) {
+                    let _ = registry.persist();
+                }
                 registry.publish_runtime_batch(vec![DaemonEventKind::HandoffCompleted])?;
                 for runtime in gated_readers {
                     runtime.resume_reader()?;
@@ -303,6 +306,8 @@ fn run_daemon(
             io::ErrorKind::InvalidData,
             "transferred runtimes require a handoff commit channel",
         ));
+    } else if registry.persistence_dirty.load(Ordering::Acquire) {
+        registry.persist()?;
     }
     let shutdown = Arc::new(AtomicBool::new(false));
     let transition = Arc::new(AtomicU8::new(TRANSITION_IDLE));
@@ -901,6 +906,9 @@ fn unsupported_request_message(request: &Request, minimum_version: u32) -> Strin
 
 fn response_for_version(response: Response, version: u32) -> Response {
     let mut response = response;
+    if version < 19 {
+        remove_workspace_default_cwds(&mut response);
+    }
     if version < 18 {
         remove_focused_terminal(&mut response);
     }
@@ -968,6 +976,26 @@ fn response_for_version(response: Response, version: u32) -> Response {
             }
         }
         response => response,
+    }
+}
+
+fn remove_workspace_default_cwds(response: &mut Response) {
+    match response {
+        Response::Snapshot { snapshot } => {
+            for workspace in &mut snapshot.workspaces {
+                workspace.default_cwd = None;
+            }
+        }
+        Response::Workspace { workspace } => workspace.default_cwd = None,
+        Response::Events {
+            snapshot: Some(snapshot),
+            ..
+        } => {
+            for workspace in &mut snapshot.workspaces {
+                workspace.default_cwd = None;
+            }
+        }
+        _ => {}
     }
 }
 
@@ -1261,6 +1289,7 @@ impl Default for Registry {
 struct Workspace {
     id: String,
     name: Mutex<String>,
+    default_cwd: Option<PathBuf>,
     shell_ids: Mutex<Vec<String>>,
     launcher_ids: Mutex<Vec<String>>,
     agent_ids: Mutex<Vec<String>>,
@@ -1851,8 +1880,13 @@ impl Registry {
                     vec![event],
                 ))
             }),
-            Request::CreateWorkspace { name, shells } => self.durable_mutation(|| {
-                let workspace = self.create_workspace(name, shells)?;
+            Request::CreateWorkspace {
+                name,
+                default_cwd,
+                shells,
+            } => self.durable_mutation(|| {
+                let workspace =
+                    self.create_workspace_with_default_cwd(name, default_cwd, shells)?;
                 let events = workspace_created_events(&workspace);
                 Ok((Response::Workspace { workspace }, events))
             }),
@@ -2141,7 +2175,8 @@ impl Registry {
         live_handoff: bool,
         transferred_events: Option<handoff::EventStreamManifest>,
     ) -> io::Result<Self> {
-        let persisted = store.load()?.unwrap_or_default();
+        let (persisted, migrated) = store.load_deferred()?;
+        let persisted = persisted.unwrap_or_default();
         let mut state = RegistryState::default();
         let mut workspace_names = HashSet::new();
         let mut run_ids = HashSet::new();
@@ -2150,6 +2185,9 @@ impl Registry {
         for saved_workspace in persisted.workspaces {
             validate_id("workspace", &saved_workspace.id)?;
             validate_persisted_name(&saved_workspace.name)?;
+            if let Some(default_cwd) = &saved_workspace.default_cwd {
+                validate_persisted_cwd(default_cwd)?;
+            }
             if !workspace_names.insert(saved_workspace.name.clone())
                 || state.workspaces.contains_key(&saved_workspace.id)
             {
@@ -2257,6 +2295,7 @@ impl Registry {
             let workspace = Arc::new(Workspace {
                 id: saved_workspace.id.clone(),
                 name: Mutex::new(saved_workspace.name),
+                default_cwd: saved_workspace.default_cwd,
                 shell_ids: Mutex::new(shell_ids),
                 launcher_ids: Mutex::new(launcher_ids),
                 agent_ids: Mutex::new(workspace_agent_ids),
@@ -2272,7 +2311,7 @@ impl Registry {
             mutation_lock: Mutex::new(()),
             persist_lock: Mutex::new(()),
             stopping: AtomicBool::new(false),
-            persistence_dirty: AtomicBool::new(false),
+            persistence_dirty: AtomicBool::new(migrated),
             notification_settings: NotificationDeliverySettings::default(),
             notification_sink: Arc::new(DisabledNotificationSink),
         };
@@ -2890,6 +2929,7 @@ impl Registry {
             saved.workspaces.push(PersistedWorkspace {
                 id: workspace.id.clone(),
                 name: lock(&workspace.name)?.clone(),
+                default_cwd: workspace.default_cwd.clone(),
                 shells,
                 launchers,
                 agents,
@@ -3190,12 +3230,25 @@ impl Registry {
             .is_some_and(|current| Arc::ptr_eq(current, shell)))
     }
 
+    #[cfg(test)]
     fn create_workspace(
         &self,
         name: String,
         specs: Vec<ShellSpec>,
     ) -> io::Result<WorkspaceSnapshot> {
+        self.create_workspace_with_default_cwd(name, None, specs)
+    }
+
+    fn create_workspace_with_default_cwd(
+        &self,
+        name: String,
+        default_cwd: Option<PathBuf>,
+        specs: Vec<ShellSpec>,
+    ) -> io::Result<WorkspaceSnapshot> {
         validate_name(&name)?;
+        if let Some(default_cwd) = &default_cwd {
+            validate_cwd(default_cwd)?;
+        }
         let workspace_id = Uuid::new_v4().to_string();
         validate_shell_specs(&specs)?;
 
@@ -3216,6 +3269,7 @@ impl Registry {
         let workspace = Arc::new(Workspace {
             id: workspace_id.clone(),
             name: Mutex::new(name),
+            default_cwd,
             shell_ids: Mutex::new(shells.iter().map(|shell| shell.id.clone()).collect()),
             launcher_ids: Mutex::new(Vec::new()),
             agent_ids: Mutex::new(Vec::new()),
@@ -3281,9 +3335,14 @@ impl Registry {
     }
 
     fn create_shell_with_workspace(&self, spec: ShellSpec) -> io::Result<ShellSnapshot> {
+        let default_cwd = spec.cwd.clone();
         loop {
             let name = self.next_workspace_name()?;
-            match self.create_workspace(name, vec![spec.clone()]) {
+            match self.create_workspace_with_default_cwd(
+                name,
+                Some(default_cwd.clone()),
+                vec![spec.clone()],
+            ) {
                 Ok(workspace) => {
                     return workspace
                         .shells
@@ -4079,6 +4138,7 @@ impl Workspace {
         Ok(WorkspaceSnapshot {
             id: self.id.clone(),
             name: lock(&self.name)?.clone(),
+            default_cwd: self.default_cwd.clone(),
             shells,
             launchers,
             agents,
@@ -6017,6 +6077,7 @@ mod tests {
 
         let result = registry.dispatch(Request::CreateWorkspace {
             name: "rolled-back".into(),
+            default_cwd: None,
             shells: Vec::new(),
         });
 
@@ -6032,6 +6093,7 @@ mod tests {
         let response = registry
             .dispatch(Request::CreateWorkspace {
                 name: "coordinated".into(),
+                default_cwd: None,
                 shells: vec![
                     ShellSpec::login("one", env::temp_dir()),
                     ShellSpec::login("two", env::temp_dir()),
@@ -6076,6 +6138,7 @@ mod tests {
         let Response::Workspace { workspace } = registry
             .dispatch(Request::CreateWorkspace {
                 name: "launchers".into(),
+                default_cwd: None,
                 shells: Vec::new(),
             })
             .unwrap()
@@ -7170,6 +7233,7 @@ mod tests {
         let workspace = WorkspaceSnapshot {
             id: "w1".into(),
             name: "workspace".into(),
+            default_cwd: None,
             shells: Vec::new(),
             launchers: Vec::new(),
             agents: vec![agent.clone()],
@@ -7305,6 +7369,7 @@ mod tests {
         let workspace = WorkspaceSnapshot {
             id: "w1".into(),
             name: "workspace".into(),
+            default_cwd: None,
             shells: Vec::new(),
             launchers: Vec::new(),
             agents: vec![agent.clone()],
@@ -7403,6 +7468,7 @@ mod tests {
                 workspaces: vec![WorkspaceSnapshot {
                     id: "w1".into(),
                     name: "workspace".into(),
+                    default_cwd: None,
                     shells: Vec::new(),
                     launchers: Vec::new(),
                     agents: vec![agent.clone()],
@@ -7650,7 +7716,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_workspace_snapshot_has_no_cwd_and_no_shells() {
+    fn pathless_workspace_snapshot_has_no_default_cwd_and_no_shells() {
         let registry = Registry::default();
 
         let workspace = registry
@@ -7659,7 +7725,79 @@ mod tests {
         let value = serde_json::to_value(&workspace).unwrap();
 
         assert!(workspace.shells.is_empty());
-        assert!(value.get("cwd").is_none());
+        assert!(workspace.default_cwd.is_none());
+        assert!(value.get("default_cwd").is_none());
+    }
+
+    #[test]
+    fn workspace_snapshot_retains_default_cwd() {
+        let registry = Registry::default();
+        let cwd = env::temp_dir();
+
+        let workspace = registry
+            .create_workspace_with_default_cwd("project".into(), Some(cwd.clone()), Vec::new())
+            .unwrap();
+
+        assert_eq!(workspace.default_cwd.as_deref(), Some(cwd.as_path()));
+    }
+
+    #[test]
+    fn protocol_eighteen_responses_hide_workspace_default_cwd() {
+        let source_workspace = WorkspaceSnapshot {
+            id: "w1".into(),
+            name: "project".into(),
+            default_cwd: Some("/tmp/project".into()),
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: Vec::new(),
+        };
+
+        let Response::Workspace { workspace } = response_for_version(
+            Response::Workspace {
+                workspace: source_workspace.clone(),
+            },
+            18,
+        ) else {
+            panic!("expected workspace response");
+        };
+
+        assert!(workspace.default_cwd.is_none());
+
+        let Response::Snapshot { snapshot } = response_for_version(
+            Response::Snapshot {
+                snapshot: Snapshot {
+                    workspaces: vec![source_workspace.clone()],
+                    focused_terminal: None,
+                },
+            },
+            18,
+        ) else {
+            panic!("expected snapshot response");
+        };
+        assert!(snapshot.workspaces[0].default_cwd.is_none());
+
+        let Response::Events {
+            snapshot: Some(snapshot),
+            ..
+        } = response_for_version(
+            Response::Events {
+                stream_id: "stream".into(),
+                cursor: EventCursor {
+                    stream_id: "stream".into(),
+                    event_id: 0,
+                },
+                snapshot: Some(Snapshot {
+                    workspaces: vec![source_workspace],
+                    focused_terminal: None,
+                }),
+                events: Vec::new(),
+            },
+            18,
+        )
+        else {
+            panic!("expected events response");
+        };
+        assert!(snapshot.workspaces[0].default_cwd.is_none());
     }
 
     #[test]
@@ -7708,6 +7846,10 @@ mod tests {
         let workspace = registry.workspace(&shell.workspace_id).unwrap();
 
         assert_eq!(&*lock(&workspace.name).unwrap(), "workspace-2");
+        assert_eq!(
+            workspace.default_cwd.as_deref(),
+            Some(env::temp_dir().as_path())
+        );
         registry.shutdown().unwrap();
     }
 

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -1297,6 +1297,7 @@ mod tests {
         let mut workspace = WorkspaceSnapshot {
             id: "w1".into(),
             name: "workspace".into(),
+            default_cwd: None,
             shells: vec![shell],
             launchers: Vec::new(),
             agents: Vec::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,8 @@ const INTEGRATION_FEATURES: &[&str] = &[
     "protocol_16",
     "protocol_17",
     "protocol_18",
+    "protocol_19",
+    "workspace_default_cwd",
     "focused_terminal_following",
     "restartable_exited_shells",
     "inactive_agent_state",
@@ -313,7 +315,11 @@ enum WorkspaceCommands {
     /// List workspaces
     List,
     /// Create an empty workspace
-    Create { name: String },
+    Create {
+        name: String,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+    },
     /// Open terminal windows and invoke launchers
     Open { target: String },
     /// Show a workspace and its shells
@@ -369,8 +375,8 @@ enum ShellCommands {
         workspace: String,
         #[arg(long)]
         name: Option<String>,
-        #[arg(long, default_value = ".")]
-        cwd: PathBuf,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
         #[arg(last = true, num_args = 1.., value_name = "COMMAND")]
         command: Vec<String>,
     },
@@ -1153,8 +1159,9 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     Ok(format!("Removed launcher {name}"))
                 }
             },
-            on_create_workspace: |name: &str| {
-                create_dashboard_workspace(&client, name).map_err(|error| error.to_string())
+            on_create_workspace: |name: &str, default_cwd: Option<&PathBuf>| {
+                create_dashboard_workspace(&client, name, default_cwd)
+                    .map_err(|error| error.to_string())
             },
             on_create_shell: |workspace_id: &str| {
                 create_dashboard_shell(&client, workspace_id, &launch_cwd)
@@ -1367,6 +1374,10 @@ fn dashboard_views_from_sessions(
             tui::WorkspaceView {
                 id: workspace.id.clone(),
                 name: workspace.name.clone(),
+                default_cwd: workspace
+                    .default_cwd
+                    .as_ref()
+                    .map(|cwd| cwd.display().to_string()),
                 items: shells.chain(launchers).collect(),
                 sessions,
                 agent_state_counts: agent_summary.states,
@@ -1411,9 +1422,10 @@ fn workspace_source_directories(workspaces: &[WorkspaceSnapshot]) -> BTreeSet<Pa
         .iter()
         .flat_map(|workspace| {
             workspace
-                .shells
+                .default_cwd
                 .iter()
-                .map(|shell| shell.cwd.clone())
+                .cloned()
+                .chain(workspace.shells.iter().map(|shell| shell.cwd.clone()))
                 .chain(
                     workspace
                         .launchers
@@ -1536,8 +1548,9 @@ fn open_directory(
             } else {
                 (
                     client
-                        .create_workspace(
+                        .create_workspace_with_default_cwd(
                             &name,
+                            Some(directory.clone()),
                             vec![shell_spec("shell-1", &directory, startup_command)],
                         )?
                         .shells
@@ -1648,12 +1661,13 @@ fn resolve_workspace_target<'a>(
 fn create_dashboard_workspace(
     client: &client::Client,
     name: &str,
+    default_cwd: Option<&PathBuf>,
 ) -> Result<String, Box<dyn Error>> {
     let name = name.trim();
     if name.is_empty() {
         return Err("workspace name cannot be empty".into());
     }
-    client.create_workspace(name, Vec::new())?;
+    client.create_workspace_with_default_cwd(name, default_cwd.cloned(), Vec::new())?;
     Ok(format!("Created empty workspace {name}"))
 }
 
@@ -1664,8 +1678,29 @@ fn create_dashboard_shell(
 ) -> Result<String, Box<dyn Error>> {
     let workspace = client.get_workspace(workspace_id)?;
     let name = unique_shell_name("shell", &workspace.shells);
-    client.create_shell(workspace_id, ShellSpec::login(&name, launch_cwd))?;
+    let cwd = resolve_shell_cwd(workspace.default_cwd.as_deref(), None, launch_cwd)?;
+    client.create_shell(workspace_id, ShellSpec::login(&name, cwd))?;
     Ok(format!("Created {name} in {}", workspace.name))
+}
+
+fn resolve_shell_cwd(
+    default_cwd: Option<&Path>,
+    requested_cwd: Option<&Path>,
+    fallback_cwd: &Path,
+) -> Result<PathBuf, Box<dyn Error>> {
+    if let Some(cwd) = requested_cwd {
+        return resolve_directory(cwd);
+    }
+    let Some(default_cwd) = default_cwd else {
+        return resolve_directory(fallback_cwd);
+    };
+    resolve_directory(default_cwd).map_err(|error| {
+        format!(
+            "workspace default working directory is unavailable: {}: {error}",
+            default_cwd.display()
+        )
+        .into()
+    })
 }
 
 fn unique_shell_name(base_name: &str, shells: &[ShellSnapshot]) -> String {
@@ -2418,9 +2453,11 @@ fn workspace_command(
                 );
             }
         }
-        WorkspaceCommands::Create { name } => {
+        WorkspaceCommands::Create { name, cwd } => {
             let name = cli_name(name, "workspace")?;
-            let workspace = client.create_workspace(name, Vec::new())?;
+            let default_cwd = cwd.as_deref().map(resolve_directory).transpose()?;
+            let workspace =
+                client.create_workspace_with_default_cwd(name, default_cwd, Vec::new())?;
             println!("Created workspace {} ({})", workspace.name, workspace.id);
         }
         WorkspaceCommands::Open { target } => {
@@ -2451,6 +2488,7 @@ fn workspace_command(
                         "workspace": {
                             "id": workspace.id,
                             "name": workspace.name,
+                            "default_cwd": workspace.default_cwd,
                             "shells": shells,
                             "launchers": workspace.launchers.iter()
                                 .map(|launcher| cli_output::launcher(launcher, Some(&workspace.name)))
@@ -2466,6 +2504,13 @@ fn workspace_command(
             }
             println!("ID\t{}", workspace.id);
             println!("NAME\t{}", workspace.name);
+            println!(
+                "DEFAULT CWD\t{}",
+                workspace
+                    .default_cwd
+                    .as_deref()
+                    .map_or_else(|| "-".into(), |cwd| cwd.display().to_string())
+            );
             println!("SHELLS\t{}", workspace.shells.len());
             println!("LAUNCHERS\t{}", workspace.launchers.len());
             println!("AGENTS\t{}", workspace.agents.len());
@@ -2553,7 +2598,11 @@ fn shell_command(command: ShellCommands, json: bool) -> Result<(), Box<dyn Error
                 .map(|name| cli_name(name, "shell"))
                 .transpose()?
                 .unwrap_or_else(|| unique_shell_name("shell", &workspace.shells));
-            let cwd = resolve_directory(&cwd)?;
+            let cwd = resolve_shell_cwd(
+                workspace.default_cwd.as_deref(),
+                cwd.as_deref(),
+                Path::new("."),
+            )?;
             let shell = client.create_shell(&workspace.id, shell_spec(name, &cwd, &command))?;
             println!("Created pending shell {} ({})", shell.name, shell.id);
         }
@@ -4302,6 +4351,7 @@ mod tests {
         WorkspaceSnapshot {
             id: id.into(),
             name: name.into(),
+            default_cwd: None,
             shells,
             launchers: Vec::new(),
             agents: Vec::new(),
@@ -4467,8 +4517,26 @@ mod tests {
                 .unwrap()
                 .command,
             Some(Commands::Workspace {
-                command: WorkspaceCommands::Create { name }
+                command: WorkspaceCommands::Create { name, cwd: None }
             }) if name == "project"
+        ));
+        assert!(matches!(
+            Cli::try_parse_from([
+                "boomux",
+                "workspace",
+                "create",
+                "project",
+                "--cwd",
+                "/tmp"
+            ])
+            .unwrap()
+            .command,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::Create {
+                    name,
+                    cwd: Some(cwd)
+                }
+            }) if name == "project" && cwd == Path::new("/tmp")
         ));
         let cli = Cli::try_parse_from([
             "boomux",
@@ -4522,8 +4590,16 @@ mod tests {
                 }
             }) if workspace == "project"
                 && name == "tests"
-                && cwd == Path::new("/tmp")
+                && cwd.as_deref() == Some(Path::new("/tmp"))
                 && command == ["cargo", "test"]
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "shell", "create", "project"])
+                .unwrap()
+                .command,
+            Some(Commands::Shell {
+                command: ShellCommands::Create { cwd: None, .. }
+            })
         ));
     }
 
@@ -5060,6 +5136,7 @@ mod tests {
         let mut views = vec![tui::WorkspaceView {
             id: "w1".into(),
             name: "project".into(),
+            default_cwd: None,
             items: Vec::new(),
             agent_state_counts: agent_attention_projection::AgentStateCounts::default(),
             attention_count: 0,
@@ -5996,7 +6073,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 18);
+        assert_eq!(protocol::PROTOCOL_VERSION, 19);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 18;
+pub const PROTOCOL_VERSION: u32 = 19;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -47,6 +47,8 @@ pub struct FocusedTerminalSnapshot {
 pub struct WorkspaceSnapshot {
     pub id: String,
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_cwd: Option<PathBuf>,
     pub shells: Vec<ShellSnapshot>,
     #[serde(default)]
     pub launchers: Vec<WorkspaceLauncherSnapshot>,
@@ -403,6 +405,8 @@ pub enum Request {
     },
     CreateWorkspace {
         name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
         shells: Vec<ShellSpec>,
     },
     CreateShell {
@@ -493,6 +497,13 @@ pub enum Request {
 impl Request {
     pub fn minimum_protocol_version(&self) -> u32 {
         match self {
+            Self::CreateWorkspace {
+                default_cwd: Some(_),
+                ..
+            }
+            | Self::CreateShell {
+                workspace_id: None, ..
+            } => 19,
             Self::RestartWithNotificationConfig { .. } => 17,
             Self::Attach {
                 environment: Some(_),
@@ -852,7 +863,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_snapshot_accepts_protocol_seven_payload_without_launchers() {
+    fn workspace_snapshot_defaults_fields_omitted_by_old_daemons() {
         let snapshot = serde_json::from_str::<WorkspaceSnapshot>(
             r#"{"id":"w1","name":"workspace","shells":[]}"#,
         )
@@ -860,6 +871,23 @@ mod tests {
 
         assert!(snapshot.launchers.is_empty());
         assert!(snapshot.agents.is_empty());
+        assert!(snapshot.default_cwd.is_none());
+    }
+
+    #[test]
+    fn old_workspace_creation_defaults_to_no_cwd() {
+        let request = serde_json::from_str::<Request>(
+            r#"{"request":"create_workspace","name":"workspace","shells":[]}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            request,
+            Request::CreateWorkspace {
+                default_cwd: None,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -925,8 +953,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_eighteen_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 18);
+    fn protocol_version_is_nineteen_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 19);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -940,6 +968,20 @@ mod tests {
     #[test]
     fn request_minimum_protocol_versions_cover_all_groups() {
         let groups = vec![
+            (
+                19,
+                vec![
+                    Request::CreateWorkspace {
+                        name: "project".into(),
+                        default_cwd: Some("/tmp/project".into()),
+                        shells: Vec::new(),
+                    },
+                    Request::CreateShell {
+                        workspace_id: None,
+                        shell: ShellSpec::login("shell", "/tmp/project"),
+                    },
+                ],
+            ),
             (
                 17,
                 vec![Request::RestartWithNotificationConfig {
@@ -968,6 +1010,7 @@ mod tests {
                     },
                     Request::CreateWorkspace {
                         name: "workspace".into(),
+                        default_cwd: None,
                         shells: Vec::new(),
                     },
                     Request::CreateShell {

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -367,6 +367,7 @@ mod tests {
         WorkspaceSnapshot {
             id: id.into(),
             name: format!("workspace-{id}"),
+            default_cwd: None,
             shells: vec![shell],
             launchers: Vec::new(),
             agents: agent_ids

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -13,8 +13,9 @@ use crate::protocol::{
     AgentAttentionSnapshot, AgentObservationSnapshot, ShellRunExitReason, TerminalProfile,
 };
 
-const STATE_VERSION: u32 = 6;
-const PREVIOUS_STATE_VERSION: u32 = 5;
+const STATE_VERSION: u32 = 7;
+const PREVIOUS_STATE_VERSION: u32 = 6;
+const VERSION_FIVE_STATE_VERSION: u32 = 5;
 const VERSION_FOUR_STATE_VERSION: u32 = 4;
 const VERSION_THREE_STATE_VERSION: u32 = 3;
 const VERSION_TWO_STATE_VERSION: u32 = 2;
@@ -42,6 +43,7 @@ impl Default for PersistedState {
 pub(crate) struct PersistedWorkspace {
     pub(crate) id: String,
     pub(crate) name: String,
+    pub(crate) default_cwd: Option<PathBuf>,
     pub(crate) shells: Vec<PersistedShell>,
     pub(crate) launchers: Vec<PersistedWorkspaceLauncher>,
     pub(crate) agents: Vec<PersistedAgentInstance>,
@@ -110,6 +112,23 @@ struct PreviousPersistedState {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PreviousPersistedWorkspace {
+    id: String,
+    name: String,
+    shells: Vec<PersistedShell>,
+    launchers: Vec<PersistedWorkspaceLauncher>,
+    agents: Vec<PersistedAgentInstance>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionFivePersistedState {
+    version: u32,
+    workspaces: Vec<VersionFivePersistedWorkspace>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionFivePersistedWorkspace {
     id: String,
     name: String,
     shells: Vec<PersistedShell>,
@@ -281,14 +300,23 @@ impl StateStore {
         Self { path, _lock: None }
     }
 
+    #[cfg(test)]
     pub(crate) fn load(&self) -> io::Result<Option<PersistedState>> {
+        let (state, migrated) = self.load_deferred()?;
+        if migrated && let Some(state) = &state {
+            self.save(state)?;
+        }
+        Ok(state)
+    }
+
+    pub(crate) fn load_deferred(&self) -> io::Result<(Option<PersistedState>, bool)> {
         let Some(parent) = self.path.parent() else {
             return Err(io::Error::other("state path has no parent"));
         };
         secure_state_dir(parent)?;
         let metadata = match fs::symlink_metadata(&self.path) {
             Ok(metadata) => metadata,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok((None, false)),
             Err(error) => return Err(error),
         };
         if !metadata.is_file() || metadata.uid() != effective_uid() {
@@ -311,37 +339,31 @@ impl StateStore {
                 format!("could not parse {}: {error}", self.path.display()),
             )
         })?;
-        let state = match version.version {
-            STATE_VERSION => parse_state(&bytes, &self.path)?,
+        let (state, migrated) = match version.version {
+            STATE_VERSION => (parse_state(&bytes, &self.path)?, false),
             PREVIOUS_STATE_VERSION => {
                 let previous: PreviousPersistedState = parse_state(&bytes, &self.path)?;
-                let state = migrate_previous_state(previous);
-                self.save(&state)?;
-                state
+                (migrate_previous_state(previous), true)
+            }
+            VERSION_FIVE_STATE_VERSION => {
+                let previous: VersionFivePersistedState = parse_state(&bytes, &self.path)?;
+                (migrate_version_five_state(previous), true)
             }
             VERSION_FOUR_STATE_VERSION => {
                 let previous: VersionFourPersistedState = parse_state(&bytes, &self.path)?;
-                let state = migrate_version_four_state(previous);
-                self.save(&state)?;
-                state
+                (migrate_version_four_state(previous), true)
             }
             VERSION_THREE_STATE_VERSION => {
                 let previous: VersionThreePersistedState = parse_state(&bytes, &self.path)?;
-                let state = migrate_version_three_state(previous);
-                self.save(&state)?;
-                state
+                (migrate_version_three_state(previous), true)
             }
             VERSION_TWO_STATE_VERSION => {
                 let previous: VersionTwoPersistedState = parse_state(&bytes, &self.path)?;
-                let state = migrate_version_two_state(previous);
-                self.save(&state)?;
-                state
+                (migrate_version_two_state(previous), true)
             }
             LEGACY_STATE_VERSION => {
                 let legacy: LegacyPersistedState = parse_state(&bytes, &self.path)?;
-                let state = migrate_legacy_state(legacy);
-                self.save(&state)?;
-                state
+                (migrate_legacy_state(legacy), true)
             }
             version => {
                 return Err(io::Error::new(
@@ -350,7 +372,7 @@ impl StateStore {
                 ));
             }
         };
-        Ok(Some(state))
+        Ok((Some(state), migrated))
     }
 
     pub(crate) fn save(&self, state: &PersistedState) -> io::Result<()> {
@@ -407,6 +429,7 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
                 name: workspace.name,
+                default_cwd: None,
                 shells: workspace
                     .shells
                     .into_iter()
@@ -444,6 +467,26 @@ fn migrate_previous_state(previous: PreviousPersistedState) -> PersistedState {
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
                 name: workspace.name,
+                default_cwd: None,
+                shells: workspace.shells,
+                launchers: workspace.launchers,
+                agents: workspace.agents,
+            })
+            .collect(),
+    }
+}
+
+fn migrate_version_five_state(previous: VersionFivePersistedState) -> PersistedState {
+    debug_assert_eq!(previous.version, VERSION_FIVE_STATE_VERSION);
+    PersistedState {
+        version: STATE_VERSION,
+        workspaces: previous
+            .workspaces
+            .into_iter()
+            .map(|workspace| PersistedWorkspace {
+                id: workspace.id,
+                name: workspace.name,
+                default_cwd: None,
                 shells: workspace.shells,
                 launchers: workspace.launchers,
                 agents: workspace
@@ -484,6 +527,7 @@ fn migrate_version_four_state(previous: VersionFourPersistedState) -> PersistedS
                 PersistedWorkspace {
                     id: workspace.id,
                     name: workspace.name,
+                    default_cwd: None,
                     shells: workspace.shells,
                     launchers: workspace.launchers,
                     agents: workspace
@@ -519,6 +563,7 @@ fn migrate_version_three_state(previous: VersionThreePersistedState) -> Persiste
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
                 name: workspace.name,
+                default_cwd: None,
                 shells: workspace.shells,
                 launchers: workspace.launchers,
                 agents: Vec::new(),
@@ -537,6 +582,7 @@ fn migrate_version_two_state(previous: VersionTwoPersistedState) -> PersistedSta
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
                 name: workspace.name,
+                default_cwd: None,
                 shells: workspace.shells,
                 launchers: Vec::new(),
                 agents: Vec::new(),
@@ -603,6 +649,7 @@ mod tests {
             workspaces: vec![PersistedWorkspace {
                 id: Uuid::new_v4().to_string(),
                 name: "saved".into(),
+                default_cwd: Some("/tmp/project".into()),
                 shells: Vec::new(),
                 launchers: vec![
                     PersistedWorkspaceLauncher {
@@ -677,6 +724,10 @@ mod tests {
         let restored = store.load().unwrap().unwrap();
 
         assert_eq!(restored.workspaces[0].name, "saved");
+        assert_eq!(
+            restored.workspaces[0].default_cwd.as_deref(),
+            Some(Path::new("/tmp/project"))
+        );
         assert_eq!(restored.workspaces[0].launchers[0].id, "launcher-1");
         assert_eq!(restored.workspaces[0].launchers[0].name, "editor");
         assert_eq!(
@@ -781,7 +832,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 6")
+                .contains("\"version\": 7")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
         assert!(migrated.workspaces[0].agents.is_empty());
@@ -831,7 +882,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 6")
+                .contains("\"version\": 7")
         );
         assert!(migrated.workspaces[0].agents.is_empty());
         fs::remove_dir_all(directory).unwrap();
@@ -869,7 +920,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 6")
+                .contains("\"version\": 7")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -945,7 +996,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 6")
+                .contains("\"version\": 7")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -980,8 +1031,40 @@ mod tests {
 
         assert!(migrated.workspaces[0].agents[0].attention.is_none());
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 6"));
+        assert!(saved.contains("\"version\": 7"));
         assert!(saved.contains("\"attention\": null"));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_six_workspaces_without_default_cwds() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            br#"{
+  "version": 6,
+  "workspaces": [{
+    "id": "w1", "name": "version-six", "shells": [], "launchers": [], "agents": []
+  }]
+}"#,
+        )
+        .unwrap();
+        let store = StateStore::at(path.clone());
+
+        let (migrated, deferred) = store.load_deferred().unwrap();
+        let migrated = migrated.unwrap();
+
+        assert!(deferred);
+        assert!(migrated.workspaces[0].default_cwd.is_none());
+        let original = fs::read_to_string(&path).unwrap();
+        assert!(original.contains("\"version\": 6"));
+        assert!(!original.contains("default_cwd"));
+        store.save(&migrated).unwrap();
+        let saved = fs::read_to_string(&path).unwrap();
+        assert!(saved.contains("\"version\": 7"));
+        assert!(saved.contains("\"default_cwd\": null"));
         fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -30,6 +30,7 @@ const PREVIEW_RESERVED_ITEM_HEIGHT: u16 = 6;
 pub(crate) struct WorkspaceView {
     pub(crate) id: String,
     pub(crate) name: String,
+    pub(crate) default_cwd: Option<String>,
     pub(crate) items: Vec<WorkspaceItemView>,
     pub(crate) sessions: Vec<AgentSessionView>,
     pub(crate) agent_state_counts: AgentStateCounts,
@@ -1221,12 +1222,16 @@ impl App {
         }
     }
 
-    fn create_workspace<F>(&mut self, name: &str, on_create_workspace: &mut F)
-    where
-        F: FnMut(&str) -> Result<String, String>,
+    fn create_workspace<F>(
+        &mut self,
+        name: &str,
+        default_cwd: Option<&PathBuf>,
+        on_create_workspace: &mut F,
+    ) where
+        F: FnMut(&str, Option<&PathBuf>) -> Result<String, String>,
     {
         self.mode = Mode::Normal;
-        self.message = Some(Message::from_result(on_create_workspace(name)));
+        self.message = Some(Message::from_result(on_create_workspace(name, default_cwd)));
     }
 
     fn rename<F>(&mut self, target: &RenameTarget, name: &str, on_rename: &mut F)
@@ -1558,7 +1563,7 @@ where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&OpenTarget) -> Result<String, String>,
     C: FnMut(&CloseTarget) -> Result<String, String>,
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&str, Option<&PathBuf>) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
     F: FnMut() -> Result<DashboardState, String>,
@@ -1583,7 +1588,7 @@ where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&OpenTarget) -> Result<String, String>,
     C: FnMut(&CloseTarget) -> Result<String, String>,
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&str, Option<&PathBuf>) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
     F: FnMut() -> Result<DashboardState, String>,
@@ -1718,7 +1723,7 @@ where
     R: FnMut(&str) -> Result<String, String>,
     O: FnMut(&OpenTarget) -> Result<String, String>,
     C: FnMut(&CloseTarget) -> Result<String, String>,
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&str, Option<&PathBuf>) -> Result<String, String>,
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
     F: FnMut() -> Result<DashboardState, String>,
@@ -1882,7 +1887,7 @@ fn handle_mode_key<W, E>(
     on_rename: &mut E,
 ) -> bool
 where
-    W: FnMut(&str) -> Result<String, String>,
+    W: FnMut(&str, Option<&PathBuf>) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
 {
     let mode = std::mem::replace(&mut app.mode, Mode::Normal);
@@ -1895,13 +1900,13 @@ where
         Mode::Palette(_) | Mode::Help => false,
         Mode::PickProject(mut picker) => match key {
             KeyCode::Enter if picker.selected().is_some() => {
-                let name = picker.selected().expect("selected project").name.clone();
-                app.create_workspace(&name, on_create_workspace);
+                let project = picker.selected().expect("selected project").clone();
+                app.create_workspace(&project.name, Some(&project.path), on_create_workspace);
                 true
             }
             KeyCode::Enter if !picker.query.trim().is_empty() => {
                 let name = picker.query.trim().to_owned();
-                app.create_workspace(&name, on_create_workspace);
+                app.create_workspace(&name, None, on_create_workspace);
                 true
             }
             KeyCode::Enter => {
@@ -2622,7 +2627,14 @@ fn selected_item_preview(app: &App) -> Option<ContextualPreview> {
 
 fn workspace_preview(workspace: &WorkspaceView) -> ContextualPreview {
     let counts = workspace.agent_state_counts;
-    let mut lines = vec![
+    let mut lines = Vec::new();
+    if let Some(default_cwd) = &workspace.default_cwd {
+        lines.push(Line::from(vec![
+            Span::styled("default  ", Style::new().fg(SUBTEXT)),
+            Span::raw(default_cwd.clone()),
+        ]));
+    }
+    lines.extend([
         Line::from(format!(
             "{:<9}{:<3}{:<9}{}",
             "shell",
@@ -2651,7 +2663,7 @@ fn workspace_preview(workspace: &WorkspaceView) -> ContextualPreview {
             ),
             Style::new().fg(SUBTEXT),
         )),
-    ];
+    ]);
     if let Some(attention) = workspace.attention.first() {
         let currency = if attention.observation_is_current {
             "current"
@@ -3253,6 +3265,7 @@ mod tests {
         WorkspaceView {
             id: id.into(),
             name: name.into(),
+            default_cwd: None,
             items: vec![WorkspaceItemView::Shell(TerminalView {
                 id: "term_1".into(),
                 name: "agent".into(),
@@ -3327,6 +3340,10 @@ mod tests {
     }
 
     fn successful_text(_: &str) -> Result<String, String> {
+        Ok(String::new())
+    }
+
+    fn successful_workspace(_: &str, _: Option<&PathBuf>) -> Result<String, String> {
         Ok(String::new())
     }
 
@@ -3818,7 +3835,7 @@ mod tests {
     }
 
     #[test]
-    fn project_suggestion_creates_workspace_by_name_only() {
+    fn project_suggestion_creates_workspace_with_default_cwd() {
         let mut app = app();
         let mut created = None;
 
@@ -3828,7 +3845,7 @@ mod tests {
                 &mut app,
                 KeyCode::Char(character),
                 KeyModifiers::NONE,
-                &mut |_| Ok(String::new()),
+                &mut |_, _| Ok(String::new()),
                 &mut |_, _| Ok(String::new()),
             );
         }
@@ -3836,15 +3853,15 @@ mod tests {
             &mut app,
             KeyCode::Enter,
             KeyModifiers::NONE,
-            &mut |name| {
-                created = Some(name.to_owned());
+            &mut |name, default_cwd| {
+                created = Some((name.to_owned(), default_cwd.cloned()));
                 Ok("Created workspace".into())
             },
             &mut |_, _| Ok(String::new()),
         );
 
         assert!(changed);
-        assert_eq!(created.as_deref(), Some("alpha"));
+        assert_eq!(created, Some(("alpha".into(), Some("/tmp/alpha".into()))));
         assert!(matches!(app.mode, Mode::Normal));
     }
 
@@ -3862,15 +3879,15 @@ mod tests {
             &mut app,
             KeyCode::Enter,
             KeyModifiers::NONE,
-            &mut |name| {
-                created = Some(name.to_owned());
+            &mut |name, default_cwd| {
+                created = Some((name.to_owned(), default_cwd.cloned()));
                 Ok("Created workspace".into())
             },
             &mut |_, _| Ok(String::new()),
         );
 
         assert!(changed);
-        assert_eq!(created.as_deref(), Some("custom workspace"));
+        assert_eq!(created, Some(("custom workspace".into(), None)));
     }
 
     #[test]
@@ -3909,7 +3926,7 @@ mod tests {
             &mut app,
             KeyCode::Char('c'),
             KeyModifiers::CONTROL,
-            &mut |_| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
             &mut |_, _| Ok(String::new()),
         );
 
@@ -3928,7 +3945,7 @@ mod tests {
             &mut app,
             KeyCode::Char('_'),
             KeyModifiers::SHIFT,
-            &mut |_| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
             &mut |_, _| Ok(String::new()),
         );
 
@@ -4083,7 +4100,7 @@ mod tests {
                 Ok("opened".into())
             },
             on_close: successful_close,
-            on_create_workspace: successful_text,
+            on_create_workspace: successful_workspace,
             on_create_shell: successful_text,
             on_rename: successful_rename,
             on_refresh: empty_refresh,
@@ -4145,7 +4162,7 @@ mod tests {
             on_restore: successful_text,
             on_open: successful_open,
             on_close: successful_close,
-            on_create_workspace: successful_text,
+            on_create_workspace: successful_workspace,
             on_create_shell: successful_text,
             on_rename: successful_rename,
             on_refresh: empty_refresh,
@@ -4173,7 +4190,7 @@ mod tests {
             on_restore: successful_text,
             on_open: successful_open,
             on_close: successful_close,
-            on_create_workspace: successful_text,
+            on_create_workspace: successful_workspace,
             on_create_shell: successful_text,
             on_rename: successful_rename,
             on_refresh: empty_refresh,
@@ -4403,7 +4420,7 @@ mod tests {
                 &mut app,
                 KeyCode::Char(character),
                 KeyModifiers::NONE,
-                &mut |_| Ok(String::new()),
+                &mut |_, _| Ok(String::new()),
                 &mut |_, _| Ok(String::new()),
             );
         }
@@ -4411,7 +4428,7 @@ mod tests {
             &mut app,
             KeyCode::Enter,
             KeyModifiers::NONE,
-            &mut |_| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
             &mut |target, name| {
                 renamed = Some((target.clone(), name.to_owned()));
                 Ok("Renamed shell".into())
@@ -4444,7 +4461,7 @@ mod tests {
                 &mut app,
                 KeyCode::Char(character),
                 KeyModifiers::NONE,
-                &mut |_| Ok(String::new()),
+                &mut |_, _| Ok(String::new()),
                 &mut |_, _| Ok(String::new()),
             );
         }
@@ -4452,7 +4469,7 @@ mod tests {
             &mut app,
             KeyCode::Enter,
             KeyModifiers::NONE,
-            &mut |_| Ok(String::new()),
+            &mut |_, _| Ok(String::new()),
             &mut |target, name| {
                 renamed = Some((target.clone(), name.to_owned()));
                 Ok("Renamed workspace".into())

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -202,6 +202,131 @@ impl Drop for TestDaemon {
 }
 
 #[test]
+fn workspace_default_cwd_is_inherited_and_survives_handoff() {
+    let mut daemon = TestDaemon::start();
+    let project = daemon.runtime_dir.join("project");
+    let other = daemon.runtime_dir.join("other");
+    fs::create_dir(&project).unwrap();
+    fs::create_dir(&other).unwrap();
+
+    let created = daemon
+        .command()
+        .args(["workspace", "create", "project", "--cwd"])
+        .arg(&project)
+        .output()
+        .unwrap();
+    assert!(
+        created.status.success(),
+        "workspace create failed: {}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    let inspected = daemon
+        .command()
+        .args(["workspace", "inspect", "project", "--json"])
+        .output()
+        .unwrap();
+    let inspected: serde_json::Value = serde_json::from_slice(&inspected.stdout).unwrap();
+    assert_eq!(
+        inspected["data"]["workspace"]["default_cwd"],
+        project.display().to_string()
+    );
+
+    let first = daemon
+        .command()
+        .current_dir(&other)
+        .args(["shell", "create", "project", "--name", "first"])
+        .output()
+        .unwrap();
+    assert!(first.status.success());
+    let workspace = daemon
+        .client
+        .snapshot()
+        .unwrap()
+        .workspaces
+        .into_iter()
+        .find(|workspace| workspace.name == "project")
+        .unwrap();
+    assert_eq!(workspace.shells[0].cwd, project);
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    wait_until(
+        || daemon.child.as_mut().unwrap().try_wait().unwrap().is_some(),
+        "old daemon did not exit after handoff",
+    );
+
+    let second = daemon
+        .command()
+        .current_dir(&other)
+        .args(["shell", "create", "project", "--name", "second"])
+        .output()
+        .unwrap();
+    assert!(second.status.success());
+    let explicit = daemon
+        .command()
+        .args(["shell", "create", "project", "--name", "explicit", "--cwd"])
+        .arg(&other)
+        .output()
+        .unwrap();
+    assert!(explicit.status.success());
+    let workspace = daemon
+        .client
+        .snapshot()
+        .unwrap()
+        .workspaces
+        .into_iter()
+        .find(|workspace| workspace.name == "project")
+        .unwrap();
+    assert_eq!(workspace.default_cwd.as_deref(), Some(project.as_path()));
+    assert_eq!(workspace.shells[1].cwd, project);
+    assert_eq!(workspace.shells[2].cwd, other);
+
+    daemon.stop_with_cli();
+    daemon.restart();
+    let restored = daemon
+        .client
+        .snapshot()
+        .unwrap()
+        .workspaces
+        .into_iter()
+        .find(|workspace| workspace.name == "project")
+        .unwrap();
+    assert_eq!(restored.default_cwd.as_deref(), Some(project.as_path()));
+    let after_restart = daemon
+        .command()
+        .current_dir(&other)
+        .args(["shell", "create", "project", "--name", "after-restart"])
+        .output()
+        .unwrap();
+    assert!(after_restart.status.success());
+    let restored = daemon
+        .client
+        .snapshot()
+        .unwrap()
+        .workspaces
+        .into_iter()
+        .find(|workspace| workspace.name == "project")
+        .unwrap();
+    assert_eq!(restored.shells[3].cwd, project);
+
+    fs::remove_dir_all(restored.default_cwd.unwrap()).unwrap();
+    let missing = daemon
+        .command()
+        .args(["shell", "create", "project", "--name", "missing"])
+        .output()
+        .unwrap();
+    assert!(!missing.status.success());
+    assert!(
+        String::from_utf8_lossy(&missing.stderr)
+            .contains("workspace default working directory is unavailable")
+    );
+}
+
+#[test]
 fn replacement_bootstrap_rejects_invalid_inherited_descriptor() {
     let output = Command::new(env!("CARGO_BIN_EXE_boomux"))
         .args(["daemon", "receive-handoff", "--channel", "999999"])
@@ -360,7 +485,7 @@ fn focused_attachment_is_exposed_in_daemon_snapshots() {
         .unwrap();
     let shell_id = workspace.shells[0].id.clone();
     let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    assert_eq!(attachment.protocol_version, 18);
+    assert_eq!(attachment.protocol_version, 19);
 
     AttachFrame::FocusGained
         .write_to(&mut attachment.stream)
@@ -3213,7 +3338,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 18);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 19);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -3261,6 +3386,8 @@ fn native_daemon_lifecycle() {
         "protocol_16",
         "protocol_17",
         "protocol_18",
+        "protocol_19",
+        "workspace_default_cwd",
         "focused_terminal_following",
         "inactive_agent_state",
         "protocol_11",
@@ -3282,7 +3409,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 18"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 19"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- persist a workspace default cwd when a dashboard project suggestion or path-based workspace is created
- inherit that default for dashboard shells and `shell create` unless `--cwd` explicitly overrides it
- add `workspace create --cwd`, inspection output, dashboard context, and updated skill/docs
- advance to protocol 19 and state version 7 while preserving old pathless workspace behavior
- defer migration writes until cold startup succeeds or live handoff reaches its ownership commit boundary

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked` (342 passed)
- `cargo test --test native_backend --locked -- --test-threads=1` (25 passed)
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js` (29 passed)

The native backend coverage verifies inheritance before and after live handoff and cold restart, explicit cwd overrides, and clear failure when a persisted default directory disappears.