### PR TITLE
feat: recover sessions after cold restarts

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -179,6 +179,10 @@ Desktop and sound delivery are independently disabled by default. Desktop uses
 event IDs. The top-level blocked and completed category flags filter both.
 
 ```toml
+[recovery]
+resume_agents = true
+persist_terminal_history = false
+
 [notifications]
 enabled = false
 blocked = true
@@ -189,6 +193,11 @@ enabled = false
 blocked = "message-new-instant"
 completed = "complete"
 ```
+
+Cold recovery resumes only a unique OpenCode or Pi external session reported by
+the lifecycle integration. Persisted terminal history is disabled by default
+because output can contain secrets; enabling it stores up to 256 KiB of
+plain-text history per shell in Boomux's user-only state file.
 
 `notifications.enabled` controls desktop delivery;
 `notifications.sound.enabled` controls sound. Test all currently configured,

--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ max_depth = 3
 [dashboard]
 follow_focused_terminal = true
 
+[recovery]
+resume_agents = true
+persist_terminal_history = false
+
 [notifications]
 enabled = false
 blocked = true
@@ -254,6 +258,21 @@ preserved until another managed terminal gains focus. Press `Space` to pin the
 current selection and pause following; press it again to unpin and catch up to
 the currently focused terminal. Set
 `dashboard.follow_focused_terminal` to `false` to disable this behavior.
+
+After a cold daemon restart, Boomux resumes a uniquely identified OpenCode or Pi
+session when its interrupted shell is next started. Recovery requires a retained
+external session ID reported by the lifecycle integration; ambiguous, completed,
+or heuristic-only Agents fall back to the shell's configured command. Set
+`recovery.resume_agents` to `false` to disable this behavior.
+
+Terminal history persistence is opt-in because terminal output can contain
+secrets. With `recovery.persist_terminal_history = true`, Boomux checkpoints up
+to 256 KiB of plain-text history per shell into the user-only
+`$XDG_STATE_HOME/boomux/state.json` file approximately every five seconds while
+output is active. The bounded history is shown before the new run starts; it
+does not restore the previous process, PTY, terminal modes, or interactive state.
+Disabling the setting again removes previously retained history from daemon
+state at startup.
 
 Desktop and sound notifications are independently disabled by default. Desktop
 delivery requires `notify-send` and a desktop notification service. Sound

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -581,9 +581,18 @@ The daemon atomically writes reproducible registry metadata to
 `~/.local/state/boomux/state.json`. Workspace, launcher, shell, and agent IDs;
  names and grouping; working directories; argument vectors; agent observations and attention;
 and last terminal profiles survive restart. The last run record also preserves
-its identity and outcome. Recovered
-shells are pending: Boomux does not claim that arbitrary
-processes, mutated environments, or PTYs survive daemon restart or crash.
+its identity and outcome. Recovered shells are pending: Boomux does not claim
+that arbitrary processes, mutated environments, or PTYs survive daemon restart
+or crash. When enabled, cold recovery substitutes an integration-native resume
+command for a uniquely identified, lifecycle-authoritative OpenCode or Pi Agent
+from an interrupted run. Ambiguous or invalid candidates use the shell's normal
+command instead.
+
+Plain-text terminal history is a separate opt-in recovery field because output
+can contain secrets. The shadow terminal checkpoints a UTF-8-safe suffix of at
+most 256 KiB per shell while output is active. A new run presents that text as
+historical context before its own banner; the text is not replayed to the child
+and does not reconstruct terminal modes or process state.
 
 `boomux daemon restart` transfers the existing listener and both ownership locks
 to a replacement process through a private, versioned `SCM_RIGHTS` handshake.
@@ -595,8 +604,8 @@ changing the child PID. Attached clients receive a reconnect request,
 acknowledge an input-ordering boundary, and reconnect to the replacement while
 remaining in raw mode. Exited shells transfer their final run metadata and
 bounded reconstructed terminal state without a PTY, pidfd, or replacement
-process. Cold startup and crash recovery remain metadata-only and restore shells
-as pending.
+process. Cold startup and crash recovery still restore shells as pending and do
+not preserve live process or PTY ownership.
 
 ## Next Technical Steps
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ struct RawConfig {
     projects: Option<RawProjectsConfig>,
     notifications: Option<RawNotificationsConfig>,
     dashboard: Option<RawDashboardConfig>,
+    recovery: Option<RawRecoveryConfig>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -46,6 +47,13 @@ struct RawNotificationSoundConfig {
 #[serde(default, deny_unknown_fields)]
 struct RawDashboardConfig {
     follow_focused_terminal: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawRecoveryConfig {
+    resume_agents: Option<bool>,
+    persist_terminal_history: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -87,7 +95,7 @@ pub(crate) fn load() -> Result<Config, Box<dyn Error>> {
 pub(crate) fn load_notification_settings()
 -> Result<boomux::daemon::NotificationDeliverySettings, Box<dyn Error>> {
     let (raw, _) = load_raw()?;
-    Ok(resolve_notifications(raw.notifications))
+    Ok(resolve_daemon_settings(raw.notifications, raw.recovery))
 }
 
 fn load_raw() -> Result<(RawConfig, Option<PathBuf>), Box<dyn Error>> {
@@ -177,6 +185,15 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
             dashboard.follow_focused_terminal = next_dashboard.follow_focused_terminal;
         }
     }
+    if let Some(next_recovery) = next.recovery {
+        let recovery = base.recovery.get_or_insert_default();
+        if next_recovery.resume_agents.is_some() {
+            recovery.resume_agents = next_recovery.resume_agents;
+        }
+        if next_recovery.persist_terminal_history.is_some() {
+            recovery.persist_terminal_history = next_recovery.persist_terminal_history;
+        }
+    }
 }
 
 fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Error>> {
@@ -207,7 +224,7 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
         terminal,
         projects: ProjectsConfig { roots, max_depth },
         path,
-        notifications: resolve_notifications(raw.notifications),
+        notifications: resolve_daemon_settings(raw.notifications, raw.recovery),
         dashboard: DashboardConfig {
             follow_focused_terminal: raw
                 .dashboard
@@ -218,10 +235,19 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
     })
 }
 
+#[cfg(test)]
 fn resolve_notifications(
     raw: Option<RawNotificationsConfig>,
 ) -> boomux::daemon::NotificationDeliverySettings {
-    let raw = raw.unwrap_or_default();
+    resolve_daemon_settings(raw, None)
+}
+
+fn resolve_daemon_settings(
+    notifications: Option<RawNotificationsConfig>,
+    recovery: Option<RawRecoveryConfig>,
+) -> boomux::daemon::NotificationDeliverySettings {
+    let raw = notifications.unwrap_or_default();
+    let recovery = recovery.unwrap_or_default();
     boomux::daemon::NotificationDeliverySettings {
         desktop: boomux::daemon::NotificationSettings {
             enabled: raw.enabled.unwrap_or(false),
@@ -237,6 +263,8 @@ fn resolve_notifications(
                 completed: sound.completed.unwrap_or_else(|| "complete".into()),
             }
         }),
+        resume_agents: recovery.resume_agents.unwrap_or(true),
+        persist_terminal_history: recovery.persist_terminal_history.unwrap_or(false),
     }
 }
 
@@ -419,6 +447,24 @@ mod tests {
     }
 
     #[test]
+    fn recovery_settings_default_and_merge_per_field() {
+        let defaults = resolve_daemon_settings(None, None);
+        assert!(defaults.resume_agents);
+        assert!(!defaults.persist_terminal_history);
+
+        let mut base: RawConfig =
+            toml::from_str("[recovery]\nresume_agents = false\npersist_terminal_history = true")
+                .unwrap();
+        let next: RawConfig = toml::from_str("[recovery]\nresume_agents = true").unwrap();
+        merge(&mut base, next);
+
+        let settings = resolve_daemon_settings(base.notifications, base.recovery);
+        assert!(settings.resume_agents);
+        assert!(settings.persist_terminal_history);
+        assert!(toml::from_str::<RawConfig>("[recovery]\nunknown = true").is_err());
+    }
+
+    #[test]
     fn notification_overrides_merge_per_field() {
         let mut base: RawConfig =
             toml::from_str("[notifications]\nenabled = true\nblocked = false\ncompleted = false")
@@ -443,6 +489,8 @@ mod tests {
                     blocked: "message-new-instant".into(),
                     completed: "service-login".into(),
                 },
+                resume_agents: true,
+                persist_terminal_history: false,
             }
         );
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -47,6 +47,8 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 const RESTART_TIMEOUT: Duration = Duration::from_secs(10);
 const IO_RETRY_DELAY: Duration = Duration::from_millis(2);
 const PERSIST_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+const TERMINAL_HISTORY_INTERVAL: Duration = Duration::from_secs(5);
+const MAX_TERMINAL_HISTORY_BYTES: usize = 256 * 1024;
 const MAX_TERMINAL_ENV_VALUE: usize = 256;
 const MAX_NAME_BYTES: usize = 256;
 const MAX_AGENT_EVIDENCE_BYTES: usize = 4 * 1024;
@@ -101,6 +103,8 @@ impl From<NotificationDeliveryConfig> for NotificationDeliverySettings {
                 blocked: config.blocked_sound,
                 completed: config.completed_sound,
             },
+            resume_agents: config.resume_agents,
+            persist_terminal_history: config.persist_terminal_history,
         }
     }
 }
@@ -114,14 +118,29 @@ impl From<NotificationDeliverySettings> for NotificationDeliveryConfig {
             completed: settings.desktop.completed,
             blocked_sound: settings.sound.blocked,
             completed_sound: settings.sound.completed,
+            resume_agents: settings.resume_agents,
+            persist_terminal_history: settings.persist_terminal_history,
         }
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NotificationDeliverySettings {
     pub desktop: NotificationSettings,
     pub sound: NotificationSoundSettings,
+    pub resume_agents: bool,
+    pub persist_terminal_history: bool,
+}
+
+impl Default for NotificationDeliverySettings {
+    fn default() -> Self {
+        Self {
+            desktop: NotificationSettings::default(),
+            sound: NotificationSoundSettings::default(),
+            resume_agents: true,
+            persist_terminal_history: false,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -268,6 +287,9 @@ fn run_daemon(
 ) -> io::Result<()> {
     let mut registry = Registry::restore(store, committed.is_some(), transferred.events)?;
     registry.notification_settings = notification_settings.clone();
+    if !registry.notification_settings.persist_terminal_history {
+        registry.clear_terminal_histories()?;
+    }
     registry.notification_sink = Arc::new(DesktopNotificationSink::new(notification_settings));
     let registry = Arc::new(registry);
     let gated_readers = registry.import_handoff(transferred.runtimes, transferred.exited)?;
@@ -1451,6 +1473,7 @@ impl ShellRun {
             output_revision: snapshot.output_revision,
             environment_has_run_id: snapshot.environment_has_run_id,
             profile,
+            terminal_history: None,
         })
     }
 }
@@ -1833,7 +1856,129 @@ fn workspace_created_events(workspace: &WorkspaceSnapshot) -> Vec<DaemonEventKin
     events
 }
 
+fn resume_identity(
+    agent: &AgentInstance,
+    shell: &Shell,
+    previous_run: &PersistedShellRun,
+) -> io::Result<Option<(String, String)>> {
+    if agent.workspace_id != shell.workspace_id
+        || agent.shell_id != shell.id
+        || agent.run_id != previous_run.id
+        || agent.cwd.as_ref() != Some(&shell.cwd)
+        || !matches!(agent.integration.as_str(), "opencode" | "pi")
+    {
+        return Ok(None);
+    }
+    let Some(external_session_id) = agent
+        .external_session_id
+        .as_ref()
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let state = lock(&agent.state)?;
+    if state.ended_at_ms.is_some()
+        || state.observation.authority != AgentAuthority::LifecycleIntegration
+        || state.observation.state == AgentState::Done
+    {
+        return Ok(None);
+    }
+    Ok(Some((
+        agent.integration.clone(),
+        external_session_id.clone(),
+    )))
+}
+
 impl Registry {
+    fn clear_terminal_histories(&self) -> io::Result<()> {
+        let state = lock(&self.state)?;
+        let mut changed = false;
+        for shell in state.shells.values() {
+            if let Some(run) = lock(&shell.last_run)?.as_mut()
+                && run.terminal_history.take().is_some()
+            {
+                changed = true;
+            }
+        }
+        drop(state);
+        if changed {
+            self.persistence_dirty.store(true, Ordering::Release);
+        }
+        Ok(())
+    }
+
+    fn agent_resume_command(
+        &self,
+        shell: &Shell,
+        previous_run: Option<&PersistedShellRun>,
+    ) -> io::Result<Option<Vec<String>>> {
+        if !self.notification_settings.resume_agents {
+            return Ok(None);
+        }
+        let Some(previous_run) = previous_run
+            .filter(|run| matches!(run.exit_reason, Some(ShellRunExitReason::Interrupted)))
+        else {
+            return Ok(None);
+        };
+        let state = lock(&self.state)?;
+        let mut candidates = Vec::new();
+        for agent in state.agents.values() {
+            if let Some(identity) = resume_identity(agent, shell, previous_run)? {
+                candidates.push(identity);
+            }
+        }
+        candidates.sort();
+        candidates.dedup();
+        let [(integration, external_session_id)] = candidates.as_slice() else {
+            return Ok(None);
+        };
+
+        let duplicate = state
+            .shells
+            .values()
+            .try_fold(false, |duplicate, other_shell| {
+                if duplicate {
+                    return Ok::<_, io::Error>(true);
+                }
+                if other_shell.id == shell.id {
+                    return Ok(false);
+                }
+                let last_run = lock(&other_shell.last_run)?;
+                let Some(last_run) = last_run.as_ref() else {
+                    return Ok(false);
+                };
+                for agent in state.agents.values() {
+                    if resume_identity(agent, other_shell, last_run)?.is_some_and(|identity| {
+                        identity.0 == *integration && identity.1 == *external_session_id
+                    }) {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            })?;
+        if duplicate {
+            return Ok(None);
+        }
+
+        let executable = if shell.command.is_empty() {
+            integration.clone()
+        } else if shell.command.len() == 1
+            && Path::new(&shell.command[0])
+                .file_name()
+                .and_then(|name| name.to_str())
+                == Some(integration.as_str())
+        {
+            shell.command[0].clone()
+        } else {
+            return Ok(None);
+        };
+        Ok(Some(vec![
+            executable,
+            "--session".into(),
+            external_session_id.clone(),
+        ]))
+    }
+
     fn dispatch(&self, request: Request) -> io::Result<Response> {
         match request {
             Request::Ping => Ok(Response::Pong),
@@ -4484,10 +4629,24 @@ fn initial_terminal_state(
     cols: u16,
     workspace_name: &str,
     shell_name: &str,
+    history: Option<&str>,
 ) -> TerminalState {
     let mut terminal = TerminalState::new(rows, cols);
+    if let Some(history) = history.filter(|history| !history.is_empty()) {
+        terminal.process(b"\x1b[2mBoomux: restored bounded history from previous run\x1b[0m\r\n");
+        terminal.process(history.replace('\n', "\r\n").as_bytes());
+        if !history.ends_with('\n') {
+            terminal.process(b"\r\n");
+        }
+    }
     terminal.process(format!("\x1b[2mBoomux: {workspace_name}/{shell_name}\x1b[0m\r\n").as_bytes());
     terminal
+}
+
+#[derive(Default)]
+struct RuntimeRecovery<'a> {
+    effective_command: Option<&'a [String]>,
+    history: Option<&'a str>,
 }
 
 fn spawn_runtime(
@@ -4497,6 +4656,7 @@ fn spawn_runtime(
     shell_name: &str,
     profile: &TerminalProfile,
     environment: Option<&UnixEnvironment>,
+    recovery: RuntimeRecovery<'_>,
 ) -> io::Result<(Arc<ShellRuntime>, PtyReader)> {
     let pty = native_pty_system()
         .openpty(PtySize {
@@ -4524,11 +4684,12 @@ fn spawn_runtime(
                 .flatten()
         })
         .unwrap_or_else(|| "/bin/sh".into());
-    let mut command = if shell.command.is_empty() {
+    let selected_command = recovery.effective_command.unwrap_or(&shell.command);
+    let mut command = if selected_command.is_empty() {
         CommandBuilder::new(client_shell)
     } else {
-        let mut command = CommandBuilder::new(&shell.command[0]);
-        command.args(&shell.command[1..]);
+        let mut command = CommandBuilder::new(&selected_command[0]);
+        command.args(&selected_command[1..]);
         command
     };
     command.cwd(&shell.cwd);
@@ -4566,7 +4727,13 @@ fn spawn_runtime(
     drop(pty.slave);
     drop(pty.master);
 
-    let terminal = initial_terminal_state(profile.rows, profile.cols, workspace_name, shell_name);
+    let terminal = initial_terminal_state(
+        profile.rows,
+        profile.cols,
+        workspace_name,
+        shell_name,
+        recovery.history,
+    );
 
     Ok((
         Arc::new(ShellRuntime {
@@ -4598,6 +4765,7 @@ fn start_pty_reader(
             let mut buffer = [0; 16 * 1024];
             let mut stopped = false;
             let mut paused = start_paused;
+            let mut last_history_checkpoint = Instant::now();
             let mut pause_cancellation: Option<Arc<AtomicBool>> = None;
             loop {
                 if paused {
@@ -4721,6 +4889,18 @@ fn start_pty_reader(
                         drop(events);
                         drop(transition);
                         registry.events.changed.notify_all();
+                        if registry.notification_settings.persist_terminal_history
+                            && last_history_checkpoint.elapsed() >= TERMINAL_HISTORY_INTERVAL
+                            && checkpoint_terminal_history(
+                                &registry,
+                                &shell,
+                                &reader_run,
+                                &reader_runtime,
+                            )
+                            .is_ok()
+                        {
+                            last_history_checkpoint = Instant::now();
+                        }
                     }
                     Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
                     Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
@@ -4747,11 +4927,20 @@ fn start_pty_reader(
                 .lock()
                 .ok()
                 .and_then(|mut process| process.try_wait_code().ok().flatten().flatten());
-            if let Some(registry) = registry.upgrade()
-                && let Err(error) =
+            if let Some(registry) = registry.upgrade() {
+                if registry.notification_settings.persist_terminal_history {
+                    let _ = checkpoint_terminal_history(
+                        &registry,
+                        &shell,
+                        &reader_run,
+                        &reader_runtime,
+                    );
+                }
+                if let Err(error) =
                     registry.record_run_exit(&shell, &reader_run, &reader_runtime, code)
-            {
-                eprintln!("boomux: could not persist shell run exit: {error}");
+                {
+                    eprintln!("boomux: could not persist shell run exit: {error}");
+                }
             }
             let _ = reader_runtime
                 .controller
@@ -4759,6 +4948,25 @@ fn start_pty_reader(
                 .map(|mut controller| controller.take());
         })?;
     *lock(&runtime.reader)? = Some(ReaderTask { commands, handle });
+    Ok(())
+}
+
+fn checkpoint_terminal_history(
+    registry: &Registry,
+    shell: &Shell,
+    run: &ShellRun,
+    runtime: &ShellRuntime,
+) -> io::Result<()> {
+    let history = lock(&runtime.terminal)?.cold_history(MAX_TERMINAL_HISTORY_BYTES);
+    let mut last_run = lock(&shell.last_run)?;
+    let Some(last_run) = last_run.as_mut().filter(|saved| saved.id == run.id) else {
+        return Ok(());
+    };
+    if last_run.terminal_history.as_deref() == Some(&history) {
+        return Ok(());
+    }
+    last_run.terminal_history = Some(history);
+    registry.persistence_dirty.store(true, Ordering::Release);
     Ok(())
 }
 
@@ -4845,6 +5053,19 @@ fn handle_attach(
     }
     let previous_run = lock(&shell.last_run)?.clone();
     let needs_start = matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending);
+    let resume_command = needs_start
+        .then(|| registry.agent_resume_command(&shell, previous_run.as_ref()))
+        .transpose()?
+        .flatten();
+    let restored_history = needs_start
+        .then(|| {
+            registry
+                .notification_settings
+                .persist_terminal_history
+                .then(|| previous_run.as_ref()?.terminal_history.clone())
+                .flatten()
+        })
+        .flatten();
     if needs_start && transition.is_none() {
         transition = Some(lock(&registry.transitions)?);
     }
@@ -4891,6 +5112,10 @@ fn handle_attach(
                 &shell_name,
                 &profile,
                 environment.as_ref(),
+                RuntimeRecovery {
+                    effective_command: resume_command.as_deref(),
+                    history: restored_history.as_deref(),
+                },
             ) {
                 Ok(runtime) => runtime,
                 Err(error) => {
@@ -5750,9 +5975,164 @@ mod tests {
 
     #[test]
     fn new_shell_terminal_starts_with_its_workspace_and_shell_name() {
-        let terminal = initial_terminal_state(24, 80, "project", "build");
+        let terminal = initial_terminal_state(24, 80, "project", "build", None);
 
         assert!(terminal.plain_text().contains("Boomux: project/build"));
+    }
+
+    #[test]
+    fn cold_terminal_history_is_presented_before_the_new_run_banner() {
+        let terminal = initial_terminal_state(24, 80, "project", "agent", Some("old output\n"));
+        let text = terminal.plain_text();
+
+        assert!(text.contains("restored bounded history from previous run\nold output"));
+        assert!(text.find("old output").unwrap() < text.find("Boomux: project/agent").unwrap());
+    }
+
+    fn add_recovery_agent(
+        registry: &Registry,
+        shell: &Shell,
+        run_id: &str,
+        integration: &str,
+        external_session_id: &str,
+    ) {
+        let agent = Arc::new(AgentInstance {
+            id: Uuid::new_v4().to_string(),
+            workspace_id: shell.workspace_id.clone(),
+            shell_id: shell.id.clone(),
+            run_id: run_id.into(),
+            name: integration.into(),
+            integration: integration.into(),
+            external_session_id: Some(external_session_id.into()),
+            cwd: Some(shell.cwd.clone()),
+            started_at_ms: 1,
+            state: Mutex::new(AgentInstanceState {
+                ended_at_ms: None,
+                observation: AgentObservationSnapshot {
+                    revision: 1,
+                    state: AgentState::Working,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "active before interruption".into(),
+                    confidence: 100,
+                    observed_at_ms: 1,
+                },
+                attention: None,
+            }),
+        });
+        lock(&registry.state)
+            .unwrap()
+            .agents
+            .insert(agent.id.clone(), agent);
+    }
+
+    fn recovery_shell(
+        registry: &Registry,
+        command: Vec<String>,
+    ) -> (Arc<Shell>, PersistedShellRun) {
+        let workspace = registry
+            .create_workspace(
+                "recovery".into(),
+                vec![ShellSpec {
+                    name: "agent".into(),
+                    command,
+                    cwd: env::temp_dir(),
+                }],
+            )
+            .unwrap();
+        let shell = registry.shell(&workspace.shells[0].id).unwrap();
+        let run = PersistedShellRun {
+            id: Uuid::new_v4().to_string(),
+            generation: 1,
+            started_at_ms: 1,
+            ended_at_ms: Some(2),
+            exit_reason: Some(ShellRunExitReason::Interrupted),
+            output_revision: 1,
+            environment_has_run_id: true,
+            profile: profile(),
+            terminal_history: None,
+        };
+        *lock(&shell.last_run).unwrap() = Some(run.clone());
+        (shell, run)
+    }
+
+    #[test]
+    fn interrupted_authoritative_agent_builds_native_resume_command() {
+        let registry = Registry::default();
+        let (shell, run) = recovery_shell(&registry, vec!["/opt/bin/opencode".into()]);
+        add_recovery_agent(&registry, &shell, &run.id, "opencode", "session-1");
+
+        assert_eq!(
+            registry.agent_resume_command(&shell, Some(&run)).unwrap(),
+            Some(vec![
+                "/opt/bin/opencode".into(),
+                "--session".into(),
+                "session-1".into()
+            ])
+        );
+
+        let agent = lock(&registry.state)
+            .unwrap()
+            .agents
+            .values()
+            .next()
+            .unwrap()
+            .clone();
+        lock(&agent.state).unwrap().observation.authority = AgentAuthority::TerminalHeuristic;
+        assert!(
+            registry
+                .agent_resume_command(&shell, Some(&run))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn recovery_falls_back_when_agent_identity_is_ambiguous_or_disabled() {
+        let mut registry = Registry::default();
+        let (shell, run) = recovery_shell(&registry, Vec::new());
+        add_recovery_agent(&registry, &shell, &run.id, "pi", "session-1");
+        add_recovery_agent(&registry, &shell, &run.id, "pi", "session-2");
+
+        assert!(
+            registry
+                .agent_resume_command(&shell, Some(&run))
+                .unwrap()
+                .is_none()
+        );
+
+        lock(&registry.state)
+            .unwrap()
+            .agents
+            .retain(|_, agent| agent.external_session_id.as_deref() == Some("session-1"));
+        registry.notification_settings.resume_agents = false;
+        assert!(
+            registry
+                .agent_resume_command(&shell, Some(&run))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn disabling_history_persistence_clears_retained_history() {
+        let registry = Registry::default();
+        let (shell, _) = recovery_shell(&registry, Vec::new());
+        lock(&shell.last_run)
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .terminal_history = Some("secret output".into());
+
+        registry.clear_terminal_histories().unwrap();
+
+        assert!(
+            lock(&shell.last_run)
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .terminal_history
+                .is_none()
+        );
     }
 
     fn agent_spec(state: AgentState) -> AgentRegistrationSpec {
@@ -5791,8 +6171,16 @@ mod tests {
             .unwrap();
         let shell = registry.shell(&workspace.shells[0].id).unwrap();
         let run = Arc::new(ShellRun::new(1));
-        let (runtime, _reader) =
-            spawn_runtime(&shell, &run, "agents", "agent-shell", &profile(), None).unwrap();
+        let (runtime, _reader) = spawn_runtime(
+            &shell,
+            &run,
+            "agents",
+            "agent-shell",
+            &profile(),
+            None,
+            RuntimeRecovery::default(),
+        )
+        .unwrap();
         *lock(&shell.last_run).unwrap() = Some(run.persisted(profile()).unwrap());
         *lock(&shell.lifecycle).unwrap() = ShellLifecycle::Running {
             profile: profile(),
@@ -7603,6 +7991,7 @@ mod tests {
             "pause-test",
             &terminal_profile,
             None,
+            RuntimeRecovery::default(),
         )
         .unwrap();
         *lock(&shell.last_run).unwrap() = Some(run.persisted(terminal_profile.clone()).unwrap());
@@ -7674,6 +8063,7 @@ mod tests {
             "short-lived",
             &terminal_profile,
             None,
+            RuntimeRecovery::default(),
         )
         .unwrap();
         *lock(&shell.last_run).unwrap() = Some(run.persisted(terminal_profile.clone()).unwrap());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -397,6 +397,14 @@ pub struct NotificationDeliveryConfig {
     pub completed: bool,
     pub blocked_sound: String,
     pub completed_sound: String,
+    #[serde(default = "default_true")]
+    pub resume_agents: bool,
+    #[serde(default)]
+    pub persist_terminal_history: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl std::fmt::Debug for UnixEnvironmentVariable {
@@ -863,6 +871,24 @@ mod tests {
     }
 
     #[test]
+    fn old_notification_config_defaults_recovery_safely() {
+        let config: NotificationDeliveryConfig = serde_json::from_str(
+            r#"{
+                "desktop_enabled": false,
+                "sound_enabled": false,
+                "blocked": true,
+                "completed": true,
+                "blocked_sound": "message-new-instant",
+                "completed_sound": "complete"
+            }"#,
+        )
+        .unwrap();
+
+        assert!(config.resume_agents);
+        assert!(!config.persist_terminal_history);
+    }
+
+    #[test]
     fn typed_errors_are_additive_within_protocol_six() {
         let legacy: Response =
             serde_json::from_str(r#"{"response":"error","message":"legacy daemon"}"#).unwrap();
@@ -1091,6 +1117,8 @@ mod tests {
                         completed: true,
                         blocked_sound: "dialog-warning".into(),
                         completed_sound: "complete".into(),
+                        resume_agents: true,
+                        persist_terminal_history: false,
                     },
                 }],
             ),

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -13,7 +13,8 @@ use crate::protocol::{
     AgentAttentionSnapshot, AgentObservationSnapshot, ShellRunExitReason, TerminalProfile,
 };
 
-const STATE_VERSION: u32 = 7;
+const STATE_VERSION: u32 = 8;
+const VERSION_SEVEN_STATE_VERSION: u32 = 7;
 const PREVIOUS_STATE_VERSION: u32 = 6;
 const VERSION_FIVE_STATE_VERSION: u32 = 5;
 const VERSION_FOUR_STATE_VERSION: u32 = 4;
@@ -95,11 +96,54 @@ pub(crate) struct PersistedShellRun {
     pub(crate) output_revision: u64,
     pub(crate) environment_has_run_id: bool,
     pub(crate) profile: TerminalProfile,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) terminal_history: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct StateVersion {
     version: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionSevenPersistedState {
+    version: u32,
+    workspaces: Vec<VersionSevenPersistedWorkspace>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionSevenPersistedWorkspace {
+    id: String,
+    name: String,
+    default_cwd: Option<PathBuf>,
+    shells: Vec<VersionSevenPersistedShell>,
+    launchers: Vec<PersistedWorkspaceLauncher>,
+    agents: Vec<PersistedAgentInstance>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionSevenPersistedShell {
+    id: String,
+    name: String,
+    cwd: PathBuf,
+    command: Vec<String>,
+    last_run: Option<VersionSevenPersistedShellRun>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionSevenPersistedShellRun {
+    id: String,
+    generation: u64,
+    started_at_ms: u64,
+    ended_at_ms: Option<u64>,
+    exit_reason: Option<ShellRunExitReason>,
+    output_revision: u64,
+    environment_has_run_id: bool,
+    profile: TerminalProfile,
 }
 
 #[derive(Deserialize)]
@@ -341,6 +385,10 @@ impl StateStore {
         })?;
         let (state, migrated) = match version.version {
             STATE_VERSION => (parse_state(&bytes, &self.path)?, false),
+            VERSION_SEVEN_STATE_VERSION => {
+                let previous: VersionSevenPersistedState = parse_state(&bytes, &self.path)?;
+                (migrate_version_seven_state(previous), true)
+            }
             PREVIOUS_STATE_VERSION => {
                 let previous: PreviousPersistedState = parse_state(&bytes, &self.path)?;
                 (migrate_previous_state(previous), true)
@@ -447,11 +495,51 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
                             output_revision: 0,
                             environment_has_run_id: false,
                             profile,
+                            terminal_history: None,
                         }),
                     })
                     .collect(),
                 launchers: Vec::new(),
                 agents: Vec::new(),
+            })
+            .collect(),
+    }
+}
+
+fn migrate_version_seven_state(previous: VersionSevenPersistedState) -> PersistedState {
+    debug_assert_eq!(previous.version, VERSION_SEVEN_STATE_VERSION);
+    PersistedState {
+        version: STATE_VERSION,
+        workspaces: previous
+            .workspaces
+            .into_iter()
+            .map(|workspace| PersistedWorkspace {
+                id: workspace.id,
+                name: workspace.name,
+                default_cwd: workspace.default_cwd,
+                shells: workspace
+                    .shells
+                    .into_iter()
+                    .map(|shell| PersistedShell {
+                        id: shell.id,
+                        name: shell.name,
+                        cwd: shell.cwd,
+                        command: shell.command,
+                        last_run: shell.last_run.map(|run| PersistedShellRun {
+                            id: run.id,
+                            generation: run.generation,
+                            started_at_ms: run.started_at_ms,
+                            ended_at_ms: run.ended_at_ms,
+                            exit_reason: run.exit_reason,
+                            output_revision: run.output_revision,
+                            environment_has_run_id: run.environment_has_run_id,
+                            profile: run.profile,
+                            terminal_history: None,
+                        }),
+                    })
+                    .collect(),
+                launchers: workspace.launchers,
+                agents: workspace.agents,
             })
             .collect(),
     }
@@ -650,7 +738,32 @@ mod tests {
                 id: Uuid::new_v4().to_string(),
                 name: "saved".into(),
                 default_cwd: Some("/tmp/project".into()),
-                shells: Vec::new(),
+                shells: vec![PersistedShell {
+                    id: "shell-1".into(),
+                    name: "agent".into(),
+                    cwd: "/tmp/project".into(),
+                    command: vec!["opencode".into()],
+                    last_run: Some(PersistedShellRun {
+                        id: "run-1".into(),
+                        generation: 1,
+                        started_at_ms: 1,
+                        ended_at_ms: Some(2),
+                        exit_reason: Some(ShellRunExitReason::Interrupted),
+                        output_revision: 3,
+                        environment_has_run_id: true,
+                        profile: TerminalProfile {
+                            term: Some("xterm-256color".into()),
+                            colorterm: None,
+                            term_program: None,
+                            term_program_version: None,
+                            rows: 24,
+                            cols: 80,
+                            pixel_width: 0,
+                            pixel_height: 0,
+                        },
+                        terminal_history: Some("bounded output".into()),
+                    }),
+                }],
                 launchers: vec![
                     PersistedWorkspaceLauncher {
                         id: "launcher-1".into(),
@@ -725,6 +838,13 @@ mod tests {
 
         assert_eq!(restored.workspaces[0].name, "saved");
         assert_eq!(
+            restored.workspaces[0].shells[0]
+                .last_run
+                .as_ref()
+                .and_then(|run| run.terminal_history.as_deref()),
+            Some("bounded output")
+        );
+        assert_eq!(
             restored.workspaces[0].default_cwd.as_deref(),
             Some(Path::new("/tmp/project"))
         );
@@ -782,6 +902,55 @@ mod tests {
     }
 
     #[test]
+    fn migrates_version_seven_runs_without_terminal_history() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            br#"{
+  "version": 7,
+  "workspaces": [{
+    "id": "w1", "name": "version-seven", "default_cwd": "/tmp/project",
+    "shells": [{
+      "id": "s1", "name": "agent", "cwd": "/tmp/project", "command": ["opencode"],
+      "last_run": {
+        "id": "r1", "generation": 1, "started_at_ms": 1, "ended_at_ms": 2,
+        "exit_reason": {"reason": "interrupted"}, "output_revision": 3,
+        "environment_has_run_id": true,
+        "profile": {
+          "term": "xterm-256color", "colorterm": null, "term_program": null,
+          "term_program_version": null, "rows": 24, "cols": 80,
+          "pixel_width": 0, "pixel_height": 0
+        }
+      }
+    }],
+    "launchers": [], "agents": []
+  }]
+}"#,
+        )
+        .unwrap();
+        let store = StateStore::at(path.clone());
+
+        let migrated = store.load().unwrap().unwrap();
+
+        assert!(
+            migrated.workspaces[0].shells[0]
+                .last_run
+                .as_ref()
+                .unwrap()
+                .terminal_history
+                .is_none()
+        );
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("\"version\": 8")
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
     fn migrates_version_one_runs_once_and_preserves_the_generated_identity() {
         let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
         let path = directory.join("boomux/state.json");
@@ -832,7 +1001,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 7")
+                .contains("\"version\": 8")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
         assert!(migrated.workspaces[0].agents.is_empty());
@@ -882,7 +1051,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 7")
+                .contains("\"version\": 8")
         );
         assert!(migrated.workspaces[0].agents.is_empty());
         fs::remove_dir_all(directory).unwrap();
@@ -920,7 +1089,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 7")
+                .contains("\"version\": 8")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -996,7 +1165,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 7")
+                .contains("\"version\": 8")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1031,7 +1200,7 @@ mod tests {
 
         assert!(migrated.workspaces[0].agents[0].attention.is_none());
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 7"));
+        assert!(saved.contains("\"version\": 8"));
         assert!(saved.contains("\"attention\": null"));
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1063,7 +1232,7 @@ mod tests {
         assert!(!original.contains("default_cwd"));
         store.save(&migrated).unwrap();
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 7"));
+        assert!(saved.contains("\"version\": 8"));
         assert!(saved.contains("\"default_cwd\": null"));
         fs::remove_dir_all(directory).unwrap();
     }

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -108,6 +108,15 @@ impl TerminalState {
             .collect()
     }
 
+    pub(crate) fn cold_history(&self, max_bytes: usize) -> String {
+        let text = self.plain_text();
+        let mut start = text.len().saturating_sub(max_bytes);
+        while !text.is_char_boundary(start) {
+            start += 1;
+        }
+        text[start..].to_owned()
+    }
+
     pub(crate) fn preview(
         &self,
         max_bytes: usize,
@@ -635,6 +644,17 @@ mod tests {
         let mut restored = TerminalState::new(2, 20);
         restored.process(&state.reconstruction());
         assert_eq!(restored.plain_text(), "one\ntwo\nthree");
+    }
+
+    #[test]
+    fn cold_history_keeps_a_utf8_safe_bounded_suffix() {
+        let mut state = TerminalState::new(2, 20);
+        state.process("prefix-abcdé".as_bytes());
+
+        let history = state.cold_history(3);
+
+        assert_eq!(history, "dé");
+        assert!(history.len() <= 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- resume unique lifecycle-authoritative OpenCode and Pi sessions when an interrupted shell starts after cold recovery
- add opt-in, UTF-8-safe terminal history checkpoints with bounded persistence and opt-out cleanup
- migrate daemon state to version 8 and document recovery behavior and security implications

## Testing
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets
- git diff --check

## Testing Notes
- resume policy and generated argv are covered with unit tests
- state migration, history bounds, restored presentation, and opt-out cleanup are covered
- no literal machine reboot or external OpenCode/Pi process was used in the automated suite