### PR TITLE
feat(doctor): report version and platform

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4094,7 +4094,19 @@ fn legacy_skill_install_path(home: &Path) -> PathBuf {
     home.join(".agents/skills/boomux-shells/SKILL.md")
 }
 
+fn doctor_version_line(version: &str, architecture: &str, operating_system: &str) -> String {
+    format!("ok  boomux: {version} ({architecture}-{operating_system})")
+}
+
 fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
+    println!(
+        "{}",
+        doctor_version_line(
+            env!("CARGO_PKG_VERSION"),
+            env::consts::ARCH,
+            env::consts::OS
+        )
+    );
     let mut healthy = true;
     let daemon_snapshot = match client::connect_or_start() {
         Ok(client) => {
@@ -6118,6 +6130,14 @@ mod tests {
             ["opencode", "pi"]
         );
         assert_eq!(protocol::PROTOCOL_VERSION, 20);
+    }
+
+    #[test]
+    fn doctor_reports_version_and_platform() {
+        assert_eq!(
+            doctor_version_line("1.2.3", "x86_64", "linux"),
+            "ok  boomux: 1.2.3 (x86_64-linux)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- show the Boomux package version at the start of `boomux doctor`
- include the compile-target architecture and operating system for installation diagnostics
- cover the exact diagnostic format with a focused unit test

## Example
`ok  boomux: 0.13.0 (x86_64-linux)`

## Verification
- `cargo fmt --all -- --check`
- `cargo test --bin boomux doctor_reports_version_and_platform --locked`
- `cargo test --lib --bins --locked` (375 tests passed)
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `git diff --check`