### PR TITLE
feat(tui): render colored shell previews

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -16,8 +16,9 @@ use std::time::Duration;
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, DaemonEvent, Envelope,
     ErrorCode, EventCursor, NotificationDeliveryConfig, Request, Response, ShellSnapshot,
-    ShellSpec, ShellStatus, Snapshot, TerminalProfile, UnixEnvironment, UnixEnvironmentVariable,
-    WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan,
+    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
+    WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -520,6 +521,40 @@ impl Client {
         }
     }
 
+    pub fn read_shell_preview(
+        &self,
+        shell_id: impl Into<String>,
+        max_bytes: usize,
+        max_lines: u16,
+    ) -> io::Result<TerminalPreview> {
+        let shell_id = shell_id.into();
+        if self.protocol_version()? < 20 {
+            let bytes = self.read_shell(shell_id, max_bytes)?;
+            let text = String::from_utf8_lossy(&bytes);
+            let lines = text.lines().collect::<Vec<_>>();
+            let start = lines.len().saturating_sub(usize::from(max_lines));
+            return Ok(TerminalPreview {
+                lines: lines[start..]
+                    .iter()
+                    .map(|line| TerminalPreviewLine {
+                        spans: vec![TerminalPreviewSpan {
+                            text: (*line).to_owned(),
+                            style: Default::default(),
+                        }],
+                    })
+                    .collect(),
+            });
+        }
+        match self.request(Request::ReadShellPreview {
+            shell_id,
+            max_bytes,
+            max_lines,
+        })? {
+            Response::ShellPreview { preview } => Ok(preview),
+            other => unexpected(other),
+        }
+    }
+
     pub fn read_shell_at(
         &self,
         shell_id: impl Into<String>,
@@ -851,6 +886,22 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 20);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    19,
+                    Response::Error {
+                        message: "protocol 20 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 19);
             assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
@@ -978,7 +1029,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 19);
+            assert_eq!(request.version, 20);
             let Request::Attach {
                 environment: Some(environment),
                 ..
@@ -995,7 +1046,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    19,
+                    20,
                     Response::Attached {
                         token: "token".into(),
                         reconstruction: Vec::new(),
@@ -1025,14 +1076,30 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 19);
+            assert_eq!(request.version, 20);
             assert!(matches!(request.message, Request::Attach { .. }));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    20,
+                    Response::Error {
+                        message: "protocol 20 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 20);
+            assert!(matches!(request.message, Request::Ping));
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
                     19,
                     Response::Error {
-                        message: "protocol 19 unsupported".into(),
+                        message: "protocol 20 unsupported".into(),
                         code: Some(ErrorCode::UnsupportedVersion),
                     },
                 ),
@@ -1105,12 +1172,84 @@ mod tests {
     }
 
     #[test]
+    fn shell_preview_falls_back_to_plain_output_from_protocol_nineteen() {
+        let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 20);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    19,
+                    Response::Error {
+                        message: "protocol 20 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 19);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(&mut stream, &Envelope::with_version(19, Response::Pong))
+                .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 19);
+            assert!(matches!(request.message, Request::ReadShell { .. }));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    19,
+                    Response::Output {
+                        bytes: b"old\nlatest".to_vec(),
+                    },
+                ),
+            )
+            .unwrap();
+        });
+        let client = Client::from_socket_path(socket);
+
+        let preview = client.read_shell_preview("s1", 1024, 1).unwrap();
+
+        assert_eq!(preview.lines.len(), 1);
+        assert_eq!(preview.lines[0].spans[0].text, "latest");
+        assert_eq!(preview.lines[0].spans[0].style, Default::default());
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
     fn negotiates_protocol_seven_without_losing_version_seven_requests() {
         let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 20);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    19,
+                    Response::Error {
+                        message: "expected an older protocol".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 19);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -32,8 +32,8 @@ use crate::protocol::{
     AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame,
     DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot,
     NotificationDeliveryConfig, Request, Response, ShellRunExitReason, ShellRunSnapshot,
-    ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalProfile, UnixEnvironment,
-    WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalProfile,
+    UnixEnvironment, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::state_store::{
     PersistedAgentInstance, PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
@@ -52,6 +52,8 @@ const MAX_NAME_BYTES: usize = 256;
 const MAX_AGENT_EVIDENCE_BYTES: usize = 4 * 1024;
 const MAX_TERMINAL_ROWS: u16 = 1_000;
 const MAX_TERMINAL_COLS: u16 = 1_000;
+const MAX_TERMINAL_PREVIEW_LINES: usize = 500;
+const MAX_TERMINAL_PREVIEW_SPANS: usize = 20_000;
 const MAX_TERMINAL_CELLS: usize = 1_000_000;
 const MAX_SHELL_READ_BYTES: usize = 1024 * 1024;
 const MAX_FOREGROUND_PROCESS_BYTES: usize = 64;
@@ -1999,6 +2001,13 @@ impl Registry {
             } => Ok(Response::Output {
                 bytes: self.read_shell(&shell_id, max_bytes)?,
             }),
+            Request::ReadShellPreview {
+                shell_id,
+                max_bytes,
+                max_lines,
+            } => Ok(Response::ShellPreview {
+                preview: self.read_shell_preview(&shell_id, max_bytes, max_lines)?,
+            }),
             Request::ReadShellAt {
                 shell_id,
                 max_bytes,
@@ -3716,6 +3725,29 @@ impl Registry {
         Ok(tail_utf8(&text, max_bytes.min(MAX_SHELL_READ_BYTES))
             .as_bytes()
             .to_vec())
+    }
+
+    fn read_shell_preview(
+        &self,
+        shell_id: &str,
+        max_bytes: usize,
+        max_lines: u16,
+    ) -> io::Result<TerminalPreview> {
+        let shell = self.shell(shell_id)?;
+        let lifecycle = lock(&shell.lifecycle)?;
+        let terminal = match &*lifecycle {
+            ShellLifecycle::Pending => return Ok(TerminalPreview::default()),
+            ShellLifecycle::Running { runtime, .. } => Arc::clone(&runtime.terminal),
+            ShellLifecycle::Exited { terminal, .. } => Arc::clone(terminal),
+            ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
+        };
+        drop(lifecycle);
+        let preview = lock(&terminal)?.preview(
+            max_bytes.min(MAX_SHELL_READ_BYTES),
+            usize::from(max_lines).min(MAX_TERMINAL_PREVIEW_LINES),
+            MAX_TERMINAL_PREVIEW_SPANS,
+        );
+        Ok(preview)
     }
 
     fn wait_agent(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1201,10 +1201,9 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 })
             },
             on_terminal_preview: |shell_id: &str| {
-                let bytes = client
-                    .read_shell(shell_id, READ_BYTES)
-                    .map_err(|error| error.to_string())?;
-                Ok(recent_lines(&String::from_utf8_lossy(&bytes), 500))
+                client
+                    .read_shell_preview(shell_id, READ_BYTES, 500)
+                    .map_err(|error| error.to_string())
             },
         },
     )?;
@@ -6073,7 +6072,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 19);
+        assert_eq!(protocol::PROTOCOL_VERSION, 20);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,10 +4,58 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 19;
+pub const PROTOCOL_VERSION: u32 = 20;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalColor {
+    #[default]
+    Default,
+    Indexed(u8),
+    Rgb {
+        red: u8,
+        green: u8,
+        blue: u8,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalStyle {
+    #[serde(default)]
+    pub foreground: TerminalColor,
+    #[serde(default)]
+    pub background: TerminalColor,
+    #[serde(default)]
+    pub bold: bool,
+    #[serde(default)]
+    pub dim: bool,
+    #[serde(default)]
+    pub italic: bool,
+    #[serde(default)]
+    pub underline: bool,
+    #[serde(default)]
+    pub inverse: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalPreviewSpan {
+    pub text: String,
+    #[serde(default)]
+    pub style: TerminalStyle,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalPreviewLine {
+    pub spans: Vec<TerminalPreviewSpan>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalPreview {
+    pub lines: Vec<TerminalPreviewLine>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Envelope<T> {
@@ -441,6 +489,11 @@ pub enum Request {
         shell_id: String,
         max_bytes: usize,
     },
+    ReadShellPreview {
+        shell_id: String,
+        max_bytes: usize,
+        max_lines: u16,
+    },
     ReadShellAt {
         shell_id: String,
         max_bytes: usize,
@@ -497,6 +550,7 @@ pub enum Request {
 impl Request {
     pub fn minimum_protocol_version(&self) -> u32 {
         match self {
+            Self::ReadShellPreview { .. } => 20,
             Self::CreateWorkspace {
                 default_cwd: Some(_),
                 ..
@@ -576,6 +630,9 @@ pub enum Response {
     },
     Output {
         bytes: Vec<u8>,
+    },
+    ShellPreview {
+        preview: TerminalPreview,
     },
     OutputState {
         bytes: Vec<u8>,
@@ -953,9 +1010,43 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_nineteen_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 19);
+    fn protocol_version_is_twenty_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 20);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
+    }
+
+    #[test]
+    fn terminal_preview_styles_round_trip() {
+        let preview = TerminalPreview {
+            lines: vec![TerminalPreviewLine {
+                spans: vec![TerminalPreviewSpan {
+                    text: "styled".into(),
+                    style: TerminalStyle {
+                        foreground: TerminalColor::Indexed(2),
+                        background: TerminalColor::Rgb {
+                            red: 3,
+                            green: 4,
+                            blue: 5,
+                        },
+                        bold: true,
+                        dim: false,
+                        italic: true,
+                        underline: true,
+                        inverse: true,
+                    },
+                }],
+            }],
+        };
+        let response = Response::ShellPreview {
+            preview: preview.clone(),
+        };
+        let encoded = serde_json::to_value(response).unwrap();
+
+        assert_eq!(encoded["response"], "shell_preview");
+        assert_eq!(
+            serde_json::from_value::<Response>(encoded).unwrap(),
+            Response::ShellPreview { preview }
+        );
     }
 
     #[test]
@@ -968,6 +1059,14 @@ mod tests {
     #[test]
     fn request_minimum_protocol_versions_cover_all_groups() {
         let groups = vec![
+            (
+                20,
+                vec![Request::ReadShellPreview {
+                    shell_id: "s1".into(),
+                    max_bytes: 1024,
+                    max_lines: 500,
+                }],
+            ),
             (
                 19,
                 vec![

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -1,3 +1,6 @@
+use crate::protocol::{
+    TerminalColor, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan, TerminalStyle,
+};
 use crate::terminal_focus::FocusMode;
 
 const SCROLLBACK_ROWS: usize = 2_000;
@@ -104,6 +107,115 @@ impl TerminalState {
             .filter(|character| !character.is_control() || matches!(character, '\n' | '\t'))
             .collect()
     }
+
+    pub(crate) fn preview(
+        &self,
+        max_bytes: usize,
+        max_lines: usize,
+        max_spans: usize,
+    ) -> TerminalPreview {
+        let screen = self.parser.screen();
+        let mut scrolled = screen.clone();
+        scrolled.set_scrollback(usize::MAX);
+        let scrollback_rows = scrolled.scrollback();
+        let mut lines = Vec::new();
+        let mut current = TerminalPreviewLine::default();
+
+        for offset in (1..=scrollback_rows).rev() {
+            scrolled.set_scrollback(offset);
+            append_preview_row(&mut lines, &mut current, &scrolled, 0);
+        }
+        scrolled.set_scrollback(0);
+        for row in 0..scrolled.size().0 {
+            append_preview_row(&mut lines, &mut current, &scrolled, row);
+        }
+        if !current.spans.is_empty() {
+            lines.push(current);
+        }
+
+        let first = lines
+            .iter()
+            .position(|line| !preview_line_is_blank(line))
+            .unwrap_or(lines.len());
+        let end = lines
+            .iter()
+            .rposition(|line| !preview_line_is_blank(line))
+            .map_or(first, |last| last + 1);
+        let lines = &lines[first..end];
+        let start = lines.len().saturating_sub(max_lines);
+        let mut selected = Vec::new();
+        let mut bytes = 0usize;
+        let mut spans = 0usize;
+        for line in lines[start..].iter().rev() {
+            let line_bytes = line.spans.iter().map(|span| span.text.len()).sum::<usize>();
+            let line_spans = line.spans.len();
+            if !selected.is_empty()
+                && (bytes.saturating_add(line_bytes) > max_bytes
+                    || spans.saturating_add(line_spans) > max_spans)
+            {
+                break;
+            }
+            bytes = bytes.saturating_add(line_bytes);
+            spans = spans.saturating_add(line_spans);
+            selected.push(line.clone());
+        }
+        selected.reverse();
+        TerminalPreview { lines: selected }
+    }
+}
+
+fn append_preview_row(
+    lines: &mut Vec<TerminalPreviewLine>,
+    current: &mut TerminalPreviewLine,
+    screen: &vt100::Screen,
+    row: u16,
+) {
+    let (_, cols) = screen.size();
+    let wrapped = screen.row_wrapped(row);
+    let last_col = if wrapped {
+        cols.checked_sub(1)
+    } else {
+        (0..cols).rfind(|col| {
+            screen.cell(row, *col).is_some_and(|cell| {
+                cell.has_contents() || CellStyle::from_cell(cell) != CellStyle::default()
+            })
+        })
+    };
+
+    if let Some(last_col) = last_col {
+        for col in 0..=last_col {
+            let Some(cell) = screen.cell(row, col) else {
+                continue;
+            };
+            if cell.is_wide_continuation() {
+                continue;
+            }
+            let text = if cell.has_contents() {
+                cell.contents()
+            } else {
+                " "
+            };
+            append_preview_span(current, text, CellStyle::from_cell(cell).into());
+        }
+    }
+    if !wrapped {
+        lines.push(std::mem::take(current));
+    }
+}
+
+fn append_preview_span(line: &mut TerminalPreviewLine, text: &str, style: TerminalStyle) {
+    if let Some(span) = line.spans.last_mut().filter(|span| span.style == style) {
+        span.text.push_str(text);
+    } else {
+        line.spans.push(TerminalPreviewSpan {
+            text: text.to_owned(),
+            style,
+        });
+    }
+}
+
+fn preview_line_is_blank(line: &TerminalPreviewLine) -> bool {
+    line.spans.iter().all(|span| span.text.trim().is_empty())
 }
 
 fn alternate_screen_start(bytes: &[u8]) -> Option<usize> {
@@ -228,6 +340,30 @@ impl CellStyle {
         write_color(output, self.foreground, true);
         write_color(output, self.background, false);
         output.push(b'm');
+    }
+}
+
+impl From<CellStyle> for TerminalStyle {
+    fn from(style: CellStyle) -> Self {
+        Self {
+            foreground: style.foreground.into(),
+            background: style.background.into(),
+            bold: style.bold,
+            dim: style.dim,
+            italic: style.italic,
+            underline: style.underline,
+            inverse: style.inverse,
+        }
+    }
+}
+
+impl From<vt100::Color> for TerminalColor {
+    fn from(color: vt100::Color) -> Self {
+        match color {
+            vt100::Color::Default => Self::Default,
+            vt100::Color::Idx(index) => Self::Indexed(index),
+            vt100::Color::Rgb(red, green, blue) => Self::Rgb { red, green, blue },
+        }
     }
 }
 
@@ -499,5 +635,63 @@ mod tests {
         let mut restored = TerminalState::new(2, 20);
         restored.process(&state.reconstruction());
         assert_eq!(restored.plain_text(), "one\ntwo\nthree");
+    }
+
+    #[test]
+    fn preview_preserves_styles_and_matches_plain_text() {
+        let mut state = TerminalState::new(3, 30);
+        state.process(b"plain \x1b[1;31mred\x1b[0m\r\n\x1b[38;2;1;2;3;48;2;4;5;6mcolor\x1b[0m");
+
+        let preview = state.preview(1024, 100, 100);
+        let text = preview
+            .lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.text.as_str())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(text, state.plain_text());
+        assert_eq!(preview.lines[0].spans.len(), 2);
+        assert_eq!(
+            preview.lines[0].spans[1].style.foreground,
+            TerminalColor::Indexed(1)
+        );
+        assert!(preview.lines[0].spans[1].style.bold);
+        assert_eq!(
+            preview.lines[1].spans[0].style.foreground,
+            TerminalColor::Rgb {
+                red: 1,
+                green: 2,
+                blue: 3
+            }
+        );
+        assert_eq!(
+            preview.lines[1].spans[0].style.background,
+            TerminalColor::Rgb {
+                red: 4,
+                green: 5,
+                blue: 6
+            }
+        );
+    }
+
+    #[test]
+    fn preview_keeps_the_newest_complete_lines_within_bounds() {
+        let mut state = TerminalState::new(2, 20);
+        state.process(b"one\r\ntwo\r\nthree");
+
+        let preview = state.preview(1024, 2, 100);
+        let text = preview
+            .lines
+            .iter()
+            .map(|line| line.spans[0].text.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(text, ["two", "three"]);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -12,6 +12,7 @@ use ratatui::widgets::{
 };
 
 use crate::agent_attention_projection::AgentStateCounts;
+use crate::protocol::{TerminalColor, TerminalPreview, TerminalPreviewLine, TerminalStyle};
 
 const BASE: Color = Color::Reset;
 const OVERLAY: Color = Color::DarkGray;
@@ -288,7 +289,7 @@ struct TerminalPreviewState {
     shell_id: String,
     run_id: Option<String>,
     output_revision: u64,
-    output: Result<String, String>,
+    output: Result<TerminalPreview, String>,
     scroll_from_bottom: usize,
 }
 
@@ -1326,7 +1327,7 @@ impl App {
 
     fn refresh_terminal_preview<P>(&mut self, on_preview: &mut P)
     where
-        P: FnMut(&str) -> Result<String, String>,
+        P: FnMut(&str) -> Result<TerminalPreview, String>,
     {
         let selected = if self.primary_tab == PrimaryTab::Workspaces && self.focus != Focus::Items {
             None
@@ -1366,11 +1367,11 @@ impl App {
             .map_or(0, |preview| {
                 let previous_count = preview
                     .output
-                    .as_deref()
+                    .as_ref()
                     .ok()
                     .map_or(0, |output| terminal_output_lines(output).len());
                 let next_count = output
-                    .as_deref()
+                    .as_ref()
                     .ok()
                     .map_or(0, |output| terminal_output_lines(output).len());
                 preview
@@ -1392,7 +1393,7 @@ impl App {
         };
         let line_count = preview
             .output
-            .as_deref()
+            .as_ref()
             .ok()
             .map_or(0, |output| terminal_output_lines(output).len());
         let max_scroll = line_count.saturating_sub(TERMINAL_PREVIEW_ROWS);
@@ -1417,7 +1418,7 @@ impl App {
         };
         let line_count = preview
             .output
-            .as_deref()
+            .as_ref()
             .ok()
             .map_or(0, |output| terminal_output_lines(output).len());
         preview.scroll_from_bottom = line_count.saturating_sub(TERMINAL_PREVIEW_ROWS);
@@ -1567,7 +1568,7 @@ where
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
     F: FnMut() -> Result<DashboardState, String>,
-    P: FnMut(&str) -> Result<String, String>,
+    P: FnMut(&str) -> Result<TerminalPreview, String>,
 {
     let mut terminal = ratatui::init();
     let mut app = App::new(state.workspaces, project_context);
@@ -1592,7 +1593,7 @@ where
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
     F: FnMut() -> Result<DashboardState, String>,
-    P: FnMut(&str) -> Result<String, String>,
+    P: FnMut(&str) -> Result<TerminalPreview, String>,
 {
     let mut last_refresh = Instant::now();
     loop {
@@ -1727,7 +1728,7 @@ where
     N: FnMut(&str) -> Result<String, String>,
     E: FnMut(&RenameTarget, &str) -> Result<String, String>,
     F: FnMut() -> Result<DashboardState, String>,
-    P: FnMut(&str) -> Result<String, String>,
+    P: FnMut(&str) -> Result<TerminalPreview, String>,
 {
     match command {
         PaletteCommand::CreateWorkspace => {
@@ -2771,7 +2772,7 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
         .filter(|preview| !is_command && preview.shell_id == terminal.id)
     {
         match &preview.output {
-            Ok(output) if output.trim().is_empty() => lines.push(Line::from(vec![
+            Ok(output) if terminal_preview_is_empty(output) => lines.push(Line::from(vec![
                 Span::styled(" Output ", Style::new().fg(BASE).bg(BLUE)),
                 Span::styled(" no terminal output", Style::new().fg(SUBTEXT)),
             ])),
@@ -2801,12 +2802,7 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
                             .add_modifier(Modifier::BOLD),
                     ),
                 ]));
-                lines.extend(
-                    viewport
-                        .lines
-                        .into_iter()
-                        .map(|line| Line::from(Span::raw(format!(" {line}")))),
-                );
+                lines.extend(viewport.lines.into_iter().map(terminal_preview_line));
             }
             Err(error) => lines.push(Line::from(Span::styled(
                 format!("Output unavailable: {error}"),
@@ -2830,32 +2826,44 @@ fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPrev
 }
 
 struct TerminalViewport {
-    lines: Vec<String>,
+    lines: Vec<TerminalPreviewLine>,
     start: usize,
     end: usize,
     total: usize,
     following: bool,
 }
 
-fn terminal_output_lines(output: &str) -> Vec<String> {
-    let mut lines: Vec<_> = output
-        .lines()
-        .map(|line| line.trim_end().to_owned())
-        .collect();
+fn terminal_output_lines(output: &TerminalPreview) -> Vec<TerminalPreviewLine> {
+    let mut lines = output.lines.clone();
+    for line in &mut lines {
+        while let Some(span) = line.spans.last_mut() {
+            let trimmed = span.text.trim_end().len();
+            span.text.truncate(trimmed);
+            if span.text.is_empty() {
+                line.spans.pop();
+            } else {
+                break;
+            }
+        }
+    }
     let first = lines
         .iter()
-        .position(|line| !line.is_empty())
+        .position(|line| !terminal_preview_line_is_empty(line))
         .unwrap_or(lines.len());
     let end = lines
         .iter()
-        .rposition(|line| !line.is_empty())
+        .rposition(|line| !terminal_preview_line_is_empty(line))
         .map_or(first, |last| last + 1);
     lines.drain(end..);
     lines.drain(..first);
     lines
 }
 
-fn terminal_viewport(output: &str, height: usize, scroll_from_bottom: usize) -> TerminalViewport {
+fn terminal_viewport(
+    output: &TerminalPreview,
+    height: usize,
+    scroll_from_bottom: usize,
+) -> TerminalViewport {
     let lines = terminal_output_lines(output);
     let total = lines.len();
     let latest_start = total.saturating_sub(height);
@@ -2868,6 +2876,56 @@ fn terminal_viewport(output: &str, height: usize, scroll_from_bottom: usize) -> 
         end,
         total,
         following: scroll_from_bottom == 0,
+    }
+}
+
+fn terminal_preview_is_empty(preview: &TerminalPreview) -> bool {
+    preview.lines.iter().all(terminal_preview_line_is_empty)
+}
+
+fn terminal_preview_line_is_empty(line: &TerminalPreviewLine) -> bool {
+    line.spans.iter().all(|span| span.text.trim().is_empty())
+}
+
+fn terminal_preview_line(line: TerminalPreviewLine) -> Line<'static> {
+    let mut spans = Vec::with_capacity(line.spans.len() + 1);
+    spans.push(Span::raw(" "));
+    spans.extend(
+        line.spans
+            .into_iter()
+            .map(|span| Span::styled(span.text, terminal_style(span.style))),
+    );
+    Line::from(spans)
+}
+
+fn terminal_style(style: TerminalStyle) -> Style {
+    let mut modifiers = Modifier::empty();
+    if style.bold {
+        modifiers |= Modifier::BOLD;
+    }
+    if style.dim {
+        modifiers |= Modifier::DIM;
+    }
+    if style.italic {
+        modifiers |= Modifier::ITALIC;
+    }
+    if style.underline {
+        modifiers |= Modifier::UNDERLINED;
+    }
+    if style.inverse {
+        modifiers |= Modifier::REVERSED;
+    }
+    Style::new()
+        .fg(terminal_color(style.foreground))
+        .bg(terminal_color(style.background))
+        .add_modifier(modifiers)
+}
+
+fn terminal_color(color: TerminalColor) -> Color {
+    match color {
+        TerminalColor::Default => Color::Reset,
+        TerminalColor::Indexed(index) => Color::Indexed(index),
+        TerminalColor::Rgb { red, green, blue } => Color::Rgb(red, green, blue),
     }
 }
 
@@ -3341,6 +3399,28 @@ mod tests {
 
     fn successful_text(_: &str) -> Result<String, String> {
         Ok(String::new())
+    }
+
+    fn successful_preview(_: &str) -> Result<TerminalPreview, String> {
+        Ok(TerminalPreview::default())
+    }
+
+    fn text_preview(text: &str) -> TerminalPreview {
+        TerminalPreview {
+            lines: text
+                .split('\n')
+                .map(|line| TerminalPreviewLine {
+                    spans: vec![crate::protocol::TerminalPreviewSpan {
+                        text: line.to_owned(),
+                        style: TerminalStyle::default(),
+                    }],
+                })
+                .collect(),
+        }
+    }
+
+    fn preview_text(line: &TerminalPreviewLine) -> String {
+        line.spans.iter().map(|span| span.text.as_str()).collect()
     }
 
     fn successful_workspace(_: &str, _: Option<&PathBuf>) -> Result<String, String> {
@@ -4104,7 +4184,7 @@ mod tests {
             on_create_shell: successful_text,
             on_rename: successful_rename,
             on_refresh: empty_refresh,
-            on_terminal_preview: successful_text,
+            on_terminal_preview: successful_preview,
         };
 
         assert!(execute_palette_command(
@@ -4166,7 +4246,7 @@ mod tests {
             on_create_shell: successful_text,
             on_rename: successful_rename,
             on_refresh: empty_refresh,
-            on_terminal_preview: successful_text,
+            on_terminal_preview: successful_preview,
         };
 
         execute_palette_command(
@@ -4194,7 +4274,7 @@ mod tests {
             on_create_shell: successful_text,
             on_rename: successful_rename,
             on_refresh: empty_refresh,
-            on_terminal_preview: successful_text,
+            on_terminal_preview: successful_preview,
         };
 
         execute_palette_command(
@@ -5096,7 +5176,7 @@ mod tests {
         let reads = std::cell::Cell::new(0);
         app.refresh_terminal_preview(&mut |_| {
             reads.set(reads.get() + 1);
-            Ok("command output".into())
+            Ok(text_preview("command output"))
         });
 
         backend_terminal
@@ -5136,7 +5216,7 @@ mod tests {
         let calls = std::cell::Cell::new(0);
         let mut read = |_: &str| {
             calls.set(calls.get() + 1);
-            Ok("first\nlatest".into())
+            Ok(text_preview("first\nlatest"))
         };
 
         app.refresh_terminal_preview(&mut read);
@@ -5175,22 +5255,67 @@ mod tests {
 
     #[test]
     fn terminal_viewport_trims_edges_and_scrolls_from_the_tail() {
-        let output = "\nold\n\nrecent one  \nrecent two\n\n";
+        let output = text_preview("\nold\n\nrecent one  \nrecent two\n\n");
 
         assert_eq!(
-            terminal_output_lines(output),
+            terminal_output_lines(&output)
+                .iter()
+                .map(preview_text)
+                .collect::<Vec<_>>(),
             ["old", "", "recent one", "recent two"]
         );
-        assert!(terminal_output_lines("\n \n").is_empty());
+        assert!(terminal_output_lines(&text_preview("\n \n")).is_empty());
 
-        let following = terminal_viewport(output, 3, 0);
-        assert_eq!(following.lines, ["", "recent one", "recent two"]);
+        let following = terminal_viewport(&output, 3, 0);
+        assert_eq!(
+            following.lines.iter().map(preview_text).collect::<Vec<_>>(),
+            ["", "recent one", "recent two"]
+        );
         assert_eq!((following.start, following.end, following.total), (1, 4, 4));
         assert!(following.following);
 
-        let scrolled = terminal_viewport(output, 2, 2);
-        assert_eq!(scrolled.lines, ["old", ""]);
+        let scrolled = terminal_viewport(&output, 2, 2);
+        assert_eq!(
+            scrolled.lines.iter().map(preview_text).collect::<Vec<_>>(),
+            ["old", ""]
+        );
         assert!(!scrolled.following);
+    }
+
+    #[test]
+    fn terminal_preview_renders_structured_colors_and_modifiers() {
+        let mut terminal = Terminal::new(TestBackend::new(4, 1)).unwrap();
+        let line = TerminalPreviewLine {
+            spans: vec![crate::protocol::TerminalPreviewSpan {
+                text: "X".into(),
+                style: TerminalStyle {
+                    foreground: TerminalColor::Indexed(196),
+                    background: TerminalColor::Rgb {
+                        red: 1,
+                        green: 2,
+                        blue: 3,
+                    },
+                    bold: true,
+                    italic: true,
+                    inverse: true,
+                    ..TerminalStyle::default()
+                },
+            }],
+        };
+
+        terminal
+            .draw(|frame| {
+                frame.render_widget(Paragraph::new(terminal_preview_line(line)), frame.area())
+            })
+            .unwrap();
+
+        let cell = &terminal.backend().buffer()[(1, 0)];
+        assert_eq!(cell.symbol(), "X");
+        assert_eq!(cell.fg, Color::Indexed(196));
+        assert_eq!(cell.bg, Color::Rgb(1, 2, 3));
+        assert!(cell.modifier.contains(Modifier::BOLD));
+        assert!(cell.modifier.contains(Modifier::ITALIC));
+        assert!(cell.modifier.contains(Modifier::REVERSED));
     }
 
     #[test]
@@ -5209,10 +5334,12 @@ mod tests {
             output_revision: 1,
         });
         let output = |count: usize| {
-            (1..=count)
-                .map(|line| format!("line {line}"))
-                .collect::<Vec<_>>()
-                .join("\n")
+            text_preview(
+                &(1..=count)
+                    .map(|line| format!("line {line}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
         };
 
         app.refresh_terminal_preview(&mut |_| Ok(output(40)));
@@ -5261,10 +5388,12 @@ mod tests {
             exit_reason: None,
             output_revision: 1,
         });
-        let output = (1..=30)
-            .map(|line| format!("viewport line {line}"))
-            .collect::<Vec<_>>()
-            .join("\n");
+        let output = text_preview(
+            &(1..=30)
+                .map(|line| format!("viewport line {line}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
         app.refresh_terminal_preview(&mut |_| Ok(output.clone()));
 
         let mut wide = Terminal::new(TestBackend::new(180, 40)).unwrap();

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -485,7 +485,7 @@ fn focused_attachment_is_exposed_in_daemon_snapshots() {
         .unwrap();
     let shell_id = workspace.shells[0].id.clone();
     let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    assert_eq!(attachment.protocol_version, 19);
+    assert_eq!(attachment.protocol_version, 20);
 
     AttachFrame::FocusGained
         .write_to(&mut attachment.stream)
@@ -698,6 +698,50 @@ fn reattachment_reflows_retained_output_for_the_new_terminal_width() {
     );
 
     drop(second);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn structured_shell_preview_preserves_color_while_plain_read_stays_plain() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "styled-preview",
+            vec![ShellSpec::login("shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    AttachFrame::Input(b"printf '\\033[31mstyled-preview-marker\\033[0m\\n'\n".to_vec())
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut attachment.stream, b"styled-preview-marker"),
+        b"styled-preview-marker"
+    ));
+
+    let preview = daemon
+        .client
+        .read_shell_preview(&shell_id, 1024 * 1024, 500)
+        .unwrap();
+    let styled = preview
+        .lines
+        .iter()
+        .flat_map(|line| &line.spans)
+        .find(|span| {
+            span.text.contains("styled-preview-marker")
+                && span.style.foreground == boomux::protocol::TerminalColor::Indexed(1)
+        });
+    assert!(
+        styled.is_some(),
+        "styled preview did not retain red output: {preview:?}"
+    );
+    let plain = daemon.client.read_shell(&shell_id, 1024 * 1024).unwrap();
+    assert!(contains(&plain, b"styled-preview-marker"));
+    assert!(!plain.contains(&b'\x1b'));
+
+    drop(attachment);
     daemon.stop_with_cli();
 }
 
@@ -3386,7 +3430,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 19);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 20);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -3457,7 +3501,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 19"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 20"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- add a protocol-20 structured shell preview response with bounded styled spans
- render indexed/RGB colors and terminal text modifiers in the dashboard without replaying raw ANSI
- preserve plain `boomux read` output and fall back to unstyled previews with protocol-19 daemons

## Verification
- cargo test
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- live protocol-20 daemon and dashboard smoke test