### PR TITLE
perf(dashboard): refresh from events instead of full polling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,6 +210,18 @@ workspace's default cwd. Git information is still collected independently from
 shell directories and cached. A default cwd does not create workspace-level Git
 identity, and mixed-directory workspaces remain valid.
 
+The dashboard establishes an atomic event-stream baseline and treats later
+events as invalidation signals for authoritative snapshot reprojection. Idle
+checks advance only the event cursor. Once per second, protocol-21 dashboards
+refresh ephemeral focus through its targeted read and foreground-process hints
+through targeted running-shell reads; they do not rebuild the complete registry.
+The daemon caches foreground inspection per shell run for one second, so
+concurrent dashboards reuse the result. Cursor expiration or cold daemon
+replacement establishes a new baseline and resets client-side focus revision
+tracking when the stream identity changes. Protocols 7-20 use a one-second
+snapshot fallback for ephemeral fields. Protocol-6 dashboards retain that
+fallback for all state because that version predates the event stream.
+
 Shell snapshots include their additive stored startup argument vector. The
 dashboard presents an empty vector as `shell` and a non-empty vector as
 `command`, making primary-process exit behavior visible without splitting the
@@ -564,6 +576,10 @@ workspace field, and requests using either new behavior require protocol 19.
 Protocol 20 adds bounded structured terminal previews, including styles and
 modifiers, so the dashboard can render colors and emphasis without replaying
 terminal control sequences. Older clients continue to use plain rendered reads.
+Protocol 21 adds a targeted focused-terminal read so event-driven dashboards can
+refresh non-durable focus without rebuilding the complete registry. Protocols
+7-20 use the event stream with a one-second snapshot fallback for ephemeral
+fields; protocol 6 retains one-second snapshot refreshes.
 
 Opt-in desktop and sound notifications are a daemon-owned projection of committed
 Agent state transitions, not durable queue state. A transition from any other

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -22,6 +22,10 @@ and do not receive acknowledgment events, while cursors still advance across
 those filtered events. Protocol 18 adds the latest non-durable focused terminal
 and its monotonic revision to baseline snapshots. It does not add an event type;
 protocol-17 clients receive the same baseline without that field.
+Protocol 21 adds a targeted focused-terminal read for clients that use events as
+registry invalidation while refreshing ephemeral focus independently. Running
+shell reads refresh foreground-process hints from a daemon-side one-second cache
+shared by concurrent clients.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,10 +15,10 @@ use std::time::Duration;
 
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, DaemonEvent, Envelope,
-    ErrorCode, EventCursor, NotificationDeliveryConfig, Request, Response, ShellSnapshot,
-    ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan,
-    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
-    WorkspaceLauncherSpec, WorkspaceSnapshot,
+    ErrorCode, EventCursor, FocusedTerminalSnapshot, NotificationDeliveryConfig, Request, Response,
+    ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalPreviewLine,
+    TerminalPreviewSpan, TerminalProfile, UnixEnvironment, UnixEnvironmentVariable,
+    WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -55,6 +55,73 @@ pub struct EventBatch {
     pub cursor: EventCursor,
     pub snapshot: Option<Snapshot>,
     pub events: Vec<DaemonEvent>,
+}
+
+#[derive(Debug)]
+pub struct SnapshotWatch {
+    cursor: Option<EventCursor>,
+    snapshot: Snapshot,
+}
+
+impl SnapshotWatch {
+    pub fn baseline(client: &Client) -> io::Result<Self> {
+        if !client.supports(protocol::ProtocolFeature::AtomicOutputReads)? {
+            return Ok(Self {
+                cursor: None,
+                snapshot: client.snapshot()?,
+            });
+        }
+        let batch = client.events(None, 1, 0)?;
+        let snapshot = batch
+            .snapshot
+            .ok_or_else(|| io::Error::other("event baseline omitted its snapshot"))?;
+        Ok(Self {
+            cursor: Some(batch.cursor),
+            snapshot,
+        })
+    }
+
+    pub fn snapshot(&self) -> &Snapshot {
+        &self.snapshot
+    }
+
+    pub fn snapshot_mut(&mut self) -> &mut Snapshot {
+        &mut self.snapshot
+    }
+
+    pub fn uses_events(&self) -> bool {
+        self.cursor.is_some()
+    }
+
+    pub fn poll(&mut self, client: &Client) -> io::Result<(bool, bool)> {
+        let Some(cursor) = self.cursor.clone() else {
+            return Ok((false, false));
+        };
+        let stream_id = cursor.stream_id.clone();
+        match client.events(Some(cursor), 256, 0) {
+            Ok(batch) => {
+                if batch.events.is_empty() {
+                    self.cursor = Some(batch.cursor);
+                    return Ok((false, false));
+                }
+                *self = Self::baseline(client)?;
+                Ok((true, self.stream_id() != Some(stream_id.as_str())))
+            }
+            Err(error) if remote_code(&error) == Some(ErrorCode::CursorExpired) => {
+                *self = Self::baseline(client)?;
+                Ok((true, self.stream_id() != Some(stream_id.as_str())))
+            }
+            Err(error) if remote_code(&error) == Some(ErrorCode::UnsupportedVersion) => {
+                *self = Self::baseline(client)?;
+                Ok((true, self.stream_id() != Some(stream_id.as_str())))
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn stream_id(&self) -> Option<&str> {
+        self.cursor.as_ref().map(|cursor| cursor.stream_id.as_str())
+    }
 }
 
 #[derive(Debug)]
@@ -332,6 +399,13 @@ impl Client {
     pub fn snapshot(&self) -> io::Result<Snapshot> {
         match self.request(Request::Snapshot)? {
             Response::Snapshot { snapshot } => Ok(snapshot),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn focused_terminal(&self) -> io::Result<Option<FocusedTerminalSnapshot>> {
+        match self.request(Request::GetFocusedTerminal)? {
+            Response::FocusedTerminal { focused_terminal } => Ok(focused_terminal),
             other => unexpected(other),
         }
     }
@@ -877,6 +951,27 @@ mod tests {
 
     use uuid::Uuid;
 
+    fn reject_protocol(listener: &UnixListener, attempted: u32, supported: u32) {
+        let (mut stream, _) = listener.accept().unwrap();
+        let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+        assert_eq!(request.version, attempted);
+        assert!(matches!(
+            request.message,
+            Request::Ping | Request::Attach { .. }
+        ));
+        protocol::write_message(
+            &mut stream,
+            &Envelope::with_version(
+                supported,
+                Response::Error {
+                    message: format!("protocol {attempted} unsupported"),
+                    code: Some(ErrorCode::UnsupportedVersion),
+                },
+            ),
+        )
+        .unwrap();
+    }
+
     fn test_profile() -> TerminalProfile {
         TerminalProfile {
             term: None,
@@ -897,6 +992,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 21, 20);
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 20);
@@ -1042,7 +1138,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 20);
+            assert_eq!(request.version, 21);
             let Request::Attach {
                 environment: Some(environment),
                 ..
@@ -1059,7 +1155,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    20,
+                    21,
                     Response::Attached {
                         token: "token".into(),
                         reconstruction: Vec::new(),
@@ -1087,21 +1183,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 20);
-            assert!(matches!(request.message, Request::Attach { .. }));
-            protocol::write_message(
-                &mut stream,
-                &Envelope::with_version(
-                    20,
-                    Response::Error {
-                        message: "protocol 20 unsupported".into(),
-                        code: Some(ErrorCode::UnsupportedVersion),
-                    },
-                ),
-            )
-            .unwrap();
+            reject_protocol(&listener, 21, 20);
+            reject_protocol(&listener, 21, 20);
 
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
@@ -1191,6 +1274,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 21, 20);
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 20);
@@ -1247,6 +1331,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 21, 20);
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
             assert_eq!(request.version, 20);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -48,6 +48,7 @@ const RESTART_TIMEOUT: Duration = Duration::from_secs(10);
 const IO_RETRY_DELAY: Duration = Duration::from_millis(2);
 const PERSIST_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const TERMINAL_HISTORY_INTERVAL: Duration = Duration::from_secs(5);
+const FOREGROUND_PROCESS_CACHE_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_TERMINAL_HISTORY_BYTES: usize = 256 * 1024;
 const MAX_TERMINAL_ENV_VALUE: usize = 256;
 const MAX_NAME_BYTES: usize = 256;
@@ -1342,6 +1343,7 @@ struct Shell {
     command: Vec<String>,
     last_run: Mutex<Option<PersistedShellRun>>,
     lifecycle: Mutex<ShellLifecycle>,
+    foreground_process_cache: Mutex<Option<(String, Instant, Option<String>)>>,
 }
 
 enum ShellLifecycle {
@@ -1976,6 +1978,9 @@ impl Registry {
             Request::Snapshot => Ok(Response::Snapshot {
                 snapshot: self.snapshot()?,
             }),
+            Request::GetFocusedTerminal => Ok(Response::FocusedTerminal {
+                focused_terminal: self.focused_terminal()?,
+            }),
             Request::GetWorkspace { workspace_id } => Ok(Response::Workspace {
                 workspace: self.workspace(&workspace_id)?.snapshot(self)?,
             }),
@@ -2380,6 +2385,7 @@ impl Registry {
                     command: saved_shell.command,
                     last_run: Mutex::new(saved_shell.last_run),
                     lifecycle: Mutex::new(ShellLifecycle::Pending),
+                    foreground_process_cache: Mutex::new(None),
                 });
                 shell_ids.push(shell.id.clone());
                 state.shells.insert(shell.id.clone(), shell);
@@ -4395,15 +4401,28 @@ impl Shell {
             ),
             ShellLifecycle::Closed => return Err(not_found("shell", &self.id)),
         };
-        let foreground_process = runtime.and_then(|runtime| {
-            lock(&runtime.master)
-                .ok()
-                .and_then(|master| master.foreground_process())
-                .or_else(|| {
-                    let pid = lock(&runtime.process).ok()?.process_id()?;
-                    foreground_process_for_session_leader(pid)
-                })
-        });
+        let foreground_process = match (runtime, run.as_ref()) {
+            (Some(runtime), Some(run)) => {
+                let mut cache = lock(&self.foreground_process_cache)?;
+                if let Some((cached_run_id, observed_at, process)) = cache.as_ref()
+                    && cached_run_id == &run.id
+                    && observed_at.elapsed() < FOREGROUND_PROCESS_CACHE_INTERVAL
+                {
+                    process.clone()
+                } else {
+                    let process = lock(&runtime.master)
+                        .ok()
+                        .and_then(|master| master.foreground_process())
+                        .or_else(|| {
+                            let pid = lock(&runtime.process).ok()?.process_id()?;
+                            foreground_process_for_session_leader(pid)
+                        });
+                    *cache = Some((run.id.clone(), Instant::now(), process.clone()));
+                    process
+                }
+            }
+            _ => None,
+        };
         Ok(ShellSnapshot {
             id: self.id.clone(),
             workspace_id: self.workspace_id.clone(),
@@ -4609,6 +4628,7 @@ fn create_pending_shell(workspace_id: &str, spec: ShellSpec) -> io::Result<Arc<S
         command: spec.command,
         last_run: Mutex::new(None),
         lifecycle: Mutex::new(ShellLifecycle::Pending),
+        foreground_process_cache: Mutex::new(None),
     }))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use clap::error::ErrorKind as ClapErrorKind;
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -41,6 +42,74 @@ mod session_projection;
 mod session_transcript;
 mod terminal;
 mod tui;
+
+const DASHBOARD_FALLBACK_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+
+struct DashboardRefresh {
+    watch: client::SnapshotWatch,
+    last_snapshot_at: Instant,
+}
+
+impl DashboardRefresh {
+    fn baseline(client: &client::Client) -> io::Result<Self> {
+        Ok(Self {
+            watch: client::SnapshotWatch::baseline(client)?,
+            last_snapshot_at: Instant::now(),
+        })
+    }
+
+    fn snapshot(&self) -> &Snapshot {
+        self.watch.snapshot()
+    }
+
+    fn check(&mut self, client: &client::Client) -> io::Result<Option<(Snapshot, bool)>> {
+        match self.watch.poll(client) {
+            Ok((changed, stream_changed)) => {
+                if changed {
+                    self.last_snapshot_at = Instant::now();
+                    return Ok(Some((self.watch.snapshot().clone(), stream_changed)));
+                }
+                if self.last_snapshot_at.elapsed() < DASHBOARD_FALLBACK_REFRESH_INTERVAL {
+                    return Ok(None);
+                }
+                if !self.watch.uses_events()
+                    || !client.supports(protocol::ProtocolFeature::FocusedTerminalRead)?
+                {
+                    *self = Self::baseline(client)?;
+                    return Ok(Some((self.watch.snapshot().clone(), false)));
+                }
+                self.refresh_ephemeral_fields(client)?;
+                self.last_snapshot_at = Instant::now();
+                Ok(Some((self.watch.snapshot().clone(), false)))
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn refresh(&mut self, client: &client::Client) -> io::Result<(Snapshot, bool)> {
+        let stream_id = self.watch.stream_id().map(str::to_owned);
+        *self = Self::baseline(client)?;
+        Ok((
+            self.watch.snapshot().clone(),
+            self.watch.stream_id() != stream_id.as_deref(),
+        ))
+    }
+
+    fn refresh_ephemeral_fields(&mut self, client: &client::Client) -> io::Result<()> {
+        self.watch.snapshot_mut().focused_terminal = client.focused_terminal()?;
+        for shell in self
+            .watch
+            .snapshot_mut()
+            .workspaces
+            .iter_mut()
+            .flat_map(|workspace| &mut workspace.shells)
+            .filter(|shell| shell.status == ShellStatus::Running)
+        {
+            shell.foreground_process = client.get_shell(&shell.id)?.foreground_process;
+        }
+        Ok(())
+    }
+}
 
 const BOOMUX_SKILL: &str = include_str!("../.agents/skills/boomux/SKILL.md");
 #[cfg(test)]
@@ -1083,7 +1152,8 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let mut git_cache = git::Cache::default();
     let mut title_cache = host_session_titles::Cache::default();
-    let snapshot = client.snapshot()?;
+    let mut refresh = DashboardRefresh::baseline(&client)?;
+    let snapshot = refresh.snapshot().clone();
     let mut views =
         dashboard_views_with_catalog(&snapshot.workspaces, &mut git_cache, &mut title_cache);
     enrich_session_titles(&mut views, &mut title_cache);
@@ -1113,11 +1183,32 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
         tui::DashboardState {
             workspaces: views,
             focused_terminal: snapshot.focused_terminal.map(focused_terminal_view),
+            reset_focus_revision: false,
         },
         config.dashboard.follow_focused_terminal,
         project_context,
         |effect| match effect {
             tui::DashboardEffect::Quit => unreachable!("quit is handled by the dashboard runtime"),
+            tui::DashboardEffect::CheckForUpdates => {
+                let result = refresh.check(&client).map_err(|error| error.to_string());
+                match result {
+                    Ok(Some((snapshot, reset_focus_revision))) => {
+                        let mut views = dashboard_views_with_catalog(
+                            &snapshot.workspaces,
+                            &mut git_cache,
+                            &mut title_cache,
+                        );
+                        enrich_session_titles(&mut views, &mut title_cache);
+                        tui::DashboardEvent::RefreshCompleted(Ok(tui::DashboardState {
+                            workspaces: views,
+                            focused_terminal: snapshot.focused_terminal.map(focused_terminal_view),
+                            reset_focus_revision,
+                        }))
+                    }
+                    Ok(None) => tui::DashboardEvent::UpdateCheckCompleted,
+                    Err(error) => tui::DashboardEvent::RefreshCompleted(Err(error)),
+                }
+            }
             tui::DashboardEffect::RestoreWorkspace(workspace_id) => {
                 let result = (|| {
                     let workspace = client
@@ -1232,7 +1323,9 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             }
             tui::DashboardEffect::Refresh => {
                 let result = (|| {
-                    let snapshot = client.snapshot().map_err(|error| error.to_string())?;
+                    let (snapshot, reset_focus_revision) = refresh
+                        .refresh(&client)
+                        .map_err(|error| error.to_string())?;
                     let mut views = dashboard_views_with_catalog(
                         &snapshot.workspaces,
                         &mut git_cache,
@@ -1242,6 +1335,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     Ok(tui::DashboardState {
                         workspaces: views,
                         focused_terminal: snapshot.focused_terminal.map(focused_terminal_view),
+                        reset_focus_revision,
                     })
                 })();
                 tui::DashboardEvent::RefreshCompleted(result)
@@ -5998,7 +6092,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 20);
+        assert_eq!(protocol::PROTOCOL_VERSION, 21);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 20;
+pub const PROTOCOL_VERSION: u32 = 21;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -77,6 +77,7 @@ define_protocol_features! {
     FocusedTerminal => (18, "request", ["protocol_18", "focused_terminal_following"]),
     WorkspaceDefaultCwd => (19, "request", ["protocol_19", "workspace_default_cwd"]),
     StructuredTerminalPreview => (20, "request", ["protocol_20", "structured_terminal_previews"]),
+    FocusedTerminalRead => (21, "request", ["protocol_21", "focused_terminal_read"]),
 }
 
 pub fn protocol_capabilities() -> impl Iterator<Item = &'static str> {
@@ -520,6 +521,7 @@ pub enum Request {
     },
     Shutdown,
     Snapshot,
+    GetFocusedTerminal,
     GetWorkspace {
         workspace_id: String,
     },
@@ -638,6 +640,7 @@ impl Request {
     pub fn required_feature(&self) -> Option<ProtocolFeature> {
         match self {
             Self::ReadShellPreview { .. } => Some(ProtocolFeature::StructuredTerminalPreview),
+            Self::GetFocusedTerminal => Some(ProtocolFeature::FocusedTerminalRead),
             Self::CreateWorkspace {
                 default_cwd: Some(_),
                 ..
@@ -704,6 +707,9 @@ pub enum Response {
     Pong,
     Snapshot {
         snapshot: Snapshot,
+    },
+    FocusedTerminal {
+        focused_terminal: Option<FocusedTerminalSnapshot>,
     },
     Workspace {
         workspace: WorkspaceSnapshot,
@@ -1125,8 +1131,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_twenty_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 20);
+    fn protocol_version_is_twenty_one_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 21);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -1172,8 +1178,33 @@ mod tests {
     }
 
     #[test]
+    fn focused_terminal_read_round_trips() {
+        let request = serde_json::to_value(Request::GetFocusedTerminal).unwrap();
+        assert_eq!(request["request"], "get_focused_terminal");
+        assert_eq!(
+            serde_json::from_value::<Request>(request).unwrap(),
+            Request::GetFocusedTerminal
+        );
+        let response = Response::FocusedTerminal {
+            focused_terminal: Some(FocusedTerminalSnapshot {
+                revision: 1,
+                workspace_id: "w1".into(),
+                shell_id: "s1".into(),
+                run_id: "r1".into(),
+            }),
+        };
+        let encoded = serde_json::to_value(&response).unwrap();
+        assert_eq!(encoded["response"], "focused_terminal");
+        assert_eq!(
+            serde_json::from_value::<Response>(encoded).unwrap(),
+            response
+        );
+    }
+
+    #[test]
     fn request_feature_requirements_cover_all_groups() {
         let groups = vec![
+            (21, vec![Request::GetFocusedTerminal]),
             (
                 20,
                 vec![Request::ReadShellPreview {
@@ -1447,6 +1478,7 @@ mod tests {
             (18, &["protocol_18", "focused_terminal_following"][..]),
             (19, &["protocol_19", "workspace_default_cwd"][..]),
             (20, &["protocol_20", "structured_terminal_previews"][..]),
+            (21, &["protocol_21", "focused_terminal_read"][..]),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -23,7 +23,7 @@ const BLUE: Color = Color::Blue;
 const GREEN: Color = Color::Green;
 const YELLOW: Color = Color::Yellow;
 const RED: Color = Color::Red;
-const REFRESH_INTERVAL: Duration = Duration::from_millis(250);
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_millis(250);
 const TERMINAL_PREVIEW_ROWS: usize = 16;
 const TERMINAL_PREVIEW_SCROLL_STEP: usize = 12;
 const PREVIEW_RESERVED_ITEM_HEIGHT: u16 = 6;
@@ -62,6 +62,7 @@ pub(crate) struct WorkspaceView {
 pub(crate) struct DashboardState {
     pub(crate) workspaces: Vec<WorkspaceView>,
     pub(crate) focused_terminal: Option<FocusedTerminalView>,
+    pub(crate) reset_focus_revision: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -399,6 +400,7 @@ pub(crate) enum DashboardEffect {
         target: RenameTarget,
         name: String,
     },
+    CheckForUpdates,
     Refresh,
     ReadTerminalPreview {
         shell_id: String,
@@ -414,6 +416,7 @@ pub(crate) enum DashboardEvent {
     },
     RefreshElapsed,
     PreviewRequested,
+    UpdateCheckCompleted,
     OperationCompleted(Result<String, String>),
     RefreshCompleted(Result<DashboardState, String>),
     TerminalPreviewCompleted {
@@ -1494,10 +1497,11 @@ impl App {
             DashboardEvent::KeyPressed { code, modifiers } => {
                 return self.update_key(code, modifiers).into_iter().collect();
             }
-            DashboardEvent::RefreshElapsed => return vec![DashboardEffect::Refresh],
+            DashboardEvent::RefreshElapsed => return vec![DashboardEffect::CheckForUpdates],
             DashboardEvent::PreviewRequested => {
                 return self.terminal_preview_effect().into_iter().collect();
             }
+            DashboardEvent::UpdateCheckCompleted => {}
             DashboardEvent::OperationCompleted(result) => {
                 self.message = Some(Message::from_result(result));
                 return vec![DashboardEffect::Refresh];
@@ -1584,6 +1588,9 @@ impl App {
         match result {
             Ok(state) => {
                 self.replace_workspaces(state.workspaces);
+                if state.reset_focus_revision {
+                    self.observed_focus_revision = None;
+                }
                 self.apply_focused_terminal(state.focused_terminal.as_ref());
             }
             Err(text) => self.message = Some(Message { text, error: true }),
@@ -1852,7 +1859,7 @@ fn run_loop<B: DashboardBackend>(
 ) -> io::Result<()> {
     let mut last_refresh = Instant::now();
     loop {
-        if last_refresh.elapsed() >= REFRESH_INTERVAL {
+        if last_refresh.elapsed() >= UPDATE_CHECK_INTERVAL {
             let effects = app.update(DashboardEvent::RefreshElapsed);
             execute_effects(&mut app, &mut backend, effects);
             last_refresh = Instant::now();
@@ -5165,6 +5172,17 @@ mod tests {
                 .as_ref()
                 .is_some_and(|message| { message.error && message.text == "failed" })
         );
+    }
+
+    #[test]
+    fn idle_refresh_tick_checks_for_updates_without_requesting_a_snapshot() {
+        let mut app = app();
+
+        assert_eq!(
+            app.update(DashboardEvent::RefreshElapsed),
+            vec![DashboardEffect::CheckForUpdates]
+        );
+        assert!(app.update(DashboardEvent::UpdateCheckCompleted).is_empty());
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -9,7 +9,7 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use boomux::client::{Attachment, Client, RemoteError};
+use boomux::client::{self, Attachment, Client, RemoteError};
 use boomux::protocol::{
     self, AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame, ErrorCode,
     ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile, UnixEnvironment,
@@ -485,7 +485,7 @@ fn focused_attachment_is_exposed_in_daemon_snapshots() {
         .unwrap();
     let shell_id = workspace.shells[0].id.clone();
     let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    assert_eq!(attachment.protocol_version, 20);
+    assert_eq!(attachment.protocol_version, 21);
 
     AttachFrame::FocusGained
         .write_to(&mut attachment.stream)
@@ -1460,6 +1460,27 @@ fn daemon_events_and_revision_reads_survive_handoff() {
             .and_then(|error| error.code),
         Some(ErrorCode::DaemonStopping)
     );
+}
+
+#[test]
+fn snapshot_watch_refreshes_on_events_and_recovers_after_cold_restart() {
+    let mut daemon = TestDaemon::start();
+    let mut watch = client::SnapshotWatch::baseline(&daemon.client).unwrap();
+    assert!(watch.snapshot().workspaces.is_empty());
+    assert_eq!(watch.poll(&daemon.client).unwrap(), (false, false));
+
+    daemon
+        .client
+        .create_workspace("watched", Vec::new())
+        .unwrap();
+    assert_eq!(watch.poll(&daemon.client).unwrap(), (true, false));
+    assert_eq!(watch.snapshot().workspaces[0].name, "watched");
+    assert_eq!(watch.poll(&daemon.client).unwrap(), (false, false));
+
+    daemon.stop_with_cli();
+    daemon.restart();
+    assert_eq!(watch.poll(&daemon.client).unwrap(), (true, true));
+    assert_eq!(watch.snapshot().workspaces[0].name, "watched");
 }
 
 #[test]
@@ -3430,7 +3451,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 20);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 21);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -3480,8 +3501,10 @@ fn native_daemon_lifecycle() {
         "protocol_18",
         "protocol_19",
         "protocol_20",
+        "protocol_21",
         "workspace_default_cwd",
         "structured_terminal_previews",
+        "focused_terminal_read",
         "focused_terminal_following",
         "inactive_agent_state",
         "protocol_11",
@@ -3503,7 +3526,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 20"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 21"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])


### PR DESCRIPTION
## Summary
- replace idle dashboard snapshots with event-stream invalidation and authoritative reprojection
- refresh non-durable focus and foreground hints through targeted protocol-21 reads with shared daemon caching
- preserve protocol 6-20 fallback behavior and recover safely across expired cursors and daemon replacement

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`

Closes #115