### PR TITLE
feat: invoke individual launchers

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -435,6 +435,7 @@ launcher-only workspace is valid, but an empty workspace cannot be opened.
 boomux launcher list --workspace "<workspace-name-or-id>"
 boomux launcher create "<name>" --workspace "<workspace-name-or-id>" --cwd "/path" -- command arg
 boomux launcher inspect "<name-or-id>" --workspace "<workspace-name-or-id>"
+boomux launcher invoke "<name-or-id>" --workspace "<workspace-name-or-id>"
 boomux launcher rename "<name-or-id>" "<new-name>" --workspace "<workspace-name-or-id>"
 boomux launcher remove "<name-or-id>" --workspace "<workspace-name-or-id>"
 ```

--- a/README.md
+++ b/README.md
@@ -150,11 +150,14 @@ not need a retained terminal:
 boomux workspace create boomux
 boomux launcher create editor --workspace boomux --cwd . -- zeditor .
 boomux launcher create browser --workspace boomux -- firefox http://localhost:3000
+boomux launcher invoke editor --workspace boomux
 boomux workspace open boomux
 ```
 
 Removing a launcher affects future workspace opens. Boomux does not track or
-terminate applications launched earlier.
+terminate applications launched earlier. Exact launcher IDs can be invoked
+without `--workspace`; launcher names use the current managed workspace or an
+explicit `--workspace`.
 
 ## Dashboard
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,12 @@ enum LauncherCommands {
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
     },
+    /// Invoke a launcher as a detached process
+    Invoke {
+        target: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
     /// Rename a launcher
     Rename {
         target: String,
@@ -871,6 +877,7 @@ impl Cli {
             Some(Commands::Launcher {
                 command:
                     LauncherCommands::Create { .. }
+                    | LauncherCommands::Invoke { .. }
                     | LauncherCommands::Rename { .. }
                     | LauncherCommands::Remove { .. },
             }) => CommandKey::Launcher,
@@ -2705,6 +2712,19 @@ fn launcher_command(command: LauncherCommands, json: bool) -> Result<(), Box<dyn
             println!("WORKSPACE\t{}", workspace.name);
             println!("CWD\t{}", launcher.cwd.display());
             println!("COMMAND\t{}", launcher.command.join(" "));
+        }
+        LauncherCommands::Invoke { target, workspace } => {
+            let snapshot = client.snapshot()?;
+            let launcher = resolve_cli_launcher(&snapshot, &target, workspace.as_deref())?;
+            let workspace = snapshot
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.id == launcher.workspace_id)
+                .ok_or_else(|| {
+                    cli_output::failure("not_found", "launcher workspace no longer exists")
+                })?;
+            invoke_workspace_launcher(workspace, launcher)?;
+            println!("Launched {} from {}", launcher.name, workspace.name);
         }
         LauncherCommands::Rename {
             target,
@@ -4557,6 +4577,25 @@ mod tests {
                 && cwd == Path::new("/tmp")
                 && command == ["zeditor", "."]
         ));
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "launcher",
+            "invoke",
+            "editor",
+            "--workspace",
+            "project",
+        ])
+        .unwrap();
+        assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Launcher {
+                command: LauncherCommands::Invoke {
+                    target,
+                    workspace: Some(workspace),
+                }
+            }) if target == "editor" && workspace == "project"
+        ));
         assert!(matches!(
             Cli::try_parse_from(["boomux", "workspace", "open", "project"])
                 .unwrap()
@@ -6313,6 +6352,7 @@ mod tests {
             "boomux launcher list",
             "boomux launcher create",
             "boomux launcher inspect",
+            "boomux launcher invoke",
             "boomux launcher rename",
             "boomux launcher remove",
             "boomux agent list",

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -3195,6 +3195,65 @@ fn workspace_launchers_persist_emit_events_and_open_without_shells() {
 }
 
 #[test]
+fn launcher_invoke_uses_tui_detached_process_semantics() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace("launcher-cli", Vec::new())
+        .unwrap();
+    let output = daemon.runtime_dir.join("launcher-invoke-output");
+    let launcher = daemon
+        .client
+        .create_launcher(
+            &workspace.id,
+            WorkspaceLauncherSpec {
+                name: "capture".into(),
+                cwd: daemon.runtime_dir.clone(),
+                command: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    "printf '%s|%s|%s|%s|%s|%s|%s|%s' \"$PWD\" \"$BOOMUX_WORKSPACE_ID\" \"$BOOMUX_WORKSPACE\" \"$BOOMUX_LAUNCHER_ID\" \"$BOOMUX_LAUNCHER_NAME\" \"$BOOMUX_INVOKE_TEST\" \"${BOOMUX_SHELL_ID-unset}\" \"$2\" > \"$1\"".into(),
+                    "launcher".into(),
+                    output.display().to_string(),
+                    "exact argument".into(),
+                ],
+            },
+        )
+        .unwrap();
+
+    let invoked = daemon
+        .command()
+        .args(["launcher", "invoke", &launcher.id])
+        .env("BOOMUX_INVOKE_TEST", "inherited")
+        .env("BOOMUX_SHELL_ID", "stale-shell")
+        .output()
+        .unwrap();
+    assert!(
+        invoked.status.success(),
+        "launcher invoke failed: {}",
+        String::from_utf8_lossy(&invoked.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(invoked.stdout).unwrap(),
+        "Launched capture from launcher-cli\n"
+    );
+    wait_until(|| output.is_file(), "invoked launcher did not run");
+    assert_eq!(
+        fs::read_to_string(output).unwrap(),
+        format!(
+            "{}|{}|{}|{}|{}|inherited|unset|exact argument",
+            daemon.runtime_dir.display(),
+            workspace.id,
+            workspace.name,
+            launcher.id,
+            launcher.name,
+        )
+    );
+
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn failed_implicit_terminal_launch_rolls_back_created_state() {
     let daemon = TestDaemon::start();
     let project = daemon.runtime_dir.join("project");

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -3237,17 +3237,17 @@ fn launcher_invoke_uses_tui_detached_process_semantics() {
         String::from_utf8(invoked.stdout).unwrap(),
         "Launched capture from launcher-cli\n"
     );
-    wait_until(|| output.is_file(), "invoked launcher did not run");
-    assert_eq!(
-        fs::read_to_string(output).unwrap(),
-        format!(
-            "{}|{}|{}|{}|{}|inherited|unset|exact argument",
-            daemon.runtime_dir.display(),
-            workspace.id,
-            workspace.name,
-            launcher.id,
-            launcher.name,
-        )
+    let expected = format!(
+        "{}|{}|{}|{}|{}|inherited|unset|exact argument",
+        daemon.runtime_dir.display(),
+        workspace.id,
+        workspace.name,
+        launcher.id,
+        launcher.name,
+    );
+    wait_until(
+        || fs::read_to_string(&output).is_ok_and(|actual| actual == expected),
+        "invoked launcher did not finish writing",
     );
 
     daemon.stop_with_cli();


### PR DESCRIPTION
## Summary

- add `boomux launcher invoke <target> [--workspace <workspace>]`
- reuse the dashboard's detached launcher execution semantics
- resolve exact launcher IDs globally and names in workspace context
- document the command and cover argv, cwd, environment, and identity behavior

## Testing

- `cargo fmt --check`
- `cargo test --locked`
- `git diff --check`

This enables external clients such as the Omarchy bar plugin to open one launcher without restoring the entire workspace.