### PR TITLE
refactor(errors): preserve typed daemon and client failures

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,6 +116,11 @@ There are no separate tab, pane, and terminal identity layers.
 `src/client.rs` resolves the socket at
 `$XDG_RUNTIME_DIR/boomux/daemon.sock`. It starts a detached daemon on demand,
 waits for the protocol ping to succeed, and exposes typed management requests.
+Its public operations return `ClientError`, which keeps transport, protocol,
+remote daemon, local validation, and lifecycle failures structurally distinct.
+Protocol negotiation uses typed mismatch and unsupported-version failures rather
+than inspecting error messages, and remote errors retain their protocol code
+without passing through `io::Error`.
 An owner-held file lock prevents concurrent daemons from unlinking each other's
 sockets or splitting the registry.
 
@@ -143,6 +148,12 @@ transition frontier, retained event state, durable collection, then applicable
 shell/runtime locks. Paths that need only a suffix of that order start at the
 first required owner; PTY output releases runtime locks before entering the
 `EventStream` publication boundary.
+
+Request handling uses `DaemonError` to retain validation, lifecycle, persistence,
+protocol, and internal failure classes until the wire boundary. Stable protocol
+codes are selected from those variants directly; transport errors remain on the
+connection path and are not reinterpreted as domain failures through
+`io::Error` downcasting.
 
 The daemon supports:
 
@@ -334,8 +345,8 @@ Read-only CLI integrations use the separate `boomux.cli/v1` JSON envelope rather
 than serializing daemon protocol snapshots directly. `boomux capabilities`
 advertises supported commands, features, schemas, and error codes without
 requiring a daemon. Protocol 6 error responses carry an additive optional code;
-new clients expose it through a typed `RemoteError`, while mixed-version peers
-retain message compatibility.
+clients expose it as `ClientError::Remote(RemoteError)`, while mixed-version
+peers retain message compatibility.
 
 Protocol 7 adds a bounded in-memory daemon event journal and atomic output-state
 reads. Clients reconnect through stream UUID/event-ID cursors and recover from

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -351,3 +351,6 @@ The stable codes are reported by `boomux capabilities --json`. Messages remain
 human-readable context and are not stable parsing targets. `run_changed` means
 a supplied run ID no longer matches the run-scoped operation; integrations must
 reacquire exact context rather than substitute or guess another run.
+The CLI maps typed client failures directly: daemon `RemoteError` codes retain
+their stable spelling, while transport, protocol, validation, and lifecycle
+variants map to the existing CLI code set without inspecting message text.

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -112,7 +112,11 @@ impl Drop for RawMode {
     }
 }
 
-pub fn run(shell_id: &str, takeover: bool, restart_exited: bool) -> io::Result<()> {
+pub fn run(
+    shell_id: &str,
+    takeover: bool,
+    restart_exited: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut profile = terminal_profile()?;
     let mut size = (
         profile.rows,
@@ -129,7 +133,7 @@ pub fn run(shell_id: &str, takeover: bool, restart_exited: bool) -> io::Result<(
     let mut focus_reporting = false;
     let mut focus = FocusTracking::default();
 
-    let result = (|| {
+    let result: Result<(), Box<dyn std::error::Error>> = (|| {
         loop {
             let report_focus =
                 ProtocolFeature::FocusedTerminal.is_supported_by(attachment.protocol_version);
@@ -189,7 +193,7 @@ fn reconnect(
     shell_id: &str,
     takeover: bool,
     profile: &TerminalProfile,
-) -> io::Result<client::Attachment> {
+) -> client::Result<client::Attachment> {
     let mut last_error = None;
     for _ in 0..RECONNECT_ATTEMPTS {
         match attach_once(client, shell_id, takeover, false, profile) {
@@ -198,7 +202,9 @@ fn reconnect(
         }
         thread::sleep(RECONNECT_DELAY);
     }
-    Err(last_error.unwrap_or_else(|| io::Error::other("daemon attachment did not reconnect")))
+    Err(client::ClientError::Lifecycle(
+        client::LifecycleError::AttachmentReconnectTimeout(last_error.map(Box::new)),
+    ))
 }
 
 fn attach_once(
@@ -207,7 +213,7 @@ fn attach_once(
     takeover: bool,
     restart_exited: bool,
     profile: &TerminalProfile,
-) -> io::Result<client::Attachment> {
+) -> client::Result<client::Attachment> {
     let transfers_environment = client.supports(ProtocolFeature::ClientEnvironment)?;
     match (restart_exited, transfers_environment) {
         (true, true) => {

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use serde::Serialize;
 
-use boomux::client::RemoteError;
+use boomux::client::{ClientError, LifecycleError, ProtocolError};
 use boomux::protocol::{
     AgentAttentionReason, AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot,
     AgentState, ErrorCode, ShellRunExitReason, ShellSnapshot, ShellStatus,
@@ -372,38 +372,56 @@ fn classify_error(command: &str, error: &(dyn Error + 'static)) -> &'static str 
         if let Some(cli) = candidate.downcast_ref::<CliError>() {
             return cli.code;
         }
-        if let Some(remote) = candidate.downcast_ref::<RemoteError>() {
-            return remote.code.map_or("unknown", protocol_error_code);
+        if let Some(client) = candidate.downcast_ref::<ClientError>() {
+            return classify_client_error(command, client);
         }
         if let Some(io_error) = candidate.downcast_ref::<io::Error>() {
-            if let Some(remote) = io_error
-                .get_ref()
-                .and_then(|inner| inner.downcast_ref::<RemoteError>())
-            {
-                return remote.code.map_or("unknown", protocol_error_code);
-            }
-            if command == "daemon.status"
-                && matches!(
-                    io_error.kind(),
-                    io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
-                )
-            {
-                return "daemon_unavailable";
-            }
-            return match io_error.kind() {
-                io::ErrorKind::InvalidInput | io::ErrorKind::InvalidData => "invalid_argument",
-                io::ErrorKind::NotFound => "not_found",
-                io::ErrorKind::AlreadyExists => "already_exists",
-                io::ErrorKind::WouldBlock | io::ErrorKind::AddrInUse => "busy",
-                io::ErrorKind::ConnectionAborted => "daemon_stopping",
-                io::ErrorKind::ConnectionRefused => "daemon_unavailable",
-                io::ErrorKind::TimedOut => "timeout",
-                _ => "internal",
-            };
+            return classify_io_error(command, io_error);
         }
         current = candidate.source();
     }
     "internal"
+}
+
+fn classify_client_error(command: &str, error: &ClientError) -> &'static str {
+    match error {
+        ClientError::Transport(error) | ClientError::Validation(error) => {
+            classify_io_error(command, error)
+        }
+        ClientError::Protocol(ProtocolError::UnsupportedVersion(_)) => "unsupported_version",
+        ClientError::Protocol(_) => "invalid_argument",
+        ClientError::Remote(error) => error.code.map_or("unknown", protocol_error_code),
+        ClientError::Lifecycle(LifecycleError::ShutdownTimeout) => "timeout",
+        ClientError::Lifecycle(LifecycleError::DaemonStart(_))
+        | ClientError::Lifecycle(LifecycleError::DaemonStartTimeout(_)) => "daemon_unavailable",
+        ClientError::Lifecycle(LifecycleError::ReplacementStartTimeout(Some(error)))
+        | ClientError::Lifecycle(LifecycleError::AttachmentReconnectTimeout(Some(error))) => {
+            classify_client_error(command, error)
+        }
+        ClientError::Lifecycle(LifecycleError::ReplacementStartTimeout(None))
+        | ClientError::Lifecycle(LifecycleError::AttachmentReconnectTimeout(None)) => "internal",
+    }
+}
+
+fn classify_io_error(command: &str, error: &io::Error) -> &'static str {
+    if command == "daemon.status"
+        && matches!(
+            error.kind(),
+            io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+        )
+    {
+        return "daemon_unavailable";
+    }
+    match error.kind() {
+        io::ErrorKind::InvalidInput | io::ErrorKind::InvalidData => "invalid_argument",
+        io::ErrorKind::NotFound => "not_found",
+        io::ErrorKind::AlreadyExists => "already_exists",
+        io::ErrorKind::WouldBlock | io::ErrorKind::AddrInUse => "busy",
+        io::ErrorKind::ConnectionAborted => "daemon_stopping",
+        io::ErrorKind::ConnectionRefused => "daemon_unavailable",
+        io::ErrorKind::TimedOut => "timeout",
+        _ => "internal",
+    }
 }
 
 #[cfg(test)]
@@ -433,6 +451,7 @@ fn protocol_error_code(code: ErrorCode) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use boomux::client::RemoteError;
     use boomux::protocol::AgentObservationSnapshot;
 
     #[test]
@@ -525,5 +544,32 @@ mod tests {
         assert!(value["occurrences"][0]["ended_at_ms"].is_null());
         assert_eq!(value["occurrences"][0]["shell_id"], "removed-shell");
         assert_eq!(value["occurrences"][0]["observation"]["state"], "inactive");
+    }
+
+    #[test]
+    fn client_errors_convert_to_stable_cli_codes() {
+        let remote = ClientError::Remote(RemoteError {
+            code: Some(ErrorCode::ShellStartFailed),
+            message: "could not start shell".into(),
+        });
+        let unsupported = ClientError::Protocol(ProtocolError::UnsupportedVersion(
+            "daemon does not support this request".into(),
+        ));
+        let transport = ClientError::Transport(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            "connection refused",
+        ));
+        let timeout = ClientError::Lifecycle(LifecycleError::ShutdownTimeout);
+
+        assert_eq!(classify_error("shell.open", &remote), "shell_start_failed");
+        assert_eq!(
+            classify_error("shell.open", &unsupported),
+            "unsupported_version"
+        );
+        assert_eq!(
+            classify_error("shell.open", &transport),
+            "daemon_unavailable"
+        );
+        assert_eq!(classify_error("daemon.stop", &timeout), "timeout");
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,6 +25,122 @@ const CONNECT_ATTEMPTS: usize = 40;
 const CONNECT_DELAY: Duration = Duration::from_millis(25);
 const SHUTDOWN_ATTEMPTS: usize = 200;
 
+pub type Result<T> = std::result::Result<T, ClientError>;
+
+#[derive(Debug)]
+pub enum ClientError {
+    Transport(io::Error),
+    Protocol(ProtocolError),
+    Remote(RemoteError),
+    Validation(io::Error),
+    Lifecycle(LifecycleError),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transport(error) | Self::Validation(error) => error.fmt(formatter),
+            Self::Protocol(error) => error.fmt(formatter),
+            Self::Remote(error) => error.fmt(formatter),
+            Self::Lifecycle(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl Error for ClientError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Transport(error) | Self::Validation(error) => Some(error),
+            Self::Protocol(error) => Some(error),
+            Self::Remote(error) => Some(error),
+            Self::Lifecycle(error) => Some(error),
+        }
+    }
+}
+
+impl From<io::Error> for ClientError {
+    fn from(error: io::Error) -> Self {
+        Self::Transport(error)
+    }
+}
+
+#[derive(Debug)]
+pub enum ProtocolError {
+    UnsupportedVersion(String),
+    VersionMismatch { expected: u32, actual: u32 },
+    InvalidMessage(io::Error),
+    EventBaselineMissing,
+    UnexpectedResponse(Box<Response>),
+}
+
+impl std::fmt::Display for ProtocolError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedVersion(message) => formatter.write_str(message),
+            Self::VersionMismatch { .. } => formatter.write_str("protocol version mismatch"),
+            Self::InvalidMessage(error) => error.fmt(formatter),
+            Self::EventBaselineMissing => {
+                formatter.write_str("event baseline omitted its snapshot")
+            }
+            Self::UnexpectedResponse(response) => {
+                write!(formatter, "unexpected daemon response: {response:?}")
+            }
+        }
+    }
+}
+
+impl Error for ProtocolError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidMessage(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum LifecycleError {
+    DaemonStart(io::Error),
+    DaemonStartTimeout(Option<Box<ClientError>>),
+    ShutdownTimeout,
+    ReplacementStartTimeout(Option<Box<ClientError>>),
+    AttachmentReconnectTimeout(Option<Box<ClientError>>),
+}
+
+impl std::fmt::Display for LifecycleError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DaemonStart(error) => write!(formatter, "daemon did not start: {error}"),
+            Self::DaemonStartTimeout(Some(error)) | Self::ReplacementStartTimeout(Some(error)) => {
+                error.fmt(formatter)
+            }
+            Self::DaemonStartTimeout(None) => formatter.write_str("daemon did not start"),
+            Self::ShutdownTimeout => {
+                formatter.write_str("Boomux daemon did not finish shutting down")
+            }
+            Self::ReplacementStartTimeout(None) => {
+                formatter.write_str("replacement daemon did not start")
+            }
+            Self::AttachmentReconnectTimeout(Some(error)) => error.fmt(formatter),
+            Self::AttachmentReconnectTimeout(None) => {
+                formatter.write_str("daemon attachment did not reconnect")
+            }
+        }
+    }
+}
+
+impl Error for LifecycleError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::DaemonStart(error) => Some(error),
+            Self::DaemonStartTimeout(Some(error))
+            | Self::ReplacementStartTimeout(Some(error))
+            | Self::AttachmentReconnectTimeout(Some(error)) => Some(error.as_ref()),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Client {
     socket_path: PathBuf,
@@ -64,7 +180,7 @@ pub struct SnapshotWatch {
 }
 
 impl SnapshotWatch {
-    pub fn baseline(client: &Client) -> io::Result<Self> {
+    pub fn baseline(client: &Client) -> Result<Self> {
         if !client.supports(protocol::ProtocolFeature::AtomicOutputReads)? {
             return Ok(Self {
                 cursor: None,
@@ -74,7 +190,7 @@ impl SnapshotWatch {
         let batch = client.events(None, 1, 0)?;
         let snapshot = batch
             .snapshot
-            .ok_or_else(|| io::Error::other("event baseline omitted its snapshot"))?;
+            .ok_or(ClientError::Protocol(ProtocolError::EventBaselineMissing))?;
         Ok(Self {
             cursor: Some(batch.cursor),
             snapshot,
@@ -93,7 +209,7 @@ impl SnapshotWatch {
         self.cursor.is_some()
     }
 
-    pub fn poll(&mut self, client: &Client) -> io::Result<(bool, bool)> {
+    pub fn poll(&mut self, client: &Client) -> Result<(bool, bool)> {
         let Some(cursor) = self.cursor.clone() else {
             return Ok((false, false));
         };
@@ -107,11 +223,18 @@ impl SnapshotWatch {
                 *self = Self::baseline(client)?;
                 Ok((true, self.stream_id() != Some(stream_id.as_str())))
             }
-            Err(error) if remote_code(&error) == Some(ErrorCode::CursorExpired) => {
+            Err(ClientError::Remote(RemoteError {
+                code: Some(ErrorCode::CursorExpired),
+                ..
+            })) => {
                 *self = Self::baseline(client)?;
                 Ok((true, self.stream_id() != Some(stream_id.as_str())))
             }
-            Err(error) if remote_code(&error) == Some(ErrorCode::UnsupportedVersion) => {
+            Err(ClientError::Remote(RemoteError {
+                code: Some(ErrorCode::UnsupportedVersion),
+                ..
+            }))
+            | Err(ClientError::Protocol(ProtocolError::UnsupportedVersion(_))) => {
                 *self = Self::baseline(client)?;
                 Ok((true, self.stream_id() != Some(stream_id.as_str())))
             }
@@ -163,7 +286,7 @@ pub fn socket_path() -> io::Result<PathBuf> {
     Ok(runtime.join("boomux").join("daemon.sock"))
 }
 
-pub fn connect_or_start() -> io::Result<Client> {
+pub fn connect_or_start() -> Result<Client> {
     let client = connect_client()?;
     match client.ping() {
         Ok(()) => return Ok(client),
@@ -171,7 +294,7 @@ pub fn connect_or_start() -> io::Result<Client> {
         Err(_) => {}
     }
 
-    let mut command = Command::new(env::current_exe()?);
+    let mut command = Command::new(env::current_exe().map_err(ClientError::Validation)?);
     command
         .args(["daemon", "run"])
         .stdin(Stdio::null())
@@ -188,12 +311,9 @@ pub fn connect_or_start() -> io::Result<Client> {
             }
         });
     }
-    command.spawn().map_err(|error| {
-        io::Error::new(
-            io::ErrorKind::ConnectionRefused,
-            format!("daemon did not start: {error}"),
-        )
-    })?;
+    command
+        .spawn()
+        .map_err(|error| ClientError::Lifecycle(LifecycleError::DaemonStart(error)))?;
 
     let mut last_error = None;
     for _ in 0..CONNECT_ATTEMPTS {
@@ -204,35 +324,35 @@ pub fn connect_or_start() -> io::Result<Client> {
         }
         thread::sleep(CONNECT_DELAY);
     }
-    Err(io::Error::new(
-        io::ErrorKind::ConnectionRefused,
-        last_error.unwrap_or_else(|| io::Error::other("daemon did not start")),
-    ))
+    Err(ClientError::Lifecycle(LifecycleError::DaemonStartTimeout(
+        last_error.map(Box::new),
+    )))
 }
 
-fn daemon_unreachable(error: &io::Error) -> bool {
-    error
-        .get_ref()
-        .is_none_or(|error| !error.is::<RemoteError>())
-        && matches!(
-            error.kind(),
+fn daemon_unreachable(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::Transport(error)
+            if matches!(
+                error.kind(),
             io::ErrorKind::NotFound
                 | io::ErrorKind::ConnectionRefused
                 | io::ErrorKind::ConnectionReset
                 | io::ErrorKind::BrokenPipe
                 | io::ErrorKind::UnexpectedEof
-        )
+            )
+    )
 }
 
-pub fn connect() -> io::Result<Client> {
+pub fn connect() -> Result<Client> {
     let client = connect_client()?;
     client.ping()?;
     Ok(client)
 }
 
-fn connect_client() -> io::Result<Client> {
+fn connect_client() -> Result<Client> {
     Ok(Client {
-        socket_path: socket_path()?,
+        socket_path: socket_path().map_err(ClientError::Validation)?,
         protocol_version: Arc::new(AtomicU32::new(protocol::PROTOCOL_VERSION)),
     })
 }
@@ -249,20 +369,20 @@ impl Client {
         &self.socket_path
     }
 
-    pub fn protocol_version(&self) -> io::Result<u32> {
+    pub fn protocol_version(&self) -> Result<u32> {
         let _ = self.probe_latest()?;
         Ok(self.protocol_version.load(Ordering::Acquire))
     }
 
-    pub fn supports(&self, feature: protocol::ProtocolFeature) -> io::Result<bool> {
+    pub fn supports(&self, feature: protocol::ProtocolFeature) -> Result<bool> {
         Ok(feature.is_supported_by(self.protocol_version()?))
     }
 
-    pub fn request(&self, request: Request) -> io::Result<Response> {
+    pub fn request(&self, request: Request) -> Result<Response> {
         self.send(request).map(|(_, _, response)| response)
     }
 
-    fn send(&self, request: Request) -> io::Result<(UnixStream, u32, Response)> {
+    fn send(&self, request: Request) -> Result<(UnixStream, u32, Response)> {
         let mut version = self.protocol_version.load(Ordering::Acquire);
         if request
             .required_feature()
@@ -274,10 +394,7 @@ impl Client {
                 .required_feature()
                 .is_some_and(|feature| !feature.is_supported_by(version))
             {
-                return Err(remote_error(
-                    ErrorCode::UnsupportedVersion,
-                    "daemon does not support this request",
-                ));
+                return Err(unsupported_version("daemon does not support this request"));
             }
         }
         match self.send_with_version(request.clone(), version) {
@@ -291,10 +408,7 @@ impl Client {
                     .required_feature()
                     .is_some_and(|feature| !feature.is_supported_by(negotiated))
                 {
-                    return Err(remote_error(
-                        ErrorCode::UnsupportedVersion,
-                        "daemon does not support this request",
-                    ));
+                    return Err(unsupported_version("daemon does not support this request"));
                 }
                 self.send_with_version(request, negotiated)
                     .map(|(stream, response)| (stream, negotiated, response))
@@ -303,37 +417,37 @@ impl Client {
         }
     }
 
-    fn send_with_version(
-        &self,
-        request: Request,
-        version: u32,
-    ) -> io::Result<(UnixStream, Response)> {
-        let mut stream = UnixStream::connect(&self.socket_path)?;
-        protocol::write_message(&mut stream, &Envelope::with_version(version, request))?;
-        let response: Envelope<Response> = protocol::read_message(&mut stream)?;
+    fn send_with_version(&self, request: Request, version: u32) -> Result<(UnixStream, Response)> {
+        let mut stream = UnixStream::connect(&self.socket_path).map_err(ClientError::Transport)?;
+        protocol::write_message(&mut stream, &Envelope::with_version(version, request))
+            .map_err(classify_wire_error)?;
+        let response: Envelope<Response> =
+            protocol::read_message(&mut stream).map_err(classify_wire_error)?;
         if response.version != version {
             if let Response::Error {
                 message,
                 code: Some(ErrorCode::UnsupportedVersion),
             } = response.message
             {
-                return Err(remote_error(ErrorCode::UnsupportedVersion, message));
+                return Err(ClientError::Remote(RemoteError {
+                    code: Some(ErrorCode::UnsupportedVersion),
+                    message,
+                }));
             }
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "protocol version mismatch",
-            ));
+            return Err(ClientError::Protocol(ProtocolError::VersionMismatch {
+                expected: version,
+                actual: response.version,
+            }));
         }
         match response.message {
-            Response::Error { message, code } => Err(io::Error::new(
-                error_kind(code),
-                RemoteError { code, message },
-            )),
+            Response::Error { message, code } => {
+                Err(ClientError::Remote(RemoteError { code, message }))
+            }
             response => Ok((stream, response)),
         }
     }
 
-    fn probe_latest(&self) -> io::Result<bool> {
+    fn probe_latest(&self) -> Result<bool> {
         for version in (protocol::MIN_PROTOCOL_VERSION..=protocol::PROTOCOL_VERSION).rev() {
             match self.send_with_version(Request::Ping, version) {
                 Ok((_, Response::Pong)) => {
@@ -345,17 +459,16 @@ impl Client {
                 Err(error) => return Err(error),
             }
         }
-        Err(remote_error(
-            ErrorCode::UnsupportedVersion,
+        Err(unsupported_version(
             "daemon has no compatible protocol version",
         ))
     }
 
-    pub fn ping(&self) -> io::Result<()> {
+    pub fn ping(&self) -> Result<()> {
         expect_ok(self.request(Request::Ping)?, Response::Pong)
     }
 
-    pub fn shutdown(&self) -> io::Result<()> {
+    pub fn shutdown(&self) -> Result<()> {
         expect_ok(self.request(Request::Shutdown)?, Response::Ok)?;
         for _ in 0..SHUTDOWN_ATTEMPTS {
             if !self.socket_path.exists() && daemon_lock_available(&self.socket_path)? {
@@ -363,27 +476,24 @@ impl Client {
             }
             thread::sleep(CONNECT_DELAY);
         }
-        Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "Boomux daemon did not finish shutting down",
-        ))
+        Err(ClientError::Lifecycle(LifecycleError::ShutdownTimeout))
     }
 
-    pub fn restart(&self) -> io::Result<()> {
+    pub fn restart(&self) -> Result<()> {
         self.restart_request(Request::Restart)
     }
 
     pub fn restart_with_notification_config(
         &self,
         notifications: NotificationDeliveryConfig,
-    ) -> io::Result<()> {
+    ) -> Result<()> {
         if !self.supports(protocol::ProtocolFeature::RestartNotificationConfig)? {
             self.restart_request(Request::Restart)?;
         }
         self.restart_request(Request::RestartWithNotificationConfig { notifications })
     }
 
-    fn restart_request(&self, request: Request) -> io::Result<()> {
+    fn restart_request(&self, request: Request) -> Result<()> {
         expect_ok(self.request(request)?, Response::Ok)?;
         let mut last_error = None;
         for _ in 0..CONNECT_ATTEMPTS {
@@ -393,24 +503,26 @@ impl Client {
             }
             thread::sleep(CONNECT_DELAY);
         }
-        Err(last_error.unwrap_or_else(|| io::Error::other("replacement daemon did not start")))
+        Err(ClientError::Lifecycle(
+            LifecycleError::ReplacementStartTimeout(last_error.map(Box::new)),
+        ))
     }
 
-    pub fn snapshot(&self) -> io::Result<Snapshot> {
+    pub fn snapshot(&self) -> Result<Snapshot> {
         match self.request(Request::Snapshot)? {
             Response::Snapshot { snapshot } => Ok(snapshot),
             other => unexpected(other),
         }
     }
 
-    pub fn focused_terminal(&self) -> io::Result<Option<FocusedTerminalSnapshot>> {
+    pub fn focused_terminal(&self) -> Result<Option<FocusedTerminalSnapshot>> {
         match self.request(Request::GetFocusedTerminal)? {
             Response::FocusedTerminal { focused_terminal } => Ok(focused_terminal),
             other => unexpected(other),
         }
     }
 
-    pub fn get_workspace(&self, workspace_id: impl Into<String>) -> io::Result<WorkspaceSnapshot> {
+    pub fn get_workspace(&self, workspace_id: impl Into<String>) -> Result<WorkspaceSnapshot> {
         match self.request(Request::GetWorkspace {
             workspace_id: workspace_id.into(),
         })? {
@@ -419,7 +531,7 @@ impl Client {
         }
     }
 
-    pub fn get_shell(&self, shell_id: impl Into<String>) -> io::Result<ShellSnapshot> {
+    pub fn get_shell(&self, shell_id: impl Into<String>) -> Result<ShellSnapshot> {
         match self.request(Request::GetShell {
             shell_id: shell_id.into(),
         })? {
@@ -431,7 +543,7 @@ impl Client {
     pub fn get_launcher(
         &self,
         launcher_id: impl Into<String>,
-    ) -> io::Result<WorkspaceLauncherSnapshot> {
+    ) -> Result<WorkspaceLauncherSnapshot> {
         match self.request(Request::GetLauncher {
             launcher_id: launcher_id.into(),
         })? {
@@ -440,7 +552,7 @@ impl Client {
         }
     }
 
-    pub fn get_agent(&self, agent_id: impl Into<String>) -> io::Result<AgentInstanceSnapshot> {
+    pub fn get_agent(&self, agent_id: impl Into<String>) -> Result<AgentInstanceSnapshot> {
         match self.request(Request::GetAgent {
             agent_id: agent_id.into(),
         })? {
@@ -453,7 +565,7 @@ impl Client {
         &self,
         name: impl Into<String>,
         shells: Vec<ShellSpec>,
-    ) -> io::Result<WorkspaceSnapshot> {
+    ) -> Result<WorkspaceSnapshot> {
         self.create_workspace_with_default_cwd(name, None, shells)
     }
 
@@ -462,7 +574,7 @@ impl Client {
         name: impl Into<String>,
         default_cwd: Option<PathBuf>,
         shells: Vec<ShellSpec>,
-    ) -> io::Result<WorkspaceSnapshot> {
+    ) -> Result<WorkspaceSnapshot> {
         match self.request(Request::CreateWorkspace {
             name: name.into(),
             default_cwd,
@@ -477,7 +589,7 @@ impl Client {
         &self,
         workspace_id: impl Into<String>,
         shell: ShellSpec,
-    ) -> io::Result<ShellSnapshot> {
+    ) -> Result<ShellSnapshot> {
         match self.request(Request::CreateShell {
             workspace_id: Some(workspace_id.into()),
             shell,
@@ -487,7 +599,7 @@ impl Client {
         }
     }
 
-    pub fn create_shell_with_workspace(&self, shell: ShellSpec) -> io::Result<ShellSnapshot> {
+    pub fn create_shell_with_workspace(&self, shell: ShellSpec) -> Result<ShellSnapshot> {
         match self.request(Request::CreateShell {
             workspace_id: None,
             shell,
@@ -501,7 +613,7 @@ impl Client {
         &self,
         workspace_id: impl Into<String>,
         spec: WorkspaceLauncherSpec,
-    ) -> io::Result<WorkspaceLauncherSnapshot> {
+    ) -> Result<WorkspaceLauncherSnapshot> {
         match self.request(Request::CreateLauncher {
             workspace_id: workspace_id.into(),
             spec,
@@ -516,7 +628,7 @@ impl Client {
         shell_id: impl Into<String>,
         run_id: impl Into<String>,
         spec: AgentRegistrationSpec,
-    ) -> io::Result<AgentInstanceSnapshot> {
+    ) -> Result<AgentInstanceSnapshot> {
         match self.request(Request::RegisterAgent {
             shell_id: shell_id.into(),
             run_id: run_id.into(),
@@ -532,7 +644,7 @@ impl Client {
         shell_id: impl Into<String>,
         run_id: impl Into<String>,
         spec: AgentRegistrationSpec,
-    ) -> io::Result<AgentInstanceSnapshot> {
+    ) -> Result<AgentInstanceSnapshot> {
         match self.request(Request::EnsureAgent {
             shell_id: shell_id.into(),
             run_id: run_id.into(),
@@ -548,7 +660,7 @@ impl Client {
         agent_id: impl Into<String>,
         run_id: impl Into<String>,
         report: AgentReport,
-    ) -> io::Result<AgentInstanceSnapshot> {
+    ) -> Result<AgentInstanceSnapshot> {
         match self.request(Request::ReportAgent {
             agent_id: agent_id.into(),
             run_id: run_id.into(),
@@ -564,17 +676,14 @@ impl Client {
         agent_id: impl Into<String>,
         after_revision: u64,
         wait_ms: u32,
-    ) -> io::Result<AgentWait> {
+    ) -> Result<AgentWait> {
         let request = Request::WaitAgent {
             agent_id: agent_id.into(),
             after_revision,
             wait_ms,
         };
         if !self.supports(protocol::ProtocolFeature::RevisionAwareAgentWait)? {
-            return Err(remote_error(
-                ErrorCode::UnsupportedVersion,
-                "daemon does not support Agent wait",
-            ));
+            return Err(unsupported_version("daemon does not support Agent wait"));
         }
         match self.request(request)? {
             Response::AgentWait { agent, changed } => Ok(AgentWait { agent, changed }),
@@ -586,7 +695,7 @@ impl Client {
         &self,
         agent_id: impl Into<String>,
         observation_revision: u64,
-    ) -> io::Result<AgentAttentionAcknowledgement> {
+    ) -> Result<AgentAttentionAcknowledgement> {
         match self.request(Request::AcknowledgeAgentAttention {
             agent_id: agent_id.into(),
             observation_revision,
@@ -598,7 +707,7 @@ impl Client {
         }
     }
 
-    pub fn read_shell(&self, shell_id: impl Into<String>, max_bytes: usize) -> io::Result<Vec<u8>> {
+    pub fn read_shell(&self, shell_id: impl Into<String>, max_bytes: usize) -> Result<Vec<u8>> {
         match self.request(Request::ReadShell {
             shell_id: shell_id.into(),
             max_bytes,
@@ -613,7 +722,7 @@ impl Client {
         shell_id: impl Into<String>,
         max_bytes: usize,
         max_lines: u16,
-    ) -> io::Result<TerminalPreview> {
+    ) -> Result<TerminalPreview> {
         let shell_id = shell_id.into();
         if !self.supports(protocol::ProtocolFeature::StructuredTerminalPreview)? {
             let bytes = self.read_shell(shell_id, max_bytes)?;
@@ -649,7 +758,7 @@ impl Client {
         run_id: Option<String>,
         after_revision: Option<u64>,
         wait_ms: u32,
-    ) -> io::Result<OutputState> {
+    ) -> Result<OutputState> {
         match self.request(Request::ReadShellAt {
             shell_id: shell_id.into(),
             max_bytes,
@@ -679,7 +788,7 @@ impl Client {
         after: Option<EventCursor>,
         limit: u16,
         wait_ms: u32,
-    ) -> io::Result<EventBatch> {
+    ) -> Result<EventBatch> {
         match self.request(Request::Events {
             after,
             limit,
@@ -704,7 +813,7 @@ impl Client {
         &self,
         workspace_id: impl Into<String>,
         name: impl Into<String>,
-    ) -> io::Result<()> {
+    ) -> Result<()> {
         expect_ok(
             self.request(Request::RenameWorkspace {
                 workspace_id: workspace_id.into(),
@@ -714,11 +823,7 @@ impl Client {
         )
     }
 
-    pub fn rename_shell(
-        &self,
-        shell_id: impl Into<String>,
-        name: impl Into<String>,
-    ) -> io::Result<()> {
+    pub fn rename_shell(&self, shell_id: impl Into<String>, name: impl Into<String>) -> Result<()> {
         expect_ok(
             self.request(Request::RenameShell {
                 shell_id: shell_id.into(),
@@ -732,7 +837,7 @@ impl Client {
         &self,
         launcher_id: impl Into<String>,
         name: impl Into<String>,
-    ) -> io::Result<()> {
+    ) -> Result<()> {
         expect_ok(
             self.request(Request::RenameLauncher {
                 launcher_id: launcher_id.into(),
@@ -742,7 +847,7 @@ impl Client {
         )
     }
 
-    pub fn remove_launcher(&self, launcher_id: impl Into<String>) -> io::Result<()> {
+    pub fn remove_launcher(&self, launcher_id: impl Into<String>) -> Result<()> {
         expect_ok(
             self.request(Request::RemoveLauncher {
                 launcher_id: launcher_id.into(),
@@ -751,7 +856,7 @@ impl Client {
         )
     }
 
-    pub fn close_workspace(&self, workspace_id: impl Into<String>) -> io::Result<()> {
+    pub fn close_workspace(&self, workspace_id: impl Into<String>) -> Result<()> {
         expect_ok(
             self.request(Request::CloseWorkspace {
                 workspace_id: workspace_id.into(),
@@ -760,7 +865,7 @@ impl Client {
         )
     }
 
-    pub fn close_shell(&self, shell_id: impl Into<String>) -> io::Result<()> {
+    pub fn close_shell(&self, shell_id: impl Into<String>) -> Result<()> {
         expect_ok(
             self.request(Request::CloseShell {
                 shell_id: shell_id.into(),
@@ -769,7 +874,7 @@ impl Client {
         )
     }
 
-    pub fn restart_shell(&self, shell_id: impl Into<String>) -> io::Result<ShellSnapshot> {
+    pub fn restart_shell(&self, shell_id: impl Into<String>) -> Result<ShellSnapshot> {
         match self.request(Request::RestartShell {
             shell_id: shell_id.into(),
         })? {
@@ -783,7 +888,7 @@ impl Client {
         shell_id: impl Into<String>,
         takeover: bool,
         profile: TerminalProfile,
-    ) -> io::Result<Attachment> {
+    ) -> Result<Attachment> {
         self.attach_with_restart(shell_id.into(), takeover, false, profile, None)
     }
 
@@ -792,7 +897,7 @@ impl Client {
         shell_id: impl Into<String>,
         takeover: bool,
         profile: TerminalProfile,
-    ) -> io::Result<Attachment> {
+    ) -> Result<Attachment> {
         self.attach_with_restart(
             shell_id.into(),
             takeover,
@@ -807,7 +912,7 @@ impl Client {
         shell_id: impl Into<String>,
         takeover: bool,
         profile: TerminalProfile,
-    ) -> io::Result<Attachment> {
+    ) -> Result<Attachment> {
         self.attach_with_restart(shell_id.into(), takeover, true, profile, None)
     }
 
@@ -816,7 +921,7 @@ impl Client {
         shell_id: impl Into<String>,
         takeover: bool,
         profile: TerminalProfile,
-    ) -> io::Result<Attachment> {
+    ) -> Result<Attachment> {
         self.attach_with_restart(
             shell_id.into(),
             takeover,
@@ -833,7 +938,7 @@ impl Client {
         restart_exited: bool,
         profile: TerminalProfile,
         environment: Option<UnixEnvironment>,
-    ) -> io::Result<Attachment> {
+    ) -> Result<Attachment> {
         let (stream, protocol_version, response) = self.send(Request::Attach {
             shell_id,
             takeover,
@@ -869,39 +974,25 @@ fn current_environment() -> UnixEnvironment {
     }
 }
 
-fn remote_code(error: &io::Error) -> Option<ErrorCode> {
-    error
-        .get_ref()
-        .and_then(|error| error.downcast_ref::<RemoteError>())
-        .and_then(|error| error.code)
-}
-
-fn is_protocol_rejection(error: &io::Error) -> bool {
-    remote_code(error) == Some(ErrorCode::UnsupportedVersion)
-        || (error.kind() == io::ErrorKind::InvalidData
-            && error.to_string() == "protocol version mismatch")
-}
-
-fn remote_error(code: ErrorCode, message: impl Into<String>) -> io::Error {
-    io::Error::new(
-        error_kind(Some(code)),
-        RemoteError {
-            code: Some(code),
-            message: message.into(),
-        },
+fn is_protocol_rejection(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::Remote(RemoteError {
+            code: Some(ErrorCode::UnsupportedVersion),
+            ..
+        }) | ClientError::Protocol(ProtocolError::VersionMismatch { .. })
     )
 }
 
-fn error_kind(code: Option<ErrorCode>) -> io::ErrorKind {
-    match code {
-        Some(ErrorCode::InvalidArgument) => io::ErrorKind::InvalidInput,
-        Some(ErrorCode::NotFound) => io::ErrorKind::NotFound,
-        Some(ErrorCode::AlreadyExists) => io::ErrorKind::AlreadyExists,
-        Some(ErrorCode::Busy) => io::ErrorKind::WouldBlock,
-        Some(ErrorCode::DaemonStopping) => io::ErrorKind::ConnectionAborted,
-        Some(ErrorCode::Timeout) => io::ErrorKind::TimedOut,
-        Some(ErrorCode::UnsupportedVersion) => io::ErrorKind::InvalidData,
-        _ => io::ErrorKind::Other,
+fn unsupported_version(message: impl Into<String>) -> ClientError {
+    ClientError::Protocol(ProtocolError::UnsupportedVersion(message.into()))
+}
+
+fn classify_wire_error(error: io::Error) -> ClientError {
+    if error.kind() == io::ErrorKind::InvalidData {
+        ClientError::Protocol(ProtocolError::InvalidMessage(error))
+    } else {
+        ClientError::Transport(error)
     }
 }
 
@@ -928,7 +1019,7 @@ fn daemon_lock_available(socket_path: &Path) -> io::Result<bool> {
     }
 }
 
-fn expect_ok(actual: Response, expected: Response) -> io::Result<()> {
+fn expect_ok(actual: Response, expected: Response) -> Result<()> {
     if actual == expected {
         Ok(())
     } else {
@@ -936,11 +1027,10 @@ fn expect_ok(actual: Response, expected: Response) -> io::Result<()> {
     }
 }
 
-fn unexpected<T>(response: Response) -> io::Result<T> {
-    Err(io::Error::new(
-        io::ErrorKind::InvalidData,
-        format!("unexpected daemon response: {response:?}"),
-    ))
+fn unexpected<T>(response: Response) -> Result<T> {
+    Err(ClientError::Protocol(ProtocolError::UnexpectedResponse(
+        Box::new(response),
+    )))
 }
 
 #[cfg(test)]
@@ -1116,9 +1206,42 @@ mod tests {
 
         let error = client.wait_agent("a1", 1, 0).unwrap_err();
 
-        assert_eq!(remote_code(&error), Some(ErrorCode::UnsupportedVersion));
+        assert!(matches!(
+            error,
+            ClientError::Protocol(ProtocolError::UnsupportedVersion(ref message))
+                if message == "daemon does not support Agent wait"
+        ));
         server.join().unwrap();
         fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn io_errors_convert_to_transport_errors() {
+        let error = ClientError::from(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            "connection refused",
+        ));
+
+        assert!(matches!(
+            error,
+            ClientError::Transport(ref error)
+                if error.kind() == io::ErrorKind::ConnectionRefused
+                    && error.to_string() == "connection refused"
+        ));
+    }
+
+    #[test]
+    fn invalid_wire_data_converts_to_a_protocol_error() {
+        let error = classify_wire_error(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid response",
+        ));
+
+        assert!(matches!(
+            error,
+            ClientError::Protocol(ProtocolError::InvalidMessage(ref error))
+                if error.to_string() == "invalid response"
+        ));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -428,7 +428,13 @@ fn run_daemon(
         socket_cleanup.disarm();
         Ok(())
     } else {
-        registry.shutdown()
+        registry.shutdown().map_err(|error| match error {
+            DaemonError::Validation(source)
+            | DaemonError::Protocol(source)
+            | DaemonError::Internal(source)
+            | DaemonError::Lifecycle { source, .. }
+            | DaemonError::Persistence { source, .. } => source,
+        })
     };
     drop(registry);
     drop(listener);
@@ -438,36 +444,116 @@ fn run_daemon(
 }
 
 struct RestartRequest {
-    reply: SyncSender<io::Result<()>>,
+    reply: SyncSender<DaemonResult<()>>,
     notification_settings: Option<NotificationDeliverySettings>,
 }
 
 #[derive(Debug)]
-struct PersistenceError(io::Error);
-
-#[derive(Debug)]
-struct DaemonCodeError {
-    code: ErrorCode,
-    message: String,
+enum DaemonError {
+    Validation(io::Error),
+    Lifecycle { code: ErrorCode, source: io::Error },
+    Persistence { message: String, source: io::Error },
+    Protocol(io::Error),
+    Internal(io::Error),
 }
 
-impl std::fmt::Display for DaemonCodeError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(&self.message)
+type DaemonResult<T> = Result<T, DaemonError>;
+
+impl DaemonError {
+    fn validation(message: impl Into<String>) -> Self {
+        Self::Validation(io::Error::new(io::ErrorKind::InvalidInput, message.into()))
+    }
+
+    fn lifecycle(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self::Lifecycle {
+            code,
+            source: io::Error::other(message.into()),
+        }
+    }
+
+    fn protocol(message: impl Into<String>) -> Self {
+        Self::Protocol(io::Error::new(io::ErrorKind::InvalidData, message.into()))
+    }
+
+    fn persistence(source: io::Error) -> Self {
+        Self::Persistence {
+            message: source.to_string(),
+            source,
+        }
+    }
+
+    fn persistence_context(source: io::Error, message: impl Into<String>) -> Self {
+        Self::Persistence {
+            message: message.into(),
+            source,
+        }
+    }
+
+    fn wire_code(&self) -> ErrorCode {
+        match self {
+            Self::Validation(_) => ErrorCode::InvalidArgument,
+            Self::Lifecycle { code, .. } => *code,
+            Self::Persistence { .. } => ErrorCode::PersistenceFailed,
+            Self::Protocol(_) => ErrorCode::UnsupportedVersion,
+            Self::Internal(_) => ErrorCode::Internal,
+        }
+    }
+
+    fn into_response(self) -> Response {
+        error_response(self.wire_code(), self.to_string())
     }
 }
 
-impl std::error::Error for DaemonCodeError {}
-
-impl std::fmt::Display for PersistenceError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(formatter)
+impl From<io::Error> for DaemonError {
+    fn from(source: io::Error) -> Self {
+        match source.kind() {
+            io::ErrorKind::InvalidInput | io::ErrorKind::InvalidData => Self::Validation(source),
+            io::ErrorKind::NotFound => Self::Lifecycle {
+                code: ErrorCode::NotFound,
+                source,
+            },
+            io::ErrorKind::AlreadyExists => Self::Lifecycle {
+                code: ErrorCode::AlreadyExists,
+                source,
+            },
+            io::ErrorKind::WouldBlock | io::ErrorKind::AddrInUse => Self::Lifecycle {
+                code: ErrorCode::Busy,
+                source,
+            },
+            io::ErrorKind::ConnectionAborted => Self::Lifecycle {
+                code: ErrorCode::DaemonStopping,
+                source,
+            },
+            io::ErrorKind::TimedOut => Self::Lifecycle {
+                code: ErrorCode::Timeout,
+                source,
+            },
+            _ => Self::Internal(source),
+        }
     }
 }
 
-impl std::error::Error for PersistenceError {
+impl std::fmt::Display for DaemonError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Persistence { message, .. } => formatter.write_str(message),
+            Self::Validation(source)
+            | Self::Protocol(source)
+            | Self::Internal(source)
+            | Self::Lifecycle { source, .. } => source.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for DaemonError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.0)
+        match self {
+            Self::Persistence { source, .. }
+            | Self::Validation(source)
+            | Self::Protocol(source)
+            | Self::Internal(source)
+            | Self::Lifecycle { source, .. } => Some(source),
+        }
     }
 }
 
@@ -541,7 +627,7 @@ fn launch_replacement(
     daemon_lock: &File,
     registry: &DaemonService,
     notification_settings: Option<NotificationDeliverySettings>,
-) -> io::Result<()> {
+) -> DaemonResult<()> {
     let _mutation = lock(&registry.mutation_lock)?;
     registry.ensure_running()?;
     registry.runtimes.begin_stopping();
@@ -573,6 +659,7 @@ fn launch_replacement(
                 notification_settings,
             },
         )
+        .map_err(DaemonError::from)
     })();
     if result.is_err() {
         registry.runtimes.cancel_stopping();
@@ -729,14 +816,12 @@ fn handle_connection(
         return send_response(
             &mut stream,
             protocol::PROTOCOL_VERSION,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                format!(
-                    "protocol version {} is unsupported; expected {}",
-                    request.version,
-                    protocol::PROTOCOL_VERSION
-                ),
-            ),
+            DaemonError::protocol(format!(
+                "protocol version {} is unsupported; expected {}",
+                request.version,
+                protocol::PROTOCOL_VERSION
+            ))
+            .into_response(),
         );
     }
     let response_version = request.version;
@@ -746,10 +831,7 @@ fn handle_connection(
         return send_response(
             &mut stream,
             response_version,
-            error_response(
-                ErrorCode::UnsupportedVersion,
-                unsupported_request_message(feature),
-            ),
+            DaemonError::protocol(unsupported_request_message(feature)).into_response(),
         );
     }
 
@@ -787,10 +869,11 @@ fn handle_connection(
             return send_response(
                 &mut stream,
                 response_version,
-                error_response(
+                DaemonError::lifecycle(
                     ErrorCode::Busy,
                     "another daemon transition is already in progress",
-                ),
+                )
+                .into_response(),
             );
         }
         return match registry.shutdown() {
@@ -803,10 +886,11 @@ fn handle_connection(
                 send_response(
                     &mut stream,
                     response_version,
-                    error_response(
-                        error_code(&error),
+                    DaemonError::lifecycle(
+                        error.wire_code(),
                         format!("could not stop Boomux daemon: {error}"),
-                    ),
+                    )
+                    .into_response(),
                 )
             }
         };
@@ -831,7 +915,8 @@ fn handle_connection(
             return send_response(
                 &mut stream,
                 response_version,
-                error_response(ErrorCode::Busy, "daemon restart is already in progress"),
+                DaemonError::lifecycle(ErrorCode::Busy, "daemon restart is already in progress")
+                    .into_response(),
             );
         }
         let (reply, response) = mpsc::sync_channel(1);
@@ -847,25 +932,22 @@ fn handle_connection(
         }
         return match response.recv_timeout(RESTART_TIMEOUT) {
             Ok(Ok(())) => send_response(&mut stream, response_version, Response::Ok),
-            Ok(Err(error)) => send_response(
-                &mut stream,
-                response_version,
-                error_response(error_code(&error), error.to_string()),
-            ),
+            Ok(Err(error)) => send_response(&mut stream, response_version, error.into_response()),
             Err(error) => send_response(
                 &mut stream,
                 response_version,
-                error_response(
+                DaemonError::lifecycle(
                     ErrorCode::Timeout,
                     format!("daemon restart timed out: {error}"),
-                ),
+                )
+                .into_response(),
             ),
         };
     }
 
     let response = match registry.dispatch(request.message) {
         Ok(response) => response,
-        Err(error) => error_response(error_code(&error), error.to_string()),
+        Err(error) => error.into_response(),
     };
     send_response(
         &mut stream,
@@ -1059,46 +1141,15 @@ fn send_response(stream: &mut UnixStream, version: u32, response: Response) -> i
     protocol::write_message(stream, &Envelope::with_version(version, response))
 }
 
+fn send_daemon_error(stream: &mut UnixStream, version: u32, error: DaemonError) -> io::Result<()> {
+    send_response(stream, version, error.into_response())
+}
+
 fn error_response(code: ErrorCode, message: impl Into<String>) -> Response {
     Response::Error {
         message: message.into(),
         code: Some(code),
     }
-}
-
-fn error_code(error: &io::Error) -> ErrorCode {
-    if let Some(error) = error
-        .get_ref()
-        .and_then(|error| error.downcast_ref::<DaemonCodeError>())
-    {
-        return error.code;
-    }
-    if error
-        .get_ref()
-        .is_some_and(|error| error.downcast_ref::<PersistenceError>().is_some())
-    {
-        return ErrorCode::PersistenceFailed;
-    }
-    match error.kind() {
-        io::ErrorKind::InvalidInput | io::ErrorKind::InvalidData => ErrorCode::InvalidArgument,
-        io::ErrorKind::NotFound => ErrorCode::NotFound,
-        io::ErrorKind::AlreadyExists => ErrorCode::AlreadyExists,
-        io::ErrorKind::WouldBlock | io::ErrorKind::AddrInUse => ErrorCode::Busy,
-        io::ErrorKind::ConnectionAborted => ErrorCode::DaemonStopping,
-        io::ErrorKind::TimedOut => ErrorCode::Timeout,
-        _ => ErrorCode::Internal,
-    }
-}
-
-fn persistence_error(error: io::Error) -> io::Error {
-    io::Error::new(error.kind(), PersistenceError(error))
-}
-
-fn coded_error(code: ErrorCode, message: impl Into<String>) -> io::Error {
-    io::Error::other(DaemonCodeError {
-        code,
-        message: message.into(),
-    })
 }
 
 struct DaemonService {
@@ -1412,14 +1463,14 @@ impl EventStream {
         &self,
         wait_ms: u32,
         stopping: impl Fn() -> bool,
-        mut inspect: impl FnMut(bool) -> io::Result<Option<T>>,
-    ) -> io::Result<T> {
+        mut inspect: impl FnMut(bool) -> DaemonResult<Option<T>>,
+    ) -> DaemonResult<T> {
         let deadline =
             Instant::now() + Duration::from_millis(u64::from(wait_ms)).min(MAX_EVENT_WAIT);
         let mut state = lock(&self.state)?;
         loop {
             if stopping() {
-                return Err(coded_error(
+                return Err(DaemonError::lifecycle(
                     ErrorCode::DaemonStopping,
                     "Boomux daemon is stopping",
                 ));
@@ -1485,7 +1536,7 @@ impl EventStream {
         limit: usize,
         wait_ms: u32,
         stopping: impl Fn() -> bool,
-    ) -> io::Result<Response> {
+    ) -> DaemonResult<Response> {
         let deadline =
             Instant::now() + Duration::from_millis(u64::from(wait_ms)).min(MAX_EVENT_WAIT);
         let mut state = lock(&self.state)?;
@@ -1498,7 +1549,7 @@ impl EventStream {
                 || after.event_id < earliest
                 || after.event_id > state.latest_id
             {
-                return Err(coded_error(
+                return Err(DaemonError::lifecycle(
                     ErrorCode::CursorExpired,
                     "event cursor is no longer available",
                 ));
@@ -1523,7 +1574,7 @@ impl EventStream {
                 });
             }
             if stopping() {
-                return Err(coded_error(
+                return Err(DaemonError::lifecycle(
                     ErrorCode::DaemonStopping,
                     "Boomux daemon is stopping",
                 ));
@@ -1918,7 +1969,7 @@ impl DurableRegistry {
         shell_id: &str,
         run_id: &str,
         spec: AgentRegistrationSpec,
-    ) -> io::Result<AgentInstanceSnapshot> {
+    ) -> DaemonResult<AgentInstanceSnapshot> {
         validate_agent_registration(&spec)?;
         validate_external_agent_authority(spec.report.authority)?;
         let shell = self.shell(shell_id)?;
@@ -1955,13 +2006,13 @@ impl DurableRegistry {
         let snapshot = agent.snapshot()?;
         let mut state = lock(&self.state)?;
         let Some(current_shell) = state.shells.get(shell_id) else {
-            return Err(not_found("shell", shell_id));
+            return Err(not_found("shell", shell_id).into());
         };
         let Some(current_workspace) = state.workspaces.get(&shell.workspace_id) else {
-            return Err(not_found("workspace", &shell.workspace_id));
+            return Err(not_found("workspace", &shell.workspace_id).into());
         };
         if !Arc::ptr_eq(current_shell, &shell) || !Arc::ptr_eq(current_workspace, &workspace) {
-            return Err(not_found("shell", shell_id));
+            return Err(not_found("shell", shell_id).into());
         }
         let lifecycle = lock(&shell.lifecycle)?;
         match &*lifecycle {
@@ -1969,12 +2020,12 @@ impl DurableRegistry {
             ShellLifecycle::Running { .. }
             | ShellLifecycle::Exited { .. }
             | ShellLifecycle::Pending => {
-                return Err(coded_error(
+                return Err(DaemonError::lifecycle(
                     ErrorCode::RunChanged,
                     "shell does not have the requested active run",
                 ));
             }
-            ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
+            ShellLifecycle::Closed => return Err(not_found("shell", shell_id).into()),
         }
         state.agents.insert(agent.id.clone(), Arc::clone(&agent));
         lock(&workspace.agent_ids)?.push(agent.id.clone());
@@ -1986,7 +2037,7 @@ impl DurableRegistry {
         shell_id: &str,
         run_id: &str,
         spec: AgentRegistrationSpec,
-    ) -> io::Result<(AgentInstanceSnapshot, bool)> {
+    ) -> DaemonResult<(AgentInstanceSnapshot, bool)> {
         validate_agent_registration(&spec)?;
         validate_external_agent_authority(spec.report.authority)?;
         let external_session_id = spec.external_session_id.as_deref().ok_or_else(|| {
@@ -2025,7 +2076,8 @@ impl DurableRegistry {
                         return Err(io::Error::new(
                             io::ErrorKind::AlreadyExists,
                             "multiple agent instances match the ensured identity",
-                        ));
+                        )
+                        .into());
                     }
                 }
             }
@@ -2042,12 +2094,12 @@ impl DurableRegistry {
         agent_id: &str,
         run_id: &str,
         report: AgentReport,
-    ) -> io::Result<(AgentInstanceSnapshot, bool, bool)> {
+    ) -> DaemonResult<(AgentInstanceSnapshot, bool, bool)> {
         validate_agent_report(&report)?;
         validate_external_agent_authority(report.authority)?;
         let agent = self.agent(agent_id)?;
         if agent.run_id != run_id {
-            return Err(coded_error(
+            return Err(DaemonError::lifecycle(
                 ErrorCode::RunChanged,
                 "agent instance is bound to a different shell run",
             ));
@@ -2061,7 +2113,8 @@ impl DurableRegistry {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "completed agent instance cannot be reported again",
-            ));
+            )
+            .into());
         }
         let repeated_working = state.observation.state == AgentState::Working
             && report.state == AgentState::Working
@@ -2106,7 +2159,7 @@ impl DurableRegistry {
         &self,
         agent_id: &str,
         observation_revision: u64,
-    ) -> io::Result<(AgentInstanceSnapshot, bool)> {
+    ) -> DaemonResult<(AgentInstanceSnapshot, bool)> {
         let agent = self.agent(agent_id)?;
         let mut state = lock(&agent.state)?;
         let Some(attention) = &state.attention else {
@@ -2114,7 +2167,7 @@ impl DurableRegistry {
             return Ok((agent.snapshot()?, false));
         };
         if attention.observation.revision != observation_revision {
-            return Err(coded_error(
+            return Err(DaemonError::lifecycle(
                 ErrorCode::RevisionAhead,
                 format!(
                     "agent attention observation revision is {}; acknowledgment supplied {}",
@@ -2499,10 +2552,9 @@ impl ShellRuntimeManager {
         expected_run_id: Option<&str>,
         after_revision: Option<u64>,
         wait_ms: u32,
-    ) -> io::Result<Response> {
+    ) -> DaemonResult<Response> {
         if expected_run_id.is_some() != after_revision.is_some() {
-            return Err(coded_error(
-                ErrorCode::InvalidArgument,
+            return Err(DaemonError::validation(
                 "run_id and after_revision must be provided together",
             ));
         }
@@ -2514,7 +2566,7 @@ impl ShellRuntimeManager {
             let (status, run, runtime, terminal) = match &*lifecycle {
                 ShellLifecycle::Pending => {
                     if expected_run_id.is_some() {
-                        return Err(coded_error(
+                        return Err(DaemonError::lifecycle(
                             ErrorCode::RunChanged,
                             "shell no longer has the requested run",
                         ));
@@ -2544,7 +2596,7 @@ impl ShellRuntimeManager {
                     None,
                     Arc::clone(terminal),
                 ),
-                ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
+                ShellLifecycle::Closed => return Err(not_found("shell", shell_id).into()),
             };
             drop(lifecycle);
             let terminal_state = lock(&terminal)?;
@@ -2591,13 +2643,13 @@ impl ShellRuntimeManager {
                 continue;
             }
             if expected_run_id.is_some_and(|expected| expected != run.id) {
-                return Err(coded_error(
+                return Err(DaemonError::lifecycle(
                     ErrorCode::RunChanged,
                     "shell run identity changed",
                 ));
             }
             if after_revision.is_some_and(|after| after > revision) {
-                return Err(coded_error(
+                return Err(DaemonError::lifecycle(
                     ErrorCode::RevisionAhead,
                     "requested output revision is ahead of the current run",
                 ));
@@ -2621,7 +2673,7 @@ impl ShellRuntimeManager {
                 });
             }
             if self.is_stopping() {
-                return Err(coded_error(
+                return Err(DaemonError::lifecycle(
                     ErrorCode::DaemonStopping,
                     "Boomux daemon is stopping",
                 ));
@@ -2629,7 +2681,7 @@ impl ShellRuntimeManager {
             let runtime = runtime.expect("running shell has a runtime");
             let wait = lock(&runtime.output_wait)?;
             if self.is_stopping() {
-                return Err(coded_error(
+                return Err(DaemonError::lifecycle(
                     ErrorCode::DaemonStopping,
                     "Boomux daemon is stopping",
                 ));
@@ -3691,7 +3743,7 @@ impl DaemonService {
         self.durable.agent_resume_command(shell, previous_run)
     }
 
-    fn dispatch(&self, request: Request) -> io::Result<Response> {
+    fn dispatch(&self, request: Request) -> DaemonResult<Response> {
         match request {
             Request::Ping => Ok(Response::Pong),
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
@@ -3947,7 +3999,7 @@ impl DaemonService {
         after: Option<&EventCursor>,
         limit: u16,
         wait_ms: u32,
-    ) -> io::Result<Response> {
+    ) -> DaemonResult<Response> {
         let limit = usize::from(limit.clamp(1, MAX_EVENT_BATCH));
         if after.is_none() {
             let _mutation = lock(&self.mutation_lock)?;
@@ -4312,8 +4364,8 @@ impl ShellRuntimeManager {
 impl DaemonService {
     fn durable_mutation<T>(
         &self,
-        operation: impl FnOnce() -> io::Result<(T, Vec<DaemonEventKind>)>,
-    ) -> io::Result<T> {
+        operation: impl FnOnce() -> DaemonResult<(T, Vec<DaemonEventKind>)>,
+    ) -> DaemonResult<T> {
         self.durable_mutation_outcome(|| {
             let (value, events) = operation()?;
             Ok(DurableMutation::Changed(value, events))
@@ -4322,8 +4374,8 @@ impl DaemonService {
 
     fn durable_mutation_outcome<T>(
         &self,
-        operation: impl FnOnce() -> io::Result<DurableMutation<T>>,
-    ) -> io::Result<T> {
+        operation: impl FnOnce() -> DaemonResult<DurableMutation<T>>,
+    ) -> DaemonResult<T> {
         let mutation = lock(&self.mutation_lock)?;
         self.ensure_running()?;
         self.flush_pending()?;
@@ -4335,13 +4387,16 @@ impl DaemonService {
             Ok(DurableMutation::Changed(value, kinds)) => {
                 if let Err(error) = transaction.reserve(kinds.len()) {
                     self.restore_backup(backup)?;
-                    return Err(error);
+                    return Err(error.into());
                 }
                 let notifications = self.notification_requests(&kinds, &backup);
                 let saved = self.capture_persisted_state()?;
                 transaction.begin_persistence(kinds.len());
                 drop(transaction);
-                match self.write_persisted_state(saved).map_err(persistence_error) {
+                match self
+                    .write_persisted_state(saved)
+                    .map_err(DaemonError::persistence)
+                {
                     Ok(()) => {
                         let mut transaction = self.events.transaction()?;
                         transaction.append_batch(kinds);
@@ -4449,7 +4504,7 @@ impl DaemonService {
         self.durable.notification_context(workspace_id, shell_id)
     }
 
-    fn flush_pending(&self) -> io::Result<bool> {
+    fn flush_pending(&self) -> DaemonResult<bool> {
         let _persistence = lock(&self.durable.persist_lock)?;
         let mut transaction = self.events.transaction()?;
         if transaction.pending_durable_batch_count() == 0
@@ -4464,7 +4519,10 @@ impl DaemonService {
         let pending = transaction.take_pending_durable(pending_count);
         transaction.begin_persistence(count);
         drop(transaction);
-        if let Err(error) = self.write_persisted_state(saved).map_err(persistence_error) {
+        if let Err(error) = self
+            .write_persisted_state(saved)
+            .map_err(DaemonError::persistence)
+        {
             let mut transaction = self.events.transaction()?;
             transaction.restore_pending_durable(pending);
             transaction.finish_persistence();
@@ -4575,7 +4633,7 @@ impl DaemonService {
         let saved = self.capture_persisted_state()?;
         transaction.begin_persistence(pending_count.saturating_add(1));
         drop(transaction);
-        match self.write_persisted_state(saved).map_err(persistence_error) {
+        match self.write_persisted_state(saved) {
             Ok(()) => {
                 let mut transaction = self.events.transaction()?;
                 transaction.append_pending_durable();
@@ -4699,7 +4757,7 @@ impl DaemonService {
             .import_focused_terminal(focused_terminal, current)
     }
 
-    fn shutdown(&self) -> io::Result<()> {
+    fn shutdown(&self) -> DaemonResult<()> {
         let _mutation = lock(&self.mutation_lock)?;
         if !self.runtimes.begin_stopping() {
             return Ok(());
@@ -4716,7 +4774,7 @@ impl DaemonService {
                 let mut transition = self.events.transition()?;
                 self.compensate_stopped_locked(&stopped, &mut transition)?;
                 self.runtimes.cancel_stopping();
-                return Err(error.source);
+                return Err(error.source.into());
             }
             stopped.push(Arc::clone(shell));
         }
@@ -4737,14 +4795,17 @@ impl DaemonService {
                         self.runtimes.restore_stopped(&shell, rollback)?;
                     }
                     self.runtimes.cancel_stopping();
-                    return Err(error);
+                    return Err(error.into());
                 }
             }
         }
         let saved = self.capture_persisted_state()?;
         transaction.begin_persistence(0);
         drop(transaction);
-        if let Err(error) = self.write_persisted_state(saved).map_err(persistence_error) {
+        if let Err(error) = self
+            .write_persisted_state(saved)
+            .map_err(DaemonError::persistence)
+        {
             let batch = rollbacks
                 .iter()
                 .filter_map(|(_, rollback)| rollback.event.clone())
@@ -4825,7 +4886,7 @@ impl DaemonService {
         shell_id: &str,
         run_id: &str,
         spec: AgentRegistrationSpec,
-    ) -> io::Result<AgentInstanceSnapshot> {
+    ) -> DaemonResult<AgentInstanceSnapshot> {
         self.durable.register_agent(shell_id, run_id, spec)
     }
 
@@ -4834,7 +4895,7 @@ impl DaemonService {
         shell_id: &str,
         run_id: &str,
         spec: AgentRegistrationSpec,
-    ) -> io::Result<(AgentInstanceSnapshot, bool)> {
+    ) -> DaemonResult<(AgentInstanceSnapshot, bool)> {
         self.durable.ensure_agent(shell_id, run_id, spec)
     }
 
@@ -4843,7 +4904,7 @@ impl DaemonService {
         agent_id: &str,
         run_id: &str,
         report: AgentReport,
-    ) -> io::Result<(AgentInstanceSnapshot, bool, bool)> {
+    ) -> DaemonResult<(AgentInstanceSnapshot, bool, bool)> {
         self.durable.report_agent(agent_id, run_id, report)
     }
 
@@ -4851,7 +4912,7 @@ impl DaemonService {
         &self,
         agent_id: &str,
         observation_revision: u64,
-    ) -> io::Result<(AgentInstanceSnapshot, bool)> {
+    ) -> DaemonResult<(AgentInstanceSnapshot, bool)> {
         self.durable
             .acknowledge_agent_attention(agent_id, observation_revision)
     }
@@ -4889,7 +4950,7 @@ impl DaemonService {
         agent_id: &str,
         after_revision: u64,
         wait_ms: u32,
-    ) -> io::Result<Response> {
+    ) -> DaemonResult<Response> {
         self.events.wait_for(
             wait_ms,
             || self.runtimes.is_stopping(),
@@ -4903,7 +4964,7 @@ impl DaemonService {
                     }));
                 }
                 if after_revision > revision {
-                    return Err(coded_error(
+                    return Err(DaemonError::lifecycle(
                         ErrorCode::RevisionAhead,
                         "requested Agent revision is ahead of the current observation",
                     ));
@@ -4926,7 +4987,7 @@ impl DaemonService {
         expected_run_id: Option<&str>,
         after_revision: Option<u64>,
         wait_ms: u32,
-    ) -> io::Result<Response> {
+    ) -> DaemonResult<Response> {
         self.runtimes.read_shell_at(
             self,
             shell_id,
@@ -4945,7 +5006,7 @@ impl DaemonService {
         self.durable.remove_workspace(workspace_id)
     }
 
-    fn close_shell(&self, shell_id: &str) -> io::Result<()> {
+    fn close_shell(&self, shell_id: &str) -> DaemonResult<()> {
         let _mutation = lock(&self.mutation_lock)?;
         self.ensure_running()?;
         let backup = self.backup()?;
@@ -4955,7 +5016,7 @@ impl DaemonService {
                 let mut transition = self.events.transition()?;
                 self.compensate_stopped_locked(std::slice::from_ref(&shell), &mut transition)?;
             }
-            return Err(error.source);
+            return Err(error.source.into());
         }
         if let Err(error) = self.flush_pending() {
             let mut transition = self.events.transition()?;
@@ -4966,14 +5027,17 @@ impl DaemonService {
         let mut transaction = self.events.transaction()?;
         if let Err(error) = transaction.reserve(1) {
             self.compensate_stopped_locked(std::slice::from_ref(&shell), &mut transaction)?;
-            return Err(error);
+            return Err(error.into());
         }
         let rollback = self.runtimes.finalize_stop(&shell)?;
         self.remove_shell(shell_id)?;
         let saved = self.capture_persisted_state()?;
         transaction.begin_persistence(1);
         drop(transaction);
-        if let Err(error) = self.write_persisted_state(saved).map_err(persistence_error) {
+        if let Err(error) = self
+            .write_persisted_state(saved)
+            .map_err(DaemonError::persistence)
+        {
             self.restore_backup(backup)?;
             let event = rollback.event.clone();
             self.runtimes.restore_stopped(&shell, rollback)?;
@@ -4995,7 +5059,7 @@ impl DaemonService {
         Ok(())
     }
 
-    fn close_workspace(&self, workspace_id: &str) -> io::Result<()> {
+    fn close_workspace(&self, workspace_id: &str) -> DaemonResult<()> {
         let _mutation = lock(&self.mutation_lock)?;
         self.ensure_running()?;
         let backup = self.backup()?;
@@ -5009,7 +5073,7 @@ impl DaemonService {
                 }
                 let mut transition = self.events.transition()?;
                 self.compensate_stopped_locked(&stopped, &mut transition)?;
-                return Err(error.source);
+                return Err(error.source.into());
             }
             stopped.push(Arc::clone(shell));
         }
@@ -5022,7 +5086,7 @@ impl DaemonService {
         let mut transaction = self.events.transaction()?;
         if let Err(error) = transaction.reserve(1) {
             self.compensate_stopped_locked(&stopped, &mut transaction)?;
-            return Err(error);
+            return Err(error.into());
         }
         let mut rollbacks = Vec::with_capacity(shells.len());
         for shell in &shells {
@@ -5032,7 +5096,7 @@ impl DaemonService {
                     for (shell, rollback) in rollbacks {
                         self.runtimes.restore_stopped(&shell, rollback)?;
                     }
-                    return Err(error);
+                    return Err(error.into());
                 }
             }
         }
@@ -5040,7 +5104,10 @@ impl DaemonService {
         let saved = self.capture_persisted_state()?;
         transaction.begin_persistence(1);
         drop(transaction);
-        if let Err(error) = self.write_persisted_state(saved).map_err(persistence_error) {
+        if let Err(error) = self
+            .write_persisted_state(saved)
+            .map_err(DaemonError::persistence)
+        {
             self.restore_backup(backup)?;
             let batch = rollbacks
                 .iter()
@@ -5066,7 +5133,7 @@ impl DaemonService {
         Ok(())
     }
 
-    fn restart_shell(&self, shell_id: &str) -> io::Result<ShellSnapshot> {
+    fn restart_shell(&self, shell_id: &str) -> DaemonResult<ShellSnapshot> {
         let _mutation = lock(&self.mutation_lock)?;
         self.ensure_running()?;
         let shell = self.shell(shell_id)?;
@@ -5075,16 +5142,16 @@ impl DaemonService {
             let old_runtime = match &*lifecycle {
                 ShellLifecycle::Pending => {
                     drop(lifecycle);
-                    return shell.snapshot();
+                    return Ok(shell.snapshot()?);
                 }
                 ShellLifecycle::Running { .. } => {
-                    return Err(coded_error(
+                    return Err(DaemonError::lifecycle(
                         ErrorCode::Busy,
                         format!("shell is still running: {shell_id}"),
                     ));
                 }
                 ShellLifecycle::Exited { runtime, .. } => runtime.clone(),
-                ShellLifecycle::Closed => return Err(not_found("shell", shell_id)),
+                ShellLifecycle::Closed => return Err(not_found("shell", shell_id).into()),
             };
             *lifecycle = ShellLifecycle::Pending;
             old_runtime
@@ -5092,7 +5159,7 @@ impl DaemonService {
         if let Some(runtime) = old_runtime {
             self.runtimes.stop_reader(&runtime)?;
         }
-        shell.snapshot()
+        Ok(shell.snapshot()?)
     }
 }
 
@@ -5723,29 +5790,17 @@ impl ShellRuntimeManager {
             environment,
         } = options;
         if let Err(error) = validate_terminal_profile(&profile) {
-            return send_response(
-                &mut stream,
-                response_version,
-                error_response(ErrorCode::InvalidArgument, error.to_string()),
-            );
+            return send_daemon_error(&mut stream, response_version, error.into());
         }
         if let Some(environment) = &environment
             && let Err(error) = validate_unix_environment(environment)
         {
-            return send_response(
-                &mut stream,
-                response_version,
-                error_response(ErrorCode::InvalidArgument, error.to_string()),
-            );
+            return send_daemon_error(&mut stream, response_version, error.into());
         }
         let shell = match registry.shell(shell_id) {
             Ok(shell) => shell,
             Err(error) => {
-                return send_response(
-                    &mut stream,
-                    response_version,
-                    error_response(error_code(&error), error.to_string()),
-                );
+                return send_daemon_error(&mut stream, response_version, error.into());
             }
         };
         let mutation = lock(&registry.mutation_lock)?;
@@ -5753,7 +5808,8 @@ impl ShellRuntimeManager {
             return send_response(
                 &mut stream,
                 response_version,
-                error_response(ErrorCode::DaemonStopping, "Boomux daemon is stopping"),
+                DaemonError::lifecycle(ErrorCode::DaemonStopping, "Boomux daemon is stopping")
+                    .into_response(),
             );
         }
         let token = Uuid::new_v4().to_string();
@@ -5763,7 +5819,8 @@ impl ShellRuntimeManager {
             return send_response(
                 &mut stream,
                 response_version,
-                error_response(ErrorCode::NotFound, format!("shell not found: {shell_id}")),
+                DaemonError::lifecycle(ErrorCode::NotFound, format!("shell not found: {shell_id}"))
+                    .into_response(),
             );
         }
         let workspace = registry.workspace(&shell.workspace_id)?;
@@ -5797,8 +5854,8 @@ impl ShellRuntimeManager {
                     .flatten()
             })
             .flatten();
-        if needs_start {
-            registry.flush_pending()?;
+        if needs_start && let Err(error) = registry.flush_pending() {
+            return send_daemon_error(&mut stream, response_version, error);
         }
         let persistence = needs_start
             .then(|| lock(&registry.durable.persist_lock))
@@ -5841,10 +5898,11 @@ impl ShellRuntimeManager {
                         return send_response(
                             &mut stream,
                             response_version,
-                            error_response(
+                            DaemonError::lifecycle(
                                 ErrorCode::ShellStartFailed,
                                 format!("could not start shell: {error}"),
-                            ),
+                            )
+                            .into_response(),
                         );
                     }
                 };
@@ -5869,7 +5927,7 @@ impl ShellRuntimeManager {
                     return send_response(
                     &mut stream,
                     response_version,
-                    error_response(
+                    DaemonError::lifecycle(
                         ErrorCode::ShellStartFailed,
                         cleanup.map_or_else(
                             |cleanup| {
@@ -5879,7 +5937,8 @@ impl ShellRuntimeManager {
                             },
                             |()| format!("could not start shell reader: {error}"),
                         ),
-                    ),
+                    )
+                    .into_response(),
                 );
                 }
             }
@@ -5911,7 +5970,11 @@ impl ShellRuntimeManager {
                     return send_response(
                         &mut stream,
                         response_version,
-                        error_response(ErrorCode::NotFound, format!("shell not found: {shell_id}")),
+                        DaemonError::lifecycle(
+                            ErrorCode::NotFound,
+                            format!("shell not found: {shell_id}"),
+                        )
+                        .into_response(),
                     );
                 }
             }
@@ -5923,29 +5986,24 @@ impl ShellRuntimeManager {
                 .expect("start event transaction is locked")
                 .begin_persistence(1);
             drop(event_transaction);
-            if let Err(error) = registry
-                .write_persisted_state(saved)
-                .map_err(persistence_error)
-            {
+            if let Err(error) = registry.write_persisted_state(saved) {
                 let cleanup = self.kill(&shell);
                 self.reset_pending(&shell)?;
                 let mut transaction = registry.events.transaction()?;
                 transaction.finish_persistence();
-                return send_response(
-                &mut stream,
-                response_version,
-                error_response(
-                    ErrorCode::PersistenceFailed,
-                    cleanup.map_or_else(
-                        |cleanup| {
-                            format!(
-                                "could not persist started shell: {error}; process cleanup also failed: {cleanup}"
-                            )
-                        },
-                        |()| format!("could not persist started shell: {error}"),
-                    ),
-                ),
-            );
+                let message = cleanup.map_or_else(
+                    |cleanup| {
+                        format!(
+                            "could not persist started shell: {error}; process cleanup also failed: {cleanup}"
+                        )
+                    },
+                    |()| format!("could not persist started shell: {error}"),
+                );
+                return send_daemon_error(
+                    &mut stream,
+                    response_version,
+                    DaemonError::persistence_context(error, message),
+                );
             }
             event_transaction = Some(registry.events.transaction()?);
         }
@@ -5996,10 +6054,11 @@ impl ShellRuntimeManager {
                 return send_response(
                     &mut stream,
                     response_version,
-                    error_response(
+                    DaemonError::lifecycle(
                         ErrorCode::Busy,
                         "shell already has an active controller; use takeover",
-                    ),
+                    )
+                    .into_response(),
                 );
             }
         }
@@ -7213,7 +7272,7 @@ mod tests {
         }
 
         let error = registry.read_events(Some(&cursor), 256, 0).unwrap_err();
-        assert_eq!(error_code(&error), ErrorCode::CursorExpired);
+        assert_eq!(error.wire_code(), ErrorCode::CursorExpired);
     }
 
     #[test]
@@ -7392,6 +7451,51 @@ mod tests {
             io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
         ));
         assert!(started.elapsed() < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn daemon_errors_convert_to_stable_codes_at_the_wire_boundary() {
+        let cases = [
+            (
+                io::Error::new(io::ErrorKind::InvalidInput, "invalid request").into(),
+                ErrorCode::InvalidArgument,
+                "invalid request",
+            ),
+            (
+                DaemonError::lifecycle(ErrorCode::RunChanged, "run changed"),
+                ErrorCode::RunChanged,
+                "run changed",
+            ),
+            (
+                DaemonError::persistence(io::Error::other("state write failed")),
+                ErrorCode::PersistenceFailed,
+                "state write failed",
+            ),
+            (
+                DaemonError::protocol("unsupported request"),
+                ErrorCode::UnsupportedVersion,
+                "unsupported request",
+            ),
+            (
+                io::Error::other("unexpected failure").into(),
+                ErrorCode::Internal,
+                "unexpected failure",
+            ),
+        ];
+
+        for (error, expected_code, expected_message) in cases {
+            let (mut server, mut client) = UnixStream::pair().unwrap();
+            send_daemon_error(&mut server, protocol::PROTOCOL_VERSION, error).unwrap();
+            let response: Envelope<Response> = protocol::read_message(&mut client).unwrap();
+            assert_eq!(response.version, protocol::PROTOCOL_VERSION);
+            assert_eq!(
+                response.message,
+                Response::Error {
+                    message: expected_message.into(),
+                    code: Some(expected_code),
+                }
+            );
+        }
     }
 
     #[test]
@@ -7762,7 +7866,7 @@ mod tests {
             run_id: Uuid::new_v4().to_string(),
             spec: agent_spec(AgentState::Working),
         });
-        assert_eq!(error_code(&wrong_run.unwrap_err()), ErrorCode::RunChanged);
+        assert_eq!(wrong_run.unwrap_err().wire_code(), ErrorCode::RunChanged);
 
         let Response::Agent { agent } = registry
             .dispatch(Request::RegisterAgent {
@@ -7778,15 +7882,14 @@ mod tests {
         assert_eq!(agent.observation.revision, 1);
         assert!(agent.ended_at_ms.is_none());
         assert_eq!(
-            error_code(
-                &registry
-                    .dispatch(Request::ReportAgent {
-                        agent_id: agent.id.clone(),
-                        run_id: Uuid::new_v4().to_string(),
-                        report: agent_spec(AgentState::Idle).report,
-                    })
-                    .unwrap_err()
-            ),
+            registry
+                .dispatch(Request::ReportAgent {
+                    agent_id: agent.id.clone(),
+                    run_id: Uuid::new_v4().to_string(),
+                    report: agent_spec(AgentState::Idle).report,
+                })
+                .unwrap_err()
+                .wire_code(),
             ErrorCode::RunChanged
         );
 
@@ -7941,8 +8044,8 @@ mod tests {
             registry
                 .ensure_agent(&shell.id, &run_id, agent_spec(AgentState::Working))
                 .unwrap_err()
-                .kind(),
-            io::ErrorKind::AlreadyExists
+                .wire_code(),
+            ErrorCode::AlreadyExists
         );
         shell.kill().unwrap();
         registry.close_workspace(&workspace.id).unwrap();
@@ -7963,8 +8066,8 @@ mod tests {
                     spec: missing_id,
                 })
                 .unwrap_err()
-                .kind(),
-            io::ErrorKind::InvalidInput
+                .wire_code(),
+            ErrorCode::InvalidArgument
         );
         let Response::Agent { agent: first } = registry
             .dispatch(Request::EnsureAgent {
@@ -8137,9 +8240,9 @@ mod tests {
             .register_agent(&shell.id, &run_id, agent_spec(AgentState::Working))
             .unwrap();
 
-        let result: io::Result<()> = registry.durable_mutation(|| {
+        let result: DaemonResult<()> = registry.durable_mutation(|| {
             registry.report_agent(&agent.id, &run_id, agent_spec(AgentState::Blocked).report)?;
-            Err(io::Error::other("force rollback"))
+            Err(io::Error::other("force rollback").into())
         });
 
         assert!(result.is_err());
@@ -8497,7 +8600,7 @@ mod tests {
             })
             .unwrap_err();
 
-        assert_eq!(error_code(&error), ErrorCode::PersistenceFailed);
+        assert_eq!(error.wire_code(), ErrorCode::PersistenceFailed);
         assert!(
             registry
                 .agent(&agent.id)
@@ -8524,7 +8627,7 @@ mod tests {
         let revision = agent.observation.revision;
 
         let mismatch = registry.acknowledge_agent_attention(&agent.id, revision + 1);
-        assert_eq!(error_code(&mismatch.unwrap_err()), ErrorCode::RevisionAhead);
+        assert_eq!(mismatch.unwrap_err().wire_code(), ErrorCode::RevisionAhead);
         assert!(
             registry
                 .agent(&agent.id)
@@ -8535,9 +8638,9 @@ mod tests {
                 .is_some()
         );
 
-        let result: io::Result<()> = registry.durable_mutation(|| {
+        let result: DaemonResult<()> = registry.durable_mutation(|| {
             registry.acknowledge_agent_attention(&agent.id, revision)?;
-            Err(io::Error::other("force rollback"))
+            Err(io::Error::other("force rollback").into())
         });
         assert!(result.is_err());
         assert!(
@@ -8614,7 +8717,10 @@ mod tests {
         };
         assert!(!changed);
         assert_eq!(
-            error_code(&registry.wait_agent(&agent.id, 2, 0).unwrap_err()),
+            registry
+                .wait_agent(&agent.id, 2, 0)
+                .unwrap_err()
+                .wire_code(),
             ErrorCode::RevisionAhead
         );
 
@@ -8691,7 +8797,7 @@ mod tests {
         registry.events.notify();
 
         assert_eq!(
-            error_code(&waiter.join().unwrap().unwrap_err()),
+            waiter.join().unwrap().unwrap_err().wire_code(),
             ErrorCode::DaemonStopping
         );
         registry.runtimes.cancel_stopping();

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ struct DashboardRefresh {
 }
 
 impl DashboardRefresh {
-    fn baseline(client: &client::Client) -> io::Result<Self> {
+    fn baseline(client: &client::Client) -> client::Result<Self> {
         Ok(Self {
             watch: client::SnapshotWatch::baseline(client)?,
             last_snapshot_at: Instant::now(),
@@ -62,7 +62,7 @@ impl DashboardRefresh {
         self.watch.snapshot()
     }
 
-    fn check(&mut self, client: &client::Client) -> io::Result<Option<(Snapshot, bool)>> {
+    fn check(&mut self, client: &client::Client) -> client::Result<Option<(Snapshot, bool)>> {
         match self.watch.poll(client) {
             Ok((changed, stream_changed)) => {
                 if changed {
@@ -86,7 +86,7 @@ impl DashboardRefresh {
         }
     }
 
-    fn refresh(&mut self, client: &client::Client) -> io::Result<(Snapshot, bool)> {
+    fn refresh(&mut self, client: &client::Client) -> client::Result<(Snapshot, bool)> {
         let stream_id = self.watch.stream_id().map(str::to_owned);
         *self = Self::baseline(client)?;
         Ok((
@@ -95,7 +95,7 @@ impl DashboardRefresh {
         ))
     }
 
-    fn refresh_ephemeral_fields(&mut self, client: &client::Client) -> io::Result<()> {
+    fn refresh_ephemeral_fields(&mut self, client: &client::Client) -> client::Result<()> {
         self.watch.snapshot_mut().focused_terminal = client.focused_terminal()?;
         for shell in self
             .watch

--- a/src/process_adapter.rs
+++ b/src/process_adapter.rs
@@ -91,13 +91,13 @@ trait Reporter {
         shell_id: &str,
         run_id: &str,
         spec: AgentRegistrationSpec,
-    ) -> io::Result<AgentInstanceSnapshot>;
+    ) -> client::Result<AgentInstanceSnapshot>;
     fn report(
         &mut self,
         agent_id: &str,
         run_id: &str,
         report: AgentReport,
-    ) -> io::Result<AgentInstanceSnapshot>;
+    ) -> client::Result<AgentInstanceSnapshot>;
 }
 
 #[derive(Default)]
@@ -106,7 +106,7 @@ struct BoomuxReporter {
 }
 
 impl BoomuxReporter {
-    fn client(&mut self) -> io::Result<&client::Client> {
+    fn client(&mut self) -> client::Result<&client::Client> {
         if self.client.is_none() {
             self.client = Some(client::connect_or_start()?);
         }
@@ -120,7 +120,7 @@ impl Reporter for BoomuxReporter {
         shell_id: &str,
         run_id: &str,
         spec: AgentRegistrationSpec,
-    ) -> io::Result<AgentInstanceSnapshot> {
+    ) -> client::Result<AgentInstanceSnapshot> {
         self.client()?.ensure_agent(shell_id, run_id, spec)
     }
 
@@ -129,7 +129,7 @@ impl Reporter for BoomuxReporter {
         agent_id: &str,
         run_id: &str,
         report: AgentReport,
-    ) -> io::Result<AgentInstanceSnapshot> {
+    ) -> client::Result<AgentInstanceSnapshot> {
         self.client()?.report_agent(agent_id, run_id, report)
     }
 }
@@ -293,11 +293,11 @@ mod tests {
             _shell_id: &str,
             _run_id: &str,
             spec: AgentRegistrationSpec,
-        ) -> io::Result<AgentInstanceSnapshot> {
+        ) -> client::Result<AgentInstanceSnapshot> {
             assert_eq!(spec.external_session_id.as_deref(), Some("session-1"));
             assert_report(&spec.report);
             if self.fail_ensure {
-                Err(io::Error::other("offline"))
+                Err(io::Error::other("offline").into())
             } else {
                 Ok(self.ensured.clone())
             }
@@ -308,10 +308,10 @@ mod tests {
             _agent_id: &str,
             _run_id: &str,
             report: AgentReport,
-        ) -> io::Result<AgentInstanceSnapshot> {
+        ) -> client::Result<AgentInstanceSnapshot> {
             self.reports.push(report);
             if self.fail_reports {
-                Err(io::Error::other("offline"))
+                Err(io::Error::other("offline").into())
             } else {
                 Ok(self.ensured.clone())
             }

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -9,7 +9,7 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use boomux::client::{self, Attachment, Client, RemoteError};
+use boomux::client::{self, Attachment, Client, ClientError, RemoteError};
 use boomux::protocol::{
     self, AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame, ErrorCode,
     ShellRunExitReason, ShellSpec, ShellStatus, TerminalProfile, UnixEnvironment,
@@ -978,13 +978,7 @@ fn exited_run_persistence_retries_after_storage_recovers() {
             .any(|event| matches!(event.kind, protocol::DaemonEventKind::RunExited { .. }))
     );
     let error = daemon.client.events(None, 256, 0).unwrap_err();
-    assert_eq!(
-        error
-            .get_ref()
-            .and_then(|error| error.downcast_ref::<RemoteError>())
-            .and_then(|error| error.code),
-        Some(ErrorCode::PersistenceFailed)
-    );
+    assert_remote_code(&error, ErrorCode::PersistenceFailed);
     let restart = daemon
         .command()
         .args(["daemon", "restart"])
@@ -1198,13 +1192,7 @@ fn graceful_restart_preserves_exited_run_and_terminal_state() {
     fs::rename(&state_directory, &saved_directory).unwrap();
     fs::write(&state_directory, b"not a directory").unwrap();
     let error = daemon.client.close_shell(&shell_id).unwrap_err();
-    assert_eq!(
-        error
-            .get_ref()
-            .and_then(|error| error.downcast_ref::<RemoteError>())
-            .and_then(|error| error.code),
-        Some(ErrorCode::PersistenceFailed)
-    );
+    assert_remote_code(&error, ErrorCode::PersistenceFailed);
     let rolled_back = daemon.client.get_shell(&shell_id).unwrap();
     assert_eq!(rolled_back.status, ShellStatus::Exited { code: Some(7) });
     assert_eq!(rolled_back.run.as_ref(), Some(&before_run));
@@ -1408,24 +1396,12 @@ fn daemon_events_and_revision_reads_survive_handoff() {
             0,
         )
         .unwrap_err();
-    assert_eq!(
-        error
-            .get_ref()
-            .and_then(|error| error.downcast_ref::<RemoteError>())
-            .and_then(|error| error.code),
-        Some(ErrorCode::RunChanged)
-    );
+    assert_remote_code(&error, ErrorCode::RunChanged);
     let error = daemon
         .client
         .read_shell_at(&shell_id, 1024, Some(run_id.clone()), Some(u64::MAX), 0)
         .unwrap_err();
-    assert_eq!(
-        error
-            .get_ref()
-            .and_then(|error| error.downcast_ref::<RemoteError>())
-            .and_then(|error| error.code),
-        Some(ErrorCode::RevisionAhead)
-    );
+    assert_remote_code(&error, ErrorCode::RevisionAhead);
 
     let waiting_client = daemon.client.clone();
     let waiting_shell_id = shell_id.clone();
@@ -1446,13 +1422,7 @@ fn daemon_events_and_revision_reads_survive_handoff() {
         .unwrap();
     assert!(restart.status.success());
     let error = wait.join().unwrap().unwrap_err();
-    assert_eq!(
-        error
-            .get_ref()
-            .and_then(|error| error.downcast_ref::<RemoteError>())
-            .and_then(|error| error.code),
-        Some(ErrorCode::DaemonStopping)
-    );
+    assert_remote_code(&error, ErrorCode::DaemonStopping);
     let handed_off = daemon.client.events(Some(cursor), 256, 1_000).unwrap();
     assert_eq!(handed_off.stream_id, stream_id);
     assert!(
@@ -1481,26 +1451,14 @@ fn daemon_events_and_revision_reads_survive_handoff() {
     daemon.stop_with_cli();
     daemon.restart();
     let error = daemon.client.events(Some(cursor), 256, 0).unwrap_err();
-    assert_eq!(
-        error
-            .get_ref()
-            .and_then(|error| error.downcast_ref::<RemoteError>())
-            .and_then(|error| error.code),
-        Some(ErrorCode::CursorExpired)
-    );
+    assert_remote_code(&error, ErrorCode::CursorExpired);
     let baseline = daemon.client.events(None, 256, 0).unwrap();
     let waiting_client = daemon.client.clone();
     let wait = thread::spawn(move || waiting_client.events(Some(baseline.cursor), 256, 5_000));
     thread::sleep(Duration::from_millis(50));
     daemon.stop_with_cli();
     let error = wait.join().unwrap().unwrap_err();
-    assert_eq!(
-        error
-            .get_ref()
-            .and_then(|error| error.downcast_ref::<RemoteError>())
-            .and_then(|error| error.code),
-        Some(ErrorCode::DaemonStopping)
-    );
+    assert_remote_code(&error, ErrorCode::DaemonStopping);
 }
 
 #[test]
@@ -3653,12 +3611,7 @@ fn native_daemon_lifecycle() {
 
     let missing_id = Uuid::new_v4().to_string();
     let error = daemon.client.get_shell(&missing_id).unwrap_err();
-    assert_eq!(error.kind(), io::ErrorKind::NotFound);
-    let remote = error
-        .get_ref()
-        .and_then(|error| error.downcast_ref::<RemoteError>())
-        .unwrap();
-    assert_eq!(remote.code, Some(ErrorCode::NotFound));
+    assert_remote_code(&error, ErrorCode::NotFound);
     let typed_failure = daemon
         .command()
         .args(["shells", "--json"])
@@ -3908,13 +3861,7 @@ fn native_daemon_lifecycle() {
         .attach(&failed_shell.id, false, profile())
         .unwrap_err();
     assert!(error.to_string().contains("could not start shell"));
-    assert_eq!(
-        error
-            .get_ref()
-            .and_then(|error| error.downcast_ref::<RemoteError>())
-            .and_then(|error| error.code),
-        Some(ErrorCode::ShellStartFailed)
-    );
+    assert_remote_code(&error, ErrorCode::ShellStartFailed);
     assert_eq!(
         daemon.client.get_shell(&failed_shell.id).unwrap().status,
         ShellStatus::Pending
@@ -4476,14 +4423,14 @@ fn contains(haystack: &[u8], needle: &[u8]) -> bool {
         .any(|window| window == needle)
 }
 
-fn assert_remote_code(error: &io::Error, expected: ErrorCode) {
-    assert_eq!(
-        error
-            .get_ref()
-            .and_then(|error| error.downcast_ref::<RemoteError>())
-            .and_then(|error| error.code),
-        Some(expected)
-    );
+fn assert_remote_code(error: &ClientError, expected: ErrorCode) {
+    assert!(matches!(
+        error,
+        ClientError::Remote(RemoteError {
+            code: Some(actual),
+            ..
+        }) if *actual == expected
+    ));
 }
 
 fn versioned_request(


### PR DESCRIPTION
## Summary
- add explicit daemon and client error enums that preserve transport, protocol, remote, validation, lifecycle, persistence, and internal failure classes
- derive daemon wire codes and CLI JSON codes directly from typed boundary errors instead of downcasting through `io::Error`
- preserve existing messages and stable codes with focused daemon, client, CLI, and native compatibility coverage

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --lib --bins --locked
- cargo test --test native_backend --locked -- --test-threads=1
- bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js

Closes #123