### PR TITLE
refactor(integrations): centralize capability descriptors

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,7 @@
 | `src/terminal_focus.rs` | Stateful parsing and restoration of child focus-reporting mode |
 | `src/tui.rs` | Dashboard state, interaction, palette, polling, and Ratatui rendering; no direct daemon transport |
 | `src/session_projection.rs` | Projection of daemon Agent state and host catalogs into client-visible sessions |
+| `src/integrations.rs` | Integration identity, display metadata, and optional installation, title/catalog, transcript, resume, and foreground capabilities |
 | `src/host_session_titles.rs` and children | Shared title/catalog policy and host-specific discovery adapters |
 | `src/host_session_source.rs` and children | Canonical host source paths, normalization, and secure source lookup |
 | `src/session_transcript.rs` and children | Shared transcript identity, bounds, pagination, and host-specific normalization |
@@ -287,13 +288,15 @@ workspace that references their exact normalized directory. The dashboard maps
 the active or latest exact match into a durable Agent's contextual preview and
 discovers catalogs asynchronously; session CLI listing performs the same bounded
 discovery synchronously. Sessions are not a dashboard kind.
-Title enrichment has its own adapter registry. Each adapter declares whether it
-also provides a session catalog. The shared layer owns asynchronous cache,
-refresh, deduplication, sanitization, and fallback policy; OpenCode and Pi modules
-own host command execution and title extraction. Neutral host source modules own
-shared path normalization and secure source discovery. Title and catalog support
-remain independent from transcript support so a future harness may implement
-the relevant capabilities without claiming transcript support.
+The integration descriptor registry is the authority for integration keys,
+display names, and optional typed capabilities. A title capability selects its
+host adapter and independently declares catalog support. The shared title layer
+owns asynchronous cache, refresh, deduplication, sanitization, and fallback
+policy; OpenCode and Pi modules own host command execution and title extraction.
+Neutral host source modules own shared path normalization and secure source
+discovery. Title and catalog support remain independent from transcript support,
+installation, foreground recognition, and recovery eligibility, so a future
+harness can implement only the capabilities it provides.
 
 Session list/inspect requires a negotiated protocol-12 snapshot because the
 projection depends on that complete Agent state model. Protocol 13 adds an
@@ -542,25 +545,25 @@ Cursor data is untrusted consistency metadata rather than authorization; exact
 projected-session resolution and canonical source access remain the security
 boundary.
 
-The transcript layer is an adapter registry keyed by the Agent integration
-name. An adapter receives only the canonical external session ID and retained
+The integration descriptor's optional transcript capability selects a host
+adapter. An adapter receives only the canonical external session ID and retained
 working directory and returns host-neutral transcript entries. Exact projected
 session resolution, access preconditions, newest-suffix pagination, byte and
 entry bounds, cursor validation, truncation, typed errors, human output, and
 `boomux.cli/v1` JSON
 remain shared. Adding Claude Code, Codex, or another harness therefore requires
-one canonical source adapter and one registry entry, not another CLI path.
+one canonical source adapter and one descriptor capability, not another CLI path.
 `boomux capabilities --json` derives `session_transcript_integrations` from this
-registry so integrations can discover support without hard-coded host lists.
+descriptor registry so integrations can discover support without hard-coded host lists.
 
 The implementation mirrors these boundaries in both adapter families:
-`host_session_titles.rs` and `session_transcript.rs` contain only shared policy,
-contracts, and registries, while their `opencode.rs` and `pi.rs` child modules
+`host_session_titles.rs` and `session_transcript.rs` contain only shared policy
+and contracts, while their `opencode.rs` and `pi.rs` child modules
 contain host-specific parsing and normalization. Shared source lookup belongs in
 `host_session_source.rs` and its host-specific child modules rather than either
 capability adapter. Adding Claude Code, Codex, or another harness means adding
-isolated title and transcript modules as supported, then registering each
-capability explicitly; existing host parsers do not grow new conditional branches.
+isolated title and transcript modules as supported, then declaring each provider
+on its descriptor; existing host parsers do not grow new conditional branches.
 
 Protocol 12 adds `inactive`. Protocol-9 through protocol-11 clients receive that
 observation as `unknown`, while protocol-12 clients can distinguish a resumable

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -26,11 +26,14 @@ the CLI version, daemon protocol version, supported JSON schemas and commands,
 stable error codes, feature names, and the package and validated version for
 each bundled integration host under `integration_hosts`. Validated versions are
 compatibility test points, not runtime pins or minimum-version guarantees.
+Integration ordering and host metadata come from the same capability descriptor
+registry used by installation, foreground recognition, recovery, titles, and
+transcripts.
 Protocol-backed feature names are derived from the same typed registry as
 request gating and negotiated client feature checks, so each name has one
 minimum protocol version authority.
-`session_transcript_integrations` lists the integration keys with registered
-canonical transcript adapters.
+`session_transcript_integrations` lists the integration keys whose descriptors
+declare canonical transcript support.
 The `desktop_notifications` feature means this binary supports daemon-owned
 notification delivery; it does not imply notifications are enabled or that
 `notify-send` and a desktop notification service are available. Configuration is

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1669,23 +1669,9 @@ impl DurableRegistry {
             return Ok(None);
         }
 
-        let executable = if shell.command.is_empty() {
-            integration.clone()
-        } else if shell.command.len() == 1
-            && Path::new(&shell.command[0])
-                .file_name()
-                .and_then(|name| name.to_str())
-                == Some(integration.as_str())
-        {
-            shell.command[0].clone()
-        } else {
-            return Ok(None);
-        };
-        Ok(Some(vec![
-            executable,
-            "--session".into(),
-            external_session_id.clone(),
-        ]))
+        Ok(crate::integrations::by_key(integration)
+            .and_then(|descriptor| descriptor.resume)
+            .and_then(|resume| resume.command(&shell.command, external_session_id)))
     }
 
     fn notification_context(&self, workspace_id: &str, shell_id: &str) -> (String, String) {
@@ -3656,7 +3642,8 @@ fn resume_identity(
         || agent.shell_id != shell.id
         || agent.run_id != previous_run.id
         || agent.cwd.as_ref() != Some(&shell.cwd)
-        || !matches!(agent.integration.as_str(), "opencode" | "pi")
+        || !crate::integrations::by_key(&agent.integration)
+            .is_some_and(|descriptor| descriptor.resume.is_some())
     {
         return Ok(None);
     }

--- a/src/dashboard_projection.rs
+++ b/src/dashboard_projection.rs
@@ -112,7 +112,11 @@ fn project_workspace(
                     agent.workspace_id == workspace.id
                         && agent.shell_id == shell.id
                         && agent.run_id == run.id
-                        && shell.foreground_process.as_deref() == Some(agent.integration.as_str())
+                        && boomux::integrations::by_key(&agent.integration)
+                            .and_then(|descriptor| descriptor.foreground)
+                            .is_some_and(|foreground| {
+                                shell.foreground_process.as_deref() == Some(foreground.process_name)
+                            })
                         && !session_projection::agent_is_active_for_run(agent, &shell.id, &run.id)
                 })
             });
@@ -144,7 +148,10 @@ fn project_workspace(
                         root_worktree: root_git.worktree,
                     }),
                 }),
-                (None, Some("opencode" | "pi")) if !suppress_foreground_hint => {
+                (None, Some(process))
+                    if boomux::integrations::by_foreground_process(process).is_some()
+                        && !suppress_foreground_hint =>
+                {
                     WorkspaceItemView::AgentShell(AgentShellView {
                         shell: shell_view,
                         agent: None,

--- a/src/host_session_titles.rs
+++ b/src/host_session_titles.rs
@@ -5,6 +5,8 @@ use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use boomux::integrations::{self, TitleProvider};
+
 mod opencode;
 mod pi;
 
@@ -45,16 +47,8 @@ struct Inspection {
 }
 
 trait TitleAdapter: Sync {
-    fn integration(&self) -> &'static str;
-
     fn inspect(&self, directory: &Path) -> Option<Inspection>;
-
-    fn provides_catalog(&self) -> bool {
-        false
-    }
 }
-
-static ADAPTERS: &[&dyn TitleAdapter] = &[opencode::ADAPTER, pi::ADAPTER];
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct CacheKey {
@@ -123,7 +117,10 @@ impl Cache {
         integration: &str,
         directory: &Path,
     ) -> Option<Vec<HostSession>> {
-        if !adapter(integration).is_some_and(|adapter| adapter.provides_catalog()) {
+        if !integrations::by_key(integration)
+            .and_then(|descriptor| descriptor.titles)
+            .is_some_and(|titles| titles.provides_catalog)
+        {
             return None;
         }
         self.refresh(integration, directory);
@@ -176,27 +173,31 @@ fn inspect(integration: &str, directory: &Path) -> Option<Inspection> {
 }
 
 pub(crate) fn catalog_integrations() -> impl Iterator<Item = &'static str> {
-    ADAPTERS
+    integrations::ALL
         .iter()
-        .filter(|adapter| adapter.provides_catalog())
-        .map(|adapter| adapter.integration())
+        .filter(|descriptor| {
+            descriptor
+                .titles
+                .is_some_and(|titles| titles.provides_catalog)
+        })
+        .map(|descriptor| descriptor.key)
 }
 
 pub(crate) fn catalog(integration: &str, directory: &Path) -> Option<Vec<HostSession>> {
-    let adapter = adapter(integration)?;
-    if !adapter.provides_catalog() {
+    if !integrations::by_key(integration)?.titles?.provides_catalog {
         return None;
     }
+    let adapter = adapter(integration)?;
     adapter
         .inspect(directory)
         .map(|inspection| inspection.catalog)
 }
 
 fn adapter(integration: &str) -> Option<&'static dyn TitleAdapter> {
-    ADAPTERS
-        .iter()
-        .copied()
-        .find(|adapter| adapter.integration() == integration)
+    match integrations::by_key(integration)?.titles?.provider {
+        TitleProvider::OpenCode => Some(opencode::ADAPTER),
+        TitleProvider::Pi => Some(pi::ADAPTER),
+    }
 }
 
 fn sanitize_title(title: &str) -> Option<String> {

--- a/src/host_session_titles/opencode.rs
+++ b/src/host_session_titles/opencode.rs
@@ -16,16 +16,8 @@ struct OpenCodeAdapter;
 pub(super) static ADAPTER: &dyn TitleAdapter = &OpenCodeAdapter;
 
 impl TitleAdapter for OpenCodeAdapter {
-    fn integration(&self) -> &'static str {
-        "opencode"
-    }
-
     fn inspect(&self, directory: &Path) -> Option<Inspection> {
         inspect_catalog(directory)
-    }
-
-    fn provides_catalog(&self) -> bool {
-        true
     }
 }
 
@@ -119,7 +111,7 @@ pub(super) fn parse_catalog(output: &[u8]) -> Option<Inspection> {
             continue;
         };
         catalog.push(HostSession {
-            integration: "opencode".into(),
+            integration: boomux::integrations::OPENCODE.key.into(),
             root_id: session.id,
             title,
             directory,

--- a/src/host_session_titles/pi.rs
+++ b/src/host_session_titles/pi.rs
@@ -12,10 +12,6 @@ struct PiAdapter;
 pub(super) static ADAPTER: &dyn TitleAdapter = &PiAdapter;
 
 impl TitleAdapter for PiAdapter {
-    fn integration(&self) -> &'static str {
-        "pi"
-    }
-
     fn inspect(&self, directory: &Path) -> Option<Inspection> {
         inspect(directory, &Environment::from_process())
     }

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -7,74 +7,77 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::str::FromStr;
 use std::time::{Duration, Instant};
 
-use clap::ValueEnum;
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use uuid::Uuid;
 
+use boomux::integrations::{InstallTargetKind, InstallationCapability, IntegrationDescriptor};
 use boomux::protocol::{AgentAuthority, ShellStatus, Snapshot};
-
-pub(crate) const OPENCODE_ASSET: &str = include_str!("../integrations/opencode/boomux.js");
-pub(crate) const PI_ASSET: &str = include_str!("../integrations/pi/boomux.js");
 
 const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_VERSION_OUTPUT_BYTES: u64 = 4096;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, ValueEnum)]
-#[serde(rename_all = "lowercase")]
-pub(crate) enum IntegrationId {
-    Opencode,
-    Pi,
-}
+#[cfg(test)]
+pub(crate) const OPENCODE_ASSET: &str = boomux::integrations::OPENCODE
+    .installation
+    .as_ref()
+    .expect("OpenCode installation capability")
+    .content;
+#[cfg(test)]
+pub(crate) const PI_ASSET: &str = boomux::integrations::PI
+    .installation
+    .as_ref()
+    .expect("Pi installation capability")
+    .content;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct IntegrationId(&'static IntegrationDescriptor);
 
 impl IntegrationId {
-    pub(crate) const ALL: [Self; 2] = [Self::Opencode, Self::Pi];
+    pub(crate) const OPENCODE: Self = Self(&boomux::integrations::OPENCODE);
+    pub(crate) const PI: Self = Self(&boomux::integrations::PI);
+    #[allow(non_upper_case_globals)]
+    pub(crate) const Opencode: Self = Self::OPENCODE;
+    #[allow(non_upper_case_globals)]
+    pub(crate) const Pi: Self = Self::PI;
 
-    pub(crate) const fn spec(self) -> &'static IntegrationSpec {
-        match self {
-            Self::Opencode => &OPENCODE,
-            Self::Pi => &PI,
+    pub(crate) const fn spec(self) -> &'static IntegrationDescriptor {
+        self.0
+    }
+
+    pub(crate) const fn installation(self) -> &'static InstallationCapability {
+        match self.spec().installation.as_ref() {
+            Some(installation) => installation,
+            None => panic!("CLI integration must support installation"),
         }
+    }
+
+    pub(crate) fn all() -> impl Iterator<Item = Self> {
+        boomux::integrations::installable().map(Self)
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct IntegrationSpec {
-    pub(crate) id: IntegrationId,
-    pub(crate) name: &'static str,
-    pub(crate) display_name: &'static str,
-    pub(crate) package: &'static str,
-    pub(crate) validated_version: &'static str,
-    pub(crate) asset_name: &'static str,
-    pub(crate) content: &'static str,
-    pub(crate) executable: &'static str,
-    pub(crate) reload_message: &'static str,
+impl FromStr for IntegrationId {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        boomux::integrations::by_key(value)
+            .filter(|descriptor| descriptor.installation.is_some())
+            .map(Self)
+            .ok_or_else(|| format!("unknown installable integration: {value}"))
+    }
 }
 
-const OPENCODE: IntegrationSpec = IntegrationSpec {
-    id: IntegrationId::Opencode,
-    name: "opencode",
-    display_name: "OpenCode",
-    package: "opencode-ai",
-    validated_version: "1.18.15",
-    asset_name: "plugin",
-    content: OPENCODE_ASSET,
-    executable: "opencode",
-    reload_message: "Restart any running OpenCode process to activate the plugin",
-};
-
-const PI: IntegrationSpec = IntegrationSpec {
-    id: IntegrationId::Pi,
-    name: "pi",
-    display_name: "Pi",
-    package: "@earendil-works/pi-coding-agent",
-    validated_version: "0.84.1",
-    asset_name: "extension",
-    content: PI_ASSET,
-    executable: "pi",
-    reload_message: "Restart any running Pi process to activate the extension",
-};
+impl Serialize for IntegrationId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.spec().key)
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct Environment {
@@ -121,11 +124,12 @@ pub(crate) struct IntegrationSummary {
 impl From<IntegrationId> for IntegrationSummary {
     fn from(id: IntegrationId) -> Self {
         let spec = id.spec();
+        let installation = id.installation();
         Self {
-            name: spec.name,
+            name: spec.key,
             display_name: spec.display_name,
-            package: spec.package,
-            validated_version: spec.validated_version,
+            package: installation.package,
+            validated_version: installation.validated_version,
         }
     }
 }
@@ -236,7 +240,11 @@ pub(crate) fn verification_targets(
     id: IntegrationId,
     shell_id: Option<&str>,
 ) -> Vec<VerificationTarget> {
-    let executable = id.spec().executable;
+    let executable = id
+        .spec()
+        .foreground
+        .expect("CLI integration must recognize its foreground process")
+        .process_name;
     let mut targets = snapshot
         .workspaces
         .iter()
@@ -262,7 +270,10 @@ pub(crate) fn check_verification_target(
     id: IntegrationId,
     target: &VerificationTarget,
 ) -> VerificationCheck {
-    let spec = id.spec();
+    let descriptor = id.spec();
+    let foreground = descriptor
+        .foreground
+        .expect("CLI integration must recognize its foreground process");
     for workspace in &snapshot.workspaces {
         let Some(shell) = workspace
             .shells
@@ -272,7 +283,7 @@ pub(crate) fn check_verification_target(
             continue;
         };
         if !matches!(shell.status, ShellStatus::Running)
-            || shell.foreground_process.as_deref() != Some(spec.executable)
+            || shell.foreground_process.as_deref() != Some(foreground.process_name)
         {
             return VerificationCheck::Missing;
         }
@@ -285,7 +296,7 @@ pub(crate) fn check_verification_target(
         let mut agents = workspace
             .agents
             .iter()
-            .filter(|agent| authoritative_agent_matches(agent, spec, shell, run))
+            .filter(|agent| authoritative_agent_matches(agent, descriptor, shell, run))
             .cloned()
             .collect::<Vec<_>>();
         agents.sort_by(|left, right| left.id.cmp(&right.id));
@@ -345,17 +356,18 @@ fn inspect_with_host_probe(
     snapshot: Option<&Snapshot>,
     probe_host: bool,
 ) -> IntegrationStatus {
-    let spec = id.spec();
-    let asset = inspect_asset(spec, environment);
-    let runtime = inspect_runtime(spec, snapshot);
+    let descriptor = id.spec();
+    let installation = id.installation();
+    let asset = inspect_asset(id, installation, environment);
+    let runtime = inspect_runtime(descriptor, snapshot);
     let recommended_action = recommended_action(asset.state, runtime.state);
     IntegrationStatus {
-        name: spec.name,
-        display_name: spec.display_name,
-        package: spec.package,
-        validated_version: spec.validated_version,
+        name: descriptor.key,
+        display_name: descriptor.display_name,
+        package: installation.package,
+        validated_version: installation.validated_version,
         host: if probe_host {
-            inspect_host(spec, environment)
+            inspect_host(installation, environment)
         } else {
             HostStatus {
                 state: HostState::NotChecked,
@@ -383,8 +395,12 @@ const fn recommended_action(asset: AssetState, runtime: RuntimeState) -> Recomme
     }
 }
 
-fn inspect_asset(spec: &IntegrationSpec, environment: &Environment) -> AssetStatus {
-    let path = match install_target(spec.id, environment) {
+fn inspect_asset(
+    id: IntegrationId,
+    installation: &InstallationCapability,
+    environment: &Environment,
+) -> AssetStatus {
+    let path = match install_target(id, environment) {
         Ok(target) => target.path,
         Err(error) => {
             return AssetStatus {
@@ -399,7 +415,7 @@ fn inspect_asset(spec: &IntegrationSpec, environment: &Environment) -> AssetStat
         .parent()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "install path has no parent"))
         .and_then(validate_existing_directory_chain)
-        .and_then(|()| inspect_existing_asset(&path, spec.content));
+        .and_then(|()| inspect_existing_asset(&path, installation.content));
     match result {
         Ok(ExistingAsset::Missing) => AssetStatus {
             state: AssetState::Missing,
@@ -424,8 +440,9 @@ fn inspect_asset(spec: &IntegrationSpec, environment: &Environment) -> AssetStat
     }
 }
 
-fn inspect_host(spec: &IntegrationSpec, environment: &Environment) -> HostStatus {
-    let Some(executable) = executable_on_path(spec.executable, environment.path.as_deref()) else {
+fn inspect_host(installation: &InstallationCapability, environment: &Environment) -> HostStatus {
+    let Some(executable) = executable_on_path(installation.executable, environment.path.as_deref())
+    else {
         return HostStatus {
             state: HostState::Missing,
             executable: None,
@@ -438,7 +455,7 @@ fn inspect_host(spec: &IntegrationSpec, environment: &Environment) -> HostStatus
     match probe_version(&executable) {
         Ok(output) => {
             let version = version_token(&output);
-            let compatibility = if version.as_deref() == Some(spec.validated_version) {
+            let compatibility = if version.as_deref() == Some(installation.validated_version) {
                 "validated"
             } else if version.is_some() {
                 "unvalidated"
@@ -463,8 +480,19 @@ fn inspect_host(spec: &IntegrationSpec, environment: &Environment) -> HostStatus
     }
 }
 
-fn inspect_runtime(spec: &IntegrationSpec, snapshot: Option<&Snapshot>) -> RuntimeStatus {
+fn inspect_runtime(
+    descriptor: &IntegrationDescriptor,
+    snapshot: Option<&Snapshot>,
+) -> RuntimeStatus {
     let Some(snapshot) = snapshot else {
+        return RuntimeStatus {
+            state: RuntimeState::NotObservable,
+            running_processes: 0,
+            tracked_processes: 0,
+            untracked_processes: 0,
+        };
+    };
+    let Some(foreground) = descriptor.foreground else {
         return RuntimeStatus {
             state: RuntimeState::NotObservable,
             running_processes: 0,
@@ -475,7 +503,7 @@ fn inspect_runtime(spec: &IntegrationSpec, snapshot: Option<&Snapshot>) -> Runti
     let running = snapshot.workspaces.iter().flat_map(|workspace| {
         workspace.shells.iter().filter_map(move |shell| {
             (matches!(shell.status, ShellStatus::Running)
-                && shell.foreground_process.as_deref() == Some(spec.executable))
+                && shell.foreground_process.as_deref() == Some(foreground.process_name))
             .then_some((workspace, shell))
         })
     });
@@ -487,7 +515,7 @@ fn inspect_runtime(spec: &IntegrationSpec, snapshot: Option<&Snapshot>) -> Runti
             workspace
                 .agents
                 .iter()
-                .any(|agent| authoritative_agent_matches(agent, spec, shell, run))
+                .any(|agent| authoritative_agent_matches(agent, descriptor, shell, run))
         }) {
             tracked_processes += 1;
         }
@@ -510,11 +538,11 @@ fn inspect_runtime(spec: &IntegrationSpec, snapshot: Option<&Snapshot>) -> Runti
 
 fn authoritative_agent_matches(
     agent: &boomux::protocol::AgentInstanceSnapshot,
-    spec: &IntegrationSpec,
+    descriptor: &IntegrationDescriptor,
     shell: &boomux::protocol::ShellSnapshot,
     run: &boomux::protocol::ShellRunSnapshot,
 ) -> bool {
-    agent.integration == spec.name
+    agent.integration == descriptor.key
         && agent.observation.authority == AgentAuthority::LifecycleIntegration
         && crate::session_projection::agent_is_active_for_run(agent, &shell.id, &run.id)
 }
@@ -704,13 +732,14 @@ pub(crate) fn install(
     environment: &Environment,
     force: bool,
 ) -> Result<InstallResult, Box<dyn Error>> {
-    let spec = id.spec();
+    let descriptor = id.spec();
+    let installation = id.installation();
     let target = install_target(id, environment)?;
     let directory = ensure_safe_directory(&target.directory)?;
-    let result = install_asset_at(&directory, &target.path, spec.content, force)?;
+    let result = install_asset_at(&directory, &target.path, installation.content, force)?;
     Ok(InstallResult {
         integration: id,
-        name: spec.name,
+        name: descriptor.key,
         result,
         path: target.path.display().to_string(),
         restart_required: result != InstallOutcome::Unchanged,
@@ -722,10 +751,11 @@ pub(crate) fn plan_install(
     environment: &Environment,
     force: bool,
 ) -> Result<InstallPlan, Box<dyn Error>> {
-    let spec = id.spec();
+    let descriptor = id.spec();
+    let installation = id.installation();
     let target = install_target(id, environment)?;
     validate_existing_directory_chain(&target.directory)?;
-    let existing = inspect_existing_asset(&target.path, spec.content)?;
+    let existing = inspect_existing_asset(&target.path, installation.content)?;
     let (current_state, action) = match existing {
         ExistingAsset::Missing => (AssetState::Missing, InstallAction::Install),
         ExistingAsset::Current => (AssetState::Current, InstallAction::Unchanged),
@@ -734,7 +764,7 @@ pub(crate) fn plan_install(
     };
     Ok(InstallPlan {
         integration: id,
-        name: spec.name,
+        name: descriptor.key,
         current_state,
         action,
         path: target.path.display().to_string(),
@@ -747,10 +777,12 @@ pub(crate) fn preflight_uninstall(
     environment: &Environment,
     force: bool,
 ) -> Result<(), Box<dyn Error>> {
-    let spec = id.spec();
+    let installation = id.installation();
     let target = install_target(id, environment)?;
     validate_existing_directory_chain(&target.directory)?;
-    if inspect_existing_asset(&target.path, spec.content)? == ExistingAsset::Modified && !force {
+    if inspect_existing_asset(&target.path, installation.content)? == ExistingAsset::Modified
+        && !force
+    {
         return Err(modified_uninstall_error(&target.path).into());
     }
     Ok(())
@@ -761,10 +793,11 @@ pub(crate) fn uninstall(
     environment: &Environment,
     force: bool,
 ) -> Result<UninstallResult, Box<dyn Error>> {
-    let spec = id.spec();
+    let descriptor = id.spec();
+    let installation = id.installation();
     let target = install_target(id, environment)?;
     validate_existing_directory_chain(&target.directory)?;
-    let existing = inspect_existing_asset(&target.path, spec.content)?;
+    let existing = inspect_existing_asset(&target.path, installation.content)?;
     let result = match existing {
         ExistingAsset::Missing => UninstallOutcome::NotInstalled,
         ExistingAsset::Modified if !force => {
@@ -777,7 +810,7 @@ pub(crate) fn uninstall(
     };
     Ok(UninstallResult {
         integration: id,
-        name: spec.name,
+        name: descriptor.key,
         result,
         path: target.path.display().to_string(),
         restart_required: result == UninstallOutcome::Removed,
@@ -791,13 +824,14 @@ pub(crate) fn install_at(
     force: bool,
 ) -> Result<InstallResult, Box<dyn Error>> {
     require_absolute_root(config_root, config_root_name(id))?;
-    let spec = id.spec();
+    let descriptor = id.spec();
+    let installation = id.installation();
     let target = target_at(id, config_root);
     let directory = ensure_safe_directory(&target.directory)?;
-    let result = install_asset_at(&directory, &target.path, spec.content, force)?;
+    let result = install_asset_at(&directory, &target.path, installation.content, force)?;
     Ok(InstallResult {
         integration: id,
-        name: spec.name,
+        name: descriptor.key,
         result,
         path: target.path.display().to_string(),
         restart_required: result != InstallOutcome::Unchanged,
@@ -823,12 +857,12 @@ fn install_target(
 }
 
 fn config_root(id: IntegrationId, environment: &Environment) -> Result<PathBuf, Box<dyn Error>> {
-    match id {
-        IntegrationId::Opencode => opencode_config_root(
+    match id.installation().target {
+        InstallTargetKind::OpenCode => opencode_config_root(
             environment.xdg_config_home.clone(),
             environment.home.clone(),
         ),
-        IntegrationId::Pi => pi_config_root(
+        InstallTargetKind::Pi => pi_config_root(
             environment.pi_coding_agent_dir.clone(),
             environment.home.clone(),
         ),
@@ -836,12 +870,12 @@ fn config_root(id: IntegrationId, environment: &Environment) -> Result<PathBuf, 
 }
 
 fn target_at(id: IntegrationId, config_root: &Path) -> InstallTarget {
-    match id {
-        IntegrationId::Opencode => InstallTarget {
+    match id.installation().target {
+        InstallTargetKind::OpenCode => InstallTarget {
             directory: config_root.join("opencode/plugins"),
             path: config_root.join("opencode/plugins/boomux.js"),
         },
-        IntegrationId::Pi => InstallTarget {
+        InstallTargetKind::Pi => InstallTarget {
             directory: config_root.join("extensions"),
             path: config_root.join("extensions/boomux.js"),
         },
@@ -850,9 +884,9 @@ fn target_at(id: IntegrationId, config_root: &Path) -> InstallTarget {
 
 #[cfg(test)]
 const fn config_root_name(id: IntegrationId) -> &'static str {
-    match id {
-        IntegrationId::Opencode => "XDG configuration root",
-        IntegrationId::Pi => "Pi configuration root",
+    match id.installation().target {
+        InstallTargetKind::OpenCode => "XDG configuration root",
+        InstallTargetKind::Pi => "Pi configuration root",
     }
 }
 
@@ -1114,11 +1148,14 @@ mod tests {
 
     #[test]
     fn descriptors_have_unique_names_and_expected_metadata() {
-        assert_eq!(IntegrationId::Opencode.spec().package, "opencode-ai");
-        assert_eq!(IntegrationId::Pi.spec().validated_version, "0.84.1");
+        assert_eq!(
+            IntegrationId::Opencode.installation().package,
+            "opencode-ai"
+        );
+        assert_eq!(IntegrationId::Pi.installation().validated_version, "0.84.1");
         assert_ne!(
-            IntegrationId::Opencode.spec().name,
-            IntegrationId::Pi.spec().name
+            IntegrationId::Opencode.spec().key,
+            IntegrationId::Pi.spec().key
         );
     }
 

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,0 +1,274 @@
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstallTargetKind {
+    OpenCode,
+    Pi,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InstallationCapability {
+    pub package: &'static str,
+    pub validated_version: &'static str,
+    pub asset_name: &'static str,
+    pub content: &'static str,
+    pub executable: &'static str,
+    pub reload_message: &'static str,
+    pub target: InstallTargetKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TitleProvider {
+    OpenCode,
+    Pi,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TitleCapability {
+    pub provider: TitleProvider,
+    pub provides_catalog: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TranscriptProvider {
+    OpenCode,
+    Pi,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TranscriptCapability {
+    pub provider: TranscriptProvider,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResumeCapability {
+    pub executable: &'static str,
+    pub session_argument: &'static str,
+}
+
+impl ResumeCapability {
+    pub fn command(
+        self,
+        stored_command: &[String],
+        external_session_id: &str,
+    ) -> Option<Vec<String>> {
+        let executable = if stored_command.is_empty() {
+            self.executable.to_owned()
+        } else if stored_command.len() == 1
+            && Path::new(&stored_command[0])
+                .file_name()
+                .and_then(|name| name.to_str())
+                == Some(self.executable)
+        {
+            stored_command[0].clone()
+        } else {
+            return None;
+        };
+        Some(vec![
+            executable,
+            self.session_argument.to_owned(),
+            external_session_id.to_owned(),
+        ])
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ForegroundCapability {
+    pub process_name: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IntegrationDescriptor {
+    pub key: &'static str,
+    pub display_name: &'static str,
+    pub installation: Option<InstallationCapability>,
+    pub titles: Option<TitleCapability>,
+    pub transcript: Option<TranscriptCapability>,
+    pub resume: Option<ResumeCapability>,
+    pub foreground: Option<ForegroundCapability>,
+}
+
+pub const OPENCODE: IntegrationDescriptor = IntegrationDescriptor {
+    key: "opencode",
+    display_name: "OpenCode",
+    installation: Some(InstallationCapability {
+        package: "opencode-ai",
+        validated_version: "1.18.15",
+        asset_name: "plugin",
+        content: include_str!("../integrations/opencode/boomux.js"),
+        executable: "opencode",
+        reload_message: "Restart any running OpenCode process to activate the plugin",
+        target: InstallTargetKind::OpenCode,
+    }),
+    titles: Some(TitleCapability {
+        provider: TitleProvider::OpenCode,
+        provides_catalog: true,
+    }),
+    transcript: Some(TranscriptCapability {
+        provider: TranscriptProvider::OpenCode,
+    }),
+    resume: Some(ResumeCapability {
+        executable: "opencode",
+        session_argument: "--session",
+    }),
+    foreground: Some(ForegroundCapability {
+        process_name: "opencode",
+    }),
+};
+
+pub const PI: IntegrationDescriptor = IntegrationDescriptor {
+    key: "pi",
+    display_name: "Pi",
+    installation: Some(InstallationCapability {
+        package: "@earendil-works/pi-coding-agent",
+        validated_version: "0.84.1",
+        asset_name: "extension",
+        content: include_str!("../integrations/pi/boomux.js"),
+        executable: "pi",
+        reload_message: "Restart any running Pi process to activate the extension",
+        target: InstallTargetKind::Pi,
+    }),
+    titles: Some(TitleCapability {
+        provider: TitleProvider::Pi,
+        provides_catalog: false,
+    }),
+    transcript: Some(TranscriptCapability {
+        provider: TranscriptProvider::Pi,
+    }),
+    resume: Some(ResumeCapability {
+        executable: "pi",
+        session_argument: "--session",
+    }),
+    foreground: Some(ForegroundCapability { process_name: "pi" }),
+};
+
+pub const ALL: &[IntegrationDescriptor] = &[OPENCODE, PI];
+
+pub fn by_key(key: &str) -> Option<&'static IntegrationDescriptor> {
+    descriptor_by_key(ALL, key)
+}
+
+pub fn by_foreground_process(process_name: &str) -> Option<&'static IntegrationDescriptor> {
+    descriptor_by_foreground_process(ALL, process_name)
+}
+
+pub fn installable() -> impl Iterator<Item = &'static IntegrationDescriptor> {
+    installable_in(ALL)
+}
+
+fn descriptor_by_foreground_process<'a>(
+    descriptors: &'a [IntegrationDescriptor],
+    process_name: &str,
+) -> Option<&'a IntegrationDescriptor> {
+    descriptors.iter().find(|descriptor| {
+        descriptor
+            .foreground
+            .is_some_and(|foreground| foreground.process_name == process_name)
+    })
+}
+
+fn installable_in(
+    descriptors: &[IntegrationDescriptor],
+) -> impl Iterator<Item = &IntegrationDescriptor> {
+    descriptors
+        .iter()
+        .filter(|descriptor| descriptor.installation.is_some())
+}
+
+pub fn display_name(key: &str) -> &str {
+    by_key(key).map_or(key, |descriptor| descriptor.display_name)
+}
+
+fn descriptor_by_key<'a>(
+    descriptors: &'a [IntegrationDescriptor],
+    key: &str,
+) -> Option<&'a IntegrationDescriptor> {
+    descriptors.iter().find(|descriptor| descriptor.key == key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partial_capabilities_are_explicit_and_discoverable() {
+        const PARTIAL: IntegrationDescriptor = IntegrationDescriptor {
+            key: "partial",
+            display_name: "Partial Host",
+            installation: None,
+            titles: Some(TitleCapability {
+                provider: TitleProvider::Pi,
+                provides_catalog: false,
+            }),
+            transcript: None,
+            resume: None,
+            foreground: Some(ForegroundCapability {
+                process_name: "partial-agent",
+            }),
+        };
+
+        let descriptors = [OPENCODE, PARTIAL];
+        let descriptor = descriptor_by_key(&descriptors, "partial").expect("partial descriptor");
+        assert_eq!(descriptor.display_name, "Partial Host");
+        assert!(descriptor.installation.is_none());
+        assert!(descriptor.titles.is_some());
+        assert!(descriptor.transcript.is_none());
+        assert!(descriptor.resume.is_none());
+        assert_eq!(
+            descriptor
+                .foreground
+                .map(|capability| capability.process_name),
+            Some("partial-agent")
+        );
+        assert_eq!(
+            descriptor_by_foreground_process(&descriptors, "partial-agent")
+                .map(|descriptor| descriptor.key),
+            Some("partial")
+        );
+        assert_eq!(
+            installable_in(&descriptors)
+                .map(|descriptor| descriptor.key)
+                .collect::<Vec<_>>(),
+            ["opencode"]
+        );
+    }
+
+    #[test]
+    fn production_keys_and_foreground_processes_are_unique() {
+        for (index, descriptor) in ALL.iter().enumerate() {
+            assert!(
+                ALL[index + 1..]
+                    .iter()
+                    .all(|other| other.key != descriptor.key)
+            );
+            if let Some(foreground) = descriptor.foreground {
+                assert!(ALL[index + 1..].iter().all(|other| {
+                    other.foreground.map(|value| value.process_name)
+                        != Some(foreground.process_name)
+                }));
+                assert_eq!(
+                    by_foreground_process(foreground.process_name).map(|found| found.key),
+                    Some(descriptor.key)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn resume_capability_preserves_exact_executable_path() {
+        let resume = OPENCODE.resume.expect("resume capability");
+        assert_eq!(
+            resume.command(&["/usr/bin/opencode".into()], "session-1"),
+            Some(vec![
+                "/usr/bin/opencode".into(),
+                "--session".into(),
+                "session-1".into()
+            ])
+        );
+        assert!(
+            resume
+                .command(&["opencode".into(), "--continue".into()], "session-1")
+                .is_none()
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod daemon;
 mod desktop_notifications;
 mod fd_transfer;
 mod handoff;
+pub mod integrations;
 pub mod protocol;
 mod state_store;
 mod terminal_focus;

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,12 +630,11 @@ enum IntegrationCommands {
     List,
     /// Inspect host, asset, and runtime reporting status
     Status {
-        #[arg(value_enum)]
         integration: Option<integration_management::IntegrationId>,
     },
     /// Install one integration or every bundled integration
     Install {
-        #[arg(value_enum, required_unless_present = "all", conflicts_with = "all")]
+        #[arg(required_unless_present = "all", conflicts_with = "all")]
         integration: Option<integration_management::IntegrationId>,
         #[arg(long, conflicts_with = "integration")]
         all: bool,
@@ -646,7 +645,7 @@ enum IntegrationCommands {
     },
     /// Remove one integration or every bundled integration
     Uninstall {
-        #[arg(value_enum, required_unless_present = "all", conflicts_with = "all")]
+        #[arg(required_unless_present = "all", conflicts_with = "all")]
         integration: Option<integration_management::IntegrationId>,
         #[arg(long, conflicts_with = "integration")]
         all: bool,
@@ -655,7 +654,6 @@ enum IntegrationCommands {
     },
     /// Inspect, install, and explain verification for one integration
     Setup {
-        #[arg(value_enum)]
         integration: integration_management::IntegrationId,
         /// Accept the proposed installation without prompting
         #[arg(long)]
@@ -666,7 +664,6 @@ enum IntegrationCommands {
     },
     /// Verify authoritative lifecycle reporting in a running host shell
     Verify {
-        #[arg(value_enum)]
         integration: integration_management::IntegrationId,
         #[arg(long, value_name = "ID")]
         shell: Option<String>,
@@ -1698,7 +1695,7 @@ fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), B
             dry_run,
         } => {
             let integrations = if all {
-                integration_management::IntegrationId::ALL.to_vec()
+                integration_management::IntegrationId::all().collect()
             } else {
                 vec![integration.ok_or_else(|| {
                     cli_output::failure(
@@ -1715,7 +1712,7 @@ fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), B
             force,
         } => {
             let integrations = if all {
-                integration_management::IntegrationId::ALL.to_vec()
+                integration_management::IntegrationId::all().collect()
             } else {
                 vec![integration.ok_or_else(|| {
                     cli_output::failure(
@@ -1765,14 +1762,14 @@ fn verify_integration(
                 format!(
                     "shell {} is not a running {} host shell",
                     shell_id.expect("checked above"),
-                    spec.name
+                    spec.key
                 ),
             ));
         }
         [] => {
             return Err(cli_output::failure(
                 "not_found",
-                format!("no running {} host shell found", spec.name),
+                format!("no running {} host shell found", spec.key),
             ));
         }
         _ => {
@@ -1799,7 +1796,7 @@ fn verify_integration(
                     return print_json(
                         CommandKey::IntegrationVerify,
                         serde_json::json!({
-                            "integration": spec.name,
+                            "integration": spec.key,
                             "verified": true,
                             "shell_id": target.shell_id,
                             "run_id": target.run_id,
@@ -1818,7 +1815,7 @@ fn verify_integration(
                     "not_found",
                     format!(
                         "shell {} is no longer a running {} host shell",
-                        target.shell_id, spec.name
+                        target.shell_id, spec.key
                     ),
                 ));
             }
@@ -1836,7 +1833,7 @@ fn verify_integration(
                 io::ErrorKind::TimedOut,
                 format!(
                     "did not observe lifecycle integration reporting for {} in shell {} within {} ms",
-                    spec.name, target.shell_id, wait_ms
+                    spec.key, target.shell_id, wait_ms
                 ),
             )
             .into());
@@ -1885,7 +1882,7 @@ fn format_ambiguous_verification_targets(
         write!(
             output,
             "\n  {workspace} / {shell}\n    boomux integration verify {} --shell {shell_id}",
-            spec.name
+            spec.key
         )
         .expect("writing to a string cannot fail");
     }
@@ -1893,8 +1890,7 @@ fn format_ambiguous_verification_targets(
 }
 
 fn list_integrations(json: bool) -> Result<(), Box<dyn Error>> {
-    let integrations = integration_management::IntegrationId::ALL
-        .into_iter()
+    let integrations = integration_management::IntegrationId::all()
         .map(integration_management::IntegrationSummary::from)
         .collect::<Vec<_>>();
     if json {
@@ -1945,7 +1941,7 @@ fn integration_status(
     let environment = integration_management::Environment::from_process();
     let snapshot = client::connect().and_then(|client| client.snapshot()).ok();
     let integrations = integration.map_or_else(
-        || integration_management::IntegrationId::ALL.to_vec(),
+        || integration_management::IntegrationId::all().collect(),
         |integration| vec![integration],
     );
     let statuses = integrations
@@ -2073,18 +2069,19 @@ fn install_integrations(
         }
         for plan in &plans {
             let spec = plan.integration.spec();
+            let installation = plan.integration.installation();
             match plan.action {
                 integration_management::InstallAction::Install => println!(
                     "Would install Boomux {} {} at {}",
-                    spec.display_name, spec.asset_name, plan.path
+                    spec.display_name, installation.asset_name, plan.path
                 ),
                 integration_management::InstallAction::Replace => println!(
                     "Would replace Boomux {} {} at {}",
-                    spec.display_name, spec.asset_name, plan.path
+                    spec.display_name, installation.asset_name, plan.path
                 ),
                 integration_management::InstallAction::Unchanged => println!(
                     "Boomux {} {} is already installed at {}",
-                    spec.display_name, spec.asset_name, plan.path
+                    spec.display_name, installation.asset_name, plan.path
                 ),
             }
         }
@@ -2108,22 +2105,23 @@ fn install_integrations(
 fn print_integration_install_results(results: &[integration_management::InstallResult]) {
     for result in results {
         let spec = result.integration.spec();
+        let installation = result.integration.installation();
         match result.result {
             integration_management::InstallOutcome::Unchanged => println!(
                 "Boomux {} {} is already installed at {}",
-                spec.display_name, spec.asset_name, result.path
+                spec.display_name, installation.asset_name, result.path
             ),
             integration_management::InstallOutcome::Installed => println!(
                 "Installed Boomux {} {} at {}",
-                spec.display_name, spec.asset_name, result.path
+                spec.display_name, installation.asset_name, result.path
             ),
             integration_management::InstallOutcome::Replaced => println!(
                 "Replaced Boomux {} {} at {}",
-                spec.display_name, spec.asset_name, result.path
+                spec.display_name, installation.asset_name, result.path
             ),
         }
         if result.restart_required {
-            println!("{}", spec.reload_message);
+            println!("{}", installation.reload_message);
         }
     }
 }
@@ -2150,18 +2148,19 @@ fn uninstall_integrations(
     }
     for result in &results {
         let spec = result.integration.spec();
+        let installation = result.integration.installation();
         match result.result {
             integration_management::UninstallOutcome::Removed => println!(
                 "Removed Boomux {} {} from {}",
-                spec.display_name, spec.asset_name, result.path
+                spec.display_name, installation.asset_name, result.path
             ),
             integration_management::UninstallOutcome::NotInstalled => println!(
                 "Boomux {} {} is not installed at {}",
-                spec.display_name, spec.asset_name, result.path
+                spec.display_name, installation.asset_name, result.path
             ),
         }
         if result.restart_required {
-            println!("{}", spec.reload_message);
+            println!("{}", installation.reload_message);
         }
     }
     Ok(())
@@ -2181,6 +2180,7 @@ fn setup_integration(
     );
 
     let spec = integration.spec();
+    let installation = integration.installation();
     if status.asset.state == integration_management::AssetState::Current {
         print_setup_next_step(integration, status.runtime.state);
         return Ok(());
@@ -2203,7 +2203,10 @@ fn setup_integration(
         integration_management::InstallAction::Replace => "replace",
         integration_management::InstallAction::Unchanged => "leave unchanged",
     };
-    println!("Plan: {action} Boomux {} at {}", spec.asset_name, plan.path);
+    println!(
+        "Plan: {action} Boomux {} at {}",
+        installation.asset_name, plan.path
+    );
 
     if yes && replacing && !force {
         return Err(io::Error::new(
@@ -2228,7 +2231,7 @@ fn setup_integration(
     print_integration_install_results(&[result]);
     println!(
         "After restarting {}, run: boomux integration verify {}",
-        spec.display_name, spec.name
+        spec.display_name, spec.key
     );
     Ok(())
 }
@@ -2258,7 +2261,7 @@ fn print_setup_next_step(
     } else {
         println!(
             "The asset is current. Restart {}, open it in a Boomux-managed shell, then run: boomux integration verify {}",
-            spec.display_name, spec.name
+            spec.display_name, spec.key
         );
     }
 }
@@ -2293,15 +2296,15 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "internal",
         "unknown",
     ];
-    let integration_hosts = integration_management::IntegrationId::ALL
-        .into_iter()
+    let integration_hosts = integration_management::IntegrationId::all()
         .map(|integration| {
             let spec = integration.spec();
+            let installation = integration.installation();
             (
-                spec.name.to_owned(),
+                spec.key.to_owned(),
                 serde_json::json!({
-                    "package": spec.package,
-                    "validated_version": spec.validated_version,
+                    "package": installation.package,
+                    "validated_version": installation.validated_version,
                 }),
             )
         })
@@ -2332,11 +2335,11 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
     );
     println!(
         "INTEGRATION HOSTS\t{}",
-        integration_management::IntegrationId::ALL
-            .into_iter()
+        integration_management::IntegrationId::all()
             .map(|integration| {
                 let spec = integration.spec();
-                format!("{}={}", spec.name, spec.validated_version)
+                let installation = integration.installation();
+                format!("{}={}", spec.key, installation.validated_version)
             })
             .collect::<Vec<_>>()
             .join(",")
@@ -4190,7 +4193,7 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
         }
     }
     let integration_environment = integration_management::Environment::from_process();
-    for integration in integration_management::IntegrationId::ALL {
+    for integration in integration_management::IntegrationId::all() {
         let status = integration_management::inspect_without_host_probe(
             integration,
             &integration_environment,
@@ -4210,12 +4213,13 @@ fn print_integration_diagnostic(
     status: &integration_management::IntegrationStatus,
 ) -> bool {
     let spec = integration.spec();
+    let installation = integration.installation();
     let path = status.asset.path.as_deref().unwrap_or("unresolved path");
     if status.asset.state == integration_management::AssetState::Unavailable {
         eprintln!(
             "err {} integration: cannot inspect {} at {path}: {}",
-            spec.name,
-            spec.asset_name,
+            spec.key,
+            installation.asset_name,
             status.asset.error.as_deref().unwrap_or("unknown error")
         );
         return false;
@@ -4223,8 +4227,8 @@ fn print_integration_diagnostic(
     if status.runtime.running_processes == 0 {
         println!(
             "ok  {} integration: {} {} at {path}",
-            spec.name,
-            spec.asset_name,
+            spec.key,
+            installation.asset_name,
             status.asset.state.as_str(),
         );
         return true;
@@ -4232,10 +4236,10 @@ fn print_integration_diagnostic(
     if status.asset.state != integration_management::AssetState::Current {
         eprintln!(
             "err {} integration: {} {} at {path}; run boomux integration install {}{}",
-            spec.name,
-            spec.asset_name,
+            spec.key,
+            installation.asset_name,
             status.asset.state.as_str(),
-            spec.name,
+            spec.key,
             if status.asset.state == integration_management::AssetState::Modified {
                 " --force"
             } else {
@@ -4247,13 +4251,13 @@ fn print_integration_diagnostic(
     if status.runtime.untracked_processes == 0 {
         println!(
             "ok  {} integration: lifecycle registration active",
-            spec.name
+            spec.key
         );
         true
     } else {
         eprintln!(
             "err {} integration: {} foreground process(es) are untracked; restart {} and verify it loads {path}",
-            spec.name, status.runtime.untracked_processes, spec.display_name
+            spec.key, status.runtime.untracked_processes, spec.display_name
         );
         false
     }
@@ -5929,8 +5933,7 @@ mod tests {
 
     #[test]
     fn formats_integration_output_without_tab_alignment() {
-        let integrations = integration_management::IntegrationId::ALL
-            .into_iter()
+        let integrations = integration_management::IntegrationId::all()
             .map(integration_management::IntegrationSummary::from)
             .collect::<Vec<_>>();
         assert_eq!(
@@ -6117,13 +6120,13 @@ mod tests {
         }
         assert_eq!(
             integration_management::IntegrationId::Opencode
-                .spec()
+                .installation()
                 .validated_version,
             "1.18.15"
         );
         assert_eq!(
             integration_management::IntegrationId::Pi
-                .spec()
+                .installation()
                 .validated_version,
             "0.84.1"
         );

--- a/src/session_transcript.rs
+++ b/src/session_transcript.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use boomux::integrations::{self, TranscriptProvider};
+
 use crate::host_session_source::normalize_absolute;
 use crate::session_projection::SessionProjection;
 
@@ -24,8 +26,6 @@ const CURSOR_PREFIX: &str = "v1.";
 const CURSOR_MAX_BYTES: usize = 4096;
 
 trait TranscriptAdapter: Sync {
-    fn integration(&self) -> &'static str;
-
     fn normalization_revision(&self) -> u32;
 
     fn read(&self, request: TranscriptRequest<'_>)
@@ -37,8 +37,6 @@ struct TranscriptRequest<'a> {
     directory: &'a Path,
     external_session_id: &'a str,
 }
-
-static ADAPTERS: &[&dyn TranscriptAdapter] = &[opencode::ADAPTER, pi::ADAPTER];
 
 #[derive(Debug)]
 pub(crate) struct TranscriptError {
@@ -129,22 +127,30 @@ pub(crate) fn read(
     limit: usize,
     max_bytes: usize,
 ) -> Result<Transcript, TranscriptError> {
-    read_with_adapters(session, before, limit, max_bytes, ADAPTERS)
+    let adapter = integrations::by_key(&session.integration)
+        .and_then(|descriptor| descriptor.transcript)
+        .map(|transcript| match transcript.provider {
+            TranscriptProvider::OpenCode => opencode::ADAPTER,
+            TranscriptProvider::Pi => pi::ADAPTER,
+        })
+        .ok_or_else(|| unsupported_integration(&session.integration))?;
+    read_with_adapter(session, before, limit, max_bytes, adapter)
 }
 
 pub(crate) fn supported_integrations() -> Vec<&'static str> {
-    ADAPTERS
+    integrations::ALL
         .iter()
-        .map(|adapter| adapter.integration())
+        .filter(|descriptor| descriptor.transcript.is_some())
+        .map(|descriptor| descriptor.key)
         .collect()
 }
 
-fn read_with_adapters(
+fn read_with_adapter(
     session: &SessionProjection,
     before: Option<&str>,
     limit: usize,
     max_bytes: usize,
-    adapters: &[&dyn TranscriptAdapter],
+    adapter: &dyn TranscriptAdapter,
 ) -> Result<Transcript, TranscriptError> {
     let external_session_id = session.external_session_id.as_deref().ok_or_else(|| {
         TranscriptError::new(
@@ -159,18 +165,6 @@ fn read_with_adapters(
         )
     })?;
 
-    let adapter = adapters
-        .iter()
-        .find(|adapter| adapter.integration() == session.integration)
-        .ok_or_else(|| {
-            TranscriptError::new(
-                "unsupported_integration",
-                format!(
-                    "session transcript integration is not supported: {}",
-                    session.integration
-                ),
-            )
-        })?;
     let source_fingerprint =
         source_context_fingerprint(&session.integration, external_session_id, directory)?;
     let cursor = before.map(decode_cursor).transpose()?;
@@ -222,6 +216,13 @@ fn read_with_adapters(
             max_bytes,
         },
     ))
+}
+
+fn unsupported_integration(integration: &str) -> TranscriptError {
+    TranscriptError::new(
+        "unsupported_integration",
+        format!("session transcript integration is not supported: {integration}"),
+    )
 }
 
 fn message_entry(
@@ -468,10 +469,6 @@ mod tests {
     struct FutureHarnessAdapter;
 
     impl TranscriptAdapter for FutureHarnessAdapter {
-        fn integration(&self) -> &'static str {
-            "future-harness"
-        }
-
         fn normalization_revision(&self) -> u32 {
             1
         }
@@ -507,10 +504,6 @@ mod tests {
     }
 
     impl TranscriptAdapter for MutableAdapter {
-        fn integration(&self) -> &'static str {
-            "mutable"
-        }
-
         fn normalization_revision(&self) -> u32 {
             self.revision.load(Ordering::Relaxed)
         }
@@ -536,13 +529,7 @@ mod tests {
         limit: usize,
         max_bytes: usize,
     ) -> Result<Transcript, TranscriptError> {
-        read_with_adapters(
-            session,
-            before,
-            limit,
-            max_bytes,
-            &[adapter as &dyn TranscriptAdapter],
-        )
+        read_with_adapter(session, before, limit, max_bytes, adapter)
     }
 
     fn session(integration: &str) -> SessionProjection {
@@ -679,14 +666,8 @@ mod tests {
     #[test]
     fn registered_adapter_uses_the_shared_identity_and_bounding_contract() {
         let adapter = FutureHarnessAdapter;
-        let transcript = read_with_adapters(
-            &session("future-harness"),
-            None,
-            10,
-            7,
-            &[&adapter as &dyn TranscriptAdapter],
-        )
-        .unwrap();
+        let transcript =
+            read_with_adapter(&session("future-harness"), None, 10, 7, &adapter).unwrap();
 
         assert_eq!(transcript.integration, "future-harness");
         assert_eq!(transcript.entries[0].text.as_deref(), Some("adapter"));
@@ -699,14 +680,7 @@ mod tests {
         let mut catalog_only = session("future-harness");
         catalog_only.occurrences.clear();
 
-        let transcript = read_with_adapters(
-            &catalog_only,
-            None,
-            10,
-            usize::MAX,
-            &[&adapter as &dyn TranscriptAdapter],
-        )
-        .unwrap();
+        let transcript = read_with_adapter(&catalog_only, None, 10, usize::MAX, &adapter).unwrap();
 
         assert_eq!(
             transcript.entries[0].text.as_deref(),

--- a/src/session_transcript/opencode.rs
+++ b/src/session_transcript/opencode.rs
@@ -21,10 +21,6 @@ struct OpenCodeAdapter;
 pub(super) static ADAPTER: &dyn TranscriptAdapter = &OpenCodeAdapter;
 
 impl TranscriptAdapter for OpenCodeAdapter {
-    fn integration(&self) -> &'static str {
-        "opencode"
-    }
-
     fn normalization_revision(&self) -> u32 {
         1
     }

--- a/src/session_transcript/pi.rs
+++ b/src/session_transcript/pi.rs
@@ -20,10 +20,6 @@ struct PiAdapter;
 pub(super) static ADAPTER: &dyn TranscriptAdapter = &PiAdapter;
 
 impl TranscriptAdapter for PiAdapter {
-    fn integration(&self) -> &'static str {
-        "pi"
-    }
-
     fn normalization_revision(&self) -> u32 {
         1
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3461,11 +3461,7 @@ fn session_task_label(session: &AgentSessionView) -> Option<&str> {
 }
 
 fn integration_display_name(integration: &str) -> &str {
-    match integration {
-        "opencode" => "OpenCode",
-        "pi" => "Pi",
-        other => other,
-    }
+    boomux::integrations::display_name(integration)
 }
 
 fn item_column_widths(width: u16, rows: &[[String; 6]]) -> Vec<Constraint> {


### PR DESCRIPTION
## Summary
- centralize integration identity, display metadata, and optional capabilities in typed descriptors
- route installation, titles/catalogs, transcripts, recovery, foreground recognition, and display naming through the descriptor registry
- document the descriptor boundary and cover partial-capability extension and registry uniqueness

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --lib --bins --locked
- cargo test --test native_backend --locked -- --test-threads=1
- bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js

Closes #122