### PR TITLE
feat: generate names for unnamed shells and agents

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -270,13 +270,14 @@ Use these mutation commands only for a lifecycle integration that directly
 observes the external agent session:
 
 ```console
-boomux agent register "<name>" --integration "<integration>" --external-session-id "<id>" --shell-id "<shell-id>" --run-id "<run-id>" --state working --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100 --json
-boomux agent ensure "<name>" --integration "<integration>" --external-session-id "<id>" --shell-id "<shell-id>" --run-id "<run-id>" --state working --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100 --json
+boomux agent register [<name>] --integration "<integration>" --external-session-id "<id>" --shell-id "<shell-id>" --run-id "<run-id>" --state working --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100 --json
+boomux agent ensure [<name>] --integration "<integration>" --external-session-id "<id>" --shell-id "<shell-id>" --run-id "<run-id>" --state working --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100 --json
 boomux agent report "<exact-agent-id>" --shell-id "<same-shell-id>" --run-id "<original-run-id>" --state blocked --authority lifecycle-integration --evidence "<direct evidence>" --confidence 100 --json
 boomux agent report "<exact-agent-id>" --shell-id "<same-shell-id>" --run-id "<original-run-id>" --state done --authority lifecycle-integration --evidence "<completion evidence>" --confidence 100 --json
 ```
 
-`--external-session-id` is optional for `register` and required for `ensure`.
+Omitting the descriptive Agent name generates a random lowercase
+`adjective-noun` name. `--external-session-id` is optional for `register` and required for `ensure`.
 Use `ensure` when an integration needs idempotent identity recovery after a
 reload. Its key is integration, external session ID, shell ID, and run ID; a
 match returns the existing durable snapshot without applying the supplied name
@@ -308,7 +309,7 @@ Use the process adapter only when the caller already knows the canonical root
 external session ID:
 
 ```console
-boomux agent supervise "<name>" --integration "<integration>" --external-session-id "<canonical-root-id>" --shell-id "<shell-id>" --run-id "<run-id>" -- command arg
+boomux agent supervise [<name>] --integration "<integration>" --external-session-id "<canonical-root-id>" --shell-id "<shell-id>" --run-id "<run-id>" -- command arg
 ```
 
 Inside the target managed process, `--shell-id` and `--run-id` default to
@@ -461,7 +462,7 @@ boomux shell close "<name-or-id>" --workspace "<workspace-name-or-id>"
 `shell create` records a pending shell. Without `--cwd`, it uses the workspace
 default when present and otherwise the current directory. An unavailable stored
 default is an error rather than a silent fallback. Omit `--name` to let Boomux
-generate a unique shell name. A shell cannot close itself through the CLI.
+generate a unique lowercase `adjective-noun` shell name. A shell cannot close itself through the CLI.
 Closing one shell terminates its process session and removes its retained
 terminal state, but durable Agent records remain in the workspace as historical
 occurrences.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | Create a generated workspace | `boomux .` |
 | Create or add to a named workspace | `boomux . --name feature-x` |
 | Create an empty workspace with a default directory | `boomux workspace create feature-x --cwd .` |
+| Add a randomly named shell | `boomux shell create feature-x` |
 | Open the new shell in another terminal | `boomux . --name feature-x --new` |
 | Run one command | `boomux . --name feature-x --new -- lazygit` |
 | Choose a terminal | `boomux . --terminal Alacritty.desktop` |
@@ -138,6 +139,9 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 Without `--name`, Boomux creates the next `workspace-N` and stores the selected
 path as its default for later shells. With `--name`, it adds a shell to an
 existing exact-name workspace or creates a workspace with that default.
+Shells created without an explicit shell name receive a memorable lowercase
+`adjective-noun` name such as `quiet-otter`; that concrete name is retained like
+any explicit name.
 `--terminal` implies `--new`. Terminal selection uses the CLI override, then
 Boomux configuration, then the normal `xdg-terminal-exec` policy.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,6 +77,10 @@ name resolution, and dashboard backend orchestration. `src/dashboard_projection.
 converts daemon snapshots and projected sessions into typed TUI view models.
 `src/session_projection.rs` is the shared binary projection used by the CLI and
 dashboard to combine one daemon snapshot with bounded host session catalogs.
+Omitted Shell and Agent Instance names are resolved here to random lowercase
+`adjective-noun` values before requests are sent. Generated shell names are
+checked against the workspace snapshot and retried on a typed daemon collision;
+the resulting concrete names use the ordinary protocol and durable state fields.
 
 ### Protocol
 
@@ -403,10 +407,11 @@ reports after completion are rejected.
 `src/process_adapter.rs` implements the first process-adapter foundation behind:
 
 ```console
-boomux agent supervise <name> --integration <integration> --external-session-id <canonical-root-id> [--shell-id <shell-id>] [--run-id <run-id>] -- <exact argv>
+boomux agent supervise [<name>] --integration <integration> --external-session-id <canonical-root-id> [--shell-id <shell-id>] [--run-id <run-id>] -- <exact argv>
 ```
 
-Shell and run IDs default from `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID`. The
+An omitted descriptive Agent name is generated as `adjective-noun`. Shell and
+run IDs default from `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID`. The
 supervisor validates the supplied identity, spawns the exact argv directly with
 inherited stdin, stdout, and stderr, and waits for that child. It returns the
 child's exit code, or `128 + signal` for signal termination. There is no PTY,

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -214,6 +214,11 @@ the unchanged snapshot. Equal-authority changed reports update the observation.
 an unchanged success, while conflicting later reports fail. Completed records
 remain durable and inspectable.
 
+The positional name is optional for `agent register` and `agent ensure`. When
+omitted, the CLI supplies a random lowercase `adjective-noun` value before the
+request. The returned Agent object always contains the concrete durable name.
+Explicit names and an existing record returned by `agent.ensure` are unchanged.
+
 Protocol 15 raises one durable outstanding attention item for every accepted
 `blocked` or `done` observation. The item records `reason` (`blocked` or
 `completed`) and a copy of the exact raising observation, so later working or

--- a/src/generated_names.rs
+++ b/src/generated_names.rs
@@ -1,0 +1,90 @@
+use std::collections::BTreeSet;
+
+use uuid::Uuid;
+
+const ADJECTIVES: &[&str] = &[
+    "agile", "amber", "bold", "brave", "bright", "brisk", "calm", "clever", "cool", "coral",
+    "cosmic", "crisp", "daring", "eager", "fair", "fast", "gentle", "golden", "grand", "happy",
+    "hazy", "keen", "kind", "lively", "lucid", "lucky", "mellow", "merry", "misty", "noble",
+    "quiet", "rapid", "ready", "rosy", "royal", "sage", "sharp", "silver", "sleek", "solar",
+    "steady", "swift", "tidy", "vivid", "warm", "wild", "wise", "witty",
+];
+
+const NOUNS: &[&str] = &[
+    "badger", "bear", "beaver", "bison", "cedar", "comet", "crane", "dolphin", "eagle", "ember",
+    "falcon", "fern", "fox", "gecko", "heron", "ibis", "jay", "koala", "lark", "lynx", "maple",
+    "marmot", "otter", "owl", "panda", "pine", "puma", "raven", "reef", "robin", "sable", "seal",
+    "shark", "sparrow", "spruce", "starling", "tiger", "trout", "turtle", "whale", "willow",
+    "wolf", "wren", "yak",
+];
+
+pub(crate) fn random() -> String {
+    from_seed(random_seed(), std::iter::empty()).expect("the generated name catalog is nonempty")
+}
+
+pub(crate) fn random_excluding<'a>(
+    unavailable: impl IntoIterator<Item = &'a str>,
+) -> Option<String> {
+    from_seed(random_seed(), unavailable)
+}
+
+fn random_seed() -> u64 {
+    let bytes = Uuid::new_v4();
+    u64::from_le_bytes(
+        bytes.as_bytes()[..8]
+            .try_into()
+            .expect("UUID prefix is 8 bytes"),
+    )
+}
+
+fn from_seed<'a>(seed: u64, unavailable: impl IntoIterator<Item = &'a str>) -> Option<String> {
+    let unavailable = unavailable.into_iter().collect::<BTreeSet<_>>();
+    let count = ADJECTIVES.len() * NOUNS.len();
+    let start = seed as usize % count;
+    (0..count).find_map(|offset| {
+        let index = (start + offset) % count;
+        let name = format!(
+            "{}-{}",
+            ADJECTIVES[index / NOUNS.len()],
+            NOUNS[index % NOUNS.len()]
+        );
+        (!unavailable.contains(name.as_str())).then_some(name)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_names_are_stable_for_injected_entropy() {
+        assert_eq!(from_seed(0, []), Some("agile-badger".into()));
+        assert_eq!(from_seed(1, []), Some("agile-bear".into()));
+        assert_eq!(
+            from_seed((NOUNS.len() + 1) as u64, []),
+            Some("amber-bear".into())
+        );
+    }
+
+    #[test]
+    fn generated_names_skip_collisions_and_wrap() {
+        assert_eq!(
+            from_seed(0, ["agile-badger", "agile-bear"]),
+            Some("agile-beaver".into())
+        );
+        let last = format!("{}-{}", ADJECTIVES.last().unwrap(), NOUNS.last().unwrap());
+        assert_eq!(
+            from_seed((ADJECTIVES.len() * NOUNS.len() - 1) as u64, [last.as_str()]),
+            Some("agile-badger".into())
+        );
+    }
+
+    #[test]
+    fn exhausted_catalog_returns_none() {
+        let names = ADJECTIVES
+            .iter()
+            .flat_map(|adjective| NOUNS.iter().map(move |noun| format!("{adjective}-{noun}")))
+            .collect::<Vec<_>>();
+        assert_eq!(from_seed(0, names.iter().map(String::as_str)), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod agent_attention_projection;
 mod cli_output;
 mod config;
 mod dashboard_projection;
+mod generated_names;
 mod git;
 mod host_session_source;
 mod host_session_titles;
@@ -506,7 +507,7 @@ enum SessionCommands {
 
 #[derive(Args)]
 struct AgentSuperviseArgs {
-    name: String,
+    name: Option<String>,
     #[arg(long)]
     integration: String,
     #[arg(long)]
@@ -521,7 +522,7 @@ struct AgentSuperviseArgs {
 
 #[derive(Args)]
 struct AgentRegistrationArgs {
-    name: String,
+    name: Option<String>,
     #[arg(long)]
     integration: String,
     #[arg(long)]
@@ -1480,12 +1481,8 @@ fn open_directory(
     let (shell, workspace_name, created_workspace) = if let Some(name) = requested_name {
         let (shell, created_workspace) =
             if let Some(workspace) = find_workspace(&snapshot.workspaces, &name) {
-                let shell_name = unique_shell_name("shell", &workspace.shells);
                 (
-                    client.create_shell(
-                        &workspace.id,
-                        shell_spec(shell_name, &directory, startup_command),
-                    )?,
+                    create_generated_shell(&client, &workspace.id, &directory, startup_command)?,
                     false,
                 )
             } else {
@@ -1494,7 +1491,11 @@ fn open_directory(
                         .create_workspace_with_default_cwd(
                             &name,
                             Some(directory.clone()),
-                            vec![shell_spec("shell-1", &directory, startup_command)],
+                            vec![shell_spec(
+                                generated_names::random(),
+                                &directory,
+                                startup_command,
+                            )],
                         )?
                         .shells
                         .into_iter()
@@ -1506,7 +1507,7 @@ fn open_directory(
         (shell, name, created_workspace)
     } else {
         let shell = client.create_shell_with_workspace(shell_spec(
-            "shell-1",
+            generated_names::random(),
             &directory,
             startup_command,
         ))?;
@@ -1583,6 +1584,12 @@ fn cli_name(name: String, kind: &str) -> Result<String, Box<dyn Error>> {
     Ok(name.to_owned())
 }
 
+fn cli_name_or_generated(name: Option<String>, kind: &str) -> Result<String, Box<dyn Error>> {
+    name.map(|name| cli_name(name, kind))
+        .transpose()
+        .map(|name| name.unwrap_or_else(generated_names::random))
+}
+
 fn find_workspace<'a>(
     workspaces: &'a [WorkspaceSnapshot],
     name: &str,
@@ -1620,10 +1627,9 @@ fn create_dashboard_shell(
     launch_cwd: &Path,
 ) -> Result<String, Box<dyn Error>> {
     let workspace = client.get_workspace(workspace_id)?;
-    let name = unique_shell_name("shell", &workspace.shells);
     let cwd = resolve_shell_cwd(workspace.default_cwd.as_deref(), None, launch_cwd)?;
-    client.create_shell(workspace_id, ShellSpec::login(&name, cwd))?;
-    Ok(format!("Created {name} in {}", workspace.name))
+    let shell = create_generated_shell(client, workspace_id, &cwd, &[])?;
+    Ok(format!("Created {} in {}", shell.name, workspace.name))
 }
 
 fn resolve_shell_cwd(
@@ -1646,25 +1652,38 @@ fn resolve_shell_cwd(
     })
 }
 
-fn unique_shell_name(base_name: &str, shells: &[ShellSnapshot]) -> String {
-    let highest_suffix = shells
-        .iter()
-        .filter_map(|shell| {
-            if shell.name == base_name {
-                Some(1)
-            } else {
-                shell
-                    .name
-                    .strip_prefix(base_name)
-                    .and_then(|suffix| suffix.strip_prefix('-'))
-                    .and_then(|suffix| suffix.parse::<usize>().ok())
+fn create_generated_shell(
+    client: &client::Client,
+    workspace_id: &str,
+    cwd: &Path,
+    command: &[String],
+) -> Result<ShellSnapshot, Box<dyn Error>> {
+    let mut rejected = BTreeSet::new();
+    loop {
+        let workspace = client.get_workspace(workspace_id)?;
+        let name = generated_names::random_excluding(
+            workspace
+                .shells
+                .iter()
+                .map(|shell| shell.name.as_str())
+                .chain(rejected.iter().map(String::as_str)),
+        )
+        .ok_or_else(|| {
+            cli_output::failure(
+                "already_exists",
+                "all generated shell names are already in use",
+            )
+        })?;
+        match client.create_shell(workspace_id, shell_spec(&name, cwd, command)) {
+            Ok(shell) => return Ok(shell),
+            Err(client::ClientError::Remote(error))
+                if error.code == Some(protocol::ErrorCode::AlreadyExists) =>
+            {
+                rejected.insert(name);
             }
-        })
-        .max();
-    highest_suffix.map_or_else(
-        || base_name.to_owned(),
-        |suffix| format!("{base_name}-{}", suffix + 1),
-    )
+            Err(error) => return Err(error.into()),
+        }
+    }
 }
 
 fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), Box<dyn Error>> {
@@ -2549,16 +2568,19 @@ fn shell_command(command: ShellCommands, json: bool) -> Result<(), Box<dyn Error
         } => {
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &workspace)?;
-            let name = name
-                .map(|name| cli_name(name, "shell"))
-                .transpose()?
-                .unwrap_or_else(|| unique_shell_name("shell", &workspace.shells));
             let cwd = resolve_shell_cwd(
                 workspace.default_cwd.as_deref(),
                 cwd.as_deref(),
                 Path::new("."),
             )?;
-            let shell = client.create_shell(&workspace.id, shell_spec(name, &cwd, &command))?;
+            let shell = if let Some(name) = name {
+                client.create_shell(
+                    &workspace.id,
+                    shell_spec(cli_name(name, "shell")?, &cwd, &command),
+                )?
+            } else {
+                create_generated_shell(&client, &workspace.id, &cwd, &command)?
+            };
             println!("Created pending shell {} ({})", shell.name, shell.id);
         }
         ShellCommands::Inspect { target, workspace } => {
@@ -3280,7 +3302,7 @@ fn supervise_agent(
     )?;
     Ok(process_adapter::supervise(
         process_adapter::SuperviseSpec {
-            name: arguments.name,
+            name: cli_name_or_generated(arguments.name, "agent")?,
             integration: arguments.integration,
             external_session_id: arguments.external_session_id,
             shell_id,
@@ -3303,7 +3325,7 @@ fn register_or_ensure_agent(
         env::var("BOOMUX_RUN_ID").ok(),
     )?;
     let spec = AgentRegistrationSpec {
-        name: cli_name(arguments.name, "agent")?,
+        name: cli_name_or_generated(arguments.name, "agent")?,
         integration: arguments.integration,
         external_session_id: arguments.external_session_id,
         report: AgentReport {
@@ -4893,6 +4915,28 @@ mod tests {
         .unwrap();
         assert_eq!(register.command_descriptor().key, "agent.register");
         assert_eq!(register.command_descriptor().output, OutputMode::Json);
+        let unnamed_register = Cli::try_parse_from([
+            "boomux",
+            "agent",
+            "register",
+            "--integration",
+            "test",
+            "--state",
+            "working",
+            "--authority",
+            "process-adapter",
+            "--evidence",
+            "running",
+            "--confidence",
+            "80",
+        ])
+        .unwrap();
+        assert!(matches!(
+            unnamed_register.command,
+            Some(Commands::Agent {
+                command: AgentCommands::Register(AgentRegistrationArgs { name: None, .. })
+            })
+        ));
         assert!(
             Cli::try_parse_from([
                 "boomux",
@@ -4953,6 +4997,28 @@ mod tests {
             Some(Commands::Agent {
                 command: AgentCommands::Supervise(AgentSuperviseArgs { command, .. })
             }) if command == ["agent-bin", "literal; argument"]
+        ));
+        let unnamed_supervise = Cli::try_parse_from([
+            "boomux",
+            "agent",
+            "supervise",
+            "--integration",
+            "opencode",
+            "--external-session-id",
+            "session-1",
+            "--shell-id",
+            "s1",
+            "--run-id",
+            "r1",
+            "--",
+            "agent-bin",
+        ])
+        .unwrap();
+        assert!(matches!(
+            unnamed_supervise.command,
+            Some(Commands::Agent {
+                command: AgentCommands::Supervise(AgentSuperviseArgs { name: None, .. })
+            })
         ));
         assert!(
             Cli::try_parse_from([
@@ -5187,6 +5253,18 @@ mod tests {
     }
 
     #[test]
+    fn resolves_explicit_and_generated_cli_names() {
+        assert_eq!(
+            cli_name_or_generated(Some("  explicit  ".into()), "agent").unwrap(),
+            "explicit"
+        );
+        let generated = cli_name_or_generated(None, "agent").unwrap();
+        let (adjective, noun) = generated.split_once('-').unwrap();
+        assert!(adjective.bytes().all(|byte| byte.is_ascii_lowercase()));
+        assert!(noun.bytes().all(|byte| byte.is_ascii_lowercase()));
+    }
+
+    #[test]
     fn resolves_shell_ids_and_contextual_names() {
         let snapshot = Snapshot {
             workspaces: vec![
@@ -5206,14 +5284,6 @@ mod tests {
             "s1"
         );
         assert!(resolve_shell_target(&snapshot, None, "tests").is_err());
-    }
-
-    #[test]
-    fn generates_unique_native_shell_names() {
-        let shells = vec![shell("s1", "w1", "shell-1"), shell("s2", "w1", "api")];
-        assert_eq!(unique_shell_name("shell", &shells), "shell-2");
-        assert_eq!(unique_shell_name("api", &shells), "api-2");
-        assert_eq!(unique_shell_name("logs", &shells), "logs");
     }
 
     #[test]

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -9,7 +9,7 @@ use boomux::protocol::{
     self, AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, ErrorCode, ShellSpec,
 };
 
-use crate::support::{TestDaemon, assert_remote_code, contains, profile};
+use crate::support::{TestDaemon, assert_generated_name, assert_remote_code, contains, profile};
 
 #[test]
 fn agent_runtime_is_revisioned_durable_and_version_compatible() {
@@ -49,7 +49,6 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
             .args([
                 "agent",
                 "ensure",
-                "runtime-agent",
                 "--integration",
                 "native-test",
                 "--external-session-id",
@@ -86,9 +85,12 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert_eq!(ensure["data"]["agent"]["external_session_id"], "session-1");
     assert_eq!(ensure["data"]["agent"]["workspace_name"], "agent-runtime");
     assert_eq!(ensure["data"]["agent"]["observation"]["revision"], 1);
+    let generated_name = ensure["data"]["agent"]["name"].as_str().unwrap();
+    assert_generated_name(generated_name);
 
     let repeated = ensure_agent(&daemon);
     assert_eq!(repeated["data"]["agent"]["id"], agent_id);
+    assert_eq!(repeated["data"]["agent"]["name"], generated_name);
     assert_eq!(repeated["data"]["agent"]["observation"]["revision"], 1);
     let ensured_events = daemon
         .client
@@ -494,7 +496,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
 
     let list = daemon.command().args(["agent", "list"]).output().unwrap();
     assert!(list.status.success());
-    assert!(contains(&list.stdout, b"runtime-agent"));
+    assert!(contains(&list.stdout, generated_name.as_bytes()));
     assert!(contains(&list.stdout, agent_id.as_bytes()));
     let list = daemon
         .command()
@@ -533,7 +535,7 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
         .find(|session| session["external_session_id"] == "session-1")
         .unwrap();
     let session_id = projected["id"].as_str().unwrap();
-    assert_eq!(projected["description"], "runtime-agent");
+    assert_eq!(projected["description"], generated_name);
     assert_eq!(projected["occurrence_count"], 1);
 
     let session_inspect = daemon
@@ -870,6 +872,82 @@ fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     assert!(cursor.event_id > filtered_cursor.event_id);
 
     daemon.stop_with_cli();
+}
+
+#[test]
+fn unnamed_agent_registration_and_supervision_generate_names() {
+    let daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "generated-agent-names",
+            vec![ShellSpec::login("runtime", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+
+    let registered = daemon
+        .command()
+        .args([
+            "agent",
+            "register",
+            "--integration",
+            "native-test",
+            "--external-session-id",
+            "registered-session",
+            "--shell-id",
+            &shell_id,
+            "--run-id",
+            &run_id,
+            "--state",
+            "working",
+            "--authority",
+            "lifecycle-integration",
+            "--evidence",
+            "registered",
+            "--confidence",
+            "100",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(registered.status.success());
+    let registered: serde_json::Value = serde_json::from_slice(&registered.stdout).unwrap();
+    assert_generated_name(registered["data"]["agent"]["name"].as_str().unwrap());
+
+    let supervised = daemon
+        .command()
+        .args([
+            "agent",
+            "supervise",
+            "--integration",
+            "native-test",
+            "--external-session-id",
+            "supervised-session",
+            "--shell-id",
+            &shell_id,
+            "--run-id",
+            &run_id,
+            "--",
+            "/bin/true",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        supervised.status.success(),
+        "{}",
+        String::from_utf8_lossy(&supervised.stderr)
+    );
+    let agents = daemon.client.get_workspace(&workspace.id).unwrap().agents;
+    let supervised = agents
+        .iter()
+        .find(|agent| agent.external_session_id.as_deref() == Some("supervised-session"))
+        .expect("supervisor did not register its agent");
+    assert_generated_name(&supervised.name);
+
+    drop(attachment.stream);
 }
 
 #[test]

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -8,8 +8,8 @@ use boomux::protocol::{self, AttachFrame, ErrorCode, ShellRunExitReason, ShellSp
 use uuid::Uuid;
 
 use crate::support::{
-    TestDaemon, acknowledge_reconnect, assert_remote_code, contains, parse_pid, process_exists,
-    profile, read_until, wait_for_attach_with_profile, wait_until,
+    TestDaemon, acknowledge_reconnect, assert_generated_name, assert_remote_code, contains,
+    parse_pid, process_exists, profile, read_until, wait_for_attach_with_profile, wait_until,
 };
 
 #[test]
@@ -309,6 +309,27 @@ fn native_daemon_lifecycle() {
     assert_eq!(output["command"], "shell.inspect");
     assert_eq!(output["data"]["shell"]["status"], "pending");
     assert!(output["data"]["shell"]["run"].is_null());
+    let output = daemon
+        .command()
+        .args(["shell", "create", "cli-renamed", "--cwd"])
+        .arg(std::env::temp_dir())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "unnamed shell create failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let generated = daemon
+        .client
+        .get_workspace(&cli_workspace.id)
+        .unwrap()
+        .shells
+        .into_iter()
+        .find(|shell| shell.name != "checks")
+        .expect("unnamed shell was not created");
+    assert_generated_name(&generated.name);
+    assert_eq!(generated.status, ShellStatus::Pending);
     let output = daemon
         .command()
         .args([

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -12,6 +12,16 @@ use uuid::Uuid;
 
 pub(crate) const TIMEOUT: Duration = Duration::from_secs(10);
 
+pub(crate) fn assert_generated_name(name: &str) {
+    let Some((adjective, noun)) = name.split_once('-') else {
+        panic!("generated name is not adjective-noun: {name}");
+    };
+    assert!(!adjective.is_empty());
+    assert!(!noun.is_empty());
+    assert!(adjective.bytes().all(|byte| byte.is_ascii_lowercase()));
+    assert!(noun.bytes().all(|byte| byte.is_ascii_lowercase()));
+}
+
 pub(crate) struct TestDaemon {
     pub(crate) executable: PathBuf,
     pub(crate) runtime_dir: PathBuf,


### PR DESCRIPTION
## Summary

- generate memorable lowercase `adjective-noun` names for shells created without an explicit shell name
- make Agent Instance names optional for `agent register`, `agent ensure`, and `agent supervise`
- retry generated shell names on typed workspace collisions while preserving explicit names and `workspace-N` allocation
- document generated-name behavior and cover CLI parsing, persistence-facing projections, and native Agent/shell flows

## Compatibility

- keeps concrete names on the existing protocol and persistence fields, so no protocol or state version change is required
- keeps OpenCode and Pi integration-supplied names unchanged

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`
- `cargo check --release --locked`
- `cargo package --locked --allow-dirty`