### PR TITLE
docs: add contributor navigation guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,88 @@
 # Repository Workflow
 
+## Start Here
+
+Use repository documentation in this order:
+
+1. `CONTEXT.md` defines canonical product terms and distinctions. Preserve those
+   semantics when names in code are less precise.
+2. `docs/architecture.md` describes the current implementation boundaries and
+   cross-cutting invariants.
+3. Contract documents such as `docs/cli-json.md`, `docs/event-stream.md`, and
+   `docs/live-pty-handoff.md` govern their named interfaces and guarantees.
+4. `docs/adr/` records accepted decisions and rationale.
+5. `docs/lifecycle-validation.md` records compatibility evidence from specific
+   host versions; it is evidence, not a general specification.
+6. `docs/roadmap.md` is non-authoritative future intent. Documents marked as
+   historical explain how the design was reached but do not override current
+   architecture, source, or tests.
+
+For exact protocol and persistence versions, source and compatibility tests are
+authoritative. Start a change in the owning module listed in the architecture
+module map, then read its colocated tests and the relevant contract document.
+
+## Validation
+
+Run the same checks as CI:
+
+```console
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features --locked -- -D warnings
+cargo test --lib --bins --locked
+cargo test --test native_backend --locked -- --test-threads=1
+bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js
+```
+
+Run the narrowest relevant tests while iterating, then run the complete set
+before opening a PR. Native backend tests are intentionally serial because they
+exercise process, socket, PTY, and daemon lifecycle behavior.
+
+### Testing By Change Type
+
+| Change | Expected coverage |
+| --- | --- |
+| Protocol field or request | Protocol serialization/defaulting and minimum-version tests, client negotiation tests, and native mixed-version behavior |
+| Persisted state shape | `state_store.rs` migration tests and a cold-recovery native test |
+| PTY, attachment, or process lifecycle | Colocated unit tests plus serial `native_backend` scenarios |
+| Graceful handoff | Serial native tests covering rollback, reconnect, PID preservation, and later cleanup |
+| TUI state or rendering | Focused `tui.rs` model, input, and rendering tests |
+| OpenCode or Pi reducer | The corresponding Bun integration test |
+| Host compatibility claim | Focused fixtures plus an update to `docs/lifecycle-validation.md` when validated live |
+
+## Safety And Compatibility
+
+- `boomux daemon stop` terminates every managed process. Prefer
+  `boomux daemon restart` when testing compatible rebuilt binaries.
+- Preserve exact argument vectors; do not introduce shell interpolation into
+  launchers, commands, process adapters, or integration execution.
+- Treat shell runs and Agent instances as run-scoped. Never infer permanent
+  Agent completion from process exit or quiet terminal output.
+- Do not persist attachment environments. They are ephemeral startup input and
+  may contain private data.
+- Preserve persistence-before-event publication and the documented daemon lock
+  order when changing coordinated mutations.
+
+### Protocol Changes
+
+- Bump `PROTOCOL_VERSION` only when wire behavior requires it.
+- Update `Request::minimum_protocol_version` for new requests.
+- Define additive defaults and old-client response filtering or downgrade
+  behavior.
+- Add round-trip, old-peer, client-negotiation, and native compatibility tests.
+- Update advertised capabilities when the new behavior is integration-visible.
+- Update the protocol history in `docs/architecture.md` and any affected
+  contract document.
+
+### Persistence Changes
+
+- Bump `STATE_VERSION` when the durable representation changes.
+- Retain the previous schema and add an explicit migration; never silently
+  reinterpret persisted fields.
+- Add migration, invalid-state, cold-recovery, and graceful-handoff coverage as
+  applicable.
+- Keep state bounded, owner-validated, atomically replaced, and reproducible.
+- Document changes to recovery guarantees in `docs/architecture.md`.
+
 ## Commits
 
 - Use Conventional Commits for every commit: `type(scope): description` or

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,5 +1,8 @@
 # Domain Glossary
 
+> **Status: Canonical terminology.** These product distinctions govern naming
+> and semantics even when implementation names are less precise.
+
 ## Workspace Launcher
 
 A durable detached argument-vector command associated with a workspace and invoked on every

--- a/README.md
+++ b/README.md
@@ -388,13 +388,19 @@ Revision-aware output reads and daemon event cursors are documented in
 
 ## Further Documentation
 
+- [Domain glossary](CONTEXT.md)
 - [Architecture](docs/architecture.md)
 - [CLI JSON contract](docs/cli-json.md)
 - [Daemon events and revision-aware reads](docs/event-stream.md)
 - [Live PTY handoff](docs/live-pty-handoff.md)
 - [Integration lifecycle validation](docs/lifecycle-validation.md)
+- [Roadmap](docs/roadmap.md)
 
 ## Development
+
+Contributors should begin with [`AGENTS.md`](AGENTS.md) for documentation
+authority, module ownership, compatibility checklists, safety guidance, and the
+CI-equivalent validation commands.
 
 ```console
 cargo run

--- a/docs/adr/0001-separate-workspace-launchers-from-shells.md
+++ b/docs/adr/0001-separate-workspace-launchers-from-shells.md
@@ -1,5 +1,7 @@
 # Separate Workspace Launchers From Shells
 
+Status: Accepted
+
 Workspace launchers are durable workspace configuration with ephemeral, detached invocations;
 they are not auto-deleting or hidden shells. This preserves shells as observable durable process
 slots while allowing every explicit workspace open to start desktop applications without PTYs,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,52 @@
 # Architecture
 
+> **Status: Current reference.** This document describes the implemented
+> architecture. `CONTEXT.md` is authoritative for domain terminology; source and
+> compatibility tests are authoritative for exact protocol and state versions.
+
+## Module Ownership
+
+| Path | Responsibility |
+| --- | --- |
+| `src/main.rs` | CLI schema, process composition, command dispatch, and snapshot-to-UI orchestration |
+| `src/protocol.rs` | Versioned control and attachment wire models, framing, and request version requirements |
+| `src/client.rs` | Daemon discovery/startup, protocol negotiation, typed management requests, and attachment setup |
+| `src/daemon.rs` | Runtime authority for workspaces, shells, agents, PTYs, processes, events, persistence coordination, and handoff |
+| `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
+| `src/handoff.rs`, `src/fd_transfer.rs` | Graceful daemon replacement records and Unix descriptor transfer |
+| `src/attach.rs` | Terminal-side raw mode, control frames, live input/output, resize, focus, and reconnect handling |
+| `src/terminal.rs` | Selection and launch of native terminal windows through `xdg-terminal-exec` |
+| `src/terminal_state.rs` | Shadow VT parsing, bounded reconstruction, logical output, and structured previews |
+| `src/terminal_focus.rs` | Stateful parsing and restoration of child focus-reporting mode |
+| `src/tui.rs` | Dashboard state, interaction, palette, polling, and Ratatui rendering; no direct daemon transport |
+| `src/session_projection.rs` | Projection of daemon Agent state and host catalogs into client-visible sessions |
+| `src/host_session_titles.rs` and children | Shared title/catalog policy and host-specific discovery adapters |
+| `src/host_session_source.rs` and children | Canonical host source paths, normalization, and secure source lookup |
+| `src/session_transcript.rs` and children | Shared transcript identity, bounds, pagination, and host-specific normalization |
+| `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
+| `src/process_adapter.rs` | Exact-argv child supervision and fail-open process-bound Agent observation |
+| `src/config.rs`, `src/projects.rs`, `src/git.rs` | Layered configuration, bounded project discovery, and asynchronous Git metadata |
+| `src/cli_output.rs` | Stable `boomux.cli/v1` output and error presentation |
+| `src/desktop_notifications.rs` | Bounded fail-open desktop and sound delivery |
+
+## Invariant Index
+
+- **Durable identity and lifecycle:** `CONTEXT.md` and the Protocol section below.
+  Primary coverage lives in protocol, daemon, state-store, and native-backend
+  tests.
+- **Persistence before event publication:** Transition Coordinator below and
+  [`event-stream.md`](event-stream.md).
+- **Single PTY reader during replacement:**
+  [`live-pty-handoff.md`](live-pty-handoff.md), enforced by handoff and native
+  replacement tests.
+- **Exact run binding and Agent authority:** Agent runtime sections below and
+  `CONTEXT.md`; process exit never implies Agent completion.
+- **Ephemeral attachment environment:** Daemon and Runtime Semantics sections
+  below; startup environment is validated but never persisted or projected.
+- **Exact argument vectors:** workspace launchers, process adapters, terminal
+  launch, and integration management execute argv directly without shell
+  interpretation.
+
 ## Product Boundary
 
 Boomux is a native-terminal session manager, not a terminal emulator or an
@@ -342,8 +389,9 @@ bundled harnesses, inspect host versions, assets, and current-run lifecycle
 reporting, and install one or all assets with each write atomic and accompanied
 by reload guidance.
 Individual host installers remain equivalent shortcuts over the same registry
-and safe primitives. Guided consent, end-to-end verification, and uninstall
-remain future workflow additions.
+and safe primitives. `integration setup` provides guided consent and reload
+guidance, `integration verify` checks current-run authoritative lifecycle
+reporting, and `integration uninstall` safely removes one or all managed assets.
 
 Observed host compatibility and provider-dependent gaps are recorded in
 [`lifecycle-validation.md`](lifecycle-validation.md). Focused unit fixtures
@@ -499,6 +547,13 @@ controller for the current shell run, and uses a monotonic revision so clients
 can distinguish a later refocus of the same shell. Protocol-17 responses omit
 the additive field. Graceful handoff transfers a still-current focus target;
 cold daemon recovery clears it.
+
+Protocol 19 adds optional workspace default working directories and shell
+creation without an explicit workspace. Older responses omit the additive
+workspace field, and requests using either new behavior require protocol 19.
+Protocol 20 adds bounded structured terminal previews, including styles and
+modifiers, so the dashboard can render colors and emphasis without replaying
+terminal control sequences. Older clients continue to use plain rendered reads.
 
 Opt-in desktop and sound notifications are a daemon-owned projection of committed
 Agent state transitions, not durable queue state. A transition from any other

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -1,5 +1,8 @@
 # CLI JSON Contract
 
+> **Status: Current stable contract.** Incompatible output requires a new schema
+> value; human-readable output is not a parsing contract.
+
 Boomux exposes a versioned JSON contract for integrations. Human output remains
 the default; pass `--json` to a supported command to emit one
 JSON document on stdout:

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -1,5 +1,9 @@
 # Daemon Event Stream
 
+> **Status: Current protocol contract.** Source and compatibility tests are
+> authoritative for exact version gates; this document defines event and cursor
+> semantics.
+
 Boomux protocol 7 added bounded long polling for daemon events and atomic,
 revision-aware terminal reads. Protocol 9 adds run-scoped agent snapshots and
 events while retaining negotiation with older management clients. Protocol 10

--- a/docs/lifecycle-validation.md
+++ b/docs/lifecycle-validation.md
@@ -1,5 +1,8 @@
 # Lifecycle Integration Validation
 
+> **Status: Version-specific validation record.** This is observed compatibility
+> evidence for the named host and Boomux versions, not a timeless host contract.
+
 This record separates observed host behavior from reducer fixtures and intended
 semantics. Host compatibility is not inferred from process names, terminal
 output, or database recency.

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -1,5 +1,9 @@
 # Live PTY Handoff
 
+> **Status: Current invariant reference and completed delivery record.** The
+> invariants and transfer behavior are current; all delivery slices below are
+> implemented.
+
 ## Goal
 
 Replace the Boomux daemon without terminating running shell processes or ending
@@ -20,7 +24,7 @@ handoff is an explicit, acknowledged upgrade path.
 
 ## Transfer Manifest
 
-The private handoff channel will carry a versioned manifest followed by Unix
+The private handoff channel carries a versioned manifest followed by Unix
 `SCM_RIGHTS` descriptors:
 
 - Existing listener socket

--- a/docs/native-terminal-follow-up.md
+++ b/docs/native-terminal-follow-up.md
@@ -2,14 +2,20 @@
 
 Date: 2026-08-03
 
+> **Status: Historical implementation plan.** The terminal handshake, VT
+> reconstruction, persistence, and graceful handoff phases are implemented.
+> Current behavior is documented in `architecture.md`; the manual matrix and
+> unresolved emulator/performance questions remain useful validation context.
+
 ## Purpose
 
 Boomux owns its PTYs and shell processes. Live attachment is transparent, and
 the terminal initialization, reconstruction, persistence, and graceful handoff
 phases described here are implemented.
 
-This document records the remaining work needed to make Boomux shells behave
-consistently in Ghostty, Alacritty, Kitty, and other XDG terminal emulators.
+This document records the implementation plan and the remaining validation work
+for consistent behavior in Ghostty, Alacritty, Kitty, and other XDG terminal
+emulators.
 
 ## Current Status
 
@@ -78,11 +84,11 @@ only after the application decides to emit it.
 The PTY begins with the first attachment's rows, columns, pixel width, and pixel
 height. Pixel dimensions may remain zero when the terminal does not report them.
 
-## Phase 1: Terminal Handshake
+## Phase 1: Terminal Handshake (Complete)
 
-### Target Sequence
+### Implemented Sequence
 
-Change shell creation to a two-stage operation:
+Shell creation uses this two-stage operation:
 
 ```text
 create pending shell metadata
@@ -95,7 +101,7 @@ create pending shell metadata
 
 ### Protocol Model
 
-The initial attachment request should include a bounded, explicit profile:
+The initial attachment request includes a bounded, explicit profile:
 
 ```rust
 struct TerminalProfile {
@@ -110,16 +116,17 @@ struct TerminalProfile {
 }
 ```
 
-Forward the attachment client's environment only in the startup request that
-can create a new run. Preserve Unix bytes, reject invalid names, duplicates, and
-NUL bytes, redact the payload from debug output, and never persist it.
+The attachment client's environment is forwarded only in the startup request
+that can create a new run. Boomux preserves Unix bytes, rejects invalid names,
+duplicates, and NUL bytes, redacts the payload from debug output, and never
+persists it.
 
 Read cell and pixel dimensions from `TIOCGWINSZ` on Unix. Pixel dimensions may
 legitimately remain zero when the emulator or kernel does not report them.
 
 ### Shell Lifecycle
 
-Extend the shell state model:
+The shell state model is:
 
 ```text
 Pending -> Running -> Exited
@@ -166,9 +173,8 @@ testing shows that warnings are insufficient.
 
 ### Product Decision
 
-Workspace creation must remain empty. A future explicit shell creation or first
-attachment can create pending shell metadata and delay the command until a
-terminal profile is available.
+Workspace creation remains empty. Explicit shell creation creates pending shell
+metadata and delays the command until a terminal profile is available.
 
 Boomux uses option 2:
 
@@ -181,7 +187,7 @@ Boomux uses option 2:
 Pending shells remain visible and retryable until opened. Headless startup is
 not supported without a concrete terminal profile.
 
-## Phase 2: VT Reconnection State
+## Phase 2: VT Reconnection State (Implemented; Performance Validation Open)
 
 ### Implementation
 
@@ -199,9 +205,9 @@ styles, modes, and the current alternate screen. Known limits remain for:
 Historical OSC title, notification, hyperlink, and clipboard commands are
 intentionally omitted so reconnection cannot repeat their side effects.
 
-### Target Data Flow
+### Implemented Data Flow
 
-Keep the native live path unchanged and parse a shadow copy:
+The native live path remains unchanged while Boomux parses a shadow copy:
 
 ```text
 PTY output
@@ -247,7 +253,8 @@ effects merely to reconstruct presentation.
 - Truncation never begins by emitting an incomplete escape sequence.
 - Live Kitty graphics, Sixel, hyperlinks, and OSC behavior remain unchanged.
 - `boomux read` returns plain logical lines without ANSI escape sequences.
-- Slow parsing cannot block the PTY reader or child process.
+- [Open] Profile whether synchronous shadow parsing creates meaningful PTY
+  backpressure and move it off the reader if necessary.
 
 ### Open Engineering Decisions
 
@@ -255,7 +262,7 @@ effects merely to reconstruct presentation.
 - Evaluate moving shadow parsing off the PTY reader if profiling shows meaningful
   backpressure.
 
-## Phase 3: Restart Persistence
+## Phase 3: Restart Persistence (Complete)
 
 The daemon atomically persists versioned JSON state at
 `$XDG_STATE_HOME/boomux/state.json`, with the XDG default
@@ -265,7 +272,8 @@ Persist only reproducible metadata under `$XDG_STATE_HOME/boomux`:
 
 - Workspace and shell IDs
 - Workspace and shell names and grouping
-- Shell working directories; workspaces have no path
+- Workspace default working directories and authoritative per-shell working
+  directories
 - Explicit shell startup commands
 - Last terminal profile when useful for diagnostics
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-Boomux is under active development. This document tracks shipped capabilities
-and possible directions for exploration; future ideas are not release
-commitments.
+> **Status: Non-authoritative roadmap.** This document tracks shipped work and
+> possible exploration. Future ideas are not release commitments and do not
+> override `CONTEXT.md`, `architecture.md`, source, or tests.
 
 ## Completed
 
@@ -112,7 +112,7 @@ eternal process.
    root/subagent aggregation where available, blocked prompts, idle transitions,
    explicit completion semantics, and graceful daemon replacement against real
    sessions.
-2. [In progress] Build a first-class integration setup workflow that discovers supported
+2. [Complete] Build a first-class integration setup workflow that discovers supported
    installed harnesses, explains why authoritative lifecycle access is required,
    previews and obtains consent for configuration changes, installs or updates
    each integration safely, prompts for required harness reloads, and verifies
@@ -120,8 +120,8 @@ eternal process.
    version compatibility, diagnostics, repair, and uninstall paths so stronger
    guarantees do not require users to manage plugin files manually.
    Unified list, status, host-version detection, runtime registration diagnosis,
-   and atomic single/all installation are complete; guided verification,
-   consented previews, repair guidance, and uninstall remain.
+   atomic single/all installation, guided setup, current-run verification,
+   repair guidance, and uninstall are complete.
 3. [Complete] Aggregate agent states into workspace counts and add an explainable,
    persistent attention queue for blocked and completed work.
 4. [Complete] Add revision-aware `agent wait` so scripts can await durable state


### PR DESCRIPTION
## Summary
- define documentation authority, module ownership, and cross-cutting invariant entry points
- document CI-equivalent validation, change-specific test expectations, and daemon safety guidance
- add protocol and persistence compatibility checklists
- label canonical, contract, validation, roadmap, ADR, and historical documents by role
- correct stale integration workflow, protocol 19/20, workspace cwd, and terminal-plan statements
- link contributor guidance from the README

## Verification
- independent documentation review against source and issue acceptance criteria
- `git diff --check`
- `cargo fmt --all -- --check`
- verified referenced repository files and removed stale phrases

Closes #110