### PR TITLE
feat(schedule): add durable agent schedule management

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boomux
-description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, attention, projected sessions, notifications, process supervision, and integrations. Use when asked to discover shells, agents, or sessions, read terminal output, supervise an explicitly identified external session, report agent lifecycle state, configure or test notifications, install or remove the OpenCode or Pi integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
-compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; agent mutation and supervision require exact shell-run context, and supervision requires a caller-supplied canonical external session ID.
+description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, attention, projected sessions, recurring Agent schedules, notifications, process supervision, and integrations. Use when asked to discover shells, agents, sessions, or schedules, read terminal output, manage explicitly authorized recurring Agent prompts, supervise an explicitly identified external session, report agent lifecycle state, configure or test notifications, install or remove the OpenCode or Pi integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
+compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; schedule names require BOOMUX_WORKSPACE_ID or explicit --workspace; agent mutation and supervision require exact shell-run context, and continuation schedules or supervision require caller-supplied exact canonical session identity.
 metadata:
   author: boomux
-  version: "9"
+  version: "10"
 ---
 
 # Boomux
@@ -50,12 +50,12 @@ boomux capabilities --json
 
 Parse `data` on success and `error.code` on a nonzero exit; do not parse human
 tables or `error.message`. JSON mutation support includes Agent register,
-ensure, and report; attention acknowledgment; and integration installation and
-uninstallation.
+ensure, and report; attention acknowledgment; schedule create, pause, resume,
+and remove; and integration installation and uninstallation.
 
 Most daemon-backed inspection commands automatically start Boomux when it is
 not running. This includes `list`, `shells`, `read`, `events`, workspace, shell,
-and launcher inspection, Agent, attention, and session inspection, and
+and launcher inspection, Agent, attention, session, and schedule inspection, and
 `doctor`. Use `boomux daemon status` first when starting the daemon would be an
 unwanted side effect. `capabilities`, `integration list`, and `integration
 status` do not start it.
@@ -249,6 +249,52 @@ When `has_more` is true, prepend older pages by passing the exact opaque
 cursor and start a fresh read on `cursor_expired`. Do not decode, edit, or reuse
 a cursor for another projected session.
 
+## Manage Agent Schedules
+
+Schedule prompts are durable private content. Require authorization before
+creating one or using `schedule inspect`, because inspect is the only management
+surface that discloses the prompt. Enabling a schedule authorizes future
+unattended Agent process and tool activity; never pass `--enabled` or run
+`schedule resume` without explicit authorization for that continuing effect.
+
+```console
+boomux schedule create "<name>" --workspace "<workspace-name-or-id>" --cwd "/absolute/project/path" --integration opencode --prompt-file "/path/to/prompt.txt" --weekdays 09:00 --json
+boomux schedule list --json
+boomux schedule list --workspace "<workspace-name-or-id>" --json
+boomux schedule inspect "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
+boomux schedule pause "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
+boomux schedule resume "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
+boomux schedule remove "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
+```
+
+Create requires explicit workspace, cwd, integration, exactly one prompt source,
+and exactly one trigger source. `--prompt` preserves the accepted bytes;
+`--prompt-file` snapshots exact UTF-8, including a final newline, and does not
+track later file changes. Use `--cron '<five fields>'`, `--every Nm|Nh`, `--daily
+HH:MM`, `--weekdays HH:MM`, or `--weekly DAY@HH:MM`. Omitted `--timezone`
+snapshots the system IANA timezone. New schedules default to fresh, paused, and
+skip-overlap policy. `--fresh` conflicts with `--continue`; `--paused` conflicts
+with `--enabled`.
+
+For continuation, first obtain the exact opaque projected session ID from
+`session list --workspace ... --json`, then pass it as `--continue`. It must
+resolve in that workspace, expose a canonical external session ID, and match the
+selected integration. Never substitute a description, external ID, latest
+session, Agent ID, or shell ID.
+
+List, create, pause, resume, and remove responses are prompt-free. Inspect
+returns the private prompt under `data.schedule.prompt`; do not log or repeat it
+unless needed for the authorized request. Exact schedule IDs resolve globally.
+Names resolve only with explicit `--workspace` or `BOOMUX_WORKSPACE_ID`.
+Removing a schedule removes its persisted prompt. Workspace close removes every
+owned schedule and persisted prompt and must be confirmed with that full scope.
+
+This version is the schedule management surface. Dispatch arrives in later
+scheduler and integration stack layers; do not claim that enabling immediately
+executes timed work. Capabilities advertise durable schedule management only;
+dispatch modes and prompt transport are not public capabilities until the
+dispatcher ships.
+
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.
 `boomux read` and top-level `boomux close` require an exact shell ID outside a
@@ -395,11 +441,12 @@ and catch up to the currently focused terminal.
 Boomux reads `$XDG_CONFIG_HOME/boomux/config.toml`, falling back to
 `~/.config/boomux/config.toml`. `BOOMUX_CONFIG` points to an additional
 field-level override loaded last. Configuration controls terminal selection,
-project discovery roots and depth, dashboard focus following, and desktop and
-sound notifications. Unknown fields are rejected. Selecting a discovered
-project in the dashboard persists its canonical path as the workspace default
-cwd for later shells. Set `[dashboard] follow_focused_terminal = false` to
-disable the default focus-following behavior.
+project discovery roots and depth, dashboard focus following, schedule
+concurrency, and desktop and sound notifications. Unknown fields are rejected.
+Selecting a discovered project in the dashboard persists its canonical path as
+the workspace default cwd for later shells. Set
+`[dashboard] follow_focused_terminal = false` to disable the default
+focus-following behavior.
 
 ## Manage Workspaces
 
@@ -416,12 +463,12 @@ boomux workspace close "<name-or-id>"
 `workspace create` creates an empty workspace. `--cwd` stores an optional
 default used by dashboard shells and `shell create` when no explicit cwd is
 given. The default does not prevent individual shells from using other paths.
-`workspace close` terminates
-every running shell process session and removes the workspace, all shell and
-launcher definitions, retained terminal state, and all durable Agent and
-attention records associated with it. Canonical OpenCode or Pi host data is not
-deleted. A workspace cannot close itself from one of its own shells. Confirm
-the exact target and full removal scope first.
+`workspace close` terminates every running shell process session and removes the
+workspace, all shell and launcher definitions, schedules and persisted prompts,
+retained terminal state, and all durable Agent and attention records associated
+with it. Canonical OpenCode or Pi host data is not deleted. A workspace cannot
+close itself from one of its own shells. Confirm the exact target and full
+removal scope first.
 
 `workspace open` is an active, non-transactional restore operation. It invokes
 every launcher in creation order and attempts to open every shell even if an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,8 +126,10 @@ name = "boomux"
 version = "0.15.0"
 dependencies = [
  "base64",
+ "chrono-tz",
  "clap",
  "crossterm",
+ "iana-time-zone",
  "libc",
  "nix",
  "portable-pty",
@@ -153,6 +164,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +184,25 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
 
 [[package]]
 name = "clap"
@@ -232,6 +272,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -412,6 +458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +541,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "ident_case"
@@ -755,6 +831,24 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1039,6 +1133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1168,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1390,10 +1496,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,10 @@ license = "MIT"
 
 [dependencies]
 base64 = "0.22"
+chrono-tz = "0.10"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
+iana-time-zone = "0.1"
 libc = "0.2"
 nix = { version = "0.28", default-features = false, features = ["socket", "uio"] }
 portable-pty = "0.9"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | **Managed shell** | A persistent terminal session, usually running your login shell. |
 | **Command** | A managed terminal session that runs one command instead of a login shell. |
 | **Launcher** | A desktop command run when its workspace opens. Boomux does not retain its output or process. |
+| **Agent schedule** | A durable workspace-owned recurring Agent prompt. New schedules are paused until explicitly enabled. |
 
 ### What Keeps Running
 
@@ -118,7 +119,7 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | Close a terminal window | The managed process keeps running. |
 | Quit the dashboard | All managed processes keep running. |
 | Close a shell in Boomux | That shell's process is terminated. |
-| Close a workspace in Boomux | Its shells are terminated and its metadata is removed. |
+| Close a workspace in Boomux | Its shells are terminated; schedules, persisted prompts, and workspace metadata are removed. |
 | Run `boomux daemon restart` | Live shells are handed to the replacement daemon. |
 | System reboot or unexpected daemon loss | Live processes are lost; workspace and shell definitions remain, and reopening them starts new processes. |
 
@@ -135,6 +136,7 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | Choose a terminal | `boomux . --terminal Alacritty.desktop` |
 | Open the dashboard | `boomux` or `boomux ui` |
 | Inspect daemon health | `boomux doctor` |
+| List recurring Agent work | `boomux schedule list --workspace feature-x` |
 
 Without `--name`, Boomux creates the next `workspace-N` and stores the selected
 path as its default for later shells. With `--name`, it adds a shell to an
@@ -195,9 +197,10 @@ outstanding attention item.
 | `x`, then `y` | Confirm closing or removing the selection. |
 | `q` or `Esc` | Quit from normal mode. |
 
-Closing a workspace terminates its managed shells. Closing a shell or command
-terminates its managed process. Removing a launcher affects future workspace
-opens only. Press `?` in the dashboard for context-specific controls.
+Closing a workspace terminates its managed shells and removes its schedules and
+persisted prompts. Closing a shell or command terminates its managed process.
+Removing a launcher affects future workspace opens only. Press `?` in the
+dashboard for context-specific controls.
 
 ## Omarchy Plugin
 
@@ -284,6 +287,36 @@ Boomux does not redact host transcript content. Use transcript commands only
 when reading that session's content is appropriate. Opaque continuation cursors
 can request older pages; discard one and start a fresh read if Boomux reports
 that it expired.
+
+### Agent Schedules
+
+Create and manage a recurring Agent prompt in one workspace:
+
+```console
+boomux schedule create review --workspace my-project --cwd . --integration opencode --prompt-file ./review-prompt.txt --weekdays 09:00
+boomux schedule list --workspace my-project
+boomux schedule inspect review --workspace my-project
+boomux schedule resume review --workspace my-project
+boomux schedule pause review --workspace my-project
+boomux schedule remove review --workspace my-project
+```
+
+Creation snapshots the exact UTF-8 prompt file, including its trailing newline,
+canonicalizes the working directory, trigger, and IANA timezone, and defaults to
+a fresh, paused schedule with overlap skipped. Use `--enabled` only when future
+unattended Agent process and tool activity is authorized. `--continue
+<projected-session-id>` pins the exact canonical session returned by `session
+list`; it never means latest and never falls back to fresh.
+
+List, create, pause, resume, and remove outputs do not disclose prompt text.
+`schedule inspect` is the only prompt disclosure command and should be used only
+when reading the stored private instructions is authorized. Removing a schedule
+deletes its persisted prompt. Closing the workspace removes every owned schedule
+and persisted prompt.
+
+This release provides the durable management surface. Timed dispatch is added by
+later scheduler and integration stack layers; enabling now records consent state
+but does not by itself make this CLI layer dispatch work.
 
 ### Agent Skill
 
@@ -392,6 +425,7 @@ boomux launcher --help
 boomux agent --help
 boomux attention --help
 boomux session --help
+boomux schedule --help
 boomux notification --help
 boomux integration --help
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@
 | `src/session_transcript.rs` and children | Shared transcript identity, bounds, pagination, and host-specific normalization |
 | `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
 | `src/process_adapter.rs` | Exact-argv child supervision and fail-open process-bound Agent observation |
+| `src/scheduling.rs` | Bounded canonical cron, IANA timezone, prompt, and schedule identity validation |
 | `src/config.rs`, `src/projects.rs`, `src/git.rs` | Layered configuration, bounded project discovery, and asynchronous Git metadata |
 | `src/cli_output.rs` | Stable `boomux.cli/v1` output and error presentation |
 | `src/desktop_notifications.rs` | Bounded fail-open desktop and sound delivery |
@@ -358,20 +359,26 @@ requiring a daemon. Protocol 6 error responses carry an additive optional code;
 clients expose it as `ClientError::Remote(RemoteError)`, while mixed-version
 peers retain message compatibility.
 
-### Scheduled Agent Work (Accepted, Not Yet Implemented)
+### Scheduled Agent Work (Management Implemented; Dispatch Planned)
 
-Agent scheduling will add two durable identities without changing ShellRun,
-Agent Instance, or projected Agent Session semantics. An Agent Schedule belongs
-to exactly one workspace and snapshots a bounded prompt revision, explicit
-working directory, integration, session policy, canonical five-field cron
-expression, IANA timezone, and dispatch policy. A Scheduled Execution records
-one manual or timed decision against exact schedule and prompt revisions. An
-execution that binds the internal runner acquires a shell run, even when the
-external host later fails to launch. The first such execution lazily creates one
-schedule-owned durable shell that later executions reuse for distinct runs;
-ordinary shell or workspace open never starts or restarts it. Lifecycle
-integration may bind an Agent Instance to the exact execution run under the
-existing authority rules.
+Protocol 22 and state schema 9 implement the Agent Schedule identity without
+changing ShellRun, Agent Instance, or projected Agent Session semantics. A
+schedule belongs to exactly one workspace and snapshots a bounded prompt
+revision, explicit working directory, integration, session policy, canonical
+five-field cron expression, IANA timezone, and overlap policy. Create, list,
+exact inspect, pause, resume, remove, cold recovery, graceful handoff, workspace
+closure, and prompt-free events are available. Exact inspection is the only
+management response that contains prompt content; protocol-21 and older peers
+omit schedule summaries and events while their cursors still advance.
+
+Scheduled Execution, timing, and process dispatch remain planned. An execution
+will record one manual or timed decision against exact schedule and prompt
+revisions. An execution that binds the internal runner acquires a shell run, even
+when the external host later fails to launch. The first such execution lazily
+creates one schedule-owned durable shell that later executions reuse for
+distinct runs; ordinary shell or workspace open never starts or restarts it.
+Lifecycle integration may bind an Agent Instance to the exact execution run
+under the existing authority rules.
 
 The schedule-owned shell stores a stable internal runner argument vector rather
 than a host prompt. Each persisted execution claim snapshots its working
@@ -683,6 +690,12 @@ Protocol 21 adds a targeted focused-terminal read so event-driven dashboards can
 refresh non-durable focus without rebuilding the complete registry. Protocols
 7-20 use the event stream with a one-second snapshot fallback for ephemeral
 fields; protocol 6 retains one-second snapshot refreshes.
+Protocol 22 adds workspace-owned Agent Schedule definitions and prompt-free
+schedule events. Schedule requests require protocol 22. Older snapshots omit the
+additive schedule summaries, and older event readers filter schedule events
+without rewinding their cursor. State schema 9 explicitly migrates schema 8
+workspaces with empty schedule collections rather than reinterpreting missing
+durable fields.
 
 Opt-in desktop and sound notifications are a daemon-owned projection of committed
 Agent state transitions, not durable queue state. A transition from any other

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -66,6 +66,12 @@ The following commands support `--json`:
 - `boomux session list`
 - `boomux session inspect`
 - `boomux session read`
+- `boomux schedule create`
+- `boomux schedule list`
+- `boomux schedule inspect`
+- `boomux schedule pause`
+- `boomux schedule resume`
+- `boomux schedule remove`
 - `boomux integration list`
 - `boomux integration status [opencode|pi]`
 - `boomux integration install <opencode|pi>`
@@ -75,10 +81,10 @@ The following commands support `--json`:
 - `boomux integration verify <opencode|pi>`
 - `boomux daemon status`
 
-JSON mutations are deliberately narrow: only `agent register`, `agent ensure`,
-`agent report`, `attention acknowledge`, `integration install`, and
-`integration uninstall` support the contract. Other mutation commands retain
-human output. Passing `--json` to an unsupported command fails with
+JSON mutations are deliberately narrow. Agent register, ensure, and report;
+attention acknowledgment; schedule create, pause, resume, and remove; and
+integration install and uninstall support the contract. Other mutation commands
+retain human output. Passing `--json` to an unsupported command fails with
 `invalid_argument` before performing the operation.
 
 `boomux integration setup <opencode|pi>` is intentionally human-oriented and
@@ -94,10 +100,11 @@ Command payloads are:
 - `list`: a `shells` array.
 - `shells`: workspace identity plus a `shells` array.
 - `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`,
-  `launcher_count`, `agent_count`, fixed `agent_state_counts`, and
+  `launcher_count`, `schedule_count`, `agent_count`, fixed `agent_state_counts`, and
   `attention_count`.
 - `workspace.inspect`: one `workspace` object containing `id`, `name`, nullable
-  `default_cwd`, and `shells`, `launchers`, and `agents` arrays.
+  `default_cwd`, and prompt-free `shells`, `launchers`, `schedules`, and `agents`
+  arrays.
 - `shell.inspect`: one `shell` object.
 - `launcher.list`: workspace identity plus a `launchers` array.
 - `launcher.inspect`: one `launcher` object.
@@ -116,6 +123,15 @@ Command payloads are:
   opaque session ID.
 - `session.read`: one bounded canonical `transcript` selected only by exact
   opaque session ID.
+- `schedule.create`, `schedule.pause`, and `schedule.resume`: one prompt-free
+  `schedule` summary. New schedules default to `fresh` and `paused`; resume
+  changes state to `enabled`.
+- `schedule.list`: a prompt-free `schedules` array, globally or limited by
+  `--workspace`.
+- `schedule.inspect`: one exact `schedule` detail and the only schedule command
+  that includes its `prompt`.
+- `schedule.remove`: `removed: true` plus the removed prompt-free `schedule`
+  summary.
 - `integration.list`: an `integrations` array containing bundled integration
   names, display names, packages, and validated host versions.
 - `integration.status`: an `integrations` array containing independent `host`,
@@ -145,6 +161,10 @@ Command payloads are:
 
 Integration arrays are ordered `opencode`, then `pi`. List entries contain
 `name`, `display_name`, `package`, and `validated_version`.
+
+Protocol 22 advertises `protocol_22`, `agent_schedule_management`, and
+`durable_agent_schedules`. These capabilities describe durable management only;
+they do not advertise timed or manual dispatch.
 
 Status entries contain those four fields plus `host`, `asset`, `runtime`, and
 `recommended_action`.
@@ -324,6 +344,45 @@ changes, and adapter-normalization changes return
 `cursor_expired`; callers discard the cursor and request a fresh newest page.
 Malformed, oversized, or cross-session cursors return `invalid_argument`.
 Pagination remains client-side and does not create daemon cursor state.
+
+## Schedule Data
+
+Schedule summaries contain `id`, `workspace_id`, nullable `workspace_name`,
+`name`, `cwd`, `integration`, `session_mode`, nullable `external_session_id`,
+`cron`, `timezone`, `state`, `overlap_policy`, `revision`, `prompt_revision`,
+`trigger_revision`, `created_at_ms`, `updated_at_ms`,
+`evaluation_frontier_ms`, and nullable `execution_shell_id`. Optional values are
+JSON `null`. State is `paused` or `enabled`; session mode is `fresh` or
+`continue`; the initial overlap policy is always `skip`.
+All schedule commands require negotiated daemon protocol 22 and return
+`unsupported_version` against an older daemon rather than presenting an empty
+schedule list.
+
+Only `schedule.inspect` adds `prompt`. Prompts are intentionally absent from
+list, create, pause, resume, remove, capabilities, events, and errors. Inspection
+is an explicit private-content disclosure. A prompt file is read once at create
+time as exact UTF-8, including a trailing newline; later file changes do not
+alter the persisted prompt revision. Files must be regular and prompts are
+bounded to 65,536 UTF-8 bytes.
+
+Create requires explicit `--workspace`, `--cwd`, and `--integration`, exactly
+one of `--prompt` or `--prompt-file`, and exactly one trigger source. `--cron`
+accepts the canonical numeric five-field subset. `--every Nm|Nh`, `--daily
+HH:MM`, `--weekdays HH:MM`, and `--weekly DAY@HH:MM` compile to that canonical
+cron representation. `--timezone` accepts an IANA timezone; omission snapshots
+the current system IANA timezone or fails if it cannot be resolved. `--fresh`
+conflicts with `--continue`, and `--paused` conflicts with `--enabled`.
+
+`--continue` accepts only an exact opaque projected session ID resolved in the
+selected workspace. The projection must have a canonical external session ID
+and its integration must equal `--integration`; descriptions, external IDs,
+latest-session selection, and names are never substitutes.
+
+Exact schedule IDs resolve globally for inspect, pause, resume, and remove.
+Schedule names resolve only with explicit `--workspace` or the exact current
+`BOOMUX_WORKSPACE_ID`. List is global unless `--workspace` is supplied. Removing
+a schedule removes its persisted prompt. Closing a workspace removes all owned
+schedules and persisted prompts along with the workspace.
 
 `read` returns `shell_id`, `run_id`, `output_revision`, `changed`, `status`, and
 `output`. Output is a JSON string containing the same bounded plain rendered text

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -26,6 +26,9 @@ Protocol 21 adds a targeted focused-terminal read for clients that use events as
 registry invalidation while refreshing ephemeral focus independently. Running
 shell reads refresh foreground-process hints from a daemon-side one-second cache
 shared by concurrent clients.
+Protocol 22 adds durable Agent Schedule management. Workspace snapshots include
+ordered, prompt-free schedule summaries, while exact schedule inspection is the
+only management response that discloses the current prompt.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns
@@ -63,6 +66,8 @@ The event vocabulary is:
 - `run_started`, `output_changed`, `run_exited`
 - `agent_registered`, `agent_state_changed`, `agent_completed`,
   `agent_attention_acknowledged`
+- `agent_schedule_created`, `agent_schedule_paused`, `agent_schedule_resumed`,
+  `agent_schedule_removed`
 - `handoff_completed`
 
 Output events carry run identity and the latest output revision, not raw PTY
@@ -92,11 +97,27 @@ resulting Agent snapshot after the item is removed. The acknowledgment is
 conditional on its raising observation revision, persists before publication,
 and does not increment the lifecycle observation revision.
 
+Schedule create, pause, resume, and remove events never contain prompt content.
+Create and changed pause/resume operations publish the complete prompt-free
+schedule summary after persistence. Idempotent pause or resume emits no event and
+does not advance the schedule revision. Removing a schedule emits only its
+workspace and schedule identities.
+
+Closing a workspace removes all of its schedules and stored prompts as part of
+the workspace transaction. The stream publishes the existing single
+`workspace_closed` event; it does not publish one `agent_schedule_removed` event
+per owned schedule.
+
 Protocol-8 and older event clients do not receive protocol-9 agent snapshots or
 agent events. Filtering does not rewrite the journal: their returned cursor
 still advances across filtered agent events, preserving the stream's total
 publication order. Agent get, register, and report requests require protocol 9;
 ensure requires protocol 10.
+
+Protocol-21 and older clients receive workspace snapshots without schedules and
+do not receive schedule events. The returned cursor still advances across those
+filtered events, preserving the stream's total publication order. Schedule
+management requests require protocol 22.
 
 Event IDs provide one total publication order. The daemon transition coordinator
 couples durable lifecycle mutation, persistence, and event publication. Events

--- a/src/agent_attention_projection.rs
+++ b/src/agent_attention_projection.rs
@@ -182,6 +182,7 @@ mod tests {
                 foreground_process: None,
             }],
             launchers: Vec::<WorkspaceLauncherSnapshot>::new(),
+            schedules: Vec::new(),
             agents,
         }
     }

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use boomux::client::{ClientError, LifecycleError, ProtocolError};
 use boomux::protocol::{
     AgentAttentionReason, AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot,
+    AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSnapshot, AgentScheduleState,
     AgentState, ErrorCode, ShellRunExitReason, ShellSnapshot, ShellStatus,
     WorkspaceLauncherSnapshot,
 };
@@ -82,6 +83,7 @@ pub(crate) struct WorkspaceSummary {
     pub(crate) name: String,
     pub(crate) shell_count: usize,
     pub(crate) launcher_count: usize,
+    pub(crate) schedule_count: usize,
     pub(crate) agent_count: usize,
     pub(crate) agent_state_counts: AgentStateCounts,
     pub(crate) attention_count: usize,
@@ -95,6 +97,36 @@ pub(crate) struct LauncherData {
     pub(crate) name: String,
     pub(crate) cwd: String,
     pub(crate) command: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ScheduleData {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) workspace_name: Option<String>,
+    pub(crate) name: String,
+    pub(crate) cwd: String,
+    pub(crate) integration: String,
+    pub(crate) session_mode: &'static str,
+    pub(crate) external_session_id: Option<String>,
+    pub(crate) cron: String,
+    pub(crate) timezone: String,
+    pub(crate) state: &'static str,
+    pub(crate) overlap_policy: &'static str,
+    pub(crate) revision: u64,
+    pub(crate) prompt_revision: u64,
+    pub(crate) trigger_revision: u64,
+    pub(crate) created_at_ms: u64,
+    pub(crate) updated_at_ms: u64,
+    pub(crate) evaluation_frontier_ms: u64,
+    pub(crate) execution_shell_id: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ScheduleInspectionData {
+    #[serde(flatten)]
+    pub(crate) schedule: ScheduleData,
+    pub(crate) prompt: String,
 }
 
 #[derive(Serialize)]
@@ -257,6 +289,59 @@ pub(crate) fn launcher(
     }
 }
 
+pub(crate) fn schedule(
+    schedule: &AgentScheduleSnapshot,
+    workspace_name: Option<&str>,
+) -> ScheduleData {
+    let (session_mode, external_session_id) = match &schedule.session {
+        AgentScheduleSession::Fresh => ("fresh", None),
+        AgentScheduleSession::Continue {
+            external_session_id,
+        } => ("continue", Some(external_session_id.clone())),
+    };
+    ScheduleData {
+        id: schedule.id.clone(),
+        workspace_id: schedule.workspace_id.clone(),
+        workspace_name: workspace_name.map(str::to_owned),
+        name: schedule.name.clone(),
+        cwd: schedule.cwd.display().to_string(),
+        integration: schedule.integration.clone(),
+        session_mode,
+        external_session_id,
+        cron: schedule.trigger.cron.clone(),
+        timezone: schedule.trigger.timezone.clone(),
+        state: schedule_state(schedule.state),
+        overlap_policy: match schedule.overlap_policy {
+            AgentScheduleOverlapPolicy::Skip => "skip",
+        },
+        revision: schedule.revision,
+        prompt_revision: schedule.prompt_revision,
+        trigger_revision: schedule.trigger_revision,
+        created_at_ms: schedule.created_at_ms,
+        updated_at_ms: schedule.updated_at_ms,
+        evaluation_frontier_ms: schedule.evaluation_frontier_ms,
+        execution_shell_id: schedule.execution_shell_id.clone(),
+    }
+}
+
+pub(crate) fn schedule_inspection(
+    schedule: &AgentScheduleSnapshot,
+    workspace_name: Option<&str>,
+    prompt: &str,
+) -> ScheduleInspectionData {
+    ScheduleInspectionData {
+        schedule: self::schedule(schedule, workspace_name),
+        prompt: prompt.to_owned(),
+    }
+}
+
+pub(crate) fn schedule_state(state: AgentScheduleState) -> &'static str {
+    match state {
+        AgentScheduleState::Paused => "paused",
+        AgentScheduleState::Enabled => "enabled",
+    }
+}
+
 pub(crate) fn agent(agent: &AgentInstanceSnapshot, workspace_name: Option<&str>) -> AgentData {
     AgentData {
         id: agent.id.clone(),
@@ -374,6 +459,12 @@ fn classify_error(command: &str, error: &(dyn Error + 'static)) -> &'static str 
         }
         if let Some(client) = candidate.downcast_ref::<ClientError>() {
             return classify_client_error(command, client);
+        }
+        if candidate
+            .downcast_ref::<boomux::scheduling::SchedulingError>()
+            .is_some()
+        {
+            return "invalid_argument";
         }
         if let Some(io_error) = candidate.downcast_ref::<io::Error>() {
             return classify_io_error(command, io_error);
@@ -547,6 +638,44 @@ mod tests {
     }
 
     #[test]
+    fn schedule_summary_is_prompt_free_and_inspection_discloses_prompt() {
+        let snapshot = AgentScheduleSnapshot {
+            id: "schedule-1".into(),
+            workspace_id: "w1".into(),
+            name: "review".into(),
+            cwd: "/tmp/project".into(),
+            integration: "opencode".into(),
+            session: AgentScheduleSession::Fresh,
+            trigger: boomux::protocol::AgentScheduleTrigger {
+                cron: "0 9 * * 1-5".into(),
+                timezone: "UTC".into(),
+            },
+            state: AgentScheduleState::Paused,
+            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            revision: 1,
+            prompt_revision: 2,
+            trigger_revision: 1,
+            created_at_ms: 10,
+            updated_at_ms: 11,
+            evaluation_frontier_ms: 11,
+            execution_shell_id: None,
+        };
+        let private = "private prompt contents\n";
+
+        let summary = serde_json::to_value(schedule(&snapshot, Some("project"))).unwrap();
+        assert!(summary.get("prompt").is_none());
+        assert!(!summary.to_string().contains(private));
+        assert!(summary["external_session_id"].is_null());
+        assert!(summary["execution_shell_id"].is_null());
+        assert_eq!(summary["session_mode"], "fresh");
+        assert_eq!(summary["state"], "paused");
+
+        let inspection =
+            serde_json::to_value(schedule_inspection(&snapshot, Some("project"), private)).unwrap();
+        assert_eq!(inspection["prompt"], private);
+    }
+
+    #[test]
     fn client_errors_convert_to_stable_cli_codes() {
         let remote = ClientError::Remote(RemoteError {
             code: Some(ErrorCode::ShellStartFailed),
@@ -560,6 +689,7 @@ mod tests {
             "connection refused",
         ));
         let timeout = ClientError::Lifecycle(LifecycleError::ShutdownTimeout);
+        let schedule = boomux::scheduling::canonicalize_cron("not a cron").unwrap_err();
 
         assert_eq!(classify_error("shell.open", &remote), "shell_start_failed");
         assert_eq!(
@@ -571,5 +701,9 @@ mod tests {
             "daemon_unavailable"
         );
         assert_eq!(classify_error("daemon.stop", &timeout), "timeout");
+        assert_eq!(
+            classify_error("schedule.create", &schedule),
+            "invalid_argument"
+        );
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,11 +14,12 @@ use std::thread;
 use std::time::Duration;
 
 use crate::protocol::{
-    self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, DaemonEvent, Envelope,
-    ErrorCode, EventCursor, FocusedTerminalSnapshot, NotificationDeliveryConfig, Request, Response,
-    ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalPreviewLine,
-    TerminalPreviewSpan, TerminalProfile, UnixEnvironment, UnixEnvironmentVariable,
-    WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
+    AgentScheduleSnapshot, AgentScheduleSpec, DaemonEvent, Envelope, ErrorCode, EventCursor,
+    FocusedTerminalSnapshot, NotificationDeliveryConfig, Request, Response, ShellSnapshot,
+    ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan,
+    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
+    WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -564,6 +565,18 @@ impl Client {
         }
     }
 
+    pub fn get_agent_schedule(
+        &self,
+        schedule_id: impl Into<String>,
+    ) -> Result<AgentScheduleInspection> {
+        match self.request(Request::GetAgentSchedule {
+            schedule_id: schedule_id.into(),
+        })? {
+            Response::AgentScheduleInspection { inspection } => Ok(inspection),
+            other => unexpected(other),
+        }
+    }
+
     pub fn create_workspace(
         &self,
         name: impl Into<String>,
@@ -622,6 +635,20 @@ impl Client {
             spec,
         })? {
             Response::Launcher { launcher } => Ok(launcher),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn create_agent_schedule(
+        &self,
+        workspace_id: impl Into<String>,
+        spec: AgentScheduleSpec,
+    ) -> Result<AgentScheduleSnapshot> {
+        match self.request(Request::CreateAgentSchedule {
+            workspace_id: workspace_id.into(),
+            spec,
+        })? {
+            Response::AgentSchedule { schedule } => Ok(schedule),
             other => unexpected(other),
         }
     }
@@ -859,6 +886,39 @@ impl Client {
         )
     }
 
+    pub fn pause_agent_schedule(
+        &self,
+        schedule_id: impl Into<String>,
+    ) -> Result<AgentScheduleSnapshot> {
+        match self.request(Request::PauseAgentSchedule {
+            schedule_id: schedule_id.into(),
+        })? {
+            Response::AgentSchedule { schedule } => Ok(schedule),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn resume_agent_schedule(
+        &self,
+        schedule_id: impl Into<String>,
+    ) -> Result<AgentScheduleSnapshot> {
+        match self.request(Request::ResumeAgentSchedule {
+            schedule_id: schedule_id.into(),
+        })? {
+            Response::AgentSchedule { schedule } => Ok(schedule),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn remove_agent_schedule(&self, schedule_id: impl Into<String>) -> Result<()> {
+        expect_ok(
+            self.request(Request::RemoveAgentSchedule {
+                schedule_id: schedule_id.into(),
+            })?,
+            Response::Ok,
+        )
+    }
+
     pub fn close_workspace(&self, workspace_id: impl Into<String>) -> Result<()> {
         expect_ok(
             self.request(Request::CloseWorkspace {
@@ -1085,6 +1145,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 22, 21);
             reject_protocol(&listener, 21, 20);
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
@@ -1264,7 +1325,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 21);
+            assert_eq!(request.version, 22);
             let Request::Attach {
                 environment: Some(environment),
                 ..
@@ -1281,7 +1342,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    21,
+                    22,
                     Response::Attached {
                         token: "token".into(),
                         reconstruction: Vec::new(),
@@ -1309,80 +1370,52 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, 21, 20);
-            reject_protocol(&listener, 21, 20);
-
-            let (mut stream, _) = listener.accept().unwrap();
-            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 20);
-            assert!(matches!(request.message, Request::Ping));
-            protocol::write_message(
-                &mut stream,
-                &Envelope::with_version(
-                    19,
-                    Response::Error {
-                        message: "protocol 20 unsupported".into(),
-                        code: Some(ErrorCode::UnsupportedVersion),
-                    },
-                ),
-            )
-            .unwrap();
-
-            let (mut stream, _) = listener.accept().unwrap();
-            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 19);
-            assert!(matches!(request.message, Request::Ping));
-            protocol::write_message(
-                &mut stream,
-                &Envelope::with_version(
-                    18,
-                    Response::Error {
-                        message: "protocol 19 unsupported".into(),
-                        code: Some(ErrorCode::UnsupportedVersion),
-                    },
-                ),
-            )
-            .unwrap();
-
-            let (mut stream, _) = listener.accept().unwrap();
-            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 18);
-            assert!(matches!(request.message, Request::Ping));
-            protocol::write_message(
-                &mut stream,
-                &Envelope::with_version(
-                    17,
-                    Response::Error {
-                        message: "protocol 18 unsupported".into(),
-                        code: Some(ErrorCode::UnsupportedVersion),
-                    },
-                ),
-            )
-            .unwrap();
-
-            let (mut stream, _) = listener.accept().unwrap();
-            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 17);
-            assert!(matches!(request.message, Request::Ping));
-            protocol::write_message(&mut stream, &Envelope::with_version(17, Response::Pong))
-                .unwrap();
-
-            let (mut stream, _) = listener.accept().unwrap();
-            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 17);
-            assert!(matches!(request.message, Request::Attach { .. }));
-            protocol::write_message(
-                &mut stream,
-                &Envelope::with_version(
-                    17,
-                    Response::Attached {
-                        token: "token".into(),
-                        reconstruction: Vec::new(),
-                        warning: None,
-                    },
-                ),
-            )
-            .unwrap();
+            loop {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                if request.version > 17 {
+                    assert!(matches!(
+                        request.message,
+                        Request::Ping | Request::Attach { .. }
+                    ));
+                    protocol::write_message(
+                        &mut stream,
+                        &Envelope::with_version(
+                            request.version - 1,
+                            Response::Error {
+                                message: format!("protocol {} unsupported", request.version),
+                                code: Some(ErrorCode::UnsupportedVersion),
+                            },
+                        ),
+                    )
+                    .unwrap();
+                    continue;
+                }
+                assert_eq!(request.version, 17);
+                match request.message {
+                    Request::Ping => protocol::write_message(
+                        &mut stream,
+                        &Envelope::with_version(17, Response::Pong),
+                    )
+                    .unwrap(),
+                    Request::Attach { .. } => {
+                        protocol::write_message(
+                            &mut stream,
+                            &Envelope::with_version(
+                                17,
+                                Response::Attached {
+                                    token: "token".into(),
+                                    reconstruction: Vec::new(),
+                                    warning: None,
+                                },
+                            ),
+                        )
+                        .unwrap();
+                        break;
+                    }
+                    request => panic!("unexpected request: {request:?}"),
+                }
+            }
         });
         let client = Client::from_socket_path(socket);
 
@@ -1400,6 +1433,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 22, 21);
             reject_protocol(&listener, 21, 20);
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
@@ -1457,6 +1491,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 22, 21);
             reject_protocol(&listener, 21, 20);
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -29,15 +29,17 @@ use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::protocol::{
     self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
-    AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame,
-    DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot,
+    AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
+    AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSnapshot, AgentScheduleSpec,
+    AgentScheduleState, AgentScheduleTrigger, AgentState, AttachFrame, DaemonEvent,
+    DaemonEventKind, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot,
     NotificationDeliveryConfig, Request, Response, ShellRunExitReason, ShellRunSnapshot,
     ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalProfile,
     UnixEnvironment, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::state_store::{
-    PersistedAgentInstance, PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
-    PersistedWorkspaceLauncher, StateStore,
+    PersistedAgentInstance, PersistedAgentSchedule, PersistedShell, PersistedShellRun,
+    PersistedState, PersistedWorkspace, PersistedWorkspaceLauncher, StateStore,
 };
 use crate::terminal_state::TerminalState;
 
@@ -966,6 +968,9 @@ fn unsupported_request_message(feature: protocol::ProtocolFeature) -> String {
 
 fn response_for_version(response: Response, version: u32) -> Response {
     let mut response = response;
+    if !protocol::ProtocolFeature::AgentSchedules.is_supported_by(version) {
+        remove_agent_schedules(&mut response);
+    }
     if !protocol::ProtocolFeature::WorkspaceDefaultCwd.is_supported_by(version) {
         remove_workspace_default_cwds(&mut response);
     }
@@ -1036,6 +1041,36 @@ fn response_for_version(response: Response, version: u32) -> Response {
             }
         }
         response => response,
+    }
+}
+
+fn remove_agent_schedules(response: &mut Response) {
+    match response {
+        Response::Snapshot { snapshot } => {
+            for workspace in &mut snapshot.workspaces {
+                workspace.schedules.clear();
+            }
+        }
+        Response::Workspace { workspace } => workspace.schedules.clear(),
+        Response::Events {
+            snapshot, events, ..
+        } => {
+            if let Some(snapshot) = snapshot {
+                for workspace in &mut snapshot.workspaces {
+                    workspace.schedules.clear();
+                }
+            }
+            events.retain(|event| {
+                !matches!(
+                    event.kind,
+                    DaemonEventKind::AgentScheduleCreated { .. }
+                        | DaemonEventKind::AgentSchedulePaused { .. }
+                        | DaemonEventKind::AgentScheduleResumed { .. }
+                        | DaemonEventKind::AgentScheduleRemoved { .. }
+                )
+            });
+        }
+        _ => {}
     }
 }
 
@@ -1247,6 +1282,10 @@ enum DurableUndo {
         workspace: Arc<Workspace>,
         launcher: Arc<WorkspaceLauncher>,
     },
+    CreatedSchedule {
+        workspace: Arc<Workspace>,
+        schedule: Arc<AgentSchedule>,
+    },
     RegisteredAgent {
         workspace: Arc<Workspace>,
         agent: Arc<AgentInstance>,
@@ -1267,9 +1306,18 @@ enum DurableUndo {
         agent: Arc<AgentInstance>,
         previous: AgentInstanceState,
     },
+    ScheduleState {
+        schedule: Arc<AgentSchedule>,
+        previous: AgentScheduleMutableState,
+    },
     RemovedLauncher {
         workspace: Arc<Workspace>,
         launcher: Arc<WorkspaceLauncher>,
+        index: usize,
+    },
+    RemovedSchedule {
+        workspace: Arc<Workspace>,
+        schedule: Arc<AgentSchedule>,
         index: usize,
     },
     RemovedShell {
@@ -1282,6 +1330,7 @@ enum DurableUndo {
         shells: Vec<Arc<Shell>>,
         launchers: Vec<Arc<WorkspaceLauncher>>,
         agents: Vec<Arc<AgentInstance>>,
+        schedules: Vec<Arc<AgentSchedule>>,
     },
 }
 
@@ -1798,6 +1847,14 @@ impl DurableRegistry {
             .ok_or_else(|| not_found("agent instance", id))
     }
 
+    fn schedule(&self, id: &str) -> io::Result<Arc<AgentSchedule>> {
+        lock(&self.state)?
+            .schedules
+            .get(id)
+            .cloned()
+            .ok_or_else(|| not_found("agent schedule", id))
+    }
+
     fn contains_shell(&self, shell: &Arc<Shell>) -> io::Result<bool> {
         Ok(lock(&self.state)?
             .shells
@@ -1908,6 +1965,7 @@ impl DurableRegistry {
             shell_ids: Mutex::new(shells.iter().map(|shell| shell.id.clone()).collect()),
             launcher_ids: Mutex::new(Vec::new()),
             agent_ids: Mutex::new(Vec::new()),
+            schedule_ids: Mutex::new(Vec::new()),
         });
         let snapshot = WorkspaceSnapshot {
             id: workspace_id.clone(),
@@ -1919,6 +1977,7 @@ impl DurableRegistry {
                 .collect::<io::Result<_>>()?,
             launchers: Vec::new(),
             agents: Vec::new(),
+            schedules: Vec::new(),
         };
         let mut state = lock(&self.state)?;
         if state
@@ -2049,6 +2108,118 @@ impl DurableRegistry {
                 workspace,
                 launcher,
             },
+        ))
+    }
+
+    fn create_schedule(
+        &self,
+        workspace_id: &str,
+        mut spec: AgentScheduleSpec,
+    ) -> io::Result<(AgentScheduleSnapshot, DurableUndo)> {
+        validate_name(&spec.name)?;
+        validate_cwd(&spec.cwd)?;
+        validate_schedule_spec(&spec)?;
+        spec.trigger.cron = crate::scheduling::canonicalize_cron(&spec.trigger.cron)
+            .map_err(schedule_validation_error)?;
+        spec.trigger.timezone = crate::scheduling::canonicalize_timezone(&spec.trigger.timezone)
+            .map_err(schedule_validation_error)?;
+        validate_schedule_capability(&spec.integration, &spec.session)?;
+        let workspace = self.workspace(workspace_id)?;
+        let now = unix_time_ms();
+        let schedule = Arc::new(AgentSchedule {
+            id: Uuid::new_v4().to_string(),
+            workspace_id: workspace_id.into(),
+            name: spec.name,
+            cwd: spec.cwd,
+            integration: spec.integration,
+            prompt: spec.prompt,
+            session: spec.session,
+            trigger: spec.trigger,
+            overlap_policy: spec.overlap_policy,
+            prompt_revision: 1,
+            trigger_revision: 1,
+            created_at_ms: now,
+            state: Mutex::new(AgentScheduleMutableState {
+                state: spec.state,
+                revision: 1,
+                updated_at_ms: now,
+                evaluation_frontier_ms: now,
+                execution_shell_id: None,
+            }),
+        });
+        let snapshot = schedule.snapshot()?;
+        let mut state = lock(&self.state)?;
+        let Some(current) = state.workspaces.get(workspace_id) else {
+            return Err(not_found("workspace", workspace_id));
+        };
+        if !Arc::ptr_eq(current, &workspace) {
+            return Err(not_found("workspace", workspace_id));
+        }
+        let mut schedule_ids = lock(&workspace.schedule_ids)?;
+        if schedule_ids.len() >= crate::scheduling::MAX_SCHEDULES_PER_WORKSPACE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "workspace may contain at most {} agent schedules",
+                    crate::scheduling::MAX_SCHEDULES_PER_WORKSPACE
+                ),
+            ));
+        }
+        if schedule_ids.iter().any(|id| {
+            state
+                .schedules
+                .get(id)
+                .is_some_and(|existing| existing.name == snapshot.name)
+        }) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("agent schedule name already exists: {}", snapshot.name),
+            ));
+        }
+        state
+            .schedules
+            .insert(schedule.id.clone(), Arc::clone(&schedule));
+        schedule_ids.push(schedule.id.clone());
+        drop(schedule_ids);
+        drop(state);
+        Ok((
+            snapshot,
+            DurableUndo::CreatedSchedule {
+                workspace,
+                schedule,
+            },
+        ))
+    }
+
+    fn set_schedule_state(
+        &self,
+        schedule_id: &str,
+        next: AgentScheduleState,
+    ) -> io::Result<(AgentScheduleSnapshot, Option<DurableUndo>)> {
+        let schedule = self.schedule(schedule_id)?;
+        if next == AgentScheduleState::Enabled {
+            validate_schedule_capability(&schedule.integration, &schedule.session)?;
+        }
+        let mut state = lock(&schedule.state)?;
+        if state.state == next {
+            return Ok((schedule.snapshot_from(&state), None));
+        }
+        let previous = state.clone();
+        let now = unix_time_ms().max(state.updated_at_ms.saturating_add(1));
+        state.state = next;
+        state.revision = state
+            .revision
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("agent schedule revision exhausted"))?;
+        state.updated_at_ms = now;
+        if next == AgentScheduleState::Enabled {
+            state.evaluation_frontier_ms = now.max(state.evaluation_frontier_ms);
+        }
+        let snapshot = schedule.snapshot_from(&state);
+        drop(state);
+        Ok((
+            snapshot,
+            Some(DurableUndo::ScheduleState { schedule, previous }),
         ))
     }
 
@@ -2450,6 +2621,20 @@ impl DurableRegistry {
                 }
                 lock(&workspace.launcher_ids)?.retain(|id| id != &launcher.id);
             }
+            DurableUndo::CreatedSchedule {
+                workspace,
+                schedule,
+            } => {
+                let mut state = lock(&self.state)?;
+                if state
+                    .schedules
+                    .get(&schedule.id)
+                    .is_some_and(|current| Arc::ptr_eq(current, &schedule))
+                {
+                    state.schedules.remove(&schedule.id);
+                }
+                lock(&workspace.schedule_ids)?.retain(|id| id != &schedule.id);
+            }
             DurableUndo::RegisteredAgent { workspace, agent } => {
                 let mut state = lock(&self.state)?;
                 if state
@@ -2474,6 +2659,9 @@ impl DurableRegistry {
             DurableUndo::AgentState { agent, previous } => {
                 *lock(&agent.state)? = previous;
             }
+            DurableUndo::ScheduleState { schedule, previous } => {
+                *lock(&schedule.state)? = previous;
+            }
             DurableUndo::RemovedLauncher {
                 workspace,
                 launcher,
@@ -2483,6 +2671,16 @@ impl DurableRegistry {
                     .launchers
                     .insert(launcher.id.clone(), Arc::clone(&launcher));
                 lock(&workspace.launcher_ids)?.insert(index, launcher.id.clone());
+            }
+            DurableUndo::RemovedSchedule {
+                workspace,
+                schedule,
+                index,
+            } => {
+                lock(&self.state)?
+                    .schedules
+                    .insert(schedule.id.clone(), Arc::clone(&schedule));
+                lock(&workspace.schedule_ids)?.insert(index, schedule.id.clone());
             }
             DurableUndo::RemovedShell {
                 workspace,
@@ -2499,6 +2697,7 @@ impl DurableRegistry {
                 shells,
                 launchers,
                 agents,
+                schedules,
             } => {
                 let mut state = lock(&self.state)?;
                 for shell in shells {
@@ -2509,6 +2708,9 @@ impl DurableRegistry {
                 }
                 for agent in agents {
                     state.agents.insert(agent.id.clone(), agent);
+                }
+                for schedule in schedules {
+                    state.schedules.insert(schedule.id.clone(), schedule);
                 }
                 state.workspaces.insert(workspace.id.clone(), workspace);
             }
@@ -2585,6 +2787,14 @@ impl DurableRegistry {
                 };
                 agents.push(agent.persisted()?);
             }
+            let ids = lock(&workspace.schedule_ids)?.clone();
+            let mut schedules = Vec::with_capacity(ids.len());
+            for id in ids {
+                let Some(schedule) = state.schedules.get(&id) else {
+                    continue;
+                };
+                schedules.push(schedule.persisted()?);
+            }
             saved.workspaces.push(PersistedWorkspace {
                 id: workspace.id.clone(),
                 name: lock(&workspace.name)?.clone(),
@@ -2592,6 +2802,7 @@ impl DurableRegistry {
                 shells,
                 launchers,
                 agents,
+                schedules,
             });
         }
         Ok(PersistenceGeneration {
@@ -3283,6 +3494,7 @@ struct DurableState {
     shells: HashMap<String, Arc<Shell>>,
     launchers: HashMap<String, Arc<WorkspaceLauncher>>,
     agents: HashMap<String, Arc<AgentInstance>>,
+    schedules: HashMap<String, Arc<AgentSchedule>>,
 }
 
 impl Default for DaemonService {
@@ -3317,6 +3529,32 @@ struct Workspace {
     shell_ids: Mutex<Vec<String>>,
     launcher_ids: Mutex<Vec<String>>,
     agent_ids: Mutex<Vec<String>>,
+    schedule_ids: Mutex<Vec<String>>,
+}
+
+struct AgentSchedule {
+    id: String,
+    workspace_id: String,
+    name: String,
+    cwd: PathBuf,
+    integration: String,
+    prompt: String,
+    session: AgentScheduleSession,
+    trigger: AgentScheduleTrigger,
+    overlap_policy: AgentScheduleOverlapPolicy,
+    prompt_revision: u64,
+    trigger_revision: u64,
+    created_at_ms: u64,
+    state: Mutex<AgentScheduleMutableState>,
+}
+
+#[derive(Clone)]
+struct AgentScheduleMutableState {
+    state: AgentScheduleState,
+    revision: u64,
+    updated_at_ms: u64,
+    evaluation_frontier_ms: u64,
+    execution_shell_id: Option<String>,
 }
 
 struct AgentInstance {
@@ -3973,6 +4211,12 @@ impl DaemonService {
             Request::GetAgent { agent_id } => Ok(Response::Agent {
                 agent: self.agent(&agent_id)?.snapshot()?,
             }),
+            Request::GetAgentSchedule { schedule_id } => {
+                let schedule = self.schedule(&schedule_id)?;
+                Ok(Response::AgentScheduleInspection {
+                    inspection: schedule.inspection()?,
+                })
+            }
             Request::WaitAgent {
                 agent_id,
                 after_revision,
@@ -4040,6 +4284,14 @@ impl DaemonService {
                     name: launcher.name.clone(),
                 };
                 Ok((Response::Launcher { launcher }, vec![event]))
+            }),
+            Request::CreateAgentSchedule { workspace_id, spec } => self.durable_mutation(|undo| {
+                let schedule = self.create_schedule_mutation(undo, &workspace_id, spec)?;
+                let event = DaemonEventKind::AgentScheduleCreated {
+                    workspace_id,
+                    schedule: schedule.clone(),
+                };
+                Ok((Response::AgentSchedule { schedule }, vec![event]))
             }),
             Request::RegisterAgent {
                 shell_id,
@@ -4187,6 +4439,22 @@ impl DaemonService {
                     }],
                 ))
             }),
+            Request::PauseAgentSchedule { schedule_id } => {
+                self.change_schedule_state(&schedule_id, AgentScheduleState::Paused)
+            }
+            Request::ResumeAgentSchedule { schedule_id } => {
+                self.change_schedule_state(&schedule_id, AgentScheduleState::Enabled)
+            }
+            Request::RemoveAgentSchedule { schedule_id } => self.durable_mutation(|undo| {
+                let schedule = self.remove_schedule_mutation(undo, &schedule_id)?;
+                Ok((
+                    Response::Ok,
+                    vec![DaemonEventKind::AgentScheduleRemoved {
+                        workspace_id: schedule.workspace_id.clone(),
+                        schedule_id,
+                    }],
+                ))
+            }),
             Request::Attach { .. } => unreachable!("attach is handled before dispatch"),
         }
     }
@@ -4232,6 +4500,7 @@ impl DaemonService {
         let mut workspace_names = HashSet::new();
         let mut run_ids = HashSet::new();
         let mut agent_ids = HashSet::new();
+        let mut schedule_ids = HashSet::new();
         let mut recovered_interrupted_run = false;
         for saved_workspace in persisted.workspaces {
             validate_id("workspace", &saved_workspace.id)?;
@@ -4344,6 +4613,32 @@ impl DaemonService {
                 workspace_agent_ids.push(agent.id.clone());
                 state.agents.insert(agent.id.clone(), agent);
             }
+            if saved_workspace.schedules.len() > crate::scheduling::MAX_SCHEDULES_PER_WORKSPACE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Boomux state contains too many agent schedules in a workspace",
+                ));
+            }
+            let mut schedule_names = HashSet::new();
+            let mut workspace_schedule_ids = Vec::with_capacity(saved_workspace.schedules.len());
+            for saved_schedule in saved_workspace.schedules {
+                validate_id("agent schedule", &saved_schedule.id)?;
+                validate_persisted_schedule(&saved_schedule)?;
+                if !schedule_ids.insert(saved_schedule.id.clone())
+                    || !schedule_names.insert(saved_schedule.name.clone())
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Boomux state contains a duplicate agent schedule",
+                    ));
+                }
+                let schedule = Arc::new(AgentSchedule::from_persisted(
+                    &saved_workspace.id,
+                    saved_schedule,
+                ));
+                workspace_schedule_ids.push(schedule.id.clone());
+                state.schedules.insert(schedule.id.clone(), schedule);
+            }
             let workspace = Arc::new(Workspace {
                 id: saved_workspace.id.clone(),
                 name: Mutex::new(saved_workspace.name),
@@ -4351,6 +4646,7 @@ impl DaemonService {
                 shell_ids: Mutex::new(shell_ids),
                 launcher_ids: Mutex::new(launcher_ids),
                 agent_ids: Mutex::new(workspace_agent_ids),
+                schedule_ids: Mutex::new(workspace_schedule_ids),
             });
             state.workspaces.insert(saved_workspace.id, workspace);
         }
@@ -5291,6 +5587,10 @@ impl DaemonService {
         self.durable.agent(id)
     }
 
+    fn schedule(&self, id: &str) -> io::Result<Arc<AgentSchedule>> {
+        self.durable.schedule(id)
+    }
+
     fn contains_shell(&self, shell: &Arc<Shell>) -> io::Result<bool> {
         self.durable.contains_shell(shell)
     }
@@ -5365,6 +5665,47 @@ impl DaemonService {
         let (snapshot, record) = self.durable.create_launcher(workspace_id, spec)?;
         undo.record(record);
         Ok(snapshot)
+    }
+
+    fn create_schedule_mutation(
+        &self,
+        undo: &mut DurableUndoLog,
+        workspace_id: &str,
+        spec: AgentScheduleSpec,
+    ) -> io::Result<AgentScheduleSnapshot> {
+        let (snapshot, record) = self.durable.create_schedule(workspace_id, spec)?;
+        undo.record(record);
+        Ok(snapshot)
+    }
+
+    fn change_schedule_state(
+        &self,
+        schedule_id: &str,
+        next: AgentScheduleState,
+    ) -> DaemonResult<Response> {
+        self.durable_mutation_outcome(|undo| {
+            let (schedule, record) = self.durable.set_schedule_state(schedule_id, next)?;
+            let Some(record) = record else {
+                return Ok(DurableMutation::Unchanged(Response::AgentSchedule {
+                    schedule,
+                }));
+            };
+            undo.record(record);
+            let event = match next {
+                AgentScheduleState::Paused => DaemonEventKind::AgentSchedulePaused {
+                    workspace_id: schedule.workspace_id.clone(),
+                    schedule: schedule.clone(),
+                },
+                AgentScheduleState::Enabled => DaemonEventKind::AgentScheduleResumed {
+                    workspace_id: schedule.workspace_id.clone(),
+                    schedule: schedule.clone(),
+                },
+            };
+            Ok(DurableMutation::Changed(
+                Response::AgentSchedule { schedule },
+                vec![event],
+            ))
+        })
     }
 
     #[cfg(test)]
@@ -5560,6 +5901,40 @@ impl DaemonService {
         Ok(result)
     }
 
+    fn remove_schedule_mutation(
+        &self,
+        undo: &mut DurableUndoLog,
+        schedule_id: &str,
+    ) -> io::Result<Arc<AgentSchedule>> {
+        let mut state = lock(&self.durable.state)?;
+        let schedule = state
+            .schedules
+            .get(schedule_id)
+            .cloned()
+            .ok_or_else(|| not_found("agent schedule", schedule_id))?;
+        let workspace = state
+            .workspaces
+            .get(&schedule.workspace_id)
+            .cloned()
+            .ok_or_else(|| not_found("workspace", &schedule.workspace_id))?;
+        let mut schedule_ids = lock(&workspace.schedule_ids)?;
+        let index = schedule_ids
+            .iter()
+            .position(|id| id == schedule_id)
+            .ok_or_else(|| not_found("agent schedule", schedule_id))?;
+        state.schedules.remove(schedule_id);
+        schedule_ids.remove(index);
+        drop(schedule_ids);
+        drop(state);
+        let result = Arc::clone(&schedule);
+        undo.record(DurableUndo::RemovedSchedule {
+            workspace,
+            schedule,
+            index,
+        });
+        Ok(result)
+    }
+
     fn read_shell(&self, shell_id: &str, max_bytes: usize) -> io::Result<Vec<u8>> {
         let shell = self.shell(shell_id)?;
         self.runtimes.read_shell(&shell, max_bytes)
@@ -5667,6 +6042,7 @@ impl DaemonService {
         let shell_ids = lock(&workspace.shell_ids)?.clone();
         let launcher_ids = lock(&workspace.launcher_ids)?.clone();
         let agent_ids = lock(&workspace.agent_ids)?.clone();
+        let schedule_ids = lock(&workspace.schedule_ids)?.clone();
         let shells = shell_ids
             .iter()
             .filter_map(|id| state.shells.get(id).cloned())
@@ -5679,6 +6055,10 @@ impl DaemonService {
             .iter()
             .filter_map(|id| state.agents.get(id).cloned())
             .collect();
+        let schedules = schedule_ids
+            .iter()
+            .filter_map(|id| state.schedules.get(id).cloned())
+            .collect();
         state.workspaces.remove(workspace_id);
         for id in shell_ids {
             state.shells.remove(&id);
@@ -5689,12 +6069,16 @@ impl DaemonService {
         for id in agent_ids {
             state.agents.remove(&id);
         }
+        for id in schedule_ids {
+            state.schedules.remove(&id);
+        }
         drop(state);
         Ok(DurableUndo::RemovedWorkspace {
             workspace,
             shells,
             launchers,
             agents,
+            schedules,
         })
     }
 
@@ -5760,7 +6144,7 @@ impl DaemonService {
 
 impl Workspace {
     fn snapshot(&self, registry: &DurableRegistry) -> io::Result<WorkspaceSnapshot> {
-        let (shells, launchers, agents) = {
+        let (shells, launchers, agents, schedules) = {
             let state = lock(&registry.state)?;
             let shell_ids = lock(&self.shell_ids)?;
             let shells = shell_ids
@@ -5777,7 +6161,12 @@ impl Workspace {
                 .iter()
                 .filter_map(|id| state.agents.get(id).cloned())
                 .collect::<Vec<_>>();
-            (shells, launchers, agents)
+            let schedule_ids = lock(&self.schedule_ids)?;
+            let schedules = schedule_ids
+                .iter()
+                .filter_map(|id| state.schedules.get(id).cloned())
+                .collect::<Vec<_>>();
+            (shells, launchers, agents, schedules)
         };
         let shells = shells
             .iter()
@@ -5791,6 +6180,10 @@ impl Workspace {
             .iter()
             .map(|agent| agent.snapshot())
             .collect::<io::Result<_>>()?;
+        let schedules = schedules
+            .iter()
+            .map(|schedule| schedule.snapshot())
+            .collect::<io::Result<_>>()?;
         Ok(WorkspaceSnapshot {
             id: self.id.clone(),
             name: lock(&self.name)?.clone(),
@@ -5798,6 +6191,88 @@ impl Workspace {
             shells,
             launchers,
             agents,
+            schedules,
+        })
+    }
+}
+
+impl AgentSchedule {
+    fn from_persisted(workspace_id: &str, saved: PersistedAgentSchedule) -> Self {
+        Self {
+            id: saved.id,
+            workspace_id: workspace_id.into(),
+            name: saved.name,
+            cwd: saved.cwd,
+            integration: saved.integration,
+            prompt: saved.prompt,
+            session: saved.session,
+            trigger: saved.trigger,
+            overlap_policy: saved.overlap_policy,
+            prompt_revision: saved.prompt_revision,
+            trigger_revision: saved.trigger_revision,
+            created_at_ms: saved.created_at_ms,
+            state: Mutex::new(AgentScheduleMutableState {
+                state: saved.state,
+                revision: saved.revision,
+                updated_at_ms: saved.updated_at_ms,
+                evaluation_frontier_ms: saved.evaluation_frontier_ms,
+                execution_shell_id: saved.execution_shell_id,
+            }),
+        }
+    }
+
+    fn snapshot(&self) -> io::Result<AgentScheduleSnapshot> {
+        let state = lock(&self.state)?;
+        Ok(self.snapshot_from(&state))
+    }
+
+    fn snapshot_from(&self, state: &AgentScheduleMutableState) -> AgentScheduleSnapshot {
+        AgentScheduleSnapshot {
+            id: self.id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            name: self.name.clone(),
+            cwd: self.cwd.clone(),
+            integration: self.integration.clone(),
+            session: self.session.clone(),
+            trigger: self.trigger.clone(),
+            state: state.state,
+            overlap_policy: self.overlap_policy,
+            revision: state.revision,
+            prompt_revision: self.prompt_revision,
+            trigger_revision: self.trigger_revision,
+            created_at_ms: self.created_at_ms,
+            updated_at_ms: state.updated_at_ms,
+            evaluation_frontier_ms: state.evaluation_frontier_ms,
+            execution_shell_id: state.execution_shell_id.clone(),
+        }
+    }
+
+    fn inspection(&self) -> io::Result<AgentScheduleInspection> {
+        Ok(AgentScheduleInspection {
+            schedule: self.snapshot()?,
+            prompt: self.prompt.clone(),
+        })
+    }
+
+    fn persisted(&self) -> io::Result<PersistedAgentSchedule> {
+        let snapshot = self.snapshot()?;
+        Ok(PersistedAgentSchedule {
+            id: snapshot.id,
+            name: snapshot.name,
+            cwd: snapshot.cwd,
+            integration: snapshot.integration,
+            prompt: self.prompt.clone(),
+            session: snapshot.session,
+            trigger: snapshot.trigger,
+            state: snapshot.state,
+            overlap_policy: snapshot.overlap_policy,
+            revision: snapshot.revision,
+            prompt_revision: snapshot.prompt_revision,
+            trigger_revision: snapshot.trigger_revision,
+            created_at_ms: snapshot.created_at_ms,
+            updated_at_ms: snapshot.updated_at_ms,
+            evaluation_frontier_ms: snapshot.evaluation_frontier_ms,
+            execution_shell_id: snapshot.execution_shell_id,
         })
     }
 }
@@ -7172,6 +7647,99 @@ fn validate_persisted_cwd(cwd: &Path) -> io::Result<()> {
     }
 }
 
+fn schedule_validation_error(error: crate::scheduling::SchedulingError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, error.to_string())
+}
+
+fn validate_schedule_spec(spec: &AgentScheduleSpec) -> io::Result<()> {
+    crate::scheduling::validate_prompt(&spec.prompt).map_err(schedule_validation_error)?;
+    crate::scheduling::validate_integration_key(&spec.integration)
+        .map_err(schedule_validation_error)?;
+    if let AgentScheduleSession::Continue {
+        external_session_id,
+    } = &spec.session
+    {
+        crate::scheduling::validate_external_session_id(external_session_id)
+            .map_err(schedule_validation_error)?;
+    }
+    if spec.overlap_policy != AgentScheduleOverlapPolicy::Skip {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "agent schedule overlap policy must be skip",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_schedule_capability(
+    integration: &str,
+    session: &AgentScheduleSession,
+) -> io::Result<()> {
+    let capability = crate::integrations::by_key(integration)
+        .and_then(|descriptor| descriptor.schedule_dispatch)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "integration does not support scheduled dispatch",
+            )
+        })?;
+    let supported = match session {
+        AgentScheduleSession::Fresh => capability.fresh,
+        AgentScheduleSession::Continue { .. } => capability.continuation,
+    };
+    if !supported {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "integration does not support the requested scheduled session mode",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_persisted_schedule(schedule: &PersistedAgentSchedule) -> io::Result<()> {
+    validate_name(&schedule.name)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    validate_persisted_cwd(&schedule.cwd)?;
+    crate::scheduling::validate_prompt(&schedule.prompt)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    crate::scheduling::validate_integration_key(&schedule.integration)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    if let AgentScheduleSession::Continue {
+        external_session_id,
+    } = &schedule.session
+    {
+        crate::scheduling::validate_external_session_id(external_session_id)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    }
+    if schedule.state == AgentScheduleState::Enabled {
+        validate_schedule_capability(&schedule.integration, &schedule.session)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    }
+    let cron = crate::scheduling::canonicalize_cron(&schedule.trigger.cron)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    let timezone = crate::scheduling::canonicalize_timezone(&schedule.trigger.timezone)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    if cron != schedule.trigger.cron
+        || timezone != schedule.trigger.timezone
+        || schedule.overlap_policy != AgentScheduleOverlapPolicy::Skip
+        || schedule.revision == 0
+        || schedule.prompt_revision == 0
+        || schedule.trigger_revision == 0
+        || schedule.prompt_revision > schedule.revision
+        || schedule.trigger_revision > schedule.revision
+        || schedule.updated_at_ms < schedule.created_at_ms
+        || schedule.evaluation_frontier_ms < schedule.created_at_ms
+        || schedule.evaluation_frontier_ms > schedule.updated_at_ms
+        || schedule.execution_shell_id.is_some()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux state contains an invalid agent schedule",
+        ));
+    }
+    Ok(())
+}
+
 fn validate_id(kind: &str, id: &str) -> io::Result<()> {
     Uuid::parse_str(id).map(|_| ()).map_err(|_| {
         io::Error::new(
@@ -8052,6 +8620,322 @@ mod tests {
             io::ErrorKind::InvalidInput
         );
         assert!(validate_persisted_name("real\nlegacy row").is_ok());
+    }
+
+    fn schedule_spec(prompt: &str) -> AgentScheduleSpec {
+        AgentScheduleSpec {
+            name: "nightly".into(),
+            cwd: env::temp_dir(),
+            integration: "opencode".into(),
+            prompt: prompt.into(),
+            session: AgentScheduleSession::Fresh,
+            trigger: AgentScheduleTrigger {
+                cron: " 0  2 * * * ".into(),
+                timezone: "UTC".into(),
+            },
+            state: AgentScheduleState::Paused,
+            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+        }
+    }
+
+    #[test]
+    fn restored_enabled_schedules_require_current_dispatch_capability() {
+        let mut schedule = PersistedAgentSchedule {
+            id: Uuid::new_v4().to_string(),
+            name: "nightly".into(),
+            cwd: env::temp_dir(),
+            integration: "unsupported".into(),
+            prompt: "review changes".into(),
+            session: AgentScheduleSession::Fresh,
+            trigger: AgentScheduleTrigger {
+                cron: "0 2 * * *".into(),
+                timezone: "UTC".into(),
+            },
+            state: AgentScheduleState::Enabled,
+            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            revision: 1,
+            prompt_revision: 1,
+            trigger_revision: 1,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            evaluation_frontier_ms: 1,
+            execution_shell_id: None,
+        };
+
+        assert_eq!(
+            validate_persisted_schedule(&schedule).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        schedule.state = AgentScheduleState::Paused;
+        assert!(validate_persisted_schedule(&schedule).is_ok());
+    }
+
+    #[test]
+    fn schedule_management_is_prompt_private_and_idempotent() {
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace("scheduled".into(), Vec::new())
+            .unwrap();
+        let prompt = "private schedule instructions";
+        let Response::AgentSchedule { schedule } = registry
+            .dispatch(Request::CreateAgentSchedule {
+                workspace_id: workspace.id.clone(),
+                spec: schedule_spec(prompt),
+            })
+            .unwrap()
+        else {
+            panic!("expected schedule response");
+        };
+        assert_eq!(schedule.trigger.cron, "0 2 * * *");
+        assert_eq!(schedule.revision, 1);
+        assert!(schedule.execution_shell_id.is_none());
+        assert_eq!(
+            registry.snapshot().unwrap().workspaces[0].schedules,
+            std::slice::from_ref(&schedule)
+        );
+        assert!(
+            !serde_json::to_string(&registry.snapshot().unwrap())
+                .unwrap()
+                .contains(prompt)
+        );
+
+        let Response::AgentScheduleInspection { inspection } = registry
+            .dispatch(Request::GetAgentSchedule {
+                schedule_id: schedule.id.clone(),
+            })
+            .unwrap()
+        else {
+            panic!("expected schedule inspection");
+        };
+        assert_eq!(inspection.prompt, prompt);
+
+        let Response::AgentSchedule { schedule: paused } = registry
+            .dispatch(Request::PauseAgentSchedule {
+                schedule_id: schedule.id.clone(),
+            })
+            .unwrap()
+        else {
+            panic!("expected paused schedule");
+        };
+        assert_eq!(paused.revision, 1);
+        let Response::AgentSchedule { schedule: resumed } = registry
+            .dispatch(Request::ResumeAgentSchedule {
+                schedule_id: schedule.id.clone(),
+            })
+            .unwrap()
+        else {
+            panic!("expected resumed schedule");
+        };
+        assert_eq!(resumed.revision, 2);
+        assert!(resumed.evaluation_frontier_ms >= schedule.evaluation_frontier_ms);
+        let Response::AgentSchedule { schedule: repeated } = registry
+            .dispatch(Request::ResumeAgentSchedule {
+                schedule_id: schedule.id.clone(),
+            })
+            .unwrap()
+        else {
+            panic!("expected resumed schedule");
+        };
+        assert_eq!(repeated, resumed);
+
+        let events = lock(&registry.events.state).unwrap().events.clone();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event.kind,
+                    DaemonEventKind::AgentScheduleCreated { .. }
+                        | DaemonEventKind::AgentSchedulePaused { .. }
+                        | DaemonEventKind::AgentScheduleResumed { .. }
+                ))
+                .count(),
+            2
+        );
+        assert!(!serde_json::to_string(&events).unwrap().contains(prompt));
+    }
+
+    #[test]
+    fn schedules_restore_remove_with_workspace_and_rollback_on_failure() {
+        let directory = env::temp_dir().join(format!("boomux-schedules-{}", Uuid::new_v4()));
+        let path = directory.join("state/state.json");
+        let registry = DaemonService::restore(StateStore::at(path.clone()), false, None).unwrap();
+        let Response::Workspace { workspace } = registry
+            .dispatch(Request::CreateWorkspace {
+                name: "scheduled".into(),
+                default_cwd: None,
+                shells: Vec::new(),
+            })
+            .unwrap()
+        else {
+            panic!("expected workspace");
+        };
+        registry.fail_after_next_mutation();
+        assert!(
+            registry
+                .dispatch(Request::CreateAgentSchedule {
+                    workspace_id: workspace.id.clone(),
+                    spec: schedule_spec("rolled back prompt"),
+                })
+                .is_err()
+        );
+        assert!(
+            registry.snapshot().unwrap().workspaces[0]
+                .schedules
+                .is_empty()
+        );
+        let Response::AgentSchedule { schedule } = registry
+            .dispatch(Request::CreateAgentSchedule {
+                workspace_id: workspace.id.clone(),
+                spec: schedule_spec("persisted private prompt"),
+            })
+            .unwrap()
+        else {
+            panic!("expected schedule");
+        };
+        drop(registry);
+
+        let registry = DaemonService::restore(StateStore::at(path), false, None).unwrap();
+        let restored = registry
+            .dispatch(Request::GetAgentSchedule {
+                schedule_id: schedule.id.clone(),
+            })
+            .unwrap();
+        let Response::AgentScheduleInspection { inspection } = restored else {
+            panic!("expected inspection");
+        };
+        assert_eq!(inspection.prompt, "persisted private prompt");
+
+        registry.fail_after_next_mutation();
+        assert!(
+            registry
+                .dispatch(Request::ResumeAgentSchedule {
+                    schedule_id: schedule.id.clone(),
+                })
+                .is_err()
+        );
+        assert_eq!(
+            registry.schedule(&schedule.id).unwrap().snapshot().unwrap(),
+            schedule
+        );
+
+        registry.fail_after_next_mutation();
+        assert!(
+            registry
+                .dispatch(Request::RemoveAgentSchedule {
+                    schedule_id: schedule.id.clone(),
+                })
+                .is_err()
+        );
+        assert!(registry.schedule(&schedule.id).is_ok());
+
+        registry.close_workspace(&workspace.id).unwrap();
+        assert!(registry.schedule(&schedule.id).is_err());
+        let events = lock(&registry.events.state).unwrap();
+        assert_eq!(
+            events
+                .events
+                .iter()
+                .filter(|event| matches!(event.kind, DaemonEventKind::WorkspaceClosed { .. }))
+                .count(),
+            1
+        );
+        assert!(
+            !events
+                .events
+                .iter()
+                .any(|event| matches!(event.kind, DaemonEventKind::AgentScheduleRemoved { .. }))
+        );
+        drop(events);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn invalid_schedule_input_does_not_mutate_or_disclose_prompt() {
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace("scheduled".into(), Vec::new())
+            .unwrap();
+        let prompt = "private invalid prompt";
+        let mut spec = schedule_spec(prompt);
+        spec.trigger.cron = "not a cron expression".into();
+        let error = registry
+            .dispatch(Request::CreateAgentSchedule {
+                workspace_id: workspace.id,
+                spec,
+            })
+            .unwrap_err();
+        assert!(!error.to_string().contains(prompt));
+        assert!(
+            registry.snapshot().unwrap().workspaces[0]
+                .schedules
+                .is_empty()
+        );
+        assert!(lock(&registry.events.state).unwrap().events.is_empty());
+    }
+
+    #[test]
+    fn protocol_twenty_one_filters_schedules_without_rewinding_cursor() {
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace("scheduled".into(), Vec::new())
+            .unwrap();
+        registry
+            .dispatch(Request::CreateAgentSchedule {
+                workspace_id: workspace.id,
+                spec: schedule_spec("private prompt"),
+            })
+            .unwrap();
+        let Response::Events {
+            stream_id,
+            cursor,
+            snapshot,
+            events,
+        } = registry.read_events(None, 256, 0).unwrap()
+        else {
+            panic!("expected event baseline");
+        };
+        let response = response_for_version(
+            Response::Events {
+                stream_id,
+                cursor: cursor.clone(),
+                snapshot,
+                events,
+            },
+            21,
+        );
+        let Response::Events {
+            cursor: filtered_cursor,
+            snapshot: Some(snapshot),
+            events,
+            ..
+        } = response
+        else {
+            panic!("expected filtered baseline");
+        };
+        assert_eq!(filtered_cursor, cursor);
+        assert!(snapshot.workspaces[0].schedules.is_empty());
+        assert!(events.is_empty());
+
+        let retained = lock(&registry.events.state).unwrap().events.clone();
+        let response = response_for_version(
+            Response::Events {
+                stream_id: cursor.stream_id.clone(),
+                cursor: cursor.clone(),
+                snapshot: None,
+                events: retained.into(),
+            },
+            21,
+        );
+        let Response::Events {
+            cursor: filtered_cursor,
+            events,
+            ..
+        } = response
+        else {
+            panic!("expected filtered events");
+        };
+        assert_eq!(filtered_cursor, cursor);
+        assert!(events.is_empty());
     }
 
     #[test]
@@ -10099,6 +10983,7 @@ mod tests {
             shells: Vec::new(),
             launchers: Vec::new(),
             agents: vec![agent.clone()],
+            schedules: Vec::new(),
         };
         let response = Response::Events {
             stream_id: "stream".into(),
@@ -10235,6 +11120,7 @@ mod tests {
             shells: Vec::new(),
             launchers: Vec::new(),
             agents: vec![agent.clone()],
+            schedules: Vec::new(),
         };
         let Response::Workspace {
             workspace: downgraded_workspace,
@@ -10334,6 +11220,7 @@ mod tests {
                     shells: Vec::new(),
                     launchers: Vec::new(),
                     agents: vec![agent.clone()],
+                    schedules: Vec::new(),
                 }],
                 focused_terminal: None,
             }),
@@ -10618,6 +11505,7 @@ mod tests {
             shells: Vec::new(),
             launchers: Vec::new(),
             agents: Vec::new(),
+            schedules: Vec::new(),
         };
 
         let Response::Workspace { workspace } = response_for_version(

--- a/src/dashboard_projection.rs
+++ b/src/dashboard_projection.rs
@@ -337,6 +337,7 @@ mod tests {
                 foreground_process: None,
             }],
             launchers: Vec::new(),
+            schedules: Vec::new(),
             agents: Vec::new(),
         }
     }

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -1343,6 +1343,7 @@ mod tests {
             default_cwd: None,
             shells: vec![shell],
             launchers: Vec::new(),
+            schedules: Vec::new(),
             agents: Vec::new(),
         };
         let snapshot = Snapshot {

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -46,6 +46,18 @@ pub struct ResumeCapability {
     pub session_argument: &'static str,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromptTransport {
+    Argument,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ScheduleDispatchCapability {
+    pub fresh: bool,
+    pub continuation: bool,
+    pub prompt_transport: PromptTransport,
+}
+
 impl ResumeCapability {
     pub fn command(
         self,
@@ -85,6 +97,7 @@ pub struct IntegrationDescriptor {
     pub titles: Option<TitleCapability>,
     pub transcript: Option<TranscriptCapability>,
     pub resume: Option<ResumeCapability>,
+    pub schedule_dispatch: Option<ScheduleDispatchCapability>,
     pub foreground: Option<ForegroundCapability>,
 }
 
@@ -110,6 +123,11 @@ pub const OPENCODE: IntegrationDescriptor = IntegrationDescriptor {
     resume: Some(ResumeCapability {
         executable: "opencode",
         session_argument: "--session",
+    }),
+    schedule_dispatch: Some(ScheduleDispatchCapability {
+        fresh: true,
+        continuation: true,
+        prompt_transport: PromptTransport::Argument,
     }),
     foreground: Some(ForegroundCapability {
         process_name: "opencode",
@@ -138,6 +156,11 @@ pub const PI: IntegrationDescriptor = IntegrationDescriptor {
     resume: Some(ResumeCapability {
         executable: "pi",
         session_argument: "--session",
+    }),
+    schedule_dispatch: Some(ScheduleDispatchCapability {
+        fresh: true,
+        continuation: true,
+        prompt_transport: PromptTransport::Argument,
     }),
     foreground: Some(ForegroundCapability { process_name: "pi" }),
 };
@@ -202,6 +225,7 @@ mod tests {
             }),
             transcript: None,
             resume: None,
+            schedule_dispatch: None,
             foreground: Some(ForegroundCapability {
                 process_name: "partial-agent",
             }),
@@ -214,6 +238,7 @@ mod tests {
         assert!(descriptor.titles.is_some());
         assert!(descriptor.transcript.is_none());
         assert!(descriptor.resume.is_none());
+        assert!(descriptor.schedule_dispatch.is_none());
         assert_eq!(
             descriptor
                 .foreground
@@ -252,6 +277,39 @@ mod tests {
                 );
             }
         }
+
+        for descriptor in ALL {
+            assert_eq!(by_key(descriptor.key), Some(descriptor));
+            assert_eq!(display_name(descriptor.key), descriptor.display_name);
+            assert_eq!(
+                descriptor.schedule_dispatch,
+                Some(ScheduleDispatchCapability {
+                    fresh: true,
+                    continuation: true,
+                    prompt_transport: PromptTransport::Argument,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn resume_capability_does_not_imply_schedule_dispatch() {
+        const RESUME_ONLY: IntegrationDescriptor = IntegrationDescriptor {
+            key: "resume-only",
+            display_name: "Resume Only",
+            installation: None,
+            titles: None,
+            transcript: None,
+            resume: Some(ResumeCapability {
+                executable: "resume-only",
+                session_argument: "--session",
+            }),
+            schedule_dispatch: None,
+            foreground: None,
+        };
+
+        assert!(RESUME_ONLY.resume.is_some());
+        assert!(RESUME_ONLY.schedule_dispatch.is_none());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod fd_transfer;
 mod handoff;
 pub mod integrations;
 pub mod protocol;
+pub mod scheduling;
 mod state_store;
 mod terminal_focus;
 mod terminal_state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::error::Error;
 use std::ffi::OsString;
 use std::fmt::Write as _;
 use std::fs;
-use std::io;
-use std::os::unix::fs::PermissionsExt;
+use std::io::{self, Read};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
@@ -13,13 +13,14 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use clap::error::ErrorKind as ClapErrorKind;
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 use uuid::Uuid;
 
 use boomux::protocol::{
-    AgentAuthority, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentState,
-    EventCursor, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, WorkspaceLauncherSnapshot,
-    WorkspaceLauncherSpec, WorkspaceSnapshot,
+    AgentAuthority, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport,
+    AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSnapshot, AgentScheduleSpec,
+    AgentScheduleState, AgentScheduleTrigger, AgentState, EventCursor, ShellSnapshot, ShellSpec,
+    ShellStatus, Snapshot, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use boomux::{attach, client, daemon, protocol};
 
@@ -258,6 +259,11 @@ enum Commands {
     Session {
         #[command(subcommand)]
         command: SessionCommands,
+    },
+    /// Manage recurring Agent work definitions
+    Schedule {
+        #[command(subcommand)]
+        command: ScheduleCommands,
     },
     /// Inspect and install supported harness integrations
     Integration {
@@ -505,6 +511,111 @@ enum SessionCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum ScheduleCommands {
+    /// Create a durable schedule definition
+    Create(Box<ScheduleCreateArgs>),
+    /// List schedule definitions without disclosing prompts
+    List {
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+    /// Inspect a schedule, including its private prompt
+    Inspect {
+        target: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+    /// Mark a schedule paused in durable management state
+    Pause {
+        target: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+    /// Mark a schedule enabled for a later dispatcher
+    Resume {
+        target: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+    /// Remove an inactive schedule and its persisted prompt
+    Remove {
+        target: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+    },
+}
+
+#[derive(Args)]
+#[command(group(
+    ArgGroup::new("prompt_source")
+        .required(true)
+        .multiple(false)
+        .args(["prompt", "prompt_file"])
+), group(
+    ArgGroup::new("trigger_source")
+        .required(true)
+        .multiple(false)
+        .args(["cron", "every", "daily", "weekdays", "weekly"])
+), group(
+    ArgGroup::new("session_mode")
+        .multiple(false)
+        .args(["fresh", "continue_session"])
+), group(
+    ArgGroup::new("initial_state")
+        .multiple(false)
+        .args(["paused", "enabled"])
+))]
+struct ScheduleCreateArgs {
+    /// Workspace-unique schedule name
+    name: String,
+    /// Owning workspace name or ID
+    #[arg(long, value_name = "NAME_OR_ID")]
+    workspace: String,
+    /// Existing working directory to snapshot
+    #[arg(long, value_name = "PATH")]
+    cwd: PathBuf,
+    /// Integration accepted for future scheduled execution
+    #[arg(long)]
+    integration: String,
+    /// Exact inline prompt to persist
+    #[arg(long)]
+    prompt: Option<String>,
+    /// Regular UTF-8 file to snapshot as the prompt
+    #[arg(long, value_name = "PATH")]
+    prompt_file: Option<PathBuf>,
+    /// Canonical five-field cron expression
+    #[arg(long)]
+    cron: Option<String>,
+    /// Minute or hour interval, such as 15m or 6h
+    #[arg(long, value_name = "Nm|Nh")]
+    every: Option<String>,
+    /// Store a daily trigger at this local time
+    #[arg(long, value_name = "HH:MM")]
+    daily: Option<String>,
+    /// Store a weekday trigger at this local time
+    #[arg(long, value_name = "HH:MM")]
+    weekdays: Option<String>,
+    /// Store a weekly trigger for this English day and local time
+    #[arg(long, value_name = "DAY@HH:MM")]
+    weekly: Option<String>,
+    /// IANA timezone; defaults to the resolved system timezone
+    #[arg(long, value_name = "IANA_TIMEZONE")]
+    timezone: Option<String>,
+    /// Plan a new external Agent Session for every future execution
+    #[arg(long)]
+    fresh: bool,
+    /// Pin one exact projected Agent Session
+    #[arg(long = "continue", value_name = "PROJECTED_SESSION_ID")]
+    continue_session: Option<String>,
+    /// Create paused, which is the default
+    #[arg(long)]
+    paused: bool,
+    /// Record consent for a later dispatcher; this layer does not run work
+    #[arg(long)]
+    enabled: bool,
+}
+
 #[derive(Args)]
 struct AgentSuperviseArgs {
     name: Option<String>,
@@ -745,6 +856,12 @@ command_keys! {
     SessionList => ("session.list", Json),
     SessionInspect => ("session.inspect", Json),
     SessionRead => ("session.read", Json),
+    ScheduleCreate => ("schedule.create", Json),
+    ScheduleList => ("schedule.list", Json),
+    ScheduleInspect => ("schedule.inspect", Json),
+    SchedulePause => ("schedule.pause", Json),
+    ScheduleResume => ("schedule.resume", Json),
+    ScheduleRemove => ("schedule.remove", Json),
     Skill => ("skill", HumanOnly),
     Opencode => ("opencode", HumanOnly),
     Pi => ("pi", HumanOnly),
@@ -821,6 +938,24 @@ impl Cli {
             Some(Commands::Session {
                 command: SessionCommands::Read { .. },
             }) => CommandKey::SessionRead,
+            Some(Commands::Schedule {
+                command: ScheduleCommands::Create(..),
+            }) => CommandKey::ScheduleCreate,
+            Some(Commands::Schedule {
+                command: ScheduleCommands::List { .. },
+            }) => CommandKey::ScheduleList,
+            Some(Commands::Schedule {
+                command: ScheduleCommands::Inspect { .. },
+            }) => CommandKey::ScheduleInspect,
+            Some(Commands::Schedule {
+                command: ScheduleCommands::Pause { .. },
+            }) => CommandKey::SchedulePause,
+            Some(Commands::Schedule {
+                command: ScheduleCommands::Resume { .. },
+            }) => CommandKey::ScheduleResume,
+            Some(Commands::Schedule {
+                command: ScheduleCommands::Remove { .. },
+            }) => CommandKey::ScheduleRemove,
             Some(Commands::Integration {
                 command: IntegrationCommands::List,
             }) => CommandKey::IntegrationList,
@@ -1063,6 +1198,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             command: NotificationCommands::Test { reason },
         }) => test_notification(reason),
         Some(Commands::Session { command }) => session_command(command, cli.json),
+        Some(Commands::Schedule { command }) => schedule_command(command, cli.json),
         Some(Commands::Integration { command }) => integration_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
@@ -1249,7 +1385,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                             .close_workspace(workspace_id)
                             .map_err(|error| error.to_string())?;
                         Ok(format!(
-                            "Closed {name}, its launchers, and all of its shells"
+                            "Closed {name}, its launchers, shells, schedules, and persisted prompts"
                         ))
                     }
                     tui::CloseTarget::Shell(shell_id) => {
@@ -2299,17 +2435,17 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "internal",
         "unknown",
     ];
-    let integration_hosts = integration_management::IntegrationId::all()
-        .map(|integration| {
-            let spec = integration.spec();
-            let installation = integration.installation();
-            (
-                spec.key.to_owned(),
+    let integration_hosts = boomux::integrations::ALL
+        .iter()
+        .filter_map(|descriptor| {
+            let installation = descriptor.installation?;
+            Some((
+                descriptor.key.to_owned(),
                 serde_json::json!({
                     "package": installation.package,
                     "validated_version": installation.validated_version,
                 }),
-            )
+            ))
         })
         .collect::<serde_json::Map<_, _>>();
     if json {
@@ -2401,6 +2537,7 @@ fn workspace_command(
                             name: workspace.name.clone(),
                             shell_count: workspace.shells.len(),
                             launcher_count: workspace.launchers.len(),
+                            schedule_count: workspace.schedules.len(),
                             agent_count: workspace.agents.len(),
                             agent_state_counts: summary.states,
                             attention_count: summary.attention_count,
@@ -2412,15 +2549,18 @@ fn workspace_command(
                     serde_json::json!({ "workspaces": workspaces }),
                 );
             }
-            println!("NAME\tWORKSPACE ID\tSHELLS\tLAUNCHERS\tAGENTS\tBLOCKED\tDONE\tATTENTION");
+            println!(
+                "NAME\tWORKSPACE ID\tSHELLS\tLAUNCHERS\tSCHEDULES\tAGENTS\tBLOCKED\tDONE\tATTENTION"
+            );
             for workspace in workspaces {
                 let summary = agent_attention_projection::summarize_workspace(&workspace);
                 println!(
-                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
                     sanitize_table_cell(&workspace.name),
                     workspace.id,
                     workspace.shells.len(),
                     workspace.launchers.len(),
+                    workspace.schedules.len(),
                     workspace.agents.len(),
                     summary.states.blocked,
                     summary.states.done,
@@ -2468,6 +2608,9 @@ fn workspace_command(
                             "launchers": workspace.launchers.iter()
                                 .map(|launcher| cli_output::launcher(launcher, Some(&workspace.name)))
                                 .collect::<Vec<_>>(),
+                            "schedules": workspace.schedules.iter()
+                                .map(|schedule| cli_output::schedule(schedule, Some(&workspace.name)))
+                                .collect::<Vec<_>>(),
                             "agents": workspace.agents.iter()
                                 .map(|agent| cli_output::agent(agent, Some(&workspace.name)))
                                 .collect::<Vec<_>>(),
@@ -2488,6 +2631,7 @@ fn workspace_command(
             );
             println!("SHELLS\t{}", workspace.shells.len());
             println!("LAUNCHERS\t{}", workspace.launchers.len());
+            println!("SCHEDULES\t{}", workspace.schedules.len());
             println!("AGENTS\t{}", workspace.agents.len());
             println!("BLOCKED AGENTS\t{}", agent_summary.states.blocked);
             println!("COMPLETED AGENTS\t{}", agent_summary.states.done);
@@ -2514,6 +2658,20 @@ fn workspace_command(
                         launcher.id,
                         launcher.cwd.display(),
                         launcher.command.join(" ")
+                    );
+                }
+            }
+            if !workspace.schedules.is_empty() {
+                println!("\nNAME\tSCHEDULE ID\tSTATE\tINTEGRATION\tCRON\tTIMEZONE");
+                for schedule in &workspace.schedules {
+                    println!(
+                        "{}\t{}\t{}\t{}\t{}\t{}",
+                        sanitize_table_cell(&schedule.name),
+                        sanitize_table_cell(&schedule.id),
+                        cli_output::schedule_state(schedule.state),
+                        sanitize_table_cell(&schedule.integration),
+                        sanitize_table_cell(&schedule.trigger.cron),
+                        sanitize_table_cell(&schedule.trigger.timezone),
                     );
                 }
             }
@@ -2552,7 +2710,10 @@ fn workspace_command(
                 );
             }
             client.close_workspace(&workspace.id)?;
-            println!("Closed workspace {}", workspace.name);
+            println!(
+                "Closed workspace {}; its schedules and persisted prompts were removed",
+                workspace.name
+            );
         }
     }
     Ok(())
@@ -3109,6 +3270,541 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
         }
     }
     Ok(())
+}
+
+fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn Error>> {
+    let client = client::connect_or_start()?;
+    validate_schedule_protocol(client.protocol_version()?)?;
+    match command {
+        ScheduleCommands::Create(arguments) => create_schedule(&client, *arguments, json),
+        ScheduleCommands::List { workspace } => {
+            let snapshot = client.snapshot()?;
+            let selected = workspace
+                .as_deref()
+                .map(|target| resolve_workspace_target(&snapshot.workspaces, target))
+                .transpose()?;
+            let schedules = snapshot
+                .workspaces
+                .iter()
+                .filter(|candidate| selected.is_none_or(|selected| candidate.id == selected.id))
+                .flat_map(|workspace| {
+                    workspace
+                        .schedules
+                        .iter()
+                        .map(move |schedule| (schedule, workspace.name.as_str()))
+                })
+                .collect::<Vec<_>>();
+            if json {
+                let schedules = schedules
+                    .iter()
+                    .map(|(schedule, workspace_name)| {
+                        cli_output::schedule(schedule, Some(workspace_name))
+                    })
+                    .collect::<Vec<_>>();
+                return print_json(
+                    CommandKey::ScheduleList,
+                    serde_json::json!({ "schedules": schedules }),
+                );
+            }
+            println!(
+                "WORKSPACE\tNAME\tSCHEDULE ID\tSTATE\tINTEGRATION\tTRIGGER\tTIMEZONE\tSESSION"
+            );
+            for (schedule, workspace_name) in schedules {
+                println!(
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    sanitize_table_cell(workspace_name),
+                    sanitize_table_cell(&schedule.name),
+                    sanitize_table_cell(&schedule.id),
+                    cli_output::schedule_state(schedule.state),
+                    sanitize_table_cell(&schedule.integration),
+                    sanitize_table_cell(&schedule.trigger.cron),
+                    sanitize_table_cell(&schedule.trigger.timezone),
+                    sanitize_table_cell(&schedule_session_label(&schedule.session)),
+                );
+            }
+            Ok(())
+        }
+        ScheduleCommands::Inspect { target, workspace } => {
+            let snapshot = client.snapshot()?;
+            let schedule = resolve_cli_schedule(&snapshot, &target, workspace.as_deref())?;
+            let workspace_name = schedule_workspace_name(&snapshot, schedule);
+            let inspection = client.get_agent_schedule(&schedule.id)?;
+            if json {
+                return print_json(
+                    CommandKey::ScheduleInspect,
+                    serde_json::json!({
+                        "schedule": cli_output::schedule_inspection(
+                            &inspection.schedule,
+                            workspace_name,
+                            &inspection.prompt,
+                        ),
+                    }),
+                );
+            }
+            print_schedule_inspection(&inspection.schedule, workspace_name, &inspection.prompt);
+            Ok(())
+        }
+        ScheduleCommands::Pause { target, workspace } => {
+            let snapshot = client.snapshot()?;
+            let schedule = resolve_cli_schedule(&snapshot, &target, workspace.as_deref())?;
+            let workspace_name = schedule_workspace_name(&snapshot, schedule).map(str::to_owned);
+            let schedule = client.pause_agent_schedule(&schedule.id)?;
+            print_schedule_mutation(
+                CommandKey::SchedulePause,
+                &schedule,
+                workspace_name.as_deref(),
+                json,
+            )?;
+            if !json {
+                println!("Paused schedule {}", sanitize_table_cell(&schedule.name));
+            }
+            Ok(())
+        }
+        ScheduleCommands::Resume { target, workspace } => {
+            let snapshot = client.snapshot()?;
+            let schedule = resolve_cli_schedule(&snapshot, &target, workspace.as_deref())?;
+            let workspace_name = schedule_workspace_name(&snapshot, schedule).map(str::to_owned);
+            let schedule = client.resume_agent_schedule(&schedule.id)?;
+            print_schedule_mutation(
+                CommandKey::ScheduleResume,
+                &schedule,
+                workspace_name.as_deref(),
+                json,
+            )?;
+            if !json {
+                println!(
+                    "Enabled schedule {} in durable management state; scheduled dispatch is not available yet",
+                    sanitize_table_cell(&schedule.name)
+                );
+            }
+            Ok(())
+        }
+        ScheduleCommands::Remove { target, workspace } => {
+            let snapshot = client.snapshot()?;
+            let schedule = resolve_cli_schedule(&snapshot, &target, workspace.as_deref())?;
+            let removed =
+                cli_output::schedule(schedule, schedule_workspace_name(&snapshot, schedule));
+            let name = schedule.name.clone();
+            client.remove_agent_schedule(&schedule.id)?;
+            if json {
+                return print_json(
+                    CommandKey::ScheduleRemove,
+                    serde_json::json!({ "removed": true, "schedule": removed }),
+                );
+            }
+            println!(
+                "Removed schedule {} and its persisted prompt",
+                sanitize_table_cell(&name)
+            );
+            Ok(())
+        }
+    }
+}
+
+fn validate_schedule_protocol(negotiated: u32) -> Result<(), Box<dyn Error>> {
+    let feature = protocol::ProtocolFeature::AgentSchedules;
+    feature
+        .is_supported_by(negotiated)
+        .then_some(())
+        .ok_or_else(|| {
+            cli_output::failure(
+                "unsupported_version",
+                format!(
+                    "Agent schedule management requires daemon protocol {}; negotiated {negotiated}",
+                    feature.minimum_version()
+                ),
+            )
+        })
+}
+
+fn create_schedule(
+    client: &client::Client,
+    arguments: ScheduleCreateArgs,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let snapshot = client.snapshot()?;
+    let workspace = resolve_workspace_target(&snapshot.workspaces, &arguments.workspace)?;
+    let name = cli_name(arguments.name, "schedule")?;
+    let cwd = resolve_directory(&arguments.cwd).map_err(|error| {
+        cli_output::failure(
+            "invalid_argument",
+            format!("schedule working directory is invalid: {error}"),
+        )
+    })?;
+    let prompt = schedule_prompt(arguments.prompt, arguments.prompt_file.as_deref())?;
+    let cron = schedule_cron(
+        arguments.cron.as_deref(),
+        arguments.every.as_deref(),
+        arguments.daily.as_deref(),
+        arguments.weekdays.as_deref(),
+        arguments.weekly.as_deref(),
+    )?;
+    let timezone = arguments
+        .timezone
+        .as_deref()
+        .map(boomux::scheduling::canonicalize_timezone)
+        .transpose()?
+        .map_or_else(boomux::scheduling::resolve_system_timezone, Ok)?;
+    let integration = schedule_integration(&arguments.integration)?;
+    let session = if let Some(session_id) = arguments.continue_session.as_deref() {
+        let catalog = discover_host_catalog(std::slice::from_ref(workspace));
+        let sessions = session_projection::project_workspaces_with_catalog(
+            std::slice::from_ref(workspace),
+            Some(&catalog),
+        );
+        let session = session_projection::resolve_exact(&sessions, session_id).map_err(
+            |error| match error {
+                session_projection::ResolveError::NotFound => cli_output::failure(
+                    "not_found",
+                    format!(
+                        "projected session not found in workspace {}: {session_id}",
+                        workspace.name
+                    ),
+                ),
+                session_projection::ResolveError::DuplicateId => cli_output::failure(
+                    "internal",
+                    format!("duplicate projected session ID: {session_id}"),
+                ),
+            },
+        )?;
+        if session.integration != integration.key {
+            return Err(cli_output::failure(
+                "invalid_argument",
+                "continued session integration does not match --integration",
+            ));
+        }
+        let external_session_id = session.external_session_id.as_deref().ok_or_else(|| {
+            cli_output::failure(
+                "invalid_argument",
+                "continued projected session has no canonical external session ID",
+            )
+        })?;
+        boomux::scheduling::validate_external_session_id(external_session_id)?;
+        if !integration
+            .schedule_dispatch
+            .is_some_and(|dispatch| dispatch.continuation)
+        {
+            return Err(cli_output::failure(
+                "unsupported_integration",
+                "integration does not support continuation schedule dispatch",
+            ));
+        }
+        AgentScheduleSession::Continue {
+            external_session_id: external_session_id.to_owned(),
+        }
+    } else {
+        if !integration
+            .schedule_dispatch
+            .is_some_and(|dispatch| dispatch.fresh)
+        {
+            return Err(cli_output::failure(
+                "unsupported_integration",
+                "integration does not support fresh schedule dispatch",
+            ));
+        }
+        AgentScheduleSession::Fresh
+    };
+    let spec = AgentScheduleSpec {
+        name,
+        cwd,
+        integration: integration.key.to_owned(),
+        prompt,
+        session,
+        trigger: AgentScheduleTrigger { cron, timezone },
+        state: if arguments.enabled {
+            AgentScheduleState::Enabled
+        } else {
+            AgentScheduleState::Paused
+        },
+        overlap_policy: AgentScheduleOverlapPolicy::Skip,
+    };
+    let schedule = client.create_agent_schedule(&workspace.id, spec)?;
+    if json {
+        return print_json(
+            CommandKey::ScheduleCreate,
+            serde_json::json!({
+                "schedule": cli_output::schedule(&schedule, Some(&workspace.name)),
+            }),
+        );
+    }
+    println!(
+        "Created {} schedule {} ({})",
+        cli_output::schedule_state(schedule.state),
+        sanitize_table_cell(&schedule.name),
+        sanitize_table_cell(&schedule.id)
+    );
+    if schedule.state == AgentScheduleState::Enabled {
+        println!("Scheduled dispatch is not available yet; only consent state was recorded");
+    }
+    Ok(())
+}
+
+fn schedule_prompt(inline: Option<String>, file: Option<&Path>) -> Result<String, Box<dyn Error>> {
+    let prompt = match (inline, file) {
+        (Some(prompt), None) => prompt,
+        (None, Some(path)) => {
+            let metadata = fs::symlink_metadata(path).map_err(|error| {
+                io::Error::new(error.kind(), format!("cannot inspect prompt file: {error}"))
+            })?;
+            if !metadata.file_type().is_file() {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    "prompt file must be a regular file and not a symlink",
+                ));
+            }
+            let mut file = fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+                .open(path)
+                .map_err(|_| {
+                    cli_output::failure(
+                        "invalid_argument",
+                        "prompt file changed or could not be opened safely",
+                    )
+                })?;
+            if !file.metadata()?.file_type().is_file() {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    "prompt file changed before it could be read safely",
+                ));
+            }
+            let mut bytes = Vec::new();
+            file.by_ref()
+                .take((boomux::scheduling::MAX_PROMPT_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)?;
+            if bytes.len() > boomux::scheduling::MAX_PROMPT_BYTES {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    format!(
+                        "prompt must be at most {} bytes",
+                        boomux::scheduling::MAX_PROMPT_BYTES
+                    ),
+                ));
+            }
+            String::from_utf8(bytes).map_err(|_| {
+                cli_output::failure("invalid_argument", "prompt file must contain valid UTF-8")
+            })?
+        }
+        _ => {
+            return Err(cli_output::failure(
+                "invalid_argument",
+                "exactly one prompt source is required",
+            ));
+        }
+    };
+    boomux::scheduling::validate_prompt(&prompt)?;
+    Ok(prompt)
+}
+
+fn schedule_cron(
+    cron: Option<&str>,
+    every: Option<&str>,
+    daily: Option<&str>,
+    weekdays: Option<&str>,
+    weekly: Option<&str>,
+) -> Result<String, Box<dyn Error>> {
+    let expression = if let Some(cron) = cron {
+        boomux::scheduling::canonicalize_cron(cron)?
+    } else if let Some(every) = every {
+        let (amount, unit) = every.split_at(every.len().saturating_sub(1));
+        let amount = amount
+            .parse::<u8>()
+            .map_err(|_| cli_output::failure("invalid_argument", "--every must use Nm or Nh"))?;
+        match unit {
+            "m" => boomux::scheduling::every_minutes_cron(amount)?,
+            "h" => boomux::scheduling::every_hours_cron(amount)?,
+            _ => {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    "--every must use Nm or Nh",
+                ));
+            }
+        }
+    } else if let Some(time) = daily {
+        let (hour, minute) = schedule_time(time)?;
+        boomux::scheduling::daily_cron(hour, minute)?
+    } else if let Some(time) = weekdays {
+        let (hour, minute) = schedule_time(time)?;
+        boomux::scheduling::weekdays_cron(hour, minute)?
+    } else if let Some(value) = weekly {
+        let (day, time) = value.split_once('@').ok_or_else(|| {
+            cli_output::failure("invalid_argument", "--weekly must use DAY@HH:MM")
+        })?;
+        let (hour, minute) = schedule_time(time)?;
+        boomux::scheduling::weekly_cron(day, hour, minute)?
+    } else {
+        return Err(cli_output::failure(
+            "invalid_argument",
+            "exactly one trigger source is required",
+        ));
+    };
+    Ok(expression)
+}
+
+fn schedule_time(value: &str) -> Result<(u8, u8), Box<dyn Error>> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 5
+        || bytes[2] != b':'
+        || !bytes[..2].iter().chain(&bytes[3..]).all(u8::is_ascii_digit)
+    {
+        return Err(cli_output::failure(
+            "invalid_argument",
+            "schedule time must use HH:MM",
+        ));
+    }
+    Ok((value[..2].parse()?, value[3..].parse()?))
+}
+
+fn schedule_integration(
+    key: &str,
+) -> Result<&'static boomux::integrations::IntegrationDescriptor, Box<dyn Error>> {
+    boomux::scheduling::validate_integration_key(key)?;
+    boomux::integrations::by_key(key)
+        .filter(|integration| integration.schedule_dispatch.is_some())
+        .ok_or_else(|| {
+            cli_output::failure(
+                "unsupported_integration",
+                "integration does not support schedule dispatch",
+            )
+        })
+}
+
+fn print_schedule_mutation(
+    command: CommandKey,
+    schedule: &AgentScheduleSnapshot,
+    workspace_name: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    if json {
+        print_json(
+            command,
+            serde_json::json!({
+                "schedule": cli_output::schedule(schedule, workspace_name),
+            }),
+        )?;
+    }
+    Ok(())
+}
+
+fn print_schedule_inspection(
+    schedule: &AgentScheduleSnapshot,
+    workspace_name: Option<&str>,
+    prompt: &str,
+) {
+    println!("ID\t{}", sanitize_table_cell(&schedule.id));
+    println!("NAME\t{}", sanitize_table_cell(&schedule.name));
+    println!(
+        "WORKSPACE\t{}",
+        sanitize_table_cell(workspace_name.unwrap_or("-"))
+    );
+    println!("STATE\t{}", cli_output::schedule_state(schedule.state));
+    println!(
+        "CWD\t{}",
+        sanitize_table_cell(&schedule.cwd.display().to_string())
+    );
+    println!(
+        "INTEGRATION\t{}",
+        sanitize_table_cell(&schedule.integration)
+    );
+    println!(
+        "SESSION\t{}",
+        sanitize_table_cell(&schedule_session_label(&schedule.session))
+    );
+    println!("CRON\t{}", sanitize_table_cell(&schedule.trigger.cron));
+    println!(
+        "TIMEZONE\t{}",
+        sanitize_table_cell(&schedule.trigger.timezone)
+    );
+    println!("OVERLAP POLICY\tskip");
+    println!("REVISION\t{}", schedule.revision);
+    println!("PROMPT REVISION\t{}", schedule.prompt_revision);
+    println!("TRIGGER REVISION\t{}", schedule.trigger_revision);
+    println!("CREATED AT MS\t{}", schedule.created_at_ms);
+    println!("UPDATED AT MS\t{}", schedule.updated_at_ms);
+    println!(
+        "EVALUATION FRONTIER MS\t{}",
+        schedule.evaluation_frontier_ms
+    );
+    println!(
+        "EXECUTION SHELL ID\t{}",
+        sanitize_table_cell(schedule.execution_shell_id.as_deref().unwrap_or("-"))
+    );
+    println!(
+        "PROMPT (PRIVATE; ESCAPED FOR TERMINAL SAFETY)\n{}",
+        escape_terminal_text(prompt)
+    );
+}
+
+fn escape_terminal_text(value: &str) -> String {
+    value.escape_debug().to_string()
+}
+
+fn schedule_session_label(session: &AgentScheduleSession) -> String {
+    match session {
+        AgentScheduleSession::Fresh => "fresh".into(),
+        AgentScheduleSession::Continue {
+            external_session_id,
+        } => format!("continue:{external_session_id}"),
+    }
+}
+
+fn resolve_cli_schedule<'a>(
+    snapshot: &'a Snapshot,
+    target: &str,
+    workspace: Option<&str>,
+) -> Result<&'a AgentScheduleSnapshot, Box<dyn Error>> {
+    if let Some(schedule) = find_schedule(snapshot, target) {
+        return Ok(schedule);
+    }
+    let workspace_id = if let Some(workspace) = workspace {
+        resolve_workspace_target(&snapshot.workspaces, workspace)?
+            .id
+            .clone()
+    } else {
+        env::var("BOOMUX_WORKSPACE_ID").map_err(|_| {
+            cli_output::failure(
+                "context_required",
+                format!("schedule name {target:?} requires --workspace or BOOMUX_WORKSPACE_ID"),
+            )
+        })?
+    };
+    let workspace = snapshot
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == workspace_id)
+        .ok_or_else(|| cli_output::failure("not_found", "current workspace no longer exists"))?;
+    workspace
+        .schedules
+        .iter()
+        .find(|schedule| schedule.name == target)
+        .ok_or_else(|| {
+            cli_output::failure(
+                "not_found",
+                format!(
+                    "schedule {target:?} was not found in workspace {}",
+                    workspace.name
+                ),
+            )
+        })
+}
+
+fn find_schedule<'a>(snapshot: &'a Snapshot, id: &str) -> Option<&'a AgentScheduleSnapshot> {
+    snapshot
+        .workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.schedules)
+        .find(|schedule| schedule.id == id)
+}
+
+fn schedule_workspace_name<'a>(
+    snapshot: &'a Snapshot,
+    schedule: &AgentScheduleSnapshot,
+) -> Option<&'a str> {
+    snapshot
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == schedule.workspace_id)
+        .map(|workspace| workspace.name.as_str())
 }
 
 fn validate_attention_protocol(negotiated: u32) -> Result<(), Box<dyn Error>> {
@@ -4377,6 +5073,31 @@ mod tests {
             shells,
             launchers: Vec::new(),
             agents: Vec::new(),
+            schedules: Vec::new(),
+        }
+    }
+
+    fn schedule(id: &str, workspace_id: &str, name: &str) -> AgentScheduleSnapshot {
+        AgentScheduleSnapshot {
+            id: id.into(),
+            workspace_id: workspace_id.into(),
+            name: name.into(),
+            cwd: PathBuf::from("/tmp/project"),
+            integration: "opencode".into(),
+            session: AgentScheduleSession::Fresh,
+            trigger: AgentScheduleTrigger {
+                cron: "0 9 * * 1-5".into(),
+                timezone: "UTC".into(),
+            },
+            state: AgentScheduleState::Paused,
+            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            revision: 1,
+            prompt_revision: 1,
+            trigger_revision: 1,
+            created_at_ms: 10,
+            updated_at_ms: 10,
+            evaluation_frontier_ms: 10,
+            execution_shell_id: None,
         }
     }
 
@@ -6267,6 +6988,192 @@ mod tests {
     }
 
     #[test]
+    fn schedule_parser_enforces_sources_and_descriptors() {
+        let valid = [
+            "boomux",
+            "schedule",
+            "create",
+            "review",
+            "--workspace",
+            "project",
+            "--cwd",
+            "/tmp",
+            "--integration",
+            "opencode",
+            "--prompt",
+            "review exactly\n",
+            "--weekdays",
+            "09:30",
+            "--continue",
+            "projected-session",
+            "--enabled",
+            "--json",
+        ];
+        let cli = Cli::try_parse_from(valid).unwrap();
+        assert_eq!(cli.command_descriptor().key, "schedule.create");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Schedule {
+                command: ScheduleCommands::Create(arguments)
+            }) if arguments.prompt.as_deref() == Some("review exactly\n")
+                && arguments.continue_session.as_deref() == Some("projected-session")
+                && arguments.enabled
+        ));
+
+        for arguments in [
+            vec!["boomux", "schedule", "list", "--json"],
+            vec!["boomux", "schedule", "inspect", "id", "--json"],
+            vec!["boomux", "schedule", "pause", "id", "--json"],
+            vec!["boomux", "schedule", "resume", "id", "--json"],
+            vec!["boomux", "schedule", "remove", "id", "--json"],
+        ] {
+            assert_eq!(
+                Cli::try_parse_from(arguments)
+                    .unwrap()
+                    .command_descriptor()
+                    .output,
+                OutputMode::Json
+            );
+        }
+
+        let required = [
+            "boomux",
+            "schedule",
+            "create",
+            "review",
+            "--workspace",
+            "project",
+            "--cwd",
+            "/tmp",
+            "--integration",
+            "opencode",
+        ];
+        assert!(Cli::try_parse_from(required.into_iter().chain(["--daily", "09:00"])).is_err());
+        assert!(
+            Cli::try_parse_from(required.into_iter().chain([
+                "--prompt",
+                "one",
+                "--prompt-file",
+                "/tmp/prompt",
+                "--daily",
+                "09:00",
+            ]))
+            .is_err()
+        );
+        assert!(
+            Cli::try_parse_from(required.into_iter().chain([
+                "--prompt",
+                "one",
+                "--daily",
+                "09:00",
+                "--cron",
+                "0 9 * * *",
+            ]))
+            .is_err()
+        );
+        assert!(
+            Cli::try_parse_from(required.into_iter().chain([
+                "--prompt",
+                "one",
+                "--daily",
+                "09:00",
+                "--fresh",
+                "--continue",
+                "session",
+            ]))
+            .is_err()
+        );
+        assert!(
+            Cli::try_parse_from(required.into_iter().chain([
+                "--prompt",
+                "one",
+                "--daily",
+                "09:00",
+                "--paused",
+                "--enabled",
+            ]))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn schedule_helpers_preserve_prompt_files_and_resolve_targets_safely() {
+        use std::os::unix::fs::symlink;
+        use std::os::unix::net::UnixListener;
+
+        assert!(validate_schedule_protocol(21).is_err());
+        assert!(validate_schedule_protocol(22).is_ok());
+        assert_eq!(
+            schedule_cron(None, Some("15m"), None, None, None).unwrap(),
+            "*/15 * * * *"
+        );
+        assert_eq!(
+            schedule_cron(None, None, None, Some("17:30"), None).unwrap(),
+            "30 17 * * 1-5"
+        );
+        assert_eq!(
+            schedule_cron(None, None, None, None, Some("mon@08:00")).unwrap(),
+            "0 8 * * 1"
+        );
+        assert!(schedule_cron(None, None, Some("9:00"), None, None).is_err());
+
+        let directory = test_skill_home("schedule-prompt");
+        fs::create_dir_all(&directory).unwrap();
+        let path = directory.join("prompt.txt");
+        fs::write(&path, b"private instructions\n").unwrap();
+        assert_eq!(
+            schedule_prompt(None, Some(&path)).unwrap(),
+            "private instructions\n"
+        );
+        assert!(schedule_prompt(None, Some(&directory)).is_err());
+        let link = directory.join("prompt-link");
+        symlink(&path, &link).unwrap();
+        let error = schedule_prompt(None, Some(&link)).unwrap_err();
+        assert_eq!(
+            cli_output::classify_for_test("schedule.create", error.as_ref()),
+            "invalid_argument"
+        );
+        let socket = directory.join("prompt.sock");
+        let _listener = UnixListener::bind(&socket).unwrap();
+        let error = schedule_prompt(None, Some(&socket)).unwrap_err();
+        assert_eq!(
+            cli_output::classify_for_test("schedule.create", error.as_ref()),
+            "invalid_argument"
+        );
+        assert_eq!(
+            escape_terminal_text("line one\nsecret\u{1b}]52;c;payload\u{7}"),
+            "line one\\nsecret\\u{1b}]52;c;payload\\u{7}"
+        );
+        fs::write(&path, vec![b'x'; boomux::scheduling::MAX_PROMPT_BYTES + 1]).unwrap();
+        let error = schedule_prompt(None, Some(&path)).unwrap_err().to_string();
+        assert!(!error.contains(&"x".repeat(100)));
+        fs::remove_dir_all(directory).unwrap();
+
+        let mut first = workspace("w1", "first", Vec::new());
+        first.schedules.push(schedule("schedule-1", "w1", "review"));
+        let mut second = workspace("w2", "second", Vec::new());
+        second
+            .schedules
+            .push(schedule("schedule-2", "w2", "review"));
+        let snapshot = Snapshot {
+            workspaces: vec![first, second],
+            focused_terminal: None,
+        };
+        assert_eq!(
+            resolve_cli_schedule(&snapshot, "schedule-2", None)
+                .unwrap()
+                .workspace_id,
+            "w2"
+        );
+        assert_eq!(
+            resolve_cli_schedule(&snapshot, "review", Some("first"))
+                .unwrap()
+                .id,
+            "schedule-1"
+        );
+    }
+
+    #[test]
     fn capabilities_advertise_phase_two_agent_integration_surface() {
         let json_commands = json_commands().collect::<Vec<_>>();
         for command in [
@@ -6288,6 +7195,16 @@ mod tests {
             "integration.install",
             "integration.uninstall",
             "integration.verify",
+        ] {
+            assert!(json_commands.contains(&command));
+        }
+        for command in [
+            "schedule.create",
+            "schedule.list",
+            "schedule.inspect",
+            "schedule.pause",
+            "schedule.resume",
+            "schedule.remove",
         ] {
             assert!(json_commands.contains(&command));
         }
@@ -6329,7 +7246,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 21);
+        assert_eq!(protocol::PROTOCOL_VERSION, 22);
     }
 
     #[test]
@@ -6372,6 +7289,12 @@ mod tests {
                 "session.list",
                 "session.inspect",
                 "session.read",
+                "schedule.create",
+                "schedule.list",
+                "schedule.inspect",
+                "schedule.pause",
+                "schedule.resume",
+                "schedule.remove",
                 "daemon.status",
             ]
         );

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 21;
+pub const PROTOCOL_VERSION: u32 = 22;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -78,6 +78,11 @@ define_protocol_features! {
     WorkspaceDefaultCwd => (19, "request", ["protocol_19", "workspace_default_cwd"]),
     StructuredTerminalPreview => (20, "request", ["protocol_20", "structured_terminal_previews"]),
     FocusedTerminalRead => (21, "request", ["protocol_21", "focused_terminal_read"]),
+    AgentSchedules => (22, "agent schedule management", [
+        "protocol_22",
+        "agent_schedule_management",
+        "durable_agent_schedules",
+    ]),
 }
 
 pub fn protocol_capabilities() -> impl Iterator<Item = &'static str> {
@@ -182,6 +187,111 @@ pub struct WorkspaceSnapshot {
     pub launchers: Vec<WorkspaceLauncherSnapshot>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub agents: Vec<AgentInstanceSnapshot>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub schedules: Vec<AgentScheduleSnapshot>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentScheduleState {
+    #[default]
+    Paused,
+    Enabled,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum AgentScheduleSession {
+    #[default]
+    Fresh,
+    Continue {
+        external_session_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentScheduleOverlapPolicy {
+    #[default]
+    Skip,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentScheduleTrigger {
+    pub cron: String,
+    pub timezone: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentScheduleSpec {
+    pub name: String,
+    pub cwd: PathBuf,
+    pub integration: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub session: AgentScheduleSession,
+    pub trigger: AgentScheduleTrigger,
+    #[serde(default)]
+    pub state: AgentScheduleState,
+    #[serde(default)]
+    pub overlap_policy: AgentScheduleOverlapPolicy,
+}
+
+impl std::fmt::Debug for AgentScheduleSpec {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AgentScheduleSpec")
+            .field("name", &self.name)
+            .field("cwd", &self.cwd)
+            .field("integration", &self.integration)
+            .field("prompt", &"<redacted>")
+            .field("session", &self.session)
+            .field("trigger", &self.trigger)
+            .field("state", &self.state)
+            .field("overlap_policy", &self.overlap_policy)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentScheduleSnapshot {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+    pub cwd: PathBuf,
+    pub integration: String,
+    #[serde(default)]
+    pub session: AgentScheduleSession,
+    pub trigger: AgentScheduleTrigger,
+    #[serde(default)]
+    pub state: AgentScheduleState,
+    #[serde(default)]
+    pub overlap_policy: AgentScheduleOverlapPolicy,
+    pub revision: u64,
+    pub prompt_revision: u64,
+    pub trigger_revision: u64,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    pub evaluation_frontier_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_shell_id: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentScheduleInspection {
+    pub schedule: AgentScheduleSnapshot,
+    pub prompt: String,
+}
+
+impl std::fmt::Debug for AgentScheduleInspection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AgentScheduleInspection")
+            .field("schedule", &self.schedule)
+            .field("prompt", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -431,6 +541,22 @@ pub enum DaemonEventKind {
         shell_id: String,
         agent: AgentInstanceSnapshot,
     },
+    AgentScheduleCreated {
+        workspace_id: String,
+        schedule: AgentScheduleSnapshot,
+    },
+    AgentSchedulePaused {
+        workspace_id: String,
+        schedule: AgentScheduleSnapshot,
+    },
+    AgentScheduleResumed {
+        workspace_id: String,
+        schedule: AgentScheduleSnapshot,
+    },
+    AgentScheduleRemoved {
+        workspace_id: String,
+        schedule_id: String,
+    },
     HandoffCompleted,
 }
 
@@ -534,6 +660,9 @@ pub enum Request {
     GetAgent {
         agent_id: String,
     },
+    GetAgentSchedule {
+        schedule_id: String,
+    },
     WaitAgent {
         agent_id: String,
         after_revision: u64,
@@ -554,6 +683,10 @@ pub enum Request {
     CreateLauncher {
         workspace_id: String,
         spec: WorkspaceLauncherSpec,
+    },
+    CreateAgentSchedule {
+        workspace_id: String,
+        spec: AgentScheduleSpec,
     },
     RegisterAgent {
         shell_id: String,
@@ -625,6 +758,15 @@ pub enum Request {
     RemoveLauncher {
         launcher_id: String,
     },
+    PauseAgentSchedule {
+        schedule_id: String,
+    },
+    ResumeAgentSchedule {
+        schedule_id: String,
+    },
+    RemoveAgentSchedule {
+        schedule_id: String,
+    },
     Attach {
         shell_id: String,
         takeover: bool,
@@ -639,6 +781,11 @@ pub enum Request {
 impl Request {
     pub fn required_feature(&self) -> Option<ProtocolFeature> {
         match self {
+            Self::CreateAgentSchedule { .. }
+            | Self::GetAgentSchedule { .. }
+            | Self::PauseAgentSchedule { .. }
+            | Self::ResumeAgentSchedule { .. }
+            | Self::RemoveAgentSchedule { .. } => Some(ProtocolFeature::AgentSchedules),
             Self::ReadShellPreview { .. } => Some(ProtocolFeature::StructuredTerminalPreview),
             Self::GetFocusedTerminal => Some(ProtocolFeature::FocusedTerminalRead),
             Self::CreateWorkspace {
@@ -722,6 +869,12 @@ pub enum Response {
     },
     Agent {
         agent: AgentInstanceSnapshot,
+    },
+    AgentSchedule {
+        schedule: AgentScheduleSnapshot,
+    },
+    AgentScheduleInspection {
+        inspection: AgentScheduleInspection,
     },
     AgentWait {
         agent: AgentInstanceSnapshot,
@@ -922,6 +1075,32 @@ mod tests {
         }
     }
 
+    fn test_schedule() -> AgentScheduleSnapshot {
+        AgentScheduleSnapshot {
+            id: "schedule-1".into(),
+            workspace_id: "w1".into(),
+            name: "morning review".into(),
+            cwd: "/tmp/project".into(),
+            integration: "opencode".into(),
+            session: AgentScheduleSession::Continue {
+                external_session_id: "session-1".into(),
+            },
+            trigger: AgentScheduleTrigger {
+                cron: "0 9 * * 1-5".into(),
+                timezone: "America/New_York".into(),
+            },
+            state: AgentScheduleState::Enabled,
+            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            revision: 3,
+            prompt_revision: 2,
+            trigger_revision: 1,
+            created_at_ms: 10,
+            updated_at_ms: 20,
+            evaluation_frontier_ms: 30,
+            execution_shell_id: Some("shell-1".into()),
+        }
+    }
+
     #[derive(Deserialize)]
     struct ProtocolSixShellSnapshot {
         id: String,
@@ -1049,7 +1228,14 @@ mod tests {
 
         assert!(snapshot.launchers.is_empty());
         assert!(snapshot.agents.is_empty());
+        assert!(snapshot.schedules.is_empty());
         assert!(snapshot.default_cwd.is_none());
+        assert!(
+            serde_json::to_value(snapshot)
+                .unwrap()
+                .get("schedules")
+                .is_none()
+        );
     }
 
     #[test]
@@ -1131,9 +1317,171 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_twenty_one_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 21);
+    fn protocol_version_is_twenty_two_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 22);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
+    }
+
+    #[test]
+    fn agent_schedule_defaults_and_snake_case_are_stable() {
+        assert_eq!(AgentScheduleSession::default(), AgentScheduleSession::Fresh);
+        assert_eq!(AgentScheduleState::default(), AgentScheduleState::Paused);
+        assert_eq!(
+            AgentScheduleOverlapPolicy::default(),
+            AgentScheduleOverlapPolicy::Skip
+        );
+
+        let spec: AgentScheduleSpec = serde_json::from_value(serde_json::json!({
+            "name": "review",
+            "cwd": "/tmp/project",
+            "integration": "opencode",
+            "prompt": "review the changes",
+            "trigger": {"cron": "0 9 * * 1-5", "timezone": "UTC"}
+        }))
+        .unwrap();
+        assert_eq!(spec.session, AgentScheduleSession::Fresh);
+        assert_eq!(spec.state, AgentScheduleState::Paused);
+        assert_eq!(spec.overlap_policy, AgentScheduleOverlapPolicy::Skip);
+
+        let continued = serde_json::to_value(AgentScheduleSession::Continue {
+            external_session_id: "session-1".into(),
+        })
+        .unwrap();
+        assert_eq!(
+            continued,
+            serde_json::json!({"continue": {"external_session_id": "session-1"}})
+        );
+        assert_eq!(
+            serde_json::to_value(AgentScheduleState::Enabled).unwrap(),
+            "enabled"
+        );
+        assert_eq!(
+            serde_json::to_value(AgentScheduleOverlapPolicy::Skip).unwrap(),
+            "skip"
+        );
+    }
+
+    #[test]
+    fn agent_schedule_messages_round_trip() {
+        let spec = AgentScheduleSpec {
+            name: "review".into(),
+            cwd: "/tmp/project".into(),
+            integration: "opencode".into(),
+            prompt: "review the changes".into(),
+            session: AgentScheduleSession::Fresh,
+            trigger: AgentScheduleTrigger {
+                cron: "0 9 * * 1-5".into(),
+                timezone: "UTC".into(),
+            },
+            state: AgentScheduleState::Paused,
+            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+        };
+        let requests = [
+            Request::CreateAgentSchedule {
+                workspace_id: "w1".into(),
+                spec,
+            },
+            Request::GetAgentSchedule {
+                schedule_id: "schedule-1".into(),
+            },
+            Request::PauseAgentSchedule {
+                schedule_id: "schedule-1".into(),
+            },
+            Request::ResumeAgentSchedule {
+                schedule_id: "schedule-1".into(),
+            },
+            Request::RemoveAgentSchedule {
+                schedule_id: "schedule-1".into(),
+            },
+        ];
+        for request in requests {
+            let encoded = serde_json::to_value(&request).unwrap();
+            assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
+        }
+
+        let schedule = test_schedule();
+        for response in [
+            Response::AgentSchedule {
+                schedule: schedule.clone(),
+            },
+            Response::AgentScheduleInspection {
+                inspection: AgentScheduleInspection {
+                    schedule,
+                    prompt: "private prompt".into(),
+                },
+            },
+        ] {
+            let encoded = serde_json::to_value(&response).unwrap();
+            assert_eq!(
+                serde_json::from_value::<Response>(encoded).unwrap(),
+                response
+            );
+        }
+    }
+
+    #[test]
+    fn schedule_summaries_and_events_never_expose_prompts() {
+        let private_prompt = "private prompt contents";
+        let schedule = test_schedule();
+        let request = Request::CreateAgentSchedule {
+            workspace_id: "w1".into(),
+            spec: AgentScheduleSpec {
+                name: "review".into(),
+                cwd: "/tmp/project".into(),
+                integration: "opencode".into(),
+                prompt: private_prompt.into(),
+                session: AgentScheduleSession::Fresh,
+                trigger: schedule.trigger.clone(),
+                state: AgentScheduleState::Paused,
+                overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            },
+        };
+        let request_debug = format!("{request:?}");
+        assert!(!request_debug.contains(private_prompt));
+        assert!(request_debug.contains("redacted"));
+
+        let summary = serde_json::to_value(&schedule).unwrap();
+        assert!(summary.get("prompt").is_none());
+        assert!(!summary.to_string().contains(private_prompt));
+
+        let events = [
+            DaemonEventKind::AgentScheduleCreated {
+                workspace_id: "w1".into(),
+                schedule: schedule.clone(),
+            },
+            DaemonEventKind::AgentSchedulePaused {
+                workspace_id: "w1".into(),
+                schedule: schedule.clone(),
+            },
+            DaemonEventKind::AgentScheduleResumed {
+                workspace_id: "w1".into(),
+                schedule: schedule.clone(),
+            },
+            DaemonEventKind::AgentScheduleRemoved {
+                workspace_id: "w1".into(),
+                schedule_id: schedule.id.clone(),
+            },
+        ];
+        for event in events {
+            let encoded = serde_json::to_value(&event).unwrap();
+            assert!(!encoded.to_string().contains(private_prompt));
+            assert_eq!(
+                serde_json::from_value::<DaemonEventKind>(encoded).unwrap(),
+                event
+            );
+        }
+
+        let inspection = AgentScheduleInspection {
+            schedule,
+            prompt: private_prompt.into(),
+        };
+        let debug = format!("{inspection:?}");
+        assert!(!debug.contains(private_prompt));
+        assert!(debug.contains("redacted"));
+        assert_eq!(
+            serde_json::to_value(inspection).unwrap()["prompt"],
+            private_prompt
+        );
     }
 
     #[test]
@@ -1204,6 +1552,39 @@ mod tests {
     #[test]
     fn request_feature_requirements_cover_all_groups() {
         let groups = vec![
+            (
+                22,
+                vec![
+                    Request::CreateAgentSchedule {
+                        workspace_id: "w1".into(),
+                        spec: AgentScheduleSpec {
+                            name: "review".into(),
+                            cwd: "/tmp".into(),
+                            integration: "opencode".into(),
+                            prompt: "review".into(),
+                            session: AgentScheduleSession::Fresh,
+                            trigger: AgentScheduleTrigger {
+                                cron: "0 9 * * *".into(),
+                                timezone: "UTC".into(),
+                            },
+                            state: AgentScheduleState::Paused,
+                            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+                        },
+                    },
+                    Request::GetAgentSchedule {
+                        schedule_id: "schedule-1".into(),
+                    },
+                    Request::PauseAgentSchedule {
+                        schedule_id: "schedule-1".into(),
+                    },
+                    Request::ResumeAgentSchedule {
+                        schedule_id: "schedule-1".into(),
+                    },
+                    Request::RemoveAgentSchedule {
+                        schedule_id: "schedule-1".into(),
+                    },
+                ],
+            ),
             (21, vec![Request::GetFocusedTerminal]),
             (
                 20,
@@ -1479,6 +1860,14 @@ mod tests {
             (19, &["protocol_19", "workspace_default_cwd"][..]),
             (20, &["protocol_20", "structured_terminal_previews"][..]),
             (21, &["protocol_21", "focused_terminal_read"][..]),
+            (
+                22,
+                &[
+                    "protocol_22",
+                    "agent_schedule_management",
+                    "durable_agent_schedules",
+                ][..],
+            ),
         ];
 
         let actual = ProtocolFeature::ALL
@@ -1487,6 +1876,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(actual, expected);
         assert!(ProtocolFeature::StructuredTerminalPreview.is_supported_by(PROTOCOL_VERSION));
+        assert!(ProtocolFeature::AgentSchedules.is_supported_by(PROTOCOL_VERSION));
         assert_eq!(
             protocol_capabilities().collect::<Vec<_>>(),
             expected

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -1,0 +1,417 @@
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_PROMPT_BYTES: usize = 65_536;
+pub const MAX_CRON_BYTES: usize = 256;
+pub const MAX_TIMEZONE_BYTES: usize = 256;
+pub const MAX_INTEGRATION_KEY_BYTES: usize = 256;
+pub const MAX_EXTERNAL_SESSION_ID_BYTES: usize = 256;
+pub const MAX_SCHEDULES_PER_WORKSPACE: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchedulingError {
+    EmptyValue {
+        field: &'static str,
+    },
+    ValueTooLong {
+        field: &'static str,
+        max_bytes: usize,
+    },
+    InvalidValue {
+        field: &'static str,
+        reason: &'static str,
+    },
+    InvalidCron {
+        field: Option<usize>,
+        reason: &'static str,
+    },
+    InvalidConvenience {
+        reason: &'static str,
+    },
+    InvalidTimezone,
+    SystemTimezoneUnavailable,
+}
+
+impl fmt::Display for SchedulingError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyValue { field } => write!(formatter, "{field} must not be empty"),
+            Self::ValueTooLong { field, max_bytes } => {
+                write!(formatter, "{field} must be at most {max_bytes} bytes")
+            }
+            Self::InvalidValue { field, reason } => {
+                write!(formatter, "{field} is invalid: {reason}")
+            }
+            Self::InvalidCron {
+                field: Some(field),
+                reason,
+            } => write!(formatter, "cron field {field} is invalid: {reason}"),
+            Self::InvalidCron {
+                field: None,
+                reason,
+            } => write!(formatter, "cron expression is invalid: {reason}"),
+            Self::InvalidConvenience { reason } => {
+                write!(formatter, "schedule convenience is invalid: {reason}")
+            }
+            Self::InvalidTimezone => formatter.write_str("timezone is not a valid IANA timezone"),
+            Self::SystemTimezoneUnavailable => {
+                formatter.write_str("system IANA timezone could not be resolved")
+            }
+        }
+    }
+}
+
+impl Error for SchedulingError {}
+
+/// Validates and whitespace-normalizes the supported five-field cron subset.
+pub fn canonicalize_cron(expression: &str) -> Result<String, SchedulingError> {
+    validate_byte_bound("cron expression", expression, MAX_CRON_BYTES)?;
+    let fields = expression.split_whitespace().collect::<Vec<_>>();
+    if fields.len() != 5 {
+        return Err(SchedulingError::InvalidCron {
+            field: None,
+            reason: "expected exactly five fields",
+        });
+    }
+
+    const BOUNDS: [(u32, u32); 5] = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 6)];
+    for (index, (field, (minimum, maximum))) in fields.iter().zip(BOUNDS).enumerate() {
+        validate_cron_field(field, minimum, maximum).map_err(|reason| {
+            SchedulingError::InvalidCron {
+                field: Some(index + 1),
+                reason,
+            }
+        })?;
+    }
+
+    Ok(fields.join(" "))
+}
+
+pub fn every_minutes_cron(minutes: u8) -> Result<String, SchedulingError> {
+    if minutes == 0 || 60 % minutes != 0 {
+        return Err(SchedulingError::InvalidConvenience {
+            reason: "minute interval must be a positive divisor of 60",
+        });
+    }
+    Ok(match minutes {
+        1 => "* * * * *".to_owned(),
+        60 => "0 * * * *".to_owned(),
+        _ => format!("*/{minutes} * * * *"),
+    })
+}
+
+pub fn every_hours_cron(hours: u8) -> Result<String, SchedulingError> {
+    if hours == 0 || 24 % hours != 0 {
+        return Err(SchedulingError::InvalidConvenience {
+            reason: "hour interval must be a positive divisor of 24",
+        });
+    }
+    Ok(match hours {
+        1 => "0 * * * *".to_owned(),
+        24 => "0 0 * * *".to_owned(),
+        _ => format!("0 */{hours} * * *"),
+    })
+}
+
+pub fn daily_cron(hour: u8, minute: u8) -> Result<String, SchedulingError> {
+    validate_time(hour, minute)?;
+    Ok(format!("{minute} {hour} * * *"))
+}
+
+pub fn weekdays_cron(hour: u8, minute: u8) -> Result<String, SchedulingError> {
+    validate_time(hour, minute)?;
+    Ok(format!("{minute} {hour} * * 1-5"))
+}
+
+pub fn weekly_cron(day: &str, hour: u8, minute: u8) -> Result<String, SchedulingError> {
+    validate_time(hour, minute)?;
+    let day = match day.to_ascii_lowercase().as_str() {
+        "sun" | "sunday" => 0,
+        "mon" | "monday" => 1,
+        "tue" | "tues" | "tuesday" => 2,
+        "wed" | "wednesday" => 3,
+        "thu" | "thur" | "thurs" | "thursday" => 4,
+        "fri" | "friday" => 5,
+        "sat" | "saturday" => 6,
+        _ => {
+            return Err(SchedulingError::InvalidConvenience {
+                reason: "weekly day must be a common English day name",
+            });
+        }
+    };
+    Ok(format!("{minute} {hour} * * {day}"))
+}
+
+pub fn canonicalize_timezone(timezone: &str) -> Result<String, SchedulingError> {
+    validate_byte_bound("timezone", timezone, MAX_TIMEZONE_BYTES)?;
+    if timezone.trim().is_empty() {
+        return Err(SchedulingError::EmptyValue { field: "timezone" });
+    }
+    timezone
+        .parse::<chrono_tz::Tz>()
+        .map(|timezone| timezone.to_string())
+        .map_err(|_| SchedulingError::InvalidTimezone)
+}
+
+pub fn resolve_system_timezone() -> Result<String, SchedulingError> {
+    let timezone =
+        iana_time_zone::get_timezone().map_err(|_| SchedulingError::SystemTimezoneUnavailable)?;
+    canonicalize_timezone(&timezone).map_err(|_| SchedulingError::SystemTimezoneUnavailable)
+}
+
+pub fn validate_prompt(prompt: &str) -> Result<(), SchedulingError> {
+    validate_required_bounded("prompt", prompt, MAX_PROMPT_BYTES)
+}
+
+pub fn validate_integration_key(integration: &str) -> Result<(), SchedulingError> {
+    validate_identity("integration key", integration, MAX_INTEGRATION_KEY_BYTES)
+}
+
+pub fn validate_external_session_id(session_id: &str) -> Result<(), SchedulingError> {
+    validate_identity(
+        "external session ID",
+        session_id,
+        MAX_EXTERNAL_SESSION_ID_BYTES,
+    )
+}
+
+fn validate_identity(
+    field: &'static str,
+    value: &str,
+    max_bytes: usize,
+) -> Result<(), SchedulingError> {
+    validate_required_bounded(field, value, max_bytes)?;
+    if value.chars().any(char::is_control) {
+        return Err(SchedulingError::InvalidValue {
+            field,
+            reason: "control characters are not allowed",
+        });
+    }
+    Ok(())
+}
+
+fn validate_cron_field(field: &str, minimum: u32, maximum: u32) -> Result<(), &'static str> {
+    for component in field.split(',') {
+        if component.is_empty() {
+            return Err("list contains an empty item");
+        }
+        let (base, step) = match component.split_once('/') {
+            Some((base, step)) if !base.contains('/') && !step.contains('/') => {
+                if base != "*" && !base.contains('-') {
+                    return Err("steps are allowed only on a wildcard or range");
+                }
+                let step = parse_number(step).ok_or("step must be numeric")?;
+                if step == 0 || step > maximum {
+                    return Err("step is outside the field range");
+                }
+                (base, Some(step))
+            }
+            Some(_) => return Err("step syntax is malformed"),
+            None => (component, None),
+        };
+
+        if base == "*" {
+            continue;
+        }
+        if let Some((start, end)) = base.split_once('-') {
+            if start.contains('-') || end.contains('-') {
+                return Err("range syntax is malformed");
+            }
+            let start = parse_number(start).ok_or("range values must be numeric")?;
+            let end = parse_number(end).ok_or("range values must be numeric")?;
+            if start < minimum || end > maximum {
+                return Err("range value is outside the field bounds");
+            }
+            if start > end {
+                return Err("range must be ascending");
+            }
+            continue;
+        }
+        if step.is_some() {
+            return Err("step base is malformed");
+        }
+        let value = parse_number(base).ok_or("value must be numeric")?;
+        if value < minimum || value > maximum {
+            return Err("value is outside the field bounds");
+        }
+    }
+    Ok(())
+}
+
+fn parse_number(value: &str) -> Option<u32> {
+    (!value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
+        .then(|| value.parse().ok())
+        .flatten()
+}
+
+fn validate_time(hour: u8, minute: u8) -> Result<(), SchedulingError> {
+    if hour > 23 || minute > 59 {
+        return Err(SchedulingError::InvalidConvenience {
+            reason: "time must use a 00:00 through 23:59 value",
+        });
+    }
+    Ok(())
+}
+
+fn validate_required_bounded(
+    field: &'static str,
+    value: &str,
+    max_bytes: usize,
+) -> Result<(), SchedulingError> {
+    validate_byte_bound(field, value, max_bytes)?;
+    if value.trim().is_empty() {
+        return Err(SchedulingError::EmptyValue { field });
+    }
+    Ok(())
+}
+
+fn validate_byte_bound(
+    field: &'static str,
+    value: &str,
+    max_bytes: usize,
+) -> Result<(), SchedulingError> {
+    if value.len() > max_bytes {
+        return Err(SchedulingError::ValueTooLong { field, max_bytes });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cron_accepts_supported_grammar_and_normalizes_only_whitespace() {
+        for expression in [
+            "* * * * *",
+            "0,15,30,45 9-17 * 1,6,12 1-5",
+            "*/15 9-17/2 1-31/3 * 0,6",
+            "01 02 03 04 05",
+        ] {
+            assert_eq!(canonicalize_cron(expression).unwrap(), expression);
+        }
+        assert_eq!(
+            canonicalize_cron("  */15\t 9-17/2\n* * 1-5  ").unwrap(),
+            "*/15 9-17/2 * * 1-5"
+        );
+    }
+
+    #[test]
+    fn cron_rejects_unsupported_and_malformed_forms() {
+        for expression in [
+            "0 0 * *",
+            "0 0 * * * *",
+            "0 0 * JAN *",
+            "@daily",
+            "0 0 ? * *",
+            "0 0 L * *",
+            "0 0 1W * *",
+            "0 0 * * 1#2",
+            "60 0 * * *",
+            "0 24 * * *",
+            "0 0 0 * *",
+            "0 0 * 13 *",
+            "0 0 * * 7",
+            "0 0 * * 5-1",
+            "*/0 * * * *",
+            "*/61 * * * *",
+            "*/60 * * * *",
+            "0 */24 * * *",
+            "1/2 * * * *",
+            "1--2 * * * *",
+            "1,,2 * * * *",
+            "*/x * * * *",
+        ] {
+            assert!(
+                canonicalize_cron(expression).is_err(),
+                "accepted {expression}"
+            );
+        }
+    }
+
+    #[test]
+    fn cron_enforces_source_bound_without_echoing_input() {
+        let private = "s".repeat(MAX_CRON_BYTES + 1);
+        let error = canonicalize_cron(&private).unwrap_err();
+        assert!(!error.to_string().contains(&private));
+        assert_eq!(
+            error,
+            SchedulingError::ValueTooLong {
+                field: "cron expression",
+                max_bytes: MAX_CRON_BYTES,
+            }
+        );
+    }
+
+    #[test]
+    fn conveniences_compile_to_canonical_numeric_cron() {
+        assert_eq!(every_minutes_cron(1).unwrap(), "* * * * *");
+        assert_eq!(every_minutes_cron(15).unwrap(), "*/15 * * * *");
+        assert_eq!(every_minutes_cron(60).unwrap(), "0 * * * *");
+        assert_eq!(every_hours_cron(6).unwrap(), "0 */6 * * *");
+        assert_eq!(every_hours_cron(24).unwrap(), "0 0 * * *");
+        assert_eq!(daily_cron(9, 5).unwrap(), "5 9 * * *");
+        assert_eq!(weekdays_cron(17, 30).unwrap(), "30 17 * * 1-5");
+        assert_eq!(weekly_cron("MONDAY", 8, 0).unwrap(), "0 8 * * 1");
+        assert_eq!(weekly_cron("tues", 8, 0).unwrap(), "0 8 * * 2");
+
+        for expression in [
+            every_minutes_cron(20).unwrap(),
+            every_hours_cron(8).unwrap(),
+            daily_cron(23, 59).unwrap(),
+            weekdays_cron(0, 0).unwrap(),
+            weekly_cron("Sunday", 12, 30).unwrap(),
+        ] {
+            assert_eq!(canonicalize_cron(&expression).unwrap(), expression);
+        }
+    }
+
+    #[test]
+    fn conveniences_reject_invalid_intervals_times_and_days() {
+        assert!(every_minutes_cron(0).is_err());
+        assert!(every_minutes_cron(7).is_err());
+        assert!(every_hours_cron(5).is_err());
+        assert!(daily_cron(24, 0).is_err());
+        assert!(weekdays_cron(0, 60).is_err());
+        assert!(weekly_cron("funday", 0, 0).is_err());
+    }
+
+    #[test]
+    fn timezone_uses_iana_parser_and_stable_display_name() {
+        assert_eq!(
+            canonicalize_timezone("America/New_York").unwrap(),
+            "America/New_York"
+        );
+        assert_eq!(canonicalize_timezone("UTC").unwrap(), "UTC");
+        assert!(canonicalize_timezone("Not/A_Private_Zone").is_err());
+        assert!(canonicalize_timezone("").is_err());
+
+        let private = "Private/".to_owned() + &"x".repeat(MAX_TIMEZONE_BYTES);
+        let message = canonicalize_timezone(&private).unwrap_err().to_string();
+        assert!(!message.contains(&private));
+    }
+
+    #[test]
+    fn required_values_enforce_whitespace_and_byte_bounds() {
+        for prompt in ["", " \t\n"] {
+            assert!(matches!(
+                validate_prompt(prompt),
+                Err(SchedulingError::EmptyValue { field: "prompt" })
+            ));
+        }
+        assert!(validate_prompt("run tests").is_ok());
+        assert!(validate_prompt(&"x".repeat(MAX_PROMPT_BYTES)).is_ok());
+        assert!(validate_prompt(&"x".repeat(MAX_PROMPT_BYTES + 1)).is_err());
+
+        assert!(validate_integration_key("opencode").is_ok());
+        assert!(validate_integration_key(" ").is_err());
+        assert!(validate_integration_key("open\ncode").is_err());
+        assert!(validate_integration_key(&"x".repeat(MAX_INTEGRATION_KEY_BYTES + 1)).is_err());
+        assert!(validate_external_session_id("session-1").is_ok());
+        assert!(validate_external_session_id("").is_err());
+        assert!(validate_external_session_id("session\u{1b}").is_err());
+        assert!(
+            validate_external_session_id(&"x".repeat(MAX_EXTERNAL_SESSION_ID_BYTES + 1)).is_err()
+        );
+    }
+}

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -381,6 +381,7 @@ mod tests {
             default_cwd: None,
             shells: vec![shell],
             launchers: Vec::new(),
+            schedules: Vec::new(),
             agents: agent_ids
                 .iter()
                 .enumerate()

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -12,10 +12,13 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::protocol::{
-    AgentAttentionSnapshot, AgentObservationSnapshot, ShellRunExitReason, TerminalProfile,
+    AgentAttentionSnapshot, AgentObservationSnapshot, AgentScheduleOverlapPolicy,
+    AgentScheduleSession, AgentScheduleState, AgentScheduleTrigger, ShellRunExitReason,
+    TerminalProfile,
 };
 
-const STATE_VERSION: u32 = 8;
+const STATE_VERSION: u32 = 9;
+const VERSION_EIGHT_STATE_VERSION: u32 = 8;
 const VERSION_SEVEN_STATE_VERSION: u32 = 7;
 const PREVIOUS_STATE_VERSION: u32 = 6;
 const VERSION_FIVE_STATE_VERSION: u32 = 5;
@@ -50,6 +53,52 @@ pub(crate) struct PersistedWorkspace {
     pub(crate) shells: Vec<PersistedShell>,
     pub(crate) launchers: Vec<PersistedWorkspaceLauncher>,
     pub(crate) agents: Vec<PersistedAgentInstance>,
+    pub(crate) schedules: Vec<PersistedAgentSchedule>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PersistedAgentSchedule {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) cwd: PathBuf,
+    pub(crate) integration: String,
+    pub(crate) prompt: String,
+    pub(crate) session: AgentScheduleSession,
+    pub(crate) trigger: AgentScheduleTrigger,
+    pub(crate) state: AgentScheduleState,
+    pub(crate) overlap_policy: AgentScheduleOverlapPolicy,
+    pub(crate) revision: u64,
+    pub(crate) prompt_revision: u64,
+    pub(crate) trigger_revision: u64,
+    pub(crate) created_at_ms: u64,
+    pub(crate) updated_at_ms: u64,
+    pub(crate) evaluation_frontier_ms: u64,
+    pub(crate) execution_shell_id: Option<String>,
+}
+
+impl std::fmt::Debug for PersistedAgentSchedule {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PersistedAgentSchedule")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("cwd", &self.cwd)
+            .field("integration", &self.integration)
+            .field("prompt", &"<redacted>")
+            .field("session", &self.session)
+            .field("trigger", &self.trigger)
+            .field("state", &self.state)
+            .field("overlap_policy", &self.overlap_policy)
+            .field("revision", &self.revision)
+            .field("prompt_revision", &self.prompt_revision)
+            .field("trigger_revision", &self.trigger_revision)
+            .field("created_at_ms", &self.created_at_ms)
+            .field("updated_at_ms", &self.updated_at_ms)
+            .field("evaluation_frontier_ms", &self.evaluation_frontier_ms)
+            .field("execution_shell_id", &self.execution_shell_id)
+            .finish()
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -105,6 +154,24 @@ pub(crate) struct PersistedShellRun {
 #[derive(Deserialize)]
 struct StateVersion {
     version: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionEightPersistedState {
+    version: u32,
+    workspaces: Vec<VersionEightPersistedWorkspace>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionEightPersistedWorkspace {
+    id: String,
+    name: String,
+    default_cwd: Option<PathBuf>,
+    shells: Vec<PersistedShell>,
+    launchers: Vec<PersistedWorkspaceLauncher>,
+    agents: Vec<PersistedAgentInstance>,
 }
 
 #[derive(Deserialize)]
@@ -409,6 +476,10 @@ impl StateStore {
         })?;
         let (state, migrated) = match version.version {
             STATE_VERSION => (parse_state(&bytes, &self.path)?, false),
+            VERSION_EIGHT_STATE_VERSION => {
+                let previous: VersionEightPersistedState = parse_state(&bytes, &self.path)?;
+                (migrate_version_eight_state(previous), true)
+            }
             VERSION_SEVEN_STATE_VERSION => {
                 let previous: VersionSevenPersistedState = parse_state(&bytes, &self.path)?;
                 (migrate_version_seven_state(previous), true)
@@ -529,6 +600,27 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
                     .collect(),
                 launchers: Vec::new(),
                 agents: Vec::new(),
+                schedules: Vec::new(),
+            })
+            .collect(),
+    }
+}
+
+fn migrate_version_eight_state(previous: VersionEightPersistedState) -> PersistedState {
+    debug_assert_eq!(previous.version, VERSION_EIGHT_STATE_VERSION);
+    PersistedState {
+        version: STATE_VERSION,
+        workspaces: previous
+            .workspaces
+            .into_iter()
+            .map(|workspace| PersistedWorkspace {
+                id: workspace.id,
+                name: workspace.name,
+                default_cwd: workspace.default_cwd,
+                shells: workspace.shells,
+                launchers: workspace.launchers,
+                agents: workspace.agents,
+                schedules: Vec::new(),
             })
             .collect(),
     }
@@ -568,6 +660,7 @@ fn migrate_version_seven_state(previous: VersionSevenPersistedState) -> Persiste
                     .collect(),
                 launchers: workspace.launchers,
                 agents: workspace.agents,
+                schedules: Vec::new(),
             })
             .collect(),
     }
@@ -587,6 +680,7 @@ fn migrate_previous_state(previous: PreviousPersistedState) -> PersistedState {
                 shells: workspace.shells,
                 launchers: workspace.launchers,
                 agents: workspace.agents,
+                schedules: Vec::new(),
             })
             .collect(),
     }
@@ -622,6 +716,7 @@ fn migrate_version_five_state(previous: VersionFivePersistedState) -> PersistedS
                         attention: None,
                     })
                     .collect(),
+                schedules: Vec::new(),
             })
             .collect(),
     }
@@ -663,6 +758,7 @@ fn migrate_version_four_state(previous: VersionFourPersistedState) -> PersistedS
                             attention: None,
                         })
                         .collect(),
+                    schedules: Vec::new(),
                 }
             })
             .collect(),
@@ -683,6 +779,7 @@ fn migrate_version_three_state(previous: VersionThreePersistedState) -> Persiste
                 shells: workspace.shells,
                 launchers: workspace.launchers,
                 agents: Vec::new(),
+                schedules: Vec::new(),
             })
             .collect(),
     }
@@ -702,6 +799,7 @@ fn migrate_version_two_state(previous: VersionTwoPersistedState) -> PersistedSta
                 shells: workspace.shells,
                 launchers: Vec::new(),
                 agents: Vec::new(),
+                schedules: Vec::new(),
             })
             .collect(),
     }
@@ -858,8 +956,34 @@ mod tests {
                         }),
                     },
                 ],
+                schedules: vec![PersistedAgentSchedule {
+                    id: "schedule-1".into(),
+                    name: "daily review".into(),
+                    cwd: "/tmp/project".into(),
+                    integration: "opencode".into(),
+                    prompt: "Review the current changes".into(),
+                    session: AgentScheduleSession::Continue {
+                        external_session_id: "external-1".into(),
+                    },
+                    trigger: AgentScheduleTrigger {
+                        cron: "0 9 * * 1-5".into(),
+                        timezone: "America/New_York".into(),
+                    },
+                    state: AgentScheduleState::Enabled,
+                    overlap_policy: AgentScheduleOverlapPolicy::Skip,
+                    revision: 4,
+                    prompt_revision: 2,
+                    trigger_revision: 3,
+                    created_at_ms: 40,
+                    updated_at_ms: 50,
+                    evaluation_frontier_ms: 60,
+                    execution_shell_id: Some("shell-1".into()),
+                }],
             }],
         };
+        let debug = format!("{state:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("Review the current changes"));
 
         store.save(&state).unwrap();
         let restored = store.load().unwrap().unwrap();
@@ -904,6 +1028,17 @@ mod tests {
                 .map(|attention| attention.reason),
             Some(crate::protocol::AgentAttentionReason::Completed)
         );
+        let schedule = &restored.workspaces[0].schedules[0];
+        assert_eq!(schedule.id, "schedule-1");
+        assert_eq!(schedule.prompt, "Review the current changes");
+        assert_eq!(
+            schedule.session,
+            AgentScheduleSession::Continue {
+                external_session_id: "external-1".into()
+            }
+        );
+        assert_eq!(schedule.trigger.cron, "0 9 * * 1-5");
+        assert_eq!(schedule.execution_shell_id.as_deref(), Some("shell-1"));
         assert_eq!(
             fs::metadata(directory.join("boomux/state.json"))
                 .unwrap()
@@ -927,6 +1062,134 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_eight_workspaces_without_schedules() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            br#"{
+  "version": 8,
+  "workspaces": [{
+    "id": "w1", "name": "version-eight", "default_cwd": "/tmp/project",
+    "shells": [{
+      "id": "s1", "name": "agent", "cwd": "/tmp/project", "command": ["opencode"],
+      "last_run": {
+        "id": "r1", "generation": 2, "started_at_ms": 1, "ended_at_ms": 2,
+        "exit_reason": {"reason": "interrupted"}, "output_revision": 3,
+        "environment_has_run_id": true,
+        "profile": {
+          "term": "xterm-256color", "colorterm": null, "term_program": null,
+          "term_program_version": null, "rows": 24, "cols": 80,
+          "pixel_width": 0, "pixel_height": 0
+        },
+        "terminal_history": "bounded output"
+      }
+    }],
+    "launchers": [{
+      "id": "l1", "name": "editor", "cwd": "/tmp/project", "command": ["editor"]
+    }],
+    "agents": [{
+      "id": "a1", "shell_id": "s1", "run_id": "r1", "name": "agent",
+      "integration": "opencode", "external_session_id": "external-1",
+      "cwd": "/tmp/project", "started_at_ms": 1, "ended_at_ms": null,
+      "observation": {
+        "revision": 2, "state": "blocked", "authority": "lifecycle_integration",
+        "evidence": "question", "confidence": 100, "observed_at_ms": 2
+      },
+      "attention": {
+        "reason": "blocked",
+        "observation": {
+          "revision": 2, "state": "blocked", "authority": "lifecycle_integration",
+          "evidence": "question", "confidence": 100, "observed_at_ms": 2
+        }
+      }
+    }]
+  }]
+}"#,
+        )
+        .unwrap();
+        let store = StateStore::at(path.clone());
+
+        let migrated = store.load().unwrap().unwrap();
+
+        let workspace = &migrated.workspaces[0];
+        assert_eq!(
+            workspace.default_cwd.as_deref(),
+            Some(Path::new("/tmp/project"))
+        );
+        assert_eq!(
+            workspace.shells[0]
+                .last_run
+                .as_ref()
+                .and_then(|run| run.terminal_history.as_deref()),
+            Some("bounded output")
+        );
+        assert_eq!(workspace.launchers[0].command, ["editor"]);
+        assert_eq!(
+            workspace.agents[0].external_session_id.as_deref(),
+            Some("external-1")
+        );
+        assert!(workspace.agents[0].attention.is_some());
+        assert!(workspace.schedules.is_empty());
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("\"version\": 9")
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn rejects_malformed_current_schedule_schema() {
+        let schedule_missing_frontier = r#"{
+          "id":"schedule-1","name":"review","cwd":"/tmp/project",
+          "integration":"opencode","prompt":"Review changes","session":"fresh",
+          "trigger":{"cron":"0 9 * * 1-5","timezone":"UTC"},"state":"paused",
+          "overlap_policy":"skip","revision":1,"prompt_revision":1,
+          "trigger_revision":1,"created_at_ms":1,"updated_at_ms":1,
+          "execution_shell_id":null
+        }"#;
+        let schedule_with_unknown_field = r#"{
+          "id":"schedule-1","name":"review","cwd":"/tmp/project",
+          "integration":"opencode","prompt":"Review changes","session":"fresh",
+          "trigger":{"cron":"0 9 * * 1-5","timezone":"UTC"},"state":"paused",
+          "overlap_policy":"skip","revision":1,"prompt_revision":1,
+          "trigger_revision":1,"created_at_ms":1,"updated_at_ms":1,
+          "evaluation_frontier_ms":1,"execution_shell_id":null,"workspace_id":"w1"
+        }"#;
+        let schedule_with_unknown_trigger_field = r#"{
+          "id":"schedule-1","name":"review","cwd":"/tmp/project",
+          "integration":"opencode","prompt":"Review changes","session":"fresh",
+          "trigger":{"cron":"0 9 * * 1-5","timezone":"UTC","private":"ignored"},
+          "state":"paused","overlap_policy":"skip","revision":1,"prompt_revision":1,
+          "trigger_revision":1,"created_at_ms":1,"updated_at_ms":1,
+          "evaluation_frontier_ms":1,"execution_shell_id":null
+        }"#;
+
+        for schedule in [
+            schedule_missing_frontier,
+            schedule_with_unknown_field,
+            schedule_with_unknown_trigger_field,
+        ] {
+            let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+            let path = directory.join("boomux/state.json");
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(
+                &path,
+                format!(
+                    r#"{{"version":9,"workspaces":[{{"id":"w1","name":"saved","default_cwd":null,"shells":[],"launchers":[],"agents":[],"schedules":[{schedule}]}}]}}"#
+                ),
+            )
+            .unwrap();
+
+            let error = StateStore::at(path).load().unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+            fs::remove_dir_all(directory).unwrap();
+        }
     }
 
     #[test]
@@ -970,10 +1233,11 @@ mod tests {
                 .terminal_history
                 .is_none()
         );
+        assert!(migrated.workspaces[0].schedules.is_empty());
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 8")
+                .contains("\"version\": 9")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1029,10 +1293,11 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 8")
+                .contains("\"version\": 9")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
         assert!(migrated.workspaces[0].agents.is_empty());
+        assert!(migrated.workspaces[0].schedules.is_empty());
 
         let reloaded = store.load().unwrap().unwrap();
         assert_eq!(
@@ -1079,9 +1344,10 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 8")
+                .contains("\"version\": 9")
         );
         assert!(migrated.workspaces[0].agents.is_empty());
+        assert!(migrated.workspaces[0].schedules.is_empty());
         fs::remove_dir_all(directory).unwrap();
     }
 
@@ -1114,10 +1380,11 @@ mod tests {
 
         assert_eq!(migrated.workspaces[0].launchers[0].id, "l1");
         assert!(migrated.workspaces[0].agents.is_empty());
+        assert!(migrated.workspaces[0].schedules.is_empty());
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 8")
+                .contains("\"version\": 9")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1190,10 +1457,11 @@ mod tests {
             Some(Path::new("/tmp/project"))
         );
         assert!(migrated.workspaces[0].agents[1].cwd.is_none());
+        assert!(migrated.workspaces[0].schedules.is_empty());
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 8")
+                .contains("\"version\": 9")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1227,8 +1495,9 @@ mod tests {
         let migrated = store.load().unwrap().unwrap();
 
         assert!(migrated.workspaces[0].agents[0].attention.is_none());
+        assert!(migrated.workspaces[0].schedules.is_empty());
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 8"));
+        assert!(saved.contains("\"version\": 9"));
         assert!(saved.contains("\"attention\": null"));
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1255,12 +1524,13 @@ mod tests {
 
         assert!(deferred);
         assert!(migrated.workspaces[0].default_cwd.is_none());
+        assert!(migrated.workspaces[0].schedules.is_empty());
         let original = fs::read_to_string(&path).unwrap();
         assert!(original.contains("\"version\": 6"));
         assert!(!original.contains("default_cwd"));
         store.save(&migrated).unwrap();
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 8"));
+        assert!(saved.contains("\"version\": 9"));
         assert!(saved.contains("\"default_cwd\": null"));
         fs::remove_dir_all(directory).unwrap();
     }

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -12,5 +12,7 @@ mod launchers_integrations;
 mod notifications;
 #[path = "native_backend/protocol_control.rs"]
 mod protocol_control;
+#[path = "native_backend/schedules.rs"]
+mod schedules;
 #[path = "native_backend/shell_lifecycle.rs"]
 mod shell_lifecycle;

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -25,7 +25,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 21);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 22);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -59,9 +59,20 @@ fn native_daemon_lifecycle() {
         "integration.status",
         "integration.install",
         "integration.verify",
+        "schedule.create",
+        "schedule.list",
+        "schedule.inspect",
+        "schedule.pause",
+        "schedule.resume",
+        "schedule.remove",
     ] {
         assert!(json_commands.iter().any(|current| current == command));
     }
+    assert!(
+        capabilities["data"]["integration_hosts"]["opencode"]
+            .get("schedule_dispatch")
+            .is_none()
+    );
     let features = capabilities["data"]["features"].as_array().unwrap();
     for feature in [
         "revision_aware_reads",
@@ -76,6 +87,9 @@ fn native_daemon_lifecycle() {
         "protocol_19",
         "protocol_20",
         "protocol_21",
+        "protocol_22",
+        "agent_schedule_management",
+        "durable_agent_schedules",
         "workspace_default_cwd",
         "structured_terminal_previews",
         "focused_terminal_read",
@@ -100,7 +114,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 21"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 22"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])

--- a/tests/native_backend/handoff.rs
+++ b/tests/native_backend/handoff.rs
@@ -140,7 +140,7 @@ fn focused_attachment_is_exposed_in_daemon_snapshots() {
         .unwrap();
     let shell_id = workspace.shells[0].id.clone();
     let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    assert_eq!(attachment.protocol_version, 21);
+    assert_eq!(attachment.protocol_version, 22);
 
     AttachFrame::FocusGained
         .write_to(&mut attachment.stream)

--- a/tests/native_backend/schedules.rs
+++ b/tests/native_backend/schedules.rs
@@ -1,0 +1,320 @@
+use std::os::unix::net::UnixStream;
+
+use boomux::protocol::{
+    self, AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSpec, AgentScheduleState,
+    AgentScheduleTrigger,
+};
+
+use crate::support::{TestDaemon, assert_remote_code};
+
+fn schedule_spec(daemon: &TestDaemon, name: &str, prompt: &str) -> AgentScheduleSpec {
+    AgentScheduleSpec {
+        name: name.into(),
+        cwd: daemon.runtime_dir.clone(),
+        integration: "opencode".into(),
+        prompt: prompt.into(),
+        session: AgentScheduleSession::Fresh,
+        trigger: AgentScheduleTrigger {
+            cron: " 0  2 * * * ".into(),
+            timezone: "UTC".into(),
+        },
+        state: AgentScheduleState::Paused,
+        overlap_policy: AgentScheduleOverlapPolicy::Skip,
+    }
+}
+
+#[test]
+fn schedule_management_is_durable_private_and_process_free() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace("scheduled", Vec::new())
+        .unwrap();
+    let baseline = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let prompt = "private native schedule prompt";
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, schedule_spec(&daemon, "nightly", prompt))
+        .unwrap();
+    assert_eq!(schedule.trigger.cron, "0 2 * * *");
+    assert_eq!(schedule.revision, 1);
+    assert!(schedule.execution_shell_id.is_none());
+
+    let snapshot = daemon.client.get_workspace(&workspace.id).unwrap();
+    assert!(snapshot.shells.is_empty());
+    assert_eq!(snapshot.schedules, std::slice::from_ref(&schedule));
+    assert!(!serde_json::to_string(&snapshot).unwrap().contains(prompt));
+    let inspection = daemon.client.get_agent_schedule(&schedule.id).unwrap();
+    assert_eq!(inspection.prompt, prompt);
+
+    let paused = daemon.client.pause_agent_schedule(&schedule.id).unwrap();
+    assert_eq!(paused.revision, 1);
+    let resumed = daemon.client.resume_agent_schedule(&schedule.id).unwrap();
+    assert_eq!(resumed.revision, 2);
+    assert_eq!(
+        daemon.client.resume_agent_schedule(&schedule.id).unwrap(),
+        resumed
+    );
+    let events = daemon.client.events(Some(baseline), 256, 0).unwrap();
+    assert_eq!(
+        events
+            .events
+            .iter()
+            .filter(|event| matches!(
+                event.kind,
+                protocol::DaemonEventKind::AgentScheduleCreated { .. }
+                    | protocol::DaemonEventKind::AgentSchedulePaused { .. }
+                    | protocol::DaemonEventKind::AgentScheduleResumed { .. }
+            ))
+            .count(),
+        2
+    );
+    assert!(
+        !serde_json::to_string(&events.events)
+            .unwrap()
+            .contains(prompt)
+    );
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    assert_eq!(
+        daemon
+            .client
+            .get_agent_schedule(&schedule.id)
+            .unwrap()
+            .prompt,
+        prompt
+    );
+
+    daemon.crash();
+    daemon.restart();
+    assert_eq!(
+        daemon
+            .client
+            .get_agent_schedule(&schedule.id)
+            .unwrap()
+            .prompt,
+        prompt
+    );
+    assert!(
+        daemon.client.snapshot().unwrap().workspaces[0]
+            .shells
+            .is_empty()
+    );
+
+    daemon.client.remove_agent_schedule(&schedule.id).unwrap();
+    assert!(daemon.client.get_agent_schedule(&schedule.id).is_err());
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn schedule_cli_is_prompt_private_except_for_safe_explicit_inspection() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace("schedule-cli", Vec::new())
+        .unwrap();
+    let prompt = "private\nreview\u{1b}]52;c;payload\u{7}";
+    let created = daemon
+        .command()
+        .args([
+            "schedule",
+            "create",
+            "review",
+            "--workspace",
+            &workspace.id,
+            "--cwd",
+            daemon.runtime_dir.to_str().unwrap(),
+            "--integration",
+            "opencode",
+            "--prompt",
+            prompt,
+            "--cron",
+            "0 9 * * 1-5",
+            "--timezone",
+            "UTC",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        created.status.success(),
+        "{}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    assert!(!String::from_utf8_lossy(&created.stdout).contains(prompt));
+    let created: serde_json::Value = serde_json::from_slice(&created.stdout).unwrap();
+    assert_eq!(created["command"], "schedule.create");
+    assert_eq!(created["data"]["schedule"]["state"], "paused");
+    let schedule_id = created["data"]["schedule"]["id"].as_str().unwrap();
+
+    let listed = daemon
+        .command()
+        .args(["schedule", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(listed.status.success());
+    assert!(!String::from_utf8_lossy(&listed.stdout).contains(prompt));
+
+    let inspected = daemon
+        .command()
+        .args(["schedule", "inspect", schedule_id, "--json"])
+        .output()
+        .unwrap();
+    assert!(inspected.status.success());
+    let inspected: serde_json::Value = serde_json::from_slice(&inspected.stdout).unwrap();
+    assert_eq!(inspected["data"]["schedule"]["prompt"], prompt);
+
+    let human = daemon
+        .command()
+        .args(["schedule", "inspect", schedule_id])
+        .output()
+        .unwrap();
+    assert!(human.status.success());
+    assert!(!human.stdout.contains(&0x1b));
+    assert!(String::from_utf8_lossy(&human.stdout).contains("\\u{1b}"));
+
+    let workspace_inspect = daemon
+        .command()
+        .args(["workspace", "inspect", &workspace.id, "--json"])
+        .output()
+        .unwrap();
+    assert!(workspace_inspect.status.success());
+    let workspace_inspect: serde_json::Value =
+        serde_json::from_slice(&workspace_inspect.stdout).unwrap();
+    assert_eq!(
+        workspace_inspect["data"]["workspace"]["schedules"][0]["id"],
+        schedule_id
+    );
+    assert!(
+        workspace_inspect["data"]["workspace"]["schedules"][0]
+            .get("prompt")
+            .is_none()
+    );
+
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn workspace_close_removes_schedules_with_one_close_event() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace("scheduled-close", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "nightly", "private close prompt"),
+        )
+        .unwrap();
+    let cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+
+    daemon.client.close_workspace(&workspace.id).unwrap();
+
+    assert!(daemon.client.get_agent_schedule(&schedule.id).is_err());
+    let events = daemon.client.events(Some(cursor), 256, 0).unwrap();
+    assert_eq!(events.events.len(), 1);
+    assert!(matches!(
+        events.events[0].kind,
+        protocol::DaemonEventKind::WorkspaceClosed { .. }
+    ));
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn old_protocol_filters_schedules_and_invalid_create_does_not_mutate() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace("scheduled-compat", Vec::new())
+        .unwrap();
+    let first = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "first", "private first prompt"),
+        )
+        .unwrap();
+    let baseline = versioned_request(
+        &daemon,
+        21,
+        protocol::Request::Events {
+            after: None,
+            limit: 256,
+            wait_ms: 0,
+        },
+    );
+    let protocol::Response::Events {
+        cursor,
+        snapshot: Some(snapshot),
+        events,
+        ..
+    } = baseline
+    else {
+        panic!("expected old-protocol baseline");
+    };
+    assert!(events.is_empty());
+    assert!(snapshot.workspaces[0].schedules.is_empty());
+
+    daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "second", "private second prompt"),
+        )
+        .unwrap();
+    let filtered = versioned_request(
+        &daemon,
+        21,
+        protocol::Request::Events {
+            after: Some(cursor.clone()),
+            limit: 256,
+            wait_ms: 0,
+        },
+    );
+    let protocol::Response::Events {
+        cursor: advanced,
+        events,
+        ..
+    } = filtered
+    else {
+        panic!("expected old-protocol events");
+    };
+    assert!(events.is_empty());
+    assert!(advanced.event_id > cursor.event_id);
+
+    let mut invalid = schedule_spec(&daemon, "invalid", "private invalid prompt");
+    invalid.trigger.cron = "invalid".into();
+    let error = daemon
+        .client
+        .create_agent_schedule(&workspace.id, invalid)
+        .unwrap_err();
+    assert_remote_code(&error, protocol::ErrorCode::InvalidArgument);
+    let current = daemon.client.get_workspace(&workspace.id).unwrap();
+    assert_eq!(current.schedules.len(), 2);
+    assert_eq!(current.schedules[0].id, first.id);
+    daemon.stop_with_cli();
+}
+
+fn versioned_request(
+    daemon: &TestDaemon,
+    version: u32,
+    request: protocol::Request,
+) -> protocol::Response {
+    let mut stream = UnixStream::connect(daemon.client.socket_path()).unwrap();
+    protocol::write_message(
+        &mut stream,
+        &protocol::Envelope::with_version(version, request),
+    )
+    .unwrap();
+    let response: protocol::Envelope<protocol::Response> =
+        protocol::read_message(&mut stream).unwrap();
+    assert_eq!(response.version, version);
+    response.message
+}


### PR DESCRIPTION
## Summary

- add workspace-owned durable Agent Schedule definitions and protocol-22 management APIs
- add schedule CLI and stable JSON contracts with explicit prompt privacy boundaries
- migrate durable state to schema 9 and cover recovery, rollback, mixed-version, and process-free behavior

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`

Closes #148

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>