### PR TITLE
refactor(dashboard): add typed view projection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,12 @@ exercise process, socket, PTY, and daemon lifecycle behavior.
 - Use a Conventional Commit title for every PR. The title must describe the
   release impact of the complete PR, for example `feat: add workspace previews`
   or `fix(agent): preserve lifecycle registration`.
+- Choose a Release Please-recognized title deliberately: `feat` triggers a minor
+  release, `fix` and `perf` trigger a patch release, and `!` or a
+  `BREAKING CHANGE:` footer triggers a major release. Use non-release types such
+  as `refactor`, `docs`, `test`, `ci`, or `chore` only when the PR has no
+  release-visible impact; those changes ship with the next release-triggering
+  PR. Never mislabel internal work solely to force a version.
 - Squash-merge PRs into `main` so the conventional PR title becomes the
   main-branch commit consumed by Release Please.
 - Before merging, update the PR title if its release type or scope changed.
@@ -110,7 +116,3 @@ exercise process, socket, PTY, and daemon lifecycle behavior.
   feat: describe the complete release-visible change
   END_COMMIT_OVERRIDE
   ```
-
-- `feat` produces a minor release, `fix` and `perf` produce a patch release, and
-  a breaking change produces a major release under the default Release Please
-  versioning strategy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,9 @@ exercise process, socket, PTY, and daemon lifecycle behavior.
 - Use Conventional Commits for every commit: `type(scope): description` or
   `type: description`.
 - Use `feat` for user-visible capabilities, `fix` for user-visible corrections,
-  and `perf` for performance improvements. Use `docs`, `test`, `refactor`,
-  `build`, `ci`, or `chore` when the change is not release-note material.
+  `perf` for performance improvements, and `refactor` for internal product
+  improvements that preserve behavior. Use `docs`, `test`, `build`, `ci`, or
+  `chore` when the change is not release-note material.
 - Mark breaking changes with `!` after the type or scope and explain them in a
   `BREAKING CHANGE:` footer.
 - Keep the description imperative, lowercase, and concise.
@@ -100,11 +101,11 @@ exercise process, socket, PTY, and daemon lifecycle behavior.
   release impact of the complete PR, for example `feat: add workspace previews`
   or `fix(agent): preserve lifecycle registration`.
 - Choose a Release Please-recognized title deliberately: `feat` triggers a minor
-  release, `fix` and `perf` trigger a patch release, and `!` or a
+  release; `fix`, `perf`, and `refactor` trigger a patch release; and `!` or a
   `BREAKING CHANGE:` footer triggers a major release. Use non-release types such
-  as `refactor`, `docs`, `test`, `ci`, or `chore` only when the PR has no
-  release-visible impact; those changes ship with the next release-triggering
-  PR. Never mislabel internal work solely to force a version.
+  as `docs`, `test`, `build`, `ci`, or `chore` only when the PR has no
+  release-visible impact. Never mislabel internal work solely to force a
+  version.
 - Squash-merge PRs into `main` so the conventional PR title becomes the
   main-branch commit consumed by Release Please.
 - Before merging, update the PR title if its release type or scope changed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,8 @@
 
 | Path | Responsibility |
 | --- | --- |
-| `src/main.rs` | CLI schema, process composition, command dispatch, and snapshot-to-UI orchestration |
+| `src/main.rs` | CLI schema, process composition, command dispatch, and dashboard backend orchestration |
+| `src/dashboard_projection.rs` | Typed snapshot/session-to-dashboard classification, view construction, and title enrichment |
 | `src/protocol.rs` | Versioned control and attachment wire models, framing, and request version requirements |
 | `src/client.rs` | Daemon discovery/startup, protocol negotiation, typed management requests, and attachment setup |
 | `src/daemon.rs` | Runtime authority for workspaces, shells, agents, PTYs, processes, events, persistence coordination, and handoff |
@@ -71,7 +72,8 @@ persistence across attachment disconnects, naming, grouping, and orchestration.
 ### Application
 
 `src/main.rs` owns the CLI, project-name suggestions, dashboard actions, shell
-name resolution, and conversion from daemon snapshots into TUI view models.
+name resolution, and dashboard backend orchestration. `src/dashboard_projection.rs`
+converts daemon snapshots and projected sessions into typed TUI view models.
 `src/session_projection.rs` is the shared binary projection used by the CLI and
 dashboard to combine one daemon snapshot with bounded host session catalogs.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "7adc63026db4fbf60ed1f9387ce523e956af38b5",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "packages": {
     ".": {
       "release-type": "rust",

--- a/src/dashboard_projection.rs
+++ b/src/dashboard_projection.rs
@@ -1,0 +1,432 @@
+use std::path::Path;
+
+use boomux::protocol::{
+    AgentAttentionReason, AgentState, ShellRunExitReason, ShellStatus, WorkspaceSnapshot,
+};
+
+use crate::agent_attention_projection;
+use crate::git;
+use crate::host_session_titles;
+use crate::session_projection::{self, SessionProjection};
+use crate::tui::{
+    AgentAuthorityDisplay, AgentDisplayState, AgentSessionRunView, AgentSessionView,
+    AgentShellView, AgentView, AttentionReason, LauncherView, TerminalKind, TerminalRunView,
+    TerminalView, WorkspaceAttentionView, WorkspaceItemView, WorkspaceView,
+};
+
+#[cfg(test)]
+pub(crate) fn project(
+    workspaces: &[WorkspaceSnapshot],
+    git_cache: &mut git::Cache,
+) -> Vec<WorkspaceView> {
+    let sessions = session_projection::project_workspaces(workspaces);
+    project_with_sessions(workspaces, git_cache, &sessions)
+}
+
+pub(crate) fn project_with_sessions(
+    workspaces: &[WorkspaceSnapshot],
+    git_cache: &mut git::Cache,
+    sessions: &[SessionProjection],
+) -> Vec<WorkspaceView> {
+    workspaces
+        .iter()
+        .map(|workspace| project_workspace(workspace, git_cache, sessions))
+        .collect()
+}
+
+fn project_workspace(
+    workspace: &WorkspaceSnapshot,
+    git_cache: &mut git::Cache,
+    sessions: &[SessionProjection],
+) -> WorkspaceView {
+    let session_views = session_views(
+        sessions
+            .iter()
+            .filter(|session| session.workspace_id == workspace.id),
+    );
+    let agent_summary = agent_attention_projection::summarize_workspace(workspace);
+    let attention = agent_attention_projection::project_attention(std::slice::from_ref(workspace))
+        .into_iter()
+        .map(|item| WorkspaceAttentionView {
+            shell_id: item.agent.shell_id,
+            agent_name: item.agent.name,
+            reason: item.attention.reason.into(),
+            evidence: item.attention.observation.evidence,
+            observed_at_ms: item.attention.observation.observed_at_ms,
+        })
+        .collect();
+    let shells = workspace
+        .shells
+        .iter()
+        .map(|shell| {
+            let git = git_cache.inspect(&shell.cwd);
+            let shell_view = TerminalView {
+                id: shell.id.clone(),
+                name: shell.name.clone(),
+                status: shell_status(&shell.status).into(),
+                directory: shell.cwd.display().to_string(),
+                repository: git.repository,
+                branch: git.branch,
+                git_state: git.state,
+                worktree: git.worktree,
+                foreground_process: shell.foreground_process.clone(),
+                kind: if shell.command.is_empty() {
+                    TerminalKind::Shell
+                } else {
+                    TerminalKind::Command
+                },
+                command: shell.command.join(" "),
+                argv: shell.command.clone(),
+                run: shell.run.as_ref().map(|run| TerminalRunView {
+                    id: run.id.clone(),
+                    generation: run.generation,
+                    started_at_ms: run.started_at_ms,
+                    ended_at_ms: run.ended_at_ms,
+                    exit_reason: run.exit_reason.as_ref().map(shell_exit_reason),
+                    output_revision: run.output_revision,
+                }),
+            };
+            let agent = matches!(shell.status, ShellStatus::Running)
+                .then(|| {
+                    shell.run.as_ref().and_then(|run| {
+                        workspace
+                            .agents
+                            .iter()
+                            .filter(|agent| {
+                                agent.workspace_id == workspace.id
+                                    && session_projection::agent_is_active_for_run(
+                                        agent, &shell.id, &run.id,
+                                    )
+                            })
+                            .max_by(|left, right| {
+                                left.observation
+                                    .observed_at_ms
+                                    .cmp(&right.observation.observed_at_ms)
+                                    .then_with(|| left.id.cmp(&right.id))
+                            })
+                    })
+                })
+                .flatten();
+            let suppress_foreground_hint = shell.run.as_ref().is_some_and(|run| {
+                workspace.agents.iter().any(|agent| {
+                    agent.workspace_id == workspace.id
+                        && agent.shell_id == shell.id
+                        && agent.run_id == run.id
+                        && shell.foreground_process.as_deref() == Some(agent.integration.as_str())
+                        && !session_projection::agent_is_active_for_run(agent, &shell.id, &run.id)
+                })
+            });
+            let root_git = agent
+                .and_then(|agent| {
+                    sessions.iter().find(|session| {
+                        session
+                            .occurrences
+                            .iter()
+                            .any(|run| run.agent_id == agent.id)
+                    })
+                })
+                .and_then(|session| session.source_cwd.as_deref())
+                .map(|directory| git_cache.inspect(directory))
+                .unwrap_or_default();
+            match (agent, shell.foreground_process.as_deref()) {
+                (Some(agent), _) => WorkspaceItemView::AgentShell(AgentShellView {
+                    shell: shell_view,
+                    agent: Some(AgentView {
+                        id: agent.id.clone(),
+                        state: agent.observation.state.into(),
+                        integration: agent.integration.clone(),
+                        external_session_id: agent.external_session_id.clone(),
+                        authority: agent.observation.authority.into(),
+                        confidence: agent.observation.confidence,
+                        evidence: agent.observation.evidence.clone(),
+                        updated_at_ms: agent.observation.observed_at_ms,
+                        root_branch: root_git.branch,
+                        root_worktree: root_git.worktree,
+                    }),
+                }),
+                (None, Some("opencode" | "pi")) if !suppress_foreground_hint => {
+                    WorkspaceItemView::AgentShell(AgentShellView {
+                        shell: shell_view,
+                        agent: None,
+                    })
+                }
+                (None, _) => WorkspaceItemView::Shell(shell_view),
+            }
+        })
+        .collect::<Vec<_>>();
+    let launchers = workspace.launchers.iter().map(|launcher| {
+        let git = git_cache.inspect(&launcher.cwd);
+        WorkspaceItemView::Launcher(LauncherView {
+            id: launcher.id.clone(),
+            name: launcher.name.clone(),
+            directory: launcher.cwd.display().to_string(),
+            repository: git.repository,
+            branch: git.branch,
+            git_state: git.state,
+            worktree: git.worktree,
+            command: launcher.command.join(" "),
+            argv: launcher.command.clone(),
+        })
+    });
+    WorkspaceView {
+        id: workspace.id.clone(),
+        name: workspace.name.clone(),
+        default_cwd: workspace
+            .default_cwd
+            .as_ref()
+            .map(|cwd| cwd.display().to_string()),
+        items: shells.into_iter().chain(launchers).collect(),
+        sessions: session_views,
+        agent_state_counts: agent_summary.states,
+        attention_count: agent_summary.attention_count,
+        attention,
+    }
+}
+
+pub(crate) fn session_views<'a>(
+    sessions: impl IntoIterator<Item = &'a SessionProjection>,
+) -> Vec<AgentSessionView> {
+    sessions
+        .into_iter()
+        .map(|session| AgentSessionView {
+            id: session.id.clone(),
+            label: session.description.clone(),
+            integration: session.integration.clone(),
+            external_session_id: session.external_session_id.clone(),
+            state: session.state.into(),
+            state_is_current: session.state_is_current,
+            last_at_ms: session.last_at_ms,
+            source_cwd: session.source_cwd.clone(),
+            runs: session
+                .occurrences
+                .iter()
+                .map(|occurrence| AgentSessionRunView {
+                    agent_id: occurrence.agent_id.clone(),
+                    shell_name: occurrence.retained_shell_name.clone(),
+                    directory: occurrence.source_cwd.clone(),
+                })
+                .collect(),
+        })
+        .collect()
+}
+
+pub(crate) fn enrich_session_titles(
+    workspaces: &mut [WorkspaceView],
+    title_cache: &mut host_session_titles::Cache,
+) {
+    enrich_session_titles_with(workspaces, |integration, directory, external_session_id| {
+        title_cache.title(integration, directory, external_session_id)
+    });
+}
+
+pub(crate) fn enrich_session_titles_with<F>(workspaces: &mut [WorkspaceView], mut title: F)
+where
+    F: FnMut(&str, &Path, &str) -> Option<String>,
+{
+    for session in workspaces
+        .iter_mut()
+        .flat_map(|workspace| workspace.sessions.iter_mut())
+    {
+        let Some(external_session_id) = session.external_session_id.as_deref() else {
+            continue;
+        };
+        let Some(directory) = session
+            .runs
+            .iter()
+            .rev()
+            .find_map(|run| run.directory.as_deref())
+            .or(session.source_cwd.as_deref())
+        else {
+            continue;
+        };
+        if let Some(host_title) = title(&session.integration, directory, external_session_id) {
+            session.label = host_title;
+        }
+    }
+}
+
+impl From<AgentState> for AgentDisplayState {
+    fn from(state: AgentState) -> Self {
+        match state {
+            AgentState::Unknown => Self::Unknown,
+            AgentState::Working => Self::Working,
+            AgentState::Blocked => Self::Blocked,
+            AgentState::Idle => Self::Idle,
+            AgentState::Inactive => Self::Inactive,
+            AgentState::Done => Self::Done,
+        }
+    }
+}
+
+impl From<AgentAttentionReason> for AttentionReason {
+    fn from(reason: AgentAttentionReason) -> Self {
+        match reason {
+            AgentAttentionReason::Blocked => Self::Blocked,
+            AgentAttentionReason::Completed => Self::Completed,
+        }
+    }
+}
+
+impl From<boomux::protocol::AgentAuthority> for AgentAuthorityDisplay {
+    fn from(authority: boomux::protocol::AgentAuthority) -> Self {
+        match authority {
+            boomux::protocol::AgentAuthority::DaemonLifecycle => Self::DaemonLifecycle,
+            boomux::protocol::AgentAuthority::LifecycleIntegration => Self::LifecycleIntegration,
+            boomux::protocol::AgentAuthority::ProcessAdapter => Self::ProcessAdapter,
+            boomux::protocol::AgentAuthority::TerminalHeuristic => Self::TerminalHeuristic,
+        }
+    }
+}
+
+fn shell_status(status: &ShellStatus) -> &'static str {
+    match status {
+        ShellStatus::Pending => "pending",
+        ShellStatus::Running => "running",
+        ShellStatus::Exited { .. } => "exited",
+    }
+}
+
+fn shell_exit_reason(reason: &ShellRunExitReason) -> String {
+    match reason {
+        ShellRunExitReason::Exited { code: Some(code) } => format!("exited ({code})"),
+        ShellRunExitReason::Exited { code: None } => "exited (code unavailable)".into(),
+        ShellRunExitReason::Terminated => "terminated".into(),
+        ShellRunExitReason::Interrupted => "interrupted".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use boomux::protocol::{
+        AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot, ShellRunSnapshot,
+        ShellSnapshot,
+    };
+
+    use super::*;
+
+    fn workspace(command: Vec<String>) -> WorkspaceSnapshot {
+        WorkspaceSnapshot {
+            id: "workspace-1".into(),
+            name: "project".into(),
+            default_cwd: Some(PathBuf::from("/tmp/project")),
+            shells: vec![ShellSnapshot {
+                id: "shell-1".into(),
+                workspace_id: "workspace-1".into(),
+                name: "main".into(),
+                cwd: PathBuf::from("/tmp/project"),
+                command,
+                status: ShellStatus::Running,
+                run: Some(ShellRunSnapshot {
+                    id: "run-1".into(),
+                    generation: 1,
+                    started_at_ms: 1,
+                    ended_at_ms: None,
+                    exit_reason: None,
+                    output_revision: 0,
+                    environment_has_run_id: true,
+                }),
+                foreground_process: None,
+            }],
+            launchers: Vec::new(),
+            agents: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn stored_argv_projects_an_explicit_command_kind() {
+        let views = project(
+            &[workspace(vec!["cargo".into(), "test".into()])],
+            &mut git::Cache::default(),
+        );
+
+        let WorkspaceItemView::Shell(shell) = &views[0].items[0] else {
+            panic!("expected shell-backed item");
+        };
+        assert_eq!(shell.kind, TerminalKind::Command);
+        assert_eq!(shell.argv, ["cargo", "test"]);
+    }
+
+    #[test]
+    fn current_agent_projects_typed_state_and_inactive_agent_suppresses_hint() {
+        let mut workspace = workspace(Vec::new());
+        workspace.shells[0].foreground_process = Some("opencode".into());
+        workspace.agents.push(AgentInstanceSnapshot {
+            id: "agent-1".into(),
+            workspace_id: workspace.id.clone(),
+            shell_id: "shell-1".into(),
+            run_id: "run-1".into(),
+            name: "review".into(),
+            integration: "opencode".into(),
+            external_session_id: Some("session-1".into()),
+            cwd: Some(PathBuf::from("/tmp/project")),
+            started_at_ms: 1,
+            ended_at_ms: None,
+            observation: AgentObservationSnapshot {
+                revision: 1,
+                state: AgentState::Blocked,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "permission".into(),
+                confidence: 100,
+                observed_at_ms: 2,
+            },
+            attention: None,
+        });
+
+        let views = project(std::slice::from_ref(&workspace), &mut git::Cache::default());
+        let WorkspaceItemView::AgentShell(agent) = &views[0].items[0] else {
+            panic!("expected Agent shell");
+        };
+        assert_eq!(agent.state(), AgentDisplayState::Blocked);
+
+        workspace.agents[0].observation.state = AgentState::Inactive;
+        let views = project(std::slice::from_ref(&workspace), &mut git::Cache::default());
+        assert!(matches!(views[0].items[0], WorkspaceItemView::Shell(_)));
+    }
+
+    #[test]
+    fn completed_same_run_host_suppresses_hint_but_other_integration_does_not() {
+        let mut workspace = workspace(Vec::new());
+        workspace.shells[0].foreground_process = Some("opencode".into());
+        workspace.agents.push(AgentInstanceSnapshot {
+            id: "agent-1".into(),
+            workspace_id: workspace.id.clone(),
+            shell_id: "shell-1".into(),
+            run_id: "run-1".into(),
+            name: "review".into(),
+            integration: "opencode".into(),
+            external_session_id: Some("session-1".into()),
+            cwd: None,
+            started_at_ms: 1,
+            ended_at_ms: Some(2),
+            observation: AgentObservationSnapshot {
+                revision: 1,
+                state: AgentState::Done,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "done".into(),
+                confidence: 100,
+                observed_at_ms: 2,
+            },
+            attention: None,
+        });
+
+        let views = project(std::slice::from_ref(&workspace), &mut git::Cache::default());
+        assert!(matches!(views[0].items[0], WorkspaceItemView::Shell(_)));
+
+        workspace.agents[0].integration = "pi".into();
+        let views = project(std::slice::from_ref(&workspace), &mut git::Cache::default());
+        let WorkspaceItemView::AgentShell(agent) = &views[0].items[0] else {
+            panic!("expected foreground hint");
+        };
+        assert_eq!(agent.state(), AgentDisplayState::Untracked);
+
+        workspace.agents[0].integration = "opencode".into();
+        workspace.agents[0].workspace_id = "other-workspace".into();
+        let views = project(&[workspace], &mut git::Cache::default());
+        let WorkspaceItemView::AgentShell(agent) = &views[0].items[0] else {
+            panic!("expected foreground hint");
+        };
+        assert_eq!(agent.state(), AgentDisplayState::Untracked);
+    }
+}

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -13,7 +13,7 @@ use clap::ValueEnum;
 use serde::Serialize;
 use uuid::Uuid;
 
-use boomux::protocol::{AgentAuthority, AgentState, ShellStatus, Snapshot};
+use boomux::protocol::{AgentAuthority, ShellStatus, Snapshot};
 
 pub(crate) const OPENCODE_ASSET: &str = include_str!("../integrations/opencode/boomux.js");
 pub(crate) const PI_ASSET: &str = include_str!("../integrations/pi/boomux.js");
@@ -515,14 +515,8 @@ fn authoritative_agent_matches(
     run: &boomux::protocol::ShellRunSnapshot,
 ) -> bool {
     agent.integration == spec.name
-        && agent.shell_id == shell.id
-        && agent.run_id == run.id
-        && agent.ended_at_ms.is_none()
         && agent.observation.authority == AgentAuthority::LifecycleIntegration
-        && !matches!(
-            agent.observation.state,
-            AgentState::Inactive | AgentState::Done
-        )
+        && crate::session_projection::agent_is_active_for_run(agent, &shell.id, &run.id)
 }
 
 fn executable_on_path(name: &str, path: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
@@ -1072,8 +1066,8 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use boomux::protocol::{
-        AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot, ShellRunSnapshot,
-        ShellSnapshot, WorkspaceSnapshot,
+        AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot, AgentState,
+        ShellRunSnapshot, ShellSnapshot, WorkspaceSnapshot,
     };
 
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use crate::integration_management::{
 mod agent_attention_projection;
 mod cli_output;
 mod config;
+mod dashboard_projection;
 mod git;
 mod host_session_source;
 mod host_session_titles;
@@ -1298,8 +1299,7 @@ fn dashboard_views(
     workspaces: &[WorkspaceSnapshot],
     git_cache: &mut git::Cache,
 ) -> Vec<tui::WorkspaceView> {
-    let sessions = session_projection::project_workspaces(workspaces);
-    dashboard_views_from_sessions(workspaces, git_cache, &sessions)
+    dashboard_projection::project(workspaces, git_cache)
 }
 
 fn dashboard_views_with_catalog(
@@ -1309,198 +1309,7 @@ fn dashboard_views_with_catalog(
 ) -> Vec<tui::WorkspaceView> {
     let catalog = cached_host_catalog(workspaces, title_cache);
     let sessions = session_projection::project_workspaces_with_catalog(workspaces, Some(&catalog));
-    dashboard_views_from_sessions(workspaces, git_cache, &sessions)
-}
-
-fn dashboard_views_from_sessions(
-    workspaces: &[WorkspaceSnapshot],
-    git_cache: &mut git::Cache,
-    sessions: &[session_projection::SessionProjection],
-) -> Vec<tui::WorkspaceView> {
-    workspaces
-        .iter()
-        .map(|workspace| {
-            let sessions = workspace_session_views(
-                sessions
-                    .iter()
-                    .filter(|session| session.workspace_id == workspace.id),
-            );
-            let agent_summary = agent_attention_projection::summarize_workspace(workspace);
-            let attention =
-                agent_attention_projection::project_attention(std::slice::from_ref(workspace))
-                    .into_iter()
-                    .map(|item| tui::WorkspaceAttentionView {
-                        shell_id: item.agent.shell_id,
-                        agent_name: item.agent.name,
-                        reason: agent_attention_projection::attention_reason(item.attention.reason)
-                            .into(),
-                        evidence: item.attention.observation.evidence,
-                        observed_at_ms: item.attention.observation.observed_at_ms,
-                    })
-                    .collect();
-            let shells = workspace
-                .shells
-                .iter()
-                .map(|shell| {
-                    let git = git_cache.inspect(&shell.cwd);
-                    let shell_view = tui::TerminalView {
-                        id: shell.id.clone(),
-                        name: shell.name.clone(),
-                        status: shell_status(&shell.status).into(),
-                        directory: shell.cwd.display().to_string(),
-                        repository: git.repository,
-                        branch: git.branch,
-                        git_state: git.state,
-                        worktree: git.worktree,
-                        foreground_process: shell.foreground_process.clone(),
-                        command: shell.command.join(" "),
-                        argv: shell.command.clone(),
-                        run: shell.run.as_ref().map(|run| tui::TerminalRunView {
-                            id: run.id.clone(),
-                            generation: run.generation,
-                            started_at_ms: run.started_at_ms,
-                            ended_at_ms: run.ended_at_ms,
-                            exit_reason: run.exit_reason.as_ref().map(shell_exit_reason),
-                            output_revision: run.output_revision,
-                        }),
-                    };
-                    let agent = matches!(shell.status, ShellStatus::Running)
-                        .then(|| {
-                            shell.run.as_ref().and_then(|run| {
-                                workspace
-                                    .agents
-                                    .iter()
-                                    .filter(|agent| {
-                                        agent.workspace_id == workspace.id
-                                            && agent.shell_id == shell.id
-                                            && agent.run_id == run.id
-                                            && agent.ended_at_ms.is_none()
-                                            && !matches!(
-                                                agent.observation.state,
-                                                AgentState::Inactive | AgentState::Done
-                                            )
-                                    })
-                                    .max_by(|left, right| {
-                                        left.observation
-                                            .observed_at_ms
-                                            .cmp(&right.observation.observed_at_ms)
-                                            .then_with(|| left.id.cmp(&right.id))
-                                    })
-                            })
-                        })
-                        .flatten();
-                    let suppress_foreground_hint = shell.run.as_ref().is_some_and(|run| {
-                        workspace.agents.iter().any(|agent| {
-                            agent.shell_id == shell.id
-                                && agent.run_id == run.id
-                                && shell.foreground_process.as_deref()
-                                    == Some(agent.integration.as_str())
-                                && (agent.ended_at_ms.is_some()
-                                    || matches!(
-                                        agent.observation.state,
-                                        AgentState::Inactive | AgentState::Done
-                                    ))
-                        })
-                    });
-                    let root_git = agent
-                        .and_then(|agent| {
-                            sessions.iter().find(|session| {
-                                session.runs.iter().any(|run| run.agent_id == agent.id)
-                            })
-                        })
-                        .and_then(|session| session.source_cwd.as_deref())
-                        .map(|directory| git_cache.inspect(directory))
-                        .unwrap_or_default();
-                    match (agent, shell.foreground_process.as_deref()) {
-                        (Some(agent), _) => {
-                            tui::WorkspaceItemView::AgentShell(tui::AgentShellView {
-                                shell: shell_view,
-                                agent: Some(tui::AgentView {
-                                    id: agent.id.clone(),
-                                    state: cli_output::agent_state(agent.observation.state).into(),
-                                    integration: agent.integration.clone(),
-                                    external_session_id: agent.external_session_id.clone(),
-                                    authority: cli_output::agent_authority(
-                                        agent.observation.authority,
-                                    )
-                                    .into(),
-                                    confidence: agent.observation.confidence,
-                                    evidence: agent.observation.evidence.clone(),
-                                    updated_at_ms: agent.observation.observed_at_ms,
-                                    root_branch: root_git.branch,
-                                    root_worktree: root_git.worktree,
-                                }),
-                            })
-                        }
-                        (None, Some("opencode" | "pi")) if !suppress_foreground_hint => {
-                            tui::WorkspaceItemView::AgentShell(tui::AgentShellView {
-                                shell: shell_view,
-                                agent: None,
-                            })
-                        }
-                        (None, _) => tui::WorkspaceItemView::Shell(shell_view),
-                    }
-                })
-                .collect::<Vec<_>>();
-            let launchers = workspace.launchers.iter().map(|launcher| {
-                let git = git_cache.inspect(&launcher.cwd);
-                tui::WorkspaceItemView::Launcher(tui::LauncherView {
-                    id: launcher.id.clone(),
-                    name: launcher.name.clone(),
-                    directory: launcher.cwd.display().to_string(),
-                    repository: git.repository,
-                    branch: git.branch,
-                    git_state: git.state,
-                    worktree: git.worktree,
-                    command: launcher.command.join(" "),
-                    argv: launcher.command.clone(),
-                })
-            });
-            tui::WorkspaceView {
-                id: workspace.id.clone(),
-                name: workspace.name.clone(),
-                default_cwd: workspace
-                    .default_cwd
-                    .as_ref()
-                    .map(|cwd| cwd.display().to_string()),
-                items: shells.into_iter().chain(launchers).collect(),
-                sessions,
-                agent_state_counts: agent_summary.states,
-                attention_count: agent_summary.attention_count,
-                attention,
-            }
-        })
-        .collect()
-}
-
-fn workspace_session_views<'a>(
-    sessions: impl IntoIterator<Item = &'a session_projection::SessionProjection>,
-) -> Vec<tui::AgentSessionView> {
-    sessions
-        .into_iter()
-        .map(|session| {
-            let runs = session
-                .occurrences
-                .iter()
-                .map(|occurrence| tui::AgentSessionRunView {
-                    agent_id: occurrence.agent_id.clone(),
-                    shell_name: occurrence.retained_shell_name.clone(),
-                    directory: occurrence.source_cwd.clone(),
-                })
-                .collect();
-            tui::AgentSessionView {
-                id: session.id.clone(),
-                label: session.description.clone(),
-                integration: session.integration.clone(),
-                external_session_id: session.external_session_id.clone(),
-                state: cli_output::agent_state(session.state).into(),
-                state_is_current: session.state_is_current,
-                last_at_ms: session.last_at_ms,
-                source_cwd: session.source_cwd.clone(),
-                runs,
-            }
-        })
-        .collect()
+    dashboard_projection::project_with_sessions(workspaces, git_cache, &sessions)
 }
 
 fn workspace_source_directories(workspaces: &[WorkspaceSnapshot]) -> BTreeSet<PathBuf> {
@@ -1574,35 +1383,7 @@ fn enrich_session_titles(
     workspaces: &mut [tui::WorkspaceView],
     title_cache: &mut host_session_titles::Cache,
 ) {
-    enrich_session_titles_with(workspaces, |integration, directory, external_session_id| {
-        title_cache.title(integration, directory, external_session_id)
-    });
-}
-
-fn enrich_session_titles_with<F>(workspaces: &mut [tui::WorkspaceView], mut title: F)
-where
-    F: FnMut(&str, &Path, &str) -> Option<String>,
-{
-    for session in workspaces
-        .iter_mut()
-        .flat_map(|workspace| workspace.sessions.iter_mut())
-    {
-        let Some(external_session_id) = session.external_session_id.as_deref() else {
-            continue;
-        };
-        let Some(directory) = session
-            .runs
-            .iter()
-            .rev()
-            .find_map(|run| run.directory.as_deref())
-            .or(session.source_cwd.as_deref())
-        else {
-            continue;
-        };
-        if let Some(host_title) = title(&session.integration, directory, external_session_id) {
-            session.label = host_title;
-        }
-    }
+    dashboard_projection::enrich_session_titles(workspaces, title_cache);
 }
 
 fn open_directory(
@@ -5209,7 +4990,7 @@ mod tests {
         assert_eq!(views[0].sessions.len(), 1);
         let session = &views[0].sessions[0];
         assert!(Uuid::parse_str(&session.id).is_ok());
-        assert_eq!(session.state, "blocked");
+        assert_eq!(session.state, tui::AgentDisplayState::Blocked);
         assert!(session.state_is_current);
         assert_eq!(session.runs.len(), 2);
         assert_eq!(session.runs[0].shell_name.as_deref(), Some("build"));
@@ -5226,12 +5007,15 @@ mod tests {
         workspace.agents = vec![agent("agent-1", "w1", "s1")];
         let mut views = dashboard_views(&[workspace], &mut git::Cache::default());
 
-        enrich_session_titles_with(&mut views, |integration, directory, external_id| {
-            (integration == "opencode"
-                && directory == Path::new("/tmp/project")
-                && external_id == "external-1")
-                .then(|| "Review async title cache".into())
-        });
+        dashboard_projection::enrich_session_titles_with(
+            &mut views,
+            |integration, directory, external_id| {
+                (integration == "opencode"
+                    && directory == Path::new("/tmp/project")
+                    && external_id == "external-1")
+                    .then(|| "Review async title cache".into())
+            },
+        );
 
         assert_eq!(views[0].sessions[0].label, "Review async title cache");
     }
@@ -5251,7 +5035,7 @@ mod tests {
                 label: "opencode".into(),
                 integration: "opencode".into(),
                 external_session_id: Some("external-1".into()),
-                state: "inactive".into(),
+                state: tui::AgentDisplayState::Inactive,
                 state_is_current: false,
                 last_at_ms: 30,
                 source_cwd: Some("/tmp/project".into()),
@@ -5270,7 +5054,7 @@ mod tests {
             }],
         }];
 
-        enrich_session_titles_with(&mut views, |_, directory, _| {
+        dashboard_projection::enrich_session_titles_with(&mut views, |_, directory, _| {
             (directory == Path::new("/tmp/project")).then(|| "Historical title".into())
         });
 
@@ -5309,7 +5093,7 @@ mod tests {
 
         let views = dashboard_views(&[workspace], &mut git::Cache::default());
 
-        assert_eq!(views[0].sessions[0].state, "blocked");
+        assert_eq!(views[0].sessions[0].state, tui::AgentDisplayState::Blocked);
     }
 
     #[test]
@@ -5329,7 +5113,7 @@ mod tests {
 
         let views = dashboard_views(&[workspace], &mut git::Cache::default());
 
-        assert_eq!(views[0].sessions[0].state, "working");
+        assert_eq!(views[0].sessions[0].state, tui::AgentDisplayState::Working);
         assert!(views[0].sessions[0].state_is_current);
     }
 
@@ -5343,7 +5127,7 @@ mod tests {
 
         let views = dashboard_views(&[workspace], &mut git::Cache::default());
 
-        assert_eq!(views[0].sessions[0].state, "blocked");
+        assert_eq!(views[0].sessions[0].state, tui::AgentDisplayState::Blocked);
         assert!(!views[0].sessions[0].state_is_current);
     }
 
@@ -5354,13 +5138,13 @@ mod tests {
         first.started_at_ms = 10;
         workspace.agents = vec![first.clone()];
         let initial = session_projection::project_workspaces(std::slice::from_ref(&workspace));
-        let initial_id = workspace_session_views(&initial)[0].id.clone();
+        let initial_id = dashboard_projection::session_views(&initial)[0].id.clone();
 
         let mut added = agent("agent-a", "w1", "s1");
         added.started_at_ms = 10;
         workspace.agents.push(added);
         let projected = session_projection::project_workspaces(std::slice::from_ref(&workspace));
-        let sessions = workspace_session_views(&projected);
+        let sessions = dashboard_projection::session_views(&projected);
 
         assert_eq!(sessions[0].id, initial_id);
         assert_eq!(sessions[0].runs.len(), 2);
@@ -5389,13 +5173,13 @@ mod tests {
             views[0]
                 .sessions
                 .iter()
-                .any(|session| session.state == "inactive")
+                .any(|session| session.state == tui::AgentDisplayState::Inactive)
         );
         assert!(
             views[0]
                 .sessions
                 .iter()
-                .any(|session| session.state == "done")
+                .any(|session| session.state == tui::AgentDisplayState::Done)
         );
         assert!(
             views[0]
@@ -5464,8 +5248,11 @@ mod tests {
         assert_eq!(shell.command, "opencode");
         let agent = agent.as_ref().expect("durable agent");
         assert_eq!(agent.id, "a1");
-        assert_eq!(agent.state, "working");
-        assert_eq!(agent.authority, "lifecycle_integration");
+        assert_eq!(agent.state, tui::AgentDisplayState::Working);
+        assert_eq!(
+            agent.authority,
+            tui::AgentAuthorityDisplay::LifecycleIntegration
+        );
         assert_eq!(agent.confidence, 95);
         assert_eq!(agent.updated_at_ms, 11);
         assert_eq!(agent.root_branch, "-");
@@ -5561,7 +5348,7 @@ mod tests {
         };
         assert_eq!(item.shell.name, "terminal");
         let agent = item.agent.as_ref().expect("durable agent");
-        assert_eq!(agent.state, "blocked");
+        assert_eq!(agent.state, tui::AgentDisplayState::Blocked);
         assert_eq!(agent.evidence, "needs approval");
     }
 

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -292,17 +292,28 @@ fn normalized_directory(directory: &Path) -> Option<PathBuf> {
     normalize_absolute(directory)
 }
 
-fn occurrence_is_current(workspace: &WorkspaceSnapshot, agent: &AgentInstanceSnapshot) -> bool {
-    agent.workspace_id == workspace.id
+pub(crate) fn agent_is_active_for_run(
+    agent: &AgentInstanceSnapshot,
+    shell_id: &str,
+    run_id: &str,
+) -> bool {
+    agent.shell_id == shell_id
+        && agent.run_id == run_id
         && agent.ended_at_ms.is_none()
         && !matches!(
             agent.observation.state,
             AgentState::Inactive | AgentState::Done
         )
+}
+
+fn occurrence_is_current(workspace: &WorkspaceSnapshot, agent: &AgentInstanceSnapshot) -> bool {
+    agent.workspace_id == workspace.id
         && workspace.shells.iter().any(|shell| {
             matches!(shell.status, ShellStatus::Running)
-                && shell.id == agent.shell_id
-                && shell.run.as_ref().is_some_and(|run| run.id == agent.run_id)
+                && shell
+                    .run
+                    .as_ref()
+                    .is_some_and(|run| agent_is_active_for_run(agent, &shell.id, &run.id))
         })
 }
 
@@ -395,6 +406,31 @@ mod tests {
                     },
                 })
                 .collect(),
+        }
+    }
+
+    #[test]
+    fn active_run_match_requires_exact_live_nonterminal_identity() {
+        let mut workspace = workspace("w1", &["a1"]);
+        let agent = &workspace.agents[0];
+        assert!(agent_is_active_for_run(agent, "shell", "run"));
+        assert!(!agent_is_active_for_run(agent, "other", "run"));
+        assert!(!agent_is_active_for_run(agent, "shell", "other"));
+
+        workspace.agents[0].ended_at_ms = Some(30);
+        assert!(!agent_is_active_for_run(
+            &workspace.agents[0],
+            "shell",
+            "run"
+        ));
+        workspace.agents[0].ended_at_ms = None;
+        for state in [AgentState::Inactive, AgentState::Done] {
+            workspace.agents[0].observation.state = state;
+            assert!(!agent_is_active_for_run(
+                &workspace.agents[0],
+                "shell",
+                "run"
+            ));
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -74,7 +74,7 @@ pub(crate) struct FocusedTerminalView {
 pub(crate) struct WorkspaceAttentionView {
     pub(crate) shell_id: String,
     pub(crate) agent_name: String,
-    pub(crate) reason: String,
+    pub(crate) reason: AttentionReason,
     pub(crate) evidence: String,
     pub(crate) observed_at_ms: u64,
 }
@@ -84,7 +84,7 @@ pub(crate) struct AgentSessionView {
     pub(crate) label: String,
     pub(crate) integration: String,
     pub(crate) external_session_id: Option<String>,
-    pub(crate) state: String,
+    pub(crate) state: AgentDisplayState,
     pub(crate) state_is_current: bool,
     pub(crate) last_at_ms: u64,
     pub(crate) source_cwd: Option<PathBuf>,
@@ -110,19 +110,19 @@ pub(crate) struct AgentShellView {
 }
 
 impl AgentShellView {
-    fn status(&self) -> &str {
+    pub(crate) fn state(&self) -> AgentDisplayState {
         self.agent
             .as_ref()
-            .map_or("untracked", |agent| agent.state.as_str())
+            .map_or(AgentDisplayState::Untracked, |agent| agent.state)
     }
 }
 
 pub(crate) struct AgentView {
     pub(crate) id: String,
-    pub(crate) state: String,
+    pub(crate) state: AgentDisplayState,
     pub(crate) integration: String,
     pub(crate) external_session_id: Option<String>,
-    pub(crate) authority: String,
+    pub(crate) authority: AgentAuthorityDisplay,
     pub(crate) confidence: u8,
     pub(crate) evidence: String,
     pub(crate) updated_at_ms: u64,
@@ -167,6 +167,7 @@ pub(crate) struct TerminalView {
     pub(crate) git_state: String,
     pub(crate) worktree: String,
     pub(crate) foreground_process: Option<String>,
+    pub(crate) kind: TerminalKind,
     pub(crate) command: String,
     pub(crate) argv: Vec<String>,
     pub(crate) run: Option<TerminalRunView>,
@@ -182,27 +183,17 @@ pub(crate) struct TerminalRunView {
 }
 
 impl TerminalView {
-    fn kind(&self) -> &'static str {
-        if self.command.is_empty() {
-            "shell"
-        } else {
-            "command"
-        }
-    }
-
     fn detail(&self) -> &str {
-        if self.command.is_empty() {
-            &self.branch
-        } else {
-            &self.command
+        match self.kind {
+            TerminalKind::Shell => &self.branch,
+            TerminalKind::Command => &self.command,
         }
     }
 
     fn process(&self) -> &str {
-        if self.command.is_empty() {
-            self.foreground_process.as_deref().unwrap_or("shell")
-        } else {
-            &self.command
+        match self.kind {
+            TerminalKind::Shell => self.foreground_process.as_deref().unwrap_or("shell"),
+            TerminalKind::Command => &self.command,
         }
     }
 
@@ -258,7 +249,7 @@ impl WorkspaceView {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ItemKind {
+pub(crate) enum ItemKind {
     Agent,
     Launcher,
     Shell,
@@ -270,8 +261,7 @@ impl WorkspaceItemView {
         match self {
             Self::AgentShell(_) => ItemKind::Agent,
             Self::Launcher(_) => ItemKind::Launcher,
-            Self::Shell(shell) if shell.command.is_empty() => ItemKind::Shell,
-            Self::Shell(_) => ItemKind::Command,
+            Self::Shell(shell) => shell.kind.into(),
         }
     }
 
@@ -286,7 +276,7 @@ impl WorkspaceItemView {
     fn status(&self) -> &str {
         match self {
             Self::Shell(shell) => &shell.status,
-            Self::AgentShell(agent) => agent.status(),
+            Self::AgentShell(agent) => agent.state().label(),
             Self::Launcher(_) => "launcher",
         }
     }
@@ -307,6 +297,89 @@ impl ItemKind {
             Self::Launcher => "launcher",
             Self::Shell => "shell",
             Self::Command => "command",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TerminalKind {
+    Shell,
+    Command,
+}
+
+impl TerminalKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Shell => "shell",
+            Self::Command => "command",
+        }
+    }
+}
+
+impl From<TerminalKind> for ItemKind {
+    fn from(kind: TerminalKind) -> Self {
+        match kind {
+            TerminalKind::Shell => Self::Shell,
+            TerminalKind::Command => Self::Command,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AgentDisplayState {
+    Unknown,
+    Working,
+    Blocked,
+    Idle,
+    Inactive,
+    Done,
+    Untracked,
+}
+
+impl AgentDisplayState {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Working => "working",
+            Self::Blocked => "blocked",
+            Self::Idle => "idle",
+            Self::Inactive => "inactive",
+            Self::Done => "done",
+            Self::Untracked => "untracked",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AttentionReason {
+    Blocked,
+    Completed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AgentAuthorityDisplay {
+    DaemonLifecycle,
+    LifecycleIntegration,
+    ProcessAdapter,
+    TerminalHeuristic,
+}
+
+impl AgentAuthorityDisplay {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::DaemonLifecycle => "daemon_lifecycle",
+            Self::LifecycleIntegration => "lifecycle_integration",
+            Self::ProcessAdapter => "process_adapter",
+            Self::TerminalHeuristic => "terminal_heuristic",
+        }
+    }
+}
+
+impl AttentionReason {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::Completed => "completed",
         }
     }
 }
@@ -756,7 +829,8 @@ impl CommandPalette {
                         },
                     });
                 }
-                if kind == ItemKind::Agent && item.status() == "blocked" {
+                if matches!(item, WorkspaceItemView::AgentShell(agent) if agent.state() == AgentDisplayState::Blocked)
+                {
                     entries.push(PaletteEntry {
                         action_group: PaletteActionGroup::QuickAccess,
                         kind_group: PaletteKindGroup::BlockedAgents,
@@ -773,7 +847,7 @@ impl CommandPalette {
 
             for attention in &workspace.attention {
                 attention_entries.push((
-                    usize::from(attention.reason != "blocked"),
+                    usize::from(attention.reason != AttentionReason::Blocked),
                     attention.observed_at_ms,
                     workspace.id.clone(),
                     attention.shell_id.clone(),
@@ -781,10 +855,10 @@ impl CommandPalette {
                         action_group: PaletteActionGroup::QuickAccess,
                         kind_group: PaletteKindGroup::Attention,
                         label: format!("{} / {}", workspace.name, attention.agent_name),
-                        detail: format!("{}: {}", attention.reason, attention.evidence),
+                        detail: format!("{}: {}", attention.reason.label(), attention.evidence),
                         keywords: format!(
                             "attention unseen outstanding {} {} {} {}",
-                            attention.reason,
+                            attention.reason.label(),
                             attention.evidence,
                             workspace.name,
                             attention.shell_id
@@ -1427,7 +1501,7 @@ impl App {
             None
         } else {
             self.selected_item().and_then(|item| match item {
-                WorkspaceItemView::Shell(shell) if shell.command.is_empty() => Some((
+                WorkspaceItemView::Shell(shell) if shell.kind == TerminalKind::Shell => Some((
                     shell.id.clone(),
                     shell.run.as_ref().map(|run| run.id.clone()),
                     shell.run.as_ref().map_or(0, |run| run.output_revision),
@@ -2465,11 +2539,13 @@ fn help_lines(app: &App) -> Vec<Line<'static>> {
             Line::from(format!("  {summary}")),
             Line::from(format!("  {exit}")),
         ]);
-        if item.status() == "untracked" {
+        if matches!(item, WorkspaceItemView::AgentShell(agent) if agent.state() == AgentDisplayState::Untracked)
+        {
             lines.push(Line::from(
                 "  Untracked means a supported foreground host has no authoritative report.",
             ));
-        } else if item.status() == "blocked" {
+        } else if matches!(item, WorkspaceItemView::AgentShell(agent) if agent.state() == AgentDisplayState::Blocked)
+        {
             lines.push(Line::from(
                 "  Blocked means the current Agent observation requires user input.",
             ));
@@ -2633,7 +2709,7 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                         },
                     );
                     Some([
-                        agent.status().to_owned(),
+                        agent.state().label().to_owned(),
                         updated,
                         workspace.name.clone(),
                         agent.shell.name.clone(),
@@ -2682,7 +2758,7 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                             .map_or_else(|| "-".into(), |run| format!("#{}", run.generation)),
                         workspace.name.clone(),
                         shell.name.clone(),
-                        shell.kind().into(),
+                        shell.kind.label().into(),
                         shell.process().into(),
                         shell.branch.clone(),
                         shell.worktree.clone(),
@@ -2746,8 +2822,8 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                             WorkspaceItemView::AgentShell(agent) => cells.extend([
                                 Cell::from(agent.shell.name.clone()),
                                 Cell::from(Span::styled(
-                                    agent.status().to_owned(),
-                                    Style::new().fg(status_color(agent.status())),
+                                    agent.state().label().to_owned(),
+                                    Style::new().fg(agent_row_color(agent.state())),
                                 )),
                                 Cell::from(agent.shell.directory.clone()),
                                 Cell::from(agent.agent.as_ref().map_or_else(
@@ -2758,7 +2834,7 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                                             view.evidence,
                                             agent.shell.branch,
                                             view.integration,
-                                            view.authority,
+                                            view.authority.label(),
                                             view.confidence
                                         )
                                     },
@@ -2835,7 +2911,7 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
         .flat_map(|workspace| {
             workspace.items.iter().map(|item| match item {
                 WorkspaceItemView::Shell(terminal) => [
-                    terminal.kind().into(),
+                    terminal.kind.label().into(),
                     terminal.table_status(),
                     terminal.name.clone(),
                     terminal.process().into(),
@@ -2864,7 +2940,7 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
                     );
                     [
                         "agent".into(),
-                        agent_shell.status().into(),
+                        agent_shell.state().label().into(),
                         agent_shell.shell.name.clone(),
                         activity,
                         branch,
@@ -3017,7 +3093,7 @@ fn launcher_preview(launcher: &LauncherView) -> ContextualPreview {
 }
 
 fn terminal_preview(app: &App, terminal: &TerminalView) -> Option<ContextualPreview> {
-    let is_command = !terminal.command.is_empty();
+    let is_command = terminal.kind == TerminalKind::Command;
     let mut lines = Vec::new();
     if is_command {
         lines.push(terminal_preview_field(
@@ -3268,9 +3344,9 @@ fn agent_session_preview(app: &App, agent_shell: &AgentShellView) -> Option<Cont
         Line::from(vec![
             preview_label("STATUS"),
             Span::styled(
-                session.state.clone(),
+                session.state.label(),
                 Style::new()
-                    .fg(session_state_color(&session.state))
+                    .fg(session_state_color(session.state))
                     .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
@@ -3305,7 +3381,7 @@ fn agent_session_preview(app: &App, agent_shell: &AgentShellView) -> Option<Cont
             "SOURCE",
             format!(
                 "{}  ·  confidence {}%",
-                agent.authority.replace('_', " "),
+                agent.authority.label().replace('_', " "),
                 agent.confidence
             ),
         ),
@@ -3535,14 +3611,26 @@ fn current_time_ms() -> u64 {
         .as_millis() as u64
 }
 
-fn session_state_color(state: &str) -> Color {
+fn agent_row_color(state: AgentDisplayState) -> Color {
     match state {
-        "blocked" => RED,
-        "working" => TEAL,
-        "idle" => GREEN,
-        "inactive" => SUBTEXT,
-        "done" => BLUE,
-        _ => YELLOW,
+        AgentDisplayState::Untracked => YELLOW,
+        AgentDisplayState::Unknown
+        | AgentDisplayState::Working
+        | AgentDisplayState::Blocked
+        | AgentDisplayState::Idle
+        | AgentDisplayState::Inactive
+        | AgentDisplayState::Done => TEAL,
+    }
+}
+
+fn session_state_color(state: AgentDisplayState) -> Color {
+    match state {
+        AgentDisplayState::Blocked => RED,
+        AgentDisplayState::Working => TEAL,
+        AgentDisplayState::Idle => GREEN,
+        AgentDisplayState::Inactive | AgentDisplayState::Untracked => SUBTEXT,
+        AgentDisplayState::Done => BLUE,
+        AgentDisplayState::Unknown => YELLOW,
     }
 }
 
@@ -3758,6 +3846,7 @@ mod tests {
                 git_state: "clean".into(),
                 worktree: "primary".into(),
                 foreground_process: Some("bash".into()),
+                kind: TerminalKind::Shell,
                 command: String::new(),
                 argv: Vec::new(),
                 run: None,
@@ -3780,10 +3869,10 @@ mod tests {
     fn agent() -> AgentView {
         AgentView {
             id: "agent-active".into(),
-            state: "working".into(),
+            state: AgentDisplayState::Working,
             integration: "opencode".into(),
             external_session_id: Some("external-active".into()),
-            authority: "lifecycle_integration".into(),
+            authority: AgentAuthorityDisplay::LifecycleIntegration,
             confidence: 95,
             evidence: "tool call in progress".into(),
             updated_at_ms: current_time_ms(),
@@ -3804,6 +3893,7 @@ mod tests {
                 git_state: "clean".into(),
                 worktree: "primary".into(),
                 foreground_process: Some("opencode".into()),
+                kind: TerminalKind::Shell,
                 command: String::new(),
                 argv: Vec::new(),
                 run: None,
@@ -3812,13 +3902,13 @@ mod tests {
         }
     }
 
-    fn session(id: &str, state: &str) -> AgentSessionView {
+    fn session(id: &str, state: AgentDisplayState) -> AgentSessionView {
         AgentSessionView {
             id: id.into(),
             label: "OpenCode review".into(),
             integration: "opencode".into(),
             external_session_id: Some(format!("external-{id}")),
-            state: state.into(),
+            state,
             state_is_current: true,
             last_at_ms: 30,
             source_cwd: Some("/tmp/boomux".into()),
@@ -4123,6 +4213,7 @@ mod tests {
                 git_state: "clean".into(),
                 worktree: "primary".into(),
                 foreground_process: Some("opencode".into()),
+                kind: TerminalKind::Shell,
                 command: String::new(),
                 argv: Vec::new(),
                 run: None,
@@ -4142,6 +4233,11 @@ mod tests {
             git_state: "clean".into(),
             worktree: "primary".into(),
             foreground_process: Some("bash".into()),
+            kind: if command.is_empty() {
+                TerminalKind::Shell
+            } else {
+                TerminalKind::Command
+            },
             command: command.into(),
             argv: command.split_whitespace().map(str::to_owned).collect(),
             run: None,
@@ -4261,7 +4357,7 @@ mod tests {
             _ => unreachable!(),
         };
         shell.foreground_process = Some("nvim".into());
-        assert_eq!(shell.kind(), "shell");
+        assert_eq!(shell.kind, TerminalKind::Shell);
         assert_eq!(shell.process(), "nvim");
 
         let mut command = match terminal("command", "tests", "cargo test") {
@@ -4278,7 +4374,7 @@ mod tests {
             exit_reason: Some("exited (1)".into()),
             output_revision: 4,
         });
-        assert_eq!(command.kind(), "command");
+        assert_eq!(command.kind, TerminalKind::Command);
         assert_eq!(command.process(), "cargo test");
         assert_eq!(command.table_status(), "exit 1");
     }
@@ -4450,7 +4546,9 @@ mod tests {
             WorkspaceItemView::AgentShell(agent_shell()),
             launcher_view("launcher-1", "editor"),
         ];
-        mixed.sessions.push(session("durable-1", "working"));
+        mixed
+            .sessions
+            .push(session("durable-1", AgentDisplayState::Working));
         mixed.agent_state_counts.blocked = 1;
         mixed.agent_state_counts.done = 1;
         mixed.attention_count = 2;
@@ -4545,6 +4643,7 @@ mod tests {
             git_state: "clean".into(),
             worktree: "primary".into(),
             foreground_process: None,
+            kind: TerminalKind::Shell,
             command: String::new(),
             argv: Vec::new(),
             run: None,
@@ -4798,12 +4897,12 @@ mod tests {
     fn command_palette_finds_blocked_agents_and_attention() {
         let mut workspace = workspace("w1", "review");
         let mut agent = agent_shell();
-        agent.agent.as_mut().unwrap().state = "blocked".into();
+        agent.agent.as_mut().unwrap().state = AgentDisplayState::Blocked;
         workspace.items[0] = WorkspaceItemView::AgentShell(agent);
         workspace.attention = vec![WorkspaceAttentionView {
             shell_id: "term_1".into(),
             agent_name: "review-agent".into(),
-            reason: "blocked".into(),
+            reason: AttentionReason::Blocked,
             evidence: "approval required".into(),
             observed_at_ms: 1,
         }];
@@ -4848,7 +4947,7 @@ mod tests {
         completed.attention = vec![WorkspaceAttentionView {
             shell_id: "completed-shell".into(),
             agent_name: "completed-agent".into(),
-            reason: "completed".into(),
+            reason: AttentionReason::Completed,
             evidence: "finished".into(),
             observed_at_ms: 20,
         }];
@@ -4856,7 +4955,7 @@ mod tests {
         blocked.attention = vec![WorkspaceAttentionView {
             shell_id: "blocked-shell".into(),
             agent_name: "blocked-agent".into(),
-            reason: "blocked".into(),
+            reason: AttentionReason::Blocked,
             evidence: "approval required".into(),
             observed_at_ms: 10,
         }];
@@ -5556,7 +5655,7 @@ mod tests {
         app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell);
         app.workspaces[0]
             .sessions
-            .push(session("active", "working"));
+            .push(session("active", AgentDisplayState::Working));
         focus_items(&mut app);
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
@@ -5596,6 +5695,7 @@ mod tests {
             panic!("expected shell item");
         };
         command.name = "clock".into();
+        command.kind = TerminalKind::Command;
         command.command = "watch -n 1 date".into();
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
@@ -5620,7 +5720,7 @@ mod tests {
         let mut agent_shell = hinted_agent_shell();
         agent_shell.shell.name = "keepname".into();
         app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell);
-        app.workspaces[0].sessions = vec![session("active", "working")];
+        app.workspaces[0].sessions = vec![session("active", AgentDisplayState::Working)];
         focus_items(&mut app);
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
@@ -5702,23 +5802,23 @@ mod tests {
         app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell());
         focus_items(&mut app);
         let now = current_time_ms();
-        let mut active = session("active", "working");
+        let mut active = session("active", AgentDisplayState::Working);
         active.label = "Current work".into();
         active.last_at_ms = now;
-        let mut recent = session("recent", "inactive");
+        let mut recent = session("recent", AgentDisplayState::Inactive);
         recent.label = "Recent review".into();
         recent.external_session_id = Some("external-active".into());
         recent.state_is_current = false;
         recent.last_at_ms = now + 1;
-        let mut week = session("week", "done");
+        let mut week = session("week", AgentDisplayState::Done);
         week.label = "Finished build".into();
         week.state_is_current = false;
         week.last_at_ms = now - 2 * 24 * 60 * 60 * 1_000;
-        let mut older = session("older", "inactive");
+        let mut older = session("older", AgentDisplayState::Inactive);
         older.label = "Dormant review".into();
         older.state_is_current = false;
         older.last_at_ms = now - 8 * 24 * 60 * 60 * 1_000;
-        let mut pi = session("pi", "done");
+        let mut pi = session("pi", AgentDisplayState::Done);
         pi.integration = "pi".into();
         pi.label = "Pi session must be filtered".into();
         app.workspaces[0].sessions = vec![active, recent, week, older, pi];
@@ -5796,7 +5896,7 @@ mod tests {
     fn agent_session_preview_labels_historical_and_missing_context() {
         let mut workspace = workspace("w1", "boomux");
         workspace.items[0] = WorkspaceItemView::AgentShell(agent_shell());
-        let mut catalog = session("catalog", "idle");
+        let mut catalog = session("catalog", AgentDisplayState::Idle);
         catalog.external_session_id = Some("external-active".into());
         catalog.state_is_current = false;
         catalog.source_cwd = None;
@@ -5862,7 +5962,7 @@ mod tests {
         app.workspaces[0].items[0] = WorkspaceItemView::AgentShell(agent_shell());
         app.workspaces[0]
             .sessions
-            .push(session("active", "working"));
+            .push(session("active", AgentDisplayState::Working));
         focus_items(&mut app);
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
@@ -5978,12 +6078,12 @@ mod tests {
         let mut terminal_backend = Terminal::new(backend).unwrap();
         let mut one = workspace("w1", "one");
         one.items.clear();
-        let mut wrong = session("wrong", "working");
+        let mut wrong = session("wrong", AgentDisplayState::Working);
         wrong.label = "Wrong workspace session".into();
         one.sessions.push(wrong);
         let mut two = workspace("w2", "two");
         two.items = vec![WorkspaceItemView::AgentShell(agent_shell())];
-        let mut right = session("right", "working");
+        let mut right = session("right", AgentDisplayState::Working);
         right.external_session_id = Some("external-active".into());
         right.label = "Owning workspace session".into();
         two.sessions.push(right);
@@ -6054,7 +6154,9 @@ mod tests {
         let backend = TestBackend::new(180, 34);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = app();
-        app.workspaces[0].sessions.push(session("hidden", "done"));
+        app.workspaces[0]
+            .sessions
+            .push(session("hidden", AgentDisplayState::Done));
         focus_items(&mut app);
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
@@ -6472,7 +6574,7 @@ mod tests {
         workspace.attention = vec![WorkspaceAttentionView {
             shell_id: "term_1".into(),
             agent_name: "review-agent".into(),
-            reason: "blocked".into(),
+            reason: AttentionReason::Blocked,
             evidence: "approval required".into(),
             observed_at_ms: current_time_ms(),
         }];
@@ -6498,7 +6600,7 @@ mod tests {
 
     #[test]
     fn generic_agent_names_fall_back_to_shell_and_identity() {
-        let mut view = session("generic", "idle");
+        let mut view = session("generic", AgentDisplayState::Idle);
         view.label = "opencode".into();
         view.external_session_id = Some("ses_123456789".into());
 
@@ -6508,7 +6610,7 @@ mod tests {
 
     #[test]
     fn pi_sessions_keep_the_shell_and_identity_fallback() {
-        let mut view = session("pi-generic", "idle");
+        let mut view = session("pi-generic", AgentDisplayState::Idle);
         view.integration = "pi".into();
         view.label = "Pi".into();
         view.external_session_id = Some("pi_123456789".into());


### PR DESCRIPTION
## Summary
- add typed Agent state, authority, attention reason, terminal kind, and item-kind presentation models
- isolate snapshot and projected-session conversion in a focused dashboard projection module
- centralize exact active Agent shell/run matching while preserving stricter integration authority checks
- remove TUI behavior based on lifecycle strings and empty command fields
- preserve existing rendering, foreground hint, and shell-backed Agent action behavior
- clarify Release Please-triggering and non-release PR title rules in `AGENTS.md`

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked` (380 tests passed)
- `cargo test --test native_backend --locked -- --test-threads=1` (27 tests passed on complete rerun)
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js` (29 tests passed)
- `git diff --check`
- final independent regression review found no issues

Closes #112