### PR TITLE
ci: publish linux release assets

### DIFF
--- a/.github/scripts/package-release.sh
+++ b/.github/scripts/package-release.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag=${1:?usage: package-release.sh TAG TARGET}
+target=${2:?usage: package-release.sh TAG TARGET}
+version=${tag#v}
+binary="target/${target}/release/boomux"
+package="boomux-${tag}-${target}"
+archive="${package}.tar.gz"
+
+if [[ ! -x "$binary" ]]; then
+  printf 'release binary not found: %s\n' "$binary" >&2
+  exit 1
+fi
+
+actual_version=$("$binary" --version)
+if [[ "$actual_version" != "boomux ${version}" ]]; then
+  printf 'expected boomux %s, got %s\n' "$version" "$actual_version" >&2
+  exit 1
+fi
+
+rm -rf dist
+mkdir -p "dist/${package}"
+cp "$binary" "dist/${package}/boomux"
+cp LICENSE README.md "dist/${package}/"
+tar -C dist -czf "dist/${archive}" "$package"
+rm -rf "dist/${package}"
+
+(
+  cd dist
+  sha256sum "$archive" > "${archive}.sha256"
+)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build and publish
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -18,10 +23,65 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release-created: ${{ steps.release.outputs.release_created }}
+      tag-name: ${{ steps.release.outputs.tag_name || inputs.tag }}
     steps:
       - name: Run Release Please
+        id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  build-release:
+    name: Build Linux x86_64 release
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release-created == 'true' || inputs.tag != '' }}
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: stable
+      TARGET: x86_64-unknown-linux-gnu
+      TAG: ${{ needs.release-please.outputs.tag-name }}
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Build release binary
+        run: cargo build --release --locked --target "$TARGET"
+
+      - name: Package and smoke test release
+        run: bash .github/scripts/package-release.sh "$TAG" "$TARGET"
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: boomux-${{ env.TAG }}-${{ env.TARGET }}
+          path: dist/*
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish GitHub release assets
+    needs:
+      - release-please
+      - build-release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      TAG: ${{ needs.release-please.outputs.tag-name }}
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: boomux-${{ env.TAG }}-x86_64-unknown-linux-gnu
+          path: dist
+
+      - name: Upload assets to GitHub Release
+        run: gh release upload "$TAG" dist/* --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/dist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "boomux"
 version = "0.12.0"
 edition = "2024"
+license = "MIT"
 
 [dependencies]
 base64 = "0.22"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mike Gardner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,18 @@ Installing from source also requires:
 
 - A Rust toolchain.
 
-Install directly from the repository:
+Download and install the latest Linux x86_64 release with the GitHub CLI:
+
+```console
+version=$(gh release view --repo gardnmi/boomux --json tagName --jq .tagName)
+gh release download "$version" --repo gardnmi/boomux --pattern "boomux-$version-x86_64-unknown-linux-gnu.tar.gz*"
+sha256sum --check "boomux-$version-x86_64-unknown-linux-gnu.tar.gz.sha256"
+tar -xzf "boomux-$version-x86_64-unknown-linux-gnu.tar.gz"
+install -Dm755 "boomux-$version-x86_64-unknown-linux-gnu/boomux" ~/.local/bin/boomux
+boomux doctor
+```
+
+Alternatively, install directly from the repository with a Rust toolchain:
 
 ```console
 cargo install --git https://github.com/gardnmi/boomux --locked


### PR DESCRIPTION
## Summary
- add the MIT license and declare it in Cargo metadata
- build and package Linux x86_64 binaries when Release Please creates a release
- attach the versioned archive and SHA-256 checksum to the GitHub Release
- support manually rebuilding an existing release from a tag
- document binary installation while retaining source installation

## Artifacts
- `boomux-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz`
- `boomux-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz.sha256`

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib --bins --locked` (374 tests passed)
- `cargo build --release --locked --target x86_64-unknown-linux-gnu`
- packaged and verified `v0.12.0` locally
- checksum validation passed
- extracted binary reported `boomux 0.12.0`
- `bash -n .github/scripts/package-release.sh`
- `git diff --check`