### PR TITLE
fix(tui): guide first-time workspace creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,27 @@ Closing a workspace terminates its managed shells. Closing a shell or command
 terminates its managed process. Removing a launcher affects future workspace
 opens only. Press `?` in the dashboard for context-specific controls.
 
+## Omarchy Plugin
+
+Omarchy users can add the optional
+[Boomux for Omarchy](https://github.com/gardnmi/omarchy-boomux) companion plugin
+to monitor Agents and manage Boomux workspaces from the Omarchy bar. It shows
+working, idle, blocked, and completed activity; opens workspaces or individual
+items; creates workspaces, shells, and coding-agent commands; acknowledges
+durable attention; and launches the full Boomux dashboard in a native terminal.
+
+The plugin requires Boomux `0.14.0` or newer and Omarchy's Quattro shell plugin
+system. Review its source before installation because Omarchy plugins run as
+unsandboxed code inside the long-running shell process.
+
+```console
+omarchy plugin add https://github.com/gardnmi/omarchy-boomux.git --enable
+```
+
+See the [plugin documentation](https://github.com/gardnmi/omarchy-boomux#readme)
+for controls, lifecycle-integration setup, updates, removal, privacy details,
+and troubleshooting.
+
 ## Coding-Agent Integrations
 
 Boomux includes optional lifecycle integrations for OpenCode and Pi. Guided
@@ -397,6 +418,7 @@ Revision-aware output reads and daemon event cursors are documented in
 - [Daemon events and revision-aware reads](docs/event-stream.md)
 - [Live PTY handoff](docs/live-pty-handoff.md)
 - [Integration lifecycle validation](docs/lifecycle-validation.md)
+- [Boomux for Omarchy companion plugin](https://github.com/gardnmi/omarchy-boomux)
 - [Roadmap](docs/roadmap.md)
 
 ## Development

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2630,10 +2630,17 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
             Layout::vertical([Constraint::Fill(1), Constraint::Length(preview_height)]).areas(area);
         (table_area, Some(preview_area))
     });
-    let rows = app
-        .workspaces
-        .iter()
-        .map(|workspace| Row::new([Cell::from(workspace.name.as_str())]));
+    let rows = if app.workspaces.is_empty() {
+        vec![Row::new([Cell::from(Span::styled(
+            "No workspaces. Press a to create one.",
+            Style::new().fg(SUBTEXT),
+        ))])]
+    } else {
+        app.workspaces
+            .iter()
+            .map(|workspace| Row::new([Cell::from(workspace.name.as_str())]))
+            .collect()
+    };
     let table = Table::new(rows, [Constraint::Min(8)])
         .header(Row::new(["NAME"]).style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
         .block(
@@ -6519,6 +6526,24 @@ mod tests {
         assert!(!text.contains("term_1"));
         assert!(!text.contains("DIRTY"));
         assert!(text.contains("WORKTREE"));
+    }
+
+    #[test]
+    fn empty_dashboard_explains_how_to_create_a_workspace() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new(Vec::new(), project_context());
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(text.contains("No workspaces. Press a to create one."));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- show an actionable workspace empty state in the dashboard
- document the Boomux for Omarchy companion plugin and installation
- cover the empty dashboard rendering with a regression test

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`