### PR TITLE
docs(agent): define scheduled work contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@ Use repository documentation in this order:
    semantics when names in code are less precise.
 2. `docs/architecture.md` describes the current implementation boundaries and
    cross-cutting invariants.
-3. Contract documents such as `docs/cli-json.md`, `docs/event-stream.md`, and
-   `docs/live-pty-handoff.md` govern their named interfaces and guarantees.
+3. Contract documents such as `docs/cli-json.md`, `docs/event-stream.md`,
+   `docs/live-pty-handoff.md`, and `docs/scheduled-agent-work.md` govern their
+   named interfaces and guarantees.
 4. `docs/adr/` records accepted decisions and rationale.
 5. `docs/lifecycle-validation.md` records compatibility evidence from specific
    host versions; it is evidence, not a general specification.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,27 @@ A foreground process hint is not an Agent Instance and is presented as Untracked
 Catalog-only OpenCode history is a client-side projected session with Unknown state and no
 fabricated Agent occurrence.
 
+## Agent Session
+
+The canonical external conversation projected into one workspace from Agent Instances or host
+history. It can span multiple shell runs and Agent Instances that share an integration and exact
+external session identity, but it owns no process, PTY, or lifecycle observation.
+
+## Agent Schedule
+
+A durable workspace-owned definition for recurring prompt-driven Agent work with fixed execution
+context, session policy, and trigger policy. Creating a schedule does not create a shell, shell run,
+Agent Instance, or Agent Session. Its first dispatch creates one reusable schedule-owned shell for
+later execution runs, and a new schedule is paused until explicitly enabled.
+
+## Scheduled Execution
+
+A durable record of one manual or timed Agent Schedule decision, bound to the exact schedule and
+prompt revisions evaluated for that decision. A skipped or pre-shell failed dispatch has no shell
+run; an execution whose internal runner started retains that run even if the external host failed
+to launch. It may acquire an Agent Instance, whose lifecycle remains authoritative independently
+of the execution's process outcome.
+
 ## Process Adapter
 
 A process-bound observer for an agent instance whose evidence is limited to process events. The

--- a/docs/adr/0002-separate-agent-schedules-from-runtime-identity.md
+++ b/docs/adr/0002-separate-agent-schedules-from-runtime-identity.md
@@ -1,0 +1,29 @@
+# Separate Agent Schedules From Runtime Identity
+
+Status: Accepted
+
+Agent Schedules and Scheduled Executions are durable orchestration identities;
+they do not reinterpret shells, shell runs, Agent Instances, or projected Agent
+Sessions. This separation costs an additional persisted model, but preserves the
+existing authority rule that process activity and exit cannot establish Agent
+lifecycle state. It also lets skipped and failed dispatches remain observable
+without fabricating an Agent or a shell for failures that occur before runner
+binding.
+
+Each schedule lazily owns one reusable managed shell. Dispatched executions use
+distinct runs of that shell, preserving normal PTY attachment and integration
+identity without creating one durable shell per occurrence. The shell cannot be
+started by ordinary workspace restore or managed independently from its owning
+schedule, so opening a workspace never becomes an implicit schedule trigger.
+Its stored command is a stable internal schedule runner, not the revisioned host
+prompt or host command; each execution claim snapshots the inputs resolved by
+that runner.
+
+A continuation schedule pins one exact canonical external session and skips
+rather than injecting when a scheduler lease, exact current Agent occurrence, or
+integration-native signal shows that session is active. Unmanaged host activity
+can remain unknowable and is never replaced by heuristic inference. A fresh
+schedule creates a new external session for each execution. Both modes dispatch
+only through an integration capability that can construct the required exact
+argument vector; Boomux does not guess session identity or answer guarded
+prompts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,9 @@
 - **Exact argument vectors:** workspace launchers, process adapters, terminal
   launch, and integration management execute argv directly without shell
   interpretation.
+- **Scheduled Agent authority:** [`scheduled-agent-work.md`](scheduled-agent-work.md)
+  defines the accepted, not-yet-implemented boundary between scheduling,
+  process outcome, and authoritative Agent lifecycle.
 
 ## Product Boundary
 
@@ -354,6 +357,60 @@ advertises supported commands, features, schemas, and error codes without
 requiring a daemon. Protocol 6 error responses carry an additive optional code;
 clients expose it as `ClientError::Remote(RemoteError)`, while mixed-version
 peers retain message compatibility.
+
+### Scheduled Agent Work (Accepted, Not Yet Implemented)
+
+Agent scheduling will add two durable identities without changing ShellRun,
+Agent Instance, or projected Agent Session semantics. An Agent Schedule belongs
+to exactly one workspace and snapshots a bounded prompt revision, explicit
+working directory, integration, session policy, canonical five-field cron
+expression, IANA timezone, and dispatch policy. A Scheduled Execution records
+one manual or timed decision against exact schedule and prompt revisions. An
+execution that binds the internal runner acquires a shell run, even when the
+external host later fails to launch. The first such execution lazily creates one
+schedule-owned durable shell that later executions reuse for distinct runs;
+ordinary shell or workspace open never starts or restarts it. Lifecycle
+integration may bind an Agent Instance to the exact execution run under the
+existing authority rules.
+
+The schedule-owned shell stores a stable internal runner argument vector rather
+than a host prompt. Each persisted execution claim snapshots its working
+directory and dispatch inputs; the runner resolves that exact claim and invokes
+the integration adapter without shell interpretation. Schedule updates while a
+run is active affect only later claims. A durable per-schedule evaluation
+frontier and occurrence key prevent clock rollback, history pruning, restart,
+or graceful handoff from dispatching one timed occurrence twice. The frontier,
+occurrence decision, and execution record commit as one durable mutation before
+event publication.
+
+Scheduling is process orchestration, not lifecycle observation. Spawn failure,
+process exit, cancellation, and cold-daemon interruption are Scheduled Execution
+outcomes and never imply Agent `working`, `idle`, `blocked`, or `done`. Existing
+Agent attention remains the authority when a linked Agent reports `blocked`.
+The scheduler does not parse terminal output, answer guarded prompts, inject
+input into an active session, or infer a canonical external session.
+
+Fresh is the default session mode and starts a new external Agent Session for
+each dispatched execution. Continuation schedules pin one exact existing
+integration and external session identity; they never select the latest session
+or fall back to fresh work. An occurrence is skipped while a continuation lease,
+an exact current daemon Agent occurrence, the schedule, or the workspace is
+active. Boomux cannot prove inactivity in an unmanaged host process without an
+integration-provided lease and does not substitute heuristics. Daemon-wide
+scheduled concurrency defaults to four and is configurable within a positive
+bound.
+
+New schedules are paused by default. Timed work skips overlap and offline
+occurrences rather than queueing or catching up, and automatic retries are not
+part of the initial contract. The initial release also has no automatic timeout:
+an execution remains active until its process exits, the user cancels it, or a
+cold daemon loss interrupts it. Future scheduled starts use the daemon's
+startup environment as ephemeral input; it is never persisted, and environment
+changes require daemon restart. Scheduled-work support extends graceful restart
+so the invoking client's validated environment becomes the replacement daemon's
+startup environment without entering durable state or the handoff manifest.
+These limitations and scheduler health must be visible to clients. See
+[`scheduled-agent-work.md`](scheduled-agent-work.md) and [ADR 0002](adr/0002-separate-agent-schedules-from-runtime-identity.md).
 
 Protocol 7 adds a bounded in-memory daemon event journal and atomic output-state
 reads. Clients reconnect through stream UUID/event-ID cursors and recover from

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -166,6 +166,21 @@ eternal process.
 - Defer hooks, tests, focus actions, and other automatic reactions until waits,
   notification deduplication, and durable transition semantics are proven.
 
+### Scheduled Agent Work
+
+The accepted pre-implementation contract is documented in
+[`scheduled-agent-work.md`](scheduled-agent-work.md) and tracked by
+[#146](https://github.com/gardnmi/boomux/issues/146). Delivery is intentionally
+stacked: terminology and safety policy, durable management, manual dispatch,
+timed dispatch, observation, dashboard UX, companion-plugin UX, then an
+evidence-based decision about optional user-service activation.
+
+The first version uses workspace-owned paused-by-default schedules, snapshotted
+prompt revisions, fresh or exact-session continuation, canonical five-field cron
+with friendly creation conveniences, skipped overlap and missed work, no retry,
+no automatic timeout, one active execution per workspace, and a configurable
+daemon-wide concurrency limit that defaults to four.
+
 ## Distribution And Polish
 
 - Support configuration for refresh rate.

--- a/docs/scheduled-agent-work.md
+++ b/docs/scheduled-agent-work.md
@@ -1,0 +1,348 @@
+# Scheduled Agent Work
+
+> **Status: Accepted pre-implementation contract.** This document governs the
+> scheduled Agent work tracked by [#146](https://github.com/gardnmi/boomux/issues/146).
+> Source and compatibility tests become authoritative for exact protocol,
+> persistence, and bound values as each implementation slice ships.
+
+## Purpose
+
+Scheduled Agent work lets a user define a recurring prompt, dispatch it through
+a supported lifecycle integration, and inspect what happened. It is a bounded
+orchestration facility, not a workflow engine and not a new source of Agent
+lifecycle authority.
+
+## Identities And Ownership
+
+An **Agent Schedule** is durable and belongs to exactly one workspace. It owns:
+
+- A daemon-assigned identity and workspace-unique name.
+- An explicit working directory.
+- A supported integration.
+- A bounded prompt snapshot and prompt revision.
+- A session mode and any exact continuation identity.
+- A trigger expression and timezone.
+- Enabled state and dispatch policy.
+
+Closing the owning workspace removes its schedules and bounded Scheduled
+Execution history along with the workspace's other retained state. Confirmation
+must include that scope. A schedule cannot become global or move implicitly when
+its workspace closes.
+
+A **Scheduled Execution** is the durable record of one timed occurrence or
+explicit run-now decision. It captures the exact schedule revision, prompt
+revision, requested or scheduled time, working directory, integration dispatch
+mode, decision, reason, and available runtime references. Schedule edits affect
+only later executions.
+
+The identities remain separate:
+
+- A skipped or pre-shell failed Scheduled Execution has no shell or shell run.
+- An execution that starts the internal runner is associated with exactly one
+  ShellRun of its schedule-owned shell, even if later host launch fails.
+- A lifecycle integration may register an Agent Instance for that ShellRun.
+- Fresh executions project distinct Agent Sessions.
+- Continued executions can project under the same exact Agent Session while
+  retaining distinct ShellRuns and Agent Instances.
+- Removing bounded execution history does not reinterpret or delete canonical
+  host session data.
+
+## Schedule-Owned Shell
+
+The first execution that binds its internal runner lazily creates one durable
+shell owned by the Agent Schedule. Later runner-bound executions reuse that shell
+and create a new ShellRun for each occurrence. This preserves retained PTY state,
+attachment, run-scoped environment identity, and lifecycle integration without
+accumulating one durable shell per occurrence.
+
+The shell stores one stable internal Boomux schedule-runner argument vector
+containing the schedule identity, not the prompt or revisioned host command. For
+each run the runner resolves only the exact persisted execution claim, then asks
+the integration adapter to construct and execute the host argument vector without
+shell interpretation. It cannot select a later pending claim or rerun the latest
+prompt implicitly.
+
+The ownership is exclusive:
+
+- The shell is openable for an active execution and remains visible through
+  schedule and execution inspection.
+- It cannot be independently renamed, repurposed, restarted, or closed.
+- Ordinary shell open and workspace open or restore never start or restart it.
+- A process starts only after the scheduler has persisted the corresponding
+  Scheduled Execution claim.
+- Removing an inactive schedule removes its schedule-owned shell and retained
+  terminal state. Active removal remains rejected until cancellation or exit.
+- Workspace closure terminates an active run and removes the schedule and shell
+  under the workspace's confirmed lifecycle transaction.
+
+An exited schedule-owned shell can retain the latest bounded terminal state, but
+the bounded Scheduled Execution history is the authority for earlier occurrence
+outcomes. Reusing the shell does not reuse a ShellRun or Agent Instance. Each
+execution snapshots its effective working directory. An inactive schedule update
+can atomically update the shell metadata for the next run; an update during an
+active run leaves that run and shell process unchanged and applies when the next
+claim is bound.
+
+## Prompt Revisions And Privacy
+
+Creation and update snapshot the prompt content into Boomux's user-only durable
+state. A prompt-file option reads the file at that mutation boundary; later file
+changes do not silently alter the schedule. Changing prompt content creates a
+new prompt revision, and every Scheduled Execution retains the revision it used.
+
+Prompt content may contain private instructions or data. It is bounded and:
+
+- Omitted from list output, event payloads, notifications, routine diagnostics,
+  and error messages.
+- Returned only by an explicit exact-schedule inspection surface that documents
+  the disclosure.
+- Removed with its schedule according to the workspace ownership rule.
+- Never copied into audit reasons or Agent lifecycle evidence by Boomux.
+
+The prompt must reach the external host and therefore crosses the host adapter's
+trust boundary. An adapter should avoid argv transport when the host provides an
+equivalent private input channel, but some hosts can expose the prompt in process
+listings, canonical transcripts, retained terminal output, or host-generated
+errors. Setup and inspection must disclose the selected adapter's transport.
+Boomux never places prompt text in the stable internal runner argv or an
+environment variable, and it does not claim to redact host-owned content.
+
+Every manual or timed Scheduled Execution uses the daemon's startup environment
+as ephemeral process input. It is validated for child startup but never
+persisted, projected, copied into a schedule revision, or replaced by the
+run-now client's environment. A graceful replacement request carries the
+invoking client's validated full Unix environment as ephemeral replacement
+startup input. The replacement uses it for future executions while already
+running processes retain their original environments. That payload is not added
+to durable state or the handoff manifest.
+
+Environment changes therefore require `boomux daemon restart`. Diagnostics can
+explain that requirement and report a missing executable or required variable
+without printing environment values. Schedule inspection cannot expose the
+daemon environment.
+
+## Creation And Consent
+
+Creation supports explicit paused and enabled states. When neither is selected,
+the schedule is paused. Enabling is a separate authorization for future
+unattended process and tool activity. Human and JSON responses must make the
+resulting state clear, and interactive setup should preview at least the prompt,
+workspace, directory, integration, session mode, trigger, and timezone before
+enabling.
+
+Pausing prevents future timed dispatch but does not cancel nonterminal work.
+Removing a schedule with a nonterminal execution is rejected until the execution
+is explicitly cancelled or exits. Workspace closure retains its existing
+stronger semantics and terminates owned managed processes after confirmation.
+Run-now is an explicit user dispatch and remains available while a schedule is
+paused; it does not enable later timed execution.
+
+## Trigger Contract
+
+The canonical trigger is a validated standard five-field cron expression plus an
+explicit IANA timezone. Fields are minute, hour, day of month, month, and day of
+week. The initial grammar accepts numeric values, `*`, lists, ranges, and steps;
+day of week uses `0` for Sunday. When both day of month and day of week are
+restricted, either field matching selects the local time. Seconds, names,
+nicknames, and implementation-specific operators such as `?`, `L`, `W`, and `#`
+are not accepted.
+
+Manual conveniences such as every, daily, weekdays, and weekly compile to the
+same canonical expression rather than creating another persisted trigger model.
+Clients expose both a friendly rendering and the exact expression.
+
+When a timezone is omitted, creation resolves the current system IANA timezone
+and stores it; the meaning does not float with later system-timezone changes. If
+an IANA identity cannot be resolved, creation requires an explicit timezone.
+
+Time behavior is deterministic:
+
+- A nonexistent local time during a forward DST transition is skipped.
+- A repeated local time during a backward DST transition fires once at its first
+  matching instant.
+- A wall-clock correction cannot dispatch the same scheduled occurrence twice.
+- Run-now creates an independent decision and does not consume or move the next
+  timed occurrence.
+
+The daemon-native scheduler runs only while the Boomux daemon and user session
+are alive. It does not catch up work missed during downtime. On recovery it
+records one bounded, coalesced missed-period decision per affected schedule and
+computes the next future occurrence; it does not materialize an unbounded record
+for every missed minute.
+
+Every timed decision has an occurrence key containing the schedule ID, trigger
+revision, and selected scheduled UTC instant. Each schedule persists an
+evaluation frontier independently of bounded execution history. The frontier
+advances monotonically before publication and is not pruned with audit records,
+so clock rollback and history pruning cannot make an old occurrence eligible.
+Editing a trigger creates a new trigger revision whose first eligible occurrence
+is strictly after the committed edit; it never re-evaluates past wall time.
+
+The occurrence key, Scheduled Execution decision, and evaluation-frontier
+advance commit as one durable mutation before the corresponding event is
+published. A persistence failure changes none of them. This prevents a crash
+from either consuming an occurrence without its audit record or recording a
+decision while leaving that occurrence eligible for duplicate dispatch.
+
+## Session Modes
+
+Every schedule selects one mode; creation defaults to Fresh when the caller does
+not specify one:
+
+- **Fresh** asks the integration to create a new canonical external Agent
+  Session for each dispatched execution.
+- **Continue** pins one exact existing integration and canonical external
+  session identity selected by the user.
+
+Continue never means newest, most recent, directory-local, or process-local. If
+the exact session cannot be reacquired, dispatch fails visibly and does not fall
+back to fresh. A durable continuation lease keyed by integration and exact
+external session ID prevents Scheduled Executions from using that session
+concurrently. The occurrence is also skipped when daemon state contains a
+current running Agent Instance for that exact key, or when the integration's
+dispatch capability authoritatively refuses an active session. Boomux never
+injects a prompt into known active user or Agent work and never takes over its
+terminal controller.
+
+Boomux cannot prove that an exact session is inactive in an unmanaged process
+that provides no lifecycle or lease signal. The UI must describe this limit; the
+scheduler does not substitute process, catalog, argv, or terminal heuristics.
+Integrations that can acquire a stronger host-native session lease should expose
+it through their dispatch capability.
+
+An integration must advertise the applicable fresh or continuation dispatch
+capability and construct the exact host argument vector. Unsupported integrations
+or modes are rejected before a schedule is enabled. Process names, argv,
+database recency, terminal output, and catalog order are not session identity.
+
+## Dispatch And Concurrency
+
+The first release uses these policies:
+
+- At most one nonterminal Scheduled Execution per Agent Schedule.
+- At most one nonterminal Scheduled Execution per workspace.
+- Four nonterminal Scheduled Executions daemon-wide by default.
+- A user-configurable positive bounded daemon-wide limit.
+- Skip rather than queue when any applicable lease is occupied.
+- No automatic retry after skip, dispatch failure, process failure, or daemon
+  interruption.
+- No automatic timeout.
+
+An eligible decision is first persisted as **Claimed**; a policy rejection is
+persisted directly as **Skipped** and never owns a dispatch claim. One
+per-execution dispatch lease serializes claim binding, spawn, cancellation,
+workspace closure, and handoff. Cancellation or closure can revoke a claim
+before spawn, and a dispatcher must revalidate the claim under that lease before
+binding a process. Once the user-facing cancellation or closure returns, that
+claim cannot spawn later.
+
+Claimed acquires and occupies the schedule, workspace, daemon-wide, and any
+continuation concurrency leases before the eligibility decision commits. Those
+leases remain occupied through Starting and Active and release only on a
+terminal outcome. Concurrent decisions therefore cannot each pass eligibility
+and later exceed a declared limit.
+
+The claim is the idempotency authority across request retry and event reconnect.
+Graceful handoff establishes a dispatch barrier, transfers claimed executions
+with or without a live ShellRun, and prevents the old daemon from spawning after
+ownership transfer. The replacement either continues the one transferred claim
+or observes its terminal outcome. Cold recovery marks a nonterminal claim or
+active execution interrupted; it never starts a replacement process implicitly.
+
+Because there is no initial automatic timeout, blocked or hung work can remain
+active indefinitely and occupy its schedule, workspace, and daemon concurrency
+slots. Clients must show that limitation and provide explicit cancellation.
+Adding optional timeouts requires a later contract update rather than silently
+changing existing schedules.
+
+## Execution Outcomes And Agent Authority
+
+A Scheduled Execution has one of these observable states or outcomes:
+
+- **Skipped**: policy prevented dispatch, with an overlap, active-session,
+  workspace-capacity, global-capacity, or missed reason. Paused schedules do not
+  produce timed decisions.
+- **Claimed**: dispatch eligibility and idempotency ownership are durable, but a
+  ShellRun is not yet bound.
+- **Starting**: the internal runner ShellRun is bound, but the exact external
+  target has not yet launched successfully.
+- **Dispatch failed**: the scheduler claimed the work but could not create its
+  internal runner, reacquire its exact target, or launch the external host. It
+  retains a ShellRun only when the runner had already started; that run's later
+  exit metadata does not replace the execution's Dispatch failed outcome.
+- **Active**: one ShellRun was created and remains live.
+- **Exited**: the external host launched successfully and its managed primary
+  process later exited, retaining its exit reason and code.
+- **Cancelled**: an explicit user action revoked a pre-spawn claim or terminated
+  the managed process.
+- **Interrupted**: cold daemon loss ended ownership without a known ordinary
+  process exit.
+
+These are orchestration and process outcomes. They do not report or infer Agent
+`working`, `blocked`, `idle`, `inactive`, or `done`. In particular, exit code zero
+does not imply `done`, and quiet output does not imply `idle`.
+
+When a lifecycle integration registers an Agent Instance for the exact ShellRun,
+its observation remains authoritative under the existing precedence rules. A
+linked `blocked` observation uses existing durable Agent attention. A pre-spawn
+failure or skipped execution cannot fabricate an Agent Instance or attention
+revision.
+
+## User Control And Permissions
+
+The scheduler can create a process and deliver the schedule's initial prompt. It
+cannot send later input, answer permission or question prompts, acknowledge
+attention, or react automatically to terminal content. The host integration and
+its user-configured permissions remain the authority for tools and filesystem or
+network access.
+
+Explicit user cancellation and workspace closure take precedence over scheduler
+activity and cannot be undone by a later tick. Pausing affects future ticks only.
+Opening or attaching to an execution permits ordinary user interaction but does
+not silently alter its schedule or remove its concurrency lease.
+
+`boomux daemon stop` and confirmed workspace closure cancel Claimed, Starting,
+or Active Scheduled Executions before removing runtime ownership. Graceful
+daemon restart uses the transfer rule instead and does not cancel them.
+
+Removing a schedule is rejected while any execution is Claimed, Starting, or
+Active. Cancellation can move any of those states to Cancelled; cancelling
+Claimed work revokes the dispatch claim without fabricating a process outcome.
+
+## Audit And Bounds
+
+Every timed or run-now decision produces a bounded Scheduled Execution record,
+including skips and dispatch failures. Offline gaps use the coalesced record
+defined above. Records include untrusted-safe reasons and exact identity links,
+but no prompt text, environment, transcript content, tool content, or credentials.
+
+Each schedule retains every nonterminal execution plus a bounded newest suffix of
+terminal execution records; pruning removes the oldest terminal records first.
+The exact suffix bound belongs to source and compatibility tests. Scheduler
+events use the existing bounded event-stream retention and cursor-expiry model.
+The per-schedule occurrence frontier is not audit history and is never pruned
+while the schedule exists.
+
+The current prompt snapshot is retained with its schedule. An older prompt
+snapshot is retained only while a retained Scheduled Execution references that
+revision; once no retained execution references it, its content is removed.
+Pruning history does not change a nonterminal execution, schedule state, Agent
+Instance, Agent attention item, or canonical host session. Durable changes remain
+subject to persistence-before-event publication and the daemon lock order.
+
+## Deferred Work
+
+The initial contract excludes:
+
+- Workflow graphs or dependencies between schedules.
+- Arbitrary event triggers.
+- Queued overlap or catch-up execution.
+- Automatic retries.
+- Automatic timeout.
+- Automatic prompt answers or guarded actions.
+- Terminal-screen lifecycle heuristics.
+- Automatic commits, merges, or external message delivery by Boomux itself.
+- Required systemd, Omarchy, or other desktop-specific activation.
+
+Optional user-service activation remains a post-MVP evidence-based decision in
+[#153](https://github.com/gardnmi/boomux/issues/153).


### PR DESCRIPTION
## Summary

- define Agent Schedule, Scheduled Execution, and Agent Session terminology without changing ShellRun or Agent lifecycle authority
- add the accepted scheduled-work contract covering prompt privacy, cron and DST behavior, fresh and continued sessions, reusable execution shells, dispatch claims, concurrency, handoff, and bounded audit history
- record the hard-to-reverse identity boundary in ADR 0002 and link the planned stack from architecture, roadmap, and contributor guidance
- align issues #146 and #148-#152 with the accepted no-timeout MVP, canonical cron model, reusable shell, and daemon environment decisions

## Key decisions

- schedules are workspace-owned, paused by default, and snapshot bounded prompt revisions
- fresh is the default; continuation pins one exact external session and never falls back or injects into known active work
- five-field cron plus IANA timezone is canonical; friendly manual options compile to it
- one reusable schedule-owned shell provides distinct ShellRuns without unbounded shell growth
- Claimed, Starting, and Active executions occupy schedule, workspace, continuation, and configurable global leases
- overlap, offline work, and occupied capacity skip without queueing or retry; MVP has explicit cancellation and no automatic timeout
- process and dispatch outcomes never fabricate Agent lifecycle state or attention

## Stack

- Tracker: #146
- Layer: 1 of 8
- Next: #148

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`

Closes #147

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>