### PR TITLE
feat(schedule): trigger timed agent executions

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -303,10 +303,20 @@ Inspect the returned exact execution ID, and cancel only when process-tree
 termination is authorized. Execution exit or cancellation never means Agent
 `done`.
 
-This version does not evaluate cron triggers or run a timer. Enabling records
-future timed-work consent but does not itself dispatch. Do not claim workspace
-or global scheduled concurrency limits, skipped timer decisions, or
-`[scheduling]` configuration are active.
+Enabled schedules are evaluated by the daemon in their stored timezone. Timed
+work runs only while the daemon and user session are active. Offline periods are
+recorded as one coalesced missed decision, paused periods are not caught up, and
+policy contention is skipped rather than queued. Manual and timed decisions share
+one active execution per schedule and workspace, exact continuation exclusion,
+and `[scheduling] max_concurrent` (default 4, range 1-64). Use `daemon status`
+and `doctor` to inspect scheduler health and whether a config change needs
+`daemon restart`.
+
+Cron day-field semantics preserve syntax: `*` and `*/n` are wildcard-origin;
+numeric lists/ranges are restricted even when they cover the full field, and two
+restricted day fields use OR. Boomux rejects schedules with no occurrence in a
+Gregorian 400-year cycle. Treat scheduler `offline` health as not evaluating
+timed work even when the daemon still answers other requests.
 
 Exact shell IDs resolve globally. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ name = "boomux"
 version = "0.15.0"
 dependencies = [
  "base64",
+ "chrono",
  "chrono-tz",
  "clap",
  "crossterm",
@@ -191,7 +192,11 @@ version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 base64 = "0.22"
+chrono = "0.4"
 chrono-tz = "0.10"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"

--- a/README.md
+++ b/README.md
@@ -324,11 +324,32 @@ argv through a lazily created schedule-owned shell. Pass `--idempotency-key
 <uuid>` when retrying a request; the same schedule and key always return the same
 execution and never spawn twice. Execution inspection and events omit prompts.
 
+Enabled schedules are evaluated by the daemon in their stored IANA timezone.
+DST gaps are skipped, repeated local minutes fire once, and persisted occurrence
+frontiers prevent duplicates after clock rollback, restart, or graceful handoff.
+Offline periods produce one coalesced missed record rather than catch-up work;
+resuming a paused schedule starts with future occurrences only.
+
+For day-of-month/day-of-week matching, `*` and `*/n` are wildcard-origin. Numeric
+lists and ranges, including full ranges, are restricted; two restricted day
+fields use standard cron OR behavior. Triggers with no occurrence in a full
+Gregorian 400-year cycle are rejected.
+
+Manual and timed decisions skip rather than queue when their schedule, workspace,
+exact continuation session, or daemon-wide capacity is occupied. Configure the
+last bound, from 1 through 64, and apply changes with a graceful restart:
+
+```toml
+[scheduling]
+max_concurrent = 4
+```
+
 OpenCode receives the prompt as the final argument after `--`; Pi receives the
 exact prompt on stdin. Process exit, dispatch failure, cancellation, and cold
-interruption are execution outcomes and never report an Agent as done. This
-release does not evaluate cron triggers or run timers; enabling records consent
-for future timed dispatch but does not itself start work.
+interruption are execution outcomes and never report an Agent as done. Timed
+work runs only while the Boomux daemon and user session are active; inspect
+`boomux daemon status` and `boomux doctor` for scheduler health and sampled
+configuration.
 
 ### Agent Skill
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@
 | `src/session_transcript.rs` and children | Shared transcript identity, bounds, pagination, and host-specific normalization |
 | `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
 | `src/process_adapter.rs` | Exact-argv child supervision and fail-open process-bound Agent observation |
-| `src/scheduling.rs` | Bounded canonical cron, IANA timezone, prompt, and schedule identity validation |
+| `src/scheduling.rs` | Bounded canonical cron parsing and occurrence evaluation, IANA timezone and DST policy, prompt bounds, and schedule identity validation |
 | `src/config.rs`, `src/projects.rs`, `src/git.rs` | Layered configuration, bounded project discovery, and asynchronous Git metadata |
 | `src/cli_output.rs` | Stable `boomux.cli/v1` output and error presentation |
 | `src/desktop_notifications.rs` | Bounded fail-open desktop and sound delivery |
@@ -50,7 +50,7 @@
   launch, and integration management execute argv directly without shell
   interpretation.
 - **Scheduled Agent authority:** [`scheduled-agent-work.md`](scheduled-agent-work.md)
-  defines the boundary between implemented manual dispatch, future timing,
+  defines the boundary between manual and timed dispatch, concurrency policy,
   process outcome, and authoritative Agent lifecycle.
 
 ## Product Boundary
@@ -403,14 +403,15 @@ input into an active session, or infer a canonical external session.
 Fresh is the default session mode and starts a new external Agent Session for
 each dispatched execution. Continuation schedules pin one exact existing
 integration and external session identity; they never select the latest session
-or fall back to fresh work. The manual layer prevents a second nonterminal
-execution on the same schedule. Continuation leases, workspace/global
-concurrency, and timed skip decisions remain part of #150 rather than this
-dispatch layer.
+or fall back to fresh work. Manual and timed decisions atomically enforce one
+nonterminal execution per schedule and workspace, the configured daemon-wide
+bound, and exact continuation leases. Policy refusals are durable skipped
+decisions rather than queued work.
 
 New schedules are paused by default, and manual run-now remains available while
-paused. Cron evaluation, timer loops, skipped timed decisions, and `[scheduling]`
-configuration remain deferred. There is no automatic retry or timeout: an
+paused. Protocol 24 evaluates canonical cron triggers in their stored IANA
+timezone and exposes deterministic next occurrences, scheduler health, timed
+and skipped decisions, and `[scheduling] max_concurrent`. There is no automatic retry or timeout: an
 execution remains active until its process exits, the user cancels it, or runner
 or cold-daemon loss interrupts it. Scheduled starts use the daemon's
 startup environment as ephemeral input; it is never persisted, and environment
@@ -706,6 +707,28 @@ execution events, and durable schedule-owned shell identity. Protocol-22 peers
 omit execution events, schedule-owned shells, and execution-shell links. State schema 10
 explicitly migrates schema 9: existing shells become user-owned and schedules
 receive empty execution histories.
+Protocol 24 adds timezone-aware timed dispatch, skipped policy outcomes,
+deterministic next occurrences, scheduler health, and bounded schedule/workspace/
+daemon concurrency. Protocol-23 peers omit scheduler and next-occurrence fields
+and filter timed or skipped execution records and events while preserving event
+cursors. State schema 11 adds the trigger-revision-qualified durable evaluation
+frontier and timed occurrence metadata; its explicit schema-10 migration retains
+manual execution history without reinterpreting it as timed work.
+
+Cron day matching preserves syntactic wildcard origin: `*/n` is wildcard-origin,
+while numeric lists and ranges remain restricted even when they cover the full
+field. Trigger acceptance proves at least one occurrence across a Gregorian
+400-year cycle. Enabled snapshot projection propagates evaluator failures rather
+than presenting them as a normal absent next occurrence. State schema 11 also
+requires durable schedule timestamps to fit Chrono and validates timed IDs,
+frontiers, scheduled/requested ordering, and coalescing reason/state combinations.
+
+The scheduler reports active health only while its worker is running after a
+successful evaluation and next-occurrence projection. Failure marks it offline
+and uses an interruptible 50 ms through 5 second exponential retry delay without
+acknowledging deterministic test ticks. Graceful restart transfers active work
+even when a newly sampled lower limit is already exceeded; the truthful active
+count is reported and admission remains blocked until enough terminal releases.
 
 Opt-in desktop and sound notifications are a daemon-owned projection of committed
 Agent state transitions, not durable queue state. A transition from any other
@@ -733,6 +756,10 @@ daemon's inherited `XDG_CONFIG_HOME` or `BOOMUX_CONFIG` from overriding the
 configuration intentionally selected by the restart caller. A protocol-16
 daemon is first upgraded with a compatibility handoff, followed by a protocol-17
 handoff that applies the settings.
+The same two-stage rule applies when a protocol-16, protocol-22, or protocol-23
+daemon is upgraded for protocol-24 scheduling settings: after the compatibility
+handoff the client renegotiates, then sends complete notification, recovery,
+environment, and `max_concurrent` values to the replacement.
 
 ### Transition Coordinator
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -166,7 +166,11 @@ Command payloads are:
 - `read`: shell/run identity, observed output revision, and rendered output.
 - `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
   bounded event array.
-- `daemon.status`: `status`, `protocol_version`, and `socket_path`.
+- `daemon.status`: `status`, `protocol_version`, `socket_path`, and nullable
+  `scheduler`. Scheduler data contains `state`, `max_concurrent`, and
+  `active_executions`. State is `active` only for a running worker whose latest
+  evaluation and next-occurrence projection succeeded; otherwise it is
+  `offline`.
 
 ## Integration Data
 
@@ -176,21 +180,27 @@ Integration arrays are ordered `opencode`, then `pi`. List entries contain
 Protocol 22 advertises `protocol_22`, `agent_schedule_management`, and
 `durable_agent_schedules`. Protocol 23 adds `protocol_23`,
 `scheduled_execution_dispatch`, `scheduled_execution_cancellation`, and
-`schedule_owned_shells`. These capabilities advertise manual run-now dispatch;
-they do not advertise cron evaluation or timed dispatch.
+`schedule_owned_shells`. Protocol 24 adds `protocol_24`,
+`timed_schedule_dispatch`, `scheduler_health`, and
+`bounded_scheduled_execution_concurrency`.
 
 ## Execution Data
 
-Execution objects contain `id`, `workspace_id`, `schedule_id`, `state`,
+Schedule objects include nullable `next_occurrence`, containing
+`trigger_revision` and `scheduled_at_ms`. Execution objects contain `id`,
+`workspace_id`, `schedule_id`, `state`,
 `dispatch_kind`, `dispatch_key`, exact `schedule_revision`, `prompt_revision`,
-and `trigger_revision`, requested/start/end timestamps, snapshotted `cwd`,
+and `trigger_revision`, `requested_at_ms`, nullable `scheduled_at_ms`, nullable
+`coalesced_through_ms`, start/end timestamps, snapshotted `cwd`,
 `integration`, and `session`, nullable typed `reason` and `outcome`, and nullable
 `shell_id`, `run_id`, `agent_id`, and discovered `external_session_id` links.
 They never contain the retained prompt or environment.
 
-State is `claimed`, `starting`, `active`, `dispatch_failed`, `exited`,
-`cancelled`, or `interrupted`; dispatch kind is currently `manual`. Reasons are
-stable safe values `runner_start_failed`, `host_spawn_failed`,
+State is `skipped`, `claimed`, `starting`, `active`, `dispatch_failed`, `exited`,
+`cancelled`, or `interrupted`; dispatch kind is `manual` or `timed`. Reasons are
+stable safe values `overlap`, `active_session`, `workspace_capacity`,
+`global_capacity`, `missed`, `paused_race`, `invalid_target`,
+`runner_start_failed`, `host_spawn_failed`,
 `cancelled_by_user`, `cold_daemon_recovery`, or
 `runner_exited_without_report`; explicit daemon shutdown uses `daemon_shutdown`.
 Exit outcomes are tagged
@@ -384,9 +394,12 @@ Schedule summaries contain `id`, `workspace_id`, nullable `workspace_name`,
 `name`, `cwd`, `integration`, `session_mode`, nullable `external_session_id`,
 `cron`, `timezone`, `state`, `overlap_policy`, `revision`, `prompt_revision`,
 `trigger_revision`, `created_at_ms`, `updated_at_ms`,
-`evaluation_frontier_ms`, and nullable `execution_shell_id`. Optional values are
-JSON `null`. State is `paused` or `enabled`; session mode is `fresh` or
-`continue`; the initial overlap policy is always `skip`.
+`evaluation_frontier_ms`, nullable `execution_shell_id`, and nullable
+`next_occurrence`. A non-null `next_occurrence` contains `trigger_revision` and
+`scheduled_at_ms`. Optional values are JSON `null`; paused schedules have a null
+next occurrence, while an accepted enabled schedule has a non-null next
+occurrence. State is `paused` or `enabled`; session mode is `fresh` or `continue`;
+the initial overlap policy is always `skip`.
 Schedule management commands require negotiated daemon protocol 22. `schedule
 run` and every `execution` command require protocol 23. Unsupported commands
 return `unsupported_version` rather than presenting empty data.

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -30,6 +30,8 @@ Protocol 22 adds durable Agent Schedule management. Workspace snapshots include
 ordered, prompt-free schedule summaries, while exact schedule inspection is the
 only management response that discloses the current prompt.
 Protocol 23 adds durable manual Scheduled Executions and schedule-owned shells.
+Protocol 24 adds daemon-native timed decisions, skipped policy outcomes,
+deterministic next occurrences, and scheduler health.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns
@@ -105,7 +107,8 @@ schedule summary after persistence. Idempotent pause or resume emits no event an
 does not advance the schedule revision. Removing a schedule emits only its
 workspace and schedule identities.
 
-`scheduled_execution_created` publishes the persisted manual claim.
+`scheduled_execution_created` publishes every persisted manual or timed claim or
+skip decision.
 `scheduled_execution_changed` publishes later prompt-free shell/run binding,
 active, dispatch-failed, exited, cancelled, interrupted, and Agent-link changes.
 Both carry the complete public execution snapshot and never carry the retained
@@ -141,6 +144,19 @@ schedule-owned shells and execution-shell links rather than presenting those
 shells as user-owned. Historical schedule-shell ownership used for this filtering
 is retained exactly while the bounded event journal still contains a generic
 event for that shell; it cannot be evicted independently of that event.
+
+Protocol-23 clients retain manual non-skipped execution records but omit timed
+and skipped records and their events. Snapshot scheduler health and schedule
+next-occurrence fields are also omitted. Filtering never rewinds the event
+cursor, so an old client can reconnect across hidden scheduler activity without
+replaying or stalling the stream.
+
+Manual final eligibility, claim creation, shell/run binding, and runner spawn are
+serialized against Agent activity mutations. A protocol-23 client therefore
+cannot observe a manual `claimed` creation whose only terminal transition is a
+protocol-24-only policy skip. If Agent activity wins first, the execution is
+created directly as skipped and its event is hidden consistently while the
+protocol-23 cursor still advances.
 
 Event IDs provide one total publication order. The daemon transition coordinator
 couples durable lifecycle mutation, persistence, and event publication. Events

--- a/docs/scheduled-agent-work.md
+++ b/docs/scheduled-agent-work.md
@@ -1,8 +1,7 @@
 # Scheduled Agent Work
 
-> **Status: Partially implemented contract.** Schedule management and manual
-> run-now execution are implemented; timer evaluation and timed policy remain
-> deferred. This document governs the
+> **Status: Current contract.** Schedule management, manual run-now execution,
+> and daemon-native timed dispatch are implemented. This document governs the
 > scheduled Agent work tracked by [#146](https://github.com/gardnmi/boomux/issues/146).
 > Source and compatibility tests become authoritative for exact protocol,
 > persistence, and bound values as each implementation slice ships.
@@ -35,7 +34,8 @@ A **Scheduled Execution** is the durable record of one timed occurrence or
 explicit run-now decision. It captures the exact schedule revision, prompt
 revision, requested or scheduled time, working directory, integration dispatch
 mode, decision, reason, and available runtime references. Schedule edits affect
-only later executions.
+only later executions when an edit surface is added; the current CLI does not
+expose schedule editing.
 
 The identities remain separate:
 
@@ -82,17 +82,14 @@ The ownership is exclusive:
 An exited schedule-owned shell can retain the latest bounded terminal state, but
 the bounded Scheduled Execution history is the authority for earlier occurrence
 outcomes. Reusing the shell does not reuse a ShellRun or Agent Instance. Each
-execution snapshots its effective working directory. An inactive schedule update
-can atomically update the shell metadata for the next run; an update during an
-active run leaves that run and shell process unchanged and applies when the next
-claim is bound.
+execution snapshots its effective working directory.
 
 ## Prompt Revisions And Privacy
 
-Creation and update snapshot the prompt content into Boomux's user-only durable
+Creation snapshots the prompt content into Boomux's user-only durable
 state. A prompt-file option reads the file at that mutation boundary; later file
-changes do not silently alter the schedule. Changing prompt content creates a
-new prompt revision, and every Scheduled Execution retains the revision it used.
+changes do not silently alter the schedule. Every Scheduled Execution retains
+the prompt revision it used; prompt editing is not currently exposed.
 
 Prompt content may contain private instructions or data. It is bounded and:
 
@@ -151,6 +148,13 @@ restricted, either field matching selects the local time. Seconds, names,
 nicknames, and implementation-specific operators such as `?`, `L`, `W`, and `#`
 are not accepted.
 
+Restriction follows the field's syntax rather than its expanded values. A
+star-origin component such as `*` or `*/2` is wildcard-origin for the standard
+day-of-month/day-of-week rule. Numeric values, lists, and ranges remain
+restricted, including full ranges such as `1-31` and `0-6`; two restricted day
+fields use OR. Duplicate list values are harmless. Creation and restored-state
+validation reject a trigger with no occurrence in a Gregorian 400-year cycle.
+
 Manual conveniences such as every, daily, weekdays, and weekly compile to the
 same canonical expression rather than creating another persisted trigger model.
 Clients expose both a friendly rendering and the exact expression.
@@ -174,13 +178,20 @@ records one bounded, coalesced missed-period decision per affected schedule and
 computes the next future occurrence; it does not materialize an unbounded record
 for every missed minute.
 
+A delayed live tick records one coalesced `missed` decision for due instants
+before the latest due instant, then evaluates that latest instant normally. A
+paused schedule advances no frontier and creates no records. Resuming moves its
+frontier to the resume time, so paused time is never caught up. A pause that wins
+after evaluation sampled an enabled schedule but before its durable decision is
+recorded as `paused_race` rather than dispatched.
+
 Every timed decision has an occurrence key containing the schedule ID, trigger
 revision, and selected scheduled UTC instant. Each schedule persists an
 evaluation frontier independently of bounded execution history. The frontier
 advances monotonically before publication and is not pruned with audit records,
 so clock rollback and history pruning cannot make an old occurrence eligible.
-Editing a trigger creates a new trigger revision whose first eligible occurrence
-is strictly after the committed edit; it never re-evaluates past wall time.
+Trigger editing is not currently exposed. The persisted trigger revision remains
+part of occurrence identity so a future edit cannot reinterpret old decisions.
 
 The occurrence key, Scheduled Execution decision, and evaluation-frontier
 advance commit as one durable mutation before the corresponding event is
@@ -203,16 +214,20 @@ the exact session cannot be reacquired, dispatch fails visibly and does not fall
 back to fresh. A durable continuation lease keyed by integration and exact
 external session ID prevents Scheduled Executions from using that session
 concurrently. The occurrence is also skipped when daemon state contains a
-current running Agent Instance for that exact key, or when the integration's
-dispatch capability authoritatively refuses an active session. Boomux never
+current running Agent Instance for that exact key, or when its dispatch lease is
+already occupied. One dispatch eligibility lease serializes Agent
+register/ensure/report with the final policy decision, claim creation, shell/run
+binding, and runner spawn. An Agent mutation that wins the lease first produces
+`Skipped` with `active_session`; a dispatch that wins retains the lease through
+spawn eligibility. No intermediate visible claim can later become a policy skip,
+and rejection creates no shell or run. Boomux never
 injects a prompt into known active user or Agent work and never takes over its
 terminal controller.
 
 Boomux cannot prove that an exact session is inactive in an unmanaged process
 that provides no lifecycle or lease signal. The UI must describe this limit; the
 scheduler does not substitute process, catalog, argv, or terminal heuristics.
-Integrations that can acquire a stronger host-native session lease should expose
-it through their dispatch capability.
+Host-native session leases are not currently implemented.
 
 An integration must advertise the applicable fresh or continuation dispatch
 capability and construct the exact host argument vector. Unsupported integrations
@@ -221,9 +236,7 @@ database recency, terminal output, and catalog order are not session identity.
 
 ## Dispatch And Concurrency
 
-The complete initial scheduler design uses these policies. The manual run-now
-slice currently enforces only the per-schedule limit because one reusable shell
-cannot run twice; workspace and daemon-wide limits arrive with timed dispatch:
+Manual run-now and timed decisions use the same atomic policy:
 
 - At most one nonterminal Scheduled Execution per Agent Schedule.
 - At most one nonterminal Scheduled Execution per workspace.
@@ -233,6 +246,20 @@ cannot run twice; workspace and daemon-wide limits arrive with timed dispatch:
 - No automatic retry after skip, dispatch failure, process failure, or daemon
   interruption.
 - No automatic timeout.
+
+`[scheduling] max_concurrent = 4` configures the daemon-wide limit. Accepted
+values are 1 through 64. Configuration layers normally, is sampled when the
+daemon starts, and is not watched. `boomux daemon restart` applies the invoking
+client's resolved value to the replacement daemon; `boomux doctor` reports when
+the running sampled value differs. Scheduler health and the active/maximum count
+are exposed by `boomux daemon status`.
+
+Health is `active` only while the scheduler worker is running and its latest
+evaluation and next-occurrence projection succeeded. It is `offline` while
+stopped or after worker failure or panic. Evaluation failures retain any pending
+deterministic test-tick acknowledgment and retry with an interruptible nonzero
+exponential delay bounded at five seconds; one diagnostic is emitted per failure
+streak.
 
 An eligible decision is first persisted as **Claimed**; a policy rejection is
 persisted directly as **Skipped** and never owns a dispatch claim. One
@@ -267,8 +294,8 @@ changing existing schedules.
 A Scheduled Execution has one of these observable states or outcomes:
 
 - **Skipped**: policy prevented dispatch, with an overlap, active-session,
-  workspace-capacity, global-capacity, or missed reason. Paused schedules do not
-  produce timed decisions.
+  workspace-capacity, global-capacity, missed, paused-race, or invalid-target
+  reason. A schedule that remains paused produces no timed decisions.
 - **Claimed**: dispatch eligibility and idempotency ownership are durable, but a
   ShellRun is not yet bound.
 - **Starting**: the internal runner ShellRun is bound, but the exact external

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -123,6 +123,13 @@ pub(crate) struct ScheduleData {
     pub(crate) updated_at_ms: u64,
     pub(crate) evaluation_frontier_ms: u64,
     pub(crate) execution_shell_id: Option<String>,
+    pub(crate) next_occurrence: Option<ScheduledOccurrenceData>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ScheduledOccurrenceData {
+    pub(crate) trigger_revision: u64,
+    pub(crate) scheduled_at_ms: u64,
 }
 
 #[derive(Serialize)]
@@ -144,6 +151,8 @@ pub(crate) struct ExecutionData {
     pub(crate) prompt_revision: u64,
     pub(crate) trigger_revision: u64,
     pub(crate) requested_at_ms: u64,
+    pub(crate) scheduled_at_ms: Option<u64>,
+    pub(crate) coalesced_through_ms: Option<u64>,
     pub(crate) started_at_ms: Option<u64>,
     pub(crate) ended_at_ms: Option<u64>,
     pub(crate) cwd: String,
@@ -338,6 +347,7 @@ pub(crate) fn execution(execution: &ScheduledExecutionSnapshot) -> ExecutionData
         workspace_id: execution.workspace_id.clone(),
         schedule_id: execution.schedule_id.clone(),
         state: match execution.state {
+            boomux::protocol::ScheduledExecutionState::Skipped => "skipped",
             boomux::protocol::ScheduledExecutionState::Claimed => "claimed",
             boomux::protocol::ScheduledExecutionState::Starting => "starting",
             boomux::protocol::ScheduledExecutionState::Active => "active",
@@ -346,18 +356,30 @@ pub(crate) fn execution(execution: &ScheduledExecutionSnapshot) -> ExecutionData
             boomux::protocol::ScheduledExecutionState::Cancelled => "cancelled",
             boomux::protocol::ScheduledExecutionState::Interrupted => "interrupted",
         },
-        dispatch_kind: "manual",
+        dispatch_kind: match execution.dispatch_kind {
+            boomux::protocol::ScheduledExecutionDispatchKind::Manual => "manual",
+            boomux::protocol::ScheduledExecutionDispatchKind::Timed => "timed",
+        },
         dispatch_key: execution.dispatch_key.clone(),
         schedule_revision: execution.schedule_revision,
         prompt_revision: execution.prompt_revision,
         trigger_revision: execution.trigger_revision,
         requested_at_ms: execution.requested_at_ms,
+        scheduled_at_ms: execution.scheduled_at_ms,
+        coalesced_through_ms: execution.coalesced_through_ms,
         started_at_ms: execution.started_at_ms,
         ended_at_ms: execution.ended_at_ms,
         cwd: execution.cwd.display().to_string(),
         integration: execution.integration.clone(),
         session: execution.session.clone(),
         reason: execution.reason.map(|reason| match reason {
+            ScheduledExecutionReason::Overlap => "overlap",
+            ScheduledExecutionReason::ActiveSession => "active_session",
+            ScheduledExecutionReason::WorkspaceCapacity => "workspace_capacity",
+            ScheduledExecutionReason::GlobalCapacity => "global_capacity",
+            ScheduledExecutionReason::Missed => "missed",
+            ScheduledExecutionReason::PausedRace => "paused_race",
+            ScheduledExecutionReason::InvalidTarget => "invalid_target",
             ScheduledExecutionReason::RunnerStartFailed => "runner_start_failed",
             ScheduledExecutionReason::HostSpawnFailed => "host_spawn_failed",
             ScheduledExecutionReason::CancelledByUser => "cancelled_by_user",
@@ -412,6 +434,12 @@ pub(crate) fn schedule(
         updated_at_ms: schedule.updated_at_ms,
         evaluation_frontier_ms: schedule.evaluation_frontier_ms,
         execution_shell_id: schedule.execution_shell_id.clone(),
+        next_occurrence: schedule.next_occurrence.as_ref().map(|occurrence| {
+            ScheduledOccurrenceData {
+                trigger_revision: occurrence.trigger_revision,
+                scheduled_at_ms: occurrence.scheduled_at_ms,
+            }
+        }),
     }
 }
 
@@ -751,6 +779,7 @@ mod tests {
             updated_at_ms: 11,
             evaluation_frontier_ms: 11,
             execution_shell_id: None,
+            next_occurrence: None,
         };
         let private = "private prompt contents\n";
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -492,14 +492,27 @@ impl Client {
         &self,
         notifications: NotificationDeliveryConfig,
     ) -> Result<()> {
-        if !self.supports(protocol::ProtocolFeature::ScheduledExecutions)? {
-            if self.supports(protocol::ProtocolFeature::RestartNotificationConfig)? {
+        if !self.supports(protocol::ProtocolFeature::TimedScheduling)? {
+            let mut compatibility = notifications.clone();
+            compatibility.max_scheduled_execution_concurrency = 4;
+            if self.supports(protocol::ProtocolFeature::ScheduledExecutions)? {
                 self.restart_request(Request::RestartWithNotificationConfig {
-                    notifications: notifications.clone(),
+                    notifications: compatibility,
+                    environment: Some(current_environment()),
+                })?;
+            } else if self.supports(protocol::ProtocolFeature::RestartNotificationConfig)? {
+                self.restart_request(Request::RestartWithNotificationConfig {
+                    notifications: compatibility,
                     environment: None,
                 })?;
             } else {
                 self.restart_request(Request::Restart)?;
+            }
+            self.probe_latest()?;
+            if !self.supports(protocol::ProtocolFeature::TimedScheduling)? {
+                return Err(unsupported_version(
+                    "replacement daemon does not support timed scheduling settings",
+                ));
             }
         }
         self.restart_request(Request::RestartWithNotificationConfig {
@@ -1226,6 +1239,122 @@ mod tests {
         .unwrap();
     }
 
+    fn assert_two_stage_restart_from(old_version: u32) {
+        let directory = env::temp_dir().join(format!("boomux-client-restart-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let settings = NotificationDeliveryConfig {
+            desktop_enabled: true,
+            sound_enabled: false,
+            blocked: true,
+            completed: false,
+            blocked_sound: "blocked".into(),
+            completed_sound: "completed".into(),
+            resume_agents: false,
+            persist_terminal_history: true,
+            max_scheduled_execution_concurrency: 1,
+        };
+        let expected_settings = settings.clone();
+        let expected_environment = current_environment();
+        let server = thread::spawn(move || {
+            let mut upgraded = false;
+            let mut full_restart_seen = false;
+            loop {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                if !upgraded {
+                    match request.message {
+                        Request::Ping if request.version > old_version => {
+                            protocol::write_message(
+                                &mut stream,
+                                &Envelope::with_version(
+                                    old_version,
+                                    Response::Error {
+                                        message: "newer protocol unsupported".into(),
+                                        code: Some(ErrorCode::UnsupportedVersion),
+                                    },
+                                ),
+                            )
+                            .unwrap();
+                        }
+                        Request::Ping => {
+                            assert_eq!(request.version, old_version);
+                            protocol::write_message(
+                                &mut stream,
+                                &Envelope::with_version(old_version, Response::Pong),
+                            )
+                            .unwrap();
+                        }
+                        Request::Restart if old_version == 16 => {
+                            upgraded = true;
+                            protocol::write_message(
+                                &mut stream,
+                                &Envelope::with_version(old_version, Response::Ok),
+                            )
+                            .unwrap();
+                        }
+                        Request::RestartWithNotificationConfig {
+                            notifications,
+                            environment,
+                        } if old_version >= 17 => {
+                            assert_eq!(notifications.max_scheduled_execution_concurrency, 4);
+                            assert_eq!(environment.is_some(), old_version >= 23);
+                            upgraded = true;
+                            protocol::write_message(
+                                &mut stream,
+                                &Envelope::with_version(old_version, Response::Ok),
+                            )
+                            .unwrap();
+                        }
+                        request => panic!("unexpected old-daemon request: {request:?}"),
+                    }
+                } else {
+                    match request.message {
+                        Request::Ping => {
+                            protocol::write_message(
+                                &mut stream,
+                                &Envelope::with_version(request.version, Response::Pong),
+                            )
+                            .unwrap();
+                            if full_restart_seen {
+                                break;
+                            }
+                        }
+                        Request::RestartWithNotificationConfig {
+                            notifications,
+                            environment: Some(environment),
+                        } => {
+                            assert_eq!(request.version, 24);
+                            assert_eq!(notifications, expected_settings);
+                            assert_eq!(environment, expected_environment);
+                            full_restart_seen = true;
+                            protocol::write_message(
+                                &mut stream,
+                                &Envelope::with_version(24, Response::Ok),
+                            )
+                            .unwrap();
+                        }
+                        request => panic!("unexpected upgraded-daemon request: {request:?}"),
+                    }
+                }
+            }
+        });
+        let client = Client::from_socket_path(socket);
+        client
+            .restart_with_notification_config(settings.clone())
+            .unwrap();
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn mixed_version_restart_applies_full_settings_after_compatibility_handoff() {
+        for version in [16, 22, 23] {
+            assert_two_stage_restart_from(version);
+        }
+    }
+
     fn test_profile() -> TerminalProfile {
         TerminalProfile {
             term: None,
@@ -1246,6 +1375,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 24, 23);
             reject_protocol(&listener, 23, 22);
             reject_protocol(&listener, 22, 21);
             reject_protocol(&listener, 21, 20);
@@ -1427,7 +1557,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 23);
+            assert_eq!(request.version, 24);
             let Request::Attach {
                 environment: Some(environment),
                 ..
@@ -1444,7 +1574,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    23,
+                    24,
                     Response::Attached {
                         token: "token".into(),
                         reconstruction: Vec::new(),
@@ -1535,6 +1665,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 24, 23);
             reject_protocol(&listener, 23, 22);
             reject_protocol(&listener, 22, 21);
             reject_protocol(&listener, 21, 20);
@@ -1594,6 +1725,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 24, 23);
             reject_protocol(&listener, 23, 22);
             reject_protocol(&listener, 22, 21);
             reject_protocol(&listener, 21, 20);

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ use serde::Deserialize;
 
 const DEFAULT_PROJECT_SEARCH_DEPTH: usize = 3;
 const MAX_PROJECT_SEARCH_DEPTH: usize = 10;
+const DEFAULT_MAX_SCHEDULED_EXECUTION_CONCURRENCY: u16 = 4;
+const MAX_SCHEDULED_EXECUTION_CONCURRENCY: i64 = 64;
 
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -17,6 +19,7 @@ struct RawConfig {
     notifications: Option<RawNotificationsConfig>,
     dashboard: Option<RawDashboardConfig>,
     recovery: Option<RawRecoveryConfig>,
+    scheduling: Option<RawSchedulingConfig>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -54,6 +57,12 @@ struct RawDashboardConfig {
 struct RawRecoveryConfig {
     resume_agents: Option<bool>,
     persist_terminal_history: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawSchedulingConfig {
+    max_concurrent: Option<i64>,
 }
 
 #[derive(Debug)]
@@ -95,7 +104,7 @@ pub(crate) fn load() -> Result<Config, Box<dyn Error>> {
 pub(crate) fn load_notification_settings()
 -> Result<boomux::daemon::NotificationDeliverySettings, Box<dyn Error>> {
     let (raw, _) = load_raw()?;
-    Ok(resolve_daemon_settings(raw.notifications, raw.recovery))
+    resolve_daemon_settings(raw.notifications, raw.recovery, raw.scheduling)
 }
 
 fn load_raw() -> Result<(RawConfig, Option<PathBuf>), Box<dyn Error>> {
@@ -194,6 +203,12 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
             recovery.persist_terminal_history = next_recovery.persist_terminal_history;
         }
     }
+    if let Some(next_scheduling) = next.scheduling {
+        let scheduling = base.scheduling.get_or_insert_default();
+        if next_scheduling.max_concurrent.is_some() {
+            scheduling.max_concurrent = next_scheduling.max_concurrent;
+        }
+    }
 }
 
 fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Error>> {
@@ -224,7 +239,7 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
         terminal,
         projects: ProjectsConfig { roots, max_depth },
         path,
-        notifications: resolve_daemon_settings(raw.notifications, raw.recovery),
+        notifications: resolve_daemon_settings(raw.notifications, raw.recovery, raw.scheduling)?,
         dashboard: DashboardConfig {
             follow_focused_terminal: raw
                 .dashboard
@@ -239,16 +254,27 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
 fn resolve_notifications(
     raw: Option<RawNotificationsConfig>,
 ) -> boomux::daemon::NotificationDeliverySettings {
-    resolve_daemon_settings(raw, None)
+    resolve_daemon_settings(raw, None, None).expect("default scheduling config is valid")
 }
 
 fn resolve_daemon_settings(
     notifications: Option<RawNotificationsConfig>,
     recovery: Option<RawRecoveryConfig>,
-) -> boomux::daemon::NotificationDeliverySettings {
+    scheduling: Option<RawSchedulingConfig>,
+) -> Result<boomux::daemon::NotificationDeliverySettings, Box<dyn Error>> {
     let raw = notifications.unwrap_or_default();
     let recovery = recovery.unwrap_or_default();
-    boomux::daemon::NotificationDeliverySettings {
+    let max_concurrent = scheduling
+        .unwrap_or_default()
+        .max_concurrent
+        .unwrap_or(i64::from(DEFAULT_MAX_SCHEDULED_EXECUTION_CONCURRENCY));
+    if !(1..=MAX_SCHEDULED_EXECUTION_CONCURRENCY).contains(&max_concurrent) {
+        return Err(ConfigError(format!(
+            "scheduling.max_concurrent must be between 1 and {MAX_SCHEDULED_EXECUTION_CONCURRENCY}"
+        ))
+        .into());
+    }
+    Ok(boomux::daemon::NotificationDeliverySettings {
         desktop: boomux::daemon::NotificationSettings {
             enabled: raw.enabled.unwrap_or(false),
             blocked: raw.blocked.unwrap_or(true),
@@ -265,7 +291,8 @@ fn resolve_daemon_settings(
         }),
         resume_agents: recovery.resume_agents.unwrap_or(true),
         persist_terminal_history: recovery.persist_terminal_history.unwrap_or(false),
-    }
+        max_scheduled_execution_concurrency: max_concurrent as u16,
+    })
 }
 
 fn expand_root(root: &str) -> Result<PathBuf, Box<dyn Error>> {
@@ -448,7 +475,7 @@ mod tests {
 
     #[test]
     fn recovery_settings_default_and_merge_per_field() {
-        let defaults = resolve_daemon_settings(None, None);
+        let defaults = resolve_daemon_settings(None, None, None).unwrap();
         assert!(defaults.resume_agents);
         assert!(!defaults.persist_terminal_history);
 
@@ -458,7 +485,8 @@ mod tests {
         let next: RawConfig = toml::from_str("[recovery]\nresume_agents = true").unwrap();
         merge(&mut base, next);
 
-        let settings = resolve_daemon_settings(base.notifications, base.recovery);
+        let settings =
+            resolve_daemon_settings(base.notifications, base.recovery, base.scheduling).unwrap();
         assert!(settings.resume_agents);
         assert!(settings.persist_terminal_history);
         assert!(toml::from_str::<RawConfig>("[recovery]\nunknown = true").is_err());
@@ -491,6 +519,7 @@ mod tests {
                 },
                 resume_agents: true,
                 persist_terminal_history: false,
+                max_scheduled_execution_concurrency: 4,
             }
         );
     }
@@ -509,5 +538,32 @@ mod tests {
         .unwrap();
         assert!(resolve(raw.clone(), None).is_err());
         assert!(resolve_notifications(raw.notifications).desktop.enabled);
+    }
+
+    #[test]
+    fn scheduling_concurrency_defaults_layers_and_rejects_invalid_values() {
+        assert_eq!(
+            resolve(RawConfig::default(), None)
+                .unwrap()
+                .notifications
+                .max_scheduled_execution_concurrency,
+            4
+        );
+        let mut base: RawConfig = toml::from_str("[scheduling]\nmax_concurrent = 2").unwrap();
+        let next: RawConfig = toml::from_str("[scheduling]\nmax_concurrent = 9").unwrap();
+        merge(&mut base, next);
+        assert_eq!(
+            resolve(base, None)
+                .unwrap()
+                .notifications
+                .max_scheduled_execution_concurrency,
+            9
+        );
+        for value in [0, -1, 65] {
+            let raw: RawConfig =
+                toml::from_str(&format!("[scheduling]\nmax_concurrent = {value}")).unwrap();
+            assert!(resolve(raw, None).is_err());
+        }
+        assert!(toml::from_str::<RawConfig>("[scheduling]\nunknown = 1").is_err());
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -36,10 +36,10 @@ use crate::protocol::{
     DaemonEventKind, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot,
     NotificationDeliveryConfig, Request, Response, ScheduledExecutionDispatchKind,
     ScheduledExecutionOutcome, ScheduledExecutionReason, ScheduledExecutionSnapshot,
-    ScheduledExecutionState, ScheduledRunnerResult, ShellOwner, ShellRunExitReason,
-    ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
-    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
-    WorkspaceLauncherSpec, WorkspaceSnapshot,
+    ScheduledExecutionState, ScheduledOccurrence, ScheduledRunnerResult, SchedulerHealth,
+    SchedulerState, ShellOwner, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec,
+    ShellStatus, Snapshot, TerminalPreview, TerminalProfile, UnixEnvironment,
+    UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::state_store::{
     PersistedAgentInstance, PersistedAgentSchedule, PersistedScheduledExecution, PersistedShell,
@@ -56,6 +56,8 @@ const RESTART_TIMEOUT: Duration = Duration::from_secs(10);
 const IO_RETRY_DELAY: Duration = Duration::from_millis(2);
 const OUTPUT_PUBLICATION_INTERVAL: Duration = Duration::from_millis(16);
 const PERSIST_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+const SCHEDULER_RETRY_MIN: Duration = Duration::from_millis(50);
+const SCHEDULER_RETRY_MAX: Duration = Duration::from_secs(5);
 const TERMINAL_HISTORY_INTERVAL: Duration = Duration::from_secs(5);
 const FOREGROUND_PROCESS_CACHE_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_TERMINAL_HISTORY_BYTES: usize = 256 * 1024;
@@ -63,6 +65,7 @@ const MAX_TERMINAL_ENV_VALUE: usize = 256;
 const MAX_NAME_BYTES: usize = 256;
 const MAX_AGENT_EVIDENCE_BYTES: usize = 4 * 1024;
 const MAX_TERMINAL_ROWS: u16 = 1_000;
+pub const MAX_SCHEDULED_EXECUTION_CONCURRENCY: u16 = 64;
 const MAX_TERMINAL_COLS: u16 = 1_000;
 const MAX_TERMINAL_PREVIEW_LINES: usize = 500;
 const MAX_TERMINAL_PREVIEW_SPANS: usize = 20_000;
@@ -117,6 +120,7 @@ impl From<NotificationDeliveryConfig> for NotificationDeliverySettings {
             },
             resume_agents: config.resume_agents,
             persist_terminal_history: config.persist_terminal_history,
+            max_scheduled_execution_concurrency: config.max_scheduled_execution_concurrency,
         }
     }
 }
@@ -132,6 +136,7 @@ impl From<NotificationDeliverySettings> for NotificationDeliveryConfig {
             completed_sound: settings.sound.completed,
             resume_agents: settings.resume_agents,
             persist_terminal_history: settings.persist_terminal_history,
+            max_scheduled_execution_concurrency: settings.max_scheduled_execution_concurrency,
         }
     }
 }
@@ -142,6 +147,7 @@ pub struct NotificationDeliverySettings {
     pub sound: NotificationSoundSettings,
     pub resume_agents: bool,
     pub persist_terminal_history: bool,
+    pub max_scheduled_execution_concurrency: u16,
 }
 
 impl Default for NotificationDeliverySettings {
@@ -151,6 +157,7 @@ impl Default for NotificationDeliverySettings {
             sound: NotificationSoundSettings::default(),
             resume_agents: true,
             persist_terminal_history: false,
+            max_scheduled_execution_concurrency: 4,
         }
     }
 }
@@ -297,8 +304,11 @@ fn run_daemon(
     committed: Option<&mut UnixStream>,
     notification_settings: NotificationDeliverySettings,
 ) -> io::Result<()> {
-    let mut registry = DaemonService::restore(store, committed.is_some(), transferred.events)?;
+    validate_notification_delivery_settings(&notification_settings)?;
+    let live_handoff = committed.is_some();
+    let mut registry = DaemonService::restore(store, live_handoff, transferred.events)?;
     registry.startup_environment = capture_current_environment();
+    registry.configure_scheduler_clock()?;
     registry.notification_settings = notification_settings.clone();
     if !registry.notification_settings.persist_terminal_history {
         registry.clear_terminal_histories()?;
@@ -356,6 +366,12 @@ fn run_daemon(
     } else if registry.durable.persistence_dirty.load(Ordering::Acquire) {
         registry.persist()?;
     }
+    if !live_handoff {
+        registry
+            .evaluate_schedules(true)
+            .map_err(|error| io::Error::other(error.to_string()))?;
+    }
+    registry.start_scheduler()?;
     let shutdown = Arc::new(AtomicBool::new(false));
     let transition = Arc::new(AtomicU8::new(TRANSITION_IDLE));
     let (restart_sender, restart_receiver) = mpsc::channel::<RestartRequest>();
@@ -380,6 +396,7 @@ fn run_daemon(
         }
         match restart_receiver.try_recv() {
             Ok(request) => {
+                registry.stop_scheduler()?;
                 let result = launch_replacement(
                     &listener,
                     &daemon_lock,
@@ -392,6 +409,7 @@ fn run_daemon(
                     shutdown.store(true, Ordering::Release);
                 } else {
                     transition.store(TRANSITION_IDLE, Ordering::Release);
+                    registry.start_scheduler()?;
                 }
                 let _ = request.reply.send(result);
                 continue;
@@ -435,6 +453,7 @@ fn run_daemon(
     for handler in handlers {
         let _ = handler.join();
     }
+    registry.stop_scheduler()?;
     let result = if handed_off {
         socket_cleanup.disarm();
         Ok(())
@@ -912,6 +931,7 @@ fn handle_connection(
                 .into_response(),
             );
         }
+        registry.stop_scheduler()?;
         return match registry.shutdown() {
             Ok(()) => {
                 shutdown.store(true, Ordering::Release);
@@ -919,6 +939,7 @@ fn handle_connection(
             }
             Err(error) => {
                 transition.store(TRANSITION_IDLE, Ordering::Release);
+                let _ = registry.start_scheduler();
                 send_response(
                     &mut stream,
                     response_version,
@@ -937,6 +958,18 @@ fn handle_connection(
             notifications,
             environment,
         } => {
+            if !(1..=MAX_SCHEDULED_EXECUTION_CONCURRENCY)
+                .contains(&notifications.max_scheduled_execution_concurrency)
+            {
+                return send_response(
+                    &mut stream,
+                    response_version,
+                    DaemonError::validation(format!(
+                        "scheduling max_concurrent must be between 1 and {MAX_SCHEDULED_EXECUTION_CONCURRENCY}"
+                    ))
+                    .into_response(),
+                );
+            }
             if let Some(environment) = environment
                 && let Err(error) = validate_unix_environment(environment)
             {
@@ -994,10 +1027,20 @@ fn handle_connection(
         };
     }
 
-    let response = match registry.dispatch_arc(request.message) {
+    let schedule_semantics_changed = matches!(
+        &request.message,
+        Request::CreateAgentSchedule { .. }
+            | Request::PauseAgentSchedule { .. }
+            | Request::ResumeAgentSchedule { .. }
+            | Request::RemoveAgentSchedule { .. }
+    );
+    let response = match registry.dispatch_arc(request.message, response_version) {
         Ok(response) => response,
         Err(error) => error.into_response(),
     };
+    if schedule_semantics_changed && !matches!(response, Response::Error { .. }) {
+        registry.wake_scheduler();
+    }
     send_response(
         &mut stream,
         response_version,
@@ -1009,6 +1052,23 @@ fn handle_connection(
                 .unwrap_or_default(),
         ),
     )
+}
+
+fn validate_notification_delivery_settings(
+    settings: &NotificationDeliverySettings,
+) -> io::Result<()> {
+    if (1..=MAX_SCHEDULED_EXECUTION_CONCURRENCY)
+        .contains(&settings.max_scheduled_execution_concurrency)
+    {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "scheduling max_concurrent must be between 1 and {MAX_SCHEDULED_EXECUTION_CONCURRENCY}"
+            ),
+        ))
+    }
 }
 
 fn unsupported_request_message(feature: protocol::ProtocolFeature) -> String {
@@ -1030,6 +1090,9 @@ fn response_for_version_with_schedule_shells(
     schedule_shell_ids: &HashSet<String>,
 ) -> Response {
     let mut response = response;
+    if !protocol::ProtocolFeature::TimedScheduling.is_supported_by(version) {
+        remove_timed_scheduling(&mut response);
+    }
     if !protocol::ProtocolFeature::ScheduledExecutions.is_supported_by(version) {
         if let Response::Events { events, .. } = &mut response {
             events.retain(|event| {
@@ -1148,6 +1211,61 @@ fn response_for_version_with_schedule_shells(
             }
         }
         response => response,
+    }
+}
+
+fn remove_timed_scheduling(response: &mut Response) {
+    let downgrade_schedule = |schedule: &mut AgentScheduleSnapshot| {
+        schedule.next_occurrence = None;
+    };
+    let downgrade_snapshot = |snapshot: &mut Snapshot| {
+        snapshot.scheduler = None;
+        for workspace in &mut snapshot.workspaces {
+            for schedule in &mut workspace.schedules {
+                downgrade_schedule(schedule);
+            }
+        }
+    };
+    match response {
+        Response::Snapshot { snapshot } => downgrade_snapshot(snapshot),
+        Response::Workspace { workspace } => {
+            for schedule in &mut workspace.schedules {
+                downgrade_schedule(schedule);
+            }
+        }
+        Response::AgentSchedule { schedule } => downgrade_schedule(schedule),
+        Response::AgentScheduleInspection { inspection } => {
+            downgrade_schedule(&mut inspection.schedule);
+        }
+        Response::ScheduledExecution { execution }
+            if execution.dispatch_kind == ScheduledExecutionDispatchKind::Timed
+                || execution.state == ScheduledExecutionState::Skipped =>
+        {
+            *response = Response::Error {
+                code: Some(ErrorCode::NotFound),
+                message: format!("scheduled execution not found: {}", execution.id),
+            };
+        }
+        Response::ScheduledExecutions { executions } => executions.retain(|execution| {
+            execution.dispatch_kind == ScheduledExecutionDispatchKind::Manual
+                && execution.state != ScheduledExecutionState::Skipped
+        }),
+        Response::Events {
+            snapshot, events, ..
+        } => {
+            if let Some(snapshot) = snapshot {
+                downgrade_snapshot(snapshot);
+            }
+            events.retain(|event| match &event.kind {
+                DaemonEventKind::ScheduledExecutionCreated { execution, .. }
+                | DaemonEventKind::ScheduledExecutionChanged { execution, .. } => {
+                    execution.dispatch_kind == ScheduledExecutionDispatchKind::Manual
+                        && execution.state != ScheduledExecutionState::Skipped
+                }
+                _ => true,
+            });
+        }
+        _ => {}
     }
 }
 
@@ -1310,16 +1428,201 @@ fn error_response(code: ErrorCode, message: impl Into<String>) -> Response {
     }
 }
 
+fn scheduled_execution_response(
+    execution: ScheduledExecutionSnapshot,
+    response_version: u32,
+) -> DaemonResult<Response> {
+    if execution.state == ScheduledExecutionState::Skipped
+        && !protocol::ProtocolFeature::TimedScheduling.is_supported_by(response_version)
+    {
+        return Err(DaemonError::lifecycle(
+            ErrorCode::Busy,
+            "scheduled execution was skipped by the current concurrency policy",
+        ));
+    }
+    Ok(Response::ScheduledExecution { execution })
+}
+
 struct DaemonService {
     durable: DurableRegistry,
     events: EventStream,
     runtimes: ShellRuntimeManager,
     mutation_lock: Mutex<()>,
+    schedule_dispatch_lock: Mutex<()>,
     notification_settings: NotificationDeliverySettings,
     notification_sink: Arc<dyn NotificationSink>,
     startup_environment: UnixEnvironment,
+    scheduler: SchedulerWorker,
+    clock: Mutex<Arc<dyn SchedulerClock>>,
     #[cfg(test)]
     fail_after_mutation: AtomicBool,
+}
+
+trait SchedulerClock: Send + Sync {
+    fn now_ms(&self) -> u64;
+
+    fn take_tick(&self) -> io::Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn acknowledge(&self, _generation: u64) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn record_attempt(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn record_failure_diagnostic(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn resample_interval(&self) -> Duration {
+        Duration::from_secs(60)
+    }
+}
+
+struct SystemSchedulerClock;
+
+impl SchedulerClock for SystemSchedulerClock {
+    fn now_ms(&self) -> u64 {
+        unix_time_ms()
+    }
+}
+
+#[cfg(debug_assertions)]
+struct NativeTestSchedulerClock {
+    directory: PathBuf,
+    now_ms: AtomicU64,
+    generation: AtomicU64,
+}
+
+#[cfg(debug_assertions)]
+impl NativeTestSchedulerClock {
+    fn new(directory: PathBuf) -> io::Result<Self> {
+        let (generation, now_ms) = read_native_clock_tick(&directory)?;
+        Ok(Self {
+            directory,
+            now_ms: AtomicU64::new(now_ms),
+            generation: AtomicU64::new(generation.saturating_sub(1)),
+        })
+    }
+}
+
+#[cfg(debug_assertions)]
+impl SchedulerClock for NativeTestSchedulerClock {
+    fn now_ms(&self) -> u64 {
+        self.now_ms.load(Ordering::Acquire)
+    }
+
+    fn take_tick(&self) -> io::Result<Option<u64>> {
+        let (generation, now_ms) = read_native_clock_tick(&self.directory)?;
+        if generation <= self.generation.load(Ordering::Acquire) {
+            return Ok(None);
+        }
+        self.now_ms.store(now_ms, Ordering::Release);
+        self.generation.store(generation, Ordering::Release);
+        write_native_clock_marker(&self.directory.join("seen"), &generation.to_string())?;
+        Ok(Some(generation))
+    }
+
+    fn acknowledge(&self, generation: u64) -> io::Result<()> {
+        write_native_clock_marker(&self.directory.join("ack"), &generation.to_string())
+    }
+
+    fn record_attempt(&self) -> io::Result<()> {
+        let path = self.directory.join("attempts");
+        let attempts = match read_native_clock_marker(&path) {
+            Ok(value) => value.trim().parse::<u64>().unwrap_or(0),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => 0,
+            Err(error) => return Err(error),
+        };
+        write_native_clock_marker(&path, &attempts.saturating_add(1).to_string())
+    }
+
+    fn record_failure_diagnostic(&self) -> io::Result<()> {
+        let path = self.directory.join("diagnostics");
+        let diagnostics = match read_native_clock_marker(&path) {
+            Ok(value) => value.trim().parse::<u64>().unwrap_or(0),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => 0,
+            Err(error) => return Err(error),
+        };
+        write_native_clock_marker(&path, &diagnostics.saturating_add(1).to_string())
+    }
+
+    fn resample_interval(&self) -> Duration {
+        Duration::from_millis(10)
+    }
+}
+
+#[cfg(debug_assertions)]
+fn read_native_clock_tick(directory: &Path) -> io::Result<(u64, u64)> {
+    let value = read_native_clock_marker(&directory.join("tick"))?;
+    let (generation, now_ms) = value.trim().split_once(' ').ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "native clock tick is malformed")
+    })?;
+    Ok((
+        generation
+            .parse()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid tick generation"))?,
+        now_ms
+            .parse()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid tick time"))?,
+    ))
+}
+
+#[cfg(debug_assertions)]
+fn read_native_clock_marker(path: &Path) -> io::Result<String> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    validate_native_clock_marker(path, &file.metadata()?)?;
+    let mut value = String::new();
+    file.read_to_string(&mut value)?;
+    Ok(value)
+}
+
+#[cfg(debug_assertions)]
+fn write_native_clock_marker(path: &Path, value: &str) -> io::Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    validate_native_clock_marker(path, &file.metadata()?)?;
+    file.write_all(value.as_bytes())
+}
+
+#[cfg(debug_assertions)]
+fn validate_native_clock_marker(path: &Path, metadata: &fs::Metadata) -> io::Result<()> {
+    if !metadata.is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.mode() & 0o077 != 0
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("native clock marker is unsafe: {}", path.display()),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct SchedulerWorker {
+    state: Mutex<SchedulerWorkerState>,
+    changed: Condvar,
+}
+
+#[derive(Default)]
+struct SchedulerWorkerState {
+    stop: bool,
+    wake: bool,
+    running: bool,
+    healthy: bool,
+    handle: Option<thread::JoinHandle<()>>,
 }
 
 struct DurableRegistry {
@@ -2076,74 +2379,152 @@ impl DurableRegistry {
         Ok(snapshots)
     }
 
+    fn active_scheduled_execution_count(&self) -> io::Result<usize> {
+        self.active_scheduled_execution_count_excluding(None)
+    }
+
+    fn active_scheduled_execution_count_excluding(
+        &self,
+        excluding_schedule_id: Option<&str>,
+    ) -> io::Result<usize> {
+        let schedules = lock(&self.state)?
+            .schedules
+            .values()
+            .filter(|schedule| excluding_schedule_id != Some(schedule.id.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut count = 0;
+        for schedule in schedules {
+            for execution in lock(&schedule.executions)?.iter() {
+                count += usize::from(!lock(&execution.state)?.state.is_terminal());
+            }
+        }
+        Ok(count)
+    }
+
+    #[cfg(test)]
     fn claim_schedule_execution(
         &self,
         schedule_id: &str,
         dispatch_key: &str,
     ) -> DaemonResult<(ScheduledExecutionSnapshot, Option<DurableUndo>)> {
-        validate_id("dispatch idempotency key", dispatch_key)?;
+        let (execution, undo, _) = self.decide_schedule_execution(
+            schedule_id,
+            ScheduleDecision {
+                dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+                dispatch_key: dispatch_key.to_owned(),
+                scheduled_at_ms: None,
+                coalesced_through_ms: None,
+                requested_at_ms: unix_time_ms(),
+                forced_skip: None,
+            },
+            4,
+        )?;
+        Ok((execution, undo))
+    }
+
+    fn decide_schedule_execution(
+        &self,
+        schedule_id: &str,
+        decision: ScheduleDecision,
+        max_concurrent: u16,
+    ) -> DaemonResult<(ScheduledExecutionSnapshot, Option<DurableUndo>, bool)> {
+        let ScheduleDecision {
+            dispatch_kind,
+            dispatch_key,
+            scheduled_at_ms,
+            coalesced_through_ms,
+            requested_at_ms,
+            forced_skip,
+        } = decision;
+        validate_id("dispatch idempotency key", &dispatch_key)?;
         let schedule = self.schedule(schedule_id)?;
         let existing = lock(&schedule.executions)?
             .iter()
             .find(|execution| execution.dispatch_key == dispatch_key)
             .cloned();
         if let Some(existing) = existing {
-            return Ok((existing.snapshot()?, None));
+            let snapshot = existing.snapshot()?;
+            let claimed = snapshot.state == ScheduledExecutionState::Claimed;
+            return Ok((snapshot, None, claimed));
         }
-        let execution_shell_id = lock(&schedule.state)?.execution_shell_id.clone();
+        let schedule_state = lock(&schedule.state)?.clone();
+        let execution_shell_id = schedule_state.execution_shell_id.clone();
+        let mut skip_reason = forced_skip;
         if let Some(shell_id) = execution_shell_id {
             let shell = self.shell(&shell_id)?;
             if matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Running { .. }) {
-                return Err(DaemonError::lifecycle(
-                    ErrorCode::Busy,
-                    "agent schedule runner shell is still running",
-                ));
+                skip_reason.get_or_insert(ScheduledExecutionReason::Overlap);
             }
         }
-        if self.continuation_session_is_active(&schedule)? {
-            return Err(DaemonError::lifecycle(
-                ErrorCode::Busy,
-                "continued Agent session is active in a current shell run",
-            ));
-        }
-        let schedule_state = lock(&schedule.state)?.clone();
         let mut executions = lock(&schedule.executions)?;
         let mut dispatch_key_filter = lock(&schedule.dispatch_key_filter)?;
-        if dispatch_key_was_seen(&dispatch_key_filter, dispatch_key) {
+        if dispatch_key_was_seen(&dispatch_key_filter, &dispatch_key) {
             return Err(DaemonError::lifecycle(
                 ErrorCode::IdempotencyExpired,
                 "dispatch idempotency key was used by a pruned execution",
             ));
         }
-        for execution in executions.iter() {
-            if !lock(&execution.state)?.state.is_terminal() {
-                return Err(DaemonError::lifecycle(
-                    ErrorCode::Busy,
-                    "agent schedule already has a nonterminal execution",
-                ));
-            }
+        if executions
+            .iter()
+            .any(|execution| lock(&execution.state).is_ok_and(|state| !state.state.is_terminal()))
+        {
+            skip_reason.get_or_insert(ScheduledExecutionReason::Overlap);
         }
-        let now = unix_time_ms();
+        if skip_reason.is_none()
+            && (self.continuation_session_is_active(&schedule)?
+                || self.continuation_lease_is_occupied(&schedule)?)
+        {
+            skip_reason = Some(ScheduledExecutionReason::ActiveSession);
+        }
+        if skip_reason.is_none()
+            && self.workspace_has_nonterminal_execution(&schedule.workspace_id, &schedule.id)?
+        {
+            skip_reason = Some(ScheduledExecutionReason::WorkspaceCapacity);
+        }
+        if skip_reason.is_none()
+            && self.active_scheduled_execution_count_excluding(Some(&schedule.id))?
+                >= usize::from(max_concurrent)
+        {
+            skip_reason = Some(ScheduledExecutionReason::GlobalCapacity);
+        }
+        if skip_reason.is_none()
+            && validate_schedule_capability(&schedule.integration, &schedule.session).is_err()
+        {
+            skip_reason = Some(ScheduledExecutionReason::InvalidTarget);
+        }
+        let state = if skip_reason.is_some() {
+            ScheduledExecutionState::Skipped
+        } else {
+            ScheduledExecutionState::Claimed
+        };
+        let id = if let Some(scheduled_at_ms) = scheduled_at_ms {
+            timed_execution_id(&schedule.id, schedule.trigger_revision, scheduled_at_ms)
+        } else {
+            Uuid::new_v4().to_string()
+        };
         let execution = Arc::new(ScheduledExecution {
-            id: Uuid::new_v4().to_string(),
+            id,
             workspace_id: schedule.workspace_id.clone(),
             schedule_id: schedule.id.clone(),
-            dispatch_kind: ScheduledExecutionDispatchKind::Manual,
-            dispatch_key: dispatch_key.into(),
+            dispatch_kind,
+            dispatch_key: dispatch_key.clone(),
             schedule_revision: schedule_state.revision,
             prompt_revision: schedule.prompt_revision,
             trigger_revision: schedule.trigger_revision,
-            requested_at_ms: now,
+            requested_at_ms,
+            scheduled_at_ms,
+            coalesced_through_ms,
             cwd: schedule.cwd.clone(),
             integration: schedule.integration.clone(),
             session: schedule.session.clone(),
             prompt: schedule.prompt.clone(),
             runner_token: Uuid::new_v4().to_string(),
             state: Mutex::new(ScheduledExecutionMutableState {
-                state: ScheduledExecutionState::Claimed,
+                state,
                 started_at_ms: None,
-                ended_at_ms: None,
-                reason: None,
+                ended_at_ms: skip_reason.map(|_| requested_at_ms),
+                reason: skip_reason,
                 outcome: None,
                 shell_id: None,
                 run_id: None,
@@ -2154,8 +2535,11 @@ impl DurableRegistry {
         let snapshot = execution.snapshot()?;
         let previous = executions.clone();
         let previous_dispatch_key_filter = dispatch_key_filter.clone();
-        remember_dispatch_key(&mut dispatch_key_filter, dispatch_key);
+        remember_dispatch_key(&mut dispatch_key_filter, &dispatch_key);
         executions.push(execution);
+        if state.is_terminal() {
+            prune_terminal_executions(&mut executions);
+        }
         drop(dispatch_key_filter);
         drop(executions);
         Ok((
@@ -2166,7 +2550,61 @@ impl DurableRegistry {
                 previous_dispatch_key_filter,
                 execution: None,
             }),
+            state == ScheduledExecutionState::Claimed,
         ))
+    }
+
+    fn workspace_has_nonterminal_execution(
+        &self,
+        workspace_id: &str,
+        excluding_schedule_id: &str,
+    ) -> io::Result<bool> {
+        let schedules = lock(&self.state)?
+            .schedules
+            .values()
+            .filter(|schedule| {
+                schedule.workspace_id == workspace_id && schedule.id != excluding_schedule_id
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for schedule in schedules {
+            if lock(&schedule.executions)?.iter().any(|execution| {
+                lock(&execution.state).is_ok_and(|state| !state.state.is_terminal())
+            }) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn continuation_lease_is_occupied(&self, schedule: &AgentSchedule) -> io::Result<bool> {
+        let AgentScheduleSession::Continue {
+            external_session_id,
+        } = &schedule.session
+        else {
+            return Ok(false);
+        };
+        let schedules = lock(&self.state)?
+            .schedules
+            .values()
+            .filter(|candidate| candidate.id != schedule.id)
+            .cloned()
+            .collect::<Vec<_>>();
+        for candidate in schedules {
+            if candidate.integration == schedule.integration
+                && matches!(
+                    &candidate.session,
+                    AgentScheduleSession::Continue { external_session_id: candidate_id }
+                        if candidate_id == external_session_id
+                )
+                && lock(&candidate.executions)?.iter().any(|execution| {
+                    lock(&execution.state).is_ok_and(|state| !state.state.is_terminal())
+                })
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     fn continuation_session_is_active(&self, schedule: &AgentSchedule) -> io::Result<bool> {
@@ -2557,10 +2995,20 @@ impl DurableRegistry {
         ))
     }
 
+    #[cfg(test)]
     fn create_schedule(
         &self,
         workspace_id: &str,
+        spec: AgentScheduleSpec,
+    ) -> io::Result<(AgentScheduleSnapshot, DurableUndo)> {
+        self.create_schedule_at(workspace_id, spec, unix_time_ms())
+    }
+
+    fn create_schedule_at(
+        &self,
+        workspace_id: &str,
         mut spec: AgentScheduleSpec,
+        now: u64,
     ) -> io::Result<(AgentScheduleSnapshot, DurableUndo)> {
         validate_name(&spec.name)?;
         validate_cwd(&spec.cwd)?;
@@ -2569,9 +3017,11 @@ impl DurableRegistry {
             .map_err(schedule_validation_error)?;
         spec.trigger.timezone = crate::scheduling::canonicalize_timezone(&spec.trigger.timezone)
             .map_err(schedule_validation_error)?;
+        crate::scheduling::CronSchedule::compile(&spec.trigger.cron, &spec.trigger.timezone)
+            .and_then(|cron| cron.ensure_possible())
+            .map_err(schedule_validation_error)?;
         validate_schedule_capability(&spec.integration, &spec.session)?;
         let workspace = self.workspace(workspace_id)?;
-        let now = unix_time_ms();
         let schedule = Arc::new(AgentSchedule {
             id: Uuid::new_v4().to_string(),
             workspace_id: workspace_id.into(),
@@ -2590,6 +3040,7 @@ impl DurableRegistry {
                 revision: 1,
                 updated_at_ms: now,
                 evaluation_frontier_ms: now,
+                evaluation_frontier_trigger_revision: 1,
                 execution_shell_id: None,
             }),
             executions: Mutex::new(Vec::new()),
@@ -2639,21 +3090,34 @@ impl DurableRegistry {
         ))
     }
 
-    fn set_schedule_state(
+    fn set_schedule_state_at(
         &self,
         schedule_id: &str,
         next: AgentScheduleState,
+        requested_at_ms: u64,
     ) -> io::Result<(AgentScheduleSnapshot, Option<DurableUndo>)> {
         let schedule = self.schedule(schedule_id)?;
+        let mut compiled_trigger = None;
         if next == AgentScheduleState::Enabled {
+            let cron = crate::scheduling::CronSchedule::compile(
+                &schedule.trigger.cron,
+                &schedule.trigger.timezone,
+            )
+            .map_err(schedule_validation_error)?;
+            cron.ensure_possible().map_err(schedule_validation_error)?;
+            compiled_trigger = Some(cron);
             validate_schedule_capability(&schedule.integration, &schedule.session)?;
         }
         let mut state = lock(&schedule.state)?;
         if state.state == next {
-            return Ok((schedule.snapshot_from(&state), None));
+            return Ok((schedule.snapshot_from(&state)?, None));
         }
         let previous = state.clone();
-        let now = unix_time_ms().max(state.updated_at_ms.saturating_add(1));
+        let now = requested_at_ms.max(state.updated_at_ms.saturating_add(1));
+        if let Some(cron) = compiled_trigger {
+            cron.next_after_ms(now.max(state.evaluation_frontier_ms))
+                .map_err(schedule_validation_error)?;
+        }
         state.state = next;
         state.revision = state
             .revision
@@ -2662,8 +3126,9 @@ impl DurableRegistry {
         state.updated_at_ms = now;
         if next == AgentScheduleState::Enabled {
             state.evaluation_frontier_ms = now.max(state.evaluation_frontier_ms);
+            state.evaluation_frontier_trigger_revision = schedule.trigger_revision;
         }
-        let snapshot = schedule.snapshot_from(&state);
+        let snapshot = schedule.snapshot_from(&state)?;
         drop(state);
         Ok((
             snapshot,
@@ -3264,6 +3729,7 @@ impl DurableRegistry {
                 .map(|workspace| workspace.snapshot(self))
                 .collect::<io::Result<_>>()?,
             focused_terminal,
+            scheduler: None,
         })
     }
 
@@ -4074,9 +4540,12 @@ impl Default for DaemonService {
                 stopping: AtomicBool::new(false),
             },
             mutation_lock: Mutex::new(()),
+            schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
             notification_sink: Arc::new(DisabledNotificationSink),
             startup_environment: capture_current_environment(),
+            scheduler: SchedulerWorker::default(),
+            clock: Mutex::new(Arc::new(SystemSchedulerClock)),
             #[cfg(test)]
             fail_after_mutation: AtomicBool::new(false),
         }
@@ -4121,6 +4590,8 @@ struct ScheduledExecution {
     prompt_revision: u64,
     trigger_revision: u64,
     requested_at_ms: u64,
+    scheduled_at_ms: Option<u64>,
+    coalesced_through_ms: Option<u64>,
     cwd: PathBuf,
     integration: String,
     session: AgentScheduleSession,
@@ -4142,12 +4613,22 @@ struct ScheduledExecutionMutableState {
     external_session_id: Option<String>,
 }
 
+struct ScheduleDecision {
+    dispatch_kind: ScheduledExecutionDispatchKind,
+    dispatch_key: String,
+    scheduled_at_ms: Option<u64>,
+    coalesced_through_ms: Option<u64>,
+    requested_at_ms: u64,
+    forced_skip: Option<ScheduledExecutionReason>,
+}
+
 #[derive(Clone)]
 struct AgentScheduleMutableState {
     state: AgentScheduleState,
     revision: u64,
     updated_at_ms: u64,
     evaluation_frontier_ms: u64,
+    evaluation_frontier_trigger_revision: u64,
     execution_shell_id: Option<String>,
 }
 
@@ -4723,6 +5204,118 @@ fn workspace_created_events(workspace: &WorkspaceSnapshot) -> Vec<DaemonEventKin
     events
 }
 
+fn scheduler_worker(service: Weak<DaemonService>) {
+    let mut unacknowledged_tick = None;
+    let mut consecutive_failures = 0_u32;
+    let mut failure_logged = false;
+    if let Some(service) = service.upgrade()
+        && let Ok(mut state) = service.scheduler.state.lock()
+    {
+        state.running = true;
+    }
+    loop {
+        let Some(service) = service.upgrade() else {
+            return;
+        };
+        let clock = match lock(&service.clock) {
+            Ok(clock) => Arc::clone(&clock),
+            Err(_) => return,
+        };
+        let tick = clock.take_tick().map_err(DaemonError::from);
+        if let Ok(Some(generation)) = &tick {
+            unacknowledged_tick = Some(*generation);
+        }
+        let attempt = if unacknowledged_tick.is_some() {
+            clock.record_attempt().map_err(DaemonError::from)
+        } else {
+            Ok(())
+        };
+        let attempt = tick
+            .map(|_| ())
+            .and(attempt)
+            .and_then(|()| service.evaluate_schedules(false))
+            .and_then(|()| {
+                service
+                    .next_scheduled_occurrence_ms()
+                    .map_err(DaemonError::from)
+            })
+            .and_then(|next| {
+                if let Some(generation) = unacknowledged_tick {
+                    clock.acknowledge(generation).map_err(DaemonError::from)?;
+                }
+                Ok(next)
+            });
+        let (wait, retry_deadline) = match &attempt {
+            Ok(next) => {
+                consecutive_failures = 0;
+                failure_logged = false;
+                unacknowledged_tick = None;
+                let wait = next
+                    .map(|next| Duration::from_millis(next.saturating_sub(clock.now_ms())))
+                    .map_or_else(
+                        || clock.resample_interval(),
+                        |until_next| until_next.min(clock.resample_interval()),
+                    );
+                (wait, None)
+            }
+            Err(error) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                if !failure_logged {
+                    let _ = clock.record_failure_diagnostic();
+                    eprintln!("boomux: scheduler attempt failed: {error}");
+                    failure_logged = true;
+                }
+                let wait = scheduler_retry_delay(consecutive_failures);
+                (wait, Some(Instant::now() + wait))
+            }
+        };
+        let mut state = match lock(&service.scheduler.state) {
+            Ok(state) => state,
+            Err(_) => return,
+        };
+        state.healthy = attempt.is_ok();
+        if state.stop {
+            state.running = false;
+            state.healthy = false;
+            return;
+        }
+        if state.wake && retry_deadline.is_none() {
+            state.wake = false;
+            continue;
+        }
+        state.wake = false;
+        let mut remaining = wait;
+        loop {
+            let Ok((next, _)) = service.scheduler.changed.wait_timeout(state, remaining) else {
+                return;
+            };
+            state = next;
+            if state.stop {
+                state.running = false;
+                state.healthy = false;
+                return;
+            }
+            state.wake = false;
+            let Some(deadline) = retry_deadline else {
+                break;
+            };
+            let now = Instant::now();
+            if now >= deadline {
+                break;
+            }
+            remaining = deadline.saturating_duration_since(now);
+        }
+    }
+}
+
+fn scheduler_retry_delay(consecutive_failures: u32) -> Duration {
+    let shift = consecutive_failures.saturating_sub(1).min(7);
+    SCHEDULER_RETRY_MIN
+        .checked_mul(1_u32 << shift)
+        .unwrap_or(SCHEDULER_RETRY_MAX)
+        .min(SCHEDULER_RETRY_MAX)
+}
+
 fn resume_identity(
     agent: &AgentInstance,
     shell: &Shell,
@@ -4758,16 +5351,280 @@ fn resume_identity(
 }
 
 impl DaemonService {
-    fn dispatch_arc(self: &Arc<Self>, request: Request) -> DaemonResult<Response> {
+    fn clock_now_ms(&self) -> u64 {
+        lock(&self.clock)
+            .map(|clock| clock.now_ms())
+            .unwrap_or_else(|_| unix_time_ms())
+    }
+
+    fn configure_scheduler_clock(&mut self) -> io::Result<()> {
+        #[cfg(debug_assertions)]
+        if self.native_test_hooks_enabled()
+            && let Some(variable) = self
+                .startup_environment
+                .variables
+                .iter()
+                .find(|variable| variable.name == b"BOOMUX_NATIVE_TEST_CLOCK")
+        {
+            let directory = PathBuf::from(std::ffi::OsString::from_vec(variable.value.clone()));
+            let runtime = client::socket_path()?
+                .parent()
+                .ok_or_else(|| io::Error::other("daemon socket has no runtime directory"))?
+                .canonicalize()?;
+            let metadata = fs::symlink_metadata(&directory)?;
+            let canonical = directory.canonicalize()?;
+            if canonical != directory
+                || canonical == runtime
+                || !canonical.starts_with(&runtime)
+                || !metadata.is_dir()
+                || metadata.uid() != unsafe { libc::geteuid() }
+                || metadata.mode() & 0o077 != 0
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "native clock directory must be canonical, owned, private, and beneath the daemon runtime directory",
+                ));
+            }
+            for marker in ["tick", "seen", "ack", "attempts", "diagnostics"] {
+                let path = canonical.join(marker);
+                match fs::symlink_metadata(&path) {
+                    Ok(metadata) => validate_native_clock_marker(&path, &metadata)?,
+                    Err(error) if error.kind() == io::ErrorKind::NotFound && marker != "tick" => {}
+                    Err(error) => return Err(error),
+                }
+            }
+            self.clock = Mutex::new(Arc::new(NativeTestSchedulerClock::new(canonical)?));
+        }
+        Ok(())
+    }
+
+    fn start_scheduler(self: &Arc<Self>) -> io::Result<()> {
+        let mut state = lock(&self.scheduler.state)?;
+        if state.handle.is_some() {
+            return Ok(());
+        }
+        state.stop = false;
+        state.wake = true;
+        state.running = false;
+        state.healthy = false;
+        let service = Arc::downgrade(self);
+        state.handle = Some(
+            thread::Builder::new()
+                .name("boomux-scheduler".into())
+                .spawn(move || scheduler_worker(service))?,
+        );
+        self.scheduler.changed.notify_all();
+        Ok(())
+    }
+
+    fn stop_scheduler(&self) -> io::Result<()> {
+        let handle = {
+            let mut state = lock(&self.scheduler.state)?;
+            state.stop = true;
+            state.wake = true;
+            self.scheduler.changed.notify_all();
+            state.handle.take()
+        };
+        if let Some(handle) = handle {
+            handle
+                .join()
+                .map_err(|_| io::Error::other("scheduler worker panicked"))?;
+        }
+        let mut state = lock(&self.scheduler.state)?;
+        state.running = false;
+        state.healthy = false;
+        Ok(())
+    }
+
+    fn wake_scheduler(&self) {
+        if let Ok(mut state) = self.scheduler.state.lock() {
+            state.wake = true;
+            self.scheduler.changed.notify_all();
+        }
+    }
+
+    fn evaluate_schedules(self: &Arc<Self>, cold_recovery: bool) -> DaemonResult<()> {
+        let schedules = lock(&self.durable.state)?
+            .schedules
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let now = self.clock_now_ms();
+        for schedule in schedules {
+            let state = lock(&schedule.state)?.clone();
+            if state.state != AgentScheduleState::Enabled {
+                continue;
+            }
+            let cron = crate::scheduling::CronSchedule::compile(
+                &schedule.trigger.cron,
+                &schedule.trigger.timezone,
+            )
+            .map_err(|error| DaemonError::Internal(io::Error::other(error.to_string())))?;
+            let first_due = cron
+                .next_after_ms(state.evaluation_frontier_ms)
+                .map_err(|error| DaemonError::Internal(io::Error::other(error.to_string())))?;
+            if first_due > now {
+                continue;
+            }
+            let latest_due = cron.latest_at_or_before_ms(now).map_err(|error| {
+                DaemonError::Internal(io::Error::other(format!(
+                    "could not evaluate scheduled occurrence: {error}"
+                )))
+            })?;
+            if latest_due < first_due {
+                continue;
+            }
+            self.wait_for_native_pre_dispatch_barrier();
+            let _dispatch_eligibility = lock(&self.schedule_dispatch_lock)?;
+            let schedule_id = schedule.id.clone();
+            let mut dispatch = Vec::new();
+            let response = self.durable_mutation_outcome(|undo| {
+                let schedule = self.durable.schedule(&schedule_id)?;
+                let current = lock(&schedule.state)?.clone();
+                if current.evaluation_frontier_trigger_revision != schedule.trigger_revision
+                    || current.evaluation_frontier_ms >= latest_due
+                {
+                    return Ok(DurableMutation::Unchanged(Vec::new()));
+                }
+                let paused_race = current.state != AgentScheduleState::Enabled;
+                let mut decisions = Vec::new();
+                if cold_recovery || paused_race {
+                    decisions.push((
+                        first_due,
+                        Some(latest_due).filter(|through| *through > first_due),
+                        if paused_race {
+                            ScheduledExecutionReason::PausedRace
+                        } else {
+                            ScheduledExecutionReason::Missed
+                        },
+                    ));
+                } else {
+                    if first_due < latest_due {
+                        let coalesced_through = latest_due
+                            .checked_sub(1)
+                            .and_then(|ceiling| cron.latest_at_or_before_ms(ceiling).ok())
+                            .filter(|through| *through >= first_due);
+                        decisions.push((
+                            first_due,
+                            coalesced_through,
+                            ScheduledExecutionReason::Missed,
+                        ));
+                    }
+                    decisions.push((latest_due, None, ScheduledExecutionReason::Missed));
+                }
+
+                let mut snapshots = Vec::new();
+                for (scheduled_at_ms, coalesced_through_ms, default_reason) in decisions {
+                    let is_current =
+                        !cold_recovery && !paused_race && scheduled_at_ms == latest_due;
+                    let dispatch_key = timed_dispatch_key(
+                        &schedule.id,
+                        schedule.trigger_revision,
+                        scheduled_at_ms,
+                    );
+                    let (execution, record, claimed) = self.durable.decide_schedule_execution(
+                        &schedule.id,
+                        ScheduleDecision {
+                            dispatch_kind: ScheduledExecutionDispatchKind::Timed,
+                            dispatch_key,
+                            scheduled_at_ms: Some(scheduled_at_ms),
+                            coalesced_through_ms,
+                            requested_at_ms: now,
+                            forced_skip: (!is_current).then_some(default_reason),
+                        },
+                        self.notification_settings
+                            .max_scheduled_execution_concurrency,
+                    )?;
+                    if let Some(record) = record {
+                        undo.record(record);
+                    }
+                    if claimed {
+                        dispatch.push(execution.id.clone());
+                    }
+                    snapshots.push(execution);
+                }
+                let mut schedule_state = lock(&schedule.state)?;
+                let previous = schedule_state.clone();
+                schedule_state.evaluation_frontier_ms = latest_due;
+                schedule_state.evaluation_frontier_trigger_revision = schedule.trigger_revision;
+                drop(schedule_state);
+                undo.record(DurableUndo::ScheduleState { schedule, previous });
+                let events = snapshots
+                    .iter()
+                    .map(|execution| DaemonEventKind::ScheduledExecutionCreated {
+                        workspace_id: execution.workspace_id.clone(),
+                        execution: execution.clone(),
+                    })
+                    .collect();
+                Ok(DurableMutation::Changed(snapshots, events))
+            })?;
+            drop(response);
+            for execution_id in dispatch.drain(..) {
+                self.wait_for_native_claim_barrier();
+                let execution = self.durable.execution(&execution_id)?;
+                if let Err(error) = self.dispatch_schedule_execution(Arc::clone(&execution)) {
+                    let current = execution.snapshot()?;
+                    if current.state == ScheduledExecutionState::Claimed {
+                        self.terminalize_dispatch_failure(&execution)?;
+                    }
+                    eprintln!("boomux: timed scheduled dispatch failed: {error}");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn next_scheduled_occurrence_ms(&self) -> io::Result<Option<u64>> {
+        let schedules = lock(&self.durable.state)?
+            .schedules
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut next = None;
+        for schedule in schedules {
+            let state = lock(&schedule.state)?.clone();
+            if state.state != AgentScheduleState::Enabled {
+                continue;
+            }
+            let cron = crate::scheduling::CronSchedule::compile(
+                &schedule.trigger.cron,
+                &schedule.trigger.timezone,
+            )
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+            let candidate = cron
+                .next_after_ms(state.evaluation_frontier_ms)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+            next = Some(next.map_or(candidate, |current: u64| current.min(candidate)));
+        }
+        Ok(next)
+    }
+
+    fn dispatch_arc(
+        self: &Arc<Self>,
+        request: Request,
+        response_version: u32,
+    ) -> DaemonResult<Response> {
         if let Request::RunAgentSchedule {
             schedule_id,
             dispatch_key,
         } = request
         {
+            self.wait_for_native_pre_dispatch_barrier();
+            let _dispatch_eligibility = lock(&self.schedule_dispatch_lock)?;
             let response = self.durable_mutation_outcome(|undo| {
-                let (execution, record) = self
-                    .durable
-                    .claim_schedule_execution(&schedule_id, &dispatch_key)?;
+                let (execution, record, _) = self.durable.decide_schedule_execution(
+                    &schedule_id,
+                    ScheduleDecision {
+                        dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+                        dispatch_key: dispatch_key.clone(),
+                        scheduled_at_ms: None,
+                        coalesced_through_ms: None,
+                        requested_at_ms: self.clock_now_ms(),
+                        forced_skip: None,
+                    },
+                    self.notification_settings
+                        .max_scheduled_execution_concurrency,
+                )?;
                 let Some(record) = record else {
                     return Ok(DurableMutation::Unchanged(Response::ScheduledExecution {
                         execution,
@@ -4787,10 +5644,13 @@ impl DaemonService {
             let Response::ScheduledExecution { execution } = response else {
                 unreachable!("claim returns an execution")
             };
+            if execution.state == ScheduledExecutionState::Skipped {
+                return scheduled_execution_response(execution, response_version);
+            }
             self.wait_for_native_claim_barrier();
             let execution = self.durable.execution(&execution.id)?;
             return match self.dispatch_schedule_execution(Arc::clone(&execution)) {
-                Ok(execution) => Ok(Response::ScheduledExecution { execution }),
+                Ok(execution) => scheduled_execution_response(execution, response_version),
                 Err(error) => {
                     let current = execution.snapshot()?;
                     if current.state == ScheduledExecutionState::Claimed {
@@ -4845,6 +5705,29 @@ impl DaemonService {
 
     #[cfg(not(debug_assertions))]
     fn wait_for_native_claim_barrier(&self) {}
+
+    #[cfg(debug_assertions)]
+    fn wait_for_native_pre_dispatch_barrier(&self) {
+        if !self.native_test_hooks_enabled() {
+            return;
+        }
+        let Some(variable) = self
+            .startup_environment
+            .variables
+            .iter()
+            .find(|variable| variable.name == b"BOOMUX_NATIVE_TEST_PRE_DISPATCH_BARRIER")
+        else {
+            return;
+        };
+        let directory = PathBuf::from(std::ffi::OsString::from_vec(variable.value.clone()));
+        let _ = fs::write(directory.join("waiting"), b"waiting");
+        while !directory.join("release").exists() && !self.runtimes.is_stopping() {
+            thread::sleep(IO_RETRY_DELAY);
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn wait_for_native_pre_dispatch_barrier(&self) {}
 
     #[cfg(debug_assertions)]
     fn wait_for_native_start_barrier(&self) {
@@ -4982,8 +5865,7 @@ impl DaemonService {
     fn prepare_schedule_shell(
         &self,
         execution: &Arc<ScheduledExecution>,
-    ) -> DaemonResult<Arc<Shell>> {
-        let execution_id = execution.id.clone();
+    ) -> DaemonResult<Option<Arc<Shell>>> {
         let response = self.durable_mutation(|undo| {
             let schedule = self.schedule(&execution.schedule_id)?;
             let (execution_status, execution_shell_id) = {
@@ -4996,6 +5878,30 @@ impl DaemonService {
                         execution: execution.snapshot()?,
                     },
                     Vec::new(),
+                ));
+            }
+            if execution_shell_id.is_none()
+                && (self.durable.continuation_session_is_active(&schedule)?
+                    || self.durable.continuation_lease_is_occupied(&schedule)?)
+            {
+                let (skipped, record) = self.durable.mutate_execution(execution, |state| {
+                    if state.state == ScheduledExecutionState::Claimed && state.shell_id.is_none() {
+                        state.state = ScheduledExecutionState::Skipped;
+                        state.ended_at_ms =
+                            Some(self.clock_now_ms().max(execution.requested_at_ms));
+                        state.reason = Some(ScheduledExecutionReason::ActiveSession);
+                    }
+                    Ok(())
+                })?;
+                undo.record(record);
+                return Ok((
+                    Response::ScheduledExecution {
+                        execution: skipped.clone(),
+                    },
+                    vec![DaemonEventKind::ScheduledExecutionChanged {
+                        workspace_id: skipped.workspace_id.clone(),
+                        execution: skipped,
+                    }],
                 ));
             }
             if let Some(shell_id) = &execution_shell_id {
@@ -5085,11 +5991,8 @@ impl DaemonService {
             ))
         })?;
         match response {
-            Response::Shell { shell } => self.shell(&shell.id).map_err(Into::into),
-            Response::ScheduledExecution { .. } => Err(DaemonError::lifecycle(
-                ErrorCode::RunChanged,
-                format!("scheduled execution is no longer claimed: {execution_id}"),
-            )),
+            Response::Shell { shell } => self.shell(&shell.id).map(Some).map_err(Into::into),
+            Response::ScheduledExecution { .. } => Ok(None),
             _ => Err(DaemonError::Internal(io::Error::other(
                 "schedule shell preparation returned an unexpected response",
             ))),
@@ -5103,7 +6006,9 @@ impl DaemonService {
         if execution.snapshot()?.state != ScheduledExecutionState::Claimed {
             return Ok(execution.snapshot()?);
         }
-        let shell = self.prepare_schedule_shell(&execution)?;
+        let Some(shell) = self.prepare_schedule_shell(&execution)? else {
+            return execution.snapshot().map_err(Into::into);
+        };
         let _mutation = lock(&self.mutation_lock)?;
         self.ensure_running()?;
         {
@@ -5557,6 +6462,13 @@ impl DaemonService {
             }));
         }
         for execution in claimed {
+            let _dispatch_eligibility = match lock(&self.schedule_dispatch_lock) {
+                Ok(guard) => guard,
+                Err(error) => {
+                    eprintln!("boomux: could not acquire schedule dispatch lease: {error}");
+                    return;
+                }
+            };
             if let Err(error) = self.dispatch_schedule_execution(Arc::clone(&execution)) {
                 eprintln!(
                     "boomux: could not resume scheduled execution {} after handoff: {error}",
@@ -5575,6 +6487,14 @@ impl DaemonService {
     }
 
     fn dispatch(&self, request: Request) -> DaemonResult<Response> {
+        let _dispatch_eligibility = matches!(
+            &request,
+            Request::RegisterAgent { .. }
+                | Request::EnsureAgent { .. }
+                | Request::ReportAgent { .. }
+        )
+        .then(|| lock(&self.schedule_dispatch_lock))
+        .transpose()?;
         match request {
             Request::Ping => Ok(Response::Pong),
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
@@ -6297,9 +7217,12 @@ impl DaemonService {
                 stopping: AtomicBool::new(false),
             },
             mutation_lock: Mutex::new(()),
+            schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
             notification_sink: Arc::new(DisabledNotificationSink),
             startup_environment: capture_current_environment(),
+            scheduler: SchedulerWorker::default(),
+            clock: Mutex::new(Arc::new(SystemSchedulerClock)),
             #[cfg(test)]
             fail_after_mutation: AtomicBool::new(false),
         };
@@ -6976,6 +7899,7 @@ impl DaemonService {
                 transaction.finish_persistence();
                 drop(transaction);
                 self.events.notify();
+                self.wake_scheduler();
                 Ok(RunExitRecord::Recorded)
             }
             Err(error) => {
@@ -6984,6 +7908,7 @@ impl DaemonService {
                 transaction.finish_persistence();
                 drop(transaction);
                 self.events.notify();
+                self.wake_scheduler();
                 Err(error)
             }
         }
@@ -7021,7 +7946,28 @@ impl DaemonService {
     }
 
     fn snapshot(&self) -> io::Result<Snapshot> {
-        self.durable.snapshot(self.focused_terminal()?)
+        let mut snapshot = self.durable.snapshot(self.focused_terminal()?)?;
+        let active = self.scheduler.state.lock().ok().is_some_and(|scheduler| {
+            scheduler.running
+                && scheduler.healthy
+                && scheduler
+                    .handle
+                    .as_ref()
+                    .is_some_and(|handle| !handle.is_finished())
+        });
+        snapshot.scheduler = Some(SchedulerHealth {
+            state: if active {
+                SchedulerState::Active
+            } else {
+                SchedulerState::Offline
+            },
+            max_concurrent: self
+                .notification_settings
+                .max_scheduled_execution_concurrency,
+            active_executions: u16::try_from(self.durable.active_scheduled_execution_count()?)
+                .unwrap_or(u16::MAX),
+        });
+        Ok(snapshot)
     }
 
     fn schedule_shell_ids_for_downgrade(&self) -> io::Result<HashSet<String>> {
@@ -7419,7 +8365,9 @@ impl DaemonService {
         workspace_id: &str,
         spec: AgentScheduleSpec,
     ) -> io::Result<AgentScheduleSnapshot> {
-        let (snapshot, record) = self.durable.create_schedule(workspace_id, spec)?;
+        let (snapshot, record) =
+            self.durable
+                .create_schedule_at(workspace_id, spec, self.clock_now_ms())?;
         undo.record(record);
         Ok(snapshot)
     }
@@ -7430,7 +8378,9 @@ impl DaemonService {
         next: AgentScheduleState,
     ) -> DaemonResult<Response> {
         self.durable_mutation_outcome(|undo| {
-            let (schedule, record) = self.durable.set_schedule_state(schedule_id, next)?;
+            let (schedule, record) =
+                self.durable
+                    .set_schedule_state_at(schedule_id, next, self.clock_now_ms())?;
             let Some(record) = record else {
                 return Ok(DurableMutation::Unchanged(Response::AgentSchedule {
                     schedule,
@@ -7995,6 +8945,7 @@ impl AgentSchedule {
                 revision: saved.revision,
                 updated_at_ms: saved.updated_at_ms,
                 evaluation_frontier_ms: saved.evaluation_frontier_ms,
+                evaluation_frontier_trigger_revision: saved.evaluation_frontier_trigger_revision,
                 execution_shell_id: saved.execution_shell_id,
             }),
             executions: Mutex::new(
@@ -8016,11 +8967,28 @@ impl AgentSchedule {
 
     fn snapshot(&self) -> io::Result<AgentScheduleSnapshot> {
         let state = lock(&self.state)?;
-        Ok(self.snapshot_from(&state))
+        self.snapshot_from(&state)
     }
 
-    fn snapshot_from(&self, state: &AgentScheduleMutableState) -> AgentScheduleSnapshot {
-        AgentScheduleSnapshot {
+    fn snapshot_from(
+        &self,
+        state: &AgentScheduleMutableState,
+    ) -> io::Result<AgentScheduleSnapshot> {
+        let next_occurrence = if state.state == AgentScheduleState::Enabled {
+            let scheduled_at_ms = crate::scheduling::CronSchedule::compile(
+                &self.trigger.cron,
+                &self.trigger.timezone,
+            )
+            .and_then(|cron| cron.next_after_ms(state.evaluation_frontier_ms))
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+            Some(ScheduledOccurrence {
+                trigger_revision: self.trigger_revision,
+                scheduled_at_ms,
+            })
+        } else {
+            None
+        };
+        Ok(AgentScheduleSnapshot {
             id: self.id.clone(),
             workspace_id: self.workspace_id.clone(),
             name: self.name.clone(),
@@ -8037,7 +9005,8 @@ impl AgentSchedule {
             updated_at_ms: state.updated_at_ms,
             evaluation_frontier_ms: state.evaluation_frontier_ms,
             execution_shell_id: state.execution_shell_id.clone(),
-        }
+            next_occurrence,
+        })
     }
 
     fn inspection(&self) -> io::Result<AgentScheduleInspection> {
@@ -8048,7 +9017,10 @@ impl AgentSchedule {
     }
 
     fn persisted(&self) -> io::Result<PersistedAgentSchedule> {
-        let snapshot = self.snapshot()?;
+        let state = lock(&self.state)?;
+        let snapshot = self.snapshot_from(&state)?;
+        let evaluation_frontier_trigger_revision = state.evaluation_frontier_trigger_revision;
+        drop(state);
         let executions = lock(&self.executions)?
             .iter()
             .map(|execution| execution.persisted())
@@ -8070,6 +9042,7 @@ impl AgentSchedule {
             created_at_ms: snapshot.created_at_ms,
             updated_at_ms: snapshot.updated_at_ms,
             evaluation_frontier_ms: snapshot.evaluation_frontier_ms,
+            evaluation_frontier_trigger_revision,
             execution_shell_id: snapshot.execution_shell_id,
             dispatch_key_filter,
             executions,
@@ -8093,6 +9066,8 @@ impl ScheduledExecution {
             prompt_revision: saved.prompt_revision,
             trigger_revision: saved.trigger_revision,
             requested_at_ms: saved.requested_at_ms,
+            scheduled_at_ms: saved.scheduled_at_ms,
+            coalesced_through_ms: saved.coalesced_through_ms,
             cwd: saved.cwd,
             integration: saved.integration,
             session: saved.session,
@@ -8129,6 +9104,8 @@ impl ScheduledExecution {
             prompt_revision: self.prompt_revision,
             trigger_revision: self.trigger_revision,
             requested_at_ms: self.requested_at_ms,
+            scheduled_at_ms: self.scheduled_at_ms,
+            coalesced_through_ms: self.coalesced_through_ms,
             started_at_ms: state.started_at_ms,
             ended_at_ms: state.ended_at_ms,
             cwd: self.cwd.clone(),
@@ -8154,6 +9131,8 @@ impl ScheduledExecution {
             prompt_revision: self.prompt_revision,
             trigger_revision: self.trigger_revision,
             requested_at_ms: self.requested_at_ms,
+            scheduled_at_ms: self.scheduled_at_ms,
+            coalesced_through_ms: self.coalesced_through_ms,
             started_at_ms: state.started_at_ms,
             ended_at_ms: state.ended_at_ms,
             cwd: self.cwd.clone(),
@@ -9620,13 +10599,26 @@ fn validate_persisted_schedule(schedule: &PersistedAgentSchedule) -> io::Result<
         crate::scheduling::validate_external_session_id(external_session_id)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
     }
-    if schedule.state == AgentScheduleState::Enabled {
-        validate_schedule_capability(&schedule.integration, &schedule.session)
+    for timestamp in [
+        schedule.created_at_ms,
+        schedule.updated_at_ms,
+        schedule.evaluation_frontier_ms,
+    ] {
+        crate::scheduling::validate_timestamp_ms(timestamp)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
     }
     let cron = crate::scheduling::canonicalize_cron(&schedule.trigger.cron)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
     let timezone = crate::scheduling::canonicalize_timezone(&schedule.trigger.timezone)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    crate::scheduling::CronSchedule::compile(&cron, &timezone)
+        .and_then(|compiled| {
+            compiled.ensure_possible()?;
+            if schedule.state == AgentScheduleState::Enabled {
+                compiled.next_after_ms(schedule.evaluation_frontier_ms)?;
+            }
+            Ok(())
+        })
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
     if cron != schedule.trigger.cron
         || timezone != schedule.trigger.timezone
@@ -9638,7 +10630,7 @@ fn validate_persisted_schedule(schedule: &PersistedAgentSchedule) -> io::Result<
         || schedule.trigger_revision > schedule.revision
         || schedule.updated_at_ms < schedule.created_at_ms
         || schedule.evaluation_frontier_ms < schedule.created_at_ms
-        || schedule.evaluation_frontier_ms > schedule.updated_at_ms
+        || schedule.evaluation_frontier_trigger_revision != schedule.trigger_revision
     {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -9664,6 +10656,19 @@ fn validate_persisted_schedule(schedule: &PersistedAgentSchedule) -> io::Result<
         validate_persisted_cwd(&execution.cwd)?;
         crate::scheduling::validate_prompt(&execution.prompt)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        for timestamp in [
+            Some(execution.requested_at_ms),
+            execution.scheduled_at_ms,
+            execution.coalesced_through_ms,
+            execution.started_at_ms,
+            execution.ended_at_ms,
+        ]
+        .into_iter()
+        .flatten()
+        {
+            crate::scheduling::validate_timestamp_ms(timestamp)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        }
         if !execution_ids.insert(&execution.id)
             || !dispatch_keys.insert(&execution.dispatch_key)
             || !dispatch_key_was_seen(&schedule.dispatch_key_filter, &execution.dispatch_key)
@@ -9678,6 +10683,38 @@ fn validate_persisted_schedule(schedule: &PersistedAgentSchedule) -> io::Result<
             || execution.cwd != schedule.cwd
             || execution.integration != schedule.integration
             || execution.session != schedule.session
+            || match execution.dispatch_kind {
+                ScheduledExecutionDispatchKind::Manual => {
+                    execution.scheduled_at_ms.is_some() || execution.coalesced_through_ms.is_some()
+                }
+                ScheduledExecutionDispatchKind::Timed => {
+                    execution.scheduled_at_ms.is_none()
+                        || execution
+                            .scheduled_at_ms
+                            .is_some_and(|scheduled| scheduled > execution.requested_at_ms)
+                        || execution
+                            .scheduled_at_ms
+                            .is_some_and(|scheduled| scheduled > schedule.evaluation_frontier_ms)
+                        || execution.coalesced_through_ms.is_some_and(|through| {
+                            through < execution.scheduled_at_ms.unwrap_or(through)
+                                || through > schedule.evaluation_frontier_ms
+                        })
+                        || execution.scheduled_at_ms.is_some_and(|scheduled_at_ms| {
+                            execution.id
+                                != timed_execution_id(
+                                    &schedule.id,
+                                    execution.trigger_revision,
+                                    scheduled_at_ms,
+                                )
+                                || execution.dispatch_key
+                                    != timed_dispatch_key(
+                                        &schedule.id,
+                                        execution.trigger_revision,
+                                        scheduled_at_ms,
+                                    )
+                        })
+                }
+            }
             || execution
                 .started_at_ms
                 .is_some_and(|time| time < execution.requested_at_ms)
@@ -9691,6 +10728,20 @@ fn validate_persisted_schedule(schedule: &PersistedAgentSchedule) -> io::Result<
             || execution.shell_id.is_some() != execution.run_id.is_some()
                 && execution.run_id.is_some()
             || execution.agent_id.is_some() != execution.external_session_id.is_some()
+            || execution.coalesced_through_ms.is_some()
+                && !(execution.dispatch_kind == ScheduledExecutionDispatchKind::Timed
+                    && execution.state == ScheduledExecutionState::Skipped
+                    && matches!(
+                        execution.reason,
+                        Some(
+                            ScheduledExecutionReason::Missed | ScheduledExecutionReason::PausedRace
+                        )
+                    ))
+            || matches!(
+                execution.reason,
+                Some(ScheduledExecutionReason::Missed | ScheduledExecutionReason::PausedRace)
+            ) && !(execution.dispatch_kind == ScheduledExecutionDispatchKind::Timed
+                && execution.state == ScheduledExecutionState::Skipped)
             || matches!(
                 &execution.session,
                 AgentScheduleSession::Continue { external_session_id }
@@ -9715,6 +10766,26 @@ fn validate_persisted_schedule(schedule: &PersistedAgentSchedule) -> io::Result<
             validate_id("scheduled execution agent", agent_id)?;
         }
         let valid_state = match execution.state {
+            ScheduledExecutionState::Skipped => {
+                execution.started_at_ms.is_none()
+                    && execution.ended_at_ms.is_some()
+                    && execution.outcome.is_none()
+                    && execution.shell_id.is_none()
+                    && execution.run_id.is_none()
+                    && execution.agent_id.is_none()
+                    && matches!(
+                        execution.reason,
+                        Some(
+                            ScheduledExecutionReason::Overlap
+                                | ScheduledExecutionReason::ActiveSession
+                                | ScheduledExecutionReason::WorkspaceCapacity
+                                | ScheduledExecutionReason::GlobalCapacity
+                                | ScheduledExecutionReason::Missed
+                                | ScheduledExecutionReason::PausedRace
+                                | ScheduledExecutionReason::InvalidTarget
+                        )
+                    )
+            }
             ScheduledExecutionState::Claimed => {
                 execution.started_at_ms.is_none()
                     && execution.ended_at_ms.is_none()
@@ -9830,6 +10901,50 @@ fn remember_dispatch_key(filter: &mut [u8], key: &str) {
     let bit_count = filter.len().saturating_mul(8);
     for position in dispatch_key_positions(key, bit_count) {
         filter[position / 8] |= 1 << (position % 8);
+    }
+}
+
+fn timed_execution_id(schedule_id: &str, trigger_revision: u64, scheduled_at_ms: u64) -> String {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        format!("boomux:timed-execution:{schedule_id}:{trigger_revision}:{scheduled_at_ms}")
+            .as_bytes(),
+    )
+    .to_string()
+}
+
+fn timed_dispatch_key(schedule_id: &str, trigger_revision: u64, scheduled_at_ms: u64) -> String {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        format!("boomux:timed-dispatch:{schedule_id}:{trigger_revision}:{scheduled_at_ms}")
+            .as_bytes(),
+    )
+    .to_string()
+}
+
+fn prune_terminal_executions(executions: &mut Vec<Arc<ScheduledExecution>>) {
+    let mut terminal = executions
+        .iter()
+        .enumerate()
+        .filter_map(|(index, candidate)| {
+            lock(&candidate.state)
+                .ok()
+                .filter(|state| state.state.is_terminal())
+                .map(|_| (index, candidate.requested_at_ms))
+        })
+        .collect::<Vec<_>>();
+    terminal.sort_by_key(|(_, requested)| *requested);
+    let remove = terminal
+        .len()
+        .saturating_sub(MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE);
+    let mut remove = terminal
+        .into_iter()
+        .take(remove)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    remove.sort_unstable_by(|left, right| right.cmp(left));
+    for index in remove {
+        executions.remove(index);
     }
 }
 
@@ -10002,6 +11117,18 @@ fn lock<T>(mutex: &Mutex<T>) -> io::Result<MutexGuard<'_, T>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct FixedSchedulerClock(AtomicU64);
+
+    impl SchedulerClock for FixedSchedulerClock {
+        fn now_ms(&self) -> u64 {
+            self.0.load(Ordering::Acquire)
+        }
+    }
+
+    fn set_scheduler_time(registry: &DaemonService, now_ms: u64) {
+        *lock(&registry.clock).unwrap() = Arc::new(FixedSchedulerClock(AtomicU64::new(now_ms)));
+    }
     use std::sync::Barrier;
 
     use crate::protocol::{AgentAuthority, AgentState};
@@ -10352,6 +11479,47 @@ mod tests {
     }
 
     #[test]
+    fn scheduler_health_tracks_running_stopped_and_panicked_workers() {
+        let registry = Arc::new(DaemonService::default());
+        assert_eq!(
+            registry.snapshot().unwrap().scheduler.unwrap().state,
+            SchedulerState::Offline
+        );
+        registry.start_scheduler().unwrap();
+        for _ in 0..100 {
+            if registry.snapshot().unwrap().scheduler.unwrap().state == SchedulerState::Active {
+                break;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(
+            registry.snapshot().unwrap().scheduler.unwrap().state,
+            SchedulerState::Active
+        );
+        registry.stop_scheduler().unwrap();
+        assert_eq!(
+            registry.snapshot().unwrap().scheduler.unwrap().state,
+            SchedulerState::Offline
+        );
+
+        let panicked = thread::spawn(|| panic!("scheduler test panic"));
+        while !panicked.is_finished() {
+            thread::yield_now();
+        }
+        {
+            let mut state = lock(&registry.scheduler.state).unwrap();
+            state.running = true;
+            state.healthy = true;
+            state.handle = Some(panicked);
+        }
+        assert_eq!(
+            registry.snapshot().unwrap().scheduler.unwrap().state,
+            SchedulerState::Offline
+        );
+        assert!(registry.stop_scheduler().is_err());
+    }
+
+    #[test]
     fn focus_reports_require_protocol_eighteen_and_increment_revision() {
         let registry = DaemonService::default();
         let (_workspace, shell, runtime) = running_shell(&registry);
@@ -10566,6 +11734,8 @@ mod tests {
                     prompt_revision: 1,
                     trigger_revision: 1,
                     requested_at_ms: 1,
+                    scheduled_at_ms: Some(index as u64 + 1),
+                    coalesced_through_ms: None,
                     started_at_ms: None,
                     ended_at_ms: None,
                     cwd: env::temp_dir(),
@@ -10800,8 +11970,8 @@ mod tests {
     }
 
     #[test]
-    fn restored_enabled_schedules_require_current_dispatch_capability() {
-        let mut schedule = PersistedAgentSchedule {
+    fn restored_enabled_schedule_records_a_removed_dispatch_capability_as_invalid_target() {
+        let schedule = PersistedAgentSchedule {
             id: Uuid::new_v4().to_string(),
             name: "nightly".into(),
             cwd: env::temp_dir(),
@@ -10820,21 +11990,58 @@ mod tests {
             created_at_ms: 1,
             updated_at_ms: 1,
             evaluation_frontier_ms: 1,
+            evaluation_frontier_trigger_revision: 1,
             execution_shell_id: None,
             dispatch_key_filter: vec![0; DISPATCH_KEY_FILTER_BYTES],
             executions: Vec::new(),
         };
 
-        assert_eq!(
-            validate_persisted_schedule(&schedule).unwrap_err().kind(),
-            io::ErrorKind::InvalidData
-        );
-        schedule.state = AgentScheduleState::Paused;
         assert!(validate_persisted_schedule(&schedule).is_ok());
+
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace("restored-invalid-target".into(), Vec::new())
+            .unwrap();
+        let restored = Arc::new(AgentSchedule::from_persisted(&workspace.id, schedule));
+        lock(&registry.durable.state)
+            .unwrap()
+            .schedules
+            .insert(restored.id.clone(), Arc::clone(&restored));
+        lock(
+            &registry
+                .durable
+                .workspace(&workspace.id)
+                .unwrap()
+                .schedule_ids,
+        )
+        .unwrap()
+        .push(restored.id.clone());
+
+        let execution = registry
+            .durable
+            .decide_schedule_execution(
+                &restored.id,
+                ScheduleDecision {
+                    dispatch_kind: ScheduledExecutionDispatchKind::Timed,
+                    dispatch_key: timed_dispatch_key(&restored.id, 1, 60_000),
+                    scheduled_at_ms: Some(60_000),
+                    coalesced_through_ms: None,
+                    requested_at_ms: 60_000,
+                    forced_skip: None,
+                },
+                4,
+            )
+            .unwrap()
+            .0;
+        assert_eq!(execution.state, ScheduledExecutionState::Skipped);
+        assert_eq!(
+            execution.reason,
+            Some(ScheduledExecutionReason::InvalidTarget)
+        );
     }
 
     #[test]
-    fn state_ten_execution_validation_enforces_exact_state_shapes_and_revisions() {
+    fn state_eleven_execution_validation_enforces_exact_state_shapes_and_revisions() {
         let dispatch_key = Uuid::new_v4().to_string();
         let mut filter = vec![0; DISPATCH_KEY_FILTER_BYTES];
         remember_dispatch_key(&mut filter, &dispatch_key);
@@ -10847,6 +12054,8 @@ mod tests {
             prompt_revision: 1,
             trigger_revision: 1,
             requested_at_ms: 10,
+            scheduled_at_ms: None,
+            coalesced_through_ms: None,
             started_at_ms: None,
             ended_at_ms: None,
             cwd: env::temp_dir(),
@@ -10880,6 +12089,7 @@ mod tests {
             created_at_ms: 1,
             updated_at_ms: 2,
             evaluation_frontier_ms: 1,
+            evaluation_frontier_trigger_revision: 1,
             execution_shell_id: None,
             dispatch_key_filter: filter,
             executions: vec![execution],
@@ -10897,6 +12107,114 @@ mod tests {
         schedule.executions[0].run_id = Some(Uuid::new_v4().to_string());
         schedule.executions[0].started_at_ms = Some(10);
         schedule.executions[0].reason = Some(ScheduledExecutionReason::HostSpawnFailed);
+        assert!(validate_persisted_schedule(&schedule).is_err());
+    }
+
+    #[test]
+    fn state_eleven_validates_timed_matrix_frontier_and_chrono_bounds() {
+        let scheduled_at_ms = 60_000;
+        let dispatch_key =
+            timed_dispatch_key("00000000-0000-0000-0000-000000000001", 1, scheduled_at_ms);
+        let mut filter = vec![0; DISPATCH_KEY_FILTER_BYTES];
+        remember_dispatch_key(&mut filter, &dispatch_key);
+        let execution = PersistedScheduledExecution {
+            id: timed_execution_id("00000000-0000-0000-0000-000000000001", 1, scheduled_at_ms),
+            state: ScheduledExecutionState::Skipped,
+            dispatch_kind: ScheduledExecutionDispatchKind::Timed,
+            dispatch_key,
+            schedule_revision: 1,
+            prompt_revision: 1,
+            trigger_revision: 1,
+            requested_at_ms: 120_000,
+            scheduled_at_ms: Some(scheduled_at_ms),
+            coalesced_through_ms: Some(120_000),
+            started_at_ms: None,
+            ended_at_ms: Some(120_000),
+            cwd: env::temp_dir(),
+            integration: "opencode".into(),
+            session: AgentScheduleSession::Fresh,
+            prompt: "private".into(),
+            runner_token: Uuid::new_v4().to_string(),
+            reason: Some(ScheduledExecutionReason::Missed),
+            outcome: None,
+            shell_id: None,
+            run_id: None,
+            agent_id: None,
+            external_session_id: None,
+        };
+        let mut schedule = PersistedAgentSchedule {
+            id: "00000000-0000-0000-0000-000000000001".into(),
+            name: "timed-valid".into(),
+            cwd: env::temp_dir(),
+            integration: "opencode".into(),
+            prompt: "private".into(),
+            session: AgentScheduleSession::Fresh,
+            trigger: AgentScheduleTrigger {
+                cron: "0 2 * * *".into(),
+                timezone: "UTC".into(),
+            },
+            state: AgentScheduleState::Paused,
+            overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            revision: 1,
+            prompt_revision: 1,
+            trigger_revision: 1,
+            created_at_ms: 1,
+            updated_at_ms: 120_000,
+            evaluation_frontier_ms: 120_000,
+            evaluation_frontier_trigger_revision: 1,
+            execution_shell_id: None,
+            dispatch_key_filter: filter,
+            executions: vec![execution],
+        };
+        assert!(validate_persisted_schedule(&schedule).is_ok());
+
+        let clone_schedule = |schedule: &PersistedAgentSchedule| {
+            serde_json::from_value(serde_json::to_value(schedule).unwrap()).unwrap()
+        };
+        let valid = clone_schedule(&schedule);
+        schedule.executions[0].scheduled_at_ms = Some(120_001);
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule = clone_schedule(&valid);
+        schedule.executions[0].coalesced_through_ms = Some(120_001);
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule = clone_schedule(&valid);
+        schedule.executions[0].coalesced_through_ms = Some(60_000);
+        schedule.executions[0].reason = Some(ScheduledExecutionReason::Overlap);
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule = clone_schedule(&valid);
+        schedule.executions[0].dispatch_kind = ScheduledExecutionDispatchKind::Manual;
+        schedule.executions[0].scheduled_at_ms = None;
+        schedule.executions[0].coalesced_through_ms = None;
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule = clone_schedule(&valid);
+        schedule.executions[0].id = Uuid::new_v4().to_string();
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule = clone_schedule(&valid);
+        schedule.evaluation_frontier_ms = scheduled_at_ms - 1;
+        assert!(validate_persisted_schedule(&schedule).is_err());
+
+        let max =
+            u64::try_from(chrono::DateTime::<chrono::Utc>::MAX_UTC.timestamp_millis()).unwrap();
+        schedule = clone_schedule(&valid);
+        schedule.executions[0].scheduled_at_ms = Some(max + 1);
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule = clone_schedule(&valid);
+        schedule.executions[0].coalesced_through_ms = Some(max + 1);
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule = valid;
+        schedule.executions.clear();
+        schedule.dispatch_key_filter = vec![0; DISPATCH_KEY_FILTER_BYTES];
+        schedule.created_at_ms = max;
+        schedule.updated_at_ms = max;
+        schedule.evaluation_frontier_ms = max;
+        assert!(validate_persisted_schedule(&schedule).is_ok());
+        schedule.evaluation_frontier_ms = max + 1;
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule.evaluation_frontier_ms = max;
+        schedule.updated_at_ms = max + 1;
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule.updated_at_ms = max;
+        schedule.created_at_ms = max + 1;
         assert!(validate_persisted_schedule(&schedule).is_err());
     }
 
@@ -10939,6 +12257,7 @@ mod tests {
             created_at_ms: 1,
             updated_at_ms: 1,
             evaluation_frontier_ms: 1,
+            evaluation_frontier_trigger_revision: 1,
             execution_shell_id: Some(shell_id.clone()),
             dispatch_key_filter: filter,
             executions: vec![PersistedScheduledExecution {
@@ -10950,6 +12269,8 @@ mod tests {
                 prompt_revision: 1,
                 trigger_revision: 1,
                 requested_at_ms: 1,
+                scheduled_at_ms: None,
+                coalesced_through_ms: None,
                 started_at_ms: Some(1),
                 ended_at_ms: None,
                 cwd: env::temp_dir(),
@@ -11107,6 +12428,282 @@ mod tests {
     }
 
     #[test]
+    fn timed_evaluation_is_idempotent_rollback_safe_and_frontier_authoritative() {
+        let registry = Arc::new(DaemonService::default());
+        set_scheduler_time(&registry, 0);
+        let workspace = registry
+            .create_workspace("timed".into(), Vec::new())
+            .unwrap();
+        let mut spec = schedule_spec("private");
+        spec.trigger.cron = "* * * * *".into();
+        spec.state = AgentScheduleState::Enabled;
+        let Response::AgentSchedule { schedule } = registry
+            .dispatch(Request::CreateAgentSchedule {
+                workspace_id: workspace.id.clone(),
+                spec,
+            })
+            .unwrap()
+        else {
+            panic!("expected schedule");
+        };
+
+        set_scheduler_time(&registry, 180_000);
+        registry.evaluate_schedules(true).unwrap();
+        let executions = registry
+            .durable
+            .scheduled_executions(None, Some(&schedule.id))
+            .unwrap();
+        assert_eq!(executions.len(), 1);
+        assert_eq!(executions[0].state, ScheduledExecutionState::Skipped);
+        assert_eq!(executions[0].reason, Some(ScheduledExecutionReason::Missed));
+        assert_eq!(executions[0].scheduled_at_ms, Some(60_000));
+        assert_eq!(executions[0].coalesced_through_ms, Some(180_000));
+        let event_count = lock(&registry.events.state).unwrap().events.len();
+        registry.evaluate_schedules(true).unwrap();
+        assert_eq!(
+            registry
+                .durable
+                .scheduled_executions(None, Some(&schedule.id))
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            lock(&registry.events.state).unwrap().events.len(),
+            event_count
+        );
+
+        set_scheduler_time(&registry, 240_000);
+        registry.fail_after_next_mutation();
+        assert!(registry.evaluate_schedules(true).is_err());
+        assert_eq!(
+            registry
+                .durable
+                .schedule(&schedule.id)
+                .unwrap()
+                .snapshot()
+                .unwrap()
+                .evaluation_frontier_ms,
+            180_000
+        );
+        assert_eq!(
+            lock(&registry.events.state).unwrap().events.len(),
+            event_count
+        );
+        assert_eq!(
+            registry
+                .durable
+                .schedule(&schedule.id)
+                .unwrap()
+                .snapshot()
+                .unwrap()
+                .next_occurrence
+                .unwrap()
+                .scheduled_at_ms,
+            240_000
+        );
+        registry.evaluate_schedules(true).unwrap();
+        let after_retry = registry
+            .durable
+            .scheduled_executions(None, Some(&schedule.id))
+            .unwrap();
+        assert_eq!(after_retry.len(), 2);
+        assert_eq!(after_retry[0].scheduled_at_ms, Some(240_000));
+        assert_eq!(
+            registry
+                .durable
+                .schedule(&schedule.id)
+                .unwrap()
+                .snapshot()
+                .unwrap()
+                .next_occurrence
+                .unwrap()
+                .scheduled_at_ms,
+            300_000
+        );
+
+        set_scheduler_time(&registry, 120_000);
+        registry.evaluate_schedules(true).unwrap();
+        assert_eq!(
+            registry
+                .durable
+                .scheduled_executions(None, Some(&schedule.id))
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn pause_resume_and_history_pruning_do_not_reenable_old_occurrences() {
+        let registry = Arc::new(DaemonService::default());
+        set_scheduler_time(&registry, 0);
+        let workspace = registry
+            .create_workspace("timed-pruning".into(), Vec::new())
+            .unwrap();
+        let mut spec = schedule_spec("private");
+        spec.trigger.cron = "* * * * *".into();
+        spec.state = AgentScheduleState::Enabled;
+        let Response::AgentSchedule { schedule } = registry
+            .dispatch(Request::CreateAgentSchedule {
+                workspace_id: workspace.id.clone(),
+                spec,
+            })
+            .unwrap()
+        else {
+            panic!("expected schedule");
+        };
+        set_scheduler_time(&registry, 60_000);
+        registry
+            .change_schedule_state(&schedule.id, AgentScheduleState::Paused)
+            .unwrap();
+        set_scheduler_time(&registry, 600_000);
+        registry.evaluate_schedules(true).unwrap();
+        assert!(
+            registry
+                .durable
+                .scheduled_executions(None, Some(&schedule.id))
+                .unwrap()
+                .is_empty()
+        );
+        registry
+            .change_schedule_state(&schedule.id, AgentScheduleState::Enabled)
+            .unwrap();
+        for minute in 11..=(11 + MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE as u64) {
+            set_scheduler_time(&registry, minute * 60_000);
+            registry.evaluate_schedules(true).unwrap();
+        }
+        let executions = registry
+            .durable
+            .scheduled_executions(None, Some(&schedule.id))
+            .unwrap();
+        assert_eq!(executions.len(), MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE);
+        let frontier = registry
+            .durable
+            .schedule(&schedule.id)
+            .unwrap()
+            .snapshot()
+            .unwrap()
+            .evaluation_frontier_ms;
+        set_scheduler_time(&registry, frontier.saturating_sub(60_000));
+        registry.evaluate_schedules(true).unwrap();
+        assert_eq!(
+            registry
+                .durable
+                .scheduled_executions(None, Some(&schedule.id))
+                .unwrap()
+                .len(),
+            MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE
+        );
+    }
+
+    #[test]
+    fn manual_and_timed_decisions_share_atomic_capacity_and_continuation_leases() {
+        let registry = DaemonService::default();
+        let first_workspace = registry
+            .create_workspace("capacity-one".into(), Vec::new())
+            .unwrap();
+        let second_workspace = registry
+            .create_workspace("capacity-two".into(), Vec::new())
+            .unwrap();
+        let (first, _) = registry
+            .durable
+            .create_schedule(&first_workspace.id, schedule_spec("first"))
+            .unwrap();
+        let mut second_spec = schedule_spec("second");
+        second_spec.name = "second".into();
+        let (second, _) = registry
+            .durable
+            .create_schedule(&first_workspace.id, second_spec)
+            .unwrap();
+        let mut third_spec = schedule_spec("third");
+        third_spec.name = "third".into();
+        let (third, _) = registry
+            .durable
+            .create_schedule(&second_workspace.id, third_spec)
+            .unwrap();
+
+        let decide = |schedule_id: &str, max_concurrent| {
+            registry
+                .durable
+                .decide_schedule_execution(
+                    schedule_id,
+                    ScheduleDecision {
+                        dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+                        dispatch_key: Uuid::new_v4().to_string(),
+                        scheduled_at_ms: None,
+                        coalesced_through_ms: None,
+                        requested_at_ms: 1,
+                        forced_skip: None,
+                    },
+                    max_concurrent,
+                )
+                .unwrap()
+                .0
+        };
+        assert_eq!(decide(&first.id, 4).state, ScheduledExecutionState::Claimed);
+        assert_eq!(
+            decide(&first.id, 4).reason,
+            Some(ScheduledExecutionReason::Overlap)
+        );
+        assert_eq!(
+            decide(&second.id, 4).reason,
+            Some(ScheduledExecutionReason::WorkspaceCapacity)
+        );
+        assert_eq!(
+            decide(&third.id, 1).reason,
+            Some(ScheduledExecutionReason::GlobalCapacity)
+        );
+
+        let continuation_registry = DaemonService::default();
+        let first_workspace = continuation_registry
+            .create_workspace("continuation-one".into(), Vec::new())
+            .unwrap();
+        let second_workspace = continuation_registry
+            .create_workspace("continuation-two".into(), Vec::new())
+            .unwrap();
+        let mut continuation = schedule_spec("continued");
+        continuation.session = AgentScheduleSession::Continue {
+            external_session_id: "exact-session".into(),
+        };
+        let (first, _) = continuation_registry
+            .durable
+            .create_schedule(&first_workspace.id, continuation.clone())
+            .unwrap();
+        continuation.name = "continued-two".into();
+        let (second, _) = continuation_registry
+            .durable
+            .create_schedule(&second_workspace.id, continuation)
+            .unwrap();
+        let decision = |schedule_id: &str| {
+            continuation_registry
+                .durable
+                .decide_schedule_execution(
+                    schedule_id,
+                    ScheduleDecision {
+                        dispatch_kind: ScheduledExecutionDispatchKind::Timed,
+                        dispatch_key: timed_dispatch_key(schedule_id, 1, 60_000),
+                        scheduled_at_ms: Some(60_000),
+                        coalesced_through_ms: None,
+                        requested_at_ms: 60_000,
+                        forced_skip: None,
+                    },
+                    4,
+                )
+                .unwrap()
+                .0
+        };
+        assert_eq!(decision(&first.id).state, ScheduledExecutionState::Claimed);
+        let blocked = decision(&second.id);
+        assert_eq!(blocked.state, ScheduledExecutionState::Skipped);
+        assert_eq!(
+            blocked.reason,
+            Some(ScheduledExecutionReason::ActiveSession)
+        );
+        assert!(blocked.shell_id.is_none());
+    }
+
+    #[test]
     fn pruned_dispatch_keys_remain_explicitly_rejected() {
         let registry = DaemonService::default();
         let workspace = registry
@@ -11252,7 +12849,7 @@ mod tests {
         spec.trigger.cron = "not a cron expression".into();
         let error = registry
             .dispatch(Request::CreateAgentSchedule {
-                workspace_id: workspace.id,
+                workspace_id: workspace.id.clone(),
                 spec,
             })
             .unwrap_err();
@@ -11263,6 +12860,21 @@ mod tests {
                 .is_empty()
         );
         assert!(lock(&registry.events.state).unwrap().events.is_empty());
+
+        let mut impossible = schedule_spec(prompt);
+        impossible.trigger.cron = "0 0 30 2 *".into();
+        let error = registry
+            .dispatch(Request::CreateAgentSchedule {
+                workspace_id: workspace.id,
+                spec: impossible,
+            })
+            .unwrap_err();
+        assert_eq!(error.wire_code(), ErrorCode::InvalidArgument);
+        assert!(
+            registry.snapshot().unwrap().workspaces[0]
+                .schedules
+                .is_empty()
+        );
     }
 
     #[test]
@@ -11328,6 +12940,72 @@ mod tests {
         };
         assert_eq!(filtered_cursor, cursor);
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn protocol_twenty_three_filters_paginated_timed_events_without_stalling_cursor() {
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace("timed-pagination".into(), Vec::new())
+            .unwrap();
+        let (schedule, _) = registry
+            .durable
+            .create_schedule(&workspace.id, schedule_spec("private"))
+            .unwrap();
+        let Response::Events {
+            cursor: baseline, ..
+        } = registry.read_events(None, 256, 0).unwrap()
+        else {
+            panic!("expected baseline");
+        };
+        for occurrence in 1..=300_u64 {
+            let scheduled_at_ms = occurrence * 60_000;
+            let execution = registry
+                .durable
+                .decide_schedule_execution(
+                    &schedule.id,
+                    ScheduleDecision {
+                        dispatch_kind: ScheduledExecutionDispatchKind::Timed,
+                        dispatch_key: timed_dispatch_key(&schedule.id, 1, scheduled_at_ms),
+                        scheduled_at_ms: Some(scheduled_at_ms),
+                        coalesced_through_ms: None,
+                        requested_at_ms: scheduled_at_ms,
+                        forced_skip: Some(ScheduledExecutionReason::Missed),
+                    },
+                    4,
+                )
+                .unwrap()
+                .0;
+            registry
+                .events
+                .publish_runtime_batch(vec![DaemonEventKind::ScheduledExecutionCreated {
+                    workspace_id: workspace.id.clone(),
+                    execution,
+                }])
+                .unwrap();
+        }
+
+        let first =
+            response_for_version(registry.read_events(Some(&baseline), 256, 0).unwrap(), 23);
+        let first_json = serde_json::to_value(&first).unwrap();
+        assert_eq!(first_json["events"], serde_json::json!([]));
+        assert_eq!(first_json["cursor"]["event_id"], baseline.event_id + 256);
+        assert!(!first_json.to_string().contains("timed"));
+        assert!(!first_json.to_string().contains("skipped"));
+        let Response::Events {
+            cursor: first_cursor,
+            ..
+        } = first
+        else {
+            panic!("expected first filtered page");
+        };
+        let second = response_for_version(
+            registry.read_events(Some(&first_cursor), 256, 0).unwrap(),
+            23,
+        );
+        let second_json = serde_json::to_value(second).unwrap();
+        assert_eq!(second_json["events"], serde_json::json!([]));
+        assert_eq!(second_json["cursor"]["event_id"], baseline.event_id + 300);
     }
 
     #[test]
@@ -13386,6 +15064,7 @@ mod tests {
             snapshot: Some(Snapshot {
                 workspaces: vec![workspace],
                 focused_terminal: None,
+                scheduler: None,
             }),
             events: vec![
                 DaemonEvent {
@@ -13440,6 +15119,7 @@ mod tests {
                     shell_id: "s1".into(),
                     run_id: "r1".into(),
                 }),
+                scheduler: None,
             },
         };
 
@@ -13544,6 +15224,7 @@ mod tests {
                 snapshot: Some(Snapshot {
                     workspaces: vec![workspace],
                     focused_terminal: None,
+                    scheduler: None,
                 }),
                 events: vec![DaemonEvent {
                     id: 1,
@@ -13615,6 +15296,7 @@ mod tests {
                     schedules: Vec::new(),
                 }],
                 focused_terminal: None,
+                scheduler: None,
             }),
             events: vec![DaemonEvent {
                 id: 2,
@@ -13916,6 +15598,7 @@ mod tests {
                 snapshot: Snapshot {
                     workspaces: vec![source_workspace.clone()],
                     focused_terminal: None,
+                    scheduler: None,
                 },
             },
             18,
@@ -13937,6 +15620,7 @@ mod tests {
                 snapshot: Some(Snapshot {
                     workspaces: vec![source_workspace],
                     focused_terminal: None,
+                    scheduler: None,
                 }),
                 events: Vec::new(),
             },

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -233,6 +233,15 @@ fn validate_pidfd(descriptor: &OwnedFd, expected_pid: u32) -> io::Result<()> {
 }
 
 fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
+    if manifest.notifications.as_ref().is_some_and(|settings| {
+        !(1..=crate::daemon::MAX_SCHEDULED_EXECUTION_CONCURRENCY)
+            .contains(&settings.max_scheduled_execution_concurrency)
+    }) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "handoff manifest contains an invalid scheduling concurrency limit",
+        ));
+    }
     if manifest
         .runtimes
         .len()
@@ -449,5 +458,32 @@ mod tests {
             serde_json::from_value(serde_json::to_value(manifest).unwrap()).unwrap();
 
         assert_eq!(decoded.focused_terminal, Some(focused_terminal));
+    }
+
+    #[test]
+    fn manifest_rejects_invalid_scheduler_concurrency() {
+        for max_scheduled_execution_concurrency in [0, 65, u16::MAX] {
+            let manifest = Manifest {
+                runtimes: Vec::new(),
+                exited: Vec::new(),
+                event_stream: event_stream(),
+                notifications: Some(NotificationDeliveryConfig {
+                    desktop_enabled: false,
+                    sound_enabled: false,
+                    blocked: true,
+                    completed: true,
+                    blocked_sound: "blocked".into(),
+                    completed_sound: "completed".into(),
+                    resume_agents: true,
+                    persist_terminal_history: false,
+                    max_scheduled_execution_concurrency,
+                }),
+                focused_terminal: None,
+            };
+            assert_eq!(
+                validate_manifest(&manifest).unwrap_err().kind(),
+                io::ErrorKind::InvalidData
+            );
+        }
     }
 }

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -1350,6 +1350,7 @@ mod tests {
         let snapshot = Snapshot {
             workspaces: vec![workspace.clone()],
             focused_terminal: None,
+            scheduler: None,
         };
         assert_eq!(
             inspect_runtime(IntegrationId::Opencode.spec(), Some(&snapshot)).state,
@@ -1380,6 +1381,7 @@ mod tests {
         let snapshot = Snapshot {
             workspaces: vec![workspace.clone()],
             focused_terminal: None,
+            scheduler: None,
         };
         assert_eq!(
             verification_targets(&snapshot, IntegrationId::Opencode, None),
@@ -1408,6 +1410,7 @@ mod tests {
         let snapshot = Snapshot {
             workspaces: vec![workspace],
             focused_terminal: None,
+            scheduler: None,
         };
         assert_eq!(
             inspect_runtime(IntegrationId::Opencode.spec(), Some(&snapshot)).state,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1284,20 +1284,43 @@ fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Err
     match command {
         DaemonCommands::Status if json => {
             let protocol_version = client.protocol_version()?;
+            let scheduler = client.snapshot()?.scheduler;
             print_json(
                 CommandKey::DaemonStatus,
                 serde_json::json!({
                     "status": "running",
                     "protocol_version": protocol_version,
                     "socket_path": client.socket_path().display().to_string(),
+                    "scheduler": scheduler.map(|health| serde_json::json!({
+                        "state": match health.state {
+                            protocol::SchedulerState::Active => "active",
+                            protocol::SchedulerState::Offline => "offline",
+                        },
+                        "max_concurrent": health.max_concurrent,
+                        "active_executions": health.active_executions,
+                    })),
                 }),
             )?
         }
-        DaemonCommands::Status => println!(
-            "running (protocol {}, {})",
-            client.protocol_version()?,
-            client.socket_path().display()
-        ),
+        DaemonCommands::Status => {
+            let scheduler = client.snapshot()?.scheduler;
+            println!(
+                "running (protocol {}, {})",
+                client.protocol_version()?,
+                client.socket_path().display()
+            );
+            if let Some(scheduler) = scheduler {
+                println!(
+                    "scheduler {} ({}/{} active executions)",
+                    match scheduler.state {
+                        protocol::SchedulerState::Active => "active",
+                        protocol::SchedulerState::Offline => "offline",
+                    },
+                    scheduler.active_executions,
+                    scheduler.max_concurrent
+                );
+            }
+        }
         DaemonCommands::Restart => {
             client
                 .restart_with_notification_config(config::load_notification_settings()?.into())?;
@@ -3577,6 +3600,7 @@ fn print_execution(
 fn execution_state(execution: &ScheduledExecutionSnapshot) -> &'static str {
     use protocol::ScheduledExecutionState::*;
     match execution.state {
+        Skipped => "skipped",
         Claimed => "claimed",
         Starting => "starting",
         Active => "active",
@@ -5180,6 +5204,39 @@ fn doctor(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     eprintln!("    {warning}");
                 }
             }
+            match daemon_snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.scheduler.as_ref())
+            {
+                Some(scheduler)
+                    if scheduler.state == protocol::SchedulerState::Active
+                        && scheduler.max_concurrent
+                            == config.notifications.max_scheduled_execution_concurrency =>
+                {
+                    println!(
+                        "ok  scheduler: active, max_concurrent={} (sampled at daemon start)",
+                        scheduler.max_concurrent
+                    );
+                }
+                Some(scheduler) if scheduler.state == protocol::SchedulerState::Offline => {
+                    healthy = false;
+                    eprintln!("err scheduler: offline; timed schedules are not being evaluated");
+                }
+                Some(scheduler) => {
+                    healthy = false;
+                    eprintln!(
+                        "err scheduler: daemon uses max_concurrent={}, config resolves {}; restart daemon after changes",
+                        scheduler.max_concurrent,
+                        config.notifications.max_scheduled_execution_concurrency
+                    );
+                }
+                None => {
+                    healthy = false;
+                    eprintln!(
+                        "err scheduler: offline or unavailable; timed schedules require the Boomux daemon and user session"
+                    );
+                }
+            }
             let terminal = terminal_override.or(config.terminal.as_deref());
             match terminal::selected(terminal) {
                 Ok(selected) => println!("ok  terminal: {selected}"),
@@ -5440,6 +5497,7 @@ mod tests {
             updated_at_ms: 10,
             evaluation_frontier_ms: 10,
             execution_shell_id: None,
+            next_occurrence: None,
         }
     }
 
@@ -5491,6 +5549,7 @@ mod tests {
                 vec![shell("s1", "w1", "one"), shell("s2", "w1", "two")],
             )],
             focused_terminal: None,
+            scheduler: None,
         };
         let event_refreshed = Snapshot {
             workspaces: vec![workspace(
@@ -5499,6 +5558,7 @@ mod tests {
                 vec![shell("s1", "w1", "one"), shell("s2", "w1", "two")],
             )],
             focused_terminal: None,
+            scheduler: None,
         };
         let fallback_refreshed = Snapshot {
             workspaces: vec![workspace(
@@ -5507,6 +5567,7 @@ mod tests {
                 vec![shell("s1", "w1", "one"), shell("s2", "w1", "two")],
             )],
             focused_terminal: None,
+            scheduler: None,
         };
         let server = thread::spawn({
             let initial = initial.clone();
@@ -6260,6 +6321,7 @@ mod tests {
         let value = json_snapshot(Snapshot {
             workspaces: vec![project],
             focused_terminal: None,
+            scheduler: None,
         })
         .unwrap();
 
@@ -6277,6 +6339,7 @@ mod tests {
         let snapshot = Snapshot {
             workspaces: vec![workspace("w2", "w1", vec![]), project],
             focused_terminal: None,
+            scheduler: None,
         };
 
         assert_eq!(
@@ -6336,6 +6399,7 @@ mod tests {
                 workspace("w2", "two", vec![shell("s2", "w2", "tests")]),
             ],
             focused_terminal: None,
+            scheduler: None,
         };
         assert_eq!(
             resolve_shell_target(&snapshot, None, "s2").unwrap().id,
@@ -7152,6 +7216,7 @@ mod tests {
                 workspace("w1", "Alpha", vec![shell("s1", "w1", "frontend")]),
             ],
             focused_terminal: None,
+            scheduler: None,
         };
         let targets = vec![
             integration_management::VerificationTarget {
@@ -7500,6 +7565,7 @@ mod tests {
         let snapshot = Snapshot {
             workspaces: vec![first, second],
             focused_terminal: None,
+            scheduler: None,
         };
         assert_eq!(
             resolve_cli_schedule(&snapshot, "schedule-2", None)
@@ -7588,7 +7654,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 23);
+        assert_eq!(protocol::PROTOCOL_VERSION, 24);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 23;
+pub const PROTOCOL_VERSION: u32 = 24;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -89,6 +89,12 @@ define_protocol_features! {
         "scheduled_execution_cancellation",
         "schedule_owned_shells",
     ]),
+    TimedScheduling => (24, "timed scheduling", [
+        "protocol_24",
+        "timed_schedule_dispatch",
+        "scheduler_health",
+        "bounded_scheduled_execution_concurrency",
+    ]),
 }
 
 pub fn protocol_capabilities() -> impl Iterator<Item = &'static str> {
@@ -172,6 +178,22 @@ pub struct Snapshot {
     pub workspaces: Vec<WorkspaceSnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub focused_terminal: Option<FocusedTerminalSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduler: Option<SchedulerHealth>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchedulerState {
+    Active,
+    Offline,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchedulerHealth {
+    pub state: SchedulerState,
+    pub max_concurrent: u16,
+    pub active_executions: u16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -282,6 +304,14 @@ pub struct AgentScheduleSnapshot {
     pub evaluation_frontier_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_shell_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_occurrence: Option<ScheduledOccurrence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduledOccurrence {
+    pub trigger_revision: u64,
+    pub scheduled_at_ms: u64,
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -293,6 +323,7 @@ pub struct AgentScheduleInspection {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ScheduledExecutionState {
+    Skipped,
     Claimed,
     Starting,
     Active,
@@ -306,7 +337,11 @@ impl ScheduledExecutionState {
     pub fn is_terminal(self) -> bool {
         matches!(
             self,
-            Self::DispatchFailed | Self::Exited | Self::Cancelled | Self::Interrupted
+            Self::Skipped
+                | Self::DispatchFailed
+                | Self::Exited
+                | Self::Cancelled
+                | Self::Interrupted
         )
     }
 }
@@ -315,11 +350,19 @@ impl ScheduledExecutionState {
 #[serde(rename_all = "snake_case")]
 pub enum ScheduledExecutionDispatchKind {
     Manual,
+    Timed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ScheduledExecutionReason {
+    Overlap,
+    ActiveSession,
+    WorkspaceCapacity,
+    GlobalCapacity,
+    Missed,
+    PausedRace,
+    InvalidTarget,
     RunnerStartFailed,
     HostSpawnFailed,
     CancelledByUser,
@@ -347,6 +390,10 @@ pub struct ScheduledExecutionSnapshot {
     pub prompt_revision: u64,
     pub trigger_revision: u64,
     pub requested_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduled_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coalesced_through_ms: Option<u64>,
     pub started_at_ms: Option<u64>,
     pub ended_at_ms: Option<u64>,
     pub cwd: PathBuf,
@@ -748,6 +795,12 @@ pub struct NotificationDeliveryConfig {
     pub resume_agents: bool,
     #[serde(default)]
     pub persist_terminal_history: bool,
+    #[serde(default = "default_max_scheduled_execution_concurrency")]
+    pub max_scheduled_execution_concurrency: u16,
+}
+
+fn default_max_scheduled_execution_concurrency() -> u16 {
+    4
 }
 
 fn default_true() -> bool {
@@ -973,6 +1026,11 @@ impl Request {
             | Self::CreateShell {
                 workspace_id: None, ..
             } => Some(ProtocolFeature::WorkspaceDefaultCwd),
+            Self::RestartWithNotificationConfig { notifications, .. }
+                if notifications.max_scheduled_execution_concurrency != 4 =>
+            {
+                Some(ProtocolFeature::TimedScheduling)
+            }
             Self::RestartWithNotificationConfig {
                 environment: Some(_),
                 ..
@@ -1289,6 +1347,10 @@ mod tests {
             updated_at_ms: 20,
             evaluation_frontier_ms: 30,
             execution_shell_id: Some("shell-1".into()),
+            next_occurrence: Some(ScheduledOccurrence {
+                trigger_revision: 1,
+                scheduled_at_ms: 60,
+            }),
         }
     }
 
@@ -1351,6 +1413,7 @@ mod tests {
 
         assert!(config.resume_agents);
         assert!(!config.persist_terminal_history);
+        assert_eq!(config.max_scheduled_execution_concurrency, 4);
     }
 
     #[test]
@@ -1508,8 +1571,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_twenty_three_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 23);
+    fn protocol_version_is_twenty_four_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 24);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -1623,6 +1686,8 @@ mod tests {
             prompt_revision: 2,
             trigger_revision: 1,
             requested_at_ms: 10,
+            scheduled_at_ms: None,
+            coalesced_through_ms: None,
             started_at_ms: None,
             ended_at_ms: None,
             cwd: "/tmp/project".into(),
@@ -1873,6 +1938,7 @@ mod tests {
                         completed_sound: "complete".into(),
                         resume_agents: true,
                         persist_terminal_history: false,
+                        max_scheduled_execution_concurrency: 4,
                     },
                     environment: None,
                 }],
@@ -2129,6 +2195,15 @@ mod tests {
                     "scheduled_execution_dispatch",
                     "scheduled_execution_cancellation",
                     "schedule_owned_shells",
+                ][..],
+            ),
+            (
+                24,
+                &[
+                    "protocol_24",
+                    "timed_schedule_dispatch",
+                    "scheduler_health",
+                    "bounded_scheduled_execution_concurrency",
                 ][..],
             ),
         ];

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -1,12 +1,15 @@
 use std::error::Error;
 use std::fmt;
 
+use chrono::{Datelike, LocalResult, NaiveDate, TimeZone, Utc};
+
 pub const MAX_PROMPT_BYTES: usize = 65_536;
 pub const MAX_CRON_BYTES: usize = 256;
 pub const MAX_TIMEZONE_BYTES: usize = 256;
 pub const MAX_INTEGRATION_KEY_BYTES: usize = 256;
 pub const MAX_EXTERNAL_SESSION_ID_BYTES: usize = 256;
 pub const MAX_SCHEDULES_PER_WORKSPACE: usize = 64;
+const MAX_OCCURRENCE_SEARCH_DAYS: u32 = 146_097;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SchedulingError {
@@ -30,6 +33,8 @@ pub enum SchedulingError {
     },
     InvalidTimezone,
     SystemTimezoneUnavailable,
+    TimeOutOfRange,
+    OccurrenceSearchExhausted,
 }
 
 impl fmt::Display for SchedulingError {
@@ -56,6 +61,12 @@ impl fmt::Display for SchedulingError {
             Self::InvalidTimezone => formatter.write_str("timezone is not a valid IANA timezone"),
             Self::SystemTimezoneUnavailable => {
                 formatter.write_str("system IANA timezone could not be resolved")
+            }
+            Self::TimeOutOfRange => {
+                formatter.write_str("schedule time is outside the supported range")
+            }
+            Self::OccurrenceSearchExhausted => {
+                formatter.write_str("schedule has no occurrence within the bounded search range")
             }
         }
     }
@@ -85,6 +96,187 @@ pub fn canonicalize_cron(expression: &str) -> Result<String, SchedulingError> {
     }
 
     Ok(fields.join(" "))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CronSchedule {
+    minutes: Vec<u32>,
+    hours: Vec<u32>,
+    days_of_month: Vec<u32>,
+    months: Vec<u32>,
+    days_of_week: Vec<u32>,
+    any_day_of_month: bool,
+    any_day_of_week: bool,
+    timezone: chrono_tz::Tz,
+}
+
+impl CronSchedule {
+    pub fn compile(expression: &str, timezone: &str) -> Result<Self, SchedulingError> {
+        let expression = canonicalize_cron(expression)?;
+        let fields = expression.split_whitespace().collect::<Vec<_>>();
+        let timezone = canonicalize_timezone(timezone)?
+            .parse()
+            .map_err(|_| SchedulingError::InvalidTimezone)?;
+        Ok(Self {
+            minutes: compile_field(fields[0], 0, 59),
+            hours: compile_field(fields[1], 0, 23),
+            days_of_month: compile_field(fields[2], 1, 31),
+            months: compile_field(fields[3], 1, 12),
+            days_of_week: compile_field(fields[4], 0, 6),
+            any_day_of_month: wildcard_origin(fields[2]),
+            any_day_of_week: wildcard_origin(fields[4]),
+            timezone,
+        })
+    }
+
+    pub fn ensure_possible(&self) -> Result<(), SchedulingError> {
+        let mut date =
+            NaiveDate::from_ymd_opt(2000, 1, 1).ok_or(SchedulingError::TimeOutOfRange)?;
+        for _ in 0..MAX_OCCURRENCE_SEARCH_DAYS {
+            if self.date_matches(date)
+                && self.hours.iter().any(|hour| {
+                    self.minutes.iter().any(|minute| {
+                        date.and_hms_opt(*hour, *minute, 0)
+                            .and_then(|local| first_local_instant(self.timezone, local))
+                            .is_some()
+                    })
+                })
+            {
+                return Ok(());
+            }
+            date = date.succ_opt().ok_or(SchedulingError::TimeOutOfRange)?;
+        }
+        Err(SchedulingError::OccurrenceSearchExhausted)
+    }
+
+    pub fn next_after_ms(&self, frontier_ms: u64) -> Result<u64, SchedulingError> {
+        let frontier = utc_from_millis(frontier_ms)?;
+        let mut date = frontier.with_timezone(&self.timezone).date_naive();
+        for _ in 0..MAX_OCCURRENCE_SEARCH_DAYS {
+            if self.date_matches(date) {
+                for &hour in &self.hours {
+                    for &minute in &self.minutes {
+                        let local = date
+                            .and_hms_opt(hour, minute, 0)
+                            .ok_or(SchedulingError::TimeOutOfRange)?;
+                        if let Some(candidate) = first_local_instant(self.timezone, local) {
+                            let candidate_ms = millis_from_utc(candidate)?;
+                            if candidate_ms > frontier_ms {
+                                return Ok(candidate_ms);
+                            }
+                        }
+                    }
+                }
+            }
+            date = date.succ_opt().ok_or(SchedulingError::TimeOutOfRange)?;
+        }
+        Err(SchedulingError::OccurrenceSearchExhausted)
+    }
+
+    pub fn latest_at_or_before_ms(&self, ceiling_ms: u64) -> Result<u64, SchedulingError> {
+        let ceiling = utc_from_millis(ceiling_ms)?;
+        let mut date = ceiling.with_timezone(&self.timezone).date_naive();
+        for _ in 0..MAX_OCCURRENCE_SEARCH_DAYS {
+            if self.date_matches(date) {
+                for &hour in self.hours.iter().rev() {
+                    for &minute in self.minutes.iter().rev() {
+                        let local = date
+                            .and_hms_opt(hour, minute, 0)
+                            .ok_or(SchedulingError::TimeOutOfRange)?;
+                        if let Some(candidate) = first_local_instant(self.timezone, local) {
+                            let candidate_ms = millis_from_utc(candidate)?;
+                            if candidate_ms <= ceiling_ms {
+                                return Ok(candidate_ms);
+                            }
+                        }
+                    }
+                }
+            }
+            date = date.pred_opt().ok_or(SchedulingError::TimeOutOfRange)?;
+        }
+        Err(SchedulingError::OccurrenceSearchExhausted)
+    }
+
+    fn date_matches(&self, date: NaiveDate) -> bool {
+        if self.months.binary_search(&date.month()).is_err() {
+            return false;
+        }
+        let dom = self.days_of_month.binary_search(&date.day()).is_ok();
+        let dow = self
+            .days_of_week
+            .binary_search(&date.weekday().num_days_from_sunday())
+            .is_ok();
+        match (self.any_day_of_month, self.any_day_of_week) {
+            (true, true) => true,
+            (true, false) => dow,
+            (false, true) => dom,
+            (false, false) => dom || dow,
+        }
+    }
+}
+
+fn wildcard_origin(field: &str) -> bool {
+    field.split(',').any(|component| {
+        component
+            .split_once('/')
+            .map_or(component, |(base, _)| base)
+            == "*"
+    })
+}
+
+fn compile_field(field: &str, minimum: u32, maximum: u32) -> Vec<u32> {
+    let mut selected = vec![false; (maximum + 1) as usize];
+    for component in field.split(',') {
+        let (base, step) = component
+            .split_once('/')
+            .map_or((component, 1), |(base, step)| {
+                (base, step.parse::<u32>().expect("validated cron step"))
+            });
+        let (start, end) = if base == "*" {
+            (minimum, maximum)
+        } else if let Some((start, end)) = base.split_once('-') {
+            (
+                start.parse::<u32>().expect("validated cron range"),
+                end.parse::<u32>().expect("validated cron range"),
+            )
+        } else {
+            let value = base.parse::<u32>().expect("validated cron value");
+            (value, value)
+        };
+        for value in (start..=end).step_by(step as usize) {
+            selected[value as usize] = true;
+        }
+    }
+    (minimum..=maximum)
+        .filter(|value| selected[*value as usize])
+        .collect()
+}
+
+fn utc_from_millis(value: u64) -> Result<chrono::DateTime<Utc>, SchedulingError> {
+    let value = i64::try_from(value).map_err(|_| SchedulingError::TimeOutOfRange)?;
+    Utc.timestamp_millis_opt(value)
+        .single()
+        .ok_or(SchedulingError::TimeOutOfRange)
+}
+
+pub(crate) fn validate_timestamp_ms(value: u64) -> Result<(), SchedulingError> {
+    utc_from_millis(value).map(|_| ())
+}
+
+fn millis_from_utc(value: chrono::DateTime<chrono_tz::Tz>) -> Result<u64, SchedulingError> {
+    u64::try_from(value.with_timezone(&Utc).timestamp_millis())
+        .map_err(|_| SchedulingError::TimeOutOfRange)
+}
+
+fn first_local_instant(
+    timezone: chrono_tz::Tz,
+    local: chrono::NaiveDateTime,
+) -> Option<chrono::DateTime<chrono_tz::Tz>> {
+    match timezone.from_local_datetime(&local) {
+        LocalResult::None => None,
+        LocalResult::Single(value) => Some(value),
+        LocalResult::Ambiguous(first, second) => Some(first.min(second)),
+    }
 }
 
 pub fn every_minutes_cron(minutes: u8) -> Result<String, SchedulingError> {
@@ -279,6 +471,17 @@ fn validate_byte_bound(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
+
+    fn utc_ms(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> u64 {
+        u64::try_from(
+            Utc.with_ymd_and_hms(year, month, day, hour, minute, 0)
+                .single()
+                .unwrap()
+                .timestamp_millis(),
+        )
+        .unwrap()
+    }
 
     #[test]
     fn cron_accepts_supported_grammar_and_normalizes_only_whitespace() {
@@ -412,6 +615,113 @@ mod tests {
         assert!(validate_external_session_id("session\u{1b}").is_err());
         assert!(
             validate_external_session_id(&"x".repeat(MAX_EXTERNAL_SESSION_ID_BYTES + 1)).is_err()
+        );
+    }
+
+    #[test]
+    fn compiled_cron_handles_fields_dom_dow_or_and_strict_frontiers() {
+        let cron = CronSchedule::compile("0,0,30 9-11/2 * * *", "UTC").unwrap();
+        assert_eq!(
+            cron.next_after_ms(utc_ms(2026, 1, 1, 9, 0)),
+            Ok(utc_ms(2026, 1, 1, 9, 30))
+        );
+        assert_eq!(
+            cron.next_after_ms(utc_ms(2026, 1, 1, 9, 30)),
+            Ok(utc_ms(2026, 1, 1, 11, 0))
+        );
+
+        let or = CronSchedule::compile("0 0 31 * 1", "UTC").unwrap();
+        assert_eq!(
+            or.next_after_ms(utc_ms(2026, 1, 4, 23, 59)),
+            Ok(utc_ms(2026, 1, 5, 0, 0))
+        );
+        assert_eq!(
+            or.latest_at_or_before_ms(utc_ms(2026, 1, 6, 0, 0)),
+            Ok(utc_ms(2026, 1, 5, 0, 0))
+        );
+
+        let candidate = utc_ms(2026, 1, 7, 9, 0);
+        assert_eq!(cron.next_after_ms(candidate - 1), Ok(candidate));
+        assert_eq!(
+            cron.latest_at_or_before_ms(candidate - 1),
+            Ok(utc_ms(2026, 1, 6, 11, 30))
+        );
+        assert_eq!(cron.latest_at_or_before_ms(candidate), Ok(candidate));
+        assert_eq!(cron.latest_at_or_before_ms(candidate + 1), Ok(candidate));
+    }
+
+    #[test]
+    fn wildcard_origin_controls_standard_dom_dow_semantics() {
+        let stepped_dom = CronSchedule::compile("0 0 */2 * 1", "UTC").unwrap();
+        assert_eq!(
+            stepped_dom.next_after_ms(utc_ms(2024, 1, 7, 0, 0)),
+            Ok(utc_ms(2024, 1, 8, 0, 0))
+        );
+        let full_dom_range = CronSchedule::compile("0 0 1-31 * 1", "UTC").unwrap();
+        assert_eq!(
+            full_dom_range.next_after_ms(utc_ms(2024, 1, 2, 0, 0) - 1),
+            Ok(utc_ms(2024, 1, 2, 0, 0))
+        );
+
+        let stepped_dow = CronSchedule::compile("0 0 15 */2 */2", "UTC").unwrap();
+        assert_eq!(
+            stepped_dow.next_after_ms(utc_ms(2024, 1, 14, 0, 0)),
+            Ok(utc_ms(2024, 1, 15, 0, 0))
+        );
+        let full_dow_range = CronSchedule::compile("0 0 31 */2 0-6", "UTC").unwrap();
+        assert_eq!(
+            full_dow_range.next_after_ms(utc_ms(2024, 1, 2, 0, 0) - 1),
+            Ok(utc_ms(2024, 1, 2, 0, 0))
+        );
+    }
+
+    #[test]
+    fn compiled_cron_skips_new_york_gap_and_uses_first_repeated_minute_only() {
+        let gap = CronSchedule::compile("30 2 * * *", "America/New_York").unwrap();
+        assert_eq!(
+            gap.next_after_ms(utc_ms(2024, 3, 9, 8, 0)),
+            Ok(utc_ms(2024, 3, 11, 6, 30))
+        );
+
+        let repeated = CronSchedule::compile("30 1 * * *", "America/New_York").unwrap();
+        let first = utc_ms(2024, 11, 3, 5, 30);
+        assert_eq!(repeated.next_after_ms(utc_ms(2024, 11, 3, 4, 0)), Ok(first));
+        assert_eq!(
+            repeated.next_after_ms(first),
+            Ok(utc_ms(2024, 11, 4, 6, 30))
+        );
+    }
+
+    #[test]
+    fn compiled_cron_handles_lord_howe_non_hour_gap_and_impossible_dates() {
+        let gap = CronSchedule::compile("15 2 * * *", "Australia/Lord_Howe").unwrap();
+        assert_eq!(
+            gap.next_after_ms(utc_ms(2024, 10, 5, 16, 0)),
+            Ok(utc_ms(2024, 10, 6, 15, 15))
+        );
+
+        let impossible = CronSchedule::compile("0 0 30 2 *", "UTC").unwrap();
+        assert_eq!(
+            impossible.next_after_ms(utc_ms(2024, 1, 1, 0, 0)),
+            Err(SchedulingError::OccurrenceSearchExhausted)
+        );
+        assert_eq!(
+            impossible.ensure_possible(),
+            Err(SchedulingError::OccurrenceSearchExhausted)
+        );
+        for _ in 0..MAX_SCHEDULES_PER_WORKSPACE {
+            assert_eq!(
+                impossible.ensure_possible(),
+                Err(SchedulingError::OccurrenceSearchExhausted)
+            );
+        }
+
+        let fold = CronSchedule::compile("45 1 * * *", "Australia/Lord_Howe").unwrap();
+        let first = utc_ms(2024, 4, 6, 14, 45);
+        assert_eq!(fold.next_after_ms(first - 1), Ok(first));
+        assert_eq!(
+            fold.latest_at_or_before_ms(utc_ms(2024, 4, 6, 15, 20)),
+            Ok(first)
         );
     }
 }

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -18,7 +18,8 @@ use crate::protocol::{
     ShellRunExitReason, TerminalProfile,
 };
 
-const STATE_VERSION: u32 = 10;
+const STATE_VERSION: u32 = 11;
+const VERSION_TEN_STATE_VERSION: u32 = 10;
 const VERSION_NINE_STATE_VERSION: u32 = 9;
 const VERSION_EIGHT_STATE_VERSION: u32 = 8;
 const VERSION_SEVEN_STATE_VERSION: u32 = 7;
@@ -77,6 +78,7 @@ pub(crate) struct PersistedAgentSchedule {
     pub(crate) created_at_ms: u64,
     pub(crate) updated_at_ms: u64,
     pub(crate) evaluation_frontier_ms: u64,
+    pub(crate) evaluation_frontier_trigger_revision: u64,
     pub(crate) execution_shell_id: Option<String>,
     pub(crate) dispatch_key_filter: Vec<u8>,
     pub(crate) executions: Vec<PersistedScheduledExecution>,
@@ -93,6 +95,8 @@ pub(crate) struct PersistedScheduledExecution {
     pub(crate) prompt_revision: u64,
     pub(crate) trigger_revision: u64,
     pub(crate) requested_at_ms: u64,
+    pub(crate) scheduled_at_ms: Option<u64>,
+    pub(crate) coalesced_through_ms: Option<u64>,
     pub(crate) started_at_ms: Option<u64>,
     pub(crate) ended_at_ms: Option<u64>,
     pub(crate) cwd: PathBuf,
@@ -581,6 +585,7 @@ impl StateStore {
         })?;
         let (state, migrated) = match version.version {
             STATE_VERSION => (parse_state(&bytes, &self.path)?, false),
+            VERSION_TEN_STATE_VERSION => (migrate_version_ten_state(&bytes, &self.path)?, true),
             VERSION_NINE_STATE_VERSION => {
                 let previous: VersionNinePersistedState = parse_state(&bytes, &self.path)?;
                 (migrate_version_nine_state(previous), true)
@@ -663,6 +668,33 @@ impl StateStore {
         }
         result
     }
+}
+
+fn migrate_version_ten_state(bytes: &[u8], path: &Path) -> io::Result<PersistedState> {
+    let mut previous: serde_json::Value = parse_state(bytes, path)?;
+    previous["version"] = serde_json::Value::from(STATE_VERSION);
+    if let Some(workspaces) = previous["workspaces"].as_array_mut() {
+        for workspace in workspaces {
+            if let Some(schedules) = workspace["schedules"].as_array_mut() {
+                for schedule in schedules {
+                    schedule["evaluation_frontier_trigger_revision"] =
+                        schedule["trigger_revision"].clone();
+                    if let Some(executions) = schedule["executions"].as_array_mut() {
+                        for execution in executions {
+                            execution["scheduled_at_ms"] = serde_json::Value::Null;
+                            execution["coalesced_through_ms"] = serde_json::Value::Null;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    serde_json::from_value(previous).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("could not migrate {}: {error}", path.display()),
+        )
+    })
 }
 
 fn parse_state<T: for<'de> Deserialize<'de>>(bytes: &[u8], path: &Path) -> io::Result<T> {
@@ -760,6 +792,7 @@ fn migrate_version_nine_state(previous: VersionNinePersistedState) -> PersistedS
                         created_at_ms: schedule.created_at_ms,
                         updated_at_ms: schedule.updated_at_ms,
                         evaluation_frontier_ms: schedule.evaluation_frontier_ms,
+                        evaluation_frontier_trigger_revision: schedule.trigger_revision,
                         execution_shell_id: schedule.execution_shell_id,
                         dispatch_key_filter: vec![0; DISPATCH_KEY_FILTER_BYTES],
                         executions: Vec::new(),
@@ -1178,6 +1211,7 @@ mod tests {
                     created_at_ms: 40,
                     updated_at_ms: 50,
                     evaluation_frontier_ms: 60,
+                    evaluation_frontier_trigger_revision: 1,
                     execution_shell_id: Some("shell-1".into()),
                     dispatch_key_filter: vec![0; DISPATCH_KEY_FILTER_BYTES],
                     executions: Vec::new(),
@@ -1341,7 +1375,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 10")
+                .contains("\"version\": 11")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1378,7 +1412,98 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 10")
+                .contains("\"version\": 11")
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_ten_frontier_revision_and_manual_occurrence_fields() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        let dispatch_key = Uuid::new_v4().to_string();
+        let mut state = PersistedState::default();
+        state.workspaces.push(PersistedWorkspace {
+            id: Uuid::new_v4().to_string(),
+            name: "saved".into(),
+            default_cwd: None,
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: Vec::new(),
+            schedules: vec![PersistedAgentSchedule {
+                id: Uuid::new_v4().to_string(),
+                name: "review".into(),
+                cwd: "/tmp".into(),
+                integration: "opencode".into(),
+                prompt: "private".into(),
+                session: AgentScheduleSession::Fresh,
+                trigger: AgentScheduleTrigger {
+                    cron: "0 9 * * *".into(),
+                    timezone: "UTC".into(),
+                },
+                state: AgentScheduleState::Paused,
+                overlap_policy: AgentScheduleOverlapPolicy::Skip,
+                revision: 3,
+                prompt_revision: 2,
+                trigger_revision: 3,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+                evaluation_frontier_ms: 4,
+                evaluation_frontier_trigger_revision: 3,
+                execution_shell_id: None,
+                dispatch_key_filter: vec![0; DISPATCH_KEY_FILTER_BYTES],
+                executions: vec![PersistedScheduledExecution {
+                    id: Uuid::new_v4().to_string(),
+                    state: ScheduledExecutionState::DispatchFailed,
+                    dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+                    dispatch_key,
+                    schedule_revision: 3,
+                    prompt_revision: 2,
+                    trigger_revision: 3,
+                    requested_at_ms: 3,
+                    scheduled_at_ms: None,
+                    coalesced_through_ms: None,
+                    started_at_ms: None,
+                    ended_at_ms: Some(3),
+                    cwd: "/tmp".into(),
+                    integration: "opencode".into(),
+                    session: AgentScheduleSession::Fresh,
+                    prompt: "private".into(),
+                    runner_token: Uuid::new_v4().to_string(),
+                    reason: Some(ScheduledExecutionReason::RunnerStartFailed),
+                    outcome: None,
+                    shell_id: None,
+                    run_id: None,
+                    agent_id: None,
+                    external_session_id: None,
+                }],
+            }],
+        });
+        let mut value = serde_json::to_value(&state).unwrap();
+        value["version"] = serde_json::Value::from(10);
+        let schedule = &mut value["workspaces"][0]["schedules"][0];
+        schedule
+            .as_object_mut()
+            .unwrap()
+            .remove("evaluation_frontier_trigger_revision");
+        let execution = &mut schedule["executions"][0];
+        execution.as_object_mut().unwrap().remove("scheduled_at_ms");
+        execution
+            .as_object_mut()
+            .unwrap()
+            .remove("coalesced_through_ms");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, serde_json::to_vec(&value).unwrap()).unwrap();
+
+        let migrated = StateStore::at(path.clone()).load().unwrap().unwrap();
+        let schedule = &migrated.workspaces[0].schedules[0];
+        assert_eq!(schedule.evaluation_frontier_trigger_revision, 3);
+        assert_eq!(schedule.executions[0].scheduled_at_ms, None);
+        assert_eq!(schedule.executions[0].coalesced_through_ms, None);
+        assert!(
+            fs::read_to_string(path)
+                .unwrap()
+                .contains("\"version\": 11")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1477,7 +1602,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 10")
+                .contains("\"version\": 11")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1533,7 +1658,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 10")
+                .contains("\"version\": 11")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
         assert!(migrated.workspaces[0].agents.is_empty());
@@ -1584,7 +1709,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 10")
+                .contains("\"version\": 11")
         );
         assert!(migrated.workspaces[0].agents.is_empty());
         assert!(migrated.workspaces[0].schedules.is_empty());
@@ -1624,7 +1749,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 10")
+                .contains("\"version\": 11")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1701,7 +1826,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 10")
+                .contains("\"version\": 11")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1737,7 +1862,7 @@ mod tests {
         assert!(migrated.workspaces[0].agents[0].attention.is_none());
         assert!(migrated.workspaces[0].schedules.is_empty());
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 10"));
+        assert!(saved.contains("\"version\": 11"));
         assert!(saved.contains("\"attention\": null"));
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1770,7 +1895,7 @@ mod tests {
         assert!(!original.contains("default_cwd"));
         store.save(&migrated).unwrap();
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 10"));
+        assert!(saved.contains("\"version\": 11"));
         assert!(saved.contains("\"default_cwd\": null"));
         fs::remove_dir_all(directory).unwrap();
     }

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::os::unix::net::UnixStream;
 use std::process::{Command, Stdio};
 use std::thread;
@@ -11,6 +12,26 @@ use crate::support::{
     TestDaemon, acknowledge_reconnect, assert_generated_name, assert_remote_code, contains,
     parse_pid, process_exists, profile, read_until, wait_for_attach_with_profile, wait_until,
 };
+
+fn assert_unsafe_native_clock_rejected(runtime_dir: &std::path::Path, clock: &std::path::Path) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["daemon", "run"])
+        .env("XDG_RUNTIME_DIR", runtime_dir)
+        .env("XDG_STATE_HOME", runtime_dir.join("state"))
+        .env("SHELL", "/bin/sh")
+        .env("BOOMUX_NATIVE_TEST_HOOKS", "1")
+        .env("BOOMUX_NATIVE_TEST_CLOCK", clock)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_until(
+        || child.try_wait().unwrap().is_some(),
+        "daemon accepted an unsafe native clock path",
+    );
+    assert!(!child.wait().unwrap().success());
+}
 
 #[test]
 fn native_daemon_lifecycle() {
@@ -25,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 23);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 24);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -89,8 +110,12 @@ fn native_daemon_lifecycle() {
         "protocol_21",
         "protocol_22",
         "protocol_23",
+        "protocol_24",
         "agent_schedule_management",
         "durable_agent_schedules",
+        "timed_schedule_dispatch",
+        "scheduler_health",
+        "bounded_scheduled_execution_concurrency",
         "workspace_default_cwd",
         "structured_terminal_previews",
         "focused_terminal_read",
@@ -115,7 +140,9 @@ fn native_daemon_lifecycle() {
         .output()
         .unwrap();
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("running (protocol 23"));
+    let status_text = String::from_utf8_lossy(&status.stdout);
+    assert!(status_text.contains("running (protocol 24"));
+    assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
         .args(["daemon", "status", "--json"])
@@ -124,6 +151,42 @@ fn native_daemon_lifecycle() {
     let status: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
     assert_eq!(status["schema"], "boomux.cli/v1");
     assert_eq!(status["data"]["status"], "running");
+    assert_eq!(status["data"]["scheduler"]["state"], "active");
+    assert_eq!(status["data"]["scheduler"]["active_executions"], 0);
+    assert_eq!(status["data"]["scheduler"]["max_concurrent"], 4);
+    for max_concurrent in [0, 65, u16::MAX] {
+        let mut stream = UnixStream::connect(daemon.client.socket_path()).unwrap();
+        protocol::write_message(
+            &mut stream,
+            &protocol::Envelope::with_version(
+                24,
+                protocol::Request::RestartWithNotificationConfig {
+                    notifications: protocol::NotificationDeliveryConfig {
+                        desktop_enabled: false,
+                        sound_enabled: false,
+                        blocked: true,
+                        completed: true,
+                        blocked_sound: "blocked".into(),
+                        completed_sound: "completed".into(),
+                        resume_agents: true,
+                        persist_terminal_history: false,
+                        max_scheduled_execution_concurrency: max_concurrent,
+                    },
+                    environment: None,
+                },
+            ),
+        )
+        .unwrap();
+        let response: protocol::Envelope<protocol::Response> =
+            protocol::read_message(&mut stream).unwrap();
+        assert!(matches!(
+            response.message,
+            protocol::Response::Error {
+                code: Some(ErrorCode::InvalidArgument),
+                ..
+            }
+        ));
+    }
     let mut protocol_six = UnixStream::connect(daemon.client.socket_path()).unwrap();
     protocol::write_message(
         &mut protocol_six,
@@ -736,4 +799,115 @@ fn native_daemon_lifecycle() {
     assert!(daemon.client.snapshot().unwrap().workspaces.is_empty());
 
     daemon.stop_with_cli();
+}
+
+#[test]
+fn scheduling_config_is_sampled_and_applied_by_graceful_restart() {
+    let config = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let config_for_daemon = std::sync::Arc::clone(&config);
+    let daemon = TestDaemon::start_with(move |command, runtime_dir| {
+        let path = runtime_dir.join("config.toml");
+        fs::write(&path, "[scheduling]\nmax_concurrent = 2\n").unwrap();
+        *config_for_daemon.lock().unwrap() = Some(path.clone());
+        command.env("BOOMUX_CONFIG", path);
+    });
+    let config = config.lock().unwrap().clone().unwrap();
+
+    assert_eq!(
+        daemon
+            .client
+            .snapshot()
+            .unwrap()
+            .scheduler
+            .unwrap()
+            .max_concurrent,
+        2
+    );
+    fs::write(&config, "[scheduling]\nmax_concurrent = 3\n").unwrap();
+    assert_eq!(
+        daemon
+            .client
+            .snapshot()
+            .unwrap()
+            .scheduler
+            .unwrap()
+            .max_concurrent,
+        2
+    );
+
+    let doctor = daemon
+        .command()
+        .env("BOOMUX_CONFIG", &config)
+        .arg("doctor")
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&doctor.stderr).contains(
+            "daemon uses max_concurrent=2, config resolves 3; restart daemon after changes"
+        )
+    );
+
+    let restart = daemon
+        .command()
+        .env("BOOMUX_CONFIG", &config)
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "daemon restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    assert_eq!(
+        daemon
+            .client
+            .snapshot()
+            .unwrap()
+            .scheduler
+            .unwrap()
+            .max_concurrent,
+        3
+    );
+}
+
+#[test]
+fn native_clock_hook_rejects_outside_symlinked_and_unsafe_paths() {
+    for case in ["outside", "symlink", "marker-symlink", "unsafe-marker"] {
+        let runtime_dir =
+            std::env::temp_dir().join(format!("boomux-unsafe-clock-{}-{}", case, Uuid::new_v4()));
+        let private_runtime = runtime_dir.join("boomux");
+        fs::create_dir_all(&private_runtime).unwrap();
+        fs::set_permissions(&private_runtime, fs::Permissions::from_mode(0o700)).unwrap();
+        let outside = runtime_dir.join("outside-clock");
+        fs::create_dir(&outside).unwrap();
+        fs::set_permissions(&outside, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::write(outside.join("tick"), "1 1767225600000").unwrap();
+        fs::set_permissions(outside.join("tick"), fs::Permissions::from_mode(0o600)).unwrap();
+        let clock = match case {
+            "outside" => outside.clone(),
+            "symlink" => {
+                let path = private_runtime.join("clock-link");
+                symlink(&outside, &path).unwrap();
+                path
+            }
+            "marker-symlink" => {
+                let path = private_runtime.join("clock-marker-link");
+                fs::create_dir(&path).unwrap();
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+                symlink(outside.join("tick"), path.join("tick")).unwrap();
+                path
+            }
+            "unsafe-marker" => {
+                let path = private_runtime.join("clock");
+                fs::create_dir(&path).unwrap();
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+                fs::write(path.join("tick"), "1 1767225600000").unwrap();
+                fs::set_permissions(path.join("tick"), fs::Permissions::from_mode(0o644)).unwrap();
+                path
+            }
+            _ => unreachable!(),
+        };
+        assert_unsafe_native_clock_rejected(&runtime_dir, &clock);
+        fs::remove_dir_all(runtime_dir).unwrap();
+    }
 }

--- a/tests/native_backend/handoff.rs
+++ b/tests/native_backend/handoff.rs
@@ -140,7 +140,7 @@ fn focused_attachment_is_exposed_in_daemon_snapshots() {
         .unwrap();
     let shell_id = workspace.shells[0].id.clone();
     let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    assert_eq!(attachment.protocol_version, 23);
+    assert_eq!(attachment.protocol_version, 24);
 
     AttachFrame::FocusGained
         .write_to(&mut attachment.stream)

--- a/tests/native_backend/schedules.rs
+++ b/tests/native_backend/schedules.rs
@@ -430,6 +430,26 @@ fn manual_execution_succeeds_and_duplicate_key_never_spawns_twice() {
         },
         "scheduled execution did not exit",
     );
+    wait_until(
+        || {
+            daemon
+                .client
+                .events(Some(event_cursor.clone()), 256, 0)
+                .is_ok_and(|page| {
+                    page.events.iter().any(|event| {
+                        matches!(
+                            &event.kind,
+                            protocol::DaemonEventKind::ScheduledExecutionChanged {
+                                execution,
+                                ..
+                            } if execution.id == first.id
+                                && execution.state == ScheduledExecutionState::Exited
+                        )
+                    })
+                })
+        },
+        "scheduled execution exit event was not published",
+    );
     assert_eq!(fs::read_to_string(&capture).unwrap(), "spawn\n");
     assert_eq!(
         fs::read(daemon.runtime_dir.join("argv")).unwrap(),

--- a/tests/native_backend/schedules.rs
+++ b/tests/native_backend/schedules.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::thread;
+use std::time::{Duration, Instant};
 
 use boomux::client::Client;
 use boomux::protocol::{
@@ -27,6 +28,39 @@ fn schedule_spec(daemon: &TestDaemon, name: &str, prompt: &str) -> AgentSchedule
         state: AgentScheduleState::Paused,
         overlap_policy: AgentScheduleOverlapPolicy::Skip,
     }
+}
+
+fn write_scheduler_tick(clock: &std::path::Path, generation: u64, now_ms: u64) {
+    let tick = clock.join("tick");
+    fs::write(&tick, format!("{generation} {now_ms}")).unwrap();
+    fs::set_permissions(tick, fs::Permissions::from_mode(0o600)).unwrap();
+}
+
+fn create_scheduler_clock(clock: &std::path::Path) {
+    fs::create_dir_all(clock.parent().unwrap()).unwrap();
+    fs::set_permissions(clock.parent().unwrap(), fs::Permissions::from_mode(0o700)).unwrap();
+    fs::create_dir(clock).unwrap();
+    fs::set_permissions(clock, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+fn wait_for_scheduler_tick(clock: &std::path::Path, generation: u64) {
+    wait_until(
+        || {
+            fs::read_to_string(clock.join("ack"))
+                .is_ok_and(|value| value.trim() == generation.to_string())
+        },
+        "scheduler did not acknowledge deterministic tick",
+    );
+}
+
+fn wait_for_scheduler_seen(clock: &std::path::Path, generation: u64) {
+    wait_until(
+        || {
+            fs::read_to_string(clock.join("seen"))
+                .is_ok_and(|value| value.trim() == generation.to_string())
+        },
+        "scheduler did not observe deterministic tick",
+    );
 }
 
 #[test]
@@ -788,6 +822,151 @@ fn inactive_agent_does_not_block_exact_continuation_dispatch() {
 }
 
 #[test]
+fn continuation_registration_wins_before_atomic_eligibility_and_creates_no_phantom() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let barrier = runtime_dir.join("continuation-pre-dispatch-barrier");
+        fs::create_dir(&barrier).unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\n: > \"$BOOMUX_CONTINUATION_RACE_SPAWNED\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_PRE_DISPATCH_BARRIER", &barrier)
+            .env(
+                "BOOMUX_CONTINUATION_RACE_SPAWNED",
+                runtime_dir.join("continuation-race-spawned"),
+            );
+    });
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "continuation-race",
+            vec![ShellSpec {
+                name: "user".into(),
+                cwd: daemon.runtime_dir.clone(),
+                command: vec!["/bin/sh".into(), "-c".into(), "sleep 30".into()],
+            }],
+        )
+        .unwrap();
+    let attachment = daemon
+        .client
+        .attach(&workspace.shells[0].id, false, profile())
+        .unwrap();
+    let run_id = daemon
+        .client
+        .get_shell(&workspace.shells[0].id)
+        .unwrap()
+        .run
+        .unwrap()
+        .id;
+    let mut spec = schedule_spec(&daemon, "continuation-race", "must not run");
+    spec.session = AgentScheduleSession::Continue {
+        external_session_id: "exact-racing-session".into(),
+    };
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, spec)
+        .unwrap();
+    let request_client = Client::from_socket_path(daemon.client.socket_path().to_path_buf());
+    let schedule_id = schedule.id.clone();
+    let request = thread::spawn(move || {
+        request_client.run_agent_schedule(schedule_id, Uuid::new_v4().to_string())
+    });
+    let barrier = daemon.runtime_dir.join("continuation-pre-dispatch-barrier");
+    wait_until(
+        || barrier.join("waiting").is_file(),
+        "continuation pre-dispatch barrier was not reached",
+    );
+    daemon
+        .client
+        .register_agent(
+            &workspace.shells[0].id,
+            run_id,
+            AgentRegistrationSpec {
+                name: "racing-active-agent".into(),
+                integration: "opencode".into(),
+                external_session_id: Some("exact-racing-session".into()),
+                report: AgentReport {
+                    state: AgentState::Working,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "became active after claim".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    let protocol::Response::Events {
+        cursor: old_cursor, ..
+    } = versioned_request(
+        &daemon,
+        23,
+        protocol::Request::Events {
+            after: None,
+            limit: 256,
+            wait_ms: 0,
+        },
+    )
+    else {
+        panic!("expected protocol-23 baseline");
+    };
+    fs::write(barrier.join("release"), b"release").unwrap();
+    let execution = request.join().unwrap().unwrap();
+    assert_eq!(execution.state, ScheduledExecutionState::Skipped);
+    assert_eq!(
+        execution.reason,
+        Some(protocol::ScheduledExecutionReason::ActiveSession)
+    );
+    assert!(execution.shell_id.is_none());
+    assert!(execution.run_id.is_none());
+    assert!(
+        daemon
+            .client
+            .get_agent_schedule(&schedule.id)
+            .unwrap()
+            .schedule
+            .execution_shell_id
+            .is_none()
+    );
+    assert!(
+        !daemon
+            .runtime_dir
+            .join("continuation-race-spawned")
+            .exists()
+    );
+    let old_events = versioned_request(
+        &daemon,
+        23,
+        protocol::Request::Events {
+            after: Some(old_cursor.clone()),
+            limit: 256,
+            wait_ms: 0,
+        },
+    );
+    let protocol::Response::Events { cursor, events, .. } = &old_events else {
+        panic!("expected protocol-23 event page");
+    };
+    assert!(cursor.event_id > old_cursor.event_id);
+    assert!(events.is_empty());
+    let frozen = serde_json::to_value(old_events).unwrap();
+    assert_eq!(frozen["events"], serde_json::json!([]));
+    assert!(!frozen.to_string().contains("claimed"));
+    assert!(!frozen.to_string().contains("skipped"));
+    drop(attachment.stream);
+    daemon.client.close_workspace(&workspace.id).unwrap();
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn linked_agents_remain_authoritative_after_exit_and_late_ensure_repairs_links() {
     let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
         let bin = runtime_dir.join("bin");
@@ -1116,12 +1295,30 @@ fn active_execution_cancellation_terminates_the_host_process_tree() {
             .unwrap()
             .contains("private")
     );
-    assert_remote_code(
-        &daemon
-            .client
-            .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
-            .unwrap_err(),
-        protocol::ErrorCode::Busy,
+    let skipped = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    assert_eq!(skipped.state, ScheduledExecutionState::Skipped);
+    assert_eq!(
+        skipped.reason,
+        Some(protocol::ScheduledExecutionReason::Overlap)
+    );
+    let old_response = versioned_request(
+        &daemon,
+        23,
+        protocol::Request::RunAgentSchedule {
+            schedule_id: schedule.id.clone(),
+            dispatch_key: Uuid::new_v4().to_string(),
+        },
+    );
+    assert_eq!(
+        serde_json::to_value(old_response).unwrap(),
+        serde_json::json!({
+            "response": "error",
+            "message": "scheduled execution was skipped by the current concurrency policy",
+            "code": "busy"
+        })
     );
     let pids = fs::read_to_string(pids)
         .unwrap()
@@ -1677,6 +1874,124 @@ fn start_long_running_execution(
 }
 
 #[test]
+fn transferred_active_executions_block_lower_global_limit_until_release() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let config = runtime_dir.join("max-two.toml");
+        fs::write(&config, "[scheduling]\nmax_concurrent = 2\n").unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf '%s\n' \"$$\" >> \"$BOOMUX_BOUND_PIDS\"\nsleep 30\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("BOOMUX_CONFIG", config)
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_BOUND_PIDS", runtime_dir.join("bound-pids"));
+    });
+    let mut schedules = Vec::new();
+    for index in 1..=3 {
+        let workspace = daemon
+            .client
+            .create_workspace(format!("bound-{index}"), Vec::new())
+            .unwrap();
+        let schedule = daemon
+            .client
+            .create_agent_schedule(
+                &workspace.id,
+                schedule_spec(&daemon, &format!("bound-{index}"), "private"),
+            )
+            .unwrap();
+        schedules.push((workspace, schedule));
+    }
+    let mut active = Vec::new();
+    for (_, schedule) in &schedules[..2] {
+        let execution = daemon
+            .client
+            .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+            .unwrap();
+        wait_until(
+            || {
+                daemon
+                    .client
+                    .get_scheduled_execution(&execution.id)
+                    .is_ok_and(|current| current.state == ScheduledExecutionState::Active)
+            },
+            "bounded execution did not become active",
+        );
+        active.push(execution.id);
+    }
+    let mut same_workspace_spec = schedule_spec(&daemon, "same-workspace", "private");
+    same_workspace_spec.name = "same-workspace".into();
+    let same_workspace = daemon
+        .client
+        .create_agent_schedule(&schedules[0].0.id, same_workspace_spec)
+        .unwrap();
+    let skipped = daemon
+        .client
+        .run_agent_schedule(&same_workspace.id, Uuid::new_v4().to_string())
+        .unwrap();
+    assert_eq!(
+        skipped.reason,
+        Some(protocol::ScheduledExecutionReason::WorkspaceCapacity)
+    );
+
+    let config = daemon.runtime_dir.join("max-one.toml");
+    fs::write(&config, "[scheduling]\nmax_concurrent = 1\n").unwrap();
+    let mut paths = vec![daemon.runtime_dir.join("bin")];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let restart = daemon
+        .command()
+        .env("BOOMUX_CONFIG", &config)
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .env("BOOMUX_BOUND_PIDS", daemon.runtime_dir.join("bound-pids"))
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    let health = daemon.client.snapshot().unwrap().scheduler.unwrap();
+    assert_eq!(health.max_concurrent, 1);
+    assert_eq!(health.active_executions, 2);
+    let blocked = daemon
+        .client
+        .run_agent_schedule(&schedules[2].1.id, Uuid::new_v4().to_string())
+        .unwrap();
+    assert_eq!(
+        blocked.reason,
+        Some(protocol::ScheduledExecutionReason::GlobalCapacity)
+    );
+
+    for execution_id in &active {
+        daemon
+            .client
+            .cancel_scheduled_execution(execution_id)
+            .unwrap();
+    }
+    let admitted = daemon
+        .client
+        .run_agent_schedule(&schedules[2].1.id, Uuid::new_v4().to_string())
+        .unwrap();
+    assert_ne!(admitted.state, ScheduledExecutionState::Skipped);
+    daemon
+        .client
+        .cancel_scheduled_execution(&admitted.id)
+        .unwrap();
+    for (workspace, _) in schedules {
+        daemon.client.close_workspace(&workspace.id).unwrap();
+    }
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn cold_recovery_interrupts_active_execution_without_respawn() {
     let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
         let bin = runtime_dir.join("bin");
@@ -1843,6 +2158,669 @@ fn cold_recovery_clears_staged_outcome_and_survives_second_restart() {
         .unwrap();
     assert_eq!(restored_again, recovered);
     daemon.stop_with_cli();
+}
+
+#[test]
+fn deterministic_clock_dispatches_due_work_and_protocol_23_hides_it() {
+    const BASE_MS: u64 = 1_767_225_600_000;
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let clock = runtime_dir.join("boomux/scheduler-clock");
+        create_scheduler_clock(&clock);
+        write_scheduler_tick(&clock, 1, BASE_MS);
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf 'spawn\\n' >> \"$BOOMUX_TIMED_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_CLOCK", &clock)
+            .env("BOOMUX_TIMED_CAPTURE", runtime_dir.join("timed-spawns"));
+    });
+    let clock = daemon.runtime_dir.join("boomux/scheduler-clock");
+    wait_for_scheduler_tick(&clock, 1);
+    let workspace = daemon
+        .client
+        .create_workspace("timed-native", Vec::new())
+        .unwrap();
+    let mut spec = schedule_spec(&daemon, "timed-native", "private");
+    spec.trigger.cron = "* * * * *".into();
+    spec.state = AgentScheduleState::Enabled;
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, spec)
+        .unwrap();
+    assert_eq!(
+        schedule
+            .next_occurrence
+            .as_ref()
+            .map(|occurrence| occurrence.scheduled_at_ms),
+        Some(BASE_MS + 60_000)
+    );
+    let protocol::Response::Events {
+        cursor: old_cursor, ..
+    } = versioned_request(
+        &daemon,
+        23,
+        protocol::Request::Events {
+            after: None,
+            limit: 256,
+            wait_ms: 0,
+        },
+    )
+    else {
+        panic!("expected protocol-23 baseline");
+    };
+
+    write_scheduler_tick(&clock, 2, BASE_MS + 60_000);
+    wait_for_scheduler_tick(&clock, 2);
+    wait_until(
+        || {
+            daemon
+                .client
+                .scheduled_executions(None, Some(schedule.id.clone()))
+                .is_ok_and(|executions| {
+                    executions.len() == 1 && executions[0].state == ScheduledExecutionState::Exited
+                })
+        },
+        "timed execution did not complete",
+    );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("timed-spawns")).unwrap(),
+        "spawn\n"
+    );
+    let execution = daemon
+        .client
+        .scheduled_executions(None, Some(schedule.id.clone()))
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(
+        execution.dispatch_kind,
+        protocol::ScheduledExecutionDispatchKind::Timed
+    );
+    assert_eq!(execution.scheduled_at_ms, Some(BASE_MS + 60_000));
+    assert_eq!(
+        daemon
+            .client
+            .get_agent_schedule(&schedule.id)
+            .unwrap()
+            .schedule
+            .next_occurrence
+            .unwrap()
+            .scheduled_at_ms,
+        BASE_MS + 120_000
+    );
+    assert_eq!(
+        execution.id,
+        Uuid::new_v5(
+            &Uuid::NAMESPACE_OID,
+            format!(
+                "boomux:timed-execution:{}:{}:{}",
+                schedule.id,
+                schedule.trigger_revision,
+                BASE_MS + 60_000
+            )
+            .as_bytes(),
+        )
+        .to_string()
+    );
+
+    let protocol::Response::ScheduledExecutions { executions } = versioned_request(
+        &daemon,
+        23,
+        protocol::Request::ListScheduledExecutions {
+            workspace_id: None,
+            schedule_id: Some(schedule.id.clone()),
+        },
+    ) else {
+        panic!("expected protocol-23 execution list");
+    };
+    assert!(executions.is_empty());
+    assert!(matches!(
+        versioned_request(
+            &daemon,
+            23,
+            protocol::Request::GetScheduledExecution {
+                execution_id: execution.id.clone(),
+            }
+        ),
+        protocol::Response::Error {
+            code: Some(protocol::ErrorCode::NotFound),
+            ..
+        }
+    ));
+    let protocol::Response::Events { cursor, events, .. } = versioned_request(
+        &daemon,
+        23,
+        protocol::Request::Events {
+            after: Some(old_cursor.clone()),
+            limit: 256,
+            wait_ms: 0,
+        },
+    ) else {
+        panic!("expected protocol-23 event page");
+    };
+    assert!(cursor.event_id > old_cursor.event_id);
+    assert!(!events.iter().any(|event| matches!(
+        event.kind,
+        protocol::DaemonEventKind::ScheduledExecutionCreated { .. }
+            | protocol::DaemonEventKind::ScheduledExecutionChanged { .. }
+    )));
+    let protocol::Response::Snapshot { snapshot } =
+        versioned_request(&daemon, 23, protocol::Request::Snapshot)
+    else {
+        panic!("expected protocol-23 snapshot");
+    };
+    assert!(snapshot.scheduler.is_none());
+    assert!(
+        snapshot.workspaces[0].schedules[0]
+            .next_occurrence
+            .is_none()
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn paused_time_is_not_caught_up_after_resume() {
+    const BASE_MS: u64 = 1_767_225_600_000;
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let clock = runtime_dir.join("boomux/paused-scheduler-clock");
+        create_scheduler_clock(&clock);
+        write_scheduler_tick(&clock, 1, BASE_MS);
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(&host, "#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_CLOCK", &clock);
+    });
+    let clock = daemon.runtime_dir.join("boomux/paused-scheduler-clock");
+    wait_for_scheduler_tick(&clock, 1);
+    let workspace = daemon
+        .client
+        .create_workspace("paused-timed", Vec::new())
+        .unwrap();
+    let mut spec = schedule_spec(&daemon, "paused-timed", "private");
+    spec.trigger.cron = "* * * * *".into();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, spec)
+        .unwrap();
+
+    write_scheduler_tick(&clock, 2, BASE_MS + 180_000);
+    wait_for_scheduler_tick(&clock, 2);
+    assert!(
+        daemon
+            .client
+            .scheduled_executions(None, Some(schedule.id.clone()))
+            .unwrap()
+            .is_empty()
+    );
+    daemon.client.resume_agent_schedule(&schedule.id).unwrap();
+    assert_eq!(
+        daemon
+            .client
+            .get_agent_schedule(&schedule.id)
+            .unwrap()
+            .schedule
+            .next_occurrence
+            .unwrap()
+            .scheduled_at_ms,
+        BASE_MS + 240_000
+    );
+    write_scheduler_tick(&clock, 3, BASE_MS + 240_000);
+    wait_for_scheduler_tick(&clock, 3);
+    wait_until(
+        || {
+            daemon
+                .client
+                .scheduled_executions(None, Some(schedule.id.clone()))
+                .is_ok_and(|executions| {
+                    executions.len() == 1 && executions[0].state == ScheduledExecutionState::Exited
+                })
+        },
+        "first post-resume occurrence did not finish",
+    );
+    let execution = daemon
+        .client
+        .scheduled_executions(None, Some(schedule.id))
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(execution.scheduled_at_ms, Some(BASE_MS + 240_000));
+    assert_eq!(execution.coalesced_through_ms, None);
+    assert_eq!(
+        daemon
+            .client
+            .get_agent_schedule(&execution.schedule_id)
+            .unwrap()
+            .schedule
+            .next_occurrence
+            .unwrap()
+            .scheduled_at_ms,
+        BASE_MS + 300_000
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn cold_downtime_coalesces_missed_occurrences_without_spawning_and_is_stable() {
+    const BASE_MS: u64 = 1_767_225_600_000;
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let clock = runtime_dir.join("boomux/cold-scheduler-clock");
+        create_scheduler_clock(&clock);
+        write_scheduler_tick(&clock, 1, BASE_MS);
+        command.env("BOOMUX_NATIVE_TEST_CLOCK", &clock).env(
+            "BOOMUX_TIMED_CAPTURE",
+            runtime_dir.join("cold-timed-spawns"),
+        );
+    });
+    let clock = daemon.runtime_dir.join("boomux/cold-scheduler-clock");
+    wait_for_scheduler_tick(&clock, 1);
+    let workspace = daemon
+        .client
+        .create_workspace("cold-timed", Vec::new())
+        .unwrap();
+    let mut spec = schedule_spec(&daemon, "cold-timed", "private");
+    spec.trigger.cron = "* * * * *".into();
+    spec.state = AgentScheduleState::Enabled;
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, spec)
+        .unwrap();
+    daemon.crash();
+
+    write_scheduler_tick(&clock, 2, BASE_MS + 180_000);
+    let clock_for_restart = clock.clone();
+    daemon.restart_with(|command| {
+        command.env("BOOMUX_NATIVE_TEST_CLOCK", clock_for_restart);
+    });
+    wait_for_scheduler_tick(&clock, 2);
+    let executions = daemon
+        .client
+        .scheduled_executions(None, Some(schedule.id.clone()))
+        .unwrap();
+    assert_eq!(executions.len(), 1);
+    assert_eq!(executions[0].state, ScheduledExecutionState::Skipped);
+    assert_eq!(
+        executions[0].reason,
+        Some(protocol::ScheduledExecutionReason::Missed)
+    );
+    assert_eq!(executions[0].scheduled_at_ms, Some(BASE_MS + 60_000));
+    assert_eq!(executions[0].coalesced_through_ms, Some(BASE_MS + 180_000));
+    assert_eq!(
+        daemon
+            .client
+            .get_agent_schedule(&schedule.id)
+            .unwrap()
+            .schedule
+            .next_occurrence
+            .unwrap()
+            .scheduled_at_ms,
+        BASE_MS + 240_000
+    );
+    assert!(!daemon.runtime_dir.join("cold-timed-spawns").exists());
+
+    daemon.crash();
+    let clock_for_restart = clock.clone();
+    daemon.restart_with(|command| {
+        command.env("BOOMUX_NATIVE_TEST_CLOCK", clock_for_restart);
+    });
+    assert_eq!(
+        daemon
+            .client
+            .scheduled_executions(None, Some(schedule.id))
+            .unwrap(),
+        executions
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn graceful_handoff_replacement_evaluates_due_boundary_only_after_finalize() {
+    const BASE_MS: u64 = 1_767_225_600_000;
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let clock = runtime_dir.join("boomux/handoff-scheduler-clock");
+        create_scheduler_clock(&clock);
+        write_scheduler_tick(&clock, 1, BASE_MS);
+        let replacement_clock = runtime_dir.join("boomux/handoff-replacement-clock");
+        create_scheduler_clock(&replacement_clock);
+        write_scheduler_tick(&replacement_clock, 2, BASE_MS + 60_000);
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf 'spawn\\n' >> \"$BOOMUX_TIMED_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_CLOCK", &clock)
+            .env(
+                "BOOMUX_TIMED_CAPTURE",
+                runtime_dir.join("handoff-timed-spawns"),
+            );
+    });
+    let clock = daemon.runtime_dir.join("boomux/handoff-scheduler-clock");
+    wait_for_scheduler_tick(&clock, 1);
+    let workspace = daemon
+        .client
+        .create_workspace("handoff-timed", Vec::new())
+        .unwrap();
+    let mut spec = schedule_spec(&daemon, "handoff-timed", "private");
+    spec.trigger.cron = "* * * * *".into();
+    spec.state = AgentScheduleState::Enabled;
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, spec)
+        .unwrap();
+
+    let replacement_clock = daemon.runtime_dir.join("boomux/handoff-replacement-clock");
+    let mut paths = vec![daemon.runtime_dir.join("bin")];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .env("BOOMUX_NATIVE_TEST_CLOCK", &replacement_clock)
+        .env(
+            "BOOMUX_TIMED_CAPTURE",
+            daemon.runtime_dir.join("handoff-timed-spawns"),
+        )
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    wait_for_scheduler_tick(&replacement_clock, 2);
+    wait_until(
+        || {
+            daemon
+                .client
+                .scheduled_executions(None, Some(schedule.id.clone()))
+                .is_ok_and(|executions| {
+                    executions.len() == 1 && executions[0].state == ScheduledExecutionState::Exited
+                })
+        },
+        "handoff due occurrence did not finish",
+    );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("handoff-timed-spawns")).unwrap(),
+        "spawn\n"
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn graceful_handoff_transfers_an_old_daemon_due_boundary_claim_without_duplicate() {
+    const BASE_MS: u64 = 1_767_225_600_000;
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let clock = runtime_dir.join("boomux/handoff-old-claim-clock");
+        create_scheduler_clock(&clock);
+        write_scheduler_tick(&clock, 1, BASE_MS);
+        let barrier = runtime_dir.join("handoff-old-claim-barrier");
+        fs::create_dir(&barrier).unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf 'spawn\n' >> \"$BOOMUX_TIMED_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_NATIVE_TEST_CLOCK", &clock)
+            .env("BOOMUX_NATIVE_TEST_CLAIM_BARRIER", &barrier)
+            .env(
+                "BOOMUX_TIMED_CAPTURE",
+                runtime_dir.join("handoff-old-claim-spawns"),
+            );
+    });
+    let clock = daemon.runtime_dir.join("boomux/handoff-old-claim-clock");
+    wait_for_scheduler_tick(&clock, 1);
+    let workspace = daemon
+        .client
+        .create_workspace("handoff-old-claim", Vec::new())
+        .unwrap();
+    let mut spec = schedule_spec(&daemon, "handoff-old-claim", "private");
+    spec.trigger.cron = "* * * * *".into();
+    spec.state = AgentScheduleState::Enabled;
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, spec)
+        .unwrap();
+
+    write_scheduler_tick(&clock, 2, BASE_MS + 60_000);
+    let barrier = daemon.runtime_dir.join("handoff-old-claim-barrier");
+    wait_until(
+        || barrier.join("claimed").is_file(),
+        "old daemon did not commit the due-boundary claim",
+    );
+    let mut paths = vec![daemon.runtime_dir.join("bin")];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let mut restart = daemon.command();
+    restart
+        .args(["daemon", "restart"])
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .env("BOOMUX_NATIVE_TEST_CLOCK", &clock)
+        .env("BOOMUX_NATIVE_TEST_CLAIM_BARRIER", &barrier)
+        .env(
+            "BOOMUX_TIMED_CAPTURE",
+            daemon.runtime_dir.join("handoff-old-claim-spawns"),
+        );
+    let restart = thread::spawn(move || restart.output().unwrap());
+    fs::write(barrier.join("release"), b"release").unwrap();
+    let restart = restart.join().unwrap();
+    assert!(restart.status.success());
+    wait_until(
+        || {
+            daemon
+                .client
+                .scheduled_executions(None, Some(schedule.id.clone()))
+                .is_ok_and(|executions| {
+                    executions.len() == 1 && executions[0].state == ScheduledExecutionState::Exited
+                })
+        },
+        "transferred due-boundary claim did not finish",
+    );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("handoff-old-claim-spawns")).unwrap(),
+        "spawn\n"
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn timed_persistence_failure_retries_the_same_occurrence_once() {
+    const BASE_MS: u64 = 1_767_225_600_000;
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let clock = runtime_dir.join("boomux/retry-scheduler-clock");
+        create_scheduler_clock(&clock);
+        write_scheduler_tick(&clock, 1, BASE_MS);
+        command.env("BOOMUX_NATIVE_TEST_CLOCK", &clock);
+    });
+    let clock = daemon.runtime_dir.join("boomux/retry-scheduler-clock");
+    wait_for_scheduler_tick(&clock, 1);
+    let workspace = daemon
+        .client
+        .create_workspace("retry-timed", Vec::new())
+        .unwrap();
+    let mut spec = schedule_spec(&daemon, "retry-timed", "private");
+    spec.trigger.cron = "* * * * *".into();
+    spec.state = AgentScheduleState::Enabled;
+    let schedule = daemon
+        .client
+        .create_agent_schedule(&workspace.id, spec)
+        .unwrap();
+    let state_directory = daemon.runtime_dir.join("state/boomux");
+    let saved_directory = daemon.runtime_dir.join("saved-timed-retry-state");
+    fs::rename(&state_directory, &saved_directory).unwrap();
+    fs::write(&state_directory, b"not a directory").unwrap();
+
+    write_scheduler_tick(&clock, 2, BASE_MS + 180_000);
+    wait_for_scheduler_seen(&clock, 2);
+    assert!(!fs::read_to_string(clock.join("ack")).is_ok_and(|value| value.trim() == "2"));
+
+    fs::remove_file(&state_directory).unwrap();
+    fs::rename(&saved_directory, &state_directory).unwrap();
+    wait_for_scheduler_tick(&clock, 2);
+    let executions = daemon
+        .client
+        .scheduled_executions(None, Some(schedule.id))
+        .unwrap();
+    assert_eq!(executions.len(), 2);
+    assert_eq!(
+        executions
+            .iter()
+            .filter(|execution| execution.scheduled_at_ms == Some(BASE_MS + 60_000))
+            .count(),
+        1
+    );
+    let missed = executions
+        .iter()
+        .find(|execution| execution.scheduled_at_ms == Some(BASE_MS + 60_000))
+        .unwrap();
+    assert_eq!(missed.state, ScheduledExecutionState::Skipped);
+    assert_eq!(missed.coalesced_through_ms, Some(BASE_MS + 120_000));
+    assert_eq!(
+        executions
+            .iter()
+            .filter(|execution| execution.scheduled_at_ms == Some(BASE_MS + 180_000))
+            .count(),
+        1
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn persistent_scheduler_failure_backs_off_and_stop_interrupts_the_wait() {
+    const BASE_MS: u64 = 1_767_225_600_000;
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let clock = runtime_dir.join("boomux/persistent-failure-clock");
+        create_scheduler_clock(&clock);
+        write_scheduler_tick(&clock, 1, BASE_MS);
+        command.env("BOOMUX_NATIVE_TEST_CLOCK", &clock);
+    });
+    let clock = daemon.runtime_dir.join("boomux/persistent-failure-clock");
+    wait_for_scheduler_tick(&clock, 1);
+    let workspace = daemon
+        .client
+        .create_workspace("persistent-scheduler-failure", Vec::new())
+        .unwrap();
+    let mut spec = schedule_spec(&daemon, "persistent-scheduler-failure", "private");
+    spec.trigger.cron = "* * * * *".into();
+    spec.state = AgentScheduleState::Enabled;
+    daemon
+        .client
+        .create_agent_schedule(&workspace.id, spec)
+        .unwrap();
+    let baseline_attempts = fs::read_to_string(clock.join("attempts"))
+        .unwrap()
+        .trim()
+        .parse::<u64>()
+        .unwrap();
+    let state_directory = daemon.runtime_dir.join("state/boomux");
+    let saved_directory = daemon.runtime_dir.join("saved-persistent-failure-state");
+    fs::rename(&state_directory, &saved_directory).unwrap();
+    fs::write(&state_directory, b"not a directory").unwrap();
+
+    write_scheduler_tick(&clock, 2, BASE_MS + 60_000);
+    wait_for_scheduler_seen(&clock, 2);
+    for index in 0..20 {
+        let output = if index % 5 == 0 {
+            daemon.command().arg("doctor").output().unwrap()
+        } else {
+            daemon
+                .command()
+                .args(["daemon", "status"])
+                .output()
+                .unwrap()
+        };
+        if index % 5 != 0 {
+            assert!(output.status.success());
+        }
+    }
+    let attempts_after_polling = fs::read_to_string(clock.join("attempts"))
+        .unwrap()
+        .trim()
+        .parse::<u64>()
+        .unwrap();
+    assert!(attempts_after_polling <= baseline_attempts + 7);
+    wait_until(
+        || {
+            fs::read_to_string(clock.join("attempts"))
+                .ok()
+                .and_then(|value| value.trim().parse::<u64>().ok())
+                .is_some_and(|attempts| attempts >= baseline_attempts + 3)
+        },
+        "scheduler did not perform bounded retries",
+    );
+    let attempts = fs::read_to_string(clock.join("attempts"))
+        .unwrap()
+        .trim()
+        .parse::<u64>()
+        .unwrap();
+    assert!(
+        attempts <= baseline_attempts + 7,
+        "retry loop spun: {attempts}"
+    );
+    assert_eq!(
+        fs::read_to_string(clock.join("diagnostics"))
+            .unwrap()
+            .trim(),
+        "1"
+    );
+    assert!(!fs::read_to_string(clock.join("ack")).is_ok_and(|value| value.trim() == "2"));
+    assert_eq!(
+        daemon.client.snapshot().unwrap().scheduler.unwrap().state,
+        protocol::SchedulerState::Offline
+    );
+    let status = daemon
+        .command()
+        .args(["daemon", "status"])
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&status.stdout).contains("scheduler offline"));
+    let doctor = daemon.command().arg("doctor").output().unwrap();
+    assert!(
+        String::from_utf8_lossy(&doctor.stderr)
+            .contains("err scheduler: offline; timed schedules are not being evaluated")
+    );
+
+    fs::remove_file(&state_directory).unwrap();
+    fs::rename(&saved_directory, &state_directory).unwrap();
+    let started = Instant::now();
+    daemon.stop_with_cli();
+    assert!(started.elapsed() < Duration::from_secs(1));
 }
 
 #[test]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -80,16 +80,20 @@ impl TestDaemon {
     }
 
     pub(crate) fn restart(&mut self) {
+        self.restart_with(|_| {});
+    }
+
+    pub(crate) fn restart_with(&mut self, configure: impl FnOnce(&mut Command)) {
         assert!(self.child.is_none());
-        let child = self
-            .command()
+        let mut command = self.command();
+        command
             .args(["daemon", "run"])
             .env("SHELL", "/bin/sh")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .unwrap();
+            .stderr(Stdio::null());
+        configure(&mut command);
+        let child = command.spawn().unwrap();
         self.child = Some(child);
         wait_until(
             || self.client.ping().is_ok(),


### PR DESCRIPTION
## Summary

- evaluate canonical five-field cron triggers in stored IANA timezones with deterministic DST and clock-jump behavior
- atomically persist timed claim/skip decisions and occurrence frontiers for at-most-once dispatch across restart and handoff
- enforce per-schedule, workspace, continuation, and configurable daemon-wide concurrency limits
- expose next occurrences, scheduler health, startup-sampled `[scheduling] max_concurrent`, and compatibility-safe protocol-24/state-11 contracts
- add deterministic clock, persistence-failure, cold-recovery, handoff, pagination, and mixed-version native coverage

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`
- `cargo check --release --locked`
- `cargo package --locked --allow-dirty`

Closes #150

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>