### PR TITLE
fix(terminal): preserve reattached output rendering

### DIFF
--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -38,10 +38,30 @@ impl TerminalState {
     }
 
     pub(crate) fn resize(&mut self, rows: u16, cols: u16) {
-        self.parser.screen_mut().set_size(rows, cols);
-        if let Some(primary) = self.primary_before_alternate.as_mut() {
-            primary.set_size(rows, cols);
+        if self.parser.screen().size() == (rows, cols) {
+            return;
         }
+
+        let screen = self.parser.screen();
+        let primary = self.primary_before_alternate.as_ref().unwrap_or(screen);
+        let mut reconstruction = reflowable_contents_formatted(primary);
+        if screen.alternate_screen() {
+            reconstruction.extend_from_slice(b"\x1b[?1049h");
+            reconstruction.extend(screen.contents_formatted());
+        } else {
+            CellStyle::from_screen(screen).write_escape_code(&mut reconstruction);
+            reconstruction.extend_from_slice(if screen.hide_cursor() {
+                b"\x1b[?25l"
+            } else {
+                b"\x1b[?25h"
+            });
+        }
+        reconstruction.extend(screen.input_mode_formatted());
+        reconstruction.extend(self.focus_mode.restore_sequence());
+
+        let mut resized = Self::new(rows, cols);
+        resized.process(&reconstruction);
+        *self = resized;
     }
 
     pub(crate) fn reconstruction(&self) -> Vec<u8> {
@@ -117,11 +137,16 @@ fn scrollback_text(screen: &vt100::Screen) -> String {
 }
 
 fn append_scrollback(output: &mut Vec<u8>, screen: &vt100::Screen) {
-    let scrollback = scrollback_text(screen);
-    if scrollback.is_empty() {
+    let mut scrolled = screen.clone();
+    scrolled.set_scrollback(usize::MAX);
+    let scrollback_rows = scrolled.scrollback();
+    if scrollback_rows == 0 {
         return;
     }
-    append_terminal_text_bounded(output, &scrollback, MAX_RECONSTRUCTION_BYTES);
+    for offset in (1..=scrollback_rows).rev() {
+        scrolled.set_scrollback(offset);
+        append_reflowable_row(output, &scrolled, 0, true);
+    }
     for _ in 0..screen.size().0.saturating_sub(1) {
         output.extend_from_slice(b"\r\n");
     }
@@ -145,6 +170,157 @@ fn append_terminal_text_bounded(output: &mut Vec<u8>, text: &str, limit: usize) 
             break;
         }
         output.extend_from_slice(encoded);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CellStyle {
+    foreground: vt100::Color,
+    background: vt100::Color,
+    bold: bool,
+    dim: bool,
+    italic: bool,
+    underline: bool,
+    inverse: bool,
+}
+
+impl CellStyle {
+    fn from_cell(cell: &vt100::Cell) -> Self {
+        Self {
+            foreground: cell.fgcolor(),
+            background: cell.bgcolor(),
+            bold: cell.bold(),
+            dim: cell.dim(),
+            italic: cell.italic(),
+            underline: cell.underline(),
+            inverse: cell.inverse(),
+        }
+    }
+
+    fn from_screen(screen: &vt100::Screen) -> Self {
+        Self {
+            foreground: screen.fgcolor(),
+            background: screen.bgcolor(),
+            bold: screen.bold(),
+            dim: screen.dim(),
+            italic: screen.italic(),
+            underline: screen.underline(),
+            inverse: screen.inverse(),
+        }
+    }
+
+    fn write_escape_code(self, output: &mut Vec<u8>) {
+        output.extend_from_slice(b"\x1b[0");
+        if self.bold {
+            output.extend_from_slice(b";1");
+        } else if self.dim {
+            output.extend_from_slice(b";2");
+        }
+        if self.italic {
+            output.extend_from_slice(b";3");
+        }
+        if self.underline {
+            output.extend_from_slice(b";4");
+        }
+        if self.inverse {
+            output.extend_from_slice(b";7");
+        }
+        write_color(output, self.foreground, true);
+        write_color(output, self.background, false);
+        output.push(b'm');
+    }
+}
+
+fn write_color(output: &mut Vec<u8>, color: vt100::Color, foreground: bool) {
+    match color {
+        vt100::Color::Default => {}
+        vt100::Color::Idx(index) => {
+            output.extend_from_slice(if foreground { b";38;5;" } else { b";48;5;" });
+            output.extend_from_slice(index.to_string().as_bytes());
+        }
+        vt100::Color::Rgb(red, green, blue) => {
+            output.extend_from_slice(if foreground { b";38;2;" } else { b";48;2;" });
+            output.extend_from_slice(red.to_string().as_bytes());
+            output.push(b';');
+            output.extend_from_slice(green.to_string().as_bytes());
+            output.push(b';');
+            output.extend_from_slice(blue.to_string().as_bytes());
+        }
+    }
+}
+
+fn reflowable_contents_formatted(screen: &vt100::Screen) -> Vec<u8> {
+    let mut output = Vec::new();
+    let mut scrolled = screen.clone();
+    scrolled.set_scrollback(usize::MAX);
+    let scrollback_rows = scrolled.scrollback();
+
+    for offset in (1..=scrollback_rows).rev() {
+        scrolled.set_scrollback(offset);
+        append_reflowable_row(&mut output, &scrolled, 0, true);
+    }
+
+    scrolled.set_scrollback(0);
+    let (cursor_row, _) = scrolled.cursor_position();
+    let (rows, cols) = scrolled.size();
+    let last_content_row = (0..rows).rfind(|row| {
+        (0..cols).any(|col| {
+            scrolled.cell(*row, col).is_some_and(|cell| {
+                cell.has_contents() || CellStyle::from_cell(cell) != CellStyle::default()
+            })
+        })
+    });
+    let last_row = last_content_row.unwrap_or(0).max(cursor_row);
+    for row in 0..=last_row {
+        append_reflowable_row(&mut output, &scrolled, row, row < last_row);
+    }
+
+    output
+}
+
+fn append_reflowable_row(output: &mut Vec<u8>, screen: &vt100::Screen, row: u16, terminate: bool) {
+    let (_, cols) = screen.size();
+    let wrapped = screen.row_wrapped(row);
+    let last_col = if wrapped {
+        cols.checked_sub(1)
+    } else {
+        (0..cols).rfind(|col| {
+            screen.cell(row, *col).is_some_and(|cell| {
+                cell.has_contents() || CellStyle::from_cell(cell) != CellStyle::default()
+            })
+        })
+    };
+    let Some(last_col) = last_col else {
+        if terminate {
+            output.extend_from_slice(b"\r\n");
+        }
+        return;
+    };
+
+    let mut style = CellStyle::default();
+    for col in 0..=last_col {
+        let Some(cell) = screen.cell(row, col) else {
+            continue;
+        };
+        if cell.is_wide_continuation() {
+            continue;
+        }
+        let next_style = CellStyle::from_cell(cell);
+        if next_style != style {
+            next_style.write_escape_code(output);
+            style = next_style;
+        }
+        if cell.has_contents() {
+            output.extend_from_slice(cell.contents().as_bytes());
+        } else {
+            output.push(b' ');
+        }
+    }
+    if style != CellStyle::default() {
+        output.extend_from_slice(b"\x1b[0m");
+    }
+    if terminate && !wrapped {
+        output.extend_from_slice(b"\r\n");
     }
 }
 
@@ -199,6 +375,28 @@ mod tests {
     }
 
     #[test]
+    fn reconstruction_preserves_scrollback_styles() {
+        let mut source = TerminalState::new(2, 20);
+        source.process(b"\x1b[31mRRRR\x1b[0m\r\nnext\r\ncurrent");
+
+        let mut restored = TerminalState::new(2, 20);
+        restored.process(&source.reconstruction());
+        let mut scrolled = restored.parser.screen().clone();
+        scrolled.set_scrollback(usize::MAX);
+        let red_cells = (0..scrolled.size().0)
+            .flat_map(|row| (0..scrolled.size().1).map(move |col| (row, col)))
+            .filter_map(|(row, col)| scrolled.cell(row, col))
+            .filter(|cell| cell.contents() == "R")
+            .collect::<Vec<_>>();
+        assert_eq!(red_cells.len(), 4);
+        assert!(
+            red_cells
+                .iter()
+                .all(|cell| cell.fgcolor() == vt100::Color::Idx(1))
+        );
+    }
+
+    #[test]
     fn alternate_screen_is_reconstructed() {
         let mut source = TerminalState::new(4, 20);
         source.process(b"primary\x1b[?1049halt");
@@ -230,6 +428,66 @@ mod tests {
         state.resize(10, 30);
 
         assert_eq!(state.parser.screen().size(), (10, 30));
+    }
+
+    #[test]
+    fn resize_reflows_retained_output_without_truncating_it() {
+        let mut state = TerminalState::new(3, 40);
+        state.process(
+            b"one: a description that reaches the edge\r\n\
+              two: another description that reaches the edge\r\n\
+              three: final description",
+        );
+
+        state.resize(8, 20);
+
+        let rendered = state.plain_text();
+        assert!(
+            rendered.contains("one: a description that reaches the edge"),
+            "{rendered:?}"
+        );
+        assert!(
+            rendered.contains("two: another description that reaches the edge"),
+            "{rendered:?}"
+        );
+        assert!(
+            rendered.contains("three: final description"),
+            "{rendered:?}"
+        );
+    }
+
+    #[test]
+    fn resize_preserves_rendered_styles_and_reflows_the_cursor() {
+        let mut state = TerminalState::new(3, 20);
+        state.process(b"prompt> \x1b[31mRRRRRR\x1b[0m");
+
+        state.resize(5, 10);
+
+        let screen = state.parser.screen();
+        let red_cells = (0..screen.size().0)
+            .flat_map(|row| (0..screen.size().1).map(move |col| (row, col)))
+            .filter_map(|(row, col)| screen.cell(row, col))
+            .filter(|cell| cell.contents() == "R")
+            .collect::<Vec<_>>();
+        assert_eq!(red_cells.len(), 6);
+        assert!(
+            red_cells
+                .iter()
+                .all(|cell| cell.fgcolor() == vt100::Color::Idx(1))
+        );
+        assert_eq!(screen.cursor_position(), (1, 4));
+    }
+
+    #[test]
+    fn resize_preserves_active_attributes_and_cursor_visibility() {
+        let mut state = TerminalState::new(3, 20);
+        state.process(b"text\x1b[32m\x1b[?25l");
+
+        state.resize(5, 10);
+
+        let screen = state.parser.screen();
+        assert_eq!(screen.fgcolor(), vt100::Color::Idx(2));
+        assert!(screen.hide_cursor());
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -654,6 +654,54 @@ fn native_daemon_recovers_reproducible_metadata_after_restart() {
 }
 
 #[test]
+fn reattachment_reflows_retained_output_for_the_new_terminal_width() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "reflow-on-attach",
+            vec![ShellSpec::login("shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let mut wide_profile = profile();
+    wide_profile.rows = 6;
+    wide_profile.cols = 60;
+    let mut first = daemon
+        .client
+        .attach(&shell_id, false, wide_profile)
+        .unwrap();
+    AttachFrame::Input(
+        b"printf 'first: a description that must remain complete\\nsecond: another description that must remain complete\\nreflow-finished\\n'\n"
+            .to_vec(),
+    )
+    .write_to(&mut first.stream)
+    .unwrap();
+    assert!(contains(
+        &read_until(&mut first.stream, b"reflow-finished"),
+        b"reflow-finished"
+    ));
+    drop(first);
+
+    let mut narrow_profile = profile();
+    narrow_profile.rows = 12;
+    narrow_profile.cols = 24;
+    let second = wait_for_attach_with_profile(&daemon.client, &shell_id, narrow_profile);
+    let contents = String::from_utf8(daemon.client.read_shell(&shell_id, 1_024).unwrap()).unwrap();
+    assert!(
+        contents.contains("first: a description that must remain complete"),
+        "{contents:?}"
+    );
+    assert!(
+        contents.contains("second: another description that must remain complete"),
+        "{contents:?}"
+    );
+
+    drop(second);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn attach_environment_is_ephemeral_and_authoritative_for_initial_and_restarted_runs() {
     let daemon = TestDaemon::start();
     let client_shell = daemon.runtime_dir.join("client-shell");


### PR DESCRIPTION
## Summary
- reflow retained primary-screen output when an attachment changes terminal geometry
- preserve cell styles, active attributes, cursor visibility, and styled scrollback during reconstruction
- cover narrow reattachment through the daemon boundary

## Verification
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check