### PR TITLE
test: isolate agent session projection from host catalogs

### DIFF
--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -2271,9 +2271,12 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert_eq!(list["command"], "agent.list");
     assert_eq!(list["data"]["agents"][0]["id"], agent_id);
     assert_eq!(list["data"]["agents"][0]["observation"]["revision"], 1);
+    let host_bin = daemon.runtime_dir.join("host-bin");
+    fs::create_dir(&host_bin).unwrap();
     let session_list = daemon
         .command()
         .args(["session", "list", "--workspace", &workspace.id, "--json"])
+        .env("PATH", &host_bin)
         .output()
         .unwrap();
     assert!(
@@ -2301,6 +2304,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     let session_inspect = daemon
         .command()
         .args(["session", "inspect", session_id, "--json"])
+        .env("PATH", &host_bin)
         .output()
         .unwrap();
     assert!(session_inspect.status.success());
@@ -2371,6 +2375,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     let pi_sessions = daemon
         .command()
         .args(["session", "list", "--json"])
+        .env("PATH", &host_bin)
         .output()
         .unwrap();
     let pi_sessions: serde_json::Value = serde_json::from_slice(&pi_sessions.stdout).unwrap();


### PR DESCRIPTION
## Summary

- give native session projection commands a test-owned empty executable directory
- prevent installed OpenCode or Pi hosts from adding catalog-only sessions
- preserve the exact durable projected-session count assertion

Closes #132

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --locked --test native_backend agent_runtime_is_revisioned_durable_and_version_compatible -- --exact --nocapture --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1` (27/28 passed; unrelated `graceful_restart_preserves_exited_run_and_terminal_state` timing failure passed on isolated rerun)
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`