### PR TITLE
feat(schedule): dispatch scheduled agent executions

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -4,7 +4,7 @@ description: Inspect and manage Boomux persistent terminal workspaces, launchers
 compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; schedule names require BOOMUX_WORKSPACE_ID or explicit --workspace; agent mutation and supervision require exact shell-run context, and continuation schedules or supervision require caller-supplied exact canonical session identity.
 metadata:
   author: boomux
-  version: "10"
+  version: "11"
 ---
 
 # Boomux
@@ -51,7 +51,8 @@ boomux capabilities --json
 Parse `data` on success and `error.code` on a nonzero exit; do not parse human
 tables or `error.message`. JSON mutation support includes Agent register,
 ensure, and report; attention acknowledgment; schedule create, pause, resume,
-and remove; and integration installation and uninstallation.
+remove, and run; execution cancellation; and integration installation and
+uninstallation.
 
 Most daemon-backed inspection commands automatically start Boomux when it is
 not running. This includes `list`, `shells`, `read`, `events`, workspace, shell,
@@ -264,6 +265,10 @@ boomux schedule list --workspace "<workspace-name-or-id>" --json
 boomux schedule inspect "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
 boomux schedule pause "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
 boomux schedule resume "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
+boomux schedule run "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
+boomux execution list --workspace "<workspace-name-or-id>" --schedule "<schedule-name-or-id>" --json
+boomux execution inspect "<exact-execution-id>" --json
+boomux execution cancel "<exact-execution-id>" --json
 boomux schedule remove "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
 ```
 
@@ -282,18 +287,26 @@ resolve in that workspace, expose a canonical external session ID, and match the
 selected integration. Never substitute a description, external ID, latest
 session, Agent ID, or shell ID.
 
-List, create, pause, resume, and remove responses are prompt-free. Inspect
+List, create, pause, resume, remove, run, and all execution responses are
+prompt-free. Inspect
 returns the private prompt under `data.schedule.prompt`; do not log or repeat it
 unless needed for the authorized request. Exact schedule IDs resolve globally.
 Names resolve only with explicit `--workspace` or `BOOMUX_WORKSPACE_ID`.
 Removing a schedule removes its persisted prompt. Workspace close removes every
 owned schedule and persisted prompt and must be confirmed with that full scope.
 
-This version is the schedule management surface. Dispatch arrives in later
-scheduler and integration stack layers; do not claim that enabling immediately
-executes timed work. Capabilities advertise durable schedule management only;
-dispatch modes and prompt transport are not public capabilities until the
-dispatcher ships.
+`schedule run` is an explicit process-starting action and requires authorization
+for that one execution. It remains available while paused. Use
+`--idempotency-key <uuid>` for request retry; otherwise the CLI creates a UUID
+before sending. Never retry with a new key when the intent is the same dispatch.
+Inspect the returned exact execution ID, and cancel only when process-tree
+termination is authorized. Execution exit or cancellation never means Agent
+`done`.
+
+This version does not evaluate cron triggers or run a timer. Enabling records
+future timed-work consent but does not itself dispatch. Do not claim workspace
+or global scheduled concurrency limits, skipped timer decisions, or
+`[scheduling]` configuration are active.
 
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.

--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ boomux schedule list --workspace my-project
 boomux schedule inspect review --workspace my-project
 boomux schedule resume review --workspace my-project
 boomux schedule pause review --workspace my-project
+boomux schedule run review --workspace my-project
+boomux execution list --schedule review --workspace my-project
+boomux execution inspect <exact-execution-id>
+boomux execution cancel <exact-execution-id>
 boomux schedule remove review --workspace my-project
 ```
 
@@ -314,9 +318,17 @@ when reading the stored private instructions is authorized. Removing a schedule
 deletes its persisted prompt. Closing the workspace removes every owned schedule
 and persisted prompt.
 
-This release provides the durable management surface. Timed dispatch is added by
-later scheduler and integration stack layers; enabling now records consent state
-but does not by itself make this CLI layer dispatch work.
+`schedule run` is an explicit run-now action and remains available while paused.
+It creates a durable prompt-free execution claim before starting one exact host
+argv through a lazily created schedule-owned shell. Pass `--idempotency-key
+<uuid>` when retrying a request; the same schedule and key always return the same
+execution and never spawn twice. Execution inspection and events omit prompts.
+
+OpenCode receives the prompt as the final argument after `--`; Pi receives the
+exact prompt on stdin. Process exit, dispatch failure, cancellation, and cold
+interruption are execution outcomes and never report an Agent as done. This
+release does not evaluate cron triggers or run timers; enabling records consent
+for future timed dispatch but does not itself start work.
 
 ### Agent Skill
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@
   launch, and integration management execute argv directly without shell
   interpretation.
 - **Scheduled Agent authority:** [`scheduled-agent-work.md`](scheduled-agent-work.md)
-  defines the accepted, not-yet-implemented boundary between scheduling,
+  defines the boundary between implemented manual dispatch, future timing,
   process outcome, and authoritative Agent lifecycle.
 
 ## Product Boundary
@@ -359,7 +359,7 @@ requiring a daemon. Protocol 6 error responses carry an additive optional code;
 clients expose it as `ClientError::Remote(RemoteError)`, while mixed-version
 peers retain message compatibility.
 
-### Scheduled Agent Work (Management Implemented; Dispatch Planned)
+### Scheduled Agent Work (Manual Dispatch Implemented; Timing Planned)
 
 Protocol 22 and state schema 9 implement the Agent Schedule identity without
 changing ShellRun, Agent Instance, or projected Agent Session semantics. A
@@ -371,24 +371,27 @@ closure, and prompt-free events are available. Exact inspection is the only
 management response that contains prompt content; protocol-21 and older peers
 omit schedule summaries and events while their cursors still advance.
 
-Scheduled Execution, timing, and process dispatch remain planned. An execution
-will record one manual or timed decision against exact schedule and prompt
-revisions. An execution that binds the internal runner acquires a shell run, even
-when the external host later fails to launch. The first such execution lazily
-creates one schedule-owned durable shell that later executions reuse for
-distinct runs; ordinary shell or workspace open never starts or restarts it.
-Lifecycle integration may bind an Agent Instance to the exact execution run
-under the existing authority rules.
+Protocol 23 and state schema 10 add manual Scheduled Execution dispatch. A
+prompt-free public record retains one durable claim against exact schedule,
+prompt, and trigger revisions, while its exact prompt snapshot remains private
+durable dispatch input. The first execution lazily creates one schedule-owned
+durable shell; later executions reuse it with distinct ShellRuns. Ordinary shell
+or workspace open never starts or restarts that shell, but an active run remains
+attachable. Rename, close, and restart are rejected outside schedule or workspace
+ownership. State schema 10 explicitly migrates schema-9 shells to user ownership
+and schedules to empty execution histories.
 
-The schedule-owned shell stores a stable internal runner argument vector rather
-than a host prompt. Each persisted execution claim snapshots its working
-directory and dispatch inputs; the runner resolves that exact claim and invokes
-the integration adapter without shell interpretation. Schedule updates while a
-run is active affect only later claims. A durable per-schedule evaluation
-frontier and occurrence key prevent clock rollback, history pruning, restart,
-or graceful handoff from dispatching one timed occurrence twice. The frontier,
-occurrence decision, and execution record commit as one durable mutation before
-event publication.
+The shell stores only the Boomux executable, hidden runner command, and exact
+schedule ID. The runner resolves the exact schedule, `BOOMUX_SHELL_ID`, and
+`BOOMUX_RUN_ID` claim using a private per-execution capability and invokes
+integration-owned argv builders without shell interpretation. The capability is
+persisted with private dispatch input, supplied only to that runner's ephemeral
+environment, removed before the external host is spawned, and required for claim
+resolution and outcome reports. OpenCode
+uses `opencode run [--session exact-id] -- prompt`.
+Pi uses `pi [--session exact-full-id] --print`, receives the exact prompt on
+stdin, and closes stdin; host stdout and stderr remain on the PTY. The runner
+retries daemon connections through handoff without starting a daemon.
 
 Scheduling is process orchestration, not lifecycle observation. Spawn failure,
 process exit, cancellation, and cold-daemon interruption are Scheduled Execution
@@ -400,22 +403,24 @@ input into an active session, or infer a canonical external session.
 Fresh is the default session mode and starts a new external Agent Session for
 each dispatched execution. Continuation schedules pin one exact existing
 integration and external session identity; they never select the latest session
-or fall back to fresh work. An occurrence is skipped while a continuation lease,
-an exact current daemon Agent occurrence, the schedule, or the workspace is
-active. Boomux cannot prove inactivity in an unmanaged host process without an
-integration-provided lease and does not substitute heuristics. Daemon-wide
-scheduled concurrency defaults to four and is configurable within a positive
-bound.
+or fall back to fresh work. The manual layer prevents a second nonterminal
+execution on the same schedule. Continuation leases, workspace/global
+concurrency, and timed skip decisions remain part of #150 rather than this
+dispatch layer.
 
-New schedules are paused by default. Timed work skips overlap and offline
-occurrences rather than queueing or catching up, and automatic retries are not
-part of the initial contract. The initial release also has no automatic timeout:
-an execution remains active until its process exits, the user cancels it, or a
-cold daemon loss interrupts it. Future scheduled starts use the daemon's
+New schedules are paused by default, and manual run-now remains available while
+paused. Cron evaluation, timer loops, skipped timed decisions, and `[scheduling]`
+configuration remain deferred. There is no automatic retry or timeout: an
+execution remains active until its process exits, the user cancels it, or runner
+or cold-daemon loss interrupts it. Scheduled starts use the daemon's
 startup environment as ephemeral input; it is never persisted, and environment
 changes require daemon restart. Scheduled-work support extends graceful restart
 so the invoking client's validated environment becomes the replacement daemon's
 startup environment without entering durable state or the handoff manifest.
+Host exit and host-spawn-failure reports are staged on the nonterminal execution;
+the exact runner ShellRun EOF publishes `run_exited` before committing the
+terminal execution transition. This prevents a later dispatch from observing a
+terminal execution while the reusable runner shell is still live.
 These limitations and scheduler health must be visible to clients. See
 [`scheduled-agent-work.md`](scheduled-agent-work.md) and [ADR 0002](adr/0002-separate-agent-schedules-from-runtime-identity.md).
 
@@ -696,6 +701,11 @@ additive schedule summaries, and older event readers filter schedule events
 without rewinding their cursor. State schema 9 explicitly migrates schema 8
 workspaces with empty schedule collections rather than reinterpreting missing
 durable fields.
+Protocol 23 adds manual Scheduled Execution dispatch, cancellation, prompt-free
+execution events, and durable schedule-owned shell identity. Protocol-22 peers
+omit execution events, schedule-owned shells, and execution-shell links. State schema 10
+explicitly migrates schema 9: existing shells become user-owned and schedules
+receive empty execution histories.
 
 Opt-in desktop and sound notifications are a daemon-owned projection of committed
 Agent state transitions, not durable queue state. A transition from any other

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -72,6 +72,10 @@ The following commands support `--json`:
 - `boomux schedule pause`
 - `boomux schedule resume`
 - `boomux schedule remove`
+- `boomux schedule run`
+- `boomux execution list`
+- `boomux execution inspect`
+- `boomux execution cancel`
 - `boomux integration list`
 - `boomux integration status [opencode|pi]`
 - `boomux integration install <opencode|pi>`
@@ -82,7 +86,8 @@ The following commands support `--json`:
 - `boomux daemon status`
 
 JSON mutations are deliberately narrow. Agent register, ensure, and report;
-attention acknowledgment; schedule create, pause, resume, and remove; and
+attention acknowledgment; schedule create, pause, resume, remove, and run;
+execution cancellation; and
 integration install and uninstall support the contract. Other mutation commands
 retain human output. Passing `--json` to an unsupported command fails with
 `invalid_argument` before performing the operation.
@@ -132,6 +137,12 @@ Command payloads are:
   that includes its `prompt`.
 - `schedule.remove`: `removed: true` plus the removed prompt-free `schedule`
   summary.
+- `schedule.run`: one prompt-free `execution`. The CLI generates a UUID
+  `dispatch_key` before the request unless `--idempotency-key` supplies one.
+- `execution.list`: newest-first prompt-free `executions`, optionally filtered by
+  `--workspace` and `--schedule`.
+- `execution.inspect` and `execution.cancel`: one prompt-free `execution`
+  selected only by exact execution ID.
 - `integration.list`: an `integrations` array containing bundled integration
   names, display names, packages, and validated host versions.
 - `integration.status`: an `integrations` array containing independent `host`,
@@ -163,8 +174,28 @@ Integration arrays are ordered `opencode`, then `pi`. List entries contain
 `name`, `display_name`, `package`, and `validated_version`.
 
 Protocol 22 advertises `protocol_22`, `agent_schedule_management`, and
-`durable_agent_schedules`. These capabilities describe durable management only;
-they do not advertise timed or manual dispatch.
+`durable_agent_schedules`. Protocol 23 adds `protocol_23`,
+`scheduled_execution_dispatch`, `scheduled_execution_cancellation`, and
+`schedule_owned_shells`. These capabilities advertise manual run-now dispatch;
+they do not advertise cron evaluation or timed dispatch.
+
+## Execution Data
+
+Execution objects contain `id`, `workspace_id`, `schedule_id`, `state`,
+`dispatch_kind`, `dispatch_key`, exact `schedule_revision`, `prompt_revision`,
+and `trigger_revision`, requested/start/end timestamps, snapshotted `cwd`,
+`integration`, and `session`, nullable typed `reason` and `outcome`, and nullable
+`shell_id`, `run_id`, `agent_id`, and discovered `external_session_id` links.
+They never contain the retained prompt or environment.
+
+State is `claimed`, `starting`, `active`, `dispatch_failed`, `exited`,
+`cancelled`, or `interrupted`; dispatch kind is currently `manual`. Reasons are
+stable safe values `runner_start_failed`, `host_spawn_failed`,
+`cancelled_by_user`, `cold_daemon_recovery`, or
+`runner_exited_without_report`; explicit daemon shutdown uses `daemon_shutdown`.
+Exit outcomes are tagged
+`exit_code` with `code` or `signal` with `signal`. These are process-orchestration
+outcomes and never imply Agent `working`, `idle`, `blocked`, or `done`.
 
 Status entries contain those four fields plus `host`, `asset`, `runtime`, and
 `recommended_action`.
@@ -204,7 +235,9 @@ requires `--force`, while unsafe paths fail before any removal.
 ## Shell Data
 
 Shell objects use stable scalar fields: `id`, `workspace_id`, `workspace_name`,
-`name`, `cwd`, `status`, `exit_code`, and `run`. Missing values are JSON `null`,
+`name`, `cwd`, `owner`, `owner_schedule_id`, `status`, `exit_code`, and `run`.
+Owner is `user` or `schedule`; only the latter has a non-null schedule ID and is
+protected from direct rename, close, restart, and inactive open. Missing values are JSON `null`,
 not omitted or represented as human placeholders. `status` is `pending`,
 `running`, or `exited`.
 
@@ -354,12 +387,13 @@ Schedule summaries contain `id`, `workspace_id`, nullable `workspace_name`,
 `evaluation_frontier_ms`, and nullable `execution_shell_id`. Optional values are
 JSON `null`. State is `paused` or `enabled`; session mode is `fresh` or
 `continue`; the initial overlap policy is always `skip`.
-All schedule commands require negotiated daemon protocol 22 and return
-`unsupported_version` against an older daemon rather than presenting an empty
-schedule list.
+Schedule management commands require negotiated daemon protocol 22. `schedule
+run` and every `execution` command require protocol 23. Unsupported commands
+return `unsupported_version` rather than presenting empty data.
 
 Only `schedule.inspect` adds `prompt`. Prompts are intentionally absent from
-list, create, pause, resume, remove, capabilities, events, and errors. Inspection
+list, create, pause, resume, remove, run, execution records, capabilities,
+events, and errors. Inspection
 is an explicit private-content disclosure. A prompt file is read once at create
 time as exact UTF-8, including a trailing newline; later file changes do not
 alter the persisted prompt revision. Files must be regular and prompts are

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -29,6 +29,7 @@ shared by concurrent clients.
 Protocol 22 adds durable Agent Schedule management. Workspace snapshots include
 ordered, prompt-free schedule summaries, while exact schedule inspection is the
 only management response that discloses the current prompt.
+Protocol 23 adds durable manual Scheduled Executions and schedule-owned shells.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns
@@ -68,6 +69,7 @@ The event vocabulary is:
   `agent_attention_acknowledged`
 - `agent_schedule_created`, `agent_schedule_paused`, `agent_schedule_resumed`,
   `agent_schedule_removed`
+- `scheduled_execution_created`, `scheduled_execution_changed`
 - `handoff_completed`
 
 Output events carry run identity and the latest output revision, not raw PTY
@@ -103,6 +105,19 @@ schedule summary after persistence. Idempotent pause or resume emits no event an
 does not advance the schedule revision. Removing a schedule emits only its
 workspace and schedule identities.
 
+`scheduled_execution_created` publishes the persisted manual claim.
+`scheduled_execution_changed` publishes later prompt-free shell/run binding,
+active, dispatch-failed, exited, cancelled, interrupted, and Agent-link changes.
+Both carry the complete public execution snapshot and never carry the retained
+prompt or daemon startup environment. Process outcomes do not imply Agent
+lifecycle observations.
+
+An exact runner ShellRun exit reconciles a still-starting or active execution in
+the same persisted event batch. A staged host outcome produces `exited`, a staged
+host-spawn failure produces `dispatch_failed`, and an EOF without either produces
+`interrupted`. `run_exited` precedes the terminal
+`scheduled_execution_changed`. The staged host outcome remains authoritative.
+
 Closing a workspace removes all of its schedules and stored prompts as part of
 the workspace transaction. The stream publishes the existing single
 `workspace_closed` event; it does not publish one `agent_schedule_removed` event
@@ -118,6 +133,14 @@ Protocol-21 and older clients receive workspace snapshots without schedules and
 do not receive schedule events. The returned cursor still advances across those
 filtered events, preserving the stream's total publication order. Schedule
 management requests require protocol 22.
+
+Protocol-22 and older clients do not receive scheduled-execution events, but
+their cursor advances across them. Execution dispatch, list, exact inspect, and
+cancel requests require protocol 23. Protocol-22 snapshots also omit
+schedule-owned shells and execution-shell links rather than presenting those
+shells as user-owned. Historical schedule-shell ownership used for this filtering
+is retained exactly while the bounded event journal still contains a generic
+event for that shell; it cannot be evicted independently of that event.
 
 Event IDs provide one total publication order. The daemon transition coordinator
 couples durable lifecycle mutation, persistence, and event publication. Events

--- a/docs/scheduled-agent-work.md
+++ b/docs/scheduled-agent-work.md
@@ -1,6 +1,8 @@
 # Scheduled Agent Work
 
-> **Status: Accepted pre-implementation contract.** This document governs the
+> **Status: Partially implemented contract.** Schedule management and manual
+> run-now execution are implemented; timer evaluation and timed policy remain
+> deferred. This document governs the
 > scheduled Agent work tracked by [#146](https://github.com/gardnmi/boomux/issues/146).
 > Source and compatibility tests become authoritative for exact protocol,
 > persistence, and bound values as each implementation slice ships.
@@ -60,7 +62,9 @@ containing the schedule identity, not the prompt or revisioned host command. For
 each run the runner resolves only the exact persisted execution claim, then asks
 the integration adapter to construct and execute the host argument vector without
 shell interpretation. It cannot select a later pending claim or rerun the latest
-prompt implicitly.
+prompt implicitly. Claim resolution and runner reports require one private
+per-execution capability. That capability is removed from the external host's
+environment before spawn.
 
 The ownership is exclusive:
 
@@ -217,7 +221,9 @@ database recency, terminal output, and catalog order are not session identity.
 
 ## Dispatch And Concurrency
 
-The first release uses these policies:
+The complete initial scheduler design uses these policies. The manual run-now
+slice currently enforces only the per-schedule limit because one reusable shell
+cannot run twice; workspace and daemon-wide limits arrive with timed dispatch:
 
 - At most one nonterminal Scheduled Execution per Agent Schedule.
 - At most one nonterminal Scheduled Execution per workspace.
@@ -247,7 +253,8 @@ Graceful handoff establishes a dispatch barrier, transfers claimed executions
 with or without a live ShellRun, and prevents the old daemon from spawning after
 ownership transfer. The replacement either continues the one transferred claim
 or observes its terminal outcome. Cold recovery marks a nonterminal claim or
-active execution interrupted; it never starts a replacement process implicitly.
+active execution interrupted; it clears any process outcome staged before the
+runner's EOF commit and never starts a replacement process implicitly.
 
 Because there is no initial automatic timeout, blocked or hung work can remain
 active indefinitely and occupy its schedule, workspace, and daemon concurrency
@@ -275,8 +282,13 @@ A Scheduled Execution has one of these observable states or outcomes:
   process later exited, retaining its exit reason and code.
 - **Cancelled**: an explicit user action revoked a pre-spawn claim or terminated
   the managed process.
-- **Interrupted**: cold daemon loss ended ownership without a known ordinary
-  process exit.
+- **Interrupted**: cold daemon loss or internal runner exit without a terminal
+  report ended ownership without a known ordinary host outcome.
+
+The runner stages a host exit outcome or host-spawn failure while the execution
+remains Starting or Active. Exact runner-shell EOF commits the terminal state and
+publishes `run_exited` first, so a subsequent run never races a terminal record
+against a still-running reusable shell.
 
 These are orchestration and process outcomes. They do not report or infer Agent
 `working`, `blocked`, `idle`, `inactive`, or `done`. In particular, exit code zero
@@ -301,9 +313,13 @@ activity and cannot be undone by a later tick. Pausing affects future ticks only
 Opening or attaching to an execution permits ordinary user interaction but does
 not silently alter its schedule or remove its concurrency lease.
 
-`boomux daemon stop` and confirmed workspace closure cancel Claimed, Starting,
-or Active Scheduled Executions before removing runtime ownership. Graceful
-daemon restart uses the transfer rule instead and does not cancel them.
+`boomux daemon stop` marks Claimed, Starting, or Active Scheduled Executions
+Cancelled with `daemon_shutdown` before completing shutdown. Confirmed workspace
+closure terminates active owned work and removes its schedule. If an irreversible
+stop is followed by failed workspace persistence, the retained execution is
+reconciled to Interrupted and its shell remains pending rather than restoring a
+false Active process. Graceful daemon restart uses the transfer rule instead and
+does not cancel work.
 
 Removing a schedule is rejected while any execution is Claimed, Starting, or
 Active. Cancellation can move any of those states to Cancelled; cancelling
@@ -320,6 +336,10 @@ Each schedule retains every nonterminal execution plus a bounded newest suffix o
 terminal execution records; pruning removes the oldest terminal records first.
 The exact suffix bound belongs to source and compatibility tests. Scheduler
 events use the existing bounded event-stream retention and cursor-expiry model.
+Pruned dispatch keys remain represented by a bounded durable probabilistic set;
+a retry that matches it is rejected with `idempotency_expired` rather than
+creating duplicate work. A false positive is therefore a stable explicit
+rejection, never an accidental second dispatch.
 The per-schedule occurrence frontier is not audit history and is never pruned
 while the schedule exists.
 

--- a/src/agent_attention_projection.rs
+++ b/src/agent_attention_projection.rs
@@ -164,6 +164,7 @@ mod tests {
             name: "project".into(),
             default_cwd: None,
             shells: vec![boomux::protocol::ShellSnapshot {
+                owner: boomux::protocol::ShellOwner::User,
                 id: "s1".into(),
                 workspace_id: "w1".into(),
                 name: "shell".into(),

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -7,7 +7,8 @@ use boomux::client::{ClientError, LifecycleError, ProtocolError};
 use boomux::protocol::{
     AgentAttentionReason, AgentAuthority, AgentInstanceSnapshot, AgentObservationSnapshot,
     AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSnapshot, AgentScheduleState,
-    AgentState, ErrorCode, ShellRunExitReason, ShellSnapshot, ShellStatus,
+    AgentState, ErrorCode, ScheduledExecutionOutcome, ScheduledExecutionReason,
+    ScheduledExecutionSnapshot, ShellRunExitReason, ShellSnapshot, ShellStatus,
     WorkspaceLauncherSnapshot,
 };
 
@@ -59,6 +60,8 @@ pub(crate) struct ShellData {
     pub(crate) cwd: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) command: Vec<String>,
+    pub(crate) owner: &'static str,
+    pub(crate) owner_schedule_id: Option<String>,
     pub(crate) status: &'static str,
     pub(crate) exit_code: Option<u32>,
     pub(crate) foreground_process: Option<String>,
@@ -127,6 +130,38 @@ pub(crate) struct ScheduleInspectionData {
     #[serde(flatten)]
     pub(crate) schedule: ScheduleData,
     pub(crate) prompt: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ExecutionData {
+    pub(crate) id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) schedule_id: String,
+    pub(crate) state: &'static str,
+    pub(crate) dispatch_kind: &'static str,
+    pub(crate) dispatch_key: String,
+    pub(crate) schedule_revision: u64,
+    pub(crate) prompt_revision: u64,
+    pub(crate) trigger_revision: u64,
+    pub(crate) requested_at_ms: u64,
+    pub(crate) started_at_ms: Option<u64>,
+    pub(crate) ended_at_ms: Option<u64>,
+    pub(crate) cwd: String,
+    pub(crate) integration: String,
+    pub(crate) session: AgentScheduleSession,
+    pub(crate) reason: Option<&'static str>,
+    pub(crate) outcome: Option<ExecutionOutcomeData>,
+    pub(crate) shell_id: Option<String>,
+    pub(crate) run_id: Option<String>,
+    pub(crate) agent_id: Option<String>,
+    pub(crate) external_session_id: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum ExecutionOutcomeData {
+    ExitCode { code: i32 },
+    Signal { signal: i32 },
 }
 
 #[derive(Serialize)]
@@ -251,6 +286,14 @@ pub(crate) fn shell(shell: &ShellSnapshot, workspace_name: Option<&str>) -> Shel
         name: shell.name.clone(),
         cwd: shell.cwd.display().to_string(),
         command: shell.command.clone(),
+        owner: match &shell.owner {
+            boomux::protocol::ShellOwner::User => "user",
+            boomux::protocol::ShellOwner::Schedule { .. } => "schedule",
+        },
+        owner_schedule_id: match &shell.owner {
+            boomux::protocol::ShellOwner::User => None,
+            boomux::protocol::ShellOwner::Schedule { schedule_id } => Some(schedule_id.clone()),
+        },
         status,
         exit_code,
         foreground_process: shell.foreground_process.clone(),
@@ -286,6 +329,54 @@ pub(crate) fn launcher(
         name: launcher.name.clone(),
         cwd: launcher.cwd.display().to_string(),
         command: launcher.command.clone(),
+    }
+}
+
+pub(crate) fn execution(execution: &ScheduledExecutionSnapshot) -> ExecutionData {
+    ExecutionData {
+        id: execution.id.clone(),
+        workspace_id: execution.workspace_id.clone(),
+        schedule_id: execution.schedule_id.clone(),
+        state: match execution.state {
+            boomux::protocol::ScheduledExecutionState::Claimed => "claimed",
+            boomux::protocol::ScheduledExecutionState::Starting => "starting",
+            boomux::protocol::ScheduledExecutionState::Active => "active",
+            boomux::protocol::ScheduledExecutionState::DispatchFailed => "dispatch_failed",
+            boomux::protocol::ScheduledExecutionState::Exited => "exited",
+            boomux::protocol::ScheduledExecutionState::Cancelled => "cancelled",
+            boomux::protocol::ScheduledExecutionState::Interrupted => "interrupted",
+        },
+        dispatch_kind: "manual",
+        dispatch_key: execution.dispatch_key.clone(),
+        schedule_revision: execution.schedule_revision,
+        prompt_revision: execution.prompt_revision,
+        trigger_revision: execution.trigger_revision,
+        requested_at_ms: execution.requested_at_ms,
+        started_at_ms: execution.started_at_ms,
+        ended_at_ms: execution.ended_at_ms,
+        cwd: execution.cwd.display().to_string(),
+        integration: execution.integration.clone(),
+        session: execution.session.clone(),
+        reason: execution.reason.map(|reason| match reason {
+            ScheduledExecutionReason::RunnerStartFailed => "runner_start_failed",
+            ScheduledExecutionReason::HostSpawnFailed => "host_spawn_failed",
+            ScheduledExecutionReason::CancelledByUser => "cancelled_by_user",
+            ScheduledExecutionReason::ColdDaemonRecovery => "cold_daemon_recovery",
+            ScheduledExecutionReason::RunnerExitedWithoutReport => "runner_exited_without_report",
+            ScheduledExecutionReason::DaemonShutdown => "daemon_shutdown",
+        }),
+        outcome: execution.outcome.as_ref().map(|outcome| match outcome {
+            ScheduledExecutionOutcome::ExitCode { code } => {
+                ExecutionOutcomeData::ExitCode { code: *code }
+            }
+            ScheduledExecutionOutcome::Signal { signal } => {
+                ExecutionOutcomeData::Signal { signal: *signal }
+            }
+        }),
+        shell_id: execution.shell_id.clone(),
+        run_id: execution.run_id.clone(),
+        agent_id: execution.agent_id.clone(),
+        external_session_id: execution.external_session_id.clone(),
     }
 }
 
@@ -534,6 +625,7 @@ fn protocol_error_code(code: ErrorCode) -> &'static str {
         ErrorCode::CursorExpired => "cursor_expired",
         ErrorCode::RunChanged => "run_changed",
         ErrorCode::RevisionAhead => "revision_ahead",
+        ErrorCode::IdempotencyExpired => "idempotency_expired",
         ErrorCode::Internal => "internal",
         ErrorCode::Unknown => "unknown",
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,10 +16,11 @@ use std::time::Duration;
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
     AgentScheduleSnapshot, AgentScheduleSpec, DaemonEvent, Envelope, ErrorCode, EventCursor,
-    FocusedTerminalSnapshot, NotificationDeliveryConfig, Request, Response, ShellSnapshot,
-    ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan,
-    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
-    WorkspaceLauncherSpec, WorkspaceSnapshot,
+    FocusedTerminalSnapshot, NotificationDeliveryConfig, Request, Response,
+    ScheduledExecutionSnapshot, ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus,
+    Snapshot, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan, TerminalProfile,
+    UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
+    WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -491,10 +492,20 @@ impl Client {
         &self,
         notifications: NotificationDeliveryConfig,
     ) -> Result<()> {
-        if !self.supports(protocol::ProtocolFeature::RestartNotificationConfig)? {
-            self.restart_request(Request::Restart)?;
+        if !self.supports(protocol::ProtocolFeature::ScheduledExecutions)? {
+            if self.supports(protocol::ProtocolFeature::RestartNotificationConfig)? {
+                self.restart_request(Request::RestartWithNotificationConfig {
+                    notifications: notifications.clone(),
+                    environment: None,
+                })?;
+            } else {
+                self.restart_request(Request::Restart)?;
+            }
         }
-        self.restart_request(Request::RestartWithNotificationConfig { notifications })
+        self.restart_request(Request::RestartWithNotificationConfig {
+            notifications,
+            environment: Some(current_environment()),
+        })
     }
 
     fn restart_request(&self, request: Request) -> Result<()> {
@@ -649,6 +660,96 @@ impl Client {
             spec,
         })? {
             Response::AgentSchedule { schedule } => Ok(schedule),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn run_agent_schedule(
+        &self,
+        schedule_id: impl Into<String>,
+        dispatch_key: impl Into<String>,
+    ) -> Result<ScheduledExecutionSnapshot> {
+        match self.request(Request::RunAgentSchedule {
+            schedule_id: schedule_id.into(),
+            dispatch_key: dispatch_key.into(),
+        })? {
+            Response::ScheduledExecution { execution } => Ok(execution),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn scheduled_executions(
+        &self,
+        workspace_id: Option<String>,
+        schedule_id: Option<String>,
+    ) -> Result<Vec<ScheduledExecutionSnapshot>> {
+        match self.request(Request::ListScheduledExecutions {
+            workspace_id,
+            schedule_id,
+        })? {
+            Response::ScheduledExecutions { executions } => Ok(executions),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn get_scheduled_execution(
+        &self,
+        execution_id: impl Into<String>,
+    ) -> Result<ScheduledExecutionSnapshot> {
+        match self.request(Request::GetScheduledExecution {
+            execution_id: execution_id.into(),
+        })? {
+            Response::ScheduledExecution { execution } => Ok(execution),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn cancel_scheduled_execution(
+        &self,
+        execution_id: impl Into<String>,
+    ) -> Result<ScheduledExecutionSnapshot> {
+        match self.request(Request::CancelScheduledExecution {
+            execution_id: execution_id.into(),
+        })? {
+            Response::ScheduledExecution { execution } => Ok(execution),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn resolve_scheduled_execution_claim(
+        &self,
+        schedule_id: impl Into<String>,
+        shell_id: impl Into<String>,
+        run_id: impl Into<String>,
+        runner_token: impl Into<String>,
+    ) -> Result<protocol::ScheduledExecutionClaim> {
+        match self.request(Request::ResolveScheduledExecutionClaim {
+            schedule_id: schedule_id.into(),
+            shell_id: shell_id.into(),
+            run_id: run_id.into(),
+            runner_token: protocol::ScheduledRunnerCapability::new(runner_token),
+        })? {
+            Response::ScheduledExecutionClaim { claim } => Ok(claim),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn report_scheduled_runner(
+        &self,
+        execution_id: impl Into<String>,
+        shell_id: impl Into<String>,
+        run_id: impl Into<String>,
+        runner_token: impl Into<String>,
+        result: ScheduledRunnerResult,
+    ) -> Result<ScheduledExecutionSnapshot> {
+        match self.request(Request::ReportScheduledRunner {
+            execution_id: execution_id.into(),
+            shell_id: shell_id.into(),
+            run_id: run_id.into(),
+            runner_token: protocol::ScheduledRunnerCapability::new(runner_token),
+            result,
+        })? {
+            Response::ScheduledExecution { execution } => Ok(execution),
             other => unexpected(other),
         }
     }
@@ -1145,6 +1246,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 23, 22);
             reject_protocol(&listener, 22, 21);
             reject_protocol(&listener, 21, 20);
             let (mut stream, _) = listener.accept().unwrap();
@@ -1325,7 +1427,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 22);
+            assert_eq!(request.version, 23);
             let Request::Attach {
                 environment: Some(environment),
                 ..
@@ -1342,7 +1444,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    22,
+                    23,
                     Response::Attached {
                         token: "token".into(),
                         reconstruction: Vec::new(),
@@ -1433,6 +1535,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 23, 22);
             reject_protocol(&listener, 22, 21);
             reject_protocol(&listener, 21, 20);
             let (mut stream, _) = listener.accept().unwrap();
@@ -1491,6 +1594,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 23, 22);
             reject_protocol(&listener, 22, 21);
             reject_protocol(&listener, 21, 20);
             let (mut stream, _) = listener.accept().unwrap();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -18,6 +18,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::client;
@@ -33,13 +34,16 @@ use crate::protocol::{
     AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSnapshot, AgentScheduleSpec,
     AgentScheduleState, AgentScheduleTrigger, AgentState, AttachFrame, DaemonEvent,
     DaemonEventKind, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot,
-    NotificationDeliveryConfig, Request, Response, ShellRunExitReason, ShellRunSnapshot,
-    ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalProfile,
-    UnixEnvironment, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    NotificationDeliveryConfig, Request, Response, ScheduledExecutionDispatchKind,
+    ScheduledExecutionOutcome, ScheduledExecutionReason, ScheduledExecutionSnapshot,
+    ScheduledExecutionState, ScheduledRunnerResult, ShellOwner, ShellRunExitReason,
+    ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
+    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
+    WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::state_store::{
-    PersistedAgentInstance, PersistedAgentSchedule, PersistedShell, PersistedShellRun,
-    PersistedState, PersistedWorkspace, PersistedWorkspaceLauncher, StateStore,
+    PersistedAgentInstance, PersistedAgentSchedule, PersistedScheduledExecution, PersistedShell,
+    PersistedShellRun, PersistedState, PersistedWorkspace, PersistedWorkspaceLauncher, StateStore,
 };
 use crate::terminal_state::TerminalState;
 
@@ -66,6 +70,8 @@ const MAX_TERMINAL_CELLS: usize = 1_000_000;
 const MAX_SHELL_READ_BYTES: usize = 1024 * 1024;
 const MAX_FOREGROUND_PROCESS_BYTES: usize = 64;
 const MAX_RETAINED_EVENTS: usize = 8_192;
+const MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE: usize = 100;
+const DISPATCH_KEY_FILTER_BYTES: usize = 2048;
 const MAX_EVENT_BATCH: u16 = 256;
 const MAX_EVENT_WAIT: Duration = Duration::from_secs(30);
 const TRANSITION_IDLE: u8 = 0;
@@ -222,7 +228,7 @@ pub fn receive_handoff_with_notification_delivery(
                 TransferredState {
                     runtimes,
                     exited,
-                    events: Some(event_stream),
+                    events: Some(*event_stream),
                     focused_terminal: focused_terminal.map(|focused| *focused),
                 },
                 Some(&mut channel),
@@ -292,6 +298,7 @@ fn run_daemon(
     notification_settings: NotificationDeliverySettings,
 ) -> io::Result<()> {
     let mut registry = DaemonService::restore(store, committed.is_some(), transferred.events)?;
+    registry.startup_environment = capture_current_environment();
     registry.notification_settings = notification_settings.clone();
     if !registry.notification_settings.persist_terminal_history {
         registry.clear_terminal_histories()?;
@@ -329,6 +336,7 @@ fn run_daemon(
                 for runtime in gated_readers {
                     registry.runtimes.resume_reader(&runtime)?;
                 }
+                registry.resume_claimed_schedule_executions();
                 // FINALIZE is the irreversible ownership boundary. Failure to
                 // report COMMITTED must not make the old daemon resume.
                 let _ = channel.write_all(&[handoff::COMMITTED]);
@@ -377,6 +385,7 @@ fn run_daemon(
                     &daemon_lock,
                     &registry,
                     request.notification_settings,
+                    request.startup_environment,
                 );
                 if result.is_ok() {
                     handed_off = true;
@@ -448,6 +457,7 @@ fn run_daemon(
 struct RestartRequest {
     reply: SyncSender<DaemonResult<()>>,
     notification_settings: Option<NotificationDeliverySettings>,
+    startup_environment: Option<UnixEnvironment>,
 }
 
 #[derive(Debug)]
@@ -603,6 +613,17 @@ fn secure_runtime_dir(path: &Path) -> io::Result<()> {
     fs::set_permissions(path, fs::Permissions::from_mode(0o700))
 }
 
+fn capture_current_environment() -> UnixEnvironment {
+    UnixEnvironment {
+        variables: env::vars_os()
+            .map(|(name, value)| protocol::UnixEnvironmentVariable {
+                name: name.into_vec(),
+                value: value.into_vec(),
+            })
+            .collect(),
+    }
+}
+
 fn acquire_daemon_lock(runtime_dir: &Path) -> io::Result<File> {
     let lock_file = OpenOptions::new()
         .read(true)
@@ -629,6 +650,7 @@ fn launch_replacement(
     daemon_lock: &File,
     registry: &DaemonService,
     notification_settings: Option<NotificationDeliverySettings>,
+    startup_environment: Option<UnixEnvironment>,
 ) -> DaemonResult<()> {
     let _mutation = lock(&registry.mutation_lock)?;
     registry.ensure_running()?;
@@ -659,6 +681,7 @@ fn launch_replacement(
             ReplacementOptions {
                 focused_terminal,
                 notification_settings,
+                startup_environment,
             },
         )
         .map_err(DaemonError::from)
@@ -675,6 +698,7 @@ fn launch_replacement(
 struct ReplacementOptions {
     focused_terminal: Option<FocusedTerminalSnapshot>,
     notification_settings: Option<NotificationDeliverySettings>,
+    startup_environment: Option<UnixEnvironment>,
 }
 
 fn launch_replacement_process(
@@ -689,10 +713,20 @@ fn launch_replacement_process(
     let ReplacementOptions {
         focused_terminal,
         notification_settings,
+        startup_environment,
     } = options;
     let (mut channel, child_channel) = UnixStream::pair()?;
     let child_channel_fd = child_channel.as_raw_fd();
     let mut command = Command::new(replacement_executable()?);
+    if let Some(environment) = startup_environment {
+        command.env_clear();
+        for variable in environment.variables {
+            command.env(
+                std::ffi::OsString::from_vec(variable.name),
+                std::ffi::OsString::from_vec(variable.value),
+            );
+        }
+    }
     command
         .args([
             "daemon",
@@ -897,14 +931,26 @@ fn handle_connection(
             }
         };
     }
-    let restart_notification_settings = match &request.message {
-        Request::Restart => Some(None),
-        Request::RestartWithNotificationConfig { notifications } => {
-            Some(Some(notifications.clone().into()))
+    let restart_settings = match &request.message {
+        Request::Restart => Some((None, None)),
+        Request::RestartWithNotificationConfig {
+            notifications,
+            environment,
+        } => {
+            if let Some(environment) = environment
+                && let Err(error) = validate_unix_environment(environment)
+            {
+                return send_response(
+                    &mut stream,
+                    response_version,
+                    DaemonError::from(error).into_response(),
+                );
+            }
+            Some((Some(notifications.clone().into()), environment.clone()))
         }
         _ => None,
     };
-    if let Some(notification_settings) = restart_notification_settings {
+    if let Some((notification_settings, startup_environment)) = restart_settings {
         if transition
             .compare_exchange(
                 TRANSITION_IDLE,
@@ -926,6 +972,7 @@ fn handle_connection(
             .send(RestartRequest {
                 reply,
                 notification_settings,
+                startup_environment,
             })
             .is_err()
         {
@@ -947,14 +994,20 @@ fn handle_connection(
         };
     }
 
-    let response = match registry.dispatch(request.message) {
+    let response = match registry.dispatch_arc(request.message) {
         Ok(response) => response,
         Err(error) => error.into_response(),
     };
     send_response(
         &mut stream,
         response_version,
-        response_for_version(response, response_version),
+        response_for_version_with_schedule_shells(
+            response,
+            response_version,
+            &registry
+                .schedule_shell_ids_for_downgrade()
+                .unwrap_or_default(),
+        ),
     )
 }
 
@@ -966,8 +1019,62 @@ fn unsupported_request_message(feature: protocol::ProtocolFeature) -> String {
     )
 }
 
+#[cfg(test)]
 fn response_for_version(response: Response, version: u32) -> Response {
+    response_for_version_with_schedule_shells(response, version, &HashSet::new())
+}
+
+fn response_for_version_with_schedule_shells(
+    response: Response,
+    version: u32,
+    schedule_shell_ids: &HashSet<String>,
+) -> Response {
     let mut response = response;
+    if !protocol::ProtocolFeature::ScheduledExecutions.is_supported_by(version) {
+        if let Response::Events { events, .. } = &mut response {
+            events.retain(|event| {
+                !matches!(
+                    &event.kind,
+                    DaemonEventKind::ScheduledExecutionCreated { .. }
+                        | DaemonEventKind::ScheduledExecutionChanged { .. }
+                ) && !event_shell_id(&event.kind)
+                    .is_some_and(|shell_id| schedule_shell_ids.contains(shell_id))
+            });
+        }
+        let hide_schedule_shells = |workspace: &mut WorkspaceSnapshot| {
+            workspace
+                .shells
+                .retain(|shell| matches!(shell.owner, ShellOwner::User));
+            for schedule in &mut workspace.schedules {
+                schedule.execution_shell_id = None;
+            }
+        };
+        match &mut response {
+            Response::Snapshot { snapshot } => {
+                for workspace in &mut snapshot.workspaces {
+                    hide_schedule_shells(workspace);
+                }
+            }
+            Response::Workspace { workspace } => {
+                hide_schedule_shells(workspace);
+            }
+            Response::Shell { shell } if !matches!(shell.owner, ShellOwner::User) => {
+                response = Response::Error {
+                    code: Some(ErrorCode::NotFound),
+                    message: format!("shell not found: {}", shell.id),
+                };
+            }
+            Response::Events {
+                snapshot: Some(snapshot),
+                ..
+            } => {
+                for workspace in &mut snapshot.workspaces {
+                    hide_schedule_shells(workspace);
+                }
+            }
+            _ => {}
+        }
+    }
     if !protocol::ProtocolFeature::AgentSchedules.is_supported_by(version) {
         remove_agent_schedules(&mut response);
     }
@@ -1041,6 +1148,22 @@ fn response_for_version(response: Response, version: u32) -> Response {
             }
         }
         response => response,
+    }
+}
+
+fn event_shell_id(event: &DaemonEventKind) -> Option<&str> {
+    match event {
+        DaemonEventKind::ShellCreated { shell_id, .. }
+        | DaemonEventKind::ShellRenamed { shell_id, .. }
+        | DaemonEventKind::ShellClosed { shell_id, .. }
+        | DaemonEventKind::RunStarted { shell_id, .. }
+        | DaemonEventKind::OutputChanged { shell_id, .. }
+        | DaemonEventKind::RunExited { shell_id, .. }
+        | DaemonEventKind::AgentRegistered { shell_id, .. }
+        | DaemonEventKind::AgentStateChanged { shell_id, .. }
+        | DaemonEventKind::AgentCompleted { shell_id, .. }
+        | DaemonEventKind::AgentAttentionAcknowledged { shell_id, .. } => Some(shell_id),
+        _ => None,
     }
 }
 
@@ -1194,6 +1317,7 @@ struct DaemonService {
     mutation_lock: Mutex<()>,
     notification_settings: NotificationDeliverySettings,
     notification_sink: Arc<dyn NotificationSink>,
+    startup_environment: UnixEnvironment,
     #[cfg(test)]
     fail_after_mutation: AtomicBool,
 }
@@ -1309,6 +1433,12 @@ enum DurableUndo {
     ScheduleState {
         schedule: Arc<AgentSchedule>,
         previous: AgentScheduleMutableState,
+    },
+    ScheduleExecutions {
+        schedule: Arc<AgentSchedule>,
+        previous: Vec<Arc<ScheduledExecution>>,
+        previous_dispatch_key_filter: Vec<u8>,
+        execution: Option<(Arc<ScheduledExecution>, ScheduledExecutionMutableState)>,
     },
     RemovedLauncher {
         workspace: Arc<Workspace>,
@@ -1471,6 +1601,7 @@ struct EventStreamState {
     stream_id: String,
     latest_id: u64,
     events: VecDeque<DaemonEvent>,
+    schedule_shell_ids: HashSet<String>,
 }
 
 struct EventTransaction<'a> {
@@ -1598,6 +1729,7 @@ impl EventStream {
                 stream_id: Uuid::new_v4().to_string(),
                 latest_id: 0,
                 events: VecDeque::new(),
+                schedule_shell_ids: HashSet::new(),
             }),
             transitions: Mutex::new(TransitionState::default()),
             changed: Condvar::new(),
@@ -1611,11 +1743,29 @@ impl EventStream {
                 stream_id: Uuid::new_v4().to_string(),
                 latest_id: 0,
                 events: VecDeque::new(),
+                schedule_shell_ids: HashSet::new(),
             },
-            |transfer| EventStreamState {
-                stream_id: transfer.stream_id,
-                latest_id: transfer.latest_id,
-                events: transfer.events.into(),
+            |transfer| {
+                let mut schedule_shell_ids = transfer
+                    .schedule_shell_ids
+                    .into_iter()
+                    .collect::<HashSet<_>>();
+                for event in &transfer.events {
+                    if let DaemonEventKind::ScheduledExecutionCreated { execution, .. }
+                    | DaemonEventKind::ScheduledExecutionChanged { execution, .. } = &event.kind
+                        && let Some(shell_id) = &execution.shell_id
+                    {
+                        schedule_shell_ids.insert(shell_id.clone());
+                    }
+                }
+                let mut state = EventStreamState {
+                    stream_id: transfer.stream_id,
+                    latest_id: transfer.latest_id,
+                    events: transfer.events.into(),
+                    schedule_shell_ids,
+                };
+                Self::retain_referenced_schedule_shell_ids(&mut state);
+                state
             },
         );
         Self {
@@ -1648,7 +1798,12 @@ impl EventStream {
             stream_id: state.stream_id.clone(),
             latest_id: state.latest_id,
             events: state.events.iter().cloned().collect(),
+            schedule_shell_ids: state.schedule_shell_ids.iter().cloned().collect(),
         })
+    }
+
+    fn schedule_shell_ids(&self) -> io::Result<HashSet<String>> {
+        Ok(lock(&self.state)?.schedule_shell_ids.clone())
     }
 
     fn wait_for<T>(
@@ -1687,6 +1842,12 @@ impl EventStream {
         debug_assert!(Self::ensure_capacity(state, kinds.len()).is_ok());
         let mut appended = Vec::with_capacity(kinds.len());
         for kind in kinds {
+            if let DaemonEventKind::ScheduledExecutionCreated { execution, .. }
+            | DaemonEventKind::ScheduledExecutionChanged { execution, .. } = &kind
+                && let Some(shell_id) = &execution.shell_id
+            {
+                state.schedule_shell_ids.insert(shell_id.clone());
+            }
             state.latest_id += 1;
             let event = DaemonEvent {
                 id: state.latest_id,
@@ -1700,7 +1861,19 @@ impl EventStream {
             let remove = state.events.len() - MAX_RETAINED_EVENTS;
             state.events.drain(..remove);
         }
+        Self::retain_referenced_schedule_shell_ids(state);
         appended
+    }
+
+    fn retain_referenced_schedule_shell_ids(state: &mut EventStreamState) {
+        let referenced_shell_ids = state
+            .events
+            .iter()
+            .filter_map(|event| event_shell_id(&event.kind).map(str::to_owned))
+            .collect::<HashSet<_>>();
+        state
+            .schedule_shell_ids
+            .retain(|shell_id| referenced_shell_ids.contains(shell_id));
     }
 
     #[cfg(test)]
@@ -1853,6 +2026,190 @@ impl DurableRegistry {
             .get(id)
             .cloned()
             .ok_or_else(|| not_found("agent schedule", id))
+    }
+
+    fn execution(&self, id: &str) -> io::Result<Arc<ScheduledExecution>> {
+        let schedules = lock(&self.state)?
+            .schedules
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for schedule in schedules {
+            if let Some(execution) = lock(&schedule.executions)?
+                .iter()
+                .find(|execution| execution.id == id)
+            {
+                return Ok(Arc::clone(execution));
+            }
+        }
+        Err(not_found("scheduled execution", id))
+    }
+
+    fn scheduled_executions(
+        &self,
+        workspace_id: Option<&str>,
+        schedule_id: Option<&str>,
+    ) -> io::Result<Vec<ScheduledExecutionSnapshot>> {
+        let schedules = lock(&self.state)?
+            .schedules
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut snapshots = Vec::new();
+        for schedule in schedules {
+            if workspace_id.is_some_and(|id| id != schedule.workspace_id)
+                || schedule_id.is_some_and(|id| id != schedule.id)
+            {
+                continue;
+            }
+            let executions = lock(&schedule.executions)?.clone();
+            for execution in executions {
+                snapshots.push(execution.snapshot()?);
+            }
+        }
+        snapshots.sort_by(|left, right| {
+            right
+                .requested_at_ms
+                .cmp(&left.requested_at_ms)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        Ok(snapshots)
+    }
+
+    fn claim_schedule_execution(
+        &self,
+        schedule_id: &str,
+        dispatch_key: &str,
+    ) -> DaemonResult<(ScheduledExecutionSnapshot, Option<DurableUndo>)> {
+        validate_id("dispatch idempotency key", dispatch_key)?;
+        let schedule = self.schedule(schedule_id)?;
+        let existing = lock(&schedule.executions)?
+            .iter()
+            .find(|execution| execution.dispatch_key == dispatch_key)
+            .cloned();
+        if let Some(existing) = existing {
+            return Ok((existing.snapshot()?, None));
+        }
+        let execution_shell_id = lock(&schedule.state)?.execution_shell_id.clone();
+        if let Some(shell_id) = execution_shell_id {
+            let shell = self.shell(&shell_id)?;
+            if matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Running { .. }) {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::Busy,
+                    "agent schedule runner shell is still running",
+                ));
+            }
+        }
+        if self.continuation_session_is_active(&schedule)? {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::Busy,
+                "continued Agent session is active in a current shell run",
+            ));
+        }
+        let schedule_state = lock(&schedule.state)?.clone();
+        let mut executions = lock(&schedule.executions)?;
+        let mut dispatch_key_filter = lock(&schedule.dispatch_key_filter)?;
+        if dispatch_key_was_seen(&dispatch_key_filter, dispatch_key) {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::IdempotencyExpired,
+                "dispatch idempotency key was used by a pruned execution",
+            ));
+        }
+        for execution in executions.iter() {
+            if !lock(&execution.state)?.state.is_terminal() {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::Busy,
+                    "agent schedule already has a nonterminal execution",
+                ));
+            }
+        }
+        let now = unix_time_ms();
+        let execution = Arc::new(ScheduledExecution {
+            id: Uuid::new_v4().to_string(),
+            workspace_id: schedule.workspace_id.clone(),
+            schedule_id: schedule.id.clone(),
+            dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+            dispatch_key: dispatch_key.into(),
+            schedule_revision: schedule_state.revision,
+            prompt_revision: schedule.prompt_revision,
+            trigger_revision: schedule.trigger_revision,
+            requested_at_ms: now,
+            cwd: schedule.cwd.clone(),
+            integration: schedule.integration.clone(),
+            session: schedule.session.clone(),
+            prompt: schedule.prompt.clone(),
+            runner_token: Uuid::new_v4().to_string(),
+            state: Mutex::new(ScheduledExecutionMutableState {
+                state: ScheduledExecutionState::Claimed,
+                started_at_ms: None,
+                ended_at_ms: None,
+                reason: None,
+                outcome: None,
+                shell_id: None,
+                run_id: None,
+                agent_id: None,
+                external_session_id: None,
+            }),
+        });
+        let snapshot = execution.snapshot()?;
+        let previous = executions.clone();
+        let previous_dispatch_key_filter = dispatch_key_filter.clone();
+        remember_dispatch_key(&mut dispatch_key_filter, dispatch_key);
+        executions.push(execution);
+        drop(dispatch_key_filter);
+        drop(executions);
+        Ok((
+            snapshot,
+            Some(DurableUndo::ScheduleExecutions {
+                schedule,
+                previous,
+                previous_dispatch_key_filter,
+                execution: None,
+            }),
+        ))
+    }
+
+    fn continuation_session_is_active(&self, schedule: &AgentSchedule) -> io::Result<bool> {
+        let AgentScheduleSession::Continue {
+            external_session_id,
+        } = &schedule.session
+        else {
+            return Ok(false);
+        };
+        let candidates = {
+            let state = lock(&self.state)?;
+            state
+                .agents
+                .values()
+                .filter(|agent| {
+                    agent.integration == schedule.integration
+                        && agent.external_session_id.as_deref()
+                            == Some(external_session_id.as_str())
+                })
+                .filter_map(|agent| {
+                    state
+                        .shells
+                        .get(&agent.shell_id)
+                        .map(|shell| (Arc::clone(agent), Arc::clone(shell)))
+                })
+                .collect::<Vec<_>>()
+        };
+        for (agent, shell) in candidates {
+            let agent_state = lock(&agent.state)?;
+            if agent_state.ended_at_ms.is_none()
+                && !matches!(
+                    agent_state.observation.state,
+                    AgentState::Inactive | AgentState::Done
+                )
+                && matches!(
+                    &*lock(&shell.lifecycle)?,
+                    ShellLifecycle::Running { run, .. } if run.id == agent.run_id
+                )
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     fn contains_shell(&self, shell: &Arc<Shell>) -> io::Result<bool> {
@@ -2037,6 +2394,95 @@ impl DurableRegistry {
         Ok((snapshot, DurableUndo::CreatedShell { workspace, shell }))
     }
 
+    fn create_schedule_shell(
+        &self,
+        schedule: &Arc<AgentSchedule>,
+        command: Vec<String>,
+    ) -> io::Result<(Arc<Shell>, DurableUndo)> {
+        let workspace = self.workspace(&schedule.workspace_id)?;
+        let shell = Arc::new(Shell {
+            id: Uuid::new_v4().to_string(),
+            workspace_id: schedule.workspace_id.clone(),
+            name: Mutex::new(format!("schedule-{}", &schedule.id[..8])),
+            cwd: schedule.cwd.clone(),
+            command,
+            owner: ShellOwner::Schedule {
+                schedule_id: schedule.id.clone(),
+            },
+            last_run: Mutex::new(None),
+            lifecycle: Mutex::new(ShellLifecycle::Pending),
+            foreground_process_cache: Mutex::new(None),
+        });
+        let mut state = lock(&self.state)?;
+        let mut shell_ids = lock(&workspace.shell_ids)?;
+        state.shells.insert(shell.id.clone(), Arc::clone(&shell));
+        shell_ids.push(shell.id.clone());
+        drop(shell_ids);
+        drop(state);
+        Ok((
+            shell.clone(),
+            DurableUndo::CreatedShell { workspace, shell },
+        ))
+    }
+
+    fn mutate_execution(
+        &self,
+        execution: &Arc<ScheduledExecution>,
+        mutate: impl FnOnce(&mut ScheduledExecutionMutableState) -> io::Result<()>,
+    ) -> io::Result<(ScheduledExecutionSnapshot, DurableUndo)> {
+        let schedule = self.schedule(&execution.schedule_id)?;
+        let mut executions = lock(&schedule.executions)?;
+        if !executions
+            .iter()
+            .any(|current| Arc::ptr_eq(current, execution))
+        {
+            return Err(not_found("scheduled execution", &execution.id));
+        }
+        let previous = executions.clone();
+        let previous_dispatch_key_filter = lock(&schedule.dispatch_key_filter)?.clone();
+        let mut state = lock(&execution.state)?;
+        let previous_state = state.clone();
+        mutate(&mut state)?;
+        let snapshot = execution.snapshot_from(&state);
+        let became_terminal = state.state.is_terminal();
+        drop(state);
+        if became_terminal {
+            let mut terminal = executions
+                .iter()
+                .enumerate()
+                .filter_map(|(index, candidate)| {
+                    lock(&candidate.state)
+                        .ok()
+                        .filter(|state| state.state.is_terminal())
+                        .map(|_| (index, candidate.requested_at_ms))
+                })
+                .collect::<Vec<_>>();
+            terminal.sort_by_key(|(_, requested)| *requested);
+            let remove = terminal
+                .len()
+                .saturating_sub(MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE);
+            let mut remove = terminal
+                .into_iter()
+                .take(remove)
+                .map(|(index, _)| index)
+                .collect::<Vec<_>>();
+            remove.sort_unstable_by(|left, right| right.cmp(left));
+            for index in remove {
+                executions.remove(index);
+            }
+        }
+        drop(executions);
+        Ok((
+            snapshot,
+            DurableUndo::ScheduleExecutions {
+                schedule,
+                previous,
+                previous_dispatch_key_filter,
+                execution: Some((Arc::clone(execution), previous_state)),
+            },
+        ))
+    }
+
     fn create_shell_with_workspace(
         &self,
         spec: ShellSpec,
@@ -2146,6 +2592,8 @@ impl DurableRegistry {
                 evaluation_frontier_ms: now,
                 execution_shell_id: None,
             }),
+            executions: Mutex::new(Vec::new()),
+            dispatch_key_filter: Mutex::new(vec![0; DISPATCH_KEY_FILTER_BYTES]),
         });
         let snapshot = schedule.snapshot()?;
         let mut state = lock(&self.state)?;
@@ -2244,6 +2692,12 @@ impl DurableRegistry {
     fn rename_shell(&self, shell_id: &str, name: String) -> io::Result<Option<DurableUndo>> {
         validate_name(&name)?;
         let shell = self.shell(shell_id)?;
+        if !matches!(shell.owner, ShellOwner::User) {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "schedule-owned shells cannot be renamed",
+            ));
+        }
         let workspace = self.workspace(&shell.workspace_id)?;
         let state = lock(&self.state)?;
         let shell_ids = lock(&workspace.shell_ids)?;
@@ -2384,6 +2838,8 @@ impl DurableRegistry {
         let lifecycle = lock(&shell.lifecycle)?;
         match &*lifecycle {
             ShellLifecycle::Running { run, .. } if run.id == run_id => {}
+            ShellLifecycle::Exited { run, .. }
+                if run.id == run_id && matches!(shell.owner, ShellOwner::Schedule { .. }) => {}
             ShellLifecycle::Running { .. }
             | ShellLifecycle::Exited { .. }
             | ShellLifecycle::Pending => {
@@ -2561,6 +3017,63 @@ impl DurableRegistry {
         ))
     }
 
+    fn link_agent_execution(
+        &self,
+        agent: &AgentInstanceSnapshot,
+    ) -> io::Result<Option<(ScheduledExecutionSnapshot, DurableUndo)>> {
+        let shell = self.shell(&agent.shell_id)?;
+        let ShellOwner::Schedule { schedule_id } = &shell.owner else {
+            return Ok(None);
+        };
+        let schedule = self.schedule(schedule_id)?;
+        if schedule.integration != agent.integration {
+            return Ok(None);
+        }
+        let execution = lock(&schedule.executions)?
+            .iter()
+            .find(|execution| {
+                lock(&execution.state).is_ok_and(|state| {
+                    state.shell_id.as_deref() == Some(agent.shell_id.as_str())
+                        && state.run_id.as_deref() == Some(agent.run_id.as_str())
+                })
+            })
+            .cloned();
+        let Some(execution) = execution else {
+            return Ok(None);
+        };
+        match &execution.session {
+            AgentScheduleSession::Fresh => {
+                if agent.external_session_id.is_none() {
+                    return Ok(None);
+                }
+            }
+            AgentScheduleSession::Continue {
+                external_session_id,
+            } if agent.external_session_id.as_deref() != Some(external_session_id.as_str()) => {
+                return Ok(None);
+            }
+            AgentScheduleSession::Continue { .. } => {}
+        }
+        let current = execution.snapshot()?;
+        if current.agent_id.as_deref() == Some(agent.id.as_str())
+            && current.external_session_id == agent.external_session_id
+        {
+            return Ok(None);
+        }
+        if current.agent_id.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "scheduled execution is already linked to a different Agent",
+            ));
+        }
+        let (snapshot, undo) = self.mutate_execution(&execution, |state| {
+            state.agent_id = Some(agent.id.clone());
+            state.external_session_id = agent.external_session_id.clone();
+            Ok(())
+        })?;
+        Ok(Some((snapshot, undo)))
+    }
+
     fn workspace_shells(&self, workspace: &Arc<Workspace>) -> io::Result<Vec<Arc<Shell>>> {
         let state = lock(&self.state)?;
         let Some(current) = state.workspaces.get(&workspace.id) else {
@@ -2662,6 +3175,18 @@ impl DurableRegistry {
             DurableUndo::ScheduleState { schedule, previous } => {
                 *lock(&schedule.state)? = previous;
             }
+            DurableUndo::ScheduleExecutions {
+                schedule,
+                previous,
+                previous_dispatch_key_filter,
+                execution,
+            } => {
+                if let Some((execution, state)) = execution {
+                    *lock(&execution.state)? = state;
+                }
+                *lock(&schedule.executions)? = previous;
+                *lock(&schedule.dispatch_key_filter)? = previous_dispatch_key_filter;
+            }
             DurableUndo::RemovedLauncher {
                 workspace,
                 launcher,
@@ -2746,16 +3271,39 @@ impl DurableRegistry {
         Ok(lock(&self.state)?.shells.values().cloned().collect())
     }
 
+    fn schedule_shell_ids(&self) -> io::Result<HashSet<String>> {
+        let schedules = lock(&self.state)?
+            .schedules
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut ids = HashSet::new();
+        for schedule in schedules {
+            if let Some(shell_id) = lock(&schedule.state)?.execution_shell_id.clone() {
+                ids.insert(shell_id);
+            }
+        }
+        Ok(ids)
+    }
+
     fn capture_persisted_state(&self) -> io::Result<PersistenceGeneration> {
-        let state = lock(&self.state)?;
-        let mut workspaces = state.workspaces.values().cloned().collect::<Vec<_>>();
+        let (mut workspaces, shells_by_id, launchers_by_id, agents_by_id, schedules_by_id) = {
+            let state = lock(&self.state)?;
+            (
+                state.workspaces.values().cloned().collect::<Vec<_>>(),
+                state.shells.clone(),
+                state.launchers.clone(),
+                state.agents.clone(),
+                state.schedules.clone(),
+            )
+        };
         workspaces.sort_by(|left, right| left.id.cmp(&right.id));
         let mut saved = PersistedState::default();
         for workspace in workspaces {
             let ids = lock(&workspace.shell_ids)?.clone();
             let mut shells = Vec::with_capacity(ids.len());
             for id in ids {
-                let Some(shell) = state.shells.get(&id) else {
+                let Some(shell) = shells_by_id.get(&id) else {
                     continue;
                 };
                 shells.push(PersistedShell {
@@ -2763,13 +3311,14 @@ impl DurableRegistry {
                     name: lock(&shell.name)?.clone(),
                     cwd: shell.cwd.clone(),
                     command: shell.command.clone(),
+                    owner: shell.owner.clone(),
                     last_run: lock(&shell.last_run)?.clone(),
                 });
             }
             let ids = lock(&workspace.launcher_ids)?.clone();
             let mut launchers = Vec::with_capacity(ids.len());
             for id in ids {
-                let Some(launcher) = state.launchers.get(&id) else {
+                let Some(launcher) = launchers_by_id.get(&id) else {
                     continue;
                 };
                 launchers.push(PersistedWorkspaceLauncher {
@@ -2782,7 +3331,7 @@ impl DurableRegistry {
             let ids = lock(&workspace.agent_ids)?.clone();
             let mut agents = Vec::with_capacity(ids.len());
             for id in ids {
-                let Some(agent) = state.agents.get(&id) else {
+                let Some(agent) = agents_by_id.get(&id) else {
                     continue;
                 };
                 agents.push(agent.persisted()?);
@@ -2790,7 +3339,7 @@ impl DurableRegistry {
             let ids = lock(&workspace.schedule_ids)?.clone();
             let mut schedules = Vec::with_capacity(ids.len());
             for id in ids {
-                let Some(schedule) = state.schedules.get(&id) else {
+                let Some(schedule) = schedules_by_id.get(&id) else {
                     continue;
                 };
                 schedules.push(schedule.persisted()?);
@@ -3301,14 +3850,25 @@ impl ShellRuntimeManager {
     }
 
     fn kill(&self, shell: &Shell) -> io::Result<()> {
+        self.kill_with_event(shell).map(|_| ())
+    }
+
+    fn kill_with_event(&self, shell: &Shell) -> io::Result<Option<DaemonEventKind>> {
         match self.stop_runtime(shell) {
             Ok(()) => {
-                let _ = self.finalize_stop(shell)?;
-                Ok(())
+                let rollback = self.finalize_stop(shell)?;
+                Ok(rollback.event)
             }
             Err(error) => {
                 if error.stopped {
-                    let _ = self.finalize_stop(shell)?;
+                    let rollback = self.finalize_stop(shell)?;
+                    return match rollback.event {
+                        Some(_event) => Err(io::Error::new(
+                            error.source.kind(),
+                            format!("{}; run exit was finalized", error.source),
+                        )),
+                        None => Err(error.source),
+                    };
                 }
                 Err(error.source)
             }
@@ -3516,6 +4076,7 @@ impl Default for DaemonService {
             mutation_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
             notification_sink: Arc::new(DisabledNotificationSink),
+            startup_environment: capture_current_environment(),
             #[cfg(test)]
             fail_after_mutation: AtomicBool::new(false),
         }
@@ -3546,6 +4107,39 @@ struct AgentSchedule {
     trigger_revision: u64,
     created_at_ms: u64,
     state: Mutex<AgentScheduleMutableState>,
+    executions: Mutex<Vec<Arc<ScheduledExecution>>>,
+    dispatch_key_filter: Mutex<Vec<u8>>,
+}
+
+struct ScheduledExecution {
+    id: String,
+    workspace_id: String,
+    schedule_id: String,
+    dispatch_kind: ScheduledExecutionDispatchKind,
+    dispatch_key: String,
+    schedule_revision: u64,
+    prompt_revision: u64,
+    trigger_revision: u64,
+    requested_at_ms: u64,
+    cwd: PathBuf,
+    integration: String,
+    session: AgentScheduleSession,
+    prompt: String,
+    runner_token: String,
+    state: Mutex<ScheduledExecutionMutableState>,
+}
+
+#[derive(Clone)]
+struct ScheduledExecutionMutableState {
+    state: ScheduledExecutionState,
+    started_at_ms: Option<u64>,
+    ended_at_ms: Option<u64>,
+    reason: Option<ScheduledExecutionReason>,
+    outcome: Option<ScheduledExecutionOutcome>,
+    shell_id: Option<String>,
+    run_id: Option<String>,
+    agent_id: Option<String>,
+    external_session_id: Option<String>,
 }
 
 #[derive(Clone)]
@@ -3591,6 +4185,7 @@ struct Shell {
     name: Mutex<String>,
     cwd: PathBuf,
     command: Vec<String>,
+    owner: ShellOwner,
     last_run: Mutex<Option<PersistedShellRun>>,
     lifecycle: Mutex<ShellLifecycle>,
     foreground_process_cache: Mutex<Option<(String, Instant, Option<String>)>>,
@@ -4163,12 +4758,139 @@ fn resume_identity(
 }
 
 impl DaemonService {
+    fn dispatch_arc(self: &Arc<Self>, request: Request) -> DaemonResult<Response> {
+        if let Request::RunAgentSchedule {
+            schedule_id,
+            dispatch_key,
+        } = request
+        {
+            let response = self.durable_mutation_outcome(|undo| {
+                let (execution, record) = self
+                    .durable
+                    .claim_schedule_execution(&schedule_id, &dispatch_key)?;
+                let Some(record) = record else {
+                    return Ok(DurableMutation::Unchanged(Response::ScheduledExecution {
+                        execution,
+                    }));
+                };
+                undo.record(record);
+                Ok(DurableMutation::Changed(
+                    Response::ScheduledExecution {
+                        execution: execution.clone(),
+                    },
+                    vec![DaemonEventKind::ScheduledExecutionCreated {
+                        workspace_id: execution.workspace_id.clone(),
+                        execution,
+                    }],
+                ))
+            })?;
+            let Response::ScheduledExecution { execution } = response else {
+                unreachable!("claim returns an execution")
+            };
+            self.wait_for_native_claim_barrier();
+            let execution = self.durable.execution(&execution.id)?;
+            return match self.dispatch_schedule_execution(Arc::clone(&execution)) {
+                Ok(execution) => Ok(Response::ScheduledExecution { execution }),
+                Err(error) => {
+                    let current = execution.snapshot()?;
+                    if current.state == ScheduledExecutionState::Claimed {
+                        self.terminalize_dispatch_failure(&execution)
+                        .map_err(|transition| {
+                            DaemonError::Internal(io::Error::other(format!(
+                                "scheduled dispatch failed: {error}; could not record failure: {transition}"
+                            )))
+                        })?;
+                    }
+                    Err(error)
+                }
+            };
+        }
+        self.dispatch(request)
+    }
+
     fn clear_terminal_histories(&self) -> io::Result<()> {
         if self.durable.clear_terminal_histories()? {
             self.mark_persistence_dirty();
         }
         Ok(())
     }
+
+    #[cfg(debug_assertions)]
+    fn native_test_hooks_enabled(&self) -> bool {
+        self.startup_environment
+            .variables
+            .iter()
+            .any(|variable| variable.name == b"BOOMUX_NATIVE_TEST_HOOKS" && variable.value == b"1")
+    }
+
+    #[cfg(debug_assertions)]
+    fn wait_for_native_claim_barrier(&self) {
+        if !self.native_test_hooks_enabled() {
+            return;
+        }
+        let Some(variable) = self
+            .startup_environment
+            .variables
+            .iter()
+            .find(|variable| variable.name == b"BOOMUX_NATIVE_TEST_CLAIM_BARRIER")
+        else {
+            return;
+        };
+        let directory = PathBuf::from(std::ffi::OsString::from_vec(variable.value.clone()));
+        let _ = fs::write(directory.join("claimed"), b"claimed");
+        while !directory.join("release").exists() && !self.runtimes.is_stopping() {
+            thread::sleep(IO_RETRY_DELAY);
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn wait_for_native_claim_barrier(&self) {}
+
+    #[cfg(debug_assertions)]
+    fn wait_for_native_start_barrier(&self) {
+        if !self.native_test_hooks_enabled() {
+            return;
+        }
+        let Some(variable) = self
+            .startup_environment
+            .variables
+            .iter()
+            .find(|variable| variable.name == b"BOOMUX_NATIVE_TEST_START_BARRIER")
+        else {
+            return;
+        };
+        let directory = PathBuf::from(std::ffi::OsString::from_vec(variable.value.clone()));
+        let _ = fs::write(directory.join("started"), b"started");
+        while !directory.join("release").exists() && !self.runtimes.is_stopping() {
+            thread::sleep(IO_RETRY_DELAY);
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn wait_for_native_start_barrier(&self) {}
+
+    #[cfg(debug_assertions)]
+    fn wait_for_native_outcome_barrier(&self) {
+        if !self.native_test_hooks_enabled() {
+            return;
+        }
+        let Some(variable) = self
+            .startup_environment
+            .variables
+            .iter()
+            .find(|variable| variable.name == b"BOOMUX_NATIVE_TEST_OUTCOME_BARRIER")
+        else {
+            return;
+        };
+        let directory = PathBuf::from(std::ffi::OsString::from_vec(variable.value.clone()));
+        let _ = fs::write(directory.join("outcome"), b"outcome");
+        while !directory.join("release").exists() && !self.runtimes.is_stopping() {
+            thread::sleep(IO_RETRY_DELAY);
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn wait_for_native_outcome_barrier(&self) {}
 
     fn agent_resume_command(
         &self,
@@ -4184,6 +4906,672 @@ impl DaemonService {
             return Ok(None);
         };
         self.durable.agent_resume_command(shell, previous_run)
+    }
+
+    fn change_execution(
+        &self,
+        execution: &Arc<ScheduledExecution>,
+        mutate: impl FnOnce(&mut ScheduledExecutionMutableState) -> io::Result<()>,
+    ) -> DaemonResult<ScheduledExecutionSnapshot> {
+        self.durable_mutation(|undo| {
+            let (snapshot, record) = self.durable.mutate_execution(execution, mutate)?;
+            undo.record(record);
+            Ok((
+                Response::ScheduledExecution {
+                    execution: snapshot.clone(),
+                },
+                vec![DaemonEventKind::ScheduledExecutionChanged {
+                    workspace_id: snapshot.workspace_id.clone(),
+                    execution: snapshot.clone(),
+                }],
+            ))
+        })
+        .and_then(|response| match response {
+            Response::ScheduledExecution { execution } => Ok(execution),
+            _ => Err(DaemonError::Internal(io::Error::other(
+                "execution mutation returned an unexpected response",
+            ))),
+        })
+    }
+
+    fn terminalize_dispatch_failure(
+        &self,
+        execution: &Arc<ScheduledExecution>,
+    ) -> DaemonResult<ScheduledExecutionSnapshot> {
+        let _mutation = lock(&self.mutation_lock)?;
+        self.ensure_running()?;
+        let current = execution.snapshot()?;
+        if current.state.is_terminal() {
+            return Ok(current);
+        }
+        let _persistence = lock(&self.durable.persist_lock)?;
+        let mut transaction = self.events.transaction()?;
+        transaction.reserve_with_pending(1)?;
+        let (failed, _) = self.durable.mutate_execution(execution, |state| {
+            if !state.state.is_terminal() {
+                state.state = ScheduledExecutionState::DispatchFailed;
+                state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
+                state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                state.outcome = None;
+            }
+            Ok(())
+        })?;
+        let events = vec![DaemonEventKind::ScheduledExecutionChanged {
+            workspace_id: failed.workspace_id.clone(),
+            execution: failed.clone(),
+        }];
+        let saved = self.capture_persisted_state()?;
+        transaction.begin_persistence(events.len());
+        drop(transaction);
+        if let Err(error) = self.write_persisted_state(saved) {
+            let mut transaction = self.events.transaction()?;
+            transaction.finish_persistence();
+            self.queue_durable_batch_locked(events, &mut transaction);
+            drop(transaction);
+            self.events.notify();
+            return Err(DaemonError::persistence(error));
+        }
+        let mut transaction = self.events.transaction()?;
+        transaction.append_batch(events);
+        transaction.finish_persistence();
+        drop(transaction);
+        self.events.notify();
+        Ok(failed)
+    }
+
+    fn prepare_schedule_shell(
+        &self,
+        execution: &Arc<ScheduledExecution>,
+    ) -> DaemonResult<Arc<Shell>> {
+        let execution_id = execution.id.clone();
+        let response = self.durable_mutation(|undo| {
+            let schedule = self.schedule(&execution.schedule_id)?;
+            let (execution_status, execution_shell_id) = {
+                let execution_state = lock(&execution.state)?;
+                (execution_state.state, execution_state.shell_id.clone())
+            };
+            if execution_status != ScheduledExecutionState::Claimed {
+                return Ok((
+                    Response::ScheduledExecution {
+                        execution: execution.snapshot()?,
+                    },
+                    Vec::new(),
+                ));
+            }
+            if let Some(shell_id) = &execution_shell_id {
+                return Ok((
+                    Response::Shell {
+                        shell: self.shell(shell_id)?.snapshot()?,
+                    },
+                    Vec::new(),
+                ));
+            }
+            let existing_shell_id = lock(&schedule.state)?.execution_shell_id.clone();
+            let (shell, shell_created) = if let Some(shell_id) = &existing_shell_id {
+                (self.shell(shell_id)?, false)
+            } else {
+                let executable = replacement_executable()?;
+                let command = vec![
+                    executable.to_string_lossy().into_owned(),
+                    "__scheduled-runner".into(),
+                    schedule.id.clone(),
+                ];
+                let (shell, record) = self.durable.create_schedule_shell(&schedule, command)?;
+                undo.record(record);
+                let mut schedule_state = lock(&schedule.state)?;
+                if schedule_state.execution_shell_id.is_some() {
+                    return Err(DaemonError::lifecycle(
+                        ErrorCode::RunChanged,
+                        "schedule execution shell changed during preparation",
+                    ));
+                }
+                let previous = schedule_state.clone();
+                schedule_state.execution_shell_id = Some(shell.id.clone());
+                undo.record(DurableUndo::ScheduleState {
+                    schedule: Arc::clone(&schedule),
+                    previous,
+                });
+                (shell, true)
+            };
+            if shell.workspace_id != execution.workspace_id
+                || shell.owner
+                    != (ShellOwner::Schedule {
+                        schedule_id: schedule.id.clone(),
+                    })
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "schedule-owned shell does not match its schedule",
+                )
+                .into());
+            }
+            let previous_executions = lock(&schedule.executions)?.clone();
+            let previous_dispatch_key_filter = lock(&schedule.dispatch_key_filter)?.clone();
+            let mut execution_state = lock(&execution.state)?;
+            if execution_state.state != ScheduledExecutionState::Claimed
+                || execution_state.shell_id.is_some()
+            {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::RunChanged,
+                    "scheduled execution claim changed during shell preparation",
+                ));
+            }
+            let previous_state = execution_state.clone();
+            execution_state.shell_id = Some(shell.id.clone());
+            let snapshot = execution.snapshot_from(&execution_state);
+            undo.record(DurableUndo::ScheduleExecutions {
+                schedule: Arc::clone(&schedule),
+                previous: previous_executions,
+                previous_dispatch_key_filter,
+                execution: Some((Arc::clone(execution), previous_state)),
+            });
+            let mut events = Vec::new();
+            if shell_created {
+                events.push(DaemonEventKind::ShellCreated {
+                    workspace_id: shell.workspace_id.clone(),
+                    shell_id: shell.id.clone(),
+                    name: lock(&shell.name)?.clone(),
+                });
+            }
+            events.push(DaemonEventKind::ScheduledExecutionChanged {
+                workspace_id: snapshot.workspace_id.clone(),
+                execution: snapshot,
+            });
+            Ok((
+                Response::Shell {
+                    shell: shell.snapshot()?,
+                },
+                events,
+            ))
+        })?;
+        match response {
+            Response::Shell { shell } => self.shell(&shell.id).map_err(Into::into),
+            Response::ScheduledExecution { .. } => Err(DaemonError::lifecycle(
+                ErrorCode::RunChanged,
+                format!("scheduled execution is no longer claimed: {execution_id}"),
+            )),
+            _ => Err(DaemonError::Internal(io::Error::other(
+                "schedule shell preparation returned an unexpected response",
+            ))),
+        }
+    }
+
+    fn dispatch_schedule_execution(
+        self: &Arc<Self>,
+        execution: Arc<ScheduledExecution>,
+    ) -> DaemonResult<ScheduledExecutionSnapshot> {
+        if execution.snapshot()?.state != ScheduledExecutionState::Claimed {
+            return Ok(execution.snapshot()?);
+        }
+        let shell = self.prepare_schedule_shell(&execution)?;
+        let _mutation = lock(&self.mutation_lock)?;
+        self.ensure_running()?;
+        {
+            let state = lock(&execution.state)?;
+            if state.state != ScheduledExecutionState::Claimed
+                || state.shell_id.as_deref() != Some(shell.id.as_str())
+            {
+                return Ok(execution.snapshot_from(&state));
+            }
+        }
+        let old_runtime = match &*lock(&shell.lifecycle)? {
+            ShellLifecycle::Exited { runtime, .. } => runtime.clone(),
+            ShellLifecycle::Pending => None,
+            ShellLifecycle::Running { .. } => {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::Busy,
+                    "schedule-owned shell is already running",
+                ));
+            }
+            ShellLifecycle::Closed => return Err(not_found("shell", &shell.id).into()),
+        };
+        if let Some(runtime) = old_runtime {
+            self.runtimes.stop_reader(&runtime)?;
+            *lock(&shell.lifecycle)? = ShellLifecycle::Pending;
+        }
+        self.flush_pending()?;
+        let _persistence = lock(&self.durable.persist_lock)?;
+        let mut transaction = self.events.transaction()?;
+        transaction.reserve(2)?;
+        let workspace = self.workspace(&shell.workspace_id)?;
+        let workspace_name = lock(&workspace.name)?.clone();
+        let shell_name = lock(&shell.name)?.clone();
+        let profile = TerminalProfile {
+            term: Some("xterm-256color".into()),
+            colorterm: None,
+            term_program: Some("boomux-scheduled".into()),
+            term_program_version: None,
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let previous_run = lock(&shell.last_run)?.clone();
+        let generation = previous_run.as_ref().map_or(Ok(1), |run| {
+            run.generation
+                .checked_add(1)
+                .ok_or_else(|| io::Error::other("shell run generation exhausted"))
+        })?;
+        let run = Arc::new(ShellRun::new(generation));
+        let mut runner_environment = self.startup_environment.clone();
+        runner_environment
+            .variables
+            .retain(|variable| !variable.name.starts_with(b"BOOMUX_NATIVE_TEST_"));
+        runner_environment.variables.push(UnixEnvironmentVariable {
+            name: b"BOOMUX_SCHEDULE_RUNNER_TOKEN".to_vec(),
+            value: execution.runner_token.as_bytes().to_vec(),
+        });
+        let (runtime, reader) = match self.runtimes.spawn_runtime(
+            &shell,
+            &run,
+            RuntimeStart {
+                workspace_name: &workspace_name,
+                shell_name: &shell_name,
+                profile: &profile,
+                environment: Some(&runner_environment),
+                recovery: RuntimeRecovery::default(),
+            },
+        ) {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                drop(transaction);
+                drop(_persistence);
+                drop(_mutation);
+                return self.terminalize_dispatch_failure(&execution).map_err(|transition| DaemonError::Internal(io::Error::other(format!(
+                    "could not start scheduled runner: {error}; could not record failure: {transition}"
+                ))));
+            }
+        };
+        *lock(&shell.lifecycle)? = ShellLifecycle::Running {
+            profile: profile.clone(),
+            run: Arc::clone(&run),
+            runtime: Arc::clone(&runtime),
+        };
+        *lock(&shell.last_run)? = Some(run.persisted(profile)?);
+        if let Err(error) = self.runtimes.start_pty_reader(
+            Arc::downgrade(self),
+            Arc::clone(&shell),
+            Arc::clone(&run),
+            Arc::clone(&runtime),
+            reader,
+            true,
+        ) {
+            let cleanup = self.runtimes.kill(&shell);
+            let _ = self.runtimes.reset_pending(&shell);
+            drop(transaction);
+            drop(_persistence);
+            drop(_mutation);
+            return self
+                .terminalize_dispatch_failure(&execution)
+                .map_err(|transition| {
+                    DaemonError::Internal(io::Error::other(format!(
+                        "could not start scheduled runner reader: {error}; cleanup: {}; could not record failure: {transition}",
+                        cleanup
+                            .err()
+                            .map_or_else(|| "ok".into(), |error| error.to_string())
+                    )))
+                });
+        }
+        let binding = self.durable.mutate_execution(&execution, |state| {
+            if state.state != ScheduledExecutionState::Claimed
+                || state.shell_id.as_deref() != Some(shell.id.as_str())
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionAborted,
+                    "scheduled execution claim was revoked before runner binding",
+                ));
+            }
+            state.state = ScheduledExecutionState::Starting;
+            state.run_id = Some(run.id.clone());
+            Ok(())
+        });
+        let (starting, _undo) = match binding {
+            Ok(binding) => binding,
+            Err(error) => {
+                let run_event = self.runtimes.kill_with_event(&shell);
+                let _ = self.runtimes.reset_pending(&shell);
+                let failed = self
+                    .durable
+                    .mutate_execution(&execution, |state| {
+                        if !state.state.is_terminal() {
+                            state.state = ScheduledExecutionState::DispatchFailed;
+                            state.run_id.get_or_insert_with(|| run.id.clone());
+                            state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
+                            state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                            state.outcome = None;
+                        }
+                        Ok(())
+                    })
+                    .map(|(snapshot, _)| snapshot);
+                let mut events = Vec::new();
+                if let Ok(Some(event)) = run_event {
+                    events.push(event);
+                }
+                if let Ok(snapshot) = failed {
+                    events.push(DaemonEventKind::ScheduledExecutionChanged {
+                        workspace_id: snapshot.workspace_id.clone(),
+                        execution: snapshot,
+                    });
+                }
+                self.queue_durable_batch_locked(events, &mut transaction);
+                drop(transaction);
+                drop(_persistence);
+                drop(_mutation);
+                self.events.notify();
+                return Err(error.into());
+            }
+        };
+        self.wait_for_native_start_barrier();
+        let saved = match self.capture_persisted_state() {
+            Ok(saved) => saved,
+            Err(error) => {
+                let run_event = self.runtimes.kill_with_event(&shell);
+                let _ = self.runtimes.reset_pending(&shell);
+                let failed = self
+                    .durable
+                    .mutate_execution(&execution, |state| {
+                        state.state = ScheduledExecutionState::DispatchFailed;
+                        state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
+                        state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                        state.outcome = None;
+                        Ok(())
+                    })
+                    .map(|(snapshot, _)| snapshot);
+                let mut events = Vec::new();
+                if let Ok(Some(event)) = run_event {
+                    events.push(event);
+                }
+                if let Ok(snapshot) = failed {
+                    events.push(DaemonEventKind::ScheduledExecutionChanged {
+                        workspace_id: snapshot.workspace_id.clone(),
+                        execution: snapshot,
+                    });
+                }
+                self.queue_durable_batch_locked(events, &mut transaction);
+                drop(transaction);
+                drop(_persistence);
+                drop(_mutation);
+                self.events.notify();
+                return Err(error.into());
+            }
+        };
+        transaction.begin_persistence(2);
+        drop(transaction);
+        if let Err(error) = self.write_persisted_state(saved) {
+            let run_event = self.runtimes.kill_with_event(&shell);
+            let _ = self.runtimes.reset_pending(&shell);
+            let failed = self
+                .durable
+                .mutate_execution(&execution, |state| {
+                    state.state = ScheduledExecutionState::DispatchFailed;
+                    state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
+                    state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                    state.outcome = None;
+                    Ok(())
+                })
+                .map(|(snapshot, _)| snapshot);
+            let mut transaction = self.events.transaction()?;
+            transaction.finish_persistence();
+            let mut events = Vec::new();
+            if let Ok(Some(event)) = &run_event {
+                events.push(event.clone());
+            }
+            if let Ok(snapshot) = &failed {
+                events.push(DaemonEventKind::ScheduledExecutionChanged {
+                    workspace_id: snapshot.workspace_id.clone(),
+                    execution: snapshot.clone(),
+                });
+            }
+            self.queue_durable_batch_locked(events, &mut transaction);
+            drop(transaction);
+            drop(_persistence);
+            drop(_mutation);
+            self.events.notify();
+            return Err(DaemonError::persistence_context(
+                error,
+                run_event.map_or_else(
+                    |cleanup| {
+                        format!(
+                            "could not persist scheduled runner start; cleanup failed: {cleanup}"
+                        )
+                    },
+                    |_| {
+                        failed.map_or_else(
+                            |failure| {
+                                format!(
+                                    "could not persist scheduled runner start; could not record dispatch failure: {failure}"
+                                )
+                            },
+                            |_| "could not persist scheduled runner start".into(),
+                        )
+                    },
+                ),
+            ));
+        }
+        let mut transaction = self.events.transaction()?;
+        transaction.append_batch(vec![
+            DaemonEventKind::RunStarted {
+                workspace_id: shell.workspace_id.clone(),
+                shell_id: shell.id.clone(),
+                run: run.snapshot()?,
+            },
+            DaemonEventKind::ScheduledExecutionChanged {
+                workspace_id: starting.workspace_id.clone(),
+                execution: starting,
+            },
+        ]);
+        transaction.finish_persistence();
+        drop(transaction);
+        drop(_persistence);
+        drop(_mutation);
+        self.events.notify();
+        self.runtimes.resume_reader(&runtime)?;
+        Ok(execution.snapshot()?)
+    }
+
+    fn cancel_scheduled_execution(&self, execution_id: &str) -> DaemonResult<Response> {
+        let _mutation = lock(&self.mutation_lock)?;
+        self.ensure_running()?;
+        self.flush_pending()?;
+        let execution = self.durable.execution(execution_id)?;
+        let current = execution.snapshot()?;
+        if current.state.is_terminal() {
+            return Ok(Response::ScheduledExecution { execution: current });
+        }
+
+        let bound_shell = match current.state {
+            ScheduledExecutionState::Claimed => {
+                if current.run_id.is_some() {
+                    return Err(DaemonError::Internal(io::Error::other(
+                        "claimed scheduled execution has a run binding",
+                    )));
+                }
+                None
+            }
+            ScheduledExecutionState::Starting | ScheduledExecutionState::Active => {
+                let shell_id = current.shell_id.as_deref().ok_or_else(|| {
+                    DaemonError::Internal(io::Error::other(
+                        "started scheduled execution has no shell binding",
+                    ))
+                })?;
+                let run_id = current.run_id.as_deref().ok_or_else(|| {
+                    DaemonError::Internal(io::Error::other(
+                        "started scheduled execution has no run binding",
+                    ))
+                })?;
+                let shell = self.shell(shell_id)?;
+                if !matches!(
+                    &*lock(&shell.lifecycle)?,
+                    ShellLifecycle::Running { run, .. } if run.id == run_id
+                ) {
+                    return Err(DaemonError::lifecycle(
+                        ErrorCode::RunChanged,
+                        "scheduled execution no longer owns the exact shell run",
+                    ));
+                }
+                Some(shell)
+            }
+            _ => unreachable!("terminal execution returned above"),
+        };
+
+        let event_capacity = 1 + usize::from(bound_shell.is_some());
+        let mut transaction = self.events.transaction()?;
+        transaction.reserve_with_pending(event_capacity)?;
+        transaction.begin_lifecycle_reservation(event_capacity);
+        drop(transaction);
+        let _lifecycle_activity = LifecycleActivity::begin(&self.events.lifecycle_active);
+
+        let mut stop_failure = None;
+        let mut run_event = None;
+        if let Some(shell) = &bound_shell {
+            #[cfg(debug_assertions)]
+            if self.native_test_hooks_enabled()
+                && self.startup_environment.variables.iter().any(|variable| {
+                    variable.name == b"BOOMUX_NATIVE_TEST_CANCEL_STOP_FAILURE"
+                        && variable.value == b"1"
+                })
+            {
+                let mut transaction = self.events.transaction()?;
+                transaction.finish_lifecycle_reservation();
+                return Err(DaemonError::Internal(io::Error::other(
+                    "injected scheduled cancellation stop failure",
+                )));
+            }
+            if let Err(error) = self.runtimes.stop_runtime(shell) {
+                if !error.stopped {
+                    let mut transaction = self.events.transaction()?;
+                    transaction.finish_lifecycle_reservation();
+                    return Err(error.source.into());
+                }
+                stop_failure = Some(error.source);
+            }
+            match self.runtimes.finalize_stop(shell) {
+                Ok(rollback) => run_event = rollback.event,
+                Err(error) => {
+                    stop_failure.get_or_insert(error);
+                }
+            }
+            if let Err(error) = self.runtimes.reset_pending(shell) {
+                stop_failure.get_or_insert(error);
+            }
+        }
+
+        let terminal_state = if stop_failure.is_some() {
+            ScheduledExecutionState::Interrupted
+        } else {
+            ScheduledExecutionState::Cancelled
+        };
+        let terminal_reason = if stop_failure.is_some() {
+            ScheduledExecutionReason::RunnerExitedWithoutReport
+        } else {
+            ScheduledExecutionReason::CancelledByUser
+        };
+        let (cancelled, undo) = self.durable.mutate_execution(&execution, |state| {
+            state.state = terminal_state;
+            state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
+            state.reason = Some(terminal_reason);
+            state.outcome = None;
+            Ok(())
+        })?;
+        let mut events = Vec::with_capacity(event_capacity);
+        if let Some(event) = run_event {
+            events.push(event);
+        }
+        events.push(DaemonEventKind::ScheduledExecutionChanged {
+            workspace_id: cancelled.workspace_id.clone(),
+            execution: cancelled.clone(),
+        });
+
+        let persistence = lock(&self.durable.persist_lock)?;
+        let saved = match self.capture_persisted_state() {
+            Ok(saved) => saved,
+            Err(error) => {
+                let mut transaction = self.events.transaction()?;
+                if bound_shell.is_none() {
+                    let rollback = self.durable.rollback(undo);
+                    transaction.finish_lifecycle_reservation();
+                    return Err(Self::lifecycle_failure(error.into(), rollback));
+                }
+                self.queue_durable_batch_locked(events, &mut transaction);
+                transaction.finish_lifecycle_reservation();
+                return Err(error.into());
+            }
+        };
+        let mut transaction = self.events.transaction()?;
+        transaction.finish_lifecycle_reservation();
+        transaction.begin_persistence(events.len());
+        drop(transaction);
+        if let Err(error) = self.write_persisted_state(saved) {
+            let mut transaction = self.events.transaction()?;
+            transaction.finish_persistence();
+            if bound_shell.is_none() {
+                let rollback = self.durable.rollback(undo);
+                return Err(Self::lifecycle_failure(
+                    DaemonError::persistence(error),
+                    rollback,
+                ));
+            }
+            self.queue_durable_batch_locked(events, &mut transaction);
+            drop(transaction);
+            drop(persistence);
+            self.events.notify();
+            return Err(DaemonError::persistence(error));
+        }
+        let mut transaction = self.events.transaction()?;
+        transaction.append_batch(events);
+        transaction.finish_persistence();
+        drop(transaction);
+        drop(persistence);
+        self.events.notify();
+        if let Some(error) = stop_failure {
+            return Err(DaemonError::Internal(error));
+        }
+        Ok(Response::ScheduledExecution {
+            execution: cancelled,
+        })
+    }
+
+    fn resume_claimed_schedule_executions(self: &Arc<Self>) {
+        let schedules = match lock(&self.durable.state) {
+            Ok(state) => state.schedules.values().cloned().collect::<Vec<_>>(),
+            Err(error) => {
+                eprintln!("boomux: could not inspect claimed scheduled executions: {error}");
+                return;
+            }
+        };
+        let mut claimed = Vec::new();
+        for schedule in schedules {
+            let executions = match lock(&schedule.executions) {
+                Ok(executions) => executions.clone(),
+                Err(error) => {
+                    eprintln!(
+                        "boomux: could not inspect schedule {}: {error}",
+                        schedule.id
+                    );
+                    continue;
+                }
+            };
+            claimed.extend(executions.into_iter().filter(|execution| {
+                lock(&execution.state)
+                    .is_ok_and(|state| state.state == ScheduledExecutionState::Claimed)
+            }));
+        }
+        for execution in claimed {
+            if let Err(error) = self.dispatch_schedule_execution(Arc::clone(&execution)) {
+                eprintln!(
+                    "boomux: could not resume scheduled execution {} after handoff: {error}",
+                    execution.id
+                );
+                let _ = self.change_execution(&execution, |state| {
+                    if state.state == ScheduledExecutionState::Claimed {
+                        state.state = ScheduledExecutionState::DispatchFailed;
+                        state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
+                        state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                    }
+                    Ok(())
+                });
+            }
+        }
     }
 
     fn dispatch(&self, request: Request) -> DaemonResult<Response> {
@@ -4217,6 +5605,17 @@ impl DaemonService {
                     inspection: schedule.inspection()?,
                 })
             }
+            Request::ListScheduledExecutions {
+                workspace_id,
+                schedule_id,
+            } => Ok(Response::ScheduledExecutions {
+                executions: self
+                    .durable
+                    .scheduled_executions(workspace_id.as_deref(), schedule_id.as_deref())?,
+            }),
+            Request::GetScheduledExecution { execution_id } => Ok(Response::ScheduledExecution {
+                execution: self.durable.execution(&execution_id)?.snapshot()?,
+            }),
             Request::WaitAgent {
                 agent_id,
                 after_revision,
@@ -4293,6 +5692,104 @@ impl DaemonService {
                 };
                 Ok((Response::AgentSchedule { schedule }, vec![event]))
             }),
+            Request::RunAgentSchedule { .. } => {
+                unreachable!("schedule run is handled with the service Arc")
+            }
+            Request::CancelScheduledExecution { execution_id } => {
+                self.cancel_scheduled_execution(&execution_id)
+            }
+            Request::ResolveScheduledExecutionClaim {
+                schedule_id,
+                shell_id,
+                run_id,
+                runner_token,
+            } => {
+                let schedule = self.schedule(&schedule_id)?;
+                let execution = lock(&schedule.executions)?
+                    .iter()
+                    .find(|execution| {
+                        lock(&execution.state).is_ok_and(|state| {
+                            matches!(
+                                state.state,
+                                ScheduledExecutionState::Starting | ScheduledExecutionState::Active
+                            ) && state.shell_id.as_deref() == Some(shell_id.as_str())
+                                && state.run_id.as_deref() == Some(run_id.as_str())
+                                && execution.runner_token == runner_token.as_str()
+                        })
+                    })
+                    .cloned()
+                    .ok_or_else(|| {
+                        DaemonError::lifecycle(
+                            ErrorCode::RunChanged,
+                            "no scheduled execution matches the exact runner claim",
+                        )
+                    })?;
+                Ok(Response::ScheduledExecutionClaim {
+                    claim: protocol::ScheduledExecutionClaim {
+                        execution: execution.snapshot()?,
+                        prompt: execution.prompt.clone(),
+                    },
+                })
+            }
+            Request::ReportScheduledRunner {
+                execution_id,
+                shell_id,
+                run_id,
+                runner_token,
+                result,
+            } => {
+                let staged_outcome = matches!(result, ScheduledRunnerResult::Exited { .. });
+                let response = self.durable_mutation_outcome(|undo| {
+                    let execution = self.durable.execution(&execution_id)?;
+                    let current = execution.snapshot()?;
+                    if current.shell_id.as_deref() != Some(shell_id.as_str())
+                        || current.run_id.as_deref() != Some(run_id.as_str())
+                        || execution.runner_token != runner_token.as_str()
+                    {
+                        return Err(DaemonError::lifecycle(
+                            ErrorCode::RunChanged,
+                            "scheduled runner report does not match the exact execution run",
+                        ));
+                    }
+                    if current.state.is_terminal() {
+                        return Ok(DurableMutation::Unchanged(Response::ScheduledExecution {
+                            execution: current,
+                        }));
+                    }
+                    let now = unix_time_ms().max(execution.requested_at_ms);
+                    let (snapshot, record) =
+                        self.durable.mutate_execution(&execution, |state| {
+                            match result {
+                                ScheduledRunnerResult::Active => {
+                                    state.state = ScheduledExecutionState::Active;
+                                    state.started_at_ms.get_or_insert(now);
+                                }
+                                ScheduledRunnerResult::SpawnFailed => {
+                                    state.reason = Some(ScheduledExecutionReason::HostSpawnFailed);
+                                }
+                                ScheduledRunnerResult::Exited { ref outcome } => {
+                                    state.started_at_ms.get_or_insert(now);
+                                    state.outcome = Some(outcome.clone());
+                                }
+                            }
+                            Ok(())
+                        })?;
+                    undo.record(record);
+                    Ok(DurableMutation::Changed(
+                        Response::ScheduledExecution {
+                            execution: snapshot.clone(),
+                        },
+                        vec![DaemonEventKind::ScheduledExecutionChanged {
+                            workspace_id: snapshot.workspace_id.clone(),
+                            execution: snapshot,
+                        }],
+                    ))
+                })?;
+                if staged_outcome {
+                    self.wait_for_native_outcome_barrier();
+                }
+                Ok(response)
+            }
             Request::RegisterAgent {
                 shell_id,
                 run_id,
@@ -4311,6 +5808,13 @@ impl DaemonService {
                         agent: agent.clone(),
                     });
                 }
+                if let Some((execution, record)) = self.durable.link_agent_execution(&agent)? {
+                    undo.record(record);
+                    events.push(DaemonEventKind::ScheduledExecutionChanged {
+                        workspace_id: execution.workspace_id.clone(),
+                        execution,
+                    });
+                }
                 Ok((Response::Agent { agent }, events))
             }),
             Request::EnsureAgent {
@@ -4323,22 +5827,33 @@ impl DaemonService {
                 if let Some(record) = record {
                     undo.record(record);
                 }
-                if !created {
-                    return Ok(DurableMutation::Unchanged(Response::Agent { agent }));
-                }
-                let mut events = vec![DaemonEventKind::AgentRegistered {
-                    workspace_id: agent.workspace_id.clone(),
-                    shell_id: agent.shell_id.clone(),
-                    agent: agent.clone(),
-                }];
-                if agent.ended_at_ms.is_some() {
-                    events.push(DaemonEventKind::AgentCompleted {
+                let mut events = Vec::new();
+                if created {
+                    events.push(DaemonEventKind::AgentRegistered {
                         workspace_id: agent.workspace_id.clone(),
                         shell_id: agent.shell_id.clone(),
                         agent: agent.clone(),
                     });
+                    if agent.ended_at_ms.is_some() {
+                        events.push(DaemonEventKind::AgentCompleted {
+                            workspace_id: agent.workspace_id.clone(),
+                            shell_id: agent.shell_id.clone(),
+                            agent: agent.clone(),
+                        });
+                    }
                 }
-                Ok(DurableMutation::Changed(Response::Agent { agent }, events))
+                if let Some((execution, record)) = self.durable.link_agent_execution(&agent)? {
+                    undo.record(record);
+                    events.push(DaemonEventKind::ScheduledExecutionChanged {
+                        workspace_id: execution.workspace_id.clone(),
+                        execution,
+                    });
+                }
+                if events.is_empty() {
+                    Ok(DurableMutation::Unchanged(Response::Agent { agent }))
+                } else {
+                    Ok(DurableMutation::Changed(Response::Agent { agent }, events))
+                }
             }),
             Request::ReportAgent {
                 agent_id,
@@ -4501,6 +6016,8 @@ impl DaemonService {
         let mut run_ids = HashSet::new();
         let mut agent_ids = HashSet::new();
         let mut schedule_ids = HashSet::new();
+        let mut execution_ids = HashSet::new();
+        let mut linked_agent_ids = HashSet::new();
         let mut recovered_interrupted_run = false;
         for saved_workspace in persisted.workspaces {
             validate_id("workspace", &saved_workspace.id)?;
@@ -4557,6 +6074,7 @@ impl DaemonService {
                     name: Mutex::new(saved_shell.name),
                     cwd: saved_shell.cwd,
                     command: saved_shell.command,
+                    owner: saved_shell.owner,
                     last_run: Mutex::new(saved_shell.last_run),
                     lifecycle: Mutex::new(ShellLifecycle::Pending),
                     foreground_process_cache: Mutex::new(None),
@@ -4636,8 +6154,120 @@ impl DaemonService {
                     &saved_workspace.id,
                     saved_schedule,
                 ));
+                if !live_handoff {
+                    for execution in lock(&schedule.executions)?.iter() {
+                        let mut execution_state = lock(&execution.state)?;
+                        if !execution_state.state.is_terminal() {
+                            execution_state.state = ScheduledExecutionState::Interrupted;
+                            execution_state.ended_at_ms =
+                                Some(unix_time_ms().max(execution.requested_at_ms));
+                            execution_state.reason =
+                                Some(ScheduledExecutionReason::ColdDaemonRecovery);
+                            execution_state.outcome = None;
+                            recovered_interrupted_run = true;
+                        }
+                    }
+                }
                 workspace_schedule_ids.push(schedule.id.clone());
                 state.schedules.insert(schedule.id.clone(), schedule);
+            }
+            for shell_id in &shell_ids {
+                let shell = state
+                    .shells
+                    .get(shell_id)
+                    .expect("workspace shell was inserted");
+                if let ShellOwner::Schedule { schedule_id } = &shell.owner {
+                    let schedule = state.schedules.get(schedule_id).ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "schedule-owned shell references a missing schedule",
+                        )
+                    })?;
+                    if schedule.workspace_id != saved_workspace.id
+                        || lock(&schedule.state)?.execution_shell_id.as_deref()
+                            != Some(shell.id.as_str())
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "schedule-owned shell does not match its persisted schedule",
+                        ));
+                    }
+                }
+            }
+            for schedule_id in &workspace_schedule_ids {
+                let schedule = state
+                    .schedules
+                    .get(schedule_id)
+                    .expect("workspace schedule was inserted");
+                if let Some(shell_id) = &lock(&schedule.state)?.execution_shell_id {
+                    let shell = state.shells.get(shell_id).ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "agent schedule references a missing execution shell",
+                        )
+                    })?;
+                    if shell.owner
+                        != (ShellOwner::Schedule {
+                            schedule_id: schedule.id.clone(),
+                        })
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "agent schedule references a shell with the wrong owner",
+                        ));
+                    }
+                }
+                let schedule_shell_id = lock(&schedule.state)?.execution_shell_id.clone();
+                let executions = lock(&schedule.executions)?.clone();
+                for execution in executions {
+                    if !execution_ids.insert(execution.id.clone()) {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Boomux state contains a duplicate scheduled execution",
+                        ));
+                    }
+                    let execution_state = lock(&execution.state)?;
+                    if let Some(shell_id) = &execution_state.shell_id
+                        && schedule_shell_id.as_deref() != Some(shell_id.as_str())
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "scheduled execution references a shell outside its schedule",
+                        ));
+                    }
+                    if let Some(agent_id) = &execution_state.agent_id {
+                        let agent = state.agents.get(agent_id).ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "scheduled execution references a missing Agent",
+                            )
+                        })?;
+                        if !linked_agent_ids.insert(agent_id.clone())
+                            || execution_state.shell_id.as_deref() != Some(agent.shell_id.as_str())
+                            || execution_state.run_id.as_deref() != Some(agent.run_id.as_str())
+                            || execution.integration != agent.integration
+                            || execution_state.external_session_id != agent.external_session_id
+                            || matches!(
+                                &execution.session,
+                                AgentScheduleSession::Continue { external_session_id }
+                                    if execution_state.external_session_id.as_deref()
+                                        != Some(external_session_id.as_str())
+                                        || agent.external_session_id.as_deref()
+                                            != Some(external_session_id.as_str())
+                            )
+                        {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "scheduled execution has an invalid Agent link",
+                            ));
+                        }
+                    } else if execution_state.external_session_id.is_some() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "scheduled execution has a session link without an Agent",
+                        ));
+                    }
+                }
             }
             let workspace = Arc::new(Workspace {
                 id: saved_workspace.id.clone(),
@@ -4669,6 +6299,7 @@ impl DaemonService {
             mutation_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
             notification_sink: Arc::new(DisabledNotificationSink),
+            startup_environment: capture_current_environment(),
             #[cfg(test)]
             fail_after_mutation: AtomicBool::new(false),
         };
@@ -5105,6 +6736,9 @@ impl DaemonService {
                 Err(error) if failure.is_none() => failure = Some(error),
                 Err(_) => {}
             }
+            if let Ok(Some(event)) = self.reconcile_irreversibly_stopped_execution(shell) {
+                batch.push(event);
+            }
         }
         self.queue_durable_batch_locked(batch, transition);
         failure.map_or(Ok(()), Err)
@@ -5126,9 +6760,51 @@ impl DaemonService {
             {
                 failure = Some(error);
             }
+            if let Ok(Some(event)) = self.reconcile_irreversibly_stopped_execution(&shell) {
+                batch.push(event);
+            }
         }
         self.queue_durable_batch_locked(batch, transition);
         failure.map_or(Ok(()), Err)
+    }
+
+    fn reconcile_irreversibly_stopped_execution(
+        &self,
+        shell: &Arc<Shell>,
+    ) -> io::Result<Option<DaemonEventKind>> {
+        let ShellOwner::Schedule { schedule_id } = &shell.owner else {
+            return Ok(None);
+        };
+        let run_id = lock(&shell.last_run)?.as_ref().map(|run| run.id.clone());
+        let Some(run_id) = run_id else {
+            return Ok(None);
+        };
+        let schedule = self.schedule(schedule_id)?;
+        let executions = lock(&schedule.executions)?.clone();
+        let execution = executions.into_iter().find(|execution| {
+            lock(&execution.state).is_ok_and(|state| {
+                matches!(
+                    state.state,
+                    ScheduledExecutionState::Starting | ScheduledExecutionState::Active
+                ) && state.shell_id.as_deref() == Some(shell.id.as_str())
+                    && state.run_id.as_deref() == Some(run_id.as_str())
+            })
+        });
+        let Some(execution) = execution else {
+            return Ok(None);
+        };
+        let now = unix_time_ms().max(execution.requested_at_ms);
+        let (snapshot, _) = self.durable.mutate_execution(&execution, |state| {
+            state.state = ScheduledExecutionState::Interrupted;
+            state.ended_at_ms = Some(now);
+            state.reason = Some(ScheduledExecutionReason::RunnerExitedWithoutReport);
+            state.outcome = None;
+            Ok(())
+        })?;
+        Ok(Some(DaemonEventKind::ScheduledExecutionChanged {
+            workspace_id: snapshot.workspace_id.clone(),
+            execution: snapshot,
+        }))
     }
 
     fn lifecycle_failure(primary: DaemonError, compensation: io::Result<()>) -> DaemonError {
@@ -5211,6 +6887,13 @@ impl DaemonService {
         runtime: &Arc<ShellRuntime>,
         code: Option<u32>,
     ) -> io::Result<RunExitRecord> {
+        let _mutation = match self.mutation_lock.try_lock() {
+            Ok(mutation) => mutation,
+            Err(TryLockError::WouldBlock) => return Ok(RunExitRecord::Deferred),
+            Err(TryLockError::Poisoned(_)) => {
+                return Err(io::Error::other("daemon mutation lock poisoned"));
+            }
+        };
         if !self.runtimes.run_exit_is_current(shell, run, runtime)? {
             return Ok(RunExitRecord::Unchanged);
         }
@@ -5226,9 +6909,25 @@ impl DaemonService {
                 return Err(io::Error::other("daemon state lock poisoned"));
             }
         };
+        let execution = if let ShellOwner::Schedule { schedule_id } = &shell.owner {
+            let schedule = self.schedule(schedule_id)?;
+            let executions = lock(&schedule.executions)?.clone();
+            executions.into_iter().find(|execution| {
+                lock(&execution.state).is_ok_and(|state| {
+                    matches!(
+                        state.state,
+                        ScheduledExecutionState::Starting | ScheduledExecutionState::Active
+                    ) && state.shell_id.as_deref() == Some(shell.id.as_str())
+                        && state.run_id.as_deref() == Some(run.id.as_str())
+                })
+            })
+        } else {
+            None
+        };
+        let reserve = 1 + usize::from(execution.is_some());
         let mut transaction = self.events.transaction()?;
-        if let Err(error) = transaction.reserve_with_pending(1) {
-            if transaction.capacity_is_blocked_only_by_lifecycle_reservation(1) {
+        if let Err(error) = transaction.reserve_with_pending(reserve) {
+            if transaction.capacity_is_blocked_only_by_lifecycle_reservation(reserve) {
                 return Ok(RunExitRecord::Deferred);
             }
             return Err(error);
@@ -5238,6 +6937,31 @@ impl DaemonService {
         };
         let mut batch = transaction.drain_runtime_events();
         batch.push(exit_event);
+        if let Some(execution) = execution {
+            let now = unix_time_ms().max(execution.requested_at_ms);
+            let (snapshot, _) = self.durable.mutate_execution(&execution, |state| {
+                if matches!(
+                    state.state,
+                    ScheduledExecutionState::Starting | ScheduledExecutionState::Active
+                ) {
+                    state.ended_at_ms = Some(now);
+                    if state.outcome.is_some() {
+                        state.state = ScheduledExecutionState::Exited;
+                        state.reason = None;
+                    } else if state.reason == Some(ScheduledExecutionReason::HostSpawnFailed) {
+                        state.state = ScheduledExecutionState::DispatchFailed;
+                    } else {
+                        state.state = ScheduledExecutionState::Interrupted;
+                        state.reason = Some(ScheduledExecutionReason::RunnerExitedWithoutReport);
+                    }
+                }
+                Ok(())
+            })?;
+            batch.push(DaemonEventKind::ScheduledExecutionChanged {
+                workspace_id: snapshot.workspace_id.clone(),
+                execution: snapshot,
+            });
+        }
         let pending_count =
             transaction.pending_durable_event_count(transaction.pending_durable_batch_count());
         let event_count = pending_count.saturating_add(batch.len());
@@ -5298,6 +7022,12 @@ impl DaemonService {
 
     fn snapshot(&self) -> io::Result<Snapshot> {
         self.durable.snapshot(self.focused_terminal()?)
+    }
+
+    fn schedule_shell_ids_for_downgrade(&self) -> io::Result<HashSet<String>> {
+        let mut ids = self.events.schedule_shell_ids()?;
+        ids.extend(self.durable.schedule_shell_ids()?);
+        Ok(ids)
     }
 
     fn focused_terminal(&self) -> io::Result<Option<FocusedTerminalSnapshot>> {
@@ -5566,7 +7296,23 @@ impl DaemonService {
         self.lifecycle_transaction(
             true,
             || Ok(self.durable.shells()?),
-            || Ok(None),
+            || {
+                let executions = self.durable.scheduled_executions(None, None)?;
+                for snapshot in executions {
+                    if snapshot.state.is_terminal() {
+                        continue;
+                    }
+                    let execution = self.durable.execution(&snapshot.id)?;
+                    self.durable.mutate_execution(&execution, |state| {
+                        state.state = ScheduledExecutionState::Cancelled;
+                        state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
+                        state.reason = Some(ScheduledExecutionReason::DaemonShutdown);
+                        state.outcome = None;
+                        Ok(())
+                    })?;
+                }
+                Ok(None)
+            },
             |_| Vec::new(),
         )
     }
@@ -5906,6 +7652,26 @@ impl DaemonService {
         undo: &mut DurableUndoLog,
         schedule_id: &str,
     ) -> io::Result<Arc<AgentSchedule>> {
+        let schedule = self.schedule(schedule_id)?;
+        if lock(&schedule.executions)?
+            .iter()
+            .any(|execution| lock(&execution.state).is_ok_and(|state| !state.state.is_terminal()))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "agent schedule has a nonterminal execution",
+            ));
+        }
+        if let Some(shell_id) = lock(&schedule.state)?.execution_shell_id.clone() {
+            let shell = self.shell(&shell_id)?;
+            if matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Running { .. }) {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "agent schedule runner shell is still active",
+                ));
+            }
+            undo.record(self.remove_shell_mutation(&shell_id)?);
+        }
         let mut state = lock(&self.durable.state)?;
         let schedule = state
             .schedules
@@ -6083,6 +7849,12 @@ impl DaemonService {
     }
 
     fn close_shell(&self, shell_id: &str) -> DaemonResult<()> {
+        if !matches!(self.shell(shell_id)?.owner, ShellOwner::User) {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::Busy,
+                "schedule-owned shells cannot be closed directly",
+            ));
+        }
         self.lifecycle_transaction(
             false,
             || Ok(vec![self.shell(shell_id)?]),
@@ -6116,6 +7888,12 @@ impl DaemonService {
         let _mutation = lock(&self.mutation_lock)?;
         self.ensure_running()?;
         let shell = self.shell(shell_id)?;
+        if !matches!(shell.owner, ShellOwner::User) {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::Busy,
+                "schedule-owned shells cannot be restarted directly",
+            ));
+        }
         let old_runtime = {
             let mut lifecycle = lock(&shell.lifecycle)?;
             let old_runtime = match &*lifecycle {
@@ -6198,6 +7976,7 @@ impl Workspace {
 
 impl AgentSchedule {
     fn from_persisted(workspace_id: &str, saved: PersistedAgentSchedule) -> Self {
+        let schedule_id = saved.id.clone();
         Self {
             id: saved.id,
             workspace_id: workspace_id.into(),
@@ -6218,6 +7997,20 @@ impl AgentSchedule {
                 evaluation_frontier_ms: saved.evaluation_frontier_ms,
                 execution_shell_id: saved.execution_shell_id,
             }),
+            executions: Mutex::new(
+                saved
+                    .executions
+                    .into_iter()
+                    .map(|execution| {
+                        Arc::new(ScheduledExecution::from_persisted(
+                            workspace_id,
+                            &schedule_id,
+                            execution,
+                        ))
+                    })
+                    .collect(),
+            ),
+            dispatch_key_filter: Mutex::new(saved.dispatch_key_filter),
         }
     }
 
@@ -6256,6 +8049,11 @@ impl AgentSchedule {
 
     fn persisted(&self) -> io::Result<PersistedAgentSchedule> {
         let snapshot = self.snapshot()?;
+        let executions = lock(&self.executions)?
+            .iter()
+            .map(|execution| execution.persisted())
+            .collect::<io::Result<_>>()?;
+        let dispatch_key_filter = lock(&self.dispatch_key_filter)?.clone();
         Ok(PersistedAgentSchedule {
             id: snapshot.id,
             name: snapshot.name,
@@ -6273,6 +8071,102 @@ impl AgentSchedule {
             updated_at_ms: snapshot.updated_at_ms,
             evaluation_frontier_ms: snapshot.evaluation_frontier_ms,
             execution_shell_id: snapshot.execution_shell_id,
+            dispatch_key_filter,
+            executions,
+        })
+    }
+}
+
+impl ScheduledExecution {
+    fn from_persisted(
+        workspace_id: &str,
+        schedule_id: &str,
+        saved: PersistedScheduledExecution,
+    ) -> Self {
+        Self {
+            id: saved.id,
+            workspace_id: workspace_id.into(),
+            schedule_id: schedule_id.into(),
+            dispatch_kind: saved.dispatch_kind,
+            dispatch_key: saved.dispatch_key,
+            schedule_revision: saved.schedule_revision,
+            prompt_revision: saved.prompt_revision,
+            trigger_revision: saved.trigger_revision,
+            requested_at_ms: saved.requested_at_ms,
+            cwd: saved.cwd,
+            integration: saved.integration,
+            session: saved.session,
+            prompt: saved.prompt,
+            runner_token: saved.runner_token,
+            state: Mutex::new(ScheduledExecutionMutableState {
+                state: saved.state,
+                started_at_ms: saved.started_at_ms,
+                ended_at_ms: saved.ended_at_ms,
+                reason: saved.reason,
+                outcome: saved.outcome,
+                shell_id: saved.shell_id,
+                run_id: saved.run_id,
+                agent_id: saved.agent_id,
+                external_session_id: saved.external_session_id,
+            }),
+        }
+    }
+
+    fn snapshot(&self) -> io::Result<ScheduledExecutionSnapshot> {
+        let state = lock(&self.state)?;
+        Ok(self.snapshot_from(&state))
+    }
+
+    fn snapshot_from(&self, state: &ScheduledExecutionMutableState) -> ScheduledExecutionSnapshot {
+        ScheduledExecutionSnapshot {
+            id: self.id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            schedule_id: self.schedule_id.clone(),
+            state: state.state,
+            dispatch_kind: self.dispatch_kind,
+            dispatch_key: self.dispatch_key.clone(),
+            schedule_revision: self.schedule_revision,
+            prompt_revision: self.prompt_revision,
+            trigger_revision: self.trigger_revision,
+            requested_at_ms: self.requested_at_ms,
+            started_at_ms: state.started_at_ms,
+            ended_at_ms: state.ended_at_ms,
+            cwd: self.cwd.clone(),
+            integration: self.integration.clone(),
+            session: self.session.clone(),
+            reason: state.reason,
+            outcome: state.outcome.clone(),
+            shell_id: state.shell_id.clone(),
+            run_id: state.run_id.clone(),
+            agent_id: state.agent_id.clone(),
+            external_session_id: state.external_session_id.clone(),
+        }
+    }
+
+    fn persisted(&self) -> io::Result<PersistedScheduledExecution> {
+        let state = lock(&self.state)?;
+        Ok(PersistedScheduledExecution {
+            id: self.id.clone(),
+            state: state.state,
+            dispatch_kind: self.dispatch_kind,
+            dispatch_key: self.dispatch_key.clone(),
+            schedule_revision: self.schedule_revision,
+            prompt_revision: self.prompt_revision,
+            trigger_revision: self.trigger_revision,
+            requested_at_ms: self.requested_at_ms,
+            started_at_ms: state.started_at_ms,
+            ended_at_ms: state.ended_at_ms,
+            cwd: self.cwd.clone(),
+            integration: self.integration.clone(),
+            session: self.session.clone(),
+            prompt: self.prompt.clone(),
+            runner_token: self.runner_token.clone(),
+            reason: state.reason,
+            outcome: state.outcome.clone(),
+            shell_id: state.shell_id.clone(),
+            run_id: state.run_id.clone(),
+            agent_id: state.agent_id.clone(),
+            external_session_id: state.external_session_id.clone(),
         })
     }
 }
@@ -6377,6 +8271,7 @@ impl Shell {
             name: lock(&self.name)?.clone(),
             cwd: self.cwd.clone(),
             command: self.command.clone(),
+            owner: self.owner.clone(),
             status,
             run,
             foreground_process,
@@ -6393,6 +8288,7 @@ fn create_pending_shell(workspace_id: &str, spec: ShellSpec) -> io::Result<Arc<S
         name: Mutex::new(spec.name),
         cwd: spec.cwd,
         command: spec.command,
+        owner: ShellOwner::User,
         last_run: Mutex::new(None),
         lifecycle: Mutex::new(ShellLifecycle::Pending),
         foreground_process_cache: Mutex::new(None),
@@ -6897,6 +8793,19 @@ impl ShellRuntimeManager {
                 return send_daemon_error(&mut stream, response_version, error.into());
             }
         };
+        if !matches!(shell.owner, ShellOwner::User)
+            && (restart_exited || matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending))
+        {
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::lifecycle(
+                    ErrorCode::Busy,
+                    "schedule-owned shells start only through schedule dispatch",
+                )
+                .into_response(),
+            );
+        }
         let mutation = lock(&registry.mutation_lock)?;
         if registry.runtimes.is_stopping() {
             return send_response(
@@ -7730,11 +9639,158 @@ fn validate_persisted_schedule(schedule: &PersistedAgentSchedule) -> io::Result<
         || schedule.updated_at_ms < schedule.created_at_ms
         || schedule.evaluation_frontier_ms < schedule.created_at_ms
         || schedule.evaluation_frontier_ms > schedule.updated_at_ms
-        || schedule.execution_shell_id.is_some()
     {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "Boomux state contains an invalid agent schedule",
+        ));
+    }
+    if schedule.dispatch_key_filter.len() != DISPATCH_KEY_FILTER_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux state contains an invalid dispatch idempotency filter",
+        ));
+    }
+    if let Some(shell_id) = &schedule.execution_shell_id {
+        validate_id("schedule execution shell", shell_id)?;
+    }
+    let mut execution_ids = HashSet::new();
+    let mut dispatch_keys = HashSet::new();
+    let mut nonterminal_count = 0;
+    for execution in &schedule.executions {
+        validate_id("scheduled execution", &execution.id)?;
+        validate_id("scheduled execution dispatch key", &execution.dispatch_key)?;
+        validate_id("scheduled execution runner token", &execution.runner_token)?;
+        validate_persisted_cwd(&execution.cwd)?;
+        crate::scheduling::validate_prompt(&execution.prompt)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        if !execution_ids.insert(&execution.id)
+            || !dispatch_keys.insert(&execution.dispatch_key)
+            || !dispatch_key_was_seen(&schedule.dispatch_key_filter, &execution.dispatch_key)
+            || execution.schedule_revision == 0
+            || execution.prompt_revision == 0
+            || execution.trigger_revision == 0
+            || execution.prompt_revision > execution.schedule_revision
+            || execution.trigger_revision > execution.schedule_revision
+            || execution.schedule_revision > schedule.revision
+            || execution.prompt_revision > schedule.prompt_revision
+            || execution.trigger_revision > schedule.trigger_revision
+            || execution.cwd != schedule.cwd
+            || execution.integration != schedule.integration
+            || execution.session != schedule.session
+            || execution
+                .started_at_ms
+                .is_some_and(|time| time < execution.requested_at_ms)
+            || execution
+                .ended_at_ms
+                .is_some_and(|time| time < execution.requested_at_ms)
+            || execution
+                .started_at_ms
+                .zip(execution.ended_at_ms)
+                .is_some_and(|(started, ended)| ended < started)
+            || execution.shell_id.is_some() != execution.run_id.is_some()
+                && execution.run_id.is_some()
+            || execution.agent_id.is_some() != execution.external_session_id.is_some()
+            || matches!(
+                &execution.session,
+                AgentScheduleSession::Continue { external_session_id }
+                    if execution
+                        .external_session_id
+                        .as_deref()
+                        .is_some_and(|linked| linked != external_session_id)
+            )
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Boomux state contains an invalid scheduled execution",
+            ));
+        }
+        if let Some(shell_id) = &execution.shell_id {
+            validate_id("scheduled execution shell", shell_id)?;
+        }
+        if let Some(run_id) = &execution.run_id {
+            validate_id("scheduled execution run", run_id)?;
+        }
+        if let Some(agent_id) = &execution.agent_id {
+            validate_id("scheduled execution agent", agent_id)?;
+        }
+        let valid_state = match execution.state {
+            ScheduledExecutionState::Claimed => {
+                execution.started_at_ms.is_none()
+                    && execution.ended_at_ms.is_none()
+                    && execution.run_id.is_none()
+                    && execution.reason.is_none()
+                    && execution.outcome.is_none()
+                    && execution.agent_id.is_none()
+            }
+            ScheduledExecutionState::Starting => {
+                execution.run_id.is_some()
+                    && execution.started_at_ms.is_none()
+                    && execution.ended_at_ms.is_none()
+                    && execution.outcome.is_none()
+                    && matches!(
+                        execution.reason,
+                        None | Some(ScheduledExecutionReason::HostSpawnFailed)
+                    )
+            }
+            ScheduledExecutionState::Active => {
+                execution.run_id.is_some()
+                    && execution.started_at_ms.is_some()
+                    && execution.ended_at_ms.is_none()
+                    && execution.reason.is_none()
+            }
+            ScheduledExecutionState::DispatchFailed => {
+                execution.ended_at_ms.is_some()
+                    && execution.outcome.is_none()
+                    && matches!(
+                        execution.reason,
+                        Some(
+                            ScheduledExecutionReason::RunnerStartFailed
+                                | ScheduledExecutionReason::HostSpawnFailed
+                        )
+                    )
+            }
+            ScheduledExecutionState::Exited => {
+                execution.started_at_ms.is_some()
+                    && execution.ended_at_ms.is_some()
+                    && execution.outcome.is_some()
+                    && execution.reason.is_none()
+            }
+            ScheduledExecutionState::Cancelled => {
+                execution.ended_at_ms.is_some()
+                    && execution.outcome.is_none()
+                    && matches!(
+                        execution.reason,
+                        Some(
+                            ScheduledExecutionReason::CancelledByUser
+                                | ScheduledExecutionReason::DaemonShutdown
+                        )
+                    )
+            }
+            ScheduledExecutionState::Interrupted => {
+                execution.ended_at_ms.is_some()
+                    && execution.outcome.is_none()
+                    && matches!(
+                        execution.reason,
+                        Some(
+                            ScheduledExecutionReason::ColdDaemonRecovery
+                                | ScheduledExecutionReason::RunnerExitedWithoutReport
+                        )
+                    )
+            }
+        };
+        if !valid_state {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Boomux state contains an invalid scheduled execution state",
+            ));
+        }
+        nonterminal_count += usize::from(!execution.state.is_terminal());
+    }
+    if nonterminal_count > 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux state contains overlapping scheduled executions",
         ));
     }
     Ok(())
@@ -7747,6 +9803,34 @@ fn validate_id(kind: &str, id: &str) -> io::Result<()> {
             format!("persisted {kind} ID is invalid: {id}"),
         )
     })
+}
+
+fn dispatch_key_positions(key: &str, bit_count: usize) -> [usize; 3] {
+    let digest = Sha256::digest(key.as_bytes());
+    std::array::from_fn(|index| {
+        let offset = index * 8;
+        let value = u64::from_be_bytes(
+            digest[offset..offset + 8]
+                .try_into()
+                .expect("SHA-256 position is eight bytes"),
+        );
+        usize::try_from(value % bit_count as u64).unwrap_or(0)
+    })
+}
+
+fn dispatch_key_was_seen(filter: &[u8], key: &str) -> bool {
+    let bit_count = filter.len().saturating_mul(8);
+    bit_count != 0
+        && dispatch_key_positions(key, bit_count)
+            .into_iter()
+            .all(|position| filter[position / 8] & (1 << (position % 8)) != 0)
+}
+
+fn remember_dispatch_key(filter: &mut [u8], key: &str) {
+    let bit_count = filter.len().saturating_mul(8);
+    for position in dispatch_key_positions(key, bit_count) {
+        filter[position / 8] |= 1 << (position % 8);
+    }
 }
 
 fn validate_agent_registration(spec: &AgentRegistrationSpec) -> io::Result<()> {
@@ -8463,6 +10547,83 @@ mod tests {
     }
 
     #[test]
+    fn schedule_shell_filter_ownership_tracks_retained_event_lifetime() {
+        let stream = EventStream::new();
+        let workspace_id = Uuid::new_v4().to_string();
+        let mut batch = Vec::with_capacity((MAX_RETAINED_EVENTS + 1) * 2);
+        for index in 0..=MAX_RETAINED_EVENTS {
+            let shell_id = Uuid::from_u128(index as u128 + 1).to_string();
+            batch.push(DaemonEventKind::ScheduledExecutionChanged {
+                workspace_id: workspace_id.clone(),
+                execution: ScheduledExecutionSnapshot {
+                    id: Uuid::new_v4().to_string(),
+                    workspace_id: workspace_id.clone(),
+                    schedule_id: Uuid::new_v4().to_string(),
+                    state: ScheduledExecutionState::Starting,
+                    dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+                    dispatch_key: Uuid::new_v4().to_string(),
+                    schedule_revision: 1,
+                    prompt_revision: 1,
+                    trigger_revision: 1,
+                    requested_at_ms: 1,
+                    started_at_ms: None,
+                    ended_at_ms: None,
+                    cwd: env::temp_dir(),
+                    integration: "opencode".into(),
+                    session: AgentScheduleSession::Fresh,
+                    reason: None,
+                    outcome: None,
+                    shell_id: Some(shell_id.clone()),
+                    run_id: Some(Uuid::new_v4().to_string()),
+                    agent_id: None,
+                    external_session_id: None,
+                },
+            });
+            batch.push(DaemonEventKind::ShellCreated {
+                workspace_id: workspace_id.clone(),
+                shell_id,
+                name: format!("schedule-shell-{index}"),
+            });
+        }
+
+        let (events, cursor, schedule_shell_ids) = {
+            let mut state = lock(&stream.state).unwrap();
+            EventStream::append_batch_locked(&mut state, batch);
+            let retained_generic_ids = state
+                .events
+                .iter()
+                .filter_map(|event| event_shell_id(&event.kind).map(str::to_owned))
+                .collect::<HashSet<_>>();
+            assert_eq!(state.events.len(), MAX_RETAINED_EVENTS);
+            assert_eq!(state.schedule_shell_ids, retained_generic_ids);
+            assert!(state.schedule_shell_ids.len() < MAX_RETAINED_EVENTS);
+            (
+                state.events.iter().cloned().collect::<Vec<_>>(),
+                EventCursor {
+                    stream_id: state.stream_id.clone(),
+                    event_id: state.latest_id,
+                },
+                state.schedule_shell_ids.clone(),
+            )
+        };
+        let latest_id = cursor.event_id;
+        let Response::Events { cursor, events, .. } = response_for_version_with_schedule_shells(
+            Response::Events {
+                stream_id: cursor.stream_id.clone(),
+                cursor,
+                snapshot: None,
+                events,
+            },
+            22,
+            &schedule_shell_ids,
+        ) else {
+            panic!("expected downgraded events");
+        };
+        assert_eq!(cursor.event_id, latest_id);
+        assert!(events.is_empty());
+    }
+
+    #[test]
     fn blocked_publication_coalesces_output_by_shell_run() {
         let mut transition = TransitionState {
             persistence_in_flight: true,
@@ -8660,6 +10821,8 @@ mod tests {
             updated_at_ms: 1,
             evaluation_frontier_ms: 1,
             execution_shell_id: None,
+            dispatch_key_filter: vec![0; DISPATCH_KEY_FILTER_BYTES],
+            executions: Vec::new(),
         };
 
         assert_eq!(
@@ -8668,6 +10831,195 @@ mod tests {
         );
         schedule.state = AgentScheduleState::Paused;
         assert!(validate_persisted_schedule(&schedule).is_ok());
+    }
+
+    #[test]
+    fn state_ten_execution_validation_enforces_exact_state_shapes_and_revisions() {
+        let dispatch_key = Uuid::new_v4().to_string();
+        let mut filter = vec![0; DISPATCH_KEY_FILTER_BYTES];
+        remember_dispatch_key(&mut filter, &dispatch_key);
+        let execution = PersistedScheduledExecution {
+            id: Uuid::new_v4().to_string(),
+            state: ScheduledExecutionState::Claimed,
+            dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+            dispatch_key,
+            schedule_revision: 2,
+            prompt_revision: 1,
+            trigger_revision: 1,
+            requested_at_ms: 10,
+            started_at_ms: None,
+            ended_at_ms: None,
+            cwd: env::temp_dir(),
+            integration: "opencode".into(),
+            session: AgentScheduleSession::Fresh,
+            prompt: "private".into(),
+            runner_token: Uuid::new_v4().to_string(),
+            reason: None,
+            outcome: None,
+            shell_id: None,
+            run_id: None,
+            agent_id: None,
+            external_session_id: None,
+        };
+        let mut schedule = PersistedAgentSchedule {
+            id: Uuid::new_v4().to_string(),
+            name: "valid".into(),
+            cwd: env::temp_dir(),
+            integration: "opencode".into(),
+            prompt: "private".into(),
+            session: AgentScheduleSession::Fresh,
+            trigger: AgentScheduleTrigger {
+                cron: "0 2 * * *".into(),
+                timezone: "UTC".into(),
+            },
+            state: AgentScheduleState::Paused,
+            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            revision: 2,
+            prompt_revision: 1,
+            trigger_revision: 1,
+            created_at_ms: 1,
+            updated_at_ms: 2,
+            evaluation_frontier_ms: 1,
+            execution_shell_id: None,
+            dispatch_key_filter: filter,
+            executions: vec![execution],
+        };
+        assert!(validate_persisted_schedule(&schedule).is_ok());
+
+        schedule.executions[0].started_at_ms = Some(10);
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule.executions[0].started_at_ms = None;
+        schedule.executions[0].schedule_revision = 3;
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule.executions[0].schedule_revision = 2;
+        schedule.executions[0].state = ScheduledExecutionState::Active;
+        schedule.executions[0].shell_id = Some(Uuid::new_v4().to_string());
+        schedule.executions[0].run_id = Some(Uuid::new_v4().to_string());
+        schedule.executions[0].started_at_ms = Some(10);
+        schedule.executions[0].reason = Some(ScheduledExecutionReason::HostSpawnFailed);
+        assert!(validate_persisted_schedule(&schedule).is_err());
+    }
+
+    #[test]
+    fn malformed_current_state_rejects_linked_continuation_identity_mismatch() {
+        let directory = env::temp_dir().join(format!(
+            "boomux-invalid-continuation-link-{}",
+            Uuid::new_v4()
+        ));
+        let store = StateStore::at(directory.join("state/state.json"));
+        let workspace_id = Uuid::new_v4().to_string();
+        let schedule_id = Uuid::new_v4().to_string();
+        let shell_id = Uuid::new_v4().to_string();
+        let run_id = Uuid::new_v4().to_string();
+        let agent_id = Uuid::new_v4().to_string();
+        let dispatch_key = Uuid::new_v4().to_string();
+        let mut filter = vec![0; DISPATCH_KEY_FILTER_BYTES];
+        remember_dispatch_key(&mut filter, &dispatch_key);
+        let expected_session_id = "exact-continuation".to_owned();
+        let mismatched_session_id = "different-session".to_owned();
+        let session = AgentScheduleSession::Continue {
+            external_session_id: expected_session_id,
+        };
+        let schedule = PersistedAgentSchedule {
+            id: schedule_id.clone(),
+            name: "continued".into(),
+            cwd: env::temp_dir(),
+            integration: "opencode".into(),
+            prompt: "private".into(),
+            session: session.clone(),
+            trigger: AgentScheduleTrigger {
+                cron: "0 2 * * *".into(),
+                timezone: "UTC".into(),
+            },
+            state: AgentScheduleState::Paused,
+            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            revision: 1,
+            prompt_revision: 1,
+            trigger_revision: 1,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            evaluation_frontier_ms: 1,
+            execution_shell_id: Some(shell_id.clone()),
+            dispatch_key_filter: filter,
+            executions: vec![PersistedScheduledExecution {
+                id: Uuid::new_v4().to_string(),
+                state: ScheduledExecutionState::Active,
+                dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+                dispatch_key,
+                schedule_revision: 1,
+                prompt_revision: 1,
+                trigger_revision: 1,
+                requested_at_ms: 1,
+                started_at_ms: Some(1),
+                ended_at_ms: None,
+                cwd: env::temp_dir(),
+                integration: "opencode".into(),
+                session,
+                prompt: "private".into(),
+                runner_token: Uuid::new_v4().to_string(),
+                reason: None,
+                outcome: None,
+                shell_id: Some(shell_id.clone()),
+                run_id: Some(run_id.clone()),
+                agent_id: Some(agent_id.clone()),
+                external_session_id: Some(mismatched_session_id.clone()),
+            }],
+        };
+        let mut persisted = PersistedState::default();
+        persisted.workspaces = vec![PersistedWorkspace {
+            id: workspace_id,
+            name: "continued".into(),
+            default_cwd: None,
+            shells: vec![PersistedShell {
+                id: shell_id.clone(),
+                name: "scheduled".into(),
+                cwd: env::temp_dir(),
+                command: vec!["boomux".into()],
+                owner: ShellOwner::Schedule { schedule_id },
+                last_run: Some(PersistedShellRun {
+                    id: run_id.clone(),
+                    generation: 1,
+                    started_at_ms: 1,
+                    ended_at_ms: None,
+                    exit_reason: None,
+                    output_revision: 0,
+                    environment_has_run_id: true,
+                    profile: profile(),
+                    terminal_history: None,
+                }),
+            }],
+            launchers: Vec::new(),
+            agents: vec![PersistedAgentInstance {
+                id: agent_id,
+                shell_id,
+                run_id,
+                name: "continued".into(),
+                integration: "opencode".into(),
+                external_session_id: Some(mismatched_session_id),
+                cwd: Some(env::temp_dir()),
+                started_at_ms: 1,
+                ended_at_ms: None,
+                observation: AgentObservationSnapshot {
+                    revision: 1,
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "registered".into(),
+                    confidence: 100,
+                    observed_at_ms: 1,
+                },
+                attention: None,
+            }],
+            schedules: vec![schedule],
+        }];
+        store.save(&persisted).unwrap();
+        assert_eq!(
+            DaemonService::restore(store, true, None)
+                .err()
+                .expect("malformed continuation state was accepted")
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
@@ -8752,6 +11104,46 @@ mod tests {
             2
         );
         assert!(!serde_json::to_string(&events).unwrap().contains(prompt));
+    }
+
+    #[test]
+    fn pruned_dispatch_keys_remain_explicitly_rejected() {
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace("scheduled".into(), Vec::new())
+            .unwrap();
+        let (schedule, _) = registry
+            .durable
+            .create_schedule(&workspace.id, schedule_spec("private"))
+            .unwrap();
+        let first_key = Uuid::from_u128(1).to_string();
+
+        for value in 1..=MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE + 1 {
+            let key = Uuid::from_u128(value as u128).to_string();
+            let (snapshot, _) = registry
+                .durable
+                .claim_schedule_execution(&schedule.id, &key)
+                .unwrap();
+            let execution = registry.durable.execution(&snapshot.id).unwrap();
+            registry
+                .durable
+                .mutate_execution(&execution, |state| {
+                    state.state = ScheduledExecutionState::DispatchFailed;
+                    state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
+                    state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                    Ok(())
+                })
+                .unwrap();
+        }
+
+        let error = match registry
+            .durable
+            .claim_schedule_execution(&schedule.id, &first_key)
+        {
+            Err(error) => error,
+            Ok(_) => panic!("pruned dispatch key was accepted"),
+        };
+        assert_eq!(error.wire_code(), ErrorCode::IdempotencyExpired);
     }
 
     #[test]

--- a/src/dashboard_projection.rs
+++ b/src/dashboard_projection.rs
@@ -319,6 +319,7 @@ mod tests {
             name: "project".into(),
             default_cwd: Some(PathBuf::from("/tmp/project")),
             shells: vec![ShellSnapshot {
+                owner: boomux::protocol::ShellOwner::User,
                 id: "shell-1".into(),
                 workspace_id: "workspace-1".into(),
                 name: "main".into(),

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -46,6 +46,8 @@ pub(crate) struct EventStreamManifest {
     pub(crate) stream_id: String,
     pub(crate) latest_id: u64,
     pub(crate) events: Vec<DaemonEvent>,
+    #[serde(default)]
+    pub(crate) schedule_shell_ids: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -89,7 +91,7 @@ pub(crate) enum Bootstrap {
         state_lock: OwnedFd,
         runtimes: Vec<TransferredRuntime>,
         exited: Vec<TransferredExited>,
-        event_stream: EventStreamManifest,
+        event_stream: Box<EventStreamManifest>,
         notifications: Option<NotificationDeliveryConfig>,
         focused_terminal: Option<Box<FocusedTerminalSnapshot>>,
     },
@@ -178,7 +180,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             state_lock,
             runtimes,
             exited,
-            event_stream,
+            event_stream: Box::new(event_stream),
             notifications,
             focused_terminal,
         }),
@@ -266,8 +268,15 @@ fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
             ));
         }
     }
+    let mut schedule_shell_ids = std::collections::HashSet::new();
     if uuid::Uuid::parse_str(&manifest.event_stream.stream_id).is_err()
         || manifest.event_stream.events.len() > 8_192
+        || manifest.event_stream.schedule_shell_ids.len() > manifest.event_stream.events.len()
+        || manifest
+            .event_stream
+            .schedule_shell_ids
+            .iter()
+            .any(|id| uuid::Uuid::parse_str(id).is_err() || !schedule_shell_ids.insert(id))
         || manifest
             .event_stream
             .events
@@ -403,6 +412,7 @@ mod tests {
             stream_id: uuid::Uuid::new_v4().to_string(),
             latest_id: 0,
             events: Vec::new(),
+            schedule_shell_ids: Vec::new(),
         }
     }
 

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -1320,6 +1320,7 @@ mod tests {
     #[test]
     fn runtime_status_requires_exact_current_run_registration() {
         let shell = ShellSnapshot {
+            owner: boomux::protocol::ShellOwner::User,
             id: "s1".into(),
             workspace_id: "w1".into(),
             name: "shell".into(),

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -49,6 +49,7 @@ pub struct ResumeCapability {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PromptTransport {
     Argument,
+    Stdin,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -56,6 +57,65 @@ pub struct ScheduleDispatchCapability {
     pub fresh: bool,
     pub continuation: bool,
     pub prompt_transport: PromptTransport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScheduleDispatchCommand {
+    pub argv: Vec<String>,
+    pub stdin: Option<Vec<u8>>,
+}
+
+impl ScheduleDispatchCapability {
+    pub fn command(
+        self,
+        integration: &str,
+        session: &crate::protocol::AgentScheduleSession,
+        prompt: &str,
+    ) -> Option<ScheduleDispatchCommand> {
+        use crate::protocol::AgentScheduleSession;
+
+        let mut argv = vec![integration.to_owned()];
+        match (integration, session) {
+            ("opencode", AgentScheduleSession::Fresh) if self.fresh => {
+                argv.extend(["run".into(), "--".into(), prompt.into()]);
+            }
+            (
+                "opencode",
+                AgentScheduleSession::Continue {
+                    external_session_id,
+                },
+            ) if self.continuation => {
+                argv.extend([
+                    "run".into(),
+                    "--session".into(),
+                    external_session_id.clone(),
+                    "--".into(),
+                    prompt.into(),
+                ]);
+            }
+            ("pi", AgentScheduleSession::Fresh) if self.fresh => {
+                argv.push("--print".into());
+            }
+            (
+                "pi",
+                AgentScheduleSession::Continue {
+                    external_session_id,
+                },
+            ) if self.continuation => {
+                argv.extend([
+                    "--session".into(),
+                    external_session_id.clone(),
+                    "--print".into(),
+                ]);
+            }
+            _ => return None,
+        }
+        Some(ScheduleDispatchCommand {
+            argv,
+            stdin: (self.prompt_transport == PromptTransport::Stdin)
+                .then(|| prompt.as_bytes().to_vec()),
+        })
+    }
 }
 
 impl ResumeCapability {
@@ -160,7 +220,7 @@ pub const PI: IntegrationDescriptor = IntegrationDescriptor {
     schedule_dispatch: Some(ScheduleDispatchCapability {
         fresh: true,
         continuation: true,
-        prompt_transport: PromptTransport::Argument,
+        prompt_transport: PromptTransport::Stdin,
     }),
     foreground: Some(ForegroundCapability { process_name: "pi" }),
 };
@@ -281,14 +341,9 @@ mod tests {
         for descriptor in ALL {
             assert_eq!(by_key(descriptor.key), Some(descriptor));
             assert_eq!(display_name(descriptor.key), descriptor.display_name);
-            assert_eq!(
-                descriptor.schedule_dispatch,
-                Some(ScheduleDispatchCapability {
-                    fresh: true,
-                    continuation: true,
-                    prompt_transport: PromptTransport::Argument,
-                })
-            );
+            let dispatch = descriptor.schedule_dispatch.expect("dispatch capability");
+            assert!(dispatch.fresh);
+            assert!(dispatch.continuation);
         }
     }
 
@@ -327,6 +382,45 @@ mod tests {
             resume
                 .command(&["opencode".into(), "--continue".into()], "session-1")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn scheduled_dispatch_builds_exact_host_argv_and_private_transport() {
+        use crate::protocol::AgentScheduleSession;
+
+        let prompt = "-private @prompt";
+        assert_eq!(
+            OPENCODE
+                .schedule_dispatch
+                .unwrap()
+                .command("opencode", &AgentScheduleSession::Fresh, prompt)
+                .unwrap(),
+            ScheduleDispatchCommand {
+                argv: vec!["opencode".into(), "run".into(), "--".into(), prompt.into()],
+                stdin: None,
+            }
+        );
+        assert_eq!(
+            PI.schedule_dispatch
+                .unwrap()
+                .command(
+                    "pi",
+                    &AgentScheduleSession::Continue {
+                        external_session_id: "exact-full-id".into(),
+                    },
+                    prompt,
+                )
+                .unwrap(),
+            ScheduleDispatchCommand {
+                argv: vec![
+                    "pi".into(),
+                    "--session".into(),
+                    "exact-full-id".into(),
+                    "--print".into(),
+                ],
+                stdin: Some(prompt.as_bytes().to_vec()),
+            }
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::fmt::Write as _;
 use std::fs;
 use std::io::{self, Read};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-use std::os::unix::process::CommandExt;
+use std::os::unix::process::{CommandExt, ExitStatusExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
 use std::thread;
@@ -19,8 +19,9 @@ use uuid::Uuid;
 use boomux::protocol::{
     AgentAuthority, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport,
     AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSnapshot, AgentScheduleSpec,
-    AgentScheduleState, AgentScheduleTrigger, AgentState, EventCursor, ShellSnapshot, ShellSpec,
-    ShellStatus, Snapshot, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    AgentScheduleState, AgentScheduleTrigger, AgentState, EventCursor, ScheduledExecutionOutcome,
+    ScheduledExecutionSnapshot, ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus,
+    Snapshot, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use boomux::{attach, client, daemon, protocol};
 
@@ -265,6 +266,11 @@ enum Commands {
         #[command(subcommand)]
         command: ScheduleCommands,
     },
+    /// Inspect and cancel scheduled execution records
+    Execution {
+        #[command(subcommand)]
+        command: ExecutionCommands,
+    },
     /// Inspect and install supported harness integrations
     Integration {
         #[command(subcommand)]
@@ -309,6 +315,8 @@ enum Commands {
         #[arg(long)]
         restart_exited: bool,
     },
+    #[command(name = "__scheduled-runner", hide = true)]
+    ScheduledRunner { schedule_id: String },
 }
 
 #[derive(Subcommand)]
@@ -532,7 +540,7 @@ enum ScheduleCommands {
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
     },
-    /// Mark a schedule enabled for a later dispatcher
+    /// Enable future timed dispatch; run-now is independent
     Resume {
         target: String,
         #[arg(long, value_name = "NAME_OR_ID")]
@@ -544,6 +552,29 @@ enum ScheduleCommands {
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
     },
+    /// Dispatch one execution now, including while paused
+    Run {
+        target: String,
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+        #[arg(long, value_name = "UUID")]
+        idempotency_key: Option<Uuid>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ExecutionCommands {
+    /// List prompt-free execution records
+    List {
+        #[arg(long, value_name = "NAME_OR_ID")]
+        workspace: Option<String>,
+        #[arg(long, value_name = "SCHEDULE_NAME_OR_ID")]
+        schedule: Option<String>,
+    },
+    /// Inspect one execution by exact ID
+    Inspect { execution_id: String },
+    /// Cancel one nonterminal execution by exact ID
+    Cancel { execution_id: String },
 }
 
 #[derive(Args)]
@@ -611,7 +642,7 @@ struct ScheduleCreateArgs {
     /// Create paused, which is the default
     #[arg(long)]
     paused: bool,
-    /// Record consent for a later dispatcher; this layer does not run work
+    /// Record consent for future timed dispatch
     #[arg(long)]
     enabled: bool,
 }
@@ -862,6 +893,10 @@ command_keys! {
     SchedulePause => ("schedule.pause", Json),
     ScheduleResume => ("schedule.resume", Json),
     ScheduleRemove => ("schedule.remove", Json),
+    ScheduleRun => ("schedule.run", Json),
+    ExecutionList => ("execution.list", Json),
+    ExecutionInspect => ("execution.inspect", Json),
+    ExecutionCancel => ("execution.cancel", Json),
     Skill => ("skill", HumanOnly),
     Opencode => ("opencode", HumanOnly),
     Pi => ("pi", HumanOnly),
@@ -956,6 +991,18 @@ impl Cli {
             Some(Commands::Schedule {
                 command: ScheduleCommands::Remove { .. },
             }) => CommandKey::ScheduleRemove,
+            Some(Commands::Schedule {
+                command: ScheduleCommands::Run { .. },
+            }) => CommandKey::ScheduleRun,
+            Some(Commands::Execution {
+                command: ExecutionCommands::List { .. },
+            }) => CommandKey::ExecutionList,
+            Some(Commands::Execution {
+                command: ExecutionCommands::Inspect { .. },
+            }) => CommandKey::ExecutionInspect,
+            Some(Commands::Execution {
+                command: ExecutionCommands::Cancel { .. },
+            }) => CommandKey::ExecutionCancel,
             Some(Commands::Integration {
                 command: IntegrationCommands::List,
             }) => CommandKey::IntegrationList,
@@ -1019,6 +1066,7 @@ impl Cli {
             Some(Commands::Open { .. }) => CommandKey::Open,
             Some(Commands::Prompt) => CommandKey::Prompt,
             Some(Commands::Attach { .. }) => CommandKey::Attach,
+            Some(Commands::ScheduledRunner { .. }) => CommandKey::Attach,
         }
     }
 }
@@ -1136,6 +1184,9 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             attach::run(shell_id, *takeover, *restart_exited)?;
             return Ok(CliExit::Success);
         }
+        Some(Commands::ScheduledRunner { schedule_id }) => {
+            return scheduled_runner(schedule_id).map(CliExit::Child);
+        }
         _ => {}
     }
 
@@ -1199,6 +1250,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         }) => test_notification(reason),
         Some(Commands::Session { command }) => session_command(command, cli.json),
         Some(Commands::Schedule { command }) => schedule_command(command, cli.json),
+        Some(Commands::Execution { command }) => execution_command(command, cli.json),
         Some(Commands::Integration { command }) => integration_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
@@ -1220,6 +1272,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Prompt) => print_prompt_label(),
         Some(Commands::Daemon { command }) => daemon_control(command, cli.json),
         Some(Commands::Attach { .. }) => unreachable!(),
+        Some(Commands::ScheduledRunner { .. }) => unreachable!(),
         None => dashboard(cli.terminal.as_deref()),
     };
     result?;
@@ -2426,6 +2479,7 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "cursor_expired",
         "run_changed",
         "revision_ahead",
+        "idempotency_expired",
         "context_required",
         "ambiguous_target",
         "unsupported_integration",
@@ -3373,7 +3427,7 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
             )?;
             if !json {
                 println!(
-                    "Enabled schedule {} in durable management state; scheduled dispatch is not available yet",
+                    "Enabled schedule {} for future timed dispatch; use schedule run for explicit run-now work",
                     sanitize_table_cell(&schedule.name)
                 );
             }
@@ -3398,6 +3452,273 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
             );
             Ok(())
         }
+        ScheduleCommands::Run {
+            target,
+            workspace,
+            idempotency_key,
+        } => {
+            let feature = protocol::ProtocolFeature::ScheduledExecutions;
+            if !feature.is_supported_by(client.protocol_version()?) {
+                return Err(cli_output::failure(
+                    "unsupported_version",
+                    format!(
+                        "scheduled execution dispatch requires daemon protocol {}",
+                        feature.minimum_version()
+                    ),
+                ));
+            }
+            let snapshot = client.snapshot()?;
+            let schedule = resolve_cli_schedule(&snapshot, &target, workspace.as_deref())?;
+            let execution = client.run_agent_schedule(
+                &schedule.id,
+                idempotency_key.unwrap_or_else(Uuid::new_v4).to_string(),
+            )?;
+            print_execution(CommandKey::ScheduleRun, &execution, json)
+        }
+    }
+}
+
+fn execution_command(command: ExecutionCommands, json: bool) -> Result<(), Box<dyn Error>> {
+    let client = client::connect_or_start()?;
+    let feature = protocol::ProtocolFeature::ScheduledExecutions;
+    if !feature.is_supported_by(client.protocol_version()?) {
+        return Err(cli_output::failure(
+            "unsupported_version",
+            format!(
+                "scheduled execution inspection requires daemon protocol {}",
+                feature.minimum_version()
+            ),
+        ));
+    }
+    match command {
+        ExecutionCommands::List {
+            workspace,
+            schedule,
+        } => {
+            let snapshot = client.snapshot()?;
+            let workspace = workspace
+                .as_deref()
+                .map(|target| resolve_workspace_target(&snapshot.workspaces, target))
+                .transpose()?;
+            let schedule_id = schedule
+                .as_deref()
+                .map(|target| {
+                    resolve_cli_schedule(
+                        &snapshot,
+                        target,
+                        workspace.map(|workspace| workspace.id.as_str()),
+                    )
+                    .map(|schedule| schedule.id.clone())
+                })
+                .transpose()?;
+            let executions = client.scheduled_executions(
+                workspace.map(|workspace| workspace.id.clone()),
+                schedule_id,
+            )?;
+            if json {
+                let executions = executions
+                    .iter()
+                    .map(cli_output::execution)
+                    .collect::<Vec<_>>();
+                return print_json(
+                    CommandKey::ExecutionList,
+                    serde_json::json!({ "executions": executions }),
+                );
+            }
+            println!("STATE\tEXECUTION ID\tSCHEDULE ID\tREQUESTED\tSHELL ID\tRUN ID");
+            for execution in executions {
+                println!(
+                    "{}\t{}\t{}\t{}\t{}\t{}",
+                    execution_state(&execution),
+                    execution.id,
+                    execution.schedule_id,
+                    execution.requested_at_ms,
+                    execution.shell_id.as_deref().unwrap_or("-"),
+                    execution.run_id.as_deref().unwrap_or("-"),
+                );
+            }
+            Ok(())
+        }
+        ExecutionCommands::Inspect { execution_id } => {
+            let execution = client.get_scheduled_execution(execution_id)?;
+            print_execution(CommandKey::ExecutionInspect, &execution, json)
+        }
+        ExecutionCommands::Cancel { execution_id } => {
+            let execution = client.cancel_scheduled_execution(execution_id)?;
+            print_execution(CommandKey::ExecutionCancel, &execution, json)
+        }
+    }
+}
+
+fn print_execution(
+    command: CommandKey,
+    execution: &ScheduledExecutionSnapshot,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    if json {
+        return print_json(
+            command,
+            serde_json::json!({ "execution": cli_output::execution(execution) }),
+        );
+    }
+    println!("Execution {}", execution.id);
+    println!("State: {}", execution_state(execution));
+    println!("Schedule: {}", execution.schedule_id);
+    println!("Dispatch key: {}", execution.dispatch_key);
+    if let Some(shell_id) = &execution.shell_id {
+        println!("Shell: {shell_id}");
+    }
+    if let Some(run_id) = &execution.run_id {
+        println!("Run: {run_id}");
+    }
+    Ok(())
+}
+
+fn execution_state(execution: &ScheduledExecutionSnapshot) -> &'static str {
+    use protocol::ScheduledExecutionState::*;
+    match execution.state {
+        Claimed => "claimed",
+        Starting => "starting",
+        Active => "active",
+        DispatchFailed => "dispatch_failed",
+        Exited => "exited",
+        Cancelled => "cancelled",
+        Interrupted => "interrupted",
+    }
+}
+
+fn scheduled_runner(schedule_id: &str) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
+    let shell_id = env::var("BOOMUX_SHELL_ID")
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "BOOMUX_SHELL_ID is required"))?;
+    let run_id = env::var("BOOMUX_RUN_ID")
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "BOOMUX_RUN_ID is required"))?;
+    let runner_token = env::var("BOOMUX_SCHEDULE_RUNNER_TOKEN").map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "BOOMUX_SCHEDULE_RUNNER_TOKEN is required",
+        )
+    })?;
+    let claim = retry_runner_request(|client| {
+        client.resolve_scheduled_execution_claim(schedule_id, &shell_id, &run_id, &runner_token)
+    })?;
+    let descriptor = boomux::integrations::by_key(&claim.execution.integration)
+        .and_then(|descriptor| descriptor.schedule_dispatch)
+        .ok_or_else(|| io::Error::other("scheduled integration dispatch is unavailable"))?;
+    let dispatch = descriptor
+        .command(
+            &claim.execution.integration,
+            &claim.execution.session,
+            &claim.prompt,
+        )
+        .ok_or_else(|| io::Error::other("scheduled integration mode is unavailable"))?;
+    let mut command = Command::new(&dispatch.argv[0]);
+    command
+        .args(&dispatch.argv[1..])
+        .current_dir(&claim.execution.cwd)
+        .env_remove("BOOMUX_SCHEDULE_RUNNER_TOKEN")
+        .stdin(if dispatch.stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::inherit()
+        })
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            let _ = retry_runner_request(|client| {
+                client.report_scheduled_runner(
+                    &claim.execution.id,
+                    &shell_id,
+                    &run_id,
+                    &runner_token,
+                    ScheduledRunnerResult::SpawnFailed,
+                )
+            });
+            return Err(io::Error::new(
+                error.kind(),
+                format!("could not start scheduled host: {error}"),
+            )
+            .into());
+        }
+    };
+    if let Some(bytes) = dispatch.stdin {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| io::Error::other("scheduled host stdin is unavailable"))?;
+        if let Err(error) = std::io::Write::write_all(&mut stdin, &bytes) {
+            drop(stdin);
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = retry_runner_request(|client| {
+                client.report_scheduled_runner(
+                    &claim.execution.id,
+                    &shell_id,
+                    &run_id,
+                    &runner_token,
+                    ScheduledRunnerResult::SpawnFailed,
+                )
+            });
+            return Err(io::Error::new(
+                error.kind(),
+                format!("could not write scheduled host prompt: {error}"),
+            )
+            .into());
+        }
+        drop(stdin);
+    }
+    if let Err(error) = retry_runner_request(|client| {
+        client.report_scheduled_runner(
+            &claim.execution.id,
+            &shell_id,
+            &run_id,
+            &runner_token,
+            ScheduledRunnerResult::Active,
+        )
+    }) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+    let status = child.wait()?;
+    let (exit, outcome) = if let Some(code) = status.code() {
+        (
+            process_adapter::ProcessExit::Code(code),
+            ScheduledExecutionOutcome::ExitCode { code },
+        )
+    } else {
+        let signal = status.signal().unwrap_or(0);
+        (
+            process_adapter::ProcessExit::Signal(signal),
+            ScheduledExecutionOutcome::Signal { signal },
+        )
+    };
+    retry_runner_request(|client| {
+        client.report_scheduled_runner(
+            &claim.execution.id,
+            &shell_id,
+            &run_id,
+            &runner_token,
+            ScheduledRunnerResult::Exited {
+                outcome: outcome.clone(),
+            },
+        )
+    })?;
+    Ok(exit)
+}
+
+fn retry_runner_request<T>(
+    mut request: impl FnMut(&client::Client) -> client::Result<T>,
+) -> Result<T, Box<dyn Error>> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match client::connect().and_then(|client| request(&client)) {
+            Ok(value) => return Ok(value),
+            Err(error) if Instant::now() >= deadline => return Err(Box::new(error)),
+            Err(_) => {}
+        }
+        thread::sleep(Duration::from_millis(25));
     }
 }
 
@@ -3534,7 +3855,7 @@ fn create_schedule(
         sanitize_table_cell(&schedule.id)
     );
     if schedule.state == AgentScheduleState::Enabled {
-        println!("Scheduled dispatch is not available yet; only consent state was recorded");
+        println!("Timed dispatch is not available yet; use schedule run for explicit run-now work");
     }
     Ok(())
 }
@@ -4522,6 +4843,15 @@ fn open_dashboard_shell(
     terminal: Option<&str>,
 ) -> Result<String, Box<dyn Error>> {
     let shell = client.get_shell(shell_id)?;
+    if matches!(shell.owner, protocol::ShellOwner::Schedule { .. })
+        && shell.status != ShellStatus::Running
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "schedule-owned shell is attachable only while its execution is active",
+        )
+        .into());
+    }
     let workspace = client.get_workspace(&shell.workspace_id)?;
     open_terminal(
         shell_id,
@@ -4545,7 +4875,9 @@ fn open_workspace(
             failures.push(format!("launcher {}: {error}", launcher.name));
         }
     }
-    for shell in &workspace.shells {
+    for shell in workspace.shells.iter().filter(|shell| {
+        matches!(shell.owner, protocol::ShellOwner::User) || shell.status == ShellStatus::Running
+    }) {
         if let Err(error) = open_terminal(
             &shell.id,
             &format!("{} - {}", workspace.name, shell.name),
@@ -4617,6 +4949,15 @@ fn open_shell(
 ) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let shell = client.get_shell(shell_id)?;
+    if matches!(shell.owner, protocol::ShellOwner::Schedule { .. })
+        && shell.status != ShellStatus::Running
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "schedule-owned shell is attachable only while its execution is active",
+        )
+        .into());
+    }
     let title = title.map(str::to_owned).unwrap_or_else(|| {
         client
             .get_workspace(&shell.workspace_id)
@@ -5046,6 +5387,7 @@ mod tests {
 
     fn shell(id: &str, workspace_id: &str, name: &str) -> ShellSnapshot {
         ShellSnapshot {
+            owner: boomux::protocol::ShellOwner::User,
             id: id.into(),
             workspace_id: workspace_id.into(),
             name: name.into(),
@@ -7246,7 +7588,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 22);
+        assert_eq!(protocol::PROTOCOL_VERSION, 23);
     }
 
     #[test]
@@ -7295,6 +7637,10 @@ mod tests {
                 "schedule.pause",
                 "schedule.resume",
                 "schedule.remove",
+                "schedule.run",
+                "execution.list",
+                "execution.inspect",
+                "execution.cancel",
                 "daemon.status",
             ]
         );

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 22;
+pub const PROTOCOL_VERSION: u32 = 23;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -82,6 +82,12 @@ define_protocol_features! {
         "protocol_22",
         "agent_schedule_management",
         "durable_agent_schedules",
+    ]),
+    ScheduledExecutions => (23, "scheduled execution dispatch", [
+        "protocol_23",
+        "scheduled_execution_dispatch",
+        "scheduled_execution_cancellation",
+        "schedule_owned_shells",
     ]),
 }
 
@@ -284,6 +290,120 @@ pub struct AgentScheduleInspection {
     pub prompt: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScheduledExecutionState {
+    Claimed,
+    Starting,
+    Active,
+    DispatchFailed,
+    Exited,
+    Cancelled,
+    Interrupted,
+}
+
+impl ScheduledExecutionState {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::DispatchFailed | Self::Exited | Self::Cancelled | Self::Interrupted
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScheduledExecutionDispatchKind {
+    Manual,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScheduledExecutionReason {
+    RunnerStartFailed,
+    HostSpawnFailed,
+    CancelledByUser,
+    ColdDaemonRecovery,
+    RunnerExitedWithoutReport,
+    DaemonShutdown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ScheduledExecutionOutcome {
+    ExitCode { code: i32 },
+    Signal { signal: i32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduledExecutionSnapshot {
+    pub id: String,
+    pub workspace_id: String,
+    pub schedule_id: String,
+    pub state: ScheduledExecutionState,
+    pub dispatch_kind: ScheduledExecutionDispatchKind,
+    pub dispatch_key: String,
+    pub schedule_revision: u64,
+    pub prompt_revision: u64,
+    pub trigger_revision: u64,
+    pub requested_at_ms: u64,
+    pub started_at_ms: Option<u64>,
+    pub ended_at_ms: Option<u64>,
+    pub cwd: PathBuf,
+    pub integration: String,
+    pub session: AgentScheduleSession,
+    pub reason: Option<ScheduledExecutionReason>,
+    pub outcome: Option<ScheduledExecutionOutcome>,
+    pub shell_id: Option<String>,
+    pub run_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub external_session_id: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduledExecutionClaim {
+    pub execution: ScheduledExecutionSnapshot,
+    pub prompt: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ScheduledRunnerCapability(String);
+
+impl ScheduledRunnerCapability {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for ScheduledRunnerCapability {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("<redacted>")
+    }
+}
+
+impl std::fmt::Debug for ScheduledExecutionClaim {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ScheduledExecutionClaim")
+            .field("execution", &self.execution)
+            .field("prompt", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum ScheduledRunnerResult {
+    Active,
+    SpawnFailed,
+    Exited { outcome: ScheduledExecutionOutcome },
+}
+
 impl std::fmt::Debug for AgentScheduleInspection {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
@@ -395,11 +515,23 @@ pub struct ShellSnapshot {
     pub cwd: PathBuf,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub command: Vec<String>,
+    #[serde(default)]
+    pub owner: ShellOwner,
     pub status: ShellStatus,
     #[serde(default)]
     pub run: Option<ShellRunSnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub foreground_process: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ShellOwner {
+    #[default]
+    User,
+    Schedule {
+        schedule_id: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -444,6 +576,7 @@ pub enum ErrorCode {
     CursorExpired,
     RunChanged,
     RevisionAhead,
+    IdempotencyExpired,
     Internal,
     #[serde(other)]
     Unknown,
@@ -557,6 +690,14 @@ pub enum DaemonEventKind {
         workspace_id: String,
         schedule_id: String,
     },
+    ScheduledExecutionCreated {
+        workspace_id: String,
+        execution: ScheduledExecutionSnapshot,
+    },
+    ScheduledExecutionChanged {
+        workspace_id: String,
+        execution: ScheduledExecutionSnapshot,
+    },
     HandoffCompleted,
 }
 
@@ -644,6 +785,8 @@ pub enum Request {
     Restart,
     RestartWithNotificationConfig {
         notifications: NotificationDeliveryConfig,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        environment: Option<UnixEnvironment>,
     },
     Shutdown,
     Snapshot,
@@ -662,6 +805,15 @@ pub enum Request {
     },
     GetAgentSchedule {
         schedule_id: String,
+    },
+    ListScheduledExecutions {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        schedule_id: Option<String>,
+    },
+    GetScheduledExecution {
+        execution_id: String,
     },
     WaitAgent {
         agent_id: String,
@@ -687,6 +839,26 @@ pub enum Request {
     CreateAgentSchedule {
         workspace_id: String,
         spec: AgentScheduleSpec,
+    },
+    RunAgentSchedule {
+        schedule_id: String,
+        dispatch_key: String,
+    },
+    CancelScheduledExecution {
+        execution_id: String,
+    },
+    ResolveScheduledExecutionClaim {
+        schedule_id: String,
+        shell_id: String,
+        run_id: String,
+        runner_token: ScheduledRunnerCapability,
+    },
+    ReportScheduledRunner {
+        execution_id: String,
+        shell_id: String,
+        run_id: String,
+        runner_token: ScheduledRunnerCapability,
+        result: ScheduledRunnerResult,
     },
     RegisterAgent {
         shell_id: String,
@@ -781,6 +953,12 @@ pub enum Request {
 impl Request {
     pub fn required_feature(&self) -> Option<ProtocolFeature> {
         match self {
+            Self::ListScheduledExecutions { .. }
+            | Self::GetScheduledExecution { .. }
+            | Self::RunAgentSchedule { .. }
+            | Self::CancelScheduledExecution { .. }
+            | Self::ResolveScheduledExecutionClaim { .. }
+            | Self::ReportScheduledRunner { .. } => Some(ProtocolFeature::ScheduledExecutions),
             Self::CreateAgentSchedule { .. }
             | Self::GetAgentSchedule { .. }
             | Self::PauseAgentSchedule { .. }
@@ -795,6 +973,10 @@ impl Request {
             | Self::CreateShell {
                 workspace_id: None, ..
             } => Some(ProtocolFeature::WorkspaceDefaultCwd),
+            Self::RestartWithNotificationConfig {
+                environment: Some(_),
+                ..
+            } => Some(ProtocolFeature::ScheduledExecutions),
             Self::RestartWithNotificationConfig { .. } => {
                 Some(ProtocolFeature::RestartNotificationConfig)
             }
@@ -875,6 +1057,15 @@ pub enum Response {
     },
     AgentScheduleInspection {
         inspection: AgentScheduleInspection,
+    },
+    ScheduledExecution {
+        execution: ScheduledExecutionSnapshot,
+    },
+    ScheduledExecutions {
+        executions: Vec<ScheduledExecutionSnapshot>,
+    },
+    ScheduledExecutionClaim {
+        claim: ScheduledExecutionClaim,
     },
     AgentWait {
         agent: AgentInstanceSnapshot,
@@ -1317,8 +1508,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_twenty_two_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 22);
+    fn protocol_version_is_twenty_three_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 23);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -1417,6 +1608,68 @@ mod tests {
                 response
             );
         }
+    }
+
+    #[test]
+    fn scheduled_execution_wire_and_events_are_prompt_free() {
+        let execution = ScheduledExecutionSnapshot {
+            id: "execution-1".into(),
+            workspace_id: "workspace-1".into(),
+            schedule_id: "schedule-1".into(),
+            state: ScheduledExecutionState::Starting,
+            dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+            dispatch_key: "dispatch-1".into(),
+            schedule_revision: 3,
+            prompt_revision: 2,
+            trigger_revision: 1,
+            requested_at_ms: 10,
+            started_at_ms: None,
+            ended_at_ms: None,
+            cwd: "/tmp/project".into(),
+            integration: "opencode".into(),
+            session: AgentScheduleSession::Fresh,
+            reason: None,
+            outcome: None,
+            shell_id: Some("shell-1".into()),
+            run_id: Some("run-1".into()),
+            agent_id: None,
+            external_session_id: None,
+        };
+        let prompt = "PRIVATE EXECUTION PROMPT";
+        let claim = ScheduledExecutionClaim {
+            execution: execution.clone(),
+            prompt: prompt.into(),
+        };
+        assert!(!format!("{claim:?}").contains(prompt));
+        let event = DaemonEventKind::ScheduledExecutionChanged {
+            workspace_id: execution.workspace_id.clone(),
+            execution: execution.clone(),
+        };
+        assert!(!serde_json::to_string(&event).unwrap().contains(prompt));
+        let request = Request::RunAgentSchedule {
+            schedule_id: execution.schedule_id.clone(),
+            dispatch_key: execution.dispatch_key.clone(),
+        };
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(&request).unwrap()).unwrap(),
+            request
+        );
+        assert_eq!(
+            request.required_feature(),
+            Some(ProtocolFeature::ScheduledExecutions)
+        );
+        let capability = "PRIVATE RUNNER CAPABILITY";
+        let request = Request::ResolveScheduledExecutionClaim {
+            schedule_id: execution.schedule_id,
+            shell_id: execution.shell_id.unwrap(),
+            run_id: execution.run_id.unwrap(),
+            runner_token: ScheduledRunnerCapability::new(capability),
+        };
+        assert!(!format!("{request:?}").contains(capability));
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(&request).unwrap()).unwrap(),
+            request
+        );
     }
 
     #[test]
@@ -1621,6 +1874,7 @@ mod tests {
                         resume_agents: true,
                         persist_terminal_history: false,
                     },
+                    environment: None,
                 }],
             ),
             (
@@ -1868,6 +2122,15 @@ mod tests {
                     "durable_agent_schedules",
                 ][..],
             ),
+            (
+                23,
+                &[
+                    "protocol_23",
+                    "scheduled_execution_dispatch",
+                    "scheduled_execution_cancellation",
+                    "schedule_owned_shells",
+                ][..],
+            ),
         ];
 
         let actual = ProtocolFeature::ALL
@@ -2101,6 +2364,7 @@ mod tests {
             name: "shell".into(),
             cwd: "/tmp".into(),
             command: vec!["sleep".into(), "1".into()],
+            owner: ShellOwner::User,
             status: ShellStatus::Running,
             run: Some(ShellRunSnapshot {
                 id: "r1".into(),

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -358,6 +358,7 @@ mod tests {
 
     fn workspace(id: &str, agent_ids: &[&str]) -> WorkspaceSnapshot {
         let shell = boomux::protocol::ShellSnapshot {
+            owner: boomux::protocol::ShellOwner::User,
             id: "shell".into(),
             workspace_id: id.into(),
             name: "agent".into(),

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -13,11 +13,13 @@ use uuid::Uuid;
 
 use crate::protocol::{
     AgentAttentionSnapshot, AgentObservationSnapshot, AgentScheduleOverlapPolicy,
-    AgentScheduleSession, AgentScheduleState, AgentScheduleTrigger, ShellRunExitReason,
-    TerminalProfile,
+    AgentScheduleSession, AgentScheduleState, AgentScheduleTrigger, ScheduledExecutionDispatchKind,
+    ScheduledExecutionOutcome, ScheduledExecutionReason, ScheduledExecutionState, ShellOwner,
+    ShellRunExitReason, TerminalProfile,
 };
 
-const STATE_VERSION: u32 = 9;
+const STATE_VERSION: u32 = 10;
+const VERSION_NINE_STATE_VERSION: u32 = 9;
 const VERSION_EIGHT_STATE_VERSION: u32 = 8;
 const VERSION_SEVEN_STATE_VERSION: u32 = 7;
 const PREVIOUS_STATE_VERSION: u32 = 6;
@@ -27,6 +29,7 @@ const VERSION_THREE_STATE_VERSION: u32 = 3;
 const VERSION_TWO_STATE_VERSION: u32 = 2;
 const LEGACY_STATE_VERSION: u32 = 1;
 const MAX_STATE_BYTES: u64 = 8 * 1024 * 1024;
+const DISPATCH_KEY_FILTER_BYTES: usize = 2048;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -75,6 +78,46 @@ pub(crate) struct PersistedAgentSchedule {
     pub(crate) updated_at_ms: u64,
     pub(crate) evaluation_frontier_ms: u64,
     pub(crate) execution_shell_id: Option<String>,
+    pub(crate) dispatch_key_filter: Vec<u8>,
+    pub(crate) executions: Vec<PersistedScheduledExecution>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PersistedScheduledExecution {
+    pub(crate) id: String,
+    pub(crate) state: ScheduledExecutionState,
+    pub(crate) dispatch_kind: ScheduledExecutionDispatchKind,
+    pub(crate) dispatch_key: String,
+    pub(crate) schedule_revision: u64,
+    pub(crate) prompt_revision: u64,
+    pub(crate) trigger_revision: u64,
+    pub(crate) requested_at_ms: u64,
+    pub(crate) started_at_ms: Option<u64>,
+    pub(crate) ended_at_ms: Option<u64>,
+    pub(crate) cwd: PathBuf,
+    pub(crate) integration: String,
+    pub(crate) session: AgentScheduleSession,
+    pub(crate) prompt: String,
+    pub(crate) runner_token: String,
+    pub(crate) reason: Option<ScheduledExecutionReason>,
+    pub(crate) outcome: Option<ScheduledExecutionOutcome>,
+    pub(crate) shell_id: Option<String>,
+    pub(crate) run_id: Option<String>,
+    pub(crate) agent_id: Option<String>,
+    pub(crate) external_session_id: Option<String>,
+}
+
+impl std::fmt::Debug for PersistedScheduledExecution {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PersistedScheduledExecution")
+            .field("id", &self.id)
+            .field("state", &self.state)
+            .field("dispatch_key", &self.dispatch_key)
+            .field("prompt", &"<redacted>")
+            .finish_non_exhaustive()
+    }
 }
 
 impl std::fmt::Debug for PersistedAgentSchedule {
@@ -97,6 +140,7 @@ impl std::fmt::Debug for PersistedAgentSchedule {
             .field("updated_at_ms", &self.updated_at_ms)
             .field("evaluation_frontier_ms", &self.evaluation_frontier_ms)
             .field("execution_shell_id", &self.execution_shell_id)
+            .field("executions", &self.executions)
             .finish()
     }
 }
@@ -133,7 +177,68 @@ pub(crate) struct PersistedShell {
     pub(crate) name: String,
     pub(crate) cwd: PathBuf,
     pub(crate) command: Vec<String>,
+    pub(crate) owner: ShellOwner,
     pub(crate) last_run: Option<PersistedShellRun>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PreOwnershipPersistedShell {
+    id: String,
+    name: String,
+    cwd: PathBuf,
+    command: Vec<String>,
+    last_run: Option<PersistedShellRun>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionNinePersistedState {
+    version: u32,
+    workspaces: Vec<VersionNinePersistedWorkspace>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionNinePersistedWorkspace {
+    id: String,
+    name: String,
+    default_cwd: Option<PathBuf>,
+    shells: Vec<VersionNinePersistedShell>,
+    launchers: Vec<PersistedWorkspaceLauncher>,
+    agents: Vec<PersistedAgentInstance>,
+    schedules: Vec<VersionNinePersistedAgentSchedule>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionNinePersistedShell {
+    id: String,
+    name: String,
+    cwd: PathBuf,
+    command: Vec<String>,
+    last_run: Option<PersistedShellRun>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionNinePersistedAgentSchedule {
+    id: String,
+    name: String,
+    cwd: PathBuf,
+    integration: String,
+    prompt: String,
+    session: AgentScheduleSession,
+    trigger: AgentScheduleTrigger,
+    state: AgentScheduleState,
+    overlap_policy: AgentScheduleOverlapPolicy,
+    revision: u64,
+    prompt_revision: u64,
+    trigger_revision: u64,
+    created_at_ms: u64,
+    updated_at_ms: u64,
+    evaluation_frontier_ms: u64,
+    execution_shell_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -169,7 +274,7 @@ struct VersionEightPersistedWorkspace {
     id: String,
     name: String,
     default_cwd: Option<PathBuf>,
-    shells: Vec<PersistedShell>,
+    shells: Vec<PreOwnershipPersistedShell>,
     launchers: Vec<PersistedWorkspaceLauncher>,
     agents: Vec<PersistedAgentInstance>,
 }
@@ -227,7 +332,7 @@ struct PreviousPersistedState {
 struct PreviousPersistedWorkspace {
     id: String,
     name: String,
-    shells: Vec<PersistedShell>,
+    shells: Vec<PreOwnershipPersistedShell>,
     launchers: Vec<PersistedWorkspaceLauncher>,
     agents: Vec<PersistedAgentInstance>,
 }
@@ -244,7 +349,7 @@ struct VersionFivePersistedState {
 struct VersionFivePersistedWorkspace {
     id: String,
     name: String,
-    shells: Vec<PersistedShell>,
+    shells: Vec<PreOwnershipPersistedShell>,
     launchers: Vec<PersistedWorkspaceLauncher>,
     agents: Vec<PreviousPersistedAgentInstance>,
 }
@@ -276,7 +381,7 @@ struct VersionFourPersistedState {
 struct VersionFourPersistedWorkspace {
     id: String,
     name: String,
-    shells: Vec<PersistedShell>,
+    shells: Vec<PreOwnershipPersistedShell>,
     launchers: Vec<PersistedWorkspaceLauncher>,
     agents: Vec<VersionFourPersistedAgentInstance>,
 }
@@ -307,7 +412,7 @@ struct VersionThreePersistedState {
 struct VersionThreePersistedWorkspace {
     id: String,
     name: String,
-    shells: Vec<PersistedShell>,
+    shells: Vec<PreOwnershipPersistedShell>,
     launchers: Vec<PersistedWorkspaceLauncher>,
 }
 
@@ -323,7 +428,7 @@ struct VersionTwoPersistedState {
 struct VersionTwoPersistedWorkspace {
     id: String,
     name: String,
-    shells: Vec<PersistedShell>,
+    shells: Vec<PreOwnershipPersistedShell>,
 }
 
 #[derive(Deserialize)]
@@ -476,6 +581,10 @@ impl StateStore {
         })?;
         let (state, migrated) = match version.version {
             STATE_VERSION => (parse_state(&bytes, &self.path)?, false),
+            VERSION_NINE_STATE_VERSION => {
+                let previous: VersionNinePersistedState = parse_state(&bytes, &self.path)?;
+                (migrate_version_nine_state(previous), true)
+            }
             VERSION_EIGHT_STATE_VERSION => {
                 let previous: VersionEightPersistedState = parse_state(&bytes, &self.path)?;
                 (migrate_version_eight_state(previous), true)
@@ -585,6 +694,7 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
                         name: shell.name,
                         cwd: shell.cwd,
                         command: shell.command,
+                        owner: ShellOwner::User,
                         last_run: shell.last_profile.map(|profile| PersistedShellRun {
                             id: Uuid::new_v4().to_string(),
                             generation: 1,
@@ -606,6 +716,71 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
     }
 }
 
+fn migrate_version_nine_state(previous: VersionNinePersistedState) -> PersistedState {
+    debug_assert_eq!(previous.version, VERSION_NINE_STATE_VERSION);
+    PersistedState {
+        version: STATE_VERSION,
+        workspaces: previous
+            .workspaces
+            .into_iter()
+            .map(|workspace| PersistedWorkspace {
+                id: workspace.id,
+                name: workspace.name,
+                default_cwd: workspace.default_cwd,
+                shells: workspace
+                    .shells
+                    .into_iter()
+                    .map(|shell| PersistedShell {
+                        id: shell.id,
+                        name: shell.name,
+                        cwd: shell.cwd,
+                        command: shell.command,
+                        owner: ShellOwner::User,
+                        last_run: shell.last_run,
+                    })
+                    .collect(),
+                launchers: workspace.launchers,
+                agents: workspace.agents,
+                schedules: workspace
+                    .schedules
+                    .into_iter()
+                    .map(|schedule| PersistedAgentSchedule {
+                        id: schedule.id,
+                        name: schedule.name,
+                        cwd: schedule.cwd,
+                        integration: schedule.integration,
+                        prompt: schedule.prompt,
+                        session: schedule.session,
+                        trigger: schedule.trigger,
+                        state: schedule.state,
+                        overlap_policy: schedule.overlap_policy,
+                        revision: schedule.revision,
+                        prompt_revision: schedule.prompt_revision,
+                        trigger_revision: schedule.trigger_revision,
+                        created_at_ms: schedule.created_at_ms,
+                        updated_at_ms: schedule.updated_at_ms,
+                        evaluation_frontier_ms: schedule.evaluation_frontier_ms,
+                        execution_shell_id: schedule.execution_shell_id,
+                        dispatch_key_filter: vec![0; DISPATCH_KEY_FILTER_BYTES],
+                        executions: Vec::new(),
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }
+}
+
+fn migrate_pre_ownership_shell(shell: PreOwnershipPersistedShell) -> PersistedShell {
+    PersistedShell {
+        id: shell.id,
+        name: shell.name,
+        cwd: shell.cwd,
+        command: shell.command,
+        owner: ShellOwner::User,
+        last_run: shell.last_run,
+    }
+}
+
 fn migrate_version_eight_state(previous: VersionEightPersistedState) -> PersistedState {
     debug_assert_eq!(previous.version, VERSION_EIGHT_STATE_VERSION);
     PersistedState {
@@ -617,7 +792,11 @@ fn migrate_version_eight_state(previous: VersionEightPersistedState) -> Persiste
                 id: workspace.id,
                 name: workspace.name,
                 default_cwd: workspace.default_cwd,
-                shells: workspace.shells,
+                shells: workspace
+                    .shells
+                    .into_iter()
+                    .map(migrate_pre_ownership_shell)
+                    .collect(),
                 launchers: workspace.launchers,
                 agents: workspace.agents,
                 schedules: Vec::new(),
@@ -645,6 +824,7 @@ fn migrate_version_seven_state(previous: VersionSevenPersistedState) -> Persiste
                         name: shell.name,
                         cwd: shell.cwd,
                         command: shell.command,
+                        owner: ShellOwner::User,
                         last_run: shell.last_run.map(|run| PersistedShellRun {
                             id: run.id,
                             generation: run.generation,
@@ -677,7 +857,11 @@ fn migrate_previous_state(previous: PreviousPersistedState) -> PersistedState {
                 id: workspace.id,
                 name: workspace.name,
                 default_cwd: None,
-                shells: workspace.shells,
+                shells: workspace
+                    .shells
+                    .into_iter()
+                    .map(migrate_pre_ownership_shell)
+                    .collect(),
                 launchers: workspace.launchers,
                 agents: workspace.agents,
                 schedules: Vec::new(),
@@ -697,7 +881,11 @@ fn migrate_version_five_state(previous: VersionFivePersistedState) -> PersistedS
                 id: workspace.id,
                 name: workspace.name,
                 default_cwd: None,
-                shells: workspace.shells,
+                shells: workspace
+                    .shells
+                    .into_iter()
+                    .map(migrate_pre_ownership_shell)
+                    .collect(),
                 launchers: workspace.launchers,
                 agents: workspace
                     .agents
@@ -739,7 +927,11 @@ fn migrate_version_four_state(previous: VersionFourPersistedState) -> PersistedS
                     id: workspace.id,
                     name: workspace.name,
                     default_cwd: None,
-                    shells: workspace.shells,
+                    shells: workspace
+                        .shells
+                        .into_iter()
+                        .map(migrate_pre_ownership_shell)
+                        .collect(),
                     launchers: workspace.launchers,
                     agents: workspace
                         .agents
@@ -776,7 +968,11 @@ fn migrate_version_three_state(previous: VersionThreePersistedState) -> Persiste
                 id: workspace.id,
                 name: workspace.name,
                 default_cwd: None,
-                shells: workspace.shells,
+                shells: workspace
+                    .shells
+                    .into_iter()
+                    .map(migrate_pre_ownership_shell)
+                    .collect(),
                 launchers: workspace.launchers,
                 agents: Vec::new(),
                 schedules: Vec::new(),
@@ -796,7 +992,11 @@ fn migrate_version_two_state(previous: VersionTwoPersistedState) -> PersistedSta
                 id: workspace.id,
                 name: workspace.name,
                 default_cwd: None,
-                shells: workspace.shells,
+                shells: workspace
+                    .shells
+                    .into_iter()
+                    .map(migrate_pre_ownership_shell)
+                    .collect(),
                 launchers: Vec::new(),
                 agents: Vec::new(),
                 schedules: Vec::new(),
@@ -869,6 +1069,7 @@ mod tests {
                     name: "agent".into(),
                     cwd: "/tmp/project".into(),
                     command: vec!["opencode".into()],
+                    owner: ShellOwner::User,
                     last_run: Some(PersistedShellRun {
                         id: "run-1".into(),
                         generation: 1,
@@ -978,6 +1179,8 @@ mod tests {
                     updated_at_ms: 50,
                     evaluation_frontier_ms: 60,
                     execution_shell_id: Some("shell-1".into()),
+                    dispatch_key_filter: vec![0; DISPATCH_KEY_FILTER_BYTES],
+                    executions: Vec::new(),
                 }],
             }],
         };
@@ -1138,7 +1341,44 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 9")
+                .contains("\"version\": 10")
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_nine_shell_ownership_and_empty_execution_history() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"{
+              "version": 9,
+              "workspaces": [{
+                "id": "workspace-1", "name": "saved", "default_cwd": null,
+                "shells": [{"id":"shell-1","name":"shell","cwd":"/tmp","command":[],"last_run":null}],
+                "launchers": [], "agents": [],
+                "schedules": [{
+                  "id":"schedule-1","name":"review","cwd":"/tmp","integration":"opencode",
+                  "prompt":"private prompt","session":"fresh",
+                  "trigger":{"cron":"0 9 * * *","timezone":"UTC"},"state":"paused",
+                  "overlap_policy":"skip","revision":1,"prompt_revision":1,"trigger_revision":1,
+                  "created_at_ms":1,"updated_at_ms":1,"evaluation_frontier_ms":1,
+                  "execution_shell_id":null
+                }]
+              }]
+            }"#,
+        )
+        .unwrap();
+
+        let migrated = StateStore::at(path.clone()).load().unwrap().unwrap();
+        assert_eq!(migrated.workspaces[0].shells[0].owner, ShellOwner::User);
+        assert!(migrated.workspaces[0].schedules[0].executions.is_empty());
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("\"version\": 10")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1181,7 +1421,7 @@ mod tests {
             fs::write(
                 &path,
                 format!(
-                    r#"{{"version":9,"workspaces":[{{"id":"w1","name":"saved","default_cwd":null,"shells":[],"launchers":[],"agents":[],"schedules":[{schedule}]}}]}}"#
+                    r#"{{"version":10,"workspaces":[{{"id":"w1","name":"saved","default_cwd":null,"shells":[],"launchers":[],"agents":[],"schedules":[{schedule}]}}]}}"#
                 ),
             )
             .unwrap();
@@ -1237,7 +1477,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 9")
+                .contains("\"version\": 10")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1293,7 +1533,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 9")
+                .contains("\"version\": 10")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
         assert!(migrated.workspaces[0].agents.is_empty());
@@ -1344,7 +1584,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 9")
+                .contains("\"version\": 10")
         );
         assert!(migrated.workspaces[0].agents.is_empty());
         assert!(migrated.workspaces[0].schedules.is_empty());
@@ -1384,7 +1624,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 9")
+                .contains("\"version\": 10")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1461,7 +1701,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 9")
+                .contains("\"version\": 10")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1497,7 +1737,7 @@ mod tests {
         assert!(migrated.workspaces[0].agents[0].attention.is_none());
         assert!(migrated.workspaces[0].schedules.is_empty());
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 9"));
+        assert!(saved.contains("\"version\": 10"));
         assert!(saved.contains("\"attention\": null"));
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1530,7 +1770,7 @@ mod tests {
         assert!(!original.contains("default_cwd"));
         store.save(&migrated).unwrap();
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 9"));
+        assert!(saved.contains("\"version\": 10"));
         assert!(saved.contains("\"default_cwd\": null"));
         fs::remove_dir_all(directory).unwrap();
     }

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -25,7 +25,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 22);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 23);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -88,6 +88,7 @@ fn native_daemon_lifecycle() {
         "protocol_20",
         "protocol_21",
         "protocol_22",
+        "protocol_23",
         "agent_schedule_management",
         "durable_agent_schedules",
         "workspace_default_cwd",
@@ -114,7 +115,7 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 22"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 23"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])

--- a/tests/native_backend/handoff.rs
+++ b/tests/native_backend/handoff.rs
@@ -140,7 +140,7 @@ fn focused_attachment_is_exposed_in_daemon_snapshots() {
         .unwrap();
     let shell_id = workspace.shells[0].id.clone();
     let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    assert_eq!(attachment.protocol_version, 22);
+    assert_eq!(attachment.protocol_version, 23);
 
     AttachFrame::FocusGained
         .write_to(&mut attachment.stream)

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -101,7 +101,10 @@ fn workspace_launchers_persist_emit_events_and_open_without_shells() {
         "launcher-only workspace failed to open: {}",
         String::from_utf8_lossy(&opened.stderr)
     );
-    wait_until(|| output.is_file(), "workspace launcher did not run");
+    wait_until(
+        || fs::metadata(&output).is_ok_and(|metadata| metadata.len() > 0),
+        "workspace launcher did not run",
+    );
     assert_eq!(
         fs::read_to_string(&output).unwrap(),
         format!(

--- a/tests/native_backend/notifications.rs
+++ b/tests/native_backend/notifications.rs
@@ -145,9 +145,19 @@ fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
     )
     .unwrap();
     drop(attachment.stream);
+    let mut restart_paths = vec![notify_send.parent().unwrap().to_path_buf()];
+    restart_paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
     let restart = daemon
         .command()
         .env("BOOMUX_CONFIG", replacement_config)
+        .env("BOOMUX_NOTIFICATION_CAPTURE", &capture)
+        .env("BOOMUX_SOUND_CAPTURE", &sound_capture)
+        .env("BOOMUX_NOTIFICATION_HANG", &hang)
+        .env("BOOMUX_NOTIFICATION_PID", &notification_pid)
+        .env("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent")
+        .env("PATH", std::env::join_paths(restart_paths).unwrap())
         .args(["daemon", "restart"])
         .output()
         .unwrap();

--- a/tests/native_backend/schedules.rs
+++ b/tests/native_backend/schedules.rs
@@ -1,11 +1,17 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
+use std::thread;
 
+use boomux::client::Client;
 use boomux::protocol::{
-    self, AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSpec, AgentScheduleState,
-    AgentScheduleTrigger,
+    self, AgentAuthority, AgentRegistrationSpec, AgentReport, AgentScheduleOverlapPolicy,
+    AgentScheduleSession, AgentScheduleSpec, AgentScheduleState, AgentScheduleTrigger, AgentState,
+    ScheduledExecutionState, ShellSpec,
 };
+use uuid::Uuid;
 
-use crate::support::{TestDaemon, assert_remote_code};
+use crate::support::{TestDaemon, assert_remote_code, process_exists, profile, wait_until};
 
 fn schedule_spec(daemon: &TestDaemon, name: &str, prompt: &str) -> AgentScheduleSpec {
     AgentScheduleSpec {
@@ -317,4 +323,1814 @@ fn versioned_request(
         protocol::read_message(&mut stream).unwrap();
     assert_eq!(response.version, version);
     response.message
+}
+
+#[test]
+fn manual_execution_succeeds_and_duplicate_key_never_spawns_twice() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf '%s\\0' \"$@\" > \"$BOOMUX_ARGV_CAPTURE\"\nprintf '%s' \"$PWD\" > \"$BOOMUX_CWD_CAPTURE\"\nprintf '%s|%s|%s' \"${BOOMUX_SCHEDULE_RUNNER_TOKEN-unset}\" \"${BOOMUX_DISPATCH_ENV-unset}\" \"${BOOMUX_NATIVE_TEST_HOOKS-unset}\" > \"$BOOMUX_ENV_CAPTURE\"\nprintf 'spawn\\n' >> \"$BOOMUX_EXECUTION_CAPTURE\"\nexit 0\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_EXECUTION_CAPTURE", runtime_dir.join("executions"))
+            .env("BOOMUX_ARGV_CAPTURE", runtime_dir.join("argv"))
+            .env("BOOMUX_CWD_CAPTURE", runtime_dir.join("cwd"))
+            .env("BOOMUX_ENV_CAPTURE", runtime_dir.join("environment"))
+            .env("BOOMUX_DISPATCH_ENV", "daemon-start");
+    });
+    let capture = daemon.runtime_dir.join("executions");
+    let workspace = daemon
+        .client
+        .create_workspace("run-now", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "manual", "exact prompt"),
+        )
+        .unwrap();
+    let protocol::Response::Events {
+        cursor: protocol_22_cursor,
+        ..
+    } = versioned_request(
+        &daemon,
+        22,
+        protocol::Request::Events {
+            after: None,
+            limit: 256,
+            wait_ms: 0,
+        },
+    )
+    else {
+        panic!("expected protocol-22 event baseline");
+    };
+    let event_cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let key = Uuid::new_v4().to_string();
+    let first = daemon
+        .client
+        .run_agent_schedule(&schedule.id, &key)
+        .unwrap();
+    let duplicate = daemon
+        .client
+        .run_agent_schedule(&schedule.id, &key)
+        .unwrap();
+    assert_eq!(first.id, duplicate.id);
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&first.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
+        },
+        "scheduled execution did not exit",
+    );
+    assert_eq!(fs::read_to_string(&capture).unwrap(), "spawn\n");
+    assert_eq!(
+        fs::read(daemon.runtime_dir.join("argv")).unwrap(),
+        b"run\0--\0exact prompt\0"
+    );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("cwd")).unwrap(),
+        daemon.runtime_dir.display().to_string()
+    );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("environment")).unwrap(),
+        "unset|daemon-start|unset"
+    );
+    let event_page = daemon.client.events(Some(event_cursor), 256, 0).unwrap();
+    assert!(
+        !serde_json::to_string(&event_page.events)
+            .unwrap()
+            .contains("exact prompt")
+    );
+    let created = event_page
+        .events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.kind,
+                protocol::DaemonEventKind::ScheduledExecutionCreated { execution, .. }
+                    if execution.id == first.id
+            )
+        })
+        .unwrap();
+    let run_started = event_page
+        .events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.kind,
+                protocol::DaemonEventKind::RunStarted { run, .. }
+                    if Some(run.id.as_str()) == first.run_id.as_deref()
+            )
+        })
+        .unwrap();
+    let active = event_page
+        .events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.kind,
+                protocol::DaemonEventKind::ScheduledExecutionChanged { execution, .. }
+                    if execution.id == first.id
+                        && execution.state == ScheduledExecutionState::Active
+            )
+        })
+        .unwrap();
+    let run_exited = event_page
+        .events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.kind,
+                protocol::DaemonEventKind::RunExited { run, .. }
+                    if Some(run.id.as_str()) == first.run_id.as_deref()
+            )
+        })
+        .unwrap();
+    let exited = event_page
+        .events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.kind,
+                protocol::DaemonEventKind::ScheduledExecutionChanged { execution, .. }
+                    if execution.id == first.id
+                        && execution.state == ScheduledExecutionState::Exited
+            )
+        })
+        .unwrap();
+    assert!(
+        created < run_started && run_started < active && active < run_exited && run_exited < exited
+    );
+    let second = daemon
+        .command()
+        .args([
+            "schedule",
+            "run",
+            &schedule.id,
+            "--idempotency-key",
+            &Uuid::new_v4().to_string(),
+            "--json",
+        ])
+        .env("BOOMUX_DISPATCH_ENV", "run-client")
+        .output()
+        .unwrap();
+    assert!(second.status.success());
+    let second: serde_json::Value = serde_json::from_slice(&second.stdout).unwrap();
+    let second_id = second["data"]["execution"]["id"].as_str().unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(second_id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
+        },
+        "second environment execution did not exit",
+    );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("environment")).unwrap(),
+        "unset|daemon-start|unset"
+    );
+    let shell = daemon
+        .client
+        .get_shell(first.shell_id.as_ref().unwrap())
+        .unwrap();
+    assert_eq!(shell.command.len(), 3);
+    assert!(!shell.command.join(" ").contains("exact prompt"));
+    assert!(matches!(
+        shell.owner,
+        protocol::ShellOwner::Schedule { ref schedule_id } if schedule_id == &schedule.id
+    ));
+    let protocol::Response::Snapshot { snapshot } =
+        versioned_request(&daemon, 22, protocol::Request::Snapshot)
+    else {
+        panic!("expected protocol-22 snapshot");
+    };
+    assert!(snapshot.workspaces[0].shells.is_empty());
+    assert!(
+        snapshot.workspaces[0].schedules[0]
+            .execution_shell_id
+            .is_none()
+    );
+    let protocol::Response::Error { code, .. } = versioned_request(
+        &daemon,
+        22,
+        protocol::Request::GetShell {
+            shell_id: shell.id.clone(),
+        },
+    ) else {
+        panic!("expected protocol-22 schedule shell to be hidden");
+    };
+    assert_eq!(code, Some(protocol::ErrorCode::NotFound));
+    let protocol::Response::Events { cursor, events, .. } = versioned_request(
+        &daemon,
+        22,
+        protocol::Request::Events {
+            after: Some(protocol_22_cursor.clone()),
+            limit: 256,
+            wait_ms: 0,
+        },
+    ) else {
+        panic!("expected protocol-22 event page");
+    };
+    assert!(cursor.event_id > protocol_22_cursor.event_id);
+    assert!(!events.iter().any(|event| matches!(
+        event.kind,
+        protocol::DaemonEventKind::ShellCreated { .. }
+            | protocol::DaemonEventKind::RunStarted { .. }
+            | protocol::DaemonEventKind::OutputChanged { .. }
+            | protocol::DaemonEventKind::RunExited { .. }
+            | protocol::DaemonEventKind::ScheduledExecutionCreated { .. }
+            | protocol::DaemonEventKind::ScheduledExecutionChanged { .. }
+    )));
+    assert_remote_code(
+        &daemon
+            .client
+            .rename_shell(&shell.id, "renamed")
+            .unwrap_err(),
+        protocol::ErrorCode::Busy,
+    );
+    assert_remote_code(
+        &daemon.client.close_shell(&shell.id).unwrap_err(),
+        protocol::ErrorCode::Busy,
+    );
+    assert_remote_code(
+        &daemon.client.restart_shell(&shell.id).unwrap_err(),
+        protocol::ErrorCode::Busy,
+    );
+    daemon.client.remove_agent_schedule(&schedule.id).unwrap();
+    assert!(daemon.client.get_shell(&shell.id).is_err());
+    let protocol::Response::Events { events, .. } = versioned_request(
+        &daemon,
+        22,
+        protocol::Request::Events {
+            after: Some(protocol_22_cursor),
+            limit: 256,
+            wait_ms: 0,
+        },
+    ) else {
+        panic!("expected historical protocol-22 event page");
+    };
+    assert!(!events.iter().any(|event| {
+        matches!(
+            event.kind,
+            protocol::DaemonEventKind::ShellCreated { .. }
+                | protocol::DaemonEventKind::RunStarted { .. }
+                | protocol::DaemonEventKind::OutputChanged { .. }
+                | protocol::DaemonEventKind::RunExited { .. }
+        )
+    }));
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn pi_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("pi");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf '%s\\0' \"$@\" > \"$BOOMUX_PI_ARGV_DIR/$BOOMUX_PI_CASE\"\ncat > \"$BOOMUX_PI_STDIN_DIR/$BOOMUX_PI_CASE\"\nprintf '%s' \"${BOOMUX_SCHEDULE_RUNNER_TOKEN-unset}\" > \"$BOOMUX_PI_TOKEN_DIR/$BOOMUX_PI_CASE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        for directory in ["pi-argv", "pi-stdin", "pi-token"] {
+            fs::create_dir(runtime_dir.join(directory)).unwrap();
+        }
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_PI_ARGV_DIR", runtime_dir.join("pi-argv"))
+            .env("BOOMUX_PI_STDIN_DIR", runtime_dir.join("pi-stdin"))
+            .env("BOOMUX_PI_TOKEN_DIR", runtime_dir.join("pi-token"))
+            .env("BOOMUX_PI_CASE", "fresh");
+    });
+    let workspace = daemon.client.create_workspace("pi", Vec::new()).unwrap();
+    let prompt = "-@leading\nsecond line\n";
+    let mut fresh_spec = schedule_spec(&daemon, "pi-fresh", prompt);
+    fresh_spec.integration = "pi".into();
+    let fresh = daemon
+        .client
+        .create_agent_schedule(&workspace.id, fresh_spec)
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&fresh.id, Uuid::new_v4().to_string())
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
+        },
+        "fresh Pi execution did not exit",
+    );
+    assert_eq!(
+        fs::read(daemon.runtime_dir.join("pi-argv/fresh")).unwrap(),
+        b"--print\0"
+    );
+    assert_eq!(
+        fs::read(daemon.runtime_dir.join("pi-stdin/fresh")).unwrap(),
+        prompt.as_bytes()
+    );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("pi-token/fresh")).unwrap(),
+        "unset"
+    );
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .env("PATH", {
+            let mut paths = vec![daemon.runtime_dir.join("bin")];
+            paths.extend(std::env::split_paths(
+                &std::env::var_os("PATH").unwrap_or_default(),
+            ));
+            std::env::join_paths(paths).unwrap()
+        })
+        .env("BOOMUX_PI_ARGV_DIR", daemon.runtime_dir.join("pi-argv"))
+        .env("BOOMUX_PI_STDIN_DIR", daemon.runtime_dir.join("pi-stdin"))
+        .env("BOOMUX_PI_TOKEN_DIR", daemon.runtime_dir.join("pi-token"))
+        .env("BOOMUX_PI_CASE", "continue")
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    let external_id = "exact-pi-session";
+    let mut continuation_spec = schedule_spec(&daemon, "pi-continue", "continued");
+    continuation_spec.integration = "pi".into();
+    continuation_spec.session = AgentScheduleSession::Continue {
+        external_session_id: external_id.into(),
+    };
+    let continuation = daemon
+        .client
+        .create_agent_schedule(&workspace.id, continuation_spec)
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&continuation.id, Uuid::new_v4().to_string())
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
+        },
+        "continued Pi execution did not exit",
+    );
+    assert_eq!(
+        fs::read(daemon.runtime_dir.join("pi-argv/continue")).unwrap(),
+        b"--session\0exact-pi-session\0--print\0"
+    );
+    assert_eq!(
+        fs::read(daemon.runtime_dir.join("pi-stdin/continue")).unwrap(),
+        b"continued"
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn inactive_agent_does_not_block_exact_continuation_dispatch() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(&host, "#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command.env("PATH", std::env::join_paths(paths).unwrap());
+    });
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "inactive-continuation",
+            vec![ShellSpec {
+                name: "user".into(),
+                cwd: daemon.runtime_dir.clone(),
+                command: vec!["/bin/sh".into(), "-c".into(), "sleep 30".into()],
+            }],
+        )
+        .unwrap();
+    let attachment = daemon
+        .client
+        .attach(&workspace.shells[0].id, false, profile())
+        .unwrap();
+    let run_id = daemon
+        .client
+        .get_shell(&workspace.shells[0].id)
+        .unwrap()
+        .run
+        .unwrap()
+        .id;
+    daemon
+        .client
+        .register_agent(
+            &workspace.shells[0].id,
+            run_id,
+            AgentRegistrationSpec {
+                name: "inactive".into(),
+                integration: "opencode".into(),
+                external_session_id: Some("continued-session".into()),
+                report: AgentReport {
+                    state: AgentState::Inactive,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "inactive".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    let mut spec = schedule_spec(&daemon, "continue-inactive", "continue");
+    spec.session = AgentScheduleSession::Continue {
+        external_session_id: "continued-session".into(),
+    };
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, spec)
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
+        },
+        "inactive Agent incorrectly blocked continuation",
+    );
+    drop(attachment.stream);
+    daemon.client.close_workspace(&workspace.id).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn linked_agents_remain_authoritative_after_exit_and_late_ensure_repairs_links() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nif [ ! -e \"$BOOMUX_FIRST_AGENT\" ]; then\n  : > \"$BOOMUX_FIRST_AGENT\"\n  \"$BOOMUX_TEST_EXECUTABLE\" agent ensure scheduled --integration opencode --external-session-id linked-session --state working --authority lifecycle-integration --evidence running --confidence 100 >/dev/null\nfi\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_TEST_EXECUTABLE", env!("CARGO_BIN_EXE_boomux"))
+            .env("BOOMUX_FIRST_AGENT", runtime_dir.join("first-agent"));
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("agent-link", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "agent-link", "private"),
+        )
+        .unwrap();
+    let cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let first = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&first.id)
+                .is_ok_and(|execution| {
+                    execution.state == ScheduledExecutionState::Exited
+                        && execution.agent_id.is_some()
+                })
+        },
+        "first execution did not exit with an Agent link",
+    );
+    let first = daemon.client.get_scheduled_execution(&first.id).unwrap();
+    let agent = daemon
+        .client
+        .get_agent(first.agent_id.as_ref().unwrap())
+        .unwrap();
+    assert_eq!(agent.observation.state, AgentState::Working);
+    assert!(agent.ended_at_ms.is_none());
+
+    let second = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&second.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
+        },
+        "second execution did not exit",
+    );
+    let second = daemon.client.get_scheduled_execution(&second.id).unwrap();
+    assert!(second.agent_id.is_none());
+    let late = daemon
+        .client
+        .ensure_agent(
+            second.shell_id.clone().unwrap(),
+            second.run_id.clone().unwrap(),
+            AgentRegistrationSpec {
+                name: "late".into(),
+                integration: "opencode".into(),
+                external_session_id: Some("late-session".into()),
+                report: AgentReport {
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "late registration".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    let linked = daemon.client.get_scheduled_execution(&second.id).unwrap();
+    assert_eq!(linked.agent_id.as_deref(), Some(late.id.as_str()));
+    assert_eq!(linked.state, ScheduledExecutionState::Exited);
+    let events = daemon.client.events(Some(cursor), 256, 0).unwrap();
+    assert!(
+        !events
+            .events
+            .iter()
+            .any(|event| matches!(event.kind, protocol::DaemonEventKind::AgentCompleted { .. }))
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn host_spawn_failure_is_distinct_from_process_exit() {
+    let mut daemon = TestDaemon::start_with(|command, _| {
+        command.env("PATH", "/nonexistent");
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("spawn-fail", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, schedule_spec(&daemon, "fail", "private"))
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::DispatchFailed)
+        },
+        "host spawn failure was not recorded",
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn runner_exit_without_a_terminal_report_interrupts_the_execution() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(&host, "#!/bin/sh\nkill -KILL \"$PPID\"\n").unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command.env("PATH", std::env::join_paths(paths).unwrap());
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("runner-exit", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "runner-exit", "private"),
+        )
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Interrupted)
+        },
+        "runner exit did not reconcile the scheduled execution",
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn execution_cli_json_shapes_are_stable_and_prompt_free() {
+    let mut daemon = TestDaemon::start_with(|command, _| {
+        command.env("PATH", "/nonexistent");
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("execution-cli", Vec::new())
+        .unwrap();
+    let prompt = "PRIVATE CLI EXECUTION PROMPT";
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, schedule_spec(&daemon, "cli", prompt))
+        .unwrap();
+    let key = Uuid::new_v4().to_string();
+    let run = daemon
+        .command()
+        .args([
+            "schedule",
+            "run",
+            &schedule.id,
+            "--idempotency-key",
+            &key,
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(!String::from_utf8_lossy(&run.stdout).contains(prompt));
+    let run: serde_json::Value = serde_json::from_slice(&run.stdout).unwrap();
+    assert_eq!(run["command"], "schedule.run");
+    assert_eq!(run["data"]["execution"]["dispatch_key"], key);
+    let execution_id = run["data"]["execution"]["id"].as_str().unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(execution_id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::DispatchFailed)
+        },
+        "CLI execution did not record spawn failure",
+    );
+    for (arguments, expected) in [
+        (
+            vec!["execution", "list", "--schedule", &schedule.id, "--json"],
+            "execution.list",
+        ),
+        (
+            vec!["execution", "inspect", execution_id, "--json"],
+            "execution.inspect",
+        ),
+        (
+            vec!["execution", "cancel", execution_id, "--json"],
+            "execution.cancel",
+        ),
+    ] {
+        let output = daemon.command().args(arguments).output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!String::from_utf8_lossy(&output.stdout).contains(prompt));
+        let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(output["command"], expected);
+        if expected == "execution.inspect" {
+            assert!(output["data"]["execution"]["cwd"].is_string());
+            assert_eq!(output["data"]["execution"]["reason"], "host_spawn_failed");
+            assert!(output["data"]["execution"]["outcome"].is_null());
+            assert!(output["data"]["execution"]["agent_id"].is_null());
+        }
+    }
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn active_execution_cancellation_terminates_the_host_process_tree() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nsleep 30 &\nprintf '%s %s' \"$$\" \"$!\" > \"$BOOMUX_PID_CAPTURE\"\nwait\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_PID_CAPTURE", runtime_dir.join("pids"));
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("cancel", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, schedule_spec(&daemon, "cancel", "private"))
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    let pids = daemon.runtime_dir.join("pids");
+    wait_until(|| pids.is_file(), "scheduled host did not start");
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Active)
+        },
+        "scheduled execution did not become active",
+    );
+    assert_remote_code(
+        &daemon
+            .client
+            .remove_agent_schedule(&schedule.id)
+            .unwrap_err(),
+        protocol::ErrorCode::Busy,
+    );
+    let current = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    let unauthorized = versioned_request(
+        &daemon,
+        protocol::PROTOCOL_VERSION,
+        protocol::Request::ResolveScheduledExecutionClaim {
+            schedule_id: schedule.id.clone(),
+            shell_id: current.shell_id.clone().unwrap(),
+            run_id: current.run_id.clone().unwrap(),
+            runner_token: protocol::ScheduledRunnerCapability::new(Uuid::new_v4().to_string()),
+        },
+    );
+    assert!(matches!(
+        &unauthorized,
+        protocol::Response::Error {
+            code: Some(protocol::ErrorCode::RunChanged),
+            ..
+        }
+    ));
+    assert!(
+        !serde_json::to_string(&unauthorized)
+            .unwrap()
+            .contains("private")
+    );
+    assert_remote_code(
+        &daemon
+            .client
+            .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+            .unwrap_err(),
+        protocol::ErrorCode::Busy,
+    );
+    let pids = fs::read_to_string(pids)
+        .unwrap()
+        .split_whitespace()
+        .map(|pid| pid.parse::<libc::pid_t>().unwrap())
+        .collect::<Vec<_>>();
+    let cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let cancelled = daemon
+        .client
+        .cancel_scheduled_execution(&execution.id)
+        .unwrap();
+    assert_eq!(cancelled.state, ScheduledExecutionState::Cancelled);
+    wait_until(
+        || pids.iter().all(|pid| !process_exists(*pid)),
+        "scheduled process tree survived cancellation",
+    );
+    let events = daemon.client.events(Some(cursor), 256, 0).unwrap().events;
+    let run_exited = events
+        .iter()
+        .position(|event| matches!(event.kind, protocol::DaemonEventKind::RunExited { .. }))
+        .unwrap();
+    let execution_cancelled = events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.kind,
+                protocol::DaemonEventKind::ScheduledExecutionChanged { execution, .. }
+                    if execution.state == ScheduledExecutionState::Cancelled
+            )
+        })
+        .unwrap();
+    assert!(run_exited < execution_cancelled);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn cancelling_a_terminal_execution_does_not_stop_the_reused_shells_new_run() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nif [ ! -e \"$BOOMUX_EXECUTION_CAPTURE\" ]; then : > \"$BOOMUX_EXECUTION_CAPTURE\"; exit 0; fi\nprintf '%s' \"$$\" > \"$BOOMUX_PID_CAPTURE\"\nsleep 30\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_EXECUTION_CAPTURE", runtime_dir.join("first"))
+            .env("BOOMUX_PID_CAPTURE", runtime_dir.join("pid"));
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("cancel-old", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "cancel-old", "private"),
+        )
+        .unwrap();
+    let first = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&first.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
+        },
+        "first execution did not exit",
+    );
+    let second = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    let pid_path = daemon.runtime_dir.join("pid");
+    wait_until(|| pid_path.is_file(), "second execution did not start");
+    let pid = fs::read_to_string(pid_path)
+        .unwrap()
+        .parse::<libc::pid_t>()
+        .unwrap();
+
+    let unchanged = daemon.client.cancel_scheduled_execution(&first.id).unwrap();
+    assert_eq!(unchanged.state, ScheduledExecutionState::Exited);
+    assert!(process_exists(pid));
+
+    daemon
+        .client
+        .cancel_scheduled_execution(&second.id)
+        .unwrap();
+    wait_until(
+        || !process_exists(pid),
+        "second execution survived cancellation",
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn claimed_cancellation_wins_before_spawn() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let barrier = runtime_dir.join("claim-barrier");
+        fs::create_dir(&barrier).unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(&host, "#!/bin/sh\n: > \"$BOOMUX_SPAWN_CAPTURE\"\n").unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_CLAIM_BARRIER", &barrier)
+            .env("BOOMUX_SPAWN_CAPTURE", runtime_dir.join("spawned"));
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("claim-cancel", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "claim-cancel", "private"),
+        )
+        .unwrap();
+    let key = Uuid::new_v4().to_string();
+    let client = Client::from_socket_path(daemon.client.socket_path().to_path_buf());
+    let schedule_id = schedule.id.clone();
+    let key_for_thread = key.clone();
+    let run = thread::spawn(move || client.run_agent_schedule(schedule_id, key_for_thread));
+    let barrier = daemon.runtime_dir.join("claim-barrier");
+    wait_until(
+        || barrier.join("claimed").is_file(),
+        "claim barrier was not reached",
+    );
+    let claimed = daemon
+        .client
+        .scheduled_executions(None, Some(schedule.id.clone()))
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(claimed.state, ScheduledExecutionState::Claimed);
+
+    let cancelled = daemon
+        .client
+        .cancel_scheduled_execution(&claimed.id)
+        .unwrap();
+    assert_eq!(cancelled.state, ScheduledExecutionState::Cancelled);
+    fs::write(barrier.join("release"), b"release").unwrap();
+    assert_eq!(
+        run.join().unwrap().unwrap().state,
+        ScheduledExecutionState::Cancelled
+    );
+    assert!(!daemon.runtime_dir.join("spawned").exists());
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn post_claim_persistence_failure_terminalizes_without_spawning() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let barrier = runtime_dir.join("dispatch-failure-barrier");
+        fs::create_dir(&barrier).unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(&host, "#!/bin/sh\n: > \"$BOOMUX_SPAWN_CAPTURE\"\n").unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_CLAIM_BARRIER", &barrier)
+            .env(
+                "BOOMUX_SPAWN_CAPTURE",
+                runtime_dir.join("dispatch-failure-spawn"),
+            );
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("dispatch-failure", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "dispatch-failure", "private"),
+        )
+        .unwrap();
+    let request_client = Client::from_socket_path(daemon.client.socket_path().to_path_buf());
+    let schedule_id = schedule.id.clone();
+    let request = thread::spawn(move || {
+        request_client.run_agent_schedule(schedule_id, Uuid::new_v4().to_string())
+    });
+    let barrier = daemon.runtime_dir.join("dispatch-failure-barrier");
+    wait_until(
+        || barrier.join("claimed").is_file(),
+        "claim barrier was not reached",
+    );
+    let execution_id = daemon
+        .client
+        .scheduled_executions(None, Some(schedule.id.clone()))
+        .unwrap()[0]
+        .id
+        .clone();
+    let state_directory = daemon.runtime_dir.join("state/boomux");
+    let saved_directory = daemon.runtime_dir.join("saved-dispatch-failure-state");
+    fs::rename(&state_directory, &saved_directory).unwrap();
+    fs::write(&state_directory, b"not a directory").unwrap();
+    fs::write(barrier.join("release"), b"release").unwrap();
+    assert!(request.join().unwrap().is_err());
+    assert_eq!(
+        daemon
+            .client
+            .get_scheduled_execution(&execution_id)
+            .unwrap()
+            .state,
+        ScheduledExecutionState::DispatchFailed
+    );
+    assert!(!daemon.runtime_dir.join("dispatch-failure-spawn").exists());
+
+    fs::remove_file(&state_directory).unwrap();
+    fs::rename(&saved_directory, &state_directory).unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution_id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::DispatchFailed)
+        },
+        "dispatch failure was not retained after persistence recovery",
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn runner_start_persistence_failure_kills_runtime_and_terminalizes() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let barrier = runtime_dir.join("start-barrier");
+        fs::create_dir(&barrier).unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(&host, "#!/bin/sh\n: > \"$BOOMUX_HOST_CAPTURE\"\n").unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_START_BARRIER", &barrier)
+            .env(
+                "BOOMUX_HOST_CAPTURE",
+                runtime_dir.join("start-failure-host"),
+            );
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("start-failure", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "start-failure", "private"),
+        )
+        .unwrap();
+    let request_client = Client::from_socket_path(daemon.client.socket_path().to_path_buf());
+    let schedule_id = schedule.id.clone();
+    let request = thread::spawn(move || {
+        request_client.run_agent_schedule(schedule_id, Uuid::new_v4().to_string())
+    });
+    let barrier = daemon.runtime_dir.join("start-barrier");
+    wait_until(
+        || barrier.join("started").is_file(),
+        "runner start barrier was not reached",
+    );
+    let state_directory = daemon.runtime_dir.join("state/boomux");
+    let saved_directory = daemon.runtime_dir.join("saved-start-failure-state");
+    fs::rename(&state_directory, &saved_directory).unwrap();
+    fs::write(&state_directory, b"not a directory").unwrap();
+    fs::write(barrier.join("release"), b"release").unwrap();
+    assert!(request.join().unwrap().is_err());
+    let execution_id = daemon
+        .client
+        .scheduled_executions(None, Some(schedule.id.clone()))
+        .unwrap()[0]
+        .id
+        .clone();
+    let failed = daemon
+        .client
+        .get_scheduled_execution(&execution_id)
+        .unwrap();
+    assert_eq!(failed.state, ScheduledExecutionState::DispatchFailed);
+    assert_eq!(
+        daemon
+            .client
+            .get_shell(failed.shell_id.as_ref().unwrap())
+            .unwrap()
+            .status,
+        protocol::ShellStatus::Pending
+    );
+    assert!(!daemon.runtime_dir.join("start-failure-host").exists());
+
+    fs::remove_file(&state_directory).unwrap();
+    fs::rename(&saved_directory, &state_directory).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn cancellation_persistence_failure_keeps_dead_process_terminal_and_retries() {
+    let mut daemon = long_running_schedule_daemon("cancel-persistence");
+    let (workspace_id, _schedule_id, execution_id, pid) =
+        start_long_running_execution(&daemon, "cancel-persistence");
+    let cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let state_directory = daemon.runtime_dir.join("state/boomux");
+    let saved_directory = daemon.runtime_dir.join("saved-cancel-state");
+    fs::rename(&state_directory, &saved_directory).unwrap();
+    fs::write(&state_directory, b"not a directory").unwrap();
+
+    assert!(
+        daemon
+            .client
+            .cancel_scheduled_execution(&execution_id)
+            .is_err()
+    );
+    wait_until(
+        || !process_exists(pid),
+        "cancelled host survived persistence failure",
+    );
+    let execution = daemon
+        .client
+        .get_scheduled_execution(&execution_id)
+        .unwrap();
+    assert_eq!(execution.state, ScheduledExecutionState::Cancelled);
+    assert_eq!(
+        execution.reason,
+        Some(protocol::ScheduledExecutionReason::CancelledByUser)
+    );
+    assert_eq!(
+        daemon.client.get_workspace(&workspace_id).unwrap().shells[0].status,
+        protocol::ShellStatus::Pending
+    );
+
+    fs::remove_file(&state_directory).unwrap();
+    fs::rename(&saved_directory, &state_directory).unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .events(Some(cursor.clone()), 256, 0)
+                .is_ok_and(|events| {
+                    events.events.iter().any(|event| {
+                        matches!(
+                            &event.kind,
+                            protocol::DaemonEventKind::ScheduledExecutionChanged { execution, .. }
+                                if execution.id == execution_id
+                                    && execution.state == ScheduledExecutionState::Cancelled
+                        )
+                    })
+                })
+        },
+        "cancelled execution was not persisted and published after recovery",
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn cancellation_stop_failure_leaves_live_exact_run_active() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf '%s' \"$$\" > \"$BOOMUX_PID_CAPTURE\"\nsleep 30\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_PID_CAPTURE", runtime_dir.join("stop-failure-pid"))
+            .env("BOOMUX_NATIVE_TEST_CANCEL_STOP_FAILURE", "1");
+    });
+    let (workspace_id, schedule_id, execution_id, pid) =
+        start_long_running_execution(&daemon, "stop-failure");
+    assert!(
+        daemon
+            .client
+            .cancel_scheduled_execution(&execution_id)
+            .is_err()
+    );
+    assert!(process_exists(pid));
+    assert_eq!(
+        daemon
+            .client
+            .get_scheduled_execution(&execution_id)
+            .unwrap()
+            .state,
+        ScheduledExecutionState::Active
+    );
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    daemon
+        .client
+        .cancel_scheduled_execution(&execution_id)
+        .unwrap();
+    wait_until(
+        || !process_exists(pid),
+        "host survived cancellation after stop recovery",
+    );
+    daemon.client.remove_agent_schedule(&schedule_id).unwrap();
+    daemon.client.close_workspace(&workspace_id).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn failed_active_workspace_close_reconciles_execution_and_pending_shell() {
+    let mut daemon = long_running_schedule_daemon("workspace-close-persistence");
+    let (workspace_id, _schedule_id, execution_id, pid) =
+        start_long_running_execution(&daemon, "workspace-close-persistence");
+    let state_directory = daemon.runtime_dir.join("state/boomux");
+    let saved_directory = daemon.runtime_dir.join("saved-workspace-close-state");
+    fs::rename(&state_directory, &saved_directory).unwrap();
+    fs::write(&state_directory, b"not a directory").unwrap();
+
+    assert!(daemon.client.close_workspace(&workspace_id).is_err());
+    wait_until(
+        || !process_exists(pid),
+        "workspace close did not stop the host",
+    );
+    let workspace = daemon.client.get_workspace(&workspace_id).unwrap();
+    assert_eq!(workspace.shells[0].status, protocol::ShellStatus::Pending);
+    let execution = daemon
+        .client
+        .get_scheduled_execution(&execution_id)
+        .unwrap();
+    assert_eq!(execution.state, ScheduledExecutionState::Interrupted);
+    assert_eq!(execution.outcome, None);
+
+    fs::remove_file(&state_directory).unwrap();
+    fs::rename(&saved_directory, &state_directory).unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution_id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Interrupted)
+        },
+        "workspace close compensation was not persisted",
+    );
+    daemon.client.close_workspace(&workspace_id).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn active_workspace_close_kills_and_removes_scheduled_work() {
+    let mut daemon = long_running_schedule_daemon("workspace-close-active");
+    let (workspace_id, _schedule_id, execution_id, pid) =
+        start_long_running_execution(&daemon, "workspace-close-active");
+
+    daemon.client.close_workspace(&workspace_id).unwrap();
+    wait_until(
+        || !process_exists(pid),
+        "active workspace close left host alive",
+    );
+    assert!(daemon.client.get_workspace(&workspace_id).is_err());
+    assert!(
+        daemon
+            .client
+            .get_scheduled_execution(&execution_id)
+            .is_err()
+    );
+    daemon.stop_with_cli();
+}
+
+fn long_running_schedule_daemon(label: &str) -> TestDaemon {
+    let label = label.to_owned();
+    TestDaemon::start_with(move |command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf '%s' \"$$\" > \"$BOOMUX_PID_CAPTURE\"\nsleep 30\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env(
+                "BOOMUX_PID_CAPTURE",
+                runtime_dir.join(format!("{label}-pid")),
+            );
+    })
+}
+
+fn start_long_running_execution(
+    daemon: &TestDaemon,
+    label: &str,
+) -> (String, String, String, libc::pid_t) {
+    let workspace = daemon.client.create_workspace(label, Vec::new()).unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, schedule_spec(daemon, label, "private"))
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    let pid_path = daemon.runtime_dir.join(format!("{label}-pid"));
+    wait_until(|| pid_path.is_file(), "scheduled host did not start");
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Active)
+        },
+        "scheduled execution did not become active",
+    );
+    let pid = fs::read_to_string(pid_path)
+        .unwrap()
+        .parse::<libc::pid_t>()
+        .unwrap();
+    (workspace.id, schedule.id, execution.id, pid)
+}
+
+#[test]
+fn cold_recovery_interrupts_active_execution_without_respawn() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf 'spawn\\n' >> \"$BOOMUX_EXECUTION_CAPTURE\"\nprintf '%s\\n' \"$$\" >> \"$BOOMUX_PID_CAPTURE\"\nsleep 30\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_EXECUTION_CAPTURE", runtime_dir.join("executions"))
+            .env("BOOMUX_PID_CAPTURE", runtime_dir.join("pids"));
+    });
+    let workspace = daemon.client.create_workspace("cold", Vec::new()).unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, schedule_spec(&daemon, "cold", "private"))
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    let capture = daemon.runtime_dir.join("executions");
+    wait_until(|| capture.is_file(), "scheduled host did not start");
+    let active = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    let old_pid = fs::read_to_string(daemon.runtime_dir.join("pids"))
+        .unwrap()
+        .lines()
+        .next()
+        .unwrap()
+        .parse::<libc::pid_t>()
+        .unwrap();
+    daemon.crash();
+    wait_until(
+        || !process_exists(old_pid),
+        "cold-crashed host remained alive",
+    );
+    daemon.restart();
+    let recovered = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    assert_eq!(recovered.state, ScheduledExecutionState::Interrupted);
+    assert_eq!(
+        recovered.reason,
+        Some(protocol::ScheduledExecutionReason::ColdDaemonRecovery)
+    );
+    assert_eq!(recovered.outcome, None);
+    assert_eq!(recovered.shell_id, active.shell_id);
+    assert_eq!(recovered.run_id, active.run_id);
+    assert_eq!(
+        daemon
+            .client
+            .run_agent_schedule(&schedule.id, &execution.dispatch_key)
+            .unwrap()
+            .id,
+        execution.id
+    );
+    assert_eq!(fs::read_to_string(&capture).unwrap(), "spawn\n");
+    let mut paths = vec![daemon.runtime_dir.join("bin")];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .env("BOOMUX_EXECUTION_CAPTURE", &capture)
+        .env("BOOMUX_PID_CAPTURE", daemon.runtime_dir.join("pids"))
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    let next = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    wait_until(
+        || fs::read_to_string(&capture).is_ok_and(|capture| capture.lines().count() == 2),
+        "new key did not start exactly one new run",
+    );
+    let next = daemon.client.get_scheduled_execution(&next.id).unwrap();
+    assert_eq!(next.shell_id, recovered.shell_id);
+    assert_ne!(next.run_id, recovered.run_id);
+    daemon.client.cancel_scheduled_execution(&next.id).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn cold_recovery_clears_staged_outcome_and_survives_second_restart() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let barrier = runtime_dir.join("outcome-barrier");
+        fs::create_dir(&barrier).unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(&host, "#!/bin/sh\nexit 17\n").unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_OUTCOME_BARRIER", &barrier);
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("cold-staged-outcome", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "cold-staged-outcome", "private"),
+        )
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    let barrier = daemon.runtime_dir.join("outcome-barrier");
+    wait_until(
+        || barrier.join("outcome").is_file(),
+        "runner outcome was not staged before EOF",
+    );
+    let staged = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    assert_eq!(staged.state, ScheduledExecutionState::Active);
+    assert_eq!(
+        staged.outcome,
+        Some(protocol::ScheduledExecutionOutcome::ExitCode { code: 17 })
+    );
+
+    daemon.crash();
+    daemon.restart();
+    let recovered = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    assert_eq!(recovered.state, ScheduledExecutionState::Interrupted);
+    assert_eq!(
+        recovered.reason,
+        Some(protocol::ScheduledExecutionReason::ColdDaemonRecovery)
+    );
+    assert_eq!(recovered.outcome, None);
+
+    daemon.crash();
+    daemon.restart();
+    let restored_again = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    assert_eq!(restored_again, recovered);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn daemon_stop_persists_explicit_cancellation_for_active_execution() {
+    let mut daemon = long_running_schedule_daemon("daemon-stop");
+    let (_workspace_id, _schedule_id, execution_id, pid) =
+        start_long_running_execution(&daemon, "daemon-stop");
+
+    daemon.stop_with_cli();
+    wait_until(
+        || !process_exists(pid),
+        "daemon stop left scheduled host running",
+    );
+    let state: serde_json::Value = serde_json::from_slice(
+        &fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap(),
+    )
+    .unwrap();
+    let execution = state["workspaces"][0]["schedules"][0]["executions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|execution| execution["id"] == execution_id)
+        .unwrap();
+    assert_eq!(execution["state"], "cancelled");
+    assert_eq!(execution["reason"], "daemon_shutdown");
+    assert!(execution["outcome"].is_null());
+}
+
+#[test]
+fn daemon_stop_cancels_persisted_claim_before_it_can_spawn() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let barrier = runtime_dir.join("stop-claim-barrier");
+        fs::create_dir(&barrier).unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(&host, "#!/bin/sh\n: > \"$BOOMUX_STOP_SPAWN\"\n").unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_CLAIM_BARRIER", &barrier)
+            .env("BOOMUX_STOP_SPAWN", runtime_dir.join("stop-claim-spawn"));
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("stop-claim", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "stop-claim", "private"),
+        )
+        .unwrap();
+    let request_client = Client::from_socket_path(daemon.client.socket_path().to_path_buf());
+    let schedule_id = schedule.id.clone();
+    let request = thread::spawn(move || {
+        request_client.run_agent_schedule(schedule_id, Uuid::new_v4().to_string())
+    });
+    let barrier = daemon.runtime_dir.join("stop-claim-barrier");
+    wait_until(
+        || barrier.join("claimed").is_file(),
+        "claim barrier was not reached",
+    );
+    let execution_id = daemon
+        .client
+        .scheduled_executions(None, Some(schedule.id))
+        .unwrap()[0]
+        .id
+        .clone();
+
+    daemon.stop_with_cli();
+    let _ = request.join().unwrap();
+    assert!(!daemon.runtime_dir.join("stop-claim-spawn").exists());
+    let state: serde_json::Value = serde_json::from_slice(
+        &fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap(),
+    )
+    .unwrap();
+    let execution = state["workspaces"][0]["schedules"][0]["executions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|execution| execution["id"] == execution_id)
+        .unwrap();
+    assert_eq!(execution["state"], "cancelled");
+    assert_eq!(execution["reason"], "daemon_shutdown");
+}
+
+#[test]
+fn graceful_handoff_preserves_active_host_and_dispatches_at_most_once() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> \"$BOOMUX_PID_CAPTURE\"\nsleep 2\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_PID_CAPTURE", runtime_dir.join("pids"));
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("handoff", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, schedule_spec(&daemon, "handoff", "private"))
+        .unwrap();
+    let key = Uuid::new_v4().to_string();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&schedule.id, &key)
+        .unwrap();
+    let capture = daemon.runtime_dir.join("pids");
+    wait_until(|| capture.is_file(), "scheduled host did not start");
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Active)
+        },
+        "scheduled execution did not become active before handoff",
+    );
+    let active = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    let pid = fs::read_to_string(&capture)
+        .unwrap()
+        .trim()
+        .parse::<libc::pid_t>()
+        .unwrap();
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "{}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    assert!(process_exists(pid));
+    assert_eq!(
+        daemon
+            .client
+            .run_agent_schedule(&schedule.id, &key)
+            .unwrap()
+            .id,
+        execution.id
+    );
+    assert_eq!(fs::read_to_string(&capture).unwrap().lines().count(), 1);
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
+        },
+        "handoff-preserved host did not report natural exit",
+    );
+    let exited = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    assert_eq!(exited.shell_id, active.shell_id);
+    assert_eq!(exited.run_id, active.run_id);
+    assert_eq!(
+        exited.outcome,
+        Some(protocol::ScheduledExecutionOutcome::ExitCode { code: 0 })
+    );
+    wait_until(
+        || !process_exists(pid),
+        "naturally exited host PID remained alive",
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn graceful_handoff_resumes_a_persisted_claim_exactly_once() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let barrier = runtime_dir.join("handoff-claim-barrier");
+        fs::create_dir(&barrier).unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf 'spawn\\n' >> \"$BOOMUX_EXECUTION_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_CLAIM_BARRIER", &barrier)
+            .env(
+                "BOOMUX_EXECUTION_CAPTURE",
+                runtime_dir.join("claim-handoff-spawns"),
+            );
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("claim-handoff", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "claim-handoff", "private"),
+        )
+        .unwrap();
+    let key = Uuid::new_v4().to_string();
+    let request_client = Client::from_socket_path(daemon.client.socket_path().to_path_buf());
+    let schedule_id = schedule.id.clone();
+    let request_key = key.clone();
+    let request =
+        thread::spawn(move || request_client.run_agent_schedule(schedule_id, request_key));
+    let barrier = daemon.runtime_dir.join("handoff-claim-barrier");
+    wait_until(
+        || barrier.join("claimed").is_file(),
+        "claim barrier was not reached",
+    );
+    let claimed = daemon
+        .client
+        .scheduled_executions(None, Some(schedule.id.clone()))
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(claimed.state, ScheduledExecutionState::Claimed);
+
+    let mut paths = vec![daemon.runtime_dir.join("bin")];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .env(
+            "BOOMUX_EXECUTION_CAPTURE",
+            daemon.runtime_dir.join("claim-handoff-spawns"),
+        )
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "{}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    fs::write(barrier.join("release"), b"release").unwrap();
+    let _ = request.join().unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .get_scheduled_execution(&claimed.id)
+                .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
+        },
+        "replacement did not resume the persisted claim",
+    );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("claim-handoff-spawns"))
+            .unwrap()
+            .lines()
+            .count(),
+        1
+    );
+    let same = daemon
+        .client
+        .run_agent_schedule(&schedule.id, &key)
+        .unwrap();
+    assert_eq!(same.id, claimed.id);
+    daemon.stop_with_cli();
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -55,6 +55,7 @@ impl TestDaemon {
             .env("XDG_RUNTIME_DIR", &runtime_dir)
             .env("XDG_STATE_HOME", runtime_dir.join("state"))
             .env("SHELL", "/bin/sh")
+            .env("BOOMUX_NATIVE_TEST_HOOKS", "1")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
@@ -74,6 +75,7 @@ impl TestDaemon {
         let mut command = Command::new(&self.executable);
         command.env("XDG_RUNTIME_DIR", &self.runtime_dir);
         command.env("XDG_STATE_HOME", self.runtime_dir.join("state"));
+        command.env("BOOMUX_NATIVE_TEST_HOOKS", "1");
         command
     }
 


### PR DESCRIPTION
## Summary

- add durable manual Scheduled Execution claims with idempotent `schedule run`, inspection, and cancellation
- dispatch OpenCode and Pi through exact private host transports on one protected reusable schedule-owned shell
- preserve execution ownership across cancellation, cold recovery, and graceful daemon handoff without inferring Agent completion
- add protocol-23/state-10 compatibility, bounded audit history, privacy boundaries, and extensive native race/failure coverage

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`
- `cargo check --release --locked`

Closes #149

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>