### PR TITLE
fix: remove stale overview attention and harden process timing

### DIFF
--- a/src/host_session_titles.rs
+++ b/src/host_session_titles.rs
@@ -216,8 +216,8 @@ mod tests {
     use std::ffi::OsString;
     use std::fs::{self, File, FileTimes};
     use std::os::unix::fs::symlink;
-    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Barrier, Mutex};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
@@ -618,12 +618,17 @@ mod tests {
     fn cache_is_async_deduplicated_and_routes_opencode_and_pi() {
         let calls = Arc::new(Mutex::new(Vec::new()));
         let worker_calls = Arc::clone(&calls);
+        let first_inspection = Arc::new(Barrier::new(2));
+        let worker_first_inspection = Arc::clone(&first_inspection);
         let (finished_sender, finished_receiver) = mpsc::channel();
         let mut cache = Cache::with_inspector(Arc::new(move |integration, directory| {
             worker_calls
                 .lock()
                 .expect("calls lock")
                 .push((integration.to_owned(), directory.to_owned()));
+            if integration == "opencode" {
+                worker_first_inspection.wait();
+            }
             let _ = finished_sender.send(integration.to_owned());
             let catalog = (integration == "opencode")
                 .then(|| HostSession {
@@ -654,6 +659,7 @@ mod tests {
             None
         );
         assert_eq!(cache.title("pi", Path::new("/repo"), "pi-id"), None);
+        first_inspection.wait();
         finished_receiver
             .recv_timeout(Duration::from_secs(2))
             .expect("first inspection");

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -539,13 +539,26 @@ fn probe_version(executable: &Path) -> io::Result<String> {
 }
 
 fn probe_version_with_timeout(executable: &Path, timeout: Duration) -> io::Result<String> {
-    let mut child = Command::new(executable)
-        .arg("--version")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .process_group(0)
-        .spawn()?;
+    let deadline = Instant::now() + timeout;
+    let mut child = loop {
+        let result = Command::new(executable)
+            .arg("--version")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .process_group(0)
+            .spawn();
+        match result {
+            Ok(child) => break child,
+            Err(error)
+                if error.kind() == io::ErrorKind::ExecutableFileBusy
+                    && Instant::now() < deadline =>
+            {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => return Err(error),
+        }
+    };
     let stdout = child
         .stdout
         .take()
@@ -561,7 +574,6 @@ fn probe_version_with_timeout(executable: &Path, timeout: Duration) -> io::Resul
     });
     let process_group = i32::try_from(child.id())
         .map_err(|_| io::Error::other("version probe process ID exceeded i32"))?;
-    let deadline = Instant::now() + timeout;
     let result = (|| {
         let mut status = None;
         let mut output = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1279,7 +1279,6 @@ fn dashboard_views_from_sessions(
                             .into(),
                         evidence: item.attention.observation.evidence,
                         observed_at_ms: item.attention.observation.observed_at_ms,
-                        observation_is_current: item.observation_is_current,
                     })
                     .collect();
             let shells = workspace.shells.iter().map(|shell| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5632,14 +5632,22 @@ mod tests {
 
         let error = open_workspace(&workspace, None).unwrap_err();
         assert!(error.to_string().contains("launcher missing"));
-        for _ in 0..100 {
-            if marker.is_file() {
-                break;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let contents = loop {
+            if let Ok(contents) = fs::read_to_string(&marker)
+                && contents == "launched"
+            {
+                break contents;
+            }
+            if std::time::Instant::now() >= deadline {
+                break String::new();
             }
             thread::sleep(std::time::Duration::from_millis(10));
+        };
+        assert_eq!(contents, "launched");
+        if marker.is_file() {
+            fs::remove_file(marker).unwrap();
         }
-        assert_eq!(fs::read_to_string(&marker).unwrap(), "launched");
-        fs::remove_file(marker).unwrap();
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -57,7 +57,6 @@ pub(crate) struct WorkspaceAttentionView {
     pub(crate) reason: String,
     pub(crate) evidence: String,
     pub(crate) observed_at_ms: u64,
-    pub(crate) observation_is_current: bool,
 }
 
 pub(crate) struct AgentSessionView {
@@ -2804,36 +2803,6 @@ fn workspace_preview(workspace: &WorkspaceView) -> ContextualPreview {
             Style::new().fg(SUBTEXT),
         )),
     ]);
-    if let Some(attention) = workspace.attention.first() {
-        let currency = if attention.observation_is_current {
-            "current"
-        } else {
-            "stale"
-        };
-        lines.extend([
-            Line::from(Span::styled(
-                format!("{}: {}", attention.reason, attention.agent_name),
-                Style::new().fg(if attention.reason == "blocked" {
-                    RED
-                } else {
-                    BLUE
-                }),
-            )),
-            Line::from(Span::styled(
-                attention.evidence.clone(),
-                Style::new().fg(SUBTEXT),
-            )),
-            Line::from(Span::styled(
-                format!("{}  {currency}", compact_recency(attention.observed_at_ms)),
-                Style::new().fg(SUBTEXT),
-            )),
-        ]);
-    } else {
-        lines.push(Line::from(Span::styled(
-            "No outstanding attention",
-            Style::new().fg(SUBTEXT),
-        )));
-    }
     ContextualPreview {
         title: format!(" {} overview ", workspace.name),
         content_height: lines.len() as u16,
@@ -4315,7 +4284,6 @@ mod tests {
             reason: "blocked".into(),
             evidence: "approval required".into(),
             observed_at_ms: 1,
-            observation_is_current: true,
         }];
         workspace.attention_count = 1;
         let mut palette = CommandPalette::new(&[workspace]);
@@ -4361,7 +4329,6 @@ mod tests {
             reason: "completed".into(),
             evidence: "finished".into(),
             observed_at_ms: 20,
-            observation_is_current: true,
         }];
         let mut blocked = workspace("w2", "second");
         blocked.attention = vec![WorkspaceAttentionView {
@@ -4370,7 +4337,6 @@ mod tests {
             reason: "blocked".into(),
             evidence: "approval required".into(),
             observed_at_ms: 10,
-            observation_is_current: true,
         }];
         let mut palette = CommandPalette::new(&[completed, blocked]);
 
@@ -5721,7 +5687,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_preview_surfaces_most_urgent_attention() {
+    fn workspace_preview_omits_attention_details() {
         let backend = TestBackend::new(140, 34);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut workspace = workspace("w1", "review");
@@ -5731,7 +5697,6 @@ mod tests {
             reason: "blocked".into(),
             evidence: "approval required".into(),
             observed_at_ms: current_time_ms(),
-            observation_is_current: true,
         }];
         workspace.attention_count = 1;
         let mut app = App::new(vec![workspace], project_context());
@@ -5746,8 +5711,11 @@ mod tests {
             .collect();
 
         assert!(text.contains("review overview"));
-        assert!(text.contains("blocked: review-agent"));
-        assert!(text.contains("approval required"));
+        assert!(text.contains("working"));
+        assert!(text.contains("blocked"));
+        assert!(!text.contains("blocked: review-agent"));
+        assert!(!text.contains("approval required"));
+        assert!(!text.contains("No outstanding attention"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove outstanding-attention callouts, evidence, and recency from workspace overview panels
- keep lifecycle state counts in the overview and preserve durable attention for the queue and command palette
- retry transient executable-busy failures during bounded integration version probes
- make async cache and detached launcher tests wait on deterministic completion conditions

## Root Cause
Boomux intentionally retains unacknowledged attention after an Agent advances to a later lifecycle observation. The overview mixed that historical attention with latest-state counts, making a stale blocker look current even when the workspace reported zero blocked Agents.

CI also exposed three pre-existing timing assumptions: async cache work could complete before a second lookup, detached launchers create marker files before writing content, and Linux may transiently reject execution with ETXTBSY during replacement.

## Testing
- cargo clippy --all-targets -- -D warnings
- cargo test --lib --bins --locked
- cargo test --test native_backend --locked -- --test-threads=1
- git diff --check

## Manual Verification
- inspected the live workspace, Agent, and attention records to confirm the displayed blocker was stale
- installed the combined checkout and gracefully restarted the Boomux daemon