### PR TITLE
feat(schedule): expose execution history, waits, and alerts

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -266,8 +266,9 @@ boomux schedule inspect "<exact-id-or-contextual-name>" --workspace "<workspace-
 boomux schedule pause "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
 boomux schedule resume "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
 boomux schedule run "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
-boomux execution list --workspace "<workspace-name-or-id>" --schedule "<schedule-name-or-id>" --json
+boomux execution list --workspace "<workspace-name-or-id>" --schedule "<schedule-name-or-id>" --limit 100 --json
 boomux execution inspect "<exact-execution-id>" --json
+boomux execution wait "<exact-execution-id>" --after-revision "<revision>" --wait-ms 30000 --json
 boomux execution cancel "<exact-execution-id>" --json
 boomux schedule remove "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
 ```
@@ -302,6 +303,16 @@ before sending. Never retry with a new key when the intent is the same dispatch.
 Inspect the returned exact execution ID, and cancel only when process-tree
 termination is authorized. Execution exit or cancellation never means Agent
 `done`.
+
+Execution list responses are newest-first and contain `limit`, `truncated`, and
+prompt-free records. Limits are 1-1,000 and default to 100. Each execution has a
+positive durable `revision`. Wait with the exact last revision instead of polling
+lists: newer state or Agent linkage returns `changed: true`, timeout returns the
+same record with `changed: false`, and a future revision fails with
+`revision_ahead`. On `daemon_stopping`, reconnect and repeat the same revision.
+Do not stop waiting merely because process state is terminal; the canonical Agent
+link can arrive later, and its blocked attention remains under `agent inspect` or
+`attention list` with the exact Agent ID and observation revision.
 
 Enabled schedules are evaluated by the daemon in their stored timezone. Timed
 work runs only while the daemon and user session are active. Offline periods are
@@ -466,6 +477,10 @@ Boomux reads `$XDG_CONFIG_HOME/boomux/config.toml`, falling back to
 field-level override loaded last. Configuration controls terminal selection,
 project discovery roots and depth, dashboard focus following, schedule
 concurrency, and desktop and sound notifications. Unknown fields are rejected.
+Scheduled dispatch-failure and cold-interruption notification categories are
+configured independently as `[notifications] scheduled_dispatch_failed` and
+`scheduled_interrupted`; both default to false and never disclose schedule
+prompts or acknowledge Agent attention.
 Selecting a discovered project in the dashboard persists its canonical path as
 the workspace default cwd for later shells. Set
 `[dashboard] follow_focused_terminal = false` to disable the default

--- a/README.md
+++ b/README.md
@@ -299,8 +299,9 @@ boomux schedule inspect review --workspace my-project
 boomux schedule resume review --workspace my-project
 boomux schedule pause review --workspace my-project
 boomux schedule run review --workspace my-project
-boomux execution list --schedule review --workspace my-project
+boomux execution list --schedule review --workspace my-project --limit 100
 boomux execution inspect <exact-execution-id>
+boomux execution wait <exact-execution-id> --after-revision <revision>
 boomux execution cancel <exact-execution-id>
 boomux schedule remove review --workspace my-project
 ```
@@ -323,6 +324,9 @@ It creates a durable prompt-free execution claim before starting one exact host
 argv through a lazily created schedule-owned shell. Pass `--idempotency-key
 <uuid>` when retrying a request; the same schedule and key always return the same
 execution and never spawn twice. Execution inspection and events omit prompts.
+Execution lists are bounded newest-first and report truncation. Revision-aware
+wait returns on the next committed process or Agent-link change; reconnect with
+the same revision when daemon replacement reports `daemon_stopping`.
 
 Enabled schedules are evaluated by the daemon in their stored IANA timezone.
 DST gaps are skipped, repeated local minutes fire once, and persisted occurrence
@@ -387,11 +391,15 @@ persist_terminal_history = false
 enabled = false
 blocked = true
 completed = true
+scheduled_dispatch_failed = false
+scheduled_interrupted = false
 
 [notifications.sound]
 enabled = false
 blocked = "message-new-instant"
 completed = "complete"
+scheduled_dispatch_failed = "dialog-warning"
+scheduled_interrupted = "dialog-warning"
 ```
 
 Project roots provide workspace suggestions in the dashboard. Selecting one
@@ -427,7 +435,10 @@ delivery requires `canberra-gtk-play`; its `blocked` and `completed` values are
 freedesktop sound event IDs, not shell commands. Both channels use the top-level
 category filters. A completed notification is sent when an Agent finishes a
 unit of work and becomes idle, as well as when the Agent reaches its terminal
-done state.
+done state. Scheduled dispatch-failure and cold-interruption categories are
+independent and disabled by default; their bounded payload contains schedule,
+workspace, and execution identity but never the prompt. Delivery is fail-open,
+at-most-once, and does not acknowledge Agent attention.
 
 Test every configured, enabled channel with:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -359,7 +359,7 @@ requiring a daemon. Protocol 6 error responses carry an additive optional code;
 clients expose it as `ClientError::Remote(RemoteError)`, while mixed-version
 peers retain message compatibility.
 
-### Scheduled Agent Work (Manual Dispatch Implemented; Timing Planned)
+### Scheduled Agent Work
 
 Protocol 22 and state schema 9 implement the Agent Schedule identity without
 changing ShellRun, Agent Instance, or projected Agent Session semantics. A
@@ -424,6 +424,44 @@ terminal execution transition. This prevents a later dispatch from observing a
 terminal execution while the reusable runner shell is still live.
 These limitations and scheduler health must be visible to clients. See
 [`scheduled-agent-work.md`](scheduled-agent-work.md) and [ADR 0002](adr/0002-separate-agent-schedules-from-runtime-identity.md).
+
+Protocol 25 and state schema 12 add revision-exact Scheduled Execution
+observation. Every retained execution has a positive durable revision; the
+schema-12 migration assigns schema-11 records revision 1 without changing any
+other field. Exact waits use the event condition variable only for wakeup and
+read an event-frontier-owned committed execution map rather than mutable durable
+state. The map is replaced from the complete retained execution set only when
+successful persistence is published. Persistence in flight, pending durable
+batches, and lifecycle event reservations therefore cannot expose revisions that
+may roll back. A deadline still returns the last committed exact snapshot without
+waiting for blocked storage, and equal terminal process revisions continue
+waiting because a canonical Agent link may arrive later.
+Protocol-25 lists are daemon-bounded, newest-first pages with explicit limit and
+truncation. The request limit is optional on the wire; protocol 25 defaults it to
+100 and clamps it to 1 through 1,000, while protocol-23 and protocol-24 requests
+remain uncapped. List responses carry schedule-keyed next-occurrence projections
+for the complete selected schedule scope, independent of the execution page.
+Projections are sorted by schedule ID, bounded to 100, and report
+`schedule_limit` and `schedules_truncated`. Exact inspection carries its
+projection separately from durable execution state; all projection shapes and
+metadata are removed when responding below protocol 25.
+Each schedule retains all nonterminal records and 100 terminal records, pruned by
+ascending requested time and execution ID during ordinary terminalization, cold
+recovery, and shutdown. The durable dispatch-key filter remains authoritative
+after pruning.
+
+Execution events carry the complete prompt-free revision and remain in the
+ordinary 8,192-event journal with 256-event pages. Protocol-23 and protocol-24
+visibility filtering is unchanged and filtered events still advance cursors.
+Opt-in dispatch-failure and cold-interruption notification categories use the
+same bounded fail-open sink as Agent notifications, but deduplicate independently
+by execution, revision, and reason. Cold interruption is persisted before sink
+setup and delivered only for records newly changed by that recovery.
+Dispatch-failure notifications are derived when their durable event batch is
+actually published, including after a failed first write and later pending flush.
+The prior committed execution snapshot must be nonqualifying, so late Agent links
+and other revisions that retain the same terminal state and reason do not notify
+again.
 
 Protocol 7 adds a bounded in-memory daemon event journal and atomic output-state
 reads. Clients reconnect through stream UUID/event-ID cursors and recover from
@@ -714,6 +752,12 @@ and filter timed or skipped execution records and events while preserving event
 cursors. State schema 11 adds the trigger-revision-qualified durable evaluation
 frontier and timed occurrence metadata; its explicit schema-10 migration retains
 manual execution history without reinterpreting it as timed work.
+
+Protocol 25 adds positive Scheduled Execution revisions, exact revision-aware
+wait, bounded execution list metadata, and independently configured execution
+notifications. Protocol-23 and protocol-24 execution visibility remains
+unchanged. State schema 12 explicitly assigns revision 1 to every schema-11
+execution while retaining all prior fields and data.
 
 Cron day matching preserves syntactic wildcard origin: `*/n` is wildcard-origin,
 while numeric lists and ranges remain restricted even when they cover the full

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -75,6 +75,7 @@ The following commands support `--json`:
 - `boomux schedule run`
 - `boomux execution list`
 - `boomux execution inspect`
+- `boomux execution wait`
 - `boomux execution cancel`
 - `boomux integration list`
 - `boomux integration status [opencode|pi]`
@@ -139,10 +140,16 @@ Command payloads are:
   summary.
 - `schedule.run`: one prompt-free `execution`. The CLI generates a UUID
   `dispatch_key` before the request unless `--idempotency-key` supplies one.
-- `execution.list`: newest-first prompt-free `executions`, optionally filtered by
-  `--workspace` and `--schedule`.
-- `execution.inspect` and `execution.cancel`: one prompt-free `execution`
-  selected only by exact execution ID.
+- `execution.list`: newest-first prompt-free `executions`, `limit`, `truncated`,
+  `schedule_limit`, `schedules_truncated`, and schedule-keyed `schedules`
+  next-occurrence projections, optionally filtered by `--workspace` and
+  `--schedule`.
+- `execution.inspect`: one prompt-free `execution` selected only by exact
+  execution ID plus its separate nullable `next_occurrence` projection.
+- `execution.cancel`: one prompt-free `execution` selected only by exact
+  execution ID.
+- `execution.wait`: `changed` plus one prompt-free exact `execution` after a
+  revision-aware conditional read.
 - `integration.list`: an `integrations` array containing bundled integration
   names, display names, packages, and validated host versions.
 - `integration.status`: an `integrations` array containing independent `host`,
@@ -183,18 +190,55 @@ Protocol 22 advertises `protocol_22`, `agent_schedule_management`, and
 `schedule_owned_shells`. Protocol 24 adds `protocol_24`,
 `timed_schedule_dispatch`, `scheduler_health`, and
 `bounded_scheduled_execution_concurrency`.
+Protocol 25 adds `protocol_25`, `revision_aware_scheduled_execution_wait`,
+`bounded_scheduled_execution_history`, and
+`scheduled_execution_notifications`.
 
 ## Execution Data
 
 Schedule objects include nullable `next_occurrence`, containing
 `trigger_revision` and `scheduled_at_ms`. Execution objects contain `id`,
-`workspace_id`, `schedule_id`, `state`,
+`workspace_id`, `schedule_id`, positive durable `revision`, `state`,
 `dispatch_kind`, `dispatch_key`, exact `schedule_revision`, `prompt_revision`,
 and `trigger_revision`, `requested_at_ms`, nullable `scheduled_at_ms`, nullable
 `coalesced_through_ms`, start/end timestamps, snapshotted `cwd`,
 `integration`, and `session`, nullable typed `reason` and `outcome`, and nullable
 `shell_id`, `run_id`, `agent_id`, and discovered `external_session_id` links.
 They never contain the retained prompt or environment.
+
+`execution list --limit` defaults to 100 and accepts 1 through 1,000. The daemon
+applies the bound after all filters and orders by `requested_at_ms` newest first,
+then execution ID descending. `truncated` is true when more matching retained
+records exist. Protocol-23 and protocol-24 peers retain their existing manual,
+timed, and skipped visibility rules; a protocol-25 client locally bounds a list
+returned by an older daemon.
+
+On the daemon wire, `ListScheduledExecutions.limit` is optional. Protocol 25
+defaults an absent value to 100 and clamps supplied values to 1 through 1,000.
+Protocol-23 and protocol-24 requests ignore the field and remain uncapped; their
+timed/skipped compatibility filter runs before any list operation. The
+protocol-25 list response includes `schedules`, an array of `schedule_id` and
+nullable `next_occurrence` projections for the complete selected schedule scope,
+including schedules with no history and schedules absent from the execution
+page. The array is sorted by schedule ID and independently capped at 100;
+`schedule_limit` is 100 and `schedules_truncated` reports omitted schedules.
+Exact inspection carries `next_occurrence` beside `execution`. These projections
+are current scheduler calculations, not durable execution fields or execution
+revision changes, and responses below protocol 25 omit them and return zero/false
+projection metadata defaults. A current client connected to protocol 23 or 24
+locally applies the caller's execution limit to the old unbounded response and
+computes `truncated` from the received matching records.
+
+`execution wait` requires protocol 25, an exact execution ID, and
+`--after-revision`. A newer current revision returns immediately with `changed:
+true`; an equal revision waits up to `--wait-ms` and returns the unchanged record
+with `changed: false`; a future revision fails with `revision_ahead`. Revision
+zero returns every existing execution immediately. Equal terminal process state
+does not return early because later canonical Agent linkage may advance the
+revision. Replacement wakes the request with `daemon_stopping`; reconnect and
+repeat the same revision. Waits do not consume event cursors. `wait_ms` remains a
+hard deadline while persistence or pending storage is blocked; timeout returns
+the last committed exact snapshot and never an unpublished revision.
 
 State is `skipped`, `claimed`, `starting`, `active`, `dispatch_failed`, `exited`,
 `cancelled`, or `interrupted`; dispatch kind is `manual` or `timed`. Reasons are
@@ -403,6 +447,7 @@ the initial overlap policy is always `skip`.
 Schedule management commands require negotiated daemon protocol 22. `schedule
 run` and every `execution` command require protocol 23. Unsupported commands
 return `unsupported_version` rather than presenting empty data.
+`execution wait` specifically requires protocol 25.
 
 Only `schedule.inspect` adds `prompt`. Prompts are intentionally absent from
 list, create, pause, resume, remove, run, execution records, capabilities,

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -32,12 +32,25 @@ only management response that discloses the current prompt.
 Protocol 23 adds durable manual Scheduled Executions and schedule-owned shells.
 Protocol 24 adds daemon-native timed decisions, skipped policy outcomes,
 deterministic next occurrences, and scheduler health.
+Protocol 25 adds positive durable execution revisions, bounded execution-list
+metadata, and exact revision-aware execution waits.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns
 unchanged on timeout, rejects future revisions, and wakes with
 `daemon_stopping` during replacement. Callers reconnect and repeat with the same
 revision; no waiter state is persisted.
+
+`boomux execution wait <id> --after-revision <revision>` has the same
+newer/timeout/future-revision and reconnect rules. Unlike terminal Agent `done`,
+an equal terminal execution revision continues waiting because a lifecycle
+integration may still link the canonical Agent for that exact ShellRun. The wait
+uses the event condition variable as a wakeup signal and does not consume the
+global cursor. It reads only the execution map installed at the persisted event
+publication frontier. Persistence in flight, pending durable storage, and
+lifecycle reservations do not extend `wait_ms`: timeout returns `changed: false`
+with the last committed exact snapshot, including when the mutable record has an
+unpublished revision or has been provisionally pruned.
 
 ## Cursors
 
@@ -111,7 +124,8 @@ workspace and schedule identities.
 skip decision.
 `scheduled_execution_changed` publishes later prompt-free shell/run binding,
 active, dispatch-failed, exited, cancelled, interrupted, and Agent-link changes.
-Both carry the complete public execution snapshot and never carry the retained
+Both carry the complete public execution snapshot and its positive durable
+revision and never carry the retained
 prompt or daemon startup environment. Process outcomes do not imply Agent
 lifecycle observations.
 
@@ -151,6 +165,10 @@ next-occurrence fields are also omitted. Filtering never rewinds the event
 cursor, so an old client can reconnect across hidden scheduler activity without
 replaying or stalling the stream.
 
+Protocol-24 and older clients ignore the additive execution revision and bounded
+list metadata. Their existing record/event filtering remains unchanged. In all
+versions the returned cursor advances across hidden execution events.
+
 Manual final eligibility, claim creation, shell/run binding, and runner spawn are
 serialized against Agent activity mutations. A protocol-23 client therefore
 cannot observe a manual `claimed` creation whose only terminal transition is a
@@ -163,6 +181,18 @@ couples durable lifecycle mutation, persistence, and event publication. Events
 are published only after their corresponding state is persisted. If persistence
 fails, the event batch remains pending; background recovery publishes queued
 batches in transition order and exactly once.
+Execution notifications are derived at that actual publication boundary, so a
+dispatch failure whose first persistence attempt fails is notified once after a
+later pending flush, never before durable commit. Qualification compares each
+published execution event with the prior committed snapshot, so revisions that
+retain a qualifying terminal state and reason, including late Agent linkage, do
+not notify again.
+
+Lifecycle event reservations have distinct abort and persistence-transfer exits.
+An abort releases and publishes queued runtime events immediately when no durable
+batch or persistence operation still blocks publication. A successful lifecycle
+mutation transfers the reservation to persistence atomically, keeping runtime
+events behind the corresponding durable commit.
 
 The baseline snapshot and cursor are captured under this same coordinator, so no
 event can be published between those observations. PTY output revision advances

--- a/docs/scheduled-agent-work.md
+++ b/docs/scheduled-agent-work.md
@@ -327,6 +327,36 @@ linked `blocked` observation uses existing durable Agent attention. A pre-spawn
 failure or skipped execution cannot fabricate an Agent Instance or attention
 revision.
 
+## Observation And Notifications
+
+Every Scheduled Execution has a durable revision beginning at 1. Each committed
+shell/run binding, runner state or outcome change, cancellation, interruption,
+or Agent link advances it. `execution wait <id> --after-revision <revision>`
+returns the complete current prompt-free record immediately when newer, returns
+the unchanged record after `--wait-ms`, and rejects a future revision with
+`revision_ahead`. Terminal process state does not make an equal-revision wait
+return early because the exact ShellRun may acquire its canonical Agent link
+later. Waiters are not persisted; `daemon_stopping` tells a caller to reconnect
+and repeat the same revision after replacement.
+
+Execution-created and execution-changed events carry the complete prompt-free
+record and its revision. They remain reconnectable through the ordinary event
+cursor; an execution wait does not consume or advance that cursor. Persistence
+commits before either event publication or waiter wakeup.
+
+`[notifications] scheduled_dispatch_failed` and `scheduled_interrupted` are
+independent opt-in categories and default to false. The first covers terminal
+runner-start and host-spawn failure; the second covers only newly committed
+`cold_daemon_recovery` interruption. Delivery contains bounded sanitized
+workspace and schedule names plus the exact execution ID, never prompt,
+environment, evidence, transcript, or tool content. Deduplication is by exact
+execution ID, execution revision, and reason. Delivery is bounded, at-most-once,
+and fail-open and neither acknowledges nor fabricates Agent attention.
+
+Cold startup persists all newly interrupted records before installing the sink
+and enqueueing their notifications. Already-terminal records are not replayed on
+later cold or graceful starts.
+
 ## User Control And Permissions
 
 The scheduler can create a process and deliver the schedule's initial prompt. It
@@ -359,10 +389,23 @@ including skips and dispatch failures. Offline gaps use the coalesced record
 defined above. Records include untrusted-safe reasons and exact identity links,
 but no prompt text, environment, transcript content, tool content, or credentials.
 
-Each schedule retains every nonterminal execution plus a bounded newest suffix of
-terminal execution records; pruning removes the oldest terminal records first.
-The exact suffix bound belongs to source and compatibility tests. Scheduler
-events use the existing bounded event-stream retention and cursor-expiry model.
+Each schedule retains every nonterminal execution plus the newest 100 terminal
+execution records. Pruning removes terminal records first by ascending
+`requested_at_ms`, then ascending execution ID, across normal terminalization,
+cold recovery, and shutdown; nonterminal records are never removed. Protocol-25
+global list responses default to 100 records, accept limits from 1 through 1,000,
+return `limit` and `truncated`, and order descending by `requested_at_ms`, then
+execution ID. The wire request limit is optional; protocol-23 and protocol-24
+requests ignore it and remain uncapped, with their visibility filter applied
+before listing. Current next occurrences are returned as separate schedule-keyed
+projections rather than execution revision state. Projection selection covers
+every schedule in the requested global, workspace, or exact-schedule scope,
+regardless of execution history or execution-page position. It is sorted by
+schedule ID, independently capped at 100, and reports `schedule_limit` and
+`schedules_truncated`. Scheduler events share the 8,192-event journal and
+256-event page bound; a
+cursor advances across version-filtered events and expires under the ordinary
+stream/cold-restart rules.
 Pruned dispatch keys remain represented by a bounded durable probabilistic set;
 a retry that matches it is rejected with `idempotency_expired` rather than
 creating duplicate work. A false positive is therefore a stable explicit

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -144,6 +144,7 @@ pub(crate) struct ExecutionData {
     pub(crate) id: String,
     pub(crate) workspace_id: String,
     pub(crate) schedule_id: String,
+    pub(crate) revision: u64,
     pub(crate) state: &'static str,
     pub(crate) dispatch_kind: &'static str,
     pub(crate) dispatch_key: String,
@@ -346,6 +347,7 @@ pub(crate) fn execution(execution: &ScheduledExecutionSnapshot) -> ExecutionData
         id: execution.id.clone(),
         workspace_id: execution.workspace_id.clone(),
         schedule_id: execution.schedule_id.clone(),
+        revision: execution.revision,
         state: match execution.state {
             boomux::protocol::ScheduledExecutionState::Skipped => "skipped",
             boomux::protocol::ScheduledExecutionState::Claimed => "claimed",
@@ -372,21 +374,7 @@ pub(crate) fn execution(execution: &ScheduledExecutionSnapshot) -> ExecutionData
         cwd: execution.cwd.display().to_string(),
         integration: execution.integration.clone(),
         session: execution.session.clone(),
-        reason: execution.reason.map(|reason| match reason {
-            ScheduledExecutionReason::Overlap => "overlap",
-            ScheduledExecutionReason::ActiveSession => "active_session",
-            ScheduledExecutionReason::WorkspaceCapacity => "workspace_capacity",
-            ScheduledExecutionReason::GlobalCapacity => "global_capacity",
-            ScheduledExecutionReason::Missed => "missed",
-            ScheduledExecutionReason::PausedRace => "paused_race",
-            ScheduledExecutionReason::InvalidTarget => "invalid_target",
-            ScheduledExecutionReason::RunnerStartFailed => "runner_start_failed",
-            ScheduledExecutionReason::HostSpawnFailed => "host_spawn_failed",
-            ScheduledExecutionReason::CancelledByUser => "cancelled_by_user",
-            ScheduledExecutionReason::ColdDaemonRecovery => "cold_daemon_recovery",
-            ScheduledExecutionReason::RunnerExitedWithoutReport => "runner_exited_without_report",
-            ScheduledExecutionReason::DaemonShutdown => "daemon_shutdown",
-        }),
+        reason: execution.reason.map(execution_reason),
         outcome: execution.outcome.as_ref().map(|outcome| match outcome {
             ScheduledExecutionOutcome::ExitCode { code } => {
                 ExecutionOutcomeData::ExitCode { code: *code }
@@ -399,6 +387,24 @@ pub(crate) fn execution(execution: &ScheduledExecutionSnapshot) -> ExecutionData
         run_id: execution.run_id.clone(),
         agent_id: execution.agent_id.clone(),
         external_session_id: execution.external_session_id.clone(),
+    }
+}
+
+pub(crate) fn execution_reason(reason: ScheduledExecutionReason) -> &'static str {
+    match reason {
+        ScheduledExecutionReason::Overlap => "overlap",
+        ScheduledExecutionReason::ActiveSession => "active_session",
+        ScheduledExecutionReason::WorkspaceCapacity => "workspace_capacity",
+        ScheduledExecutionReason::GlobalCapacity => "global_capacity",
+        ScheduledExecutionReason::Missed => "missed",
+        ScheduledExecutionReason::PausedRace => "paused_race",
+        ScheduledExecutionReason::InvalidTarget => "invalid_target",
+        ScheduledExecutionReason::RunnerStartFailed => "runner_start_failed",
+        ScheduledExecutionReason::HostSpawnFailed => "host_spawn_failed",
+        ScheduledExecutionReason::CancelledByUser => "cancelled_by_user",
+        ScheduledExecutionReason::ColdDaemonRecovery => "cold_daemon_recovery",
+        ScheduledExecutionReason::RunnerExitedWithoutReport => "runner_exited_without_report",
+        ScheduledExecutionReason::DaemonShutdown => "daemon_shutdown",
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,10 +17,10 @@ use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
     AgentScheduleSnapshot, AgentScheduleSpec, DaemonEvent, Envelope, ErrorCode, EventCursor,
     FocusedTerminalSnapshot, NotificationDeliveryConfig, Request, Response,
-    ScheduledExecutionSnapshot, ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus,
-    Snapshot, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan, TerminalProfile,
-    UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
-    WorkspaceSnapshot,
+    ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot, ScheduledOccurrence,
+    ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
+    TerminalPreviewLine, TerminalPreviewSpan, TerminalProfile, UnixEnvironment,
+    UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -256,6 +256,28 @@ impl SnapshotWatch {
 pub struct AgentWait {
     pub agent: AgentInstanceSnapshot,
     pub changed: bool,
+}
+
+#[derive(Debug)]
+pub struct ScheduledExecutionWait {
+    pub execution: ScheduledExecutionSnapshot,
+    pub changed: bool,
+}
+
+#[derive(Debug)]
+pub struct ScheduledExecutionList {
+    pub executions: Vec<ScheduledExecutionSnapshot>,
+    pub limit: u16,
+    pub truncated: bool,
+    pub schedules: Vec<ScheduledExecutionScheduleProjection>,
+    pub schedule_limit: u16,
+    pub schedules_truncated: bool,
+}
+
+#[derive(Debug)]
+pub struct ScheduledExecutionInspection {
+    pub execution: ScheduledExecutionSnapshot,
+    pub next_occurrence: Option<ScheduledOccurrence>,
 }
 
 #[derive(Debug)]
@@ -515,6 +537,23 @@ impl Client {
                 ));
             }
         }
+        if (notifications.scheduled_dispatch_failed || notifications.scheduled_interrupted)
+            && !self.supports(protocol::ProtocolFeature::ScheduledExecutionObservation)?
+        {
+            let mut compatibility = notifications.clone();
+            compatibility.scheduled_dispatch_failed = false;
+            compatibility.scheduled_interrupted = false;
+            self.restart_request(Request::RestartWithNotificationConfig {
+                notifications: compatibility,
+                environment: Some(current_environment()),
+            })?;
+            self.probe_latest()?;
+            if !self.supports(protocol::ProtocolFeature::ScheduledExecutionObservation)? {
+                return Err(unsupported_version(
+                    "replacement daemon does not support scheduled execution notification settings",
+                ));
+            }
+        }
         self.restart_request(Request::RestartWithNotificationConfig {
             notifications,
             environment: Some(current_environment()),
@@ -686,7 +725,7 @@ impl Client {
             schedule_id: schedule_id.into(),
             dispatch_key: dispatch_key.into(),
         })? {
-            Response::ScheduledExecution { execution } => Ok(execution),
+            Response::ScheduledExecution { execution, .. } => Ok(execution),
             other => unexpected(other),
         }
     }
@@ -699,8 +738,80 @@ impl Client {
         match self.request(Request::ListScheduledExecutions {
             workspace_id,
             schedule_id,
+            limit: None,
         })? {
-            Response::ScheduledExecutions { executions } => Ok(executions),
+            Response::ScheduledExecutions { executions, .. } => Ok(executions),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn scheduled_execution_page(
+        &self,
+        workspace_id: Option<String>,
+        schedule_id: Option<String>,
+        limit: u16,
+    ) -> Result<ScheduledExecutionList> {
+        let supports_bounded =
+            self.supports(protocol::ProtocolFeature::ScheduledExecutionObservation)?;
+        match self.request(Request::ListScheduledExecutions {
+            workspace_id,
+            schedule_id,
+            limit: Some(limit),
+        })? {
+            Response::ScheduledExecutions {
+                mut executions,
+                limit: response_limit,
+                truncated,
+                schedules,
+                schedule_limit,
+                schedules_truncated,
+            } => {
+                if supports_bounded {
+                    Ok(ScheduledExecutionList {
+                        executions,
+                        limit: response_limit,
+                        truncated,
+                        schedules,
+                        schedule_limit,
+                        schedules_truncated,
+                    })
+                } else {
+                    let limit = limit.clamp(1, protocol::MAX_SCHEDULED_EXECUTION_LIST_LIMIT);
+                    let truncated = executions.len() > usize::from(limit);
+                    executions.truncate(usize::from(limit));
+                    Ok(ScheduledExecutionList {
+                        executions,
+                        limit,
+                        truncated,
+                        schedules,
+                        schedule_limit: 0,
+                        schedules_truncated: false,
+                    })
+                }
+            }
+            other => unexpected(other),
+        }
+    }
+
+    pub fn wait_scheduled_execution(
+        &self,
+        execution_id: impl Into<String>,
+        after_revision: u64,
+        wait_ms: u32,
+    ) -> Result<ScheduledExecutionWait> {
+        if !self.supports(protocol::ProtocolFeature::ScheduledExecutionObservation)? {
+            return Err(unsupported_version(
+                "daemon does not support scheduled execution wait",
+            ));
+        }
+        match self.request(Request::WaitScheduledExecution {
+            execution_id: execution_id.into(),
+            after_revision,
+            wait_ms,
+        })? {
+            Response::ScheduledExecutionWait { execution, changed } => {
+                Ok(ScheduledExecutionWait { execution, changed })
+            }
             other => unexpected(other),
         }
     }
@@ -712,7 +823,25 @@ impl Client {
         match self.request(Request::GetScheduledExecution {
             execution_id: execution_id.into(),
         })? {
-            Response::ScheduledExecution { execution } => Ok(execution),
+            Response::ScheduledExecution { execution, .. } => Ok(execution),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn inspect_scheduled_execution(
+        &self,
+        execution_id: impl Into<String>,
+    ) -> Result<ScheduledExecutionInspection> {
+        match self.request(Request::GetScheduledExecution {
+            execution_id: execution_id.into(),
+        })? {
+            Response::ScheduledExecution {
+                execution,
+                next_occurrence,
+            } => Ok(ScheduledExecutionInspection {
+                execution,
+                next_occurrence,
+            }),
             other => unexpected(other),
         }
     }
@@ -724,7 +853,7 @@ impl Client {
         match self.request(Request::CancelScheduledExecution {
             execution_id: execution_id.into(),
         })? {
-            Response::ScheduledExecution { execution } => Ok(execution),
+            Response::ScheduledExecution { execution, .. } => Ok(execution),
             other => unexpected(other),
         }
     }
@@ -762,7 +891,7 @@ impl Client {
             runner_token: protocol::ScheduledRunnerCapability::new(runner_token),
             result,
         })? {
-            Response::ScheduledExecution { execution } => Ok(execution),
+            Response::ScheduledExecution { execution, .. } => Ok(execution),
             other => unexpected(other),
         }
     }
@@ -1254,6 +1383,7 @@ mod tests {
             resume_agents: false,
             persist_terminal_history: true,
             max_scheduled_execution_concurrency: 1,
+            ..Default::default()
         };
         let expected_settings = settings.clone();
         let expected_environment = current_environment();
@@ -1325,13 +1455,13 @@ mod tests {
                             notifications,
                             environment: Some(environment),
                         } => {
-                            assert_eq!(request.version, 24);
+                            assert_eq!(request.version, protocol::PROTOCOL_VERSION);
                             assert_eq!(notifications, expected_settings);
                             assert_eq!(environment, expected_environment);
                             full_restart_seen = true;
                             protocol::write_message(
                                 &mut stream,
-                                &Envelope::with_version(24, Response::Ok),
+                                &Envelope::with_version(protocol::PROTOCOL_VERSION, Response::Ok),
                             )
                             .unwrap();
                         }
@@ -1368,6 +1498,101 @@ mod tests {
         }
     }
 
+    fn test_scheduled_execution(id: &str, requested_at_ms: u64) -> ScheduledExecutionSnapshot {
+        ScheduledExecutionSnapshot {
+            id: id.into(),
+            workspace_id: "workspace".into(),
+            schedule_id: "schedule".into(),
+            revision: 1,
+            state: protocol::ScheduledExecutionState::DispatchFailed,
+            dispatch_kind: protocol::ScheduledExecutionDispatchKind::Manual,
+            dispatch_key: format!("key-{id}"),
+            schedule_revision: 1,
+            prompt_revision: 1,
+            trigger_revision: 1,
+            requested_at_ms,
+            scheduled_at_ms: None,
+            coalesced_through_ms: None,
+            started_at_ms: None,
+            ended_at_ms: Some(requested_at_ms),
+            cwd: env::temp_dir(),
+            integration: "opencode".into(),
+            session: protocol::AgentScheduleSession::Fresh,
+            reason: Some(protocol::ScheduledExecutionReason::RunnerStartFailed),
+            outcome: None,
+            shell_id: None,
+            run_id: None,
+            agent_id: None,
+            external_session_id: None,
+        }
+    }
+
+    #[test]
+    fn current_client_bounds_unbounded_old_daemon_execution_lists() {
+        for old_version in [23, 24] {
+            let directory =
+                env::temp_dir().join(format!("boomux-old-list-{old_version}-{}", Uuid::new_v4()));
+            fs::create_dir_all(&directory).unwrap();
+            let socket = directory.join("daemon.sock");
+            let listener = UnixListener::bind(&socket).unwrap();
+            let server = thread::spawn(move || {
+                for attempted in ((old_version + 1)..=protocol::PROTOCOL_VERSION).rev() {
+                    reject_protocol(&listener, attempted, old_version);
+                }
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                assert_eq!(request.version, old_version);
+                assert!(matches!(request.message, Request::Ping));
+                protocol::write_message(
+                    &mut stream,
+                    &Envelope::with_version(old_version, Response::Pong),
+                )
+                .unwrap();
+
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                assert_eq!(request.version, old_version);
+                assert!(matches!(
+                    request.message,
+                    Request::ListScheduledExecutions { limit: Some(2), .. }
+                ));
+                protocol::write_message(
+                    &mut stream,
+                    &Envelope::with_version(
+                        old_version,
+                        Response::ScheduledExecutions {
+                            executions: vec![
+                                test_scheduled_execution("newest", 3),
+                                test_scheduled_execution("middle", 2),
+                                test_scheduled_execution("oldest", 1),
+                            ],
+                            limit: 0,
+                            truncated: false,
+                            schedules: Vec::new(),
+                            schedule_limit: 0,
+                            schedules_truncated: false,
+                        },
+                    ),
+                )
+                .unwrap();
+            });
+            let page = Client::from_socket_path(socket)
+                .scheduled_execution_page(None, None, 2)
+                .unwrap();
+            assert_eq!(page.limit, 2);
+            assert!(page.truncated);
+            assert_eq!(
+                page.executions
+                    .iter()
+                    .map(|execution| execution.id.as_str())
+                    .collect::<Vec<_>>(),
+                ["newest", "middle"]
+            );
+            server.join().unwrap();
+            fs::remove_dir_all(directory).unwrap();
+        }
+    }
+
     #[test]
     fn direct_client_negotiates_before_sending_agent_wait() {
         let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
@@ -1375,6 +1600,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 25, 24);
             reject_protocol(&listener, 24, 23);
             reject_protocol(&listener, 23, 22);
             reject_protocol(&listener, 22, 21);
@@ -1557,7 +1783,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 24);
+            assert_eq!(request.version, protocol::PROTOCOL_VERSION);
             let Request::Attach {
                 environment: Some(environment),
                 ..
@@ -1574,7 +1800,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    24,
+                    protocol::PROTOCOL_VERSION,
                     Response::Attached {
                         token: "token".into(),
                         reconstruction: Vec::new(),
@@ -1665,6 +1891,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 25, 24);
             reject_protocol(&listener, 24, 23);
             reject_protocol(&listener, 23, 22);
             reject_protocol(&listener, 22, 21);
@@ -1725,6 +1952,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 25, 24);
             reject_protocol(&listener, 24, 23);
             reject_protocol(&listener, 23, 22);
             reject_protocol(&listener, 22, 21);

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ struct RawNotificationsConfig {
     enabled: Option<bool>,
     blocked: Option<bool>,
     completed: Option<bool>,
+    scheduled_dispatch_failed: Option<bool>,
+    scheduled_interrupted: Option<bool>,
     sound: Option<RawNotificationSoundConfig>,
 }
 
@@ -44,6 +46,8 @@ struct RawNotificationSoundConfig {
     enabled: Option<bool>,
     blocked: Option<String>,
     completed: Option<String>,
+    scheduled_dispatch_failed: Option<String>,
+    scheduled_interrupted: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -175,6 +179,12 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
         if next_notifications.completed.is_some() {
             notifications.completed = next_notifications.completed;
         }
+        if next_notifications.scheduled_dispatch_failed.is_some() {
+            notifications.scheduled_dispatch_failed = next_notifications.scheduled_dispatch_failed;
+        }
+        if next_notifications.scheduled_interrupted.is_some() {
+            notifications.scheduled_interrupted = next_notifications.scheduled_interrupted;
+        }
         if let Some(next_sound) = next_notifications.sound {
             let sound = notifications.sound.get_or_insert_default();
             if next_sound.enabled.is_some() {
@@ -185,6 +195,12 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
             }
             if next_sound.completed.is_some() {
                 sound.completed = next_sound.completed;
+            }
+            if next_sound.scheduled_dispatch_failed.is_some() {
+                sound.scheduled_dispatch_failed = next_sound.scheduled_dispatch_failed;
+            }
+            if next_sound.scheduled_interrupted.is_some() {
+                sound.scheduled_interrupted = next_sound.scheduled_interrupted;
             }
         }
     }
@@ -279,6 +295,8 @@ fn resolve_daemon_settings(
             enabled: raw.enabled.unwrap_or(false),
             blocked: raw.blocked.unwrap_or(true),
             completed: raw.completed.unwrap_or(true),
+            scheduled_dispatch_failed: raw.scheduled_dispatch_failed.unwrap_or(false),
+            scheduled_interrupted: raw.scheduled_interrupted.unwrap_or(false),
         },
         sound: raw.sound.map_or_else(Default::default, |sound| {
             boomux::daemon::NotificationSoundSettings {
@@ -287,6 +305,12 @@ fn resolve_daemon_settings(
                     .blocked
                     .unwrap_or_else(|| "message-new-instant".into()),
                 completed: sound.completed.unwrap_or_else(|| "complete".into()),
+                scheduled_dispatch_failed: sound
+                    .scheduled_dispatch_failed
+                    .unwrap_or_else(|| "dialog-warning".into()),
+                scheduled_interrupted: sound
+                    .scheduled_interrupted
+                    .unwrap_or_else(|| "dialog-warning".into()),
             }
         }),
         resume_agents: recovery.resume_agents.unwrap_or(true),
@@ -471,6 +495,8 @@ mod tests {
         assert!(settings.sound.enabled);
         assert_eq!(settings.sound.blocked, "dialog-warning");
         assert_eq!(settings.sound.completed, "complete");
+        assert!(!settings.desktop.scheduled_dispatch_failed);
+        assert!(!settings.desktop.scheduled_interrupted);
     }
 
     #[test]
@@ -511,17 +537,33 @@ mod tests {
                     enabled: true,
                     blocked: false,
                     completed: true,
+                    ..Default::default()
                 },
                 sound: boomux::daemon::NotificationSoundSettings {
                     enabled: true,
                     blocked: "message-new-instant".into(),
                     completed: "service-login".into(),
+                    ..Default::default()
                 },
                 resume_agents: true,
                 persist_terminal_history: false,
                 max_scheduled_execution_concurrency: 4,
             }
         );
+    }
+
+    #[test]
+    fn scheduled_notification_categories_are_independent_and_default_disabled() {
+        let raw: RawConfig = toml::from_str(
+            "[notifications]\nenabled = true\nscheduled_dispatch_failed = true\nscheduled_interrupted = false\n[notifications.sound]\nscheduled_interrupted = \"service-logout\"",
+        )
+        .unwrap();
+        let settings = resolve_notifications(raw.notifications);
+        assert!(settings.desktop.scheduled_dispatch_failed);
+        assert!(!settings.desktop.scheduled_interrupted);
+        assert!(settings.desktop.blocked);
+        assert!(settings.desktop.completed);
+        assert_eq!(settings.sound.scheduled_interrupted, "service-logout");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -35,11 +35,12 @@ use crate::protocol::{
     AgentScheduleState, AgentScheduleTrigger, AgentState, AttachFrame, DaemonEvent,
     DaemonEventKind, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot,
     NotificationDeliveryConfig, Request, Response, ScheduledExecutionDispatchKind,
-    ScheduledExecutionOutcome, ScheduledExecutionReason, ScheduledExecutionSnapshot,
-    ScheduledExecutionState, ScheduledOccurrence, ScheduledRunnerResult, SchedulerHealth,
-    SchedulerState, ShellOwner, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec,
-    ShellStatus, Snapshot, TerminalPreview, TerminalProfile, UnixEnvironment,
-    UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    ScheduledExecutionOutcome, ScheduledExecutionReason, ScheduledExecutionScheduleProjection,
+    ScheduledExecutionSnapshot, ScheduledExecutionState, ScheduledOccurrence,
+    ScheduledRunnerResult, SchedulerHealth, SchedulerState, ShellOwner, ShellRunExitReason,
+    ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
+    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
+    WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::state_store::{
     PersistedAgentInstance, PersistedAgentSchedule, PersistedScheduledExecution, PersistedShell,
@@ -86,6 +87,8 @@ pub struct NotificationSettings {
     pub enabled: bool,
     pub blocked: bool,
     pub completed: bool,
+    pub scheduled_dispatch_failed: bool,
+    pub scheduled_interrupted: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -93,6 +96,8 @@ pub struct NotificationSoundSettings {
     pub enabled: bool,
     pub blocked: String,
     pub completed: String,
+    pub scheduled_dispatch_failed: String,
+    pub scheduled_interrupted: String,
 }
 
 impl Default for NotificationSoundSettings {
@@ -101,6 +106,8 @@ impl Default for NotificationSoundSettings {
             enabled: false,
             blocked: "message-new-instant".into(),
             completed: "complete".into(),
+            scheduled_dispatch_failed: "dialog-warning".into(),
+            scheduled_interrupted: "dialog-warning".into(),
         }
     }
 }
@@ -112,11 +119,15 @@ impl From<NotificationDeliveryConfig> for NotificationDeliverySettings {
                 enabled: config.desktop_enabled,
                 blocked: config.blocked,
                 completed: config.completed,
+                scheduled_dispatch_failed: config.scheduled_dispatch_failed,
+                scheduled_interrupted: config.scheduled_interrupted,
             },
             sound: NotificationSoundSettings {
                 enabled: config.sound_enabled,
                 blocked: config.blocked_sound,
                 completed: config.completed_sound,
+                scheduled_dispatch_failed: config.scheduled_dispatch_failed_sound,
+                scheduled_interrupted: config.scheduled_interrupted_sound,
             },
             resume_agents: config.resume_agents,
             persist_terminal_history: config.persist_terminal_history,
@@ -132,8 +143,12 @@ impl From<NotificationDeliverySettings> for NotificationDeliveryConfig {
             sound_enabled: settings.sound.enabled,
             blocked: settings.desktop.blocked,
             completed: settings.desktop.completed,
+            scheduled_dispatch_failed: settings.desktop.scheduled_dispatch_failed,
+            scheduled_interrupted: settings.desktop.scheduled_interrupted,
             blocked_sound: settings.sound.blocked,
             completed_sound: settings.sound.completed,
+            scheduled_dispatch_failed_sound: settings.sound.scheduled_dispatch_failed,
+            scheduled_interrupted_sound: settings.sound.scheduled_interrupted,
             resume_agents: settings.resume_agents,
             persist_terminal_history: settings.persist_terminal_history,
             max_scheduled_execution_concurrency: settings.max_scheduled_execution_concurrency,
@@ -187,6 +202,8 @@ impl Default for NotificationSettings {
             enabled: false,
             blocked: true,
             completed: true,
+            scheduled_dispatch_failed: false,
+            scheduled_interrupted: false,
         }
     }
 }
@@ -314,6 +331,7 @@ fn run_daemon(
         registry.clear_terminal_histories()?;
     }
     registry.notification_sink = Arc::new(DesktopNotificationSink::new(notification_settings));
+    registry.publish_cold_recovery_notifications();
     let registry = Arc::new(registry);
     let shells = registry.durable.shells()?;
     let (gated_readers, handoff_changed) = registry.runtimes.import_handoff(
@@ -1090,6 +1108,24 @@ fn response_for_version_with_schedule_shells(
     schedule_shell_ids: &HashSet<String>,
 ) -> Response {
     let mut response = response;
+    if !protocol::ProtocolFeature::ScheduledExecutionObservation.is_supported_by(version) {
+        match &mut response {
+            Response::ScheduledExecution {
+                next_occurrence, ..
+            } => *next_occurrence = None,
+            Response::ScheduledExecutions {
+                schedules,
+                schedule_limit,
+                schedules_truncated,
+                ..
+            } => {
+                schedules.clear();
+                *schedule_limit = 0;
+                *schedules_truncated = false;
+            }
+            _ => {}
+        }
+    }
     if !protocol::ProtocolFeature::TimedScheduling.is_supported_by(version) {
         remove_timed_scheduling(&mut response);
     }
@@ -1237,7 +1273,7 @@ fn remove_timed_scheduling(response: &mut Response) {
         Response::AgentScheduleInspection { inspection } => {
             downgrade_schedule(&mut inspection.schedule);
         }
-        Response::ScheduledExecution { execution }
+        Response::ScheduledExecution { execution, .. }
             if execution.dispatch_kind == ScheduledExecutionDispatchKind::Timed
                 || execution.state == ScheduledExecutionState::Skipped =>
         {
@@ -1246,7 +1282,7 @@ fn remove_timed_scheduling(response: &mut Response) {
                 message: format!("scheduled execution not found: {}", execution.id),
             };
         }
-        Response::ScheduledExecutions { executions } => executions.retain(|execution| {
+        Response::ScheduledExecutions { executions, .. } => executions.retain(|execution| {
             execution.dispatch_kind == ScheduledExecutionDispatchKind::Manual
                 && execution.state != ScheduledExecutionState::Skipped
         }),
@@ -1440,7 +1476,10 @@ fn scheduled_execution_response(
             "scheduled execution was skipped by the current concurrency policy",
         ));
     }
-    Ok(Response::ScheduledExecution { execution })
+    Ok(Response::ScheduledExecution {
+        execution,
+        next_occurrence: None,
+    })
 }
 
 struct DaemonService {
@@ -1451,6 +1490,7 @@ struct DaemonService {
     schedule_dispatch_lock: Mutex<()>,
     notification_settings: NotificationDeliverySettings,
     notification_sink: Arc<dyn NotificationSink>,
+    cold_recovery_executions: Vec<ScheduledExecutionSnapshot>,
     startup_environment: UnixEnvironment,
     scheduler: SchedulerWorker,
     clock: Mutex<Arc<dyn SchedulerClock>>,
@@ -1778,7 +1818,9 @@ struct TransitionState {
 
 impl TransitionState {
     fn publication_blocked(&self) -> bool {
-        self.persistence_in_flight || !self.pending_durable_events.is_empty()
+        self.persistence_in_flight
+            || !self.pending_durable_events.is_empty()
+            || self.lifecycle_event_reservation != 0
     }
 
     fn queue_runtime_event(&mut self, event: DaemonEventKind) {
@@ -1828,6 +1870,7 @@ struct PersistenceWrite {
 struct PersistenceGeneration {
     revision: u64,
     state: PersistedState,
+    executions: Vec<ScheduledExecutionSnapshot>,
 }
 
 impl PersistenceWriter {
@@ -1905,11 +1948,13 @@ struct EventStreamState {
     latest_id: u64,
     events: VecDeque<DaemonEvent>,
     schedule_shell_ids: HashSet<String>,
+    committed_executions: HashMap<String, ScheduledExecutionSnapshot>,
 }
 
 struct EventTransaction<'a> {
     transition: MutexGuard<'a, TransitionState>,
     events: MutexGuard<'a, EventStreamState>,
+    changed: &'a Condvar,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1959,6 +2004,15 @@ impl EventTransaction<'_> {
             .sum()
     }
 
+    fn pending_durable_events(&self) -> Vec<DaemonEventKind> {
+        self.transition
+            .pending_durable_events
+            .iter()
+            .flatten()
+            .cloned()
+            .collect()
+    }
+
     fn take_pending_durable(&mut self, batch_count: usize) -> VecDeque<Vec<DaemonEventKind>> {
         self.transition
             .pending_durable_events
@@ -1982,8 +2036,26 @@ impl EventTransaction<'_> {
         self.transition.lifecycle_event_reservation = event_count;
     }
 
-    fn finish_lifecycle_reservation(&mut self) {
+    fn replace_committed_executions(&mut self, executions: Vec<ScheduledExecutionSnapshot>) {
+        self.events.committed_executions = executions
+            .into_iter()
+            .map(|execution| (execution.id.clone(), execution))
+            .collect();
+    }
+
+    fn release_lifecycle_reservation(&mut self) {
         self.transition.lifecycle_event_reservation = 0;
+        EventStream::publish_pending_runtime_locked(&mut self.transition, &mut self.events);
+        self.changed.notify_all();
+    }
+
+    fn transfer_lifecycle_reservation_to_persistence(
+        &mut self,
+        persistence_event_count: usize,
+        retained_reservation: usize,
+    ) {
+        self.transition.lifecycle_event_reservation = retained_reservation;
+        self.begin_persistence(persistence_event_count);
     }
 
     fn append_batch(&mut self, batch: Vec<DaemonEventKind>) {
@@ -2033,6 +2105,7 @@ impl EventStream {
                 latest_id: 0,
                 events: VecDeque::new(),
                 schedule_shell_ids: HashSet::new(),
+                committed_executions: HashMap::new(),
             }),
             transitions: Mutex::new(TransitionState::default()),
             changed: Condvar::new(),
@@ -2047,6 +2120,7 @@ impl EventStream {
                 latest_id: 0,
                 events: VecDeque::new(),
                 schedule_shell_ids: HashSet::new(),
+                committed_executions: HashMap::new(),
             },
             |transfer| {
                 let mut schedule_shell_ids = transfer
@@ -2066,6 +2140,7 @@ impl EventStream {
                     latest_id: transfer.latest_id,
                     events: transfer.events.into(),
                     schedule_shell_ids,
+                    committed_executions: HashMap::new(),
                 };
                 Self::retain_referenced_schedule_shell_ids(&mut state);
                 state
@@ -2092,6 +2167,7 @@ impl EventStream {
         Ok(EventTransaction {
             transition: lock(&self.transitions)?,
             events: lock(&self.state)?,
+            changed: &self.changed,
         })
     }
 
@@ -2109,15 +2185,24 @@ impl EventStream {
         Ok(lock(&self.state)?.schedule_shell_ids.clone())
     }
 
-    fn wait_for<T>(
+    fn initialize_committed_executions(
         &self,
+        executions: Vec<ScheduledExecutionSnapshot>,
+    ) -> io::Result<()> {
+        let mut transaction = self.transaction()?;
+        transaction.replace_committed_executions(executions);
+        Ok(())
+    }
+
+    fn wait_for_scheduled_execution(
+        &self,
+        execution_id: &str,
+        after_revision: u64,
         wait_ms: u32,
         stopping: impl Fn() -> bool,
-        mut inspect: impl FnMut(bool) -> DaemonResult<Option<T>>,
-    ) -> DaemonResult<T> {
+    ) -> DaemonResult<Response> {
         let deadline =
             Instant::now() + Duration::from_millis(u64::from(wait_ms)).min(MAX_EVENT_WAIT);
-        let mut state = lock(&self.state)?;
         loop {
             if stopping() {
                 return Err(DaemonError::lifecycle(
@@ -2126,15 +2211,73 @@ impl EventStream {
                 ));
             }
             let expired = wait_ms == 0 || Instant::now() >= deadline;
-            if let Some(value) = inspect(expired)? {
+            let transition = lock(&self.transitions)?;
+            let state = lock(&self.state)?;
+            let execution = state
+                .committed_executions
+                .get(execution_id)
+                .cloned()
+                .ok_or_else(|| not_found("scheduled execution", execution_id))?;
+            if after_revision < execution.revision {
+                return Ok(Response::ScheduledExecutionWait {
+                    execution,
+                    changed: true,
+                });
+            }
+            if after_revision > execution.revision {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::RevisionAhead,
+                    "requested execution revision is ahead of the current revision",
+                ));
+            }
+            if expired {
+                return Ok(Response::ScheduledExecutionWait {
+                    execution,
+                    changed: false,
+                });
+            }
+            drop(transition);
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            let (_state, _) = self
+                .changed
+                .wait_timeout(state, timeout)
+                .map_err(|_| io::Error::other("execution wait lock poisoned"))?;
+        }
+    }
+
+    fn wait_for<T>(
+        &self,
+        wait_ms: u32,
+        stopping: impl Fn() -> bool,
+        mut inspect: impl FnMut(bool) -> DaemonResult<Option<T>>,
+    ) -> DaemonResult<T> {
+        let deadline =
+            Instant::now() + Duration::from_millis(u64::from(wait_ms)).min(MAX_EVENT_WAIT);
+        loop {
+            if stopping() {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::DaemonStopping,
+                    "Boomux daemon is stopping",
+                ));
+            }
+            let expired = wait_ms == 0 || Instant::now() >= deadline;
+            let transition = lock(&self.transitions)?;
+            let state = lock(&self.state)?;
+            let publication_blocked = transition.publication_blocked();
+            if !publication_blocked && let Some(value) = inspect(expired)? {
                 return Ok(value);
             }
+            drop(transition);
             let timeout = deadline.saturating_duration_since(Instant::now());
-            let (next, _) = self
+            let timeout = if publication_blocked && timeout.is_zero() {
+                IO_RETRY_DELAY
+            } else {
+                timeout
+            };
+            let (_state, _) = self
                 .changed
                 .wait_timeout(state, timeout)
                 .map_err(|_| io::Error::other("event wait lock poisoned"))?;
-            state = next;
         }
     }
 
@@ -2374,9 +2517,53 @@ impl DurableRegistry {
             right
                 .requested_at_ms
                 .cmp(&left.requested_at_ms)
-                .then_with(|| left.id.cmp(&right.id))
+                .then_with(|| right.id.cmp(&left.id))
         });
         Ok(snapshots)
+    }
+
+    fn scheduled_execution_page(
+        &self,
+        workspace_id: Option<&str>,
+        schedule_id: Option<&str>,
+        limit: u16,
+    ) -> io::Result<(Vec<ScheduledExecutionSnapshot>, u16, bool)> {
+        let limit = limit.clamp(1, protocol::MAX_SCHEDULED_EXECUTION_LIST_LIMIT);
+        let mut executions = self.scheduled_executions(workspace_id, schedule_id)?;
+        let truncated = executions.len() > usize::from(limit);
+        executions.truncate(usize::from(limit));
+        Ok((executions, limit, truncated))
+    }
+
+    fn scheduled_execution_schedule_projections(
+        &self,
+        workspace_id: Option<&str>,
+        schedule_id: Option<&str>,
+    ) -> io::Result<(Vec<ScheduledExecutionScheduleProjection>, u16, bool)> {
+        let mut schedules = lock(&self.state)?
+            .schedules
+            .values()
+            .filter(|schedule| {
+                workspace_id.is_none_or(|id| id == schedule.workspace_id)
+                    && schedule_id.is_none_or(|id| id == schedule.id)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        schedules.sort_by(|left, right| left.id.cmp(&right.id));
+        let limit = protocol::MAX_SCHEDULED_EXECUTION_SCHEDULE_PROJECTIONS;
+        let truncated = schedules.len() > usize::from(limit);
+        schedules.truncate(usize::from(limit));
+        let projections = schedules
+            .into_iter()
+            .map(|schedule| {
+                let snapshot = schedule.snapshot()?;
+                Ok(ScheduledExecutionScheduleProjection {
+                    schedule_id: snapshot.id,
+                    next_occurrence: snapshot.next_occurrence,
+                })
+            })
+            .collect::<io::Result<_>>()?;
+        Ok((projections, limit, truncated))
     }
 
     fn active_scheduled_execution_count(&self) -> io::Result<usize> {
@@ -2521,6 +2708,7 @@ impl DurableRegistry {
             prompt: schedule.prompt.clone(),
             runner_token: Uuid::new_v4().to_string(),
             state: Mutex::new(ScheduledExecutionMutableState {
+                revision: 1,
                 state,
                 started_at_ms: None,
                 ended_at_ms: skip_reason.map(|_| requested_at_ms),
@@ -2737,6 +2925,27 @@ impl DurableRegistry {
         (workspace, shell)
     }
 
+    fn schedule_notification_context(
+        &self,
+        workspace_id: &str,
+        schedule_id: &str,
+    ) -> (String, String) {
+        let Ok(state) = self.state.lock() else {
+            return ("unknown".into(), "removed".into());
+        };
+        let workspace = state
+            .workspaces
+            .get(workspace_id)
+            .and_then(|workspace| workspace.name.lock().ok().map(|name| name.clone()))
+            .unwrap_or_else(|| "unknown".into());
+        let schedule = state
+            .schedules
+            .get(schedule_id)
+            .map(|schedule| schedule.name.clone())
+            .unwrap_or_else(|| "removed".into());
+        (workspace, schedule)
+    }
+
     fn create_workspace(
         &self,
         name: String,
@@ -2881,33 +3090,15 @@ impl DurableRegistry {
         let mut state = lock(&execution.state)?;
         let previous_state = state.clone();
         mutate(&mut state)?;
+        state.revision = state
+            .revision
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("scheduled execution revision exhausted"))?;
         let snapshot = execution.snapshot_from(&state);
         let became_terminal = state.state.is_terminal();
         drop(state);
         if became_terminal {
-            let mut terminal = executions
-                .iter()
-                .enumerate()
-                .filter_map(|(index, candidate)| {
-                    lock(&candidate.state)
-                        .ok()
-                        .filter(|state| state.state.is_terminal())
-                        .map(|_| (index, candidate.requested_at_ms))
-                })
-                .collect::<Vec<_>>();
-            terminal.sort_by_key(|(_, requested)| *requested);
-            let remove = terminal
-                .len()
-                .saturating_sub(MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE);
-            let mut remove = terminal
-                .into_iter()
-                .take(remove)
-                .map(|(index, _)| index)
-                .collect::<Vec<_>>();
-            remove.sort_unstable_by(|left, right| right.cmp(left));
-            for index in remove {
-                executions.remove(index);
-            }
+            prune_terminal_executions(&mut executions);
         }
         drop(executions);
         Ok((
@@ -3753,6 +3944,7 @@ impl DurableRegistry {
     }
 
     fn capture_persisted_state(&self) -> io::Result<PersistenceGeneration> {
+        let executions = self.scheduled_executions(None, None)?;
         let (mut workspaces, shells_by_id, launchers_by_id, agents_by_id, schedules_by_id) = {
             let state = lock(&self.state)?;
             (
@@ -3823,6 +4015,7 @@ impl DurableRegistry {
         Ok(PersistenceGeneration {
             revision: self.persistence_revision.load(Ordering::Acquire),
             state: saved,
+            executions,
         })
     }
 
@@ -4543,6 +4736,7 @@ impl Default for DaemonService {
             schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
             notification_sink: Arc::new(DisabledNotificationSink),
+            cold_recovery_executions: Vec::new(),
             startup_environment: capture_current_environment(),
             scheduler: SchedulerWorker::default(),
             clock: Mutex::new(Arc::new(SystemSchedulerClock)),
@@ -4602,6 +4796,7 @@ struct ScheduledExecution {
 
 #[derive(Clone)]
 struct ScheduledExecutionMutableState {
+    revision: u64,
     state: ScheduledExecutionState,
     started_at_ms: Option<u64>,
     ended_at_ms: Option<u64>,
@@ -5604,6 +5799,19 @@ impl DaemonService {
         request: Request,
         response_version: u32,
     ) -> DaemonResult<Response> {
+        if let Request::ListScheduledExecutions {
+            workspace_id,
+            schedule_id,
+            limit,
+        } = request
+        {
+            return self.list_scheduled_executions(
+                workspace_id.as_deref(),
+                schedule_id.as_deref(),
+                limit,
+                response_version,
+            );
+        }
         if let Request::RunAgentSchedule {
             schedule_id,
             dispatch_key,
@@ -5628,12 +5836,14 @@ impl DaemonService {
                 let Some(record) = record else {
                     return Ok(DurableMutation::Unchanged(Response::ScheduledExecution {
                         execution,
+                        next_occurrence: None,
                     }));
                 };
                 undo.record(record);
                 Ok(DurableMutation::Changed(
                     Response::ScheduledExecution {
                         execution: execution.clone(),
+                        next_occurrence: None,
                     },
                     vec![DaemonEventKind::ScheduledExecutionCreated {
                         workspace_id: execution.workspace_id.clone(),
@@ -5641,7 +5851,7 @@ impl DaemonService {
                     }],
                 ))
             })?;
-            let Response::ScheduledExecution { execution } = response else {
+            let Response::ScheduledExecution { execution, .. } = response else {
                 unreachable!("claim returns an execution")
             };
             if execution.state == ScheduledExecutionState::Skipped {
@@ -5666,6 +5876,52 @@ impl DaemonService {
             };
         }
         self.dispatch(request)
+    }
+
+    fn list_scheduled_executions(
+        &self,
+        workspace_id: Option<&str>,
+        schedule_id: Option<&str>,
+        requested_limit: Option<u16>,
+        response_version: u32,
+    ) -> DaemonResult<Response> {
+        let mut executions = self
+            .durable
+            .scheduled_executions(workspace_id, schedule_id)?;
+        if !protocol::ProtocolFeature::TimedScheduling.is_supported_by(response_version) {
+            executions.retain(|execution| {
+                execution.dispatch_kind == ScheduledExecutionDispatchKind::Manual
+                    && execution.state != ScheduledExecutionState::Skipped
+            });
+        }
+        let observation_supported = protocol::ProtocolFeature::ScheduledExecutionObservation
+            .is_supported_by(response_version);
+        let (limit, truncated) = if observation_supported {
+            let limit = requested_limit
+                .unwrap_or(protocol::DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT)
+                .clamp(1, protocol::MAX_SCHEDULED_EXECUTION_LIST_LIMIT);
+            let truncated = executions.len() > usize::from(limit);
+            executions.truncate(usize::from(limit));
+            (limit, truncated)
+        } else {
+            (0, false)
+        };
+        let mut schedules = Vec::new();
+        let mut schedule_limit = 0;
+        let mut schedules_truncated = false;
+        if observation_supported {
+            (schedules, schedule_limit, schedules_truncated) = self
+                .durable
+                .scheduled_execution_schedule_projections(workspace_id, schedule_id)?;
+        }
+        Ok(Response::ScheduledExecutions {
+            executions,
+            limit,
+            truncated,
+            schedules,
+            schedule_limit,
+            schedules_truncated,
+        })
     }
 
     fn clear_terminal_histories(&self) -> io::Result<()> {
@@ -5802,6 +6058,7 @@ impl DaemonService {
             Ok((
                 Response::ScheduledExecution {
                     execution: snapshot.clone(),
+                    next_occurrence: None,
                 },
                 vec![DaemonEventKind::ScheduledExecutionChanged {
                     workspace_id: snapshot.workspace_id.clone(),
@@ -5810,7 +6067,7 @@ impl DaemonService {
             ))
         })
         .and_then(|response| match response {
-            Response::ScheduledExecution { execution } => Ok(execution),
+            Response::ScheduledExecution { execution, .. } => Ok(execution),
             _ => Err(DaemonError::Internal(io::Error::other(
                 "execution mutation returned an unexpected response",
             ))),
@@ -5843,22 +6100,33 @@ impl DaemonService {
             workspace_id: failed.workspace_id.clone(),
             execution: failed.clone(),
         }];
+        let notifications =
+            self.execution_notification_requests(&events, &transaction.events.committed_executions);
         let saved = self.capture_persisted_state()?;
         transaction.begin_persistence(events.len());
         drop(transaction);
-        if let Err(error) = self.write_persisted_state(saved) {
-            let mut transaction = self.events.transaction()?;
-            transaction.finish_persistence();
-            self.queue_durable_batch_locked(events, &mut transaction);
-            drop(transaction);
-            self.events.notify();
-            return Err(DaemonError::persistence(error));
-        }
+        let committed = match self.write_persisted_state(saved) {
+            Ok(committed) => committed,
+            Err(error) => {
+                let mut transaction = self.events.transaction()?;
+                transaction.finish_persistence();
+                self.queue_durable_batch_locked(events, &mut transaction);
+                drop(transaction);
+                self.events.notify();
+                return Err(DaemonError::persistence(error));
+            }
+        };
         let mut transaction = self.events.transaction()?;
+        transaction.replace_committed_executions(committed);
         transaction.append_batch(events);
         transaction.finish_persistence();
         drop(transaction);
+        drop(_persistence);
+        drop(_mutation);
         self.events.notify();
+        for notification in notifications {
+            self.notification_sink.notify(notification);
+        }
         Ok(failed)
     }
 
@@ -5876,6 +6144,7 @@ impl DaemonService {
                 return Ok((
                     Response::ScheduledExecution {
                         execution: execution.snapshot()?,
+                        next_occurrence: None,
                     },
                     Vec::new(),
                 ));
@@ -5897,6 +6166,7 @@ impl DaemonService {
                 return Ok((
                     Response::ScheduledExecution {
                         execution: skipped.clone(),
+                        next_occurrence: None,
                     },
                     vec![DaemonEventKind::ScheduledExecutionChanged {
                         workspace_id: skipped.workspace_id.clone(),
@@ -5951,26 +6221,17 @@ impl DaemonService {
                 )
                 .into());
             }
-            let previous_executions = lock(&schedule.executions)?.clone();
-            let previous_dispatch_key_filter = lock(&schedule.dispatch_key_filter)?.clone();
-            let mut execution_state = lock(&execution.state)?;
-            if execution_state.state != ScheduledExecutionState::Claimed
-                || execution_state.shell_id.is_some()
-            {
-                return Err(DaemonError::lifecycle(
-                    ErrorCode::RunChanged,
-                    "scheduled execution claim changed during shell preparation",
-                ));
-            }
-            let previous_state = execution_state.clone();
-            execution_state.shell_id = Some(shell.id.clone());
-            let snapshot = execution.snapshot_from(&execution_state);
-            undo.record(DurableUndo::ScheduleExecutions {
-                schedule: Arc::clone(&schedule),
-                previous: previous_executions,
-                previous_dispatch_key_filter,
-                execution: Some((Arc::clone(execution), previous_state)),
-            });
+            let (snapshot, record) = self.durable.mutate_execution(execution, |state| {
+                if state.state != ScheduledExecutionState::Claimed || state.shell_id.is_some() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionAborted,
+                        "scheduled execution claim changed during shell preparation",
+                    ));
+                }
+                state.shell_id = Some(shell.id.clone());
+                Ok(())
+            })?;
+            undo.record(record);
             let mut events = Vec::new();
             if shell_created {
                 events.push(DaemonEventKind::ShellCreated {
@@ -6202,37 +6463,39 @@ impl DaemonService {
         };
         transaction.begin_persistence(2);
         drop(transaction);
-        if let Err(error) = self.write_persisted_state(saved) {
-            let run_event = self.runtimes.kill_with_event(&shell);
-            let _ = self.runtimes.reset_pending(&shell);
-            let failed = self
-                .durable
-                .mutate_execution(&execution, |state| {
-                    state.state = ScheduledExecutionState::DispatchFailed;
-                    state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
-                    state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
-                    state.outcome = None;
-                    Ok(())
-                })
-                .map(|(snapshot, _)| snapshot);
-            let mut transaction = self.events.transaction()?;
-            transaction.finish_persistence();
-            let mut events = Vec::new();
-            if let Ok(Some(event)) = &run_event {
-                events.push(event.clone());
-            }
-            if let Ok(snapshot) = &failed {
-                events.push(DaemonEventKind::ScheduledExecutionChanged {
-                    workspace_id: snapshot.workspace_id.clone(),
-                    execution: snapshot.clone(),
-                });
-            }
-            self.queue_durable_batch_locked(events, &mut transaction);
-            drop(transaction);
-            drop(_persistence);
-            drop(_mutation);
-            self.events.notify();
-            return Err(DaemonError::persistence_context(
+        let committed = match self.write_persisted_state(saved) {
+            Ok(committed) => committed,
+            Err(error) => {
+                let run_event = self.runtimes.kill_with_event(&shell);
+                let _ = self.runtimes.reset_pending(&shell);
+                let failed = self
+                    .durable
+                    .mutate_execution(&execution, |state| {
+                        state.state = ScheduledExecutionState::DispatchFailed;
+                        state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
+                        state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                        state.outcome = None;
+                        Ok(())
+                    })
+                    .map(|(snapshot, _)| snapshot);
+                let mut transaction = self.events.transaction()?;
+                transaction.finish_persistence();
+                let mut events = Vec::new();
+                if let Ok(Some(event)) = &run_event {
+                    events.push(event.clone());
+                }
+                if let Ok(snapshot) = &failed {
+                    events.push(DaemonEventKind::ScheduledExecutionChanged {
+                        workspace_id: snapshot.workspace_id.clone(),
+                        execution: snapshot.clone(),
+                    });
+                }
+                self.queue_durable_batch_locked(events, &mut transaction);
+                drop(transaction);
+                drop(_persistence);
+                drop(_mutation);
+                self.events.notify();
+                return Err(DaemonError::persistence_context(
                 error,
                 run_event.map_or_else(
                     |cleanup| {
@@ -6252,8 +6515,10 @@ impl DaemonService {
                     },
                 ),
             ));
-        }
+            }
+        };
         let mut transaction = self.events.transaction()?;
+        transaction.replace_committed_executions(committed);
         transaction.append_batch(vec![
             DaemonEventKind::RunStarted {
                 workspace_id: shell.workspace_id.clone(),
@@ -6281,7 +6546,10 @@ impl DaemonService {
         let execution = self.durable.execution(execution_id)?;
         let current = execution.snapshot()?;
         if current.state.is_terminal() {
-            return Ok(Response::ScheduledExecution { execution: current });
+            return Ok(Response::ScheduledExecution {
+                execution: current,
+                next_occurrence: None,
+            });
         }
 
         let bound_shell = match current.state {
@@ -6336,8 +6604,20 @@ impl DaemonService {
                         && variable.value == b"1"
                 })
             {
+                if let Some(variable) =
+                    self.startup_environment.variables.iter().find(|variable| {
+                        variable.name == b"BOOMUX_NATIVE_TEST_CANCEL_FAILURE_BARRIER"
+                    })
+                {
+                    let barrier =
+                        PathBuf::from(std::ffi::OsString::from_vec(variable.value.clone()));
+                    fs::write(barrier.join("reserved"), b"reserved")?;
+                    while !barrier.join("release").exists() {
+                        thread::sleep(IO_RETRY_DELAY);
+                    }
+                }
                 let mut transaction = self.events.transaction()?;
-                transaction.finish_lifecycle_reservation();
+                transaction.release_lifecycle_reservation();
                 return Err(DaemonError::Internal(io::Error::other(
                     "injected scheduled cancellation stop failure",
                 )));
@@ -6345,7 +6625,7 @@ impl DaemonService {
             if let Err(error) = self.runtimes.stop_runtime(shell) {
                 if !error.stopped {
                     let mut transaction = self.events.transaction()?;
-                    transaction.finish_lifecycle_reservation();
+                    transaction.release_lifecycle_reservation();
                     return Err(error.source.into());
                 }
                 stop_failure = Some(error.source);
@@ -6394,35 +6674,38 @@ impl DaemonService {
                 let mut transaction = self.events.transaction()?;
                 if bound_shell.is_none() {
                     let rollback = self.durable.rollback(undo);
-                    transaction.finish_lifecycle_reservation();
+                    transaction.release_lifecycle_reservation();
                     return Err(Self::lifecycle_failure(error.into(), rollback));
                 }
                 self.queue_durable_batch_locked(events, &mut transaction);
-                transaction.finish_lifecycle_reservation();
+                transaction.release_lifecycle_reservation();
                 return Err(error.into());
             }
         };
         let mut transaction = self.events.transaction()?;
-        transaction.finish_lifecycle_reservation();
-        transaction.begin_persistence(events.len());
+        transaction.transfer_lifecycle_reservation_to_persistence(events.len(), 0);
         drop(transaction);
-        if let Err(error) = self.write_persisted_state(saved) {
-            let mut transaction = self.events.transaction()?;
-            transaction.finish_persistence();
-            if bound_shell.is_none() {
-                let rollback = self.durable.rollback(undo);
-                return Err(Self::lifecycle_failure(
-                    DaemonError::persistence(error),
-                    rollback,
-                ));
+        let committed = match self.write_persisted_state(saved) {
+            Ok(committed) => committed,
+            Err(error) => {
+                let mut transaction = self.events.transaction()?;
+                transaction.finish_persistence();
+                if bound_shell.is_none() {
+                    let rollback = self.durable.rollback(undo);
+                    return Err(Self::lifecycle_failure(
+                        DaemonError::persistence(error),
+                        rollback,
+                    ));
+                }
+                self.queue_durable_batch_locked(events, &mut transaction);
+                drop(transaction);
+                drop(persistence);
+                self.events.notify();
+                return Err(DaemonError::persistence(error));
             }
-            self.queue_durable_batch_locked(events, &mut transaction);
-            drop(transaction);
-            drop(persistence);
-            self.events.notify();
-            return Err(DaemonError::persistence(error));
-        }
+        };
         let mut transaction = self.events.transaction()?;
+        transaction.replace_committed_executions(committed);
         transaction.append_batch(events);
         transaction.finish_persistence();
         drop(transaction);
@@ -6433,6 +6716,7 @@ impl DaemonService {
         }
         Ok(Response::ScheduledExecution {
             execution: cancelled,
+            next_occurrence: None,
         })
     }
 
@@ -6528,14 +6812,38 @@ impl DaemonService {
             Request::ListScheduledExecutions {
                 workspace_id,
                 schedule_id,
-            } => Ok(Response::ScheduledExecutions {
-                executions: self
-                    .durable
-                    .scheduled_executions(workspace_id.as_deref(), schedule_id.as_deref())?,
-            }),
-            Request::GetScheduledExecution { execution_id } => Ok(Response::ScheduledExecution {
-                execution: self.durable.execution(&execution_id)?.snapshot()?,
-            }),
+                limit,
+            } => {
+                let (executions, limit, truncated) = self.durable.scheduled_execution_page(
+                    workspace_id.as_deref(),
+                    schedule_id.as_deref(),
+                    limit.unwrap_or(protocol::DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT),
+                )?;
+                Ok(Response::ScheduledExecutions {
+                    executions,
+                    limit,
+                    truncated,
+                    schedules: Vec::new(),
+                    schedule_limit: 0,
+                    schedules_truncated: false,
+                })
+            }
+            Request::GetScheduledExecution { execution_id } => {
+                let execution = self.durable.execution(&execution_id)?.snapshot()?;
+                let next_occurrence = self
+                    .schedule(&execution.schedule_id)?
+                    .snapshot()?
+                    .next_occurrence;
+                Ok(Response::ScheduledExecution {
+                    execution,
+                    next_occurrence,
+                })
+            }
+            Request::WaitScheduledExecution {
+                execution_id,
+                after_revision,
+                wait_ms,
+            } => self.wait_scheduled_execution(&execution_id, after_revision, wait_ms),
             Request::WaitAgent {
                 agent_id,
                 after_revision,
@@ -6674,6 +6982,25 @@ impl DaemonService {
                     if current.state.is_terminal() {
                         return Ok(DurableMutation::Unchanged(Response::ScheduledExecution {
                             execution: current,
+                            next_occurrence: None,
+                        }));
+                    }
+                    let unchanged = match &result {
+                        ScheduledRunnerResult::Active => {
+                            current.state == ScheduledExecutionState::Active
+                                && current.started_at_ms.is_some()
+                        }
+                        ScheduledRunnerResult::SpawnFailed => {
+                            current.reason == Some(ScheduledExecutionReason::HostSpawnFailed)
+                        }
+                        ScheduledRunnerResult::Exited { outcome } => {
+                            current.outcome.as_ref() == Some(outcome)
+                        }
+                    };
+                    if unchanged {
+                        return Ok(DurableMutation::Unchanged(Response::ScheduledExecution {
+                            execution: current,
+                            next_occurrence: None,
                         }));
                     }
                     let now = unix_time_ms().max(execution.requested_at_ms);
@@ -6698,6 +7025,7 @@ impl DaemonService {
                     Ok(DurableMutation::Changed(
                         Response::ScheduledExecution {
                             execution: snapshot.clone(),
+                            next_occurrence: None,
                         },
                         vec![DaemonEventKind::ScheduledExecutionChanged {
                             workspace_id: snapshot.workspace_id.clone(),
@@ -6939,6 +7267,8 @@ impl DaemonService {
         let mut execution_ids = HashSet::new();
         let mut linked_agent_ids = HashSet::new();
         let mut recovered_interrupted_run = false;
+        let mut cold_recovery_executions = Vec::new();
+        let mut cold_recovered_execution_ids = HashSet::new();
         for saved_workspace in persisted.workspaces {
             validate_id("workspace", &saved_workspace.id)?;
             validate_persisted_name(&saved_workspace.name)?;
@@ -7079,13 +7409,26 @@ impl DaemonService {
                         let mut execution_state = lock(&execution.state)?;
                         if !execution_state.state.is_terminal() {
                             execution_state.state = ScheduledExecutionState::Interrupted;
+                            execution_state.revision =
+                                execution_state.revision.checked_add(1).ok_or_else(|| {
+                                    io::Error::other("scheduled execution revision exhausted")
+                                })?;
                             execution_state.ended_at_ms =
                                 Some(unix_time_ms().max(execution.requested_at_ms));
                             execution_state.reason =
                                 Some(ScheduledExecutionReason::ColdDaemonRecovery);
                             execution_state.outcome = None;
                             recovered_interrupted_run = true;
+                            cold_recovered_execution_ids.insert(execution.id.clone());
                         }
+                    }
+                    let mut executions = lock(&schedule.executions)?;
+                    prune_terminal_executions(&mut executions);
+                    for execution in executions
+                        .iter()
+                        .filter(|execution| cold_recovered_execution_ids.contains(&execution.id))
+                    {
+                        cold_recovery_executions.push(execution.snapshot()?);
                     }
                 }
                 workspace_schedule_ids.push(schedule.id.clone());
@@ -7220,6 +7563,7 @@ impl DaemonService {
             schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
             notification_sink: Arc::new(DisabledNotificationSink),
+            cold_recovery_executions,
             startup_environment: capture_current_environment(),
             scheduler: SchedulerWorker::default(),
             clock: Mutex::new(Arc::new(SystemSchedulerClock)),
@@ -7228,6 +7572,10 @@ impl DaemonService {
         };
         if recovered_interrupted_run {
             registry.persist()?;
+        } else {
+            registry.events.initialize_committed_executions(
+                registry.durable.scheduled_executions(None, None)?,
+            )?;
         }
         Ok(registry)
     }
@@ -7455,7 +7803,11 @@ impl DaemonService {
                         undo.rollback(&self.durable),
                     ));
                 }
-                let notifications = self.notification_requests(&kinds, &undo);
+                let notifications = self.notification_requests(
+                    &kinds,
+                    &undo,
+                    &transaction.events.committed_executions,
+                );
                 let saved = match self.capture_persisted_state() {
                     Ok(saved) => saved,
                     Err(error) => {
@@ -7471,8 +7823,9 @@ impl DaemonService {
                     .write_persisted_state(saved)
                     .map_err(DaemonError::persistence)
                 {
-                    Ok(()) => {
+                    Ok(committed) => {
                         let mut transaction = self.events.transaction()?;
+                        transaction.replace_committed_executions(committed);
                         transaction.append_batch(kinds);
                         transaction.finish_persistence();
                         drop(transaction);
@@ -7540,6 +7893,7 @@ impl DaemonService {
         &self,
         kinds: &[DaemonEventKind],
         undo: &DurableUndoLog,
+        committed_executions: &HashMap<String, ScheduledExecutionSnapshot>,
     ) -> Vec<NotificationRequest> {
         let mut seen = HashSet::new();
         let mut requests = Vec::new();
@@ -7591,7 +7945,7 @@ impl DaemonService {
                 _ => continue,
             };
             if !category_enabled(&self.notification_settings, reason)
-                || !seen.insert((agent.id.as_str(), agent.observation.revision, reason))
+                || !seen.insert((agent.id.clone(), agent.observation.revision, reason))
             {
                 continue;
             }
@@ -7603,7 +7957,98 @@ impl DaemonService {
                 shell,
             });
         }
+        requests.extend(self.execution_notification_requests(kinds, committed_executions));
         requests
+    }
+
+    fn execution_notification_requests(
+        &self,
+        kinds: &[DaemonEventKind],
+        committed_executions: &HashMap<String, ScheduledExecutionSnapshot>,
+    ) -> Vec<NotificationRequest> {
+        let mut seen = HashSet::new();
+        let mut published = HashMap::new();
+        let mut requests = Vec::new();
+        for kind in kinds {
+            let DaemonEventKind::ScheduledExecutionChanged {
+                workspace_id,
+                execution,
+            } = kind
+            else {
+                continue;
+            };
+            let previous = published
+                .get(&execution.id)
+                .or_else(|| committed_executions.get(&execution.id));
+            let reason = Self::execution_notification_reason(execution);
+            let transitioned = reason.is_some()
+                && previous
+                    .and_then(Self::execution_notification_reason)
+                    .is_none();
+            published.insert(execution.id.clone(), execution.clone());
+            let Some(reason) = reason.filter(|_| transitioned) else {
+                continue;
+            };
+            if !category_enabled(&self.notification_settings, reason)
+                || !seen.insert((execution.id.clone(), execution.revision, reason))
+            {
+                continue;
+            }
+            let (workspace, schedule) = self
+                .durable
+                .schedule_notification_context(workspace_id, &execution.schedule_id);
+            requests.push(NotificationRequest {
+                reason,
+                agent: schedule,
+                workspace,
+                shell: execution.id.clone(),
+            });
+        }
+        requests
+    }
+
+    fn execution_notification_reason(
+        execution: &ScheduledExecutionSnapshot,
+    ) -> Option<NotificationReason> {
+        match (execution.state, execution.reason) {
+            (
+                ScheduledExecutionState::DispatchFailed,
+                Some(
+                    ScheduledExecutionReason::RunnerStartFailed
+                    | ScheduledExecutionReason::HostSpawnFailed,
+                ),
+            ) => Some(NotificationReason::ScheduledDispatchFailed),
+            (
+                ScheduledExecutionState::Interrupted,
+                Some(ScheduledExecutionReason::ColdDaemonRecovery),
+            ) => Some(NotificationReason::ScheduledInterrupted),
+            _ => None,
+        }
+    }
+
+    fn publish_cold_recovery_notifications(&mut self) {
+        if !category_enabled(
+            &self.notification_settings,
+            NotificationReason::ScheduledInterrupted,
+        ) {
+            self.cold_recovery_executions.clear();
+            return;
+        }
+        let mut seen = HashSet::new();
+        for execution in self.cold_recovery_executions.drain(..) {
+            if !seen.insert((execution.id.clone(), execution.revision)) {
+                continue;
+            }
+            let (workspace, schedule) = self
+                .durable
+                .schedule_notification_context(&execution.workspace_id, &execution.schedule_id);
+            self.notification_sink.notify(NotificationRequest {
+                reason: NotificationReason::ScheduledInterrupted,
+                agent: schedule,
+                workspace,
+                shell: execution.id,
+            });
+        }
     }
 
     fn notification_context(&self, workspace_id: &str, shell_id: &str) -> (String, String) {
@@ -7622,26 +8067,37 @@ impl DaemonService {
         let count = transaction.pending_durable_event_count(pending_count);
         transaction.reserve_with_pending(0)?;
         let saved = self.capture_persisted_state()?;
+        let committed_before = transaction.events.committed_executions.clone();
         let pending = transaction.take_pending_durable(pending_count);
         transaction.begin_persistence(count);
         drop(transaction);
-        if let Err(error) = self
+        let committed = match self
             .write_persisted_state(saved)
             .map_err(DaemonError::persistence)
         {
-            let mut transaction = self.events.transaction()?;
-            transaction.restore_pending_durable(pending);
-            transaction.finish_persistence();
-            return Err(error);
-        }
+            Ok(committed) => committed,
+            Err(error) => {
+                let mut transaction = self.events.transaction()?;
+                transaction.restore_pending_durable(pending);
+                transaction.finish_persistence();
+                return Err(error);
+            }
+        };
+        let notification_events = pending.iter().flatten().cloned().collect::<Vec<_>>();
+        let notifications =
+            self.execution_notification_requests(&notification_events, &committed_before);
         let mut transaction = self.events.transaction()?;
         transaction.reserve_with_pending(0)?;
+        transaction.replace_committed_executions(committed);
         for batch in pending {
             transaction.append_batch(batch);
         }
         transaction.finish_persistence();
         drop(transaction);
         self.events.notify();
+        for notification in notifications {
+            self.notification_sink.notify(notification);
+        }
         Ok(count != 0)
     }
 
@@ -7774,15 +8230,21 @@ impl DaemonService {
     fn persist(&self) -> io::Result<()> {
         let _persist = lock(&self.durable.persist_lock)?;
         let saved = self.durable.capture_persisted_state()?;
-        self.durable.write_persisted_state(saved)
+        let executions = self.write_persisted_state(saved)?;
+        self.events.initialize_committed_executions(executions)
     }
 
     fn capture_persisted_state(&self) -> io::Result<PersistenceGeneration> {
         self.durable.capture_persisted_state()
     }
 
-    fn write_persisted_state(&self, generation: PersistenceGeneration) -> io::Result<()> {
-        self.durable.write_persisted_state(generation)
+    fn write_persisted_state(
+        &self,
+        generation: PersistenceGeneration,
+    ) -> io::Result<Vec<ScheduledExecutionSnapshot>> {
+        let executions = generation.executions.clone();
+        self.durable.write_persisted_state(generation)?;
+        Ok(executions)
     }
 
     #[cfg(test)]
@@ -7888,18 +8350,30 @@ impl DaemonService {
         let pending_count =
             transaction.pending_durable_event_count(transaction.pending_durable_batch_count());
         let event_count = pending_count.saturating_add(batch.len());
+        let mut notification_events = transaction.pending_durable_events();
+        notification_events.extend(batch.iter().cloned());
+        let notifications = self.execution_notification_requests(
+            &notification_events,
+            &transaction.events.committed_executions,
+        );
         let saved = self.capture_persisted_state()?;
         transaction.begin_persistence(event_count);
         drop(transaction);
         match self.write_persisted_state(saved) {
-            Ok(()) => {
+            Ok(committed) => {
                 let mut transaction = self.events.transaction()?;
+                transaction.replace_committed_executions(committed);
                 transaction.append_pending_durable();
                 transaction.append_batch(batch);
                 transaction.finish_persistence();
                 drop(transaction);
                 self.events.notify();
                 self.wake_scheduler();
+                drop(_persistence);
+                drop(_mutation);
+                for notification in notifications {
+                    self.notification_sink.notify(notification);
+                }
                 Ok(RunExitRecord::Recorded)
             }
             Err(error) => {
@@ -8079,7 +8553,7 @@ impl DaemonService {
         &self,
         stopping: bool,
         select_shells: impl FnOnce() -> DaemonResult<Vec<Arc<Shell>>>,
-        durable_apply: impl FnOnce() -> DaemonResult<Option<DurableUndo>>,
+        durable_apply: impl FnOnce(&mut DurableUndoLog) -> DaemonResult<()>,
         committed_events: impl FnOnce(&[Arc<Shell>]) -> Vec<DaemonEventKind>,
     ) -> DaemonResult<()> {
         let _mutation = lock(&self.mutation_lock)?;
@@ -8129,7 +8603,7 @@ impl DaemonService {
                 }
                 let mut transaction = self.events.transaction()?;
                 let compensation = self.compensate_stopped_locked(&stopped, &mut transaction);
-                transaction.finish_lifecycle_reservation();
+                transaction.release_lifecycle_reservation();
                 if stopping {
                     self.runtimes.cancel_stopping();
                 }
@@ -8140,7 +8614,7 @@ impl DaemonService {
         if let Err(error) = self.flush_pending() {
             let mut transaction = self.events.transaction()?;
             let compensation = self.compensate_stopped_locked(&stopped, &mut transaction);
-            transaction.finish_lifecycle_reservation();
+            transaction.release_lifecycle_reservation();
             if stopping {
                 self.runtimes.cancel_stopping();
             }
@@ -8151,7 +8625,7 @@ impl DaemonService {
             Err(error) => {
                 let mut transaction = self.events.transaction()?;
                 let compensation = self.compensate_stopped_locked(&stopped, &mut transaction);
-                transaction.finish_lifecycle_reservation();
+                transaction.release_lifecycle_reservation();
                 if stopping {
                     self.runtimes.cancel_stopping();
                 }
@@ -8175,63 +8649,68 @@ impl DaemonService {
                     if stopping {
                         self.runtimes.cancel_stopping();
                     }
-                    transaction.finish_lifecycle_reservation();
+                    transaction.release_lifecycle_reservation();
                     return Err(Self::lifecycle_failure(error.into(), compensation));
                 }
             }
         }
-        let undo = match durable_apply() {
-            Ok(undo) => undo,
-            Err(error) => {
-                let compensation = self.restore_finalized_locked(rollbacks, &mut transaction);
-                if stopping {
-                    self.runtimes.cancel_stopping();
-                }
-                transaction.finish_lifecycle_reservation();
-                return Err(Self::lifecycle_failure(error, compensation));
+        let mut undo = DurableUndoLog::default();
+        if let Err(error) = durable_apply(&mut undo) {
+            let durable = undo.rollback(&self.durable);
+            let compensation = self.restore_finalized_locked(rollbacks, &mut transaction);
+            if stopping {
+                self.runtimes.cancel_stopping();
             }
-        };
+            transaction.release_lifecycle_reservation();
+            return Err(Self::lifecycle_failure(
+                Self::lifecycle_failure(error, durable),
+                compensation,
+            ));
+        }
         let saved = match self.capture_persisted_state() {
             Ok(saved) => saved,
             Err(error) => {
-                let durable = undo.map_or(Ok(()), |undo| self.durable.rollback(undo));
+                let durable = undo.rollback(&self.durable);
                 let runtime = self.restore_finalized_locked(rollbacks, &mut transaction);
                 if stopping {
                     self.runtimes.cancel_stopping();
                 }
-                transaction.finish_lifecycle_reservation();
+                transaction.release_lifecycle_reservation();
                 return Err(Self::lifecycle_failure(
                     Self::lifecycle_failure(error.into(), durable),
                     runtime,
                 ));
             }
         };
-        transaction.finish_lifecycle_reservation();
-        transaction.begin_lifecycle_reservation(
+        transaction.transfer_lifecycle_reservation_to_persistence(
+            committed_events.len(),
             lifecycle_event_capacity.saturating_sub(committed_events.len()),
         );
-        transaction.begin_persistence(committed_events.len());
         drop(transaction);
-        if let Err(error) = self
+        let committed = match self
             .write_persisted_state(saved)
             .map_err(DaemonError::persistence)
         {
-            let mut transaction = self.events.transaction()?;
-            let durable = undo.map_or(Ok(()), |undo| self.durable.rollback(undo));
-            let runtime = self.restore_finalized_locked(rollbacks, &mut transaction);
-            transaction.finish_lifecycle_reservation();
-            transaction.finish_persistence();
-            if stopping {
-                self.runtimes.cancel_stopping();
+            Ok(committed) => committed,
+            Err(error) => {
+                let mut transaction = self.events.transaction()?;
+                let durable = undo.rollback(&self.durable);
+                let runtime = self.restore_finalized_locked(rollbacks, &mut transaction);
+                transaction.release_lifecycle_reservation();
+                transaction.finish_persistence();
+                if stopping {
+                    self.runtimes.cancel_stopping();
+                }
+                return Err(Self::lifecycle_failure(
+                    Self::lifecycle_failure(error, durable),
+                    runtime,
+                ));
             }
-            return Err(Self::lifecycle_failure(
-                Self::lifecycle_failure(error, durable),
-                runtime,
-            ));
-        }
+        };
         let mut transaction = self.events.transaction()?;
+        transaction.replace_committed_executions(committed);
         transaction.append_batch(committed_events);
-        transaction.finish_lifecycle_reservation();
+        transaction.release_lifecycle_reservation();
         transaction.finish_persistence();
         drop(transaction);
         self.events.notify();
@@ -8242,22 +8721,23 @@ impl DaemonService {
         self.lifecycle_transaction(
             true,
             || Ok(self.durable.shells()?),
-            || {
+            |undo| {
                 let executions = self.durable.scheduled_executions(None, None)?;
                 for snapshot in executions {
                     if snapshot.state.is_terminal() {
                         continue;
                     }
                     let execution = self.durable.execution(&snapshot.id)?;
-                    self.durable.mutate_execution(&execution, |state| {
+                    let (_, record) = self.durable.mutate_execution(&execution, |state| {
                         state.state = ScheduledExecutionState::Cancelled;
                         state.ended_at_ms = Some(unix_time_ms().max(execution.requested_at_ms));
                         state.reason = Some(ScheduledExecutionReason::DaemonShutdown);
                         state.outcome = None;
                         Ok(())
                     })?;
+                    undo.record(record);
                 }
-                Ok(None)
+                Ok(())
             },
             |_| Vec::new(),
         )
@@ -8702,6 +9182,18 @@ impl DaemonService {
         )
     }
 
+    fn wait_scheduled_execution(
+        &self,
+        execution_id: &str,
+        after_revision: u64,
+        wait_ms: u32,
+    ) -> DaemonResult<Response> {
+        self.events
+            .wait_for_scheduled_execution(execution_id, after_revision, wait_ms, || {
+                self.runtimes.is_stopping()
+            })
+    }
+
     fn read_shell_at(
         &self,
         shell_id: &str,
@@ -8808,7 +9300,10 @@ impl DaemonService {
         self.lifecycle_transaction(
             false,
             || Ok(vec![self.shell(shell_id)?]),
-            || Ok(Some(self.remove_shell_mutation(shell_id)?)),
+            |undo| {
+                undo.record(self.remove_shell_mutation(shell_id)?);
+                Ok(())
+            },
             |shells| {
                 vec![DaemonEventKind::ShellClosed {
                     workspace_id: shells.first().map(|shell| shell.workspace_id.clone()),
@@ -8825,7 +9320,10 @@ impl DaemonService {
                 let workspace = self.workspace(workspace_id)?;
                 Ok(self.durable.workspace_shells(&workspace)?)
             },
-            || Ok(Some(self.remove_workspace_mutation(workspace_id)?)),
+            |undo| {
+                undo.record(self.remove_workspace_mutation(workspace_id)?);
+                Ok(())
+            },
             |_| {
                 vec![DaemonEventKind::WorkspaceClosed {
                     workspace_id: workspace_id.into(),
@@ -9074,6 +9572,7 @@ impl ScheduledExecution {
             prompt: saved.prompt,
             runner_token: saved.runner_token,
             state: Mutex::new(ScheduledExecutionMutableState {
+                revision: saved.revision,
                 state: saved.state,
                 started_at_ms: saved.started_at_ms,
                 ended_at_ms: saved.ended_at_ms,
@@ -9097,6 +9596,7 @@ impl ScheduledExecution {
             id: self.id.clone(),
             workspace_id: self.workspace_id.clone(),
             schedule_id: self.schedule_id.clone(),
+            revision: state.revision,
             state: state.state,
             dispatch_kind: self.dispatch_kind,
             dispatch_key: self.dispatch_key.clone(),
@@ -9124,6 +9624,7 @@ impl ScheduledExecution {
         let state = lock(&self.state)?;
         Ok(PersistedScheduledExecution {
             id: self.id.clone(),
+            revision: state.revision,
             state: state.state,
             dispatch_kind: self.dispatch_kind,
             dispatch_key: self.dispatch_key.clone(),
@@ -9961,6 +10462,7 @@ impl ShellRuntimeManager {
                 }
             }
         };
+        let mut committed_executions = None;
         if started {
             let saved = registry.capture_persisted_state()?;
             event_transaction
@@ -9968,25 +10470,28 @@ impl ShellRuntimeManager {
                 .expect("start event transaction is locked")
                 .begin_persistence(1);
             drop(event_transaction);
-            if let Err(error) = registry.write_persisted_state(saved) {
-                let cleanup = self.kill(&shell);
-                self.reset_pending(&shell)?;
-                let mut transaction = registry.events.transaction()?;
-                transaction.finish_persistence();
-                let message = cleanup.map_or_else(
-                    |cleanup| {
-                        format!(
-                            "could not persist started shell: {error}; process cleanup also failed: {cleanup}"
-                        )
-                    },
-                    |()| format!("could not persist started shell: {error}"),
-                );
-                return send_daemon_error(
-                    &mut stream,
-                    response_version,
-                    DaemonError::persistence_context(error, message),
-                );
-            }
+            committed_executions = Some(match registry.write_persisted_state(saved) {
+                Ok(committed) => committed,
+                Err(error) => {
+                    let cleanup = self.kill(&shell);
+                    self.reset_pending(&shell)?;
+                    let mut transaction = registry.events.transaction()?;
+                    transaction.finish_persistence();
+                    let message = cleanup.map_or_else(
+                        |cleanup| {
+                            format!(
+                                "could not persist started shell: {error}; process cleanup also failed: {cleanup}"
+                            )
+                        },
+                        |()| format!("could not persist started shell: {error}"),
+                    );
+                    return send_daemon_error(
+                        &mut stream,
+                        response_version,
+                        DaemonError::persistence_context(error, message),
+                    );
+                }
+            });
             event_transaction = Some(registry.events.transaction()?);
         }
         if started {
@@ -9997,6 +10502,9 @@ impl ShellRuntimeManager {
             let transaction = event_transaction
                 .as_mut()
                 .expect("start event transaction is locked");
+            transaction.replace_committed_executions(
+                committed_executions.expect("persisted shell start has committed executions"),
+            );
             transaction.append_batch(vec![DaemonEventKind::RunStarted {
                 workspace_id: shell.workspace_id.clone(),
                 shell_id: shell.id.clone(),
@@ -10677,6 +11185,7 @@ fn validate_persisted_schedule(schedule: &PersistedAgentSchedule) -> io::Result<
             || execution.trigger_revision == 0
             || execution.prompt_revision > execution.schedule_revision
             || execution.trigger_revision > execution.schedule_revision
+            || execution.revision == 0
             || execution.schedule_revision > schedule.revision
             || execution.prompt_revision > schedule.prompt_revision
             || execution.trigger_revision > schedule.trigger_revision
@@ -10930,17 +11439,23 @@ fn prune_terminal_executions(executions: &mut Vec<Arc<ScheduledExecution>>) {
             lock(&candidate.state)
                 .ok()
                 .filter(|state| state.state.is_terminal())
-                .map(|_| (index, candidate.requested_at_ms))
+                .map(|_| (index, candidate.requested_at_ms, candidate.id.as_str()))
         })
         .collect::<Vec<_>>();
-    terminal.sort_by_key(|(_, requested)| *requested);
+    terminal.sort_by(
+        |(_, left_requested, left_id), (_, right_requested, right_id)| {
+            left_requested
+                .cmp(right_requested)
+                .then_with(|| left_id.cmp(right_id))
+        },
+    );
     let remove = terminal
         .len()
         .saturating_sub(MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE);
     let mut remove = terminal
         .into_iter()
         .take(remove)
-        .map(|(index, _)| index)
+        .map(|(index, _, _)| index)
         .collect::<Vec<_>>();
     remove.sort_unstable_by(|left, right| right.cmp(left));
     for index in remove {
@@ -11727,6 +12242,7 @@ mod tests {
                     id: Uuid::new_v4().to_string(),
                     workspace_id: workspace_id.clone(),
                     schedule_id: Uuid::new_v4().to_string(),
+                    revision: 1,
                     state: ScheduledExecutionState::Starting,
                     dispatch_kind: ScheduledExecutionDispatchKind::Manual,
                     dispatch_key: Uuid::new_v4().to_string(),
@@ -12041,12 +12557,13 @@ mod tests {
     }
 
     #[test]
-    fn state_eleven_execution_validation_enforces_exact_state_shapes_and_revisions() {
+    fn state_twelve_execution_validation_enforces_exact_state_shapes_and_revisions() {
         let dispatch_key = Uuid::new_v4().to_string();
         let mut filter = vec![0; DISPATCH_KEY_FILTER_BYTES];
         remember_dispatch_key(&mut filter, &dispatch_key);
         let execution = PersistedScheduledExecution {
             id: Uuid::new_v4().to_string(),
+            revision: 1,
             state: ScheduledExecutionState::Claimed,
             dispatch_kind: ScheduledExecutionDispatchKind::Manual,
             dispatch_key,
@@ -12096,6 +12613,10 @@ mod tests {
         };
         assert!(validate_persisted_schedule(&schedule).is_ok());
 
+        schedule.executions[0].revision = 0;
+        assert!(validate_persisted_schedule(&schedule).is_err());
+        schedule.executions[0].revision = 1;
+
         schedule.executions[0].started_at_ms = Some(10);
         assert!(validate_persisted_schedule(&schedule).is_err());
         schedule.executions[0].started_at_ms = None;
@@ -12111,7 +12632,7 @@ mod tests {
     }
 
     #[test]
-    fn state_eleven_validates_timed_matrix_frontier_and_chrono_bounds() {
+    fn state_twelve_validates_timed_matrix_frontier_and_chrono_bounds() {
         let scheduled_at_ms = 60_000;
         let dispatch_key =
             timed_dispatch_key("00000000-0000-0000-0000-000000000001", 1, scheduled_at_ms);
@@ -12119,6 +12640,7 @@ mod tests {
         remember_dispatch_key(&mut filter, &dispatch_key);
         let execution = PersistedScheduledExecution {
             id: timed_execution_id("00000000-0000-0000-0000-000000000001", 1, scheduled_at_ms),
+            revision: 1,
             state: ScheduledExecutionState::Skipped,
             dispatch_kind: ScheduledExecutionDispatchKind::Timed,
             dispatch_key,
@@ -12262,6 +12784,7 @@ mod tests {
             dispatch_key_filter: filter,
             executions: vec![PersistedScheduledExecution {
                 id: Uuid::new_v4().to_string(),
+                revision: 1,
                 state: ScheduledExecutionState::Active,
                 dispatch_kind: ScheduledExecutionDispatchKind::Manual,
                 dispatch_key,
@@ -12714,6 +13237,7 @@ mod tests {
             .create_schedule(&workspace.id, schedule_spec("private"))
             .unwrap();
         let first_key = Uuid::from_u128(1).to_string();
+        let mut keys = Vec::new();
 
         for value in 1..=MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE + 1 {
             let key = Uuid::from_u128(value as u128).to_string();
@@ -12722,6 +13246,7 @@ mod tests {
                 .claim_schedule_execution(&schedule.id, &key)
                 .unwrap();
             let execution = registry.durable.execution(&snapshot.id).unwrap();
+            keys.push((key, snapshot.id));
             registry
                 .durable
                 .mutate_execution(&execution, |state| {
@@ -12733,14 +13258,577 @@ mod tests {
                 .unwrap();
         }
 
+        let pruned_key = keys
+            .iter()
+            .find(|(_, execution_id)| registry.durable.execution(execution_id).is_err())
+            .map(|(key, _)| key)
+            .unwrap_or(&first_key);
         let error = match registry
             .durable
-            .claim_schedule_execution(&schedule.id, &first_key)
+            .claim_schedule_execution(&schedule.id, pruned_key)
         {
             Err(error) => error,
             Ok(_) => panic!("pruned dispatch key was accepted"),
         };
         assert_eq!(error.wire_code(), ErrorCode::IdempotencyExpired);
+    }
+
+    #[test]
+    fn execution_wait_and_bounded_list_are_revision_exact() {
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace("observed".into(), Vec::new())
+            .unwrap();
+        let (schedule, _) = registry
+            .durable
+            .create_schedule(&workspace.id, schedule_spec("private"))
+            .unwrap();
+        let (claimed, _) = registry
+            .durable
+            .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+            .unwrap();
+        registry
+            .events
+            .initialize_committed_executions(
+                registry.durable.scheduled_executions(None, None).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(claimed.revision, 1);
+
+        let Response::ScheduledExecutionWait { changed, execution } = registry
+            .wait_scheduled_execution(&claimed.id, 0, 0)
+            .unwrap()
+        else {
+            panic!("expected execution wait response");
+        };
+        assert!(changed);
+        assert_eq!(execution.revision, 1);
+        let Response::ScheduledExecutionWait { changed, .. } = registry
+            .wait_scheduled_execution(&claimed.id, 1, 0)
+            .unwrap()
+        else {
+            panic!("expected execution wait timeout");
+        };
+        assert!(!changed);
+        assert_eq!(
+            registry
+                .wait_scheduled_execution(&claimed.id, 2, 0)
+                .unwrap_err()
+                .wire_code(),
+            ErrorCode::RevisionAhead
+        );
+
+        let execution = registry.durable.execution(&claimed.id).unwrap();
+        registry
+            .durable
+            .mutate_execution(&execution, |state| {
+                state.state = ScheduledExecutionState::DispatchFailed;
+                state.ended_at_ms = Some(execution.requested_at_ms);
+                state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                Ok(())
+            })
+            .unwrap();
+        let (second, _) = registry
+            .durable
+            .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+            .unwrap();
+        let second_execution = registry.durable.execution(&second.id).unwrap();
+        registry
+            .durable
+            .mutate_execution(&second_execution, |state| {
+                state.state = ScheduledExecutionState::DispatchFailed;
+                state.ended_at_ms = Some(second_execution.requested_at_ms);
+                state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                Ok(())
+            })
+            .unwrap();
+        let (page, limit, truncated) = registry
+            .durable
+            .scheduled_execution_page(None, None, 1)
+            .unwrap();
+        assert_eq!(limit, 1);
+        assert!(truncated);
+        assert_eq!(page[0].revision, 2);
+        let expected_newest = if (second.requested_at_ms, second.id.as_str())
+            > (claimed.requested_at_ms, claimed.id.as_str())
+        {
+            second.id
+        } else {
+            claimed.id
+        };
+        assert_eq!(page[0].id, expected_newest);
+    }
+
+    #[test]
+    fn execution_wait_never_observes_in_flight_or_rolled_back_revision() {
+        let directory = env::temp_dir().join(format!("boomux-execution-wait-{}", Uuid::new_v4()));
+        let gate = Arc::new((Mutex::new((false, false, false)), Condvar::new()));
+        let hook_gate = Arc::clone(&gate);
+        let store = StateStore::at_with_save_hook(
+            directory.join("state/state.json"),
+            Arc::new(move || {
+                let (state, changed) = &*hook_gate;
+                let mut state = state.lock().unwrap();
+                if !state.0 {
+                    return;
+                }
+                state.1 = true;
+                changed.notify_all();
+                while !state.2 {
+                    state = changed.wait(state).unwrap();
+                }
+            }),
+        );
+        let registry = Arc::new(DaemonService::restore(store, false, None).unwrap());
+        let workspace = registry
+            .create_workspace("wait-commit".into(), Vec::new())
+            .unwrap();
+        let (schedule, _) = registry
+            .durable
+            .create_schedule(&workspace.id, schedule_spec("private"))
+            .unwrap();
+        let (claimed, _) = registry
+            .durable
+            .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+            .unwrap();
+        registry
+            .events
+            .initialize_committed_executions(
+                registry.durable.scheduled_executions(None, None).unwrap(),
+            )
+            .unwrap();
+        let execution = registry.durable.execution(&claimed.id).unwrap();
+        {
+            let (state, _) = &*gate;
+            state.lock().unwrap().0 = true;
+        }
+        let changing_registry = Arc::clone(&registry);
+        let changing_execution = Arc::clone(&execution);
+        let mutation = thread::spawn(move || {
+            changing_registry.change_execution(&changing_execution, |state| {
+                state.state = ScheduledExecutionState::DispatchFailed;
+                state.ended_at_ms = Some(changing_execution.requested_at_ms);
+                state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                Ok(())
+            })
+        });
+        {
+            let (state, changed) = &*gate;
+            let mut state = state.lock().unwrap();
+            while !state.1 {
+                state = changed.wait(state).unwrap();
+            }
+        }
+        let (waited_tx, waited_rx) = mpsc::sync_channel(1);
+        let waiting_registry = Arc::clone(&registry);
+        let execution_id = claimed.id.clone();
+        let waiter = thread::spawn(move || {
+            let result = waiting_registry.wait_scheduled_execution(&execution_id, 1, 25);
+            waited_tx.send(result).unwrap();
+        });
+        let Response::ScheduledExecutionWait { execution, changed } = waited_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .unwrap()
+        else {
+            panic!("expected in-flight execution wait deadline");
+        };
+        assert!(!changed);
+        assert_eq!(execution.revision, 1);
+        waiter.join().unwrap();
+        {
+            let (state, changed) = &*gate;
+            let mut state = state.lock().unwrap();
+            state.2 = true;
+            changed.notify_all();
+        }
+        mutation.join().unwrap().unwrap();
+        let Response::ScheduledExecutionWait { execution, changed } = registry
+            .wait_scheduled_execution(&claimed.id, 1, 1_000)
+            .unwrap()
+        else {
+            panic!("expected committed execution wait");
+        };
+        assert!(changed);
+        assert_eq!(execution.revision, 2);
+
+        let (second, _) = registry
+            .durable
+            .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+            .unwrap();
+        let second_execution = registry.durable.execution(&second.id).unwrap();
+        registry
+            .events
+            .initialize_committed_executions(
+                registry.durable.scheduled_executions(None, None).unwrap(),
+            )
+            .unwrap();
+        registry.fail_next_persistence();
+        assert!(
+            registry
+                .change_execution(&second_execution, |state| {
+                    state.state = ScheduledExecutionState::DispatchFailed;
+                    state.ended_at_ms = Some(second_execution.requested_at_ms);
+                    state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                    Ok(())
+                })
+                .is_err()
+        );
+        let Response::ScheduledExecutionWait { execution, changed } =
+            registry.wait_scheduled_execution(&second.id, 1, 0).unwrap()
+        else {
+            panic!("expected rolled-back execution wait");
+        };
+        assert!(!changed);
+        assert_eq!(execution.revision, 1);
+
+        registry.fail_next_persistence();
+        assert!(
+            registry
+                .terminalize_dispatch_failure(&second_execution)
+                .is_err()
+        );
+        let Response::ScheduledExecutionWait { execution, changed } = registry
+            .wait_scheduled_execution(&second.id, 1, 25)
+            .unwrap()
+        else {
+            panic!("expected pending-storage execution wait deadline");
+        };
+        assert!(!changed);
+        assert_eq!(execution.revision, 1);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn lifecycle_reservation_hides_cancellation_revision_until_commit_or_rollback() {
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace("cancel-frontier".into(), Vec::new())
+            .unwrap();
+        let (schedule, _) = registry
+            .durable
+            .create_schedule(&workspace.id, schedule_spec("private"))
+            .unwrap();
+        let (claimed, _) = registry
+            .durable
+            .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+            .unwrap();
+        registry
+            .events
+            .initialize_committed_executions(
+                registry.durable.scheduled_executions(None, None).unwrap(),
+            )
+            .unwrap();
+        let mut transaction = registry.events.transaction().unwrap();
+        transaction.begin_lifecycle_reservation(1);
+        drop(transaction);
+        let execution = registry.durable.execution(&claimed.id).unwrap();
+        let (_, undo) = registry
+            .durable
+            .mutate_execution(&execution, |state| {
+                state.state = ScheduledExecutionState::Cancelled;
+                state.ended_at_ms = Some(execution.requested_at_ms);
+                state.reason = Some(ScheduledExecutionReason::CancelledByUser);
+                Ok(())
+            })
+            .unwrap();
+        let Response::ScheduledExecutionWait { execution, changed } = registry
+            .wait_scheduled_execution(&claimed.id, 1, 0)
+            .unwrap()
+        else {
+            panic!("expected committed cancellation frontier");
+        };
+        assert!(!changed);
+        assert_eq!(execution.state, ScheduledExecutionState::Claimed);
+        registry.durable.rollback(undo).unwrap();
+        let mut transaction = registry.events.transaction().unwrap();
+        transaction.release_lifecycle_reservation();
+        drop(transaction);
+        let restored = registry
+            .durable
+            .execution(&claimed.id)
+            .unwrap()
+            .snapshot()
+            .unwrap();
+        assert_eq!(restored.revision, 1);
+        assert_eq!(restored.state, ScheduledExecutionState::Claimed);
+    }
+
+    #[test]
+    fn protocol_twenty_three_and_twenty_four_lists_remain_uncapped_before_filtering() {
+        let registry = Arc::new(DaemonService::default());
+        let workspace = registry
+            .create_workspace("mixed-list".into(), Vec::new())
+            .unwrap();
+        for schedule_index in 0..2 {
+            let mut spec = schedule_spec("private");
+            spec.name = format!("schedule-{schedule_index}");
+            let (schedule, _) = registry
+                .durable
+                .create_schedule(&workspace.id, spec)
+                .unwrap();
+            for index in 0..60 {
+                let (claimed, _) = registry
+                    .durable
+                    .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+                    .unwrap();
+                let execution = registry.durable.execution(&claimed.id).unwrap();
+                registry
+                    .durable
+                    .mutate_execution(&execution, |state| {
+                        state.state = ScheduledExecutionState::DispatchFailed;
+                        state.ended_at_ms = Some(execution.requested_at_ms);
+                        state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                        Ok(())
+                    })
+                    .unwrap();
+                if index < 10 {
+                    registry
+                        .durable
+                        .decide_schedule_execution(
+                            &schedule.id,
+                            ScheduleDecision {
+                                dispatch_kind: ScheduledExecutionDispatchKind::Timed,
+                                dispatch_key: Uuid::new_v4().to_string(),
+                                scheduled_at_ms: Some(index + 1),
+                                coalesced_through_ms: Some(index + 1),
+                                requested_at_ms: index + 1,
+                                forced_skip: Some(ScheduledExecutionReason::Missed),
+                            },
+                            4,
+                        )
+                        .unwrap();
+                }
+            }
+        }
+        let mut empty_spec = schedule_spec("private");
+        empty_spec.name = "schedule-without-history".into();
+        registry
+            .durable
+            .create_schedule(&workspace.id, empty_spec)
+            .unwrap();
+        for (version, supplied_limit, expected) in
+            [(23, None, 120), (23, Some(1), 120), (24, None, 140)]
+        {
+            let Response::ScheduledExecutions {
+                executions,
+                limit,
+                truncated,
+                schedules,
+                ..
+            } = registry
+                .dispatch_arc(
+                    Request::ListScheduledExecutions {
+                        workspace_id: None,
+                        schedule_id: None,
+                        limit: supplied_limit,
+                    },
+                    version,
+                )
+                .unwrap()
+            else {
+                panic!("expected execution list");
+            };
+            assert_eq!(executions.len(), expected);
+            assert_eq!(limit, 0);
+            assert!(!truncated);
+            assert!(schedules.is_empty());
+        }
+        let Response::ScheduledExecutions {
+            executions,
+            limit,
+            truncated,
+            schedules,
+            schedule_limit,
+            schedules_truncated,
+        } = registry
+            .dispatch_arc(
+                Request::ListScheduledExecutions {
+                    workspace_id: None,
+                    schedule_id: None,
+                    limit: Some(1),
+                },
+                25,
+            )
+            .unwrap()
+        else {
+            panic!("expected bounded execution list");
+        };
+        assert_eq!(executions.len(), 1);
+        assert_eq!(limit, 1);
+        assert!(truncated);
+        assert_eq!(schedules.len(), 3);
+        assert!(
+            schedules
+                .iter()
+                .any(|projection| projection.schedule_id != executions[0].schedule_id)
+        );
+        assert_eq!(schedule_limit, 100);
+        assert!(!schedules_truncated);
+    }
+
+    #[test]
+    fn execution_list_bounds_complete_selected_schedule_projection_scope() {
+        let registry = Arc::new(DaemonService::default());
+        let workspace = registry
+            .create_workspace("projection-bound".into(), Vec::new())
+            .unwrap();
+        let second_workspace = registry
+            .create_workspace("projection-bound-second".into(), Vec::new())
+            .unwrap();
+        for index in 0..=protocol::MAX_SCHEDULED_EXECUTION_SCHEDULE_PROJECTIONS {
+            let mut spec = schedule_spec("private");
+            spec.name = format!("schedule-{index:03}");
+            let workspace_id = if index < 64 {
+                &workspace.id
+            } else {
+                &second_workspace.id
+            };
+            registry
+                .durable
+                .create_schedule(workspace_id, spec)
+                .unwrap();
+        }
+        let Response::ScheduledExecutions {
+            executions,
+            schedules,
+            schedule_limit,
+            schedules_truncated,
+            ..
+        } = registry
+            .dispatch_arc(
+                Request::ListScheduledExecutions {
+                    workspace_id: None,
+                    schedule_id: None,
+                    limit: Some(1),
+                },
+                protocol::PROTOCOL_VERSION,
+            )
+            .unwrap()
+        else {
+            panic!("expected bounded schedule projections");
+        };
+        assert!(executions.is_empty());
+        assert_eq!(schedule_limit, 100);
+        assert_eq!(schedules.len(), 100);
+        assert!(schedules_truncated);
+        assert!(
+            schedules
+                .windows(2)
+                .all(|pair| pair[0].schedule_id < pair[1].schedule_id)
+        );
+    }
+
+    #[test]
+    fn pending_runner_start_failure_notifies_once_after_recovery_commit() {
+        let directory = env::temp_dir().join(format!("boomux-pending-notify-{}", Uuid::new_v4()));
+        let sink = Arc::new(RecordingNotificationSink::default());
+        let mut registry = DaemonService::restore(
+            StateStore::at(directory.join("state/state.json")),
+            false,
+            None,
+        )
+        .unwrap();
+        registry.notification_settings.desktop = NotificationSettings {
+            enabled: true,
+            scheduled_dispatch_failed: true,
+            ..Default::default()
+        };
+        registry.notification_sink = sink.clone();
+        let workspace = registry
+            .create_workspace("runner-failure".into(), Vec::new())
+            .unwrap();
+        let (schedule, _) = registry
+            .durable
+            .create_schedule(&workspace.id, schedule_spec("PRIVATE RUNNER PROMPT"))
+            .unwrap();
+        let (claimed, _) = registry
+            .durable
+            .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+            .unwrap();
+        let execution = registry.durable.execution(&claimed.id).unwrap();
+        registry.fail_next_persistence();
+        assert!(registry.terminalize_dispatch_failure(&execution).is_err());
+        assert!(sink.requests.lock().unwrap().is_empty());
+        assert!(registry.flush_pending().unwrap());
+        let failed = execution.snapshot().unwrap();
+        assert_eq!(
+            failed.reason,
+            Some(ScheduledExecutionReason::RunnerStartFailed)
+        );
+        assert_eq!(failed.revision, 2);
+        assert_eq!(
+            registry.terminalize_dispatch_failure(&execution).unwrap(),
+            failed
+        );
+        let linked = registry
+            .change_execution(&execution, |state| {
+                state.agent_id = Some("late-exact-agent".into());
+                state.external_session_id = Some("late-exact-session".into());
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(linked.revision, 3);
+        assert_eq!(linked.agent_id.as_deref(), Some("late-exact-agent"));
+        let requests = sink.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].reason,
+            NotificationReason::ScheduledDispatchFailed
+        );
+        assert_eq!(requests[0].shell, failed.id);
+        assert!(!format!("{:?}", requests[0]).contains("PRIVATE RUNNER PROMPT"));
+        drop(requests);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn cold_interruption_notification_does_not_repeat_for_late_agent_link() {
+        let (registry, sink) = notification_registry(NotificationSettings {
+            enabled: true,
+            scheduled_interrupted: true,
+            ..Default::default()
+        });
+        let workspace = registry
+            .create_workspace("late-cold-link".into(), Vec::new())
+            .unwrap();
+        let (schedule, _) = registry
+            .durable
+            .create_schedule(&workspace.id, schedule_spec("private"))
+            .unwrap();
+        let (claimed, _) = registry
+            .durable
+            .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+            .unwrap();
+        registry
+            .events
+            .initialize_committed_executions(
+                registry.durable.scheduled_executions(None, None).unwrap(),
+            )
+            .unwrap();
+        let execution = registry.durable.execution(&claimed.id).unwrap();
+        let interrupted = registry
+            .change_execution(&execution, |state| {
+                state.state = ScheduledExecutionState::Interrupted;
+                state.ended_at_ms = Some(execution.requested_at_ms);
+                state.reason = Some(ScheduledExecutionReason::ColdDaemonRecovery);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(interrupted.revision, 2);
+        assert_eq!(sink.requests.lock().unwrap().len(), 1);
+
+        let linked = registry
+            .change_execution(&execution, |state| {
+                state.agent_id = Some("late-cold-agent".into());
+                state.external_session_id = Some("late-cold-session".into());
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(linked.revision, 3);
+        let requests = sink.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].reason, NotificationReason::ScheduledInterrupted);
     }
 
     #[test]
@@ -13345,6 +14433,35 @@ mod tests {
         )
         .unwrap();
         let (workspace, shell, _runtime) = running_shell(&registry);
+        let (schedule, _) = registry
+            .durable
+            .create_schedule(&workspace.id, schedule_spec("private"))
+            .unwrap();
+        for _ in 0..MAX_TERMINAL_EXECUTIONS_PER_SCHEDULE {
+            let (snapshot, _) = registry
+                .durable
+                .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+                .unwrap();
+            let execution = registry.durable.execution(&snapshot.id).unwrap();
+            registry
+                .durable
+                .mutate_execution(&execution, |state| {
+                    state.state = ScheduledExecutionState::DispatchFailed;
+                    state.ended_at_ms = Some(execution.requested_at_ms);
+                    state.reason = Some(ScheduledExecutionReason::RunnerStartFailed);
+                    Ok(())
+                })
+                .unwrap();
+        }
+        let (active, _) = registry
+            .durable
+            .claim_schedule_execution(&schedule.id, &Uuid::new_v4().to_string())
+            .unwrap();
+        let executions_before = registry
+            .durable
+            .scheduled_executions(None, Some(&schedule.id))
+            .unwrap();
+        assert_eq!(executions_before.len(), 101);
         registry.fail_next_persistence();
 
         assert!(registry.shutdown().is_err());
@@ -13352,6 +14469,23 @@ mod tests {
         assert!(!registry.runtimes.is_stopping());
         assert!(registry.workspace(&workspace.id).is_ok());
         assert_eq!(shell.snapshot().unwrap().status, ShellStatus::Pending);
+        assert_eq!(
+            registry
+                .durable
+                .scheduled_executions(None, Some(&schedule.id))
+                .unwrap(),
+            executions_before
+        );
+        let restored_active = registry
+            .durable
+            .execution(&active.id)
+            .unwrap()
+            .snapshot()
+            .unwrap();
+        assert_eq!(restored_active.revision, 1);
+        assert_eq!(restored_active.state, ScheduledExecutionState::Claimed);
+        assert_eq!(restored_active.reason, None);
+        assert_eq!(restored_active.outcome, None);
         let transitions = lock(&registry.events.transitions).unwrap();
         assert_eq!(transitions.lifecycle_event_reservation, 0);
         assert_eq!(transitions.pending_durable_events.len(), 1);
@@ -13467,7 +14601,7 @@ mod tests {
         .unwrap();
 
         let mut transaction = registry.events.transaction().unwrap();
-        transaction.finish_lifecycle_reservation();
+        transaction.release_lifecycle_reservation();
         drop(transaction);
         registry.events.notify();
 
@@ -13548,7 +14682,7 @@ mod tests {
         .unwrap();
         let _rollback = registry.runtimes.finalize_stop(&target).unwrap();
         let mut transaction = registry.events.transaction().unwrap();
-        transaction.finish_lifecycle_reservation();
+        transaction.release_lifecycle_reservation();
         drop(transaction);
         registry.events.notify();
         thread::sleep(Duration::from_millis(20));
@@ -14451,6 +15585,7 @@ mod tests {
             enabled: true,
             blocked: true,
             completed: true,
+            ..Default::default()
         });
         let (workspace, shell, _runtime) = running_shell(&registry);
         let run_id = shell.snapshot().unwrap().run.unwrap().id;
@@ -14567,6 +15702,7 @@ mod tests {
             enabled: true,
             blocked: true,
             completed: true,
+            ..Default::default()
         });
         let (workspace, shell, _runtime) = running_shell(&registry);
         let run_id = shell.snapshot().unwrap().run.unwrap().id;
@@ -14624,6 +15760,7 @@ mod tests {
             enabled: true,
             blocked: true,
             completed: true,
+            ..Default::default()
         });
         let (workspace, shell, _runtime) = running_shell(&registry);
         let run_id = shell.snapshot().unwrap().run.unwrap().id;
@@ -14674,6 +15811,7 @@ mod tests {
                 enabled: true,
                 blocked: true,
                 completed: true,
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/src/desktop_notifications.rs
+++ b/src/desktop_notifications.rs
@@ -16,6 +16,8 @@ const NOTIFICATION_QUEUE_CAPACITY: usize = 32;
 pub(crate) enum NotificationReason {
     Blocked,
     Completed,
+    ScheduledDispatchFailed,
+    ScheduledInterrupted,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -185,6 +187,10 @@ pub(crate) fn category_enabled(
         && match reason {
             NotificationReason::Blocked => settings.desktop.blocked,
             NotificationReason::Completed => settings.desktop.completed,
+            NotificationReason::ScheduledDispatchFailed => {
+                settings.desktop.scheduled_dispatch_failed
+            }
+            NotificationReason::ScheduledInterrupted => settings.desktop.scheduled_interrupted,
         }
 }
 
@@ -192,6 +198,8 @@ fn sound_argv(settings: &NotificationDeliverySettings, reason: NotificationReaso
     let event = match reason {
         NotificationReason::Blocked => &settings.sound.blocked,
         NotificationReason::Completed => &settings.sound.completed,
+        NotificationReason::ScheduledDispatchFailed => &settings.sound.scheduled_dispatch_failed,
+        NotificationReason::ScheduledInterrupted => &settings.sound.scheduled_interrupted,
     };
     vec![
         "canberra-gtk-play".into(),
@@ -203,21 +211,52 @@ fn sound_argv(settings: &NotificationDeliverySettings, reason: NotificationReaso
 }
 
 fn notify_send_argv(request: &NotificationRequest) -> Vec<String> {
-    let reason = match request.reason {
-        NotificationReason::Blocked => "blocked",
-        NotificationReason::Completed => "completed",
+    let (title, body) = match request.reason {
+        NotificationReason::Blocked => (
+            "Boomux Agent blocked".into(),
+            format!(
+                "{} in workspace {}, shell {}. Open Boomux or run `boomux attention list`.",
+                sanitize(&request.agent),
+                sanitize(&request.workspace),
+                sanitize(&request.shell)
+            ),
+        ),
+        NotificationReason::Completed => (
+            "Boomux Agent completed".into(),
+            format!(
+                "{} in workspace {}, shell {}. Open Boomux or run `boomux attention list`.",
+                sanitize(&request.agent),
+                sanitize(&request.workspace),
+                sanitize(&request.shell)
+            ),
+        ),
+        NotificationReason::ScheduledDispatchFailed => (
+            "Boomux scheduled dispatch failed".into(),
+            format!(
+                "Schedule {} in workspace {} failed for execution {}. Run `boomux execution inspect {}`.",
+                sanitize(&request.agent),
+                sanitize(&request.workspace),
+                sanitize(&request.shell),
+                sanitize(&request.shell)
+            ),
+        ),
+        NotificationReason::ScheduledInterrupted => (
+            "Boomux scheduled execution interrupted".into(),
+            format!(
+                "Schedule {} in workspace {} was interrupted for execution {}. Run `boomux execution inspect {}`.",
+                sanitize(&request.agent),
+                sanitize(&request.workspace),
+                sanitize(&request.shell),
+                sanitize(&request.shell)
+            ),
+        ),
     };
     vec![
         "notify-send".into(),
         "--app-name".into(),
         "Boomux".into(),
-        format!("Boomux Agent {reason}"),
-        format!(
-            "{} in workspace {}, shell {}. Open Boomux or run `boomux attention list`.",
-            sanitize(&request.agent),
-            sanitize(&request.workspace),
-            sanitize(&request.shell)
-        ),
+        title,
+        body,
     ]
 }
 
@@ -316,6 +355,7 @@ mod tests {
                 enabled: true,
                 blocked: true,
                 completed: false,
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -343,6 +383,7 @@ mod tests {
                 enabled: true,
                 blocked: "dialog-warning".into(),
                 completed: "complete".into(),
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -477,6 +477,7 @@ mod tests {
                     resume_agents: true,
                     persist_terminal_history: false,
                     max_scheduled_execution_concurrency,
+                    ..Default::default()
                 }),
                 focused_terminal: None,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -570,9 +570,23 @@ enum ExecutionCommands {
         workspace: Option<String>,
         #[arg(long, value_name = "SCHEDULE_NAME_OR_ID")]
         schedule: Option<String>,
+        #[arg(
+            long,
+            default_value_t = protocol::DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT,
+            value_parser = clap::value_parser!(u16).range(1..=protocol::MAX_SCHEDULED_EXECUTION_LIST_LIMIT as i64)
+        )]
+        limit: u16,
     },
     /// Inspect one execution by exact ID
     Inspect { execution_id: String },
+    /// Wait for an exact execution revision to advance
+    Wait {
+        execution_id: String,
+        #[arg(long)]
+        after_revision: u64,
+        #[arg(long, default_value_t = 30_000)]
+        wait_ms: u32,
+    },
     /// Cancel one nonterminal execution by exact ID
     Cancel { execution_id: String },
 }
@@ -896,6 +910,7 @@ command_keys! {
     ScheduleRun => ("schedule.run", Json),
     ExecutionList => ("execution.list", Json),
     ExecutionInspect => ("execution.inspect", Json),
+    ExecutionWait => ("execution.wait", Json),
     ExecutionCancel => ("execution.cancel", Json),
     Skill => ("skill", HumanOnly),
     Opencode => ("opencode", HumanOnly),
@@ -1000,6 +1015,9 @@ impl Cli {
             Some(Commands::Execution {
                 command: ExecutionCommands::Inspect { .. },
             }) => CommandKey::ExecutionInspect,
+            Some(Commands::Execution {
+                command: ExecutionCommands::Wait { .. },
+            }) => CommandKey::ExecutionWait,
             Some(Commands::Execution {
                 command: ExecutionCommands::Cancel { .. },
             }) => CommandKey::ExecutionCancel,
@@ -3384,11 +3402,11 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
                 );
             }
             println!(
-                "WORKSPACE\tNAME\tSCHEDULE ID\tSTATE\tINTEGRATION\tTRIGGER\tTIMEZONE\tSESSION"
+                "WORKSPACE\tNAME\tSCHEDULE ID\tSTATE\tINTEGRATION\tTRIGGER\tTIMEZONE\tSESSION\tNEXT OCCURRENCE MS"
             );
             for (schedule, workspace_name) in schedules {
                 println!(
-                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
                     sanitize_table_cell(workspace_name),
                     sanitize_table_cell(&schedule.name),
                     sanitize_table_cell(&schedule.id),
@@ -3397,6 +3415,21 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
                     sanitize_table_cell(&schedule.trigger.cron),
                     sanitize_table_cell(&schedule.trigger.timezone),
                     sanitize_table_cell(&schedule_session_label(&schedule.session)),
+                    schedule
+                        .next_occurrence
+                        .as_ref()
+                        .map(|occurrence| occurrence.scheduled_at_ms.to_string())
+                        .as_deref()
+                        .unwrap_or("-"),
+                );
+            }
+            if snapshot
+                .scheduler
+                .as_ref()
+                .is_some_and(|scheduler| scheduler.state == protocol::SchedulerState::Offline)
+            {
+                eprintln!(
+                    "Scheduler is offline: next occurrences are projections only. Run `boomux daemon status` and `boomux doctor`; fix configuration or environment and run `boomux daemon restart` before relying on timed dispatch."
                 );
             }
             Ok(())
@@ -3517,6 +3550,7 @@ fn execution_command(command: ExecutionCommands, json: bool) -> Result<(), Box<d
         ExecutionCommands::List {
             workspace,
             schedule,
+            limit,
         } => {
             let snapshot = client.snapshot()?;
             let workspace = workspace
@@ -3534,37 +3568,115 @@ fn execution_command(command: ExecutionCommands, json: bool) -> Result<(), Box<d
                     .map(|schedule| schedule.id.clone())
                 })
                 .transpose()?;
-            let executions = client.scheduled_executions(
+            let page = client.scheduled_execution_page(
                 workspace.map(|workspace| workspace.id.clone()),
                 schedule_id,
+                limit,
             )?;
             if json {
-                let executions = executions
+                let executions = page
+                    .executions
                     .iter()
                     .map(cli_output::execution)
                     .collect::<Vec<_>>();
                 return print_json(
                     CommandKey::ExecutionList,
-                    serde_json::json!({ "executions": executions }),
+                    serde_json::json!({
+                        "executions": executions,
+                        "limit": page.limit,
+                        "truncated": page.truncated,
+                        "schedule_limit": page.schedule_limit,
+                        "schedules_truncated": page.schedules_truncated,
+                        "schedules": page.schedules.iter().map(|projection| serde_json::json!({
+                            "schedule_id": projection.schedule_id,
+                            "next_occurrence": projection.next_occurrence,
+                        })).collect::<Vec<_>>(),
+                    }),
                 );
             }
-            println!("STATE\tEXECUTION ID\tSCHEDULE ID\tREQUESTED\tSHELL ID\tRUN ID");
-            for execution in executions {
+            println!(
+                "STATE\tREASON/OUTCOME\tEXECUTION ID\tSCHEDULE ID\tREQUESTED\tAGENT ID\tSHELL/RUN"
+            );
+            for execution in page.executions {
                 println!(
-                    "{}\t{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}/{}",
                     execution_state(&execution),
+                    execution_result_label(&execution),
                     execution.id,
                     execution.schedule_id,
                     execution.requested_at_ms,
+                    execution.agent_id.as_deref().unwrap_or("-"),
                     execution.shell_id.as_deref().unwrap_or("-"),
                     execution.run_id.as_deref().unwrap_or("-"),
+                );
+                if let Some(action) = execution_action(&execution) {
+                    println!("ACTION {}\t{}", execution.id, action);
+                }
+            }
+            if page.truncated {
+                println!(
+                    "Showing newest {} executions; increase --limit to see more retained history.",
+                    page.limit
+                );
+            }
+            if page.schedules_truncated {
+                println!(
+                    "Showing {} schedule projections; narrow by workspace or schedule for the remainder.",
+                    page.schedule_limit
+                );
+            }
+            for projection in page.schedules {
+                println!(
+                    "Next occurrence for schedule {}: {}",
+                    projection.schedule_id,
+                    projection
+                        .next_occurrence
+                        .map(|occurrence| occurrence.scheduled_at_ms.to_string())
+                        .unwrap_or_else(
+                            || "none (paused or scheduler projection unavailable)".into()
+                        )
                 );
             }
             Ok(())
         }
         ExecutionCommands::Inspect { execution_id } => {
-            let execution = client.get_scheduled_execution(execution_id)?;
-            print_execution(CommandKey::ExecutionInspect, &execution, json)
+            let inspection = client.inspect_scheduled_execution(execution_id)?;
+            if json {
+                return print_json(
+                    CommandKey::ExecutionInspect,
+                    serde_json::json!({
+                        "execution": cli_output::execution(&inspection.execution),
+                        "next_occurrence": inspection.next_occurrence,
+                    }),
+                );
+            }
+            print_execution(CommandKey::ExecutionInspect, &inspection.execution, false)?;
+            println!(
+                "Next occurrence: {}",
+                inspection
+                    .next_occurrence
+                    .map(|occurrence| occurrence.scheduled_at_ms.to_string())
+                    .unwrap_or_else(|| "none (paused or scheduler projection unavailable)".into())
+            );
+            Ok(())
+        }
+        ExecutionCommands::Wait {
+            execution_id,
+            after_revision,
+            wait_ms,
+        } => {
+            let waited = client.wait_scheduled_execution(execution_id, after_revision, wait_ms)?;
+            if json {
+                return print_json(
+                    CommandKey::ExecutionWait,
+                    serde_json::json!({
+                        "changed": waited.changed,
+                        "execution": cli_output::execution(&waited.execution),
+                    }),
+                );
+            }
+            println!("Changed: {}", waited.changed);
+            print_execution(CommandKey::ExecutionWait, &waited.execution, false)
         }
         ExecutionCommands::Cancel { execution_id } => {
             let execution = client.cancel_scheduled_execution(execution_id)?;
@@ -3586,15 +3698,68 @@ fn print_execution(
     }
     println!("Execution {}", execution.id);
     println!("State: {}", execution_state(execution));
+    println!("Revision: {}", execution.revision);
     println!("Schedule: {}", execution.schedule_id);
     println!("Dispatch key: {}", execution.dispatch_key);
+    println!("Result: {}", execution_result_label(execution));
+    if let Some(action) = execution_action(execution) {
+        println!("Action: {action}");
+    }
+    println!("Requested at ms: {}", execution.requested_at_ms);
+    if let Some(started_at_ms) = execution.started_at_ms {
+        println!("Started at ms: {started_at_ms}");
+    }
+    if let Some(ended_at_ms) = execution.ended_at_ms {
+        println!("Ended at ms: {ended_at_ms}");
+    }
     if let Some(shell_id) = &execution.shell_id {
         println!("Shell: {shell_id}");
     }
     if let Some(run_id) = &execution.run_id {
         println!("Run: {run_id}");
     }
+    if let Some(agent_id) = &execution.agent_id {
+        println!("Agent: {agent_id} (inspect with `boomux agent inspect {agent_id}`)");
+    }
+    if execution.state == protocol::ScheduledExecutionState::Active {
+        println!("No automatic timeout; cancel explicitly if this work is blocked or hung.");
+    }
     Ok(())
+}
+
+fn execution_result_label(execution: &ScheduledExecutionSnapshot) -> String {
+    if let Some(reason) = execution.reason {
+        return format!("reason:{}", cli_output::execution_reason(reason));
+    }
+    match execution.outcome {
+        Some(ScheduledExecutionOutcome::ExitCode { code }) => format!("exit_code:{code}"),
+        Some(ScheduledExecutionOutcome::Signal { signal }) => format!("signal:{signal}"),
+        None => "-".into(),
+    }
+}
+
+fn execution_action(execution: &ScheduledExecutionSnapshot) -> Option<String> {
+    use protocol::ScheduledExecutionReason::*;
+    let action = match execution.reason? {
+        Overlap => format!(
+            "inspect active work with `boomux execution list --schedule {}` and cancel the exact execution if authorized",
+            execution.schedule_id
+        ),
+        ActiveSession => "inspect `boomux attention list` and the linked Agent/session before retrying with `boomux schedule run`".into(),
+        WorkspaceCapacity | GlobalCapacity => "run `boomux execution list` to find active work; cancel only an exact authorized execution before retrying".into(),
+        Missed => "timed work is not caught up; check `boomux daemon status` and use `boomux schedule run` only for an authorized manual replacement".into(),
+        PausedRace => "inspect the schedule and run `boomux schedule resume <schedule> --workspace <workspace>` if future timed work is authorized".into(),
+        InvalidTarget => format!(
+            "run `boomux integration status {}` and `boomux doctor`, then restart the daemon after fixing the target",
+            execution.integration
+        ),
+        RunnerStartFailed | HostSpawnFailed => "run `boomux doctor` and `boomux daemon status`; fix daemon startup environment or integration setup, then `boomux daemon restart`".into(),
+        ColdDaemonRecovery => "the prior process cannot be resumed automatically; inspect this execution and `boomux daemon status` before an authorized `boomux schedule run`".into(),
+        RunnerExitedWithoutReport => "inspect the retained shell/run and `boomux doctor` before retrying manually".into(),
+        CancelledByUser => "no retry is automatic; use `boomux schedule run` only if a new execution is authorized".into(),
+        DaemonShutdown => "restart the daemon and use `boomux schedule run` only if a replacement execution is authorized".into(),
+    };
+    Some(action)
 }
 
 fn execution_state(execution: &ScheduledExecutionSnapshot) -> &'static str {
@@ -4064,6 +4229,15 @@ fn print_schedule_inspection(
     println!("REVISION\t{}", schedule.revision);
     println!("PROMPT REVISION\t{}", schedule.prompt_revision);
     println!("TRIGGER REVISION\t{}", schedule.trigger_revision);
+    println!(
+        "NEXT OCCURRENCE MS\t{}",
+        schedule
+            .next_occurrence
+            .as_ref()
+            .map(|occurrence| occurrence.scheduled_at_ms.to_string())
+            .as_deref()
+            .unwrap_or("-")
+    );
     println!("CREATED AT MS\t{}", schedule.created_at_ms);
     println!("UPDATED AT MS\t{}", schedule.updated_at_ms);
     println!(
@@ -7654,7 +7828,7 @@ mod tests {
             session_transcript::supported_integrations(),
             ["opencode", "pi"]
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 24);
+        assert_eq!(protocol::PROTOCOL_VERSION, 25);
     }
 
     #[test]
@@ -7706,6 +7880,7 @@ mod tests {
                 "schedule.run",
                 "execution.list",
                 "execution.inspect",
+                "execution.wait",
                 "execution.cancel",
                 "daemon.status",
             ]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 24;
+pub const PROTOCOL_VERSION: u32 = 25;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -95,7 +95,17 @@ define_protocol_features! {
         "scheduler_health",
         "bounded_scheduled_execution_concurrency",
     ]),
+    ScheduledExecutionObservation => (25, "scheduled execution observation", [
+        "protocol_25",
+        "revision_aware_scheduled_execution_wait",
+        "bounded_scheduled_execution_history",
+        "scheduled_execution_notifications",
+    ]),
 }
+
+pub const DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 100;
+pub const MAX_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 1_000;
+pub const MAX_SCHEDULED_EXECUTION_SCHEDULE_PROJECTIONS: u16 = 100;
 
 pub fn protocol_capabilities() -> impl Iterator<Item = &'static str> {
     ProtocolFeature::ALL
@@ -314,6 +324,13 @@ pub struct ScheduledOccurrence {
     pub scheduled_at_ms: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduledExecutionScheduleProjection {
+    pub schedule_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_occurrence: Option<ScheduledOccurrence>,
+}
+
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentScheduleInspection {
     pub schedule: AgentScheduleSnapshot,
@@ -383,6 +400,8 @@ pub struct ScheduledExecutionSnapshot {
     pub id: String,
     pub workspace_id: String,
     pub schedule_id: String,
+    #[serde(default)]
+    pub revision: u64,
     pub state: ScheduledExecutionState,
     pub dispatch_kind: ScheduledExecutionDispatchKind,
     pub dispatch_key: String,
@@ -789,8 +808,16 @@ pub struct NotificationDeliveryConfig {
     pub sound_enabled: bool,
     pub blocked: bool,
     pub completed: bool,
+    #[serde(default)]
+    pub scheduled_dispatch_failed: bool,
+    #[serde(default)]
+    pub scheduled_interrupted: bool,
     pub blocked_sound: String,
     pub completed_sound: String,
+    #[serde(default = "default_scheduled_dispatch_failed_sound")]
+    pub scheduled_dispatch_failed_sound: String,
+    #[serde(default = "default_scheduled_interrupted_sound")]
+    pub scheduled_interrupted_sound: String,
     #[serde(default = "default_true")]
     pub resume_agents: bool,
     #[serde(default)]
@@ -799,12 +826,40 @@ pub struct NotificationDeliveryConfig {
     pub max_scheduled_execution_concurrency: u16,
 }
 
+impl Default for NotificationDeliveryConfig {
+    fn default() -> Self {
+        Self {
+            desktop_enabled: false,
+            sound_enabled: false,
+            blocked: true,
+            completed: true,
+            scheduled_dispatch_failed: false,
+            scheduled_interrupted: false,
+            blocked_sound: "message-new-instant".into(),
+            completed_sound: "complete".into(),
+            scheduled_dispatch_failed_sound: default_scheduled_dispatch_failed_sound(),
+            scheduled_interrupted_sound: default_scheduled_interrupted_sound(),
+            resume_agents: true,
+            persist_terminal_history: false,
+            max_scheduled_execution_concurrency: 4,
+        }
+    }
+}
+
 fn default_max_scheduled_execution_concurrency() -> u16 {
     4
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_scheduled_dispatch_failed_sound() -> String {
+    "dialog-warning".into()
+}
+
+fn default_scheduled_interrupted_sound() -> String {
+    "dialog-warning".into()
 }
 
 impl std::fmt::Debug for UnixEnvironmentVariable {
@@ -864,9 +919,17 @@ pub enum Request {
         workspace_id: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         schedule_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        limit: Option<u16>,
     },
     GetScheduledExecution {
         execution_id: String,
+    },
+    WaitScheduledExecution {
+        execution_id: String,
+        after_revision: u64,
+        #[serde(default)]
+        wait_ms: u32,
     },
     WaitAgent {
         agent_id: String,
@@ -1006,6 +1069,9 @@ pub enum Request {
 impl Request {
     pub fn required_feature(&self) -> Option<ProtocolFeature> {
         match self {
+            Self::WaitScheduledExecution { .. } => {
+                Some(ProtocolFeature::ScheduledExecutionObservation)
+            }
             Self::ListScheduledExecutions { .. }
             | Self::GetScheduledExecution { .. }
             | Self::RunAgentSchedule { .. }
@@ -1026,6 +1092,12 @@ impl Request {
             | Self::CreateShell {
                 workspace_id: None, ..
             } => Some(ProtocolFeature::WorkspaceDefaultCwd),
+            Self::RestartWithNotificationConfig { notifications, .. }
+                if notifications.scheduled_dispatch_failed
+                    || notifications.scheduled_interrupted =>
+            {
+                Some(ProtocolFeature::ScheduledExecutionObservation)
+            }
             Self::RestartWithNotificationConfig { notifications, .. }
                 if notifications.max_scheduled_execution_concurrency != 4 =>
             {
@@ -1118,9 +1190,25 @@ pub enum Response {
     },
     ScheduledExecution {
         execution: ScheduledExecutionSnapshot,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        next_occurrence: Option<ScheduledOccurrence>,
     },
     ScheduledExecutions {
         executions: Vec<ScheduledExecutionSnapshot>,
+        #[serde(default)]
+        limit: u16,
+        #[serde(default)]
+        truncated: bool,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        schedules: Vec<ScheduledExecutionScheduleProjection>,
+        #[serde(default)]
+        schedule_limit: u16,
+        #[serde(default)]
+        schedules_truncated: bool,
+    },
+    ScheduledExecutionWait {
+        execution: ScheduledExecutionSnapshot,
+        changed: bool,
     },
     ScheduledExecutionClaim {
         claim: ScheduledExecutionClaim,
@@ -1354,6 +1442,88 @@ mod tests {
         }
     }
 
+    fn test_execution() -> ScheduledExecutionSnapshot {
+        ScheduledExecutionSnapshot {
+            id: "execution-1".into(),
+            workspace_id: "workspace-1".into(),
+            schedule_id: "schedule-1".into(),
+            revision: 4,
+            state: ScheduledExecutionState::Exited,
+            dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+            dispatch_key: "dispatch-1".into(),
+            schedule_revision: 3,
+            prompt_revision: 2,
+            trigger_revision: 1,
+            requested_at_ms: 10,
+            scheduled_at_ms: None,
+            coalesced_through_ms: None,
+            started_at_ms: Some(11),
+            ended_at_ms: Some(12),
+            cwd: "/tmp/project".into(),
+            integration: "opencode".into(),
+            session: AgentScheduleSession::Fresh,
+            reason: None,
+            outcome: Some(ScheduledExecutionOutcome::ExitCode { code: 0 }),
+            shell_id: Some("shell-1".into()),
+            run_id: Some("run-1".into()),
+            agent_id: None,
+            external_session_id: None,
+        }
+    }
+
+    #[test]
+    fn scheduled_execution_observation_messages_round_trip_and_list_defaults_are_bounded() {
+        let legacy: Request = serde_json::from_str(
+            r#"{"request":"list_scheduled_executions","workspace_id":null,"schedule_id":null}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            legacy,
+            Request::ListScheduledExecutions { limit: None, .. }
+        ));
+
+        let wait = Request::WaitScheduledExecution {
+            execution_id: "execution-1".into(),
+            after_revision: 3,
+            wait_ms: 30_000,
+        };
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(&wait).unwrap()).unwrap(),
+            wait
+        );
+        assert_eq!(
+            wait.required_feature(),
+            Some(ProtocolFeature::ScheduledExecutionObservation)
+        );
+
+        for response in [
+            Response::ScheduledExecutions {
+                executions: vec![test_execution()],
+                limit: 100,
+                truncated: true,
+                schedules: vec![ScheduledExecutionScheduleProjection {
+                    schedule_id: "schedule-1".into(),
+                    next_occurrence: Some(ScheduledOccurrence {
+                        trigger_revision: 1,
+                        scheduled_at_ms: 100,
+                    }),
+                }],
+                schedule_limit: 100,
+                schedules_truncated: false,
+            },
+            Response::ScheduledExecutionWait {
+                execution: test_execution(),
+                changed: true,
+            },
+        ] {
+            assert_eq!(
+                serde_json::from_value::<Response>(serde_json::to_value(&response).unwrap())
+                    .unwrap(),
+                response
+            );
+        }
+    }
+
     #[derive(Deserialize)]
     struct ProtocolSixShellSnapshot {
         id: String,
@@ -1414,6 +1584,8 @@ mod tests {
         assert!(config.resume_agents);
         assert!(!config.persist_terminal_history);
         assert_eq!(config.max_scheduled_execution_concurrency, 4);
+        assert!(!config.scheduled_dispatch_failed);
+        assert!(!config.scheduled_interrupted);
     }
 
     #[test]
@@ -1571,8 +1743,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_twenty_four_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 24);
+    fn protocol_version_is_twenty_five_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 25);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -1679,6 +1851,7 @@ mod tests {
             id: "execution-1".into(),
             workspace_id: "workspace-1".into(),
             schedule_id: "schedule-1".into(),
+            revision: 2,
             state: ScheduledExecutionState::Starting,
             dispatch_kind: ScheduledExecutionDispatchKind::Manual,
             dispatch_key: "dispatch-1".into(),
@@ -1871,6 +2044,14 @@ mod tests {
     fn request_feature_requirements_cover_all_groups() {
         let groups = vec![
             (
+                25,
+                vec![Request::WaitScheduledExecution {
+                    execution_id: "execution-1".into(),
+                    after_revision: 1,
+                    wait_ms: 30_000,
+                }],
+            ),
+            (
                 22,
                 vec![
                     Request::CreateAgentSchedule {
@@ -1939,6 +2120,7 @@ mod tests {
                         resume_agents: true,
                         persist_terminal_history: false,
                         max_scheduled_execution_concurrency: 4,
+                        ..Default::default()
                     },
                     environment: None,
                 }],
@@ -2204,6 +2386,15 @@ mod tests {
                     "timed_schedule_dispatch",
                     "scheduler_health",
                     "bounded_scheduled_execution_concurrency",
+                ][..],
+            ),
+            (
+                25,
+                &[
+                    "protocol_25",
+                    "revision_aware_scheduled_execution_wait",
+                    "bounded_scheduled_execution_history",
+                    "scheduled_execution_notifications",
                 ][..],
             ),
         ];

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -18,7 +18,8 @@ use crate::protocol::{
     ShellRunExitReason, TerminalProfile,
 };
 
-const STATE_VERSION: u32 = 11;
+const STATE_VERSION: u32 = 12;
+const VERSION_ELEVEN_STATE_VERSION: u32 = 11;
 const VERSION_TEN_STATE_VERSION: u32 = 10;
 const VERSION_NINE_STATE_VERSION: u32 = 9;
 const VERSION_EIGHT_STATE_VERSION: u32 = 8;
@@ -88,6 +89,7 @@ pub(crate) struct PersistedAgentSchedule {
 #[serde(deny_unknown_fields)]
 pub(crate) struct PersistedScheduledExecution {
     pub(crate) id: String,
+    pub(crate) revision: u64,
     pub(crate) state: ScheduledExecutionState,
     pub(crate) dispatch_kind: ScheduledExecutionDispatchKind,
     pub(crate) dispatch_key: String,
@@ -585,6 +587,9 @@ impl StateStore {
         })?;
         let (state, migrated) = match version.version {
             STATE_VERSION => (parse_state(&bytes, &self.path)?, false),
+            VERSION_ELEVEN_STATE_VERSION => {
+                (migrate_version_eleven_state(&bytes, &self.path)?, true)
+            }
             VERSION_TEN_STATE_VERSION => (migrate_version_ten_state(&bytes, &self.path)?, true),
             VERSION_NINE_STATE_VERSION => {
                 let previous: VersionNinePersistedState = parse_state(&bytes, &self.path)?;
@@ -670,9 +675,33 @@ impl StateStore {
     }
 }
 
-fn migrate_version_ten_state(bytes: &[u8], path: &Path) -> io::Result<PersistedState> {
+fn migrate_version_eleven_state(bytes: &[u8], path: &Path) -> io::Result<PersistedState> {
     let mut previous: serde_json::Value = parse_state(bytes, path)?;
     previous["version"] = serde_json::Value::from(STATE_VERSION);
+    if let Some(workspaces) = previous["workspaces"].as_array_mut() {
+        for workspace in workspaces {
+            if let Some(schedules) = workspace["schedules"].as_array_mut() {
+                for schedule in schedules {
+                    if let Some(executions) = schedule["executions"].as_array_mut() {
+                        for execution in executions {
+                            execution["revision"] = serde_json::Value::from(1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    serde_json::from_value(previous).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("could not migrate {}: {error}", path.display()),
+        )
+    })
+}
+
+fn migrate_version_ten_state(bytes: &[u8], path: &Path) -> io::Result<PersistedState> {
+    let mut previous: serde_json::Value = parse_state(bytes, path)?;
+    previous["version"] = serde_json::Value::from(VERSION_ELEVEN_STATE_VERSION);
     if let Some(workspaces) = previous["workspaces"].as_array_mut() {
         for workspace in workspaces {
             if let Some(schedules) = workspace["schedules"].as_array_mut() {
@@ -683,12 +712,14 @@ fn migrate_version_ten_state(bytes: &[u8], path: &Path) -> io::Result<PersistedS
                         for execution in executions {
                             execution["scheduled_at_ms"] = serde_json::Value::Null;
                             execution["coalesced_through_ms"] = serde_json::Value::Null;
+                            execution["revision"] = serde_json::Value::from(1);
                         }
                     }
                 }
             }
         }
     }
+    previous["version"] = serde_json::Value::from(STATE_VERSION);
     serde_json::from_value(previous).map_err(|error| {
         io::Error::new(
             io::ErrorKind::InvalidData,
@@ -1375,7 +1406,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 11")
+                .contains("\"version\": 12")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1412,7 +1443,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 11")
+                .contains("\"version\": 12")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1454,6 +1485,7 @@ mod tests {
                 dispatch_key_filter: vec![0; DISPATCH_KEY_FILTER_BYTES],
                 executions: vec![PersistedScheduledExecution {
                     id: Uuid::new_v4().to_string(),
+                    revision: 1,
                     state: ScheduledExecutionState::DispatchFailed,
                     dispatch_kind: ScheduledExecutionDispatchKind::Manual,
                     dispatch_key,
@@ -1500,10 +1532,24 @@ mod tests {
         assert_eq!(schedule.evaluation_frontier_trigger_revision, 3);
         assert_eq!(schedule.executions[0].scheduled_at_ms, None);
         assert_eq!(schedule.executions[0].coalesced_through_ms, None);
+        assert_eq!(schedule.executions[0].revision, 1);
         assert!(
-            fs::read_to_string(path)
+            fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 11")
+                .contains("\"version\": 12")
+        );
+
+        let mut version_eleven = serde_json::to_value(&migrated).unwrap();
+        version_eleven["version"] = serde_json::Value::from(11);
+        version_eleven["workspaces"][0]["schedules"][0]["executions"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("revision");
+        fs::write(&path, serde_json::to_vec(&version_eleven).unwrap()).unwrap();
+        let migrated_eleven = StateStore::at(path.clone()).load().unwrap().unwrap();
+        assert_eq!(
+            migrated_eleven.workspaces[0].schedules[0].executions[0].revision,
+            1
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1602,7 +1648,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 11")
+                .contains("\"version\": 12")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1658,7 +1704,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 11")
+                .contains("\"version\": 12")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
         assert!(migrated.workspaces[0].agents.is_empty());
@@ -1709,7 +1755,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 11")
+                .contains("\"version\": 12")
         );
         assert!(migrated.workspaces[0].agents.is_empty());
         assert!(migrated.workspaces[0].schedules.is_empty());
@@ -1749,7 +1795,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 11")
+                .contains("\"version\": 12")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1826,7 +1872,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 11")
+                .contains("\"version\": 12")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1862,7 +1908,7 @@ mod tests {
         assert!(migrated.workspaces[0].agents[0].attention.is_none());
         assert!(migrated.workspaces[0].schedules.is_empty());
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 11"));
+        assert!(saved.contains("\"version\": 12"));
         assert!(saved.contains("\"attention\": null"));
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1895,7 +1941,7 @@ mod tests {
         assert!(!original.contains("default_cwd"));
         store.save(&migrated).unwrap();
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 11"));
+        assert!(saved.contains("\"version\": 12"));
         assert!(saved.contains("\"default_cwd\": null"));
         fs::remove_dir_all(directory).unwrap();
     }

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 24);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 25);
     assert_eq!(
         capabilities["data"]["session_transcript_integrations"],
         serde_json::json!(["opencode", "pi"])
@@ -111,6 +111,10 @@ fn native_daemon_lifecycle() {
         "protocol_22",
         "protocol_23",
         "protocol_24",
+        "protocol_25",
+        "revision_aware_scheduled_execution_wait",
+        "bounded_scheduled_execution_history",
+        "scheduled_execution_notifications",
         "agent_schedule_management",
         "durable_agent_schedules",
         "timed_schedule_dispatch",
@@ -141,7 +145,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 24"));
+    assert!(status_text.contains("running (protocol 25"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -171,6 +175,7 @@ fn native_daemon_lifecycle() {
                         resume_agents: true,
                         persist_terminal_history: false,
                         max_scheduled_execution_concurrency: max_concurrent,
+                        ..Default::default()
                     },
                     environment: None,
                 },

--- a/tests/native_backend/handoff.rs
+++ b/tests/native_backend/handoff.rs
@@ -140,7 +140,7 @@ fn focused_attachment_is_exposed_in_daemon_snapshots() {
         .unwrap();
     let shell_id = workspace.shells[0].id.clone();
     let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    assert_eq!(attachment.protocol_version, 24);
+    assert_eq!(attachment.protocol_version, protocol::PROTOCOL_VERSION);
 
     AttachFrame::FocusGained
         .write_to(&mut attachment.stream)

--- a/tests/native_backend/schedules.rs
+++ b/tests/native_backend/schedules.rs
@@ -131,7 +131,21 @@ fn schedule_management_is_durable_private_and_process_free() {
     );
 
     daemon.crash();
-    daemon.restart();
+    let restart_path = {
+        let mut paths = vec![daemon.runtime_dir.join("bin")];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        std::env::join_paths(paths).unwrap()
+    };
+    let restart_config = daemon.runtime_dir.join("cold-notifications.toml");
+    let notification_capture = daemon.runtime_dir.join("cold-notifications");
+    daemon.restart_with(|command| {
+        command
+            .env("PATH", &restart_path)
+            .env("BOOMUX_CONFIG", &restart_config)
+            .env("BOOMUX_NOTIFICATION_CAPTURE", &notification_capture);
+    });
     assert_eq!(
         daemon
             .client
@@ -529,6 +543,38 @@ fn manual_execution_succeeds_and_duplicate_key_never_spawns_twice() {
     assert!(
         created < run_started && run_started < active && active < run_exited && run_exited < exited
     );
+    let revisions = event_page
+        .events
+        .iter()
+        .filter_map(|event| match &event.kind {
+            protocol::DaemonEventKind::ScheduledExecutionCreated { execution, .. }
+            | protocol::DaemonEventKind::ScheduledExecutionChanged { execution, .. }
+                if execution.id == first.id =>
+            {
+                Some(execution.clone())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        revisions
+            .iter()
+            .map(|execution| execution.revision)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5, 6]
+    );
+    assert_eq!(revisions[0].state, ScheduledExecutionState::Claimed);
+    assert!(revisions[0].shell_id.is_none());
+    assert_eq!(revisions[1].state, ScheduledExecutionState::Claimed);
+    assert!(revisions[1].shell_id.is_some());
+    assert!(revisions[1].run_id.is_none());
+    assert_eq!(revisions[2].state, ScheduledExecutionState::Starting);
+    assert!(revisions[2].run_id.is_some());
+    assert_eq!(revisions[3].state, ScheduledExecutionState::Active);
+    assert!(revisions[3].outcome.is_none());
+    assert_eq!(revisions[4].state, ScheduledExecutionState::Active);
+    assert!(revisions[4].outcome.is_some());
+    assert_eq!(revisions[5].state, ScheduledExecutionState::Exited);
     let second = daemon
         .command()
         .args([
@@ -1091,8 +1137,26 @@ fn linked_agents_remain_authoritative_after_exit_and_late_ensure_repairs_links()
 
 #[test]
 fn host_spawn_failure_is_distinct_from_process_exit() {
-    let mut daemon = TestDaemon::start_with(|command, _| {
-        command.env("PATH", "/nonexistent");
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let notify = bin.join("notify-send");
+        fs::write(
+            &notify,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$BOOMUX_NOTIFICATION_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&notify, fs::Permissions::from_mode(0o755)).unwrap();
+        let config = runtime_dir.join("scheduled-notifications.toml");
+        fs::write(
+            &config,
+            "[notifications]\nenabled = true\nscheduled_dispatch_failed = true\n",
+        )
+        .unwrap();
+        command.env("PATH", bin).env("BOOMUX_CONFIG", config).env(
+            "BOOMUX_NOTIFICATION_CAPTURE",
+            runtime_dir.join("scheduled-notifications"),
+        );
     });
     let workspace = daemon
         .client
@@ -1114,6 +1178,62 @@ fn host_spawn_failure_is_distinct_from_process_exit() {
                 .is_ok_and(|execution| execution.state == ScheduledExecutionState::DispatchFailed)
         },
         "host spawn failure was not recorded",
+    );
+    let notification_capture = daemon.runtime_dir.join("scheduled-notifications");
+    wait_until(
+        || notification_capture.is_file(),
+        "dispatch failure notification was not delivered",
+    );
+    let notification = fs::read_to_string(notification_capture).unwrap();
+    assert_eq!(notification.lines().count(), 1);
+    assert!(notification.contains(&execution.id));
+    assert!(!notification.contains("private"));
+    let failed = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    let late = daemon
+        .client
+        .ensure_agent(
+            failed.shell_id.clone().unwrap(),
+            failed.run_id.clone().unwrap(),
+            AgentRegistrationSpec {
+                name: "late spawn-failure Agent".into(),
+                integration: "opencode".into(),
+                external_session_id: Some("late-spawn-failure-session".into()),
+                report: AgentReport {
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "late exact link".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        daemon
+            .client
+            .get_scheduled_execution(&execution.id)
+            .unwrap()
+            .agent_id
+            .as_deref(),
+        Some(late.id.as_str())
+    );
+    assert_eq!(
+        daemon
+            .client
+            .run_agent_schedule(&schedule.id, &execution.dispatch_key)
+            .unwrap()
+            .id,
+        execution.id
+    );
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("scheduled-notifications"))
+            .unwrap()
+            .lines()
+            .count(),
+        1
     );
     daemon.stop_with_cli();
 }
@@ -1234,8 +1354,39 @@ fn execution_cli_json_shapes_are_stable_and_prompt_free() {
             assert_eq!(output["data"]["execution"]["reason"], "host_spawn_failed");
             assert!(output["data"]["execution"]["outcome"].is_null());
             assert!(output["data"]["execution"]["agent_id"].is_null());
+            assert!(output["data"]["execution"]["revision"].as_u64().unwrap() > 0);
+        } else if expected == "execution.list" {
+            assert_eq!(output["data"]["limit"], 100);
+            assert_eq!(output["data"]["truncated"], false);
+            assert_eq!(output["data"]["schedule_limit"], 100);
+            assert_eq!(output["data"]["schedules_truncated"], false);
+            assert_eq!(output["data"]["schedules"][0]["schedule_id"], schedule.id);
         }
     }
+    let revision = daemon
+        .client
+        .get_scheduled_execution(execution_id)
+        .unwrap()
+        .revision
+        .to_string();
+    let waited = daemon
+        .command()
+        .args([
+            "execution",
+            "wait",
+            execution_id,
+            "--after-revision",
+            &revision,
+            "--wait-ms",
+            "0",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(waited.status.success());
+    let waited: serde_json::Value = serde_json::from_slice(&waited.stdout).unwrap();
+    assert_eq!(waited["command"], "execution.wait");
+    assert_eq!(waited["data"]["changed"], false);
     daemon.stop_with_cli();
 }
 
@@ -1722,12 +1873,14 @@ fn cancellation_persistence_failure_keeps_dead_process_terminal_and_retries() {
 #[test]
 fn cancellation_stop_failure_leaves_live_exact_run_active() {
     let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let barrier = runtime_dir.join("cancel-failure-barrier");
+        fs::create_dir(&barrier).unwrap();
         let bin = runtime_dir.join("bin");
         fs::create_dir(&bin).unwrap();
         let host = bin.join("opencode");
         fs::write(
             &host,
-            "#!/bin/sh\nprintf '%s' \"$$\" > \"$BOOMUX_PID_CAPTURE\"\nsleep 30\n",
+            "#!/bin/sh\nprintf '%s' \"$$\" > \"$BOOMUX_PID_CAPTURE\"\nwhile [ ! -e \"$BOOMUX_OUTPUT_MARKER\" ]; do sleep 0.01; done\nprintf 'during-cancel-1\\n'\nsleep 0.02\nprintf 'during-cancel-2\\n'\nsleep 30\n",
         )
         .unwrap();
         fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
@@ -1738,16 +1891,64 @@ fn cancellation_stop_failure_leaves_live_exact_run_active() {
         command
             .env("PATH", std::env::join_paths(paths).unwrap())
             .env("BOOMUX_PID_CAPTURE", runtime_dir.join("stop-failure-pid"))
-            .env("BOOMUX_NATIVE_TEST_CANCEL_STOP_FAILURE", "1");
+            .env("BOOMUX_OUTPUT_MARKER", runtime_dir.join("output-marker"))
+            .env("BOOMUX_NATIVE_TEST_CANCEL_STOP_FAILURE", "1")
+            .env("BOOMUX_NATIVE_TEST_CANCEL_FAILURE_BARRIER", barrier);
     });
     let (workspace_id, schedule_id, execution_id, pid) =
         start_long_running_execution(&daemon, "stop-failure");
+    let active = daemon
+        .client
+        .get_scheduled_execution(&execution_id)
+        .unwrap();
+    let shell_id = active.shell_id.clone().unwrap();
+    let cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    let cancel_socket = daemon.client.socket_path().to_path_buf();
+    let cancel_execution_id = execution_id.clone();
+    let cancel = thread::spawn(move || {
+        Client::from_socket_path(cancel_socket).cancel_scheduled_execution(cancel_execution_id)
+    });
+    let barrier = daemon.runtime_dir.join("cancel-failure-barrier");
+    wait_until(
+        || barrier.join("reserved").is_file(),
+        "cancellation did not reserve lifecycle publication",
+    );
+    fs::write(daemon.runtime_dir.join("output-marker"), b"output").unwrap();
+    wait_until(
+        || {
+            String::from_utf8_lossy(&daemon.client.read_shell(&shell_id, 1024).unwrap())
+                .contains("during-cancel-2")
+        },
+        "concurrent cancellation output was not read",
+    );
     assert!(
         daemon
             .client
-            .cancel_scheduled_execution(&execution_id)
-            .is_err()
+            .events(Some(cursor.clone()), 256, 0)
+            .unwrap()
+            .events
+            .iter()
+            .all(|event| !matches!(event.kind, protocol::DaemonEventKind::OutputChanged { .. }))
     );
+    fs::write(barrier.join("release"), b"release").unwrap();
+    assert!(cancel.join().unwrap().is_err());
+    let output_revisions = daemon
+        .client
+        .events(Some(cursor), 256, 0)
+        .unwrap()
+        .events
+        .into_iter()
+        .filter_map(|event| match event.kind {
+            protocol::DaemonEventKind::OutputChanged {
+                shell_id: event_shell_id,
+                output_revision,
+                ..
+            } if event_shell_id == shell_id => Some(output_revision),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(output_revisions.len(), 1);
+    assert!(output_revisions.windows(2).all(|pair| pair[0] <= pair[1]));
     assert!(process_exists(pid));
     assert_eq!(
         daemon
@@ -2014,6 +2215,12 @@ fn transferred_active_executions_block_lower_global_limit_until_release() {
 #[test]
 fn cold_recovery_interrupts_active_execution_without_respawn() {
     let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let config = runtime_dir.join("cold-notifications.toml");
+        fs::write(
+            &config,
+            "[notifications]\nenabled = true\nscheduled_interrupted = true\n",
+        )
+        .unwrap();
         let bin = runtime_dir.join("bin");
         fs::create_dir(&bin).unwrap();
         let host = bin.join("opencode");
@@ -2023,14 +2230,26 @@ fn cold_recovery_interrupts_active_execution_without_respawn() {
         )
         .unwrap();
         fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let notify = bin.join("notify-send");
+        fs::write(
+            &notify,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$BOOMUX_COLD_NOTIFICATION_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&notify, fs::Permissions::from_mode(0o755)).unwrap();
         let mut paths = vec![bin];
         paths.extend(std::env::split_paths(
             &std::env::var_os("PATH").unwrap_or_default(),
         ));
         command
             .env("PATH", std::env::join_paths(paths).unwrap())
+            .env("BOOMUX_CONFIG", config)
             .env("BOOMUX_EXECUTION_CAPTURE", runtime_dir.join("executions"))
-            .env("BOOMUX_PID_CAPTURE", runtime_dir.join("pids"));
+            .env("BOOMUX_PID_CAPTURE", runtime_dir.join("pids"))
+            .env(
+                "BOOMUX_COLD_NOTIFICATION_CAPTURE",
+                runtime_dir.join("cold-notifications"),
+            );
     });
     let workspace = daemon.client.create_workspace("cold", Vec::new()).unwrap();
     let schedule = daemon
@@ -2059,7 +2278,19 @@ fn cold_recovery_interrupts_active_execution_without_respawn() {
         || !process_exists(old_pid),
         "cold-crashed host remained alive",
     );
-    daemon.restart();
+    let mut restart_paths = vec![daemon.runtime_dir.join("bin")];
+    restart_paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let restart_path = std::env::join_paths(restart_paths).unwrap();
+    let restart_config = daemon.runtime_dir.join("cold-notifications.toml");
+    let restart_notifications = daemon.runtime_dir.join("cold-notifications");
+    daemon.restart_with(move |command| {
+        command
+            .env("PATH", restart_path)
+            .env("BOOMUX_CONFIG", restart_config)
+            .env("BOOMUX_COLD_NOTIFICATION_CAPTURE", restart_notifications);
+    });
     let recovered = daemon
         .client
         .get_scheduled_execution(&execution.id)
@@ -2072,6 +2303,15 @@ fn cold_recovery_interrupts_active_execution_without_respawn() {
     assert_eq!(recovered.outcome, None);
     assert_eq!(recovered.shell_id, active.shell_id);
     assert_eq!(recovered.run_id, active.run_id);
+    let notification_capture = daemon.runtime_dir.join("cold-notifications");
+    wait_until(
+        || notification_capture.is_file(),
+        "cold interruption notification was not delivered",
+    );
+    let notification = fs::read_to_string(&notification_capture).unwrap();
+    assert_eq!(notification.lines().count(), 1);
+    assert!(notification.contains(&execution.id));
+    assert!(!notification.contains("private"));
     assert_eq!(
         daemon
             .client
@@ -2088,12 +2328,25 @@ fn cold_recovery_interrupts_active_execution_without_respawn() {
     let restart = daemon
         .command()
         .args(["daemon", "restart"])
+        .env(
+            "BOOMUX_CONFIG",
+            daemon.runtime_dir.join("cold-notifications.toml"),
+        )
         .env("PATH", std::env::join_paths(paths).unwrap())
         .env("BOOMUX_EXECUTION_CAPTURE", &capture)
         .env("BOOMUX_PID_CAPTURE", daemon.runtime_dir.join("pids"))
         .output()
         .unwrap();
     assert!(restart.status.success());
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(
+        fs::read_to_string(&notification_capture)
+            .unwrap()
+            .lines()
+            .count(),
+        1,
+        "cold interruption notification replayed on graceful restart"
+    );
     let next = daemon
         .client
         .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
@@ -2110,6 +2363,141 @@ fn cold_recovery_interrupts_active_execution_without_respawn() {
 }
 
 #[test]
+fn execution_wait_reconnects_and_terminal_execution_accepts_canonical_blocked_agent_link() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nwhile [ ! -e \"$BOOMUX_RELEASE_EXECUTION\" ]; do sleep 0.02; done\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command
+            .env("PATH", std::env::join_paths(paths).unwrap())
+            .env(
+                "BOOMUX_RELEASE_EXECUTION",
+                runtime_dir.join("release-execution"),
+            );
+    });
+    let workspace = daemon
+        .client
+        .create_workspace("execution-wait", Vec::new())
+        .unwrap();
+    let schedule = daemon
+        .client
+        .create_agent_schedule(
+            &workspace.id,
+            schedule_spec(&daemon, "execution-wait", "private wait prompt"),
+        )
+        .unwrap();
+    let execution = daemon
+        .client
+        .run_agent_schedule(&schedule.id, Uuid::new_v4().to_string())
+        .unwrap();
+    let active = loop {
+        let current = daemon
+            .client
+            .get_scheduled_execution(&execution.id)
+            .unwrap();
+        if current.state == ScheduledExecutionState::Active {
+            break current;
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    assert!(
+        !daemon
+            .client
+            .wait_scheduled_execution(&active.id, active.revision, 0)
+            .unwrap()
+            .changed
+    );
+    let waiting_socket = daemon.client.socket_path().to_path_buf();
+    let execution_id = active.id.clone();
+    let revision = active.revision;
+    let waiter = thread::spawn(move || {
+        Client::from_socket_path(waiting_socket).wait_scheduled_execution(
+            execution_id,
+            revision,
+            10_000,
+        )
+    });
+    thread::sleep(Duration::from_millis(50));
+
+    let mut paths = vec![daemon.runtime_dir.join("bin")];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let restart = daemon
+        .command()
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    let error = waiter.join().unwrap().unwrap_err();
+    assert_remote_code(&error, protocol::ErrorCode::DaemonStopping);
+
+    let before_terminal = daemon
+        .client
+        .get_scheduled_execution(&execution.id)
+        .unwrap();
+    fs::write(daemon.runtime_dir.join("release-execution"), "release").unwrap();
+    let mut after_revision = before_terminal.revision;
+    let terminal = loop {
+        let waited = daemon
+            .client
+            .wait_scheduled_execution(&execution.id, after_revision, 1_000)
+            .unwrap();
+        assert!(waited.changed);
+        if waited.execution.state == ScheduledExecutionState::Exited {
+            break waited.execution;
+        }
+        after_revision = waited.execution.revision;
+    };
+
+    let agent = daemon
+        .client
+        .register_agent(
+            terminal.shell_id.clone().unwrap(),
+            terminal.run_id.clone().unwrap(),
+            AgentRegistrationSpec {
+                name: "blocked scheduled agent".into(),
+                integration: "opencode".into(),
+                external_session_id: Some("exact-blocked-session".into()),
+                report: AgentReport {
+                    state: AgentState::Blocked,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "permission required".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    let attention = agent.attention.as_ref().expect("blocked attention");
+    assert_eq!(attention.observation.revision, agent.observation.revision);
+    let linked = daemon
+        .client
+        .wait_scheduled_execution(&execution.id, terminal.revision, 1_000)
+        .unwrap();
+    assert!(linked.changed);
+    assert_eq!(
+        linked.execution.agent_id.as_deref(),
+        Some(agent.id.as_str())
+    );
+    assert_eq!(
+        linked.execution.external_session_id.as_deref(),
+        agent.external_session_id.as_deref()
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn cold_recovery_clears_staged_outcome_and_survives_second_restart() {
     let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
         let barrier = runtime_dir.join("outcome-barrier");
@@ -2119,13 +2507,31 @@ fn cold_recovery_clears_staged_outcome_and_survives_second_restart() {
         let host = bin.join("opencode");
         fs::write(&host, "#!/bin/sh\nexit 17\n").unwrap();
         fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
+        let notify = bin.join("notify-send");
+        fs::write(
+            &notify,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$BOOMUX_NOTIFICATION_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&notify, fs::Permissions::from_mode(0o755)).unwrap();
+        let config = runtime_dir.join("cold-notifications.toml");
+        fs::write(
+            &config,
+            "[notifications]\nenabled = true\nscheduled_interrupted = true\n",
+        )
+        .unwrap();
         let mut paths = vec![bin];
         paths.extend(std::env::split_paths(
             &std::env::var_os("PATH").unwrap_or_default(),
         ));
         command
             .env("PATH", std::env::join_paths(paths).unwrap())
-            .env("BOOMUX_NATIVE_TEST_OUTCOME_BARRIER", &barrier);
+            .env("BOOMUX_NATIVE_TEST_OUTCOME_BARRIER", &barrier)
+            .env("BOOMUX_CONFIG", config)
+            .env(
+                "BOOMUX_NOTIFICATION_CAPTURE",
+                runtime_dir.join("cold-notifications"),
+            );
     });
     let workspace = daemon
         .client
@@ -2157,8 +2563,22 @@ fn cold_recovery_clears_staged_outcome_and_survives_second_restart() {
         Some(protocol::ScheduledExecutionOutcome::ExitCode { code: 17 })
     );
 
+    let restart_path = {
+        let mut paths = vec![daemon.runtime_dir.join("bin")];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        std::env::join_paths(paths).unwrap()
+    };
+    let restart_config = daemon.runtime_dir.join("cold-notifications.toml");
+    let notification_capture = daemon.runtime_dir.join("cold-notifications");
     daemon.crash();
-    daemon.restart();
+    daemon.restart_with(|command| {
+        command
+            .env("PATH", &restart_path)
+            .env("BOOMUX_CONFIG", &restart_config)
+            .env("BOOMUX_NOTIFICATION_CAPTURE", &notification_capture);
+    });
     let recovered = daemon
         .client
         .get_scheduled_execution(&execution.id)
@@ -2169,14 +2589,38 @@ fn cold_recovery_clears_staged_outcome_and_survives_second_restart() {
         Some(protocol::ScheduledExecutionReason::ColdDaemonRecovery)
     );
     assert_eq!(recovered.outcome, None);
+    wait_until(
+        || notification_capture.is_file(),
+        "cold interruption notification was not delivered",
+    );
+    assert_eq!(
+        fs::read_to_string(&notification_capture)
+            .unwrap()
+            .lines()
+            .count(),
+        1
+    );
 
     daemon.crash();
-    daemon.restart();
+    daemon.restart_with(|command| {
+        command
+            .env("PATH", &restart_path)
+            .env("BOOMUX_CONFIG", &restart_config)
+            .env("BOOMUX_NOTIFICATION_CAPTURE", &notification_capture);
+    });
     let restored_again = daemon
         .client
         .get_scheduled_execution(&execution.id)
         .unwrap();
     assert_eq!(restored_again, recovered);
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(
+        fs::read_to_string(notification_capture)
+            .unwrap()
+            .lines()
+            .count(),
+        1
+    );
     daemon.stop_with_cli();
 }
 
@@ -2294,12 +2738,13 @@ fn deterministic_clock_dispatches_due_work_and_protocol_23_hides_it() {
         .to_string()
     );
 
-    let protocol::Response::ScheduledExecutions { executions } = versioned_request(
+    let protocol::Response::ScheduledExecutions { executions, .. } = versioned_request(
         &daemon,
         23,
         protocol::Request::ListScheduledExecutions {
             workspace_id: None,
             schedule_id: Some(schedule.id.clone()),
+            limit: None,
         },
     ) else {
         panic!("expected protocol-23 execution list");


### PR DESCRIPTION
## Summary

- add protocol-25 revision-aware execution waits and bounded history projections
- retain deterministic execution revisions and pruning through state-schema-12 migration
- expose reconnectable execution changes, next occurrences, and actionable CLI output
- add independent private alerts for dispatch failure and cold interruption
- preserve blocked Agent attention authority and protocol-23/24 compatibility

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`

## Stack

- Base PR: #161
- Merge after #161, then retarget this PR to `main` if GitHub does not update it automatically.

Closes #151