### PR TITLE
feat(cli): expose discovered projects

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -58,8 +58,8 @@ Most daemon-backed inspection commands automatically start Boomux when it is
 not running. This includes `list`, `shells`, `read`, `events`, workspace, shell,
 and launcher inspection, Agent, attention, session, and schedule inspection, and
 `doctor`. Use `boomux daemon status` first when starting the daemon would be an
-unwanted side effect. `capabilities`, `integration list`, and `integration
-status` do not start it.
+unwanted side effect. `capabilities`, `project list`, `integration list`, and
+`integration status` do not start it.
 
 Inspect bundled lifecycle integrations with:
 
@@ -504,6 +504,16 @@ Selecting a discovered project in the dashboard persists its canonical path as
 the workspace default cwd for later shells. Set
 `[dashboard] follow_focused_terminal = false` to disable the default
 focus-following behavior.
+
+Discover the same configured projects locally without starting the daemon:
+
+```console
+boomux project list --json
+```
+
+Use the canonical `path` returned for workspace creation. An empty list with
+`roots_configured: false` means no roots are configured; inspect `warnings` when
+configured roots cannot be scanned.
 
 ## Manage Workspaces
 

--- a/README.md
+++ b/README.md
@@ -425,6 +425,16 @@ stores its path as the workspace default for shells added later. Free-text and
 legacy workspaces without a default continue to use the directory where the
 dashboard was opened. An explicit shell cwd always takes precedence.
 
+List the same discovered projects without starting the daemon:
+
+```console
+boomux project list
+boomux project list --json
+```
+
+JSON output uses the stable `boomux.cli/v1` contract and includes canonical
+paths, root groups and ordering, warnings, and whether any roots are configured.
+
 The dashboard follows the most recently focused Boomux terminal by default,
 selecting its workspace and shell or Agent row. Manual dashboard navigation is
 preserved until another managed terminal gains focus. Press `Space` to pin the

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -48,6 +48,7 @@ The following commands support `--json`:
 - `boomux shells`
 - `boomux read`
 - `boomux events`
+- `boomux project list`
 - `boomux workspace list`
 - `boomux workspace inspect`
 - `boomux shell inspect`
@@ -103,6 +104,9 @@ Command payloads are:
   arrays of schemas, commands, features, and error codes.
 - `list`: a `shells` array.
 - `shells`: workspace identity plus a `shells` array.
+- `project.list`: `roots_configured`, a `projects` array, and a `warnings`
+  array. This command reads local configuration and the filesystem without
+  starting or contacting the daemon.
 - `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`,
   `launcher_count`, `schedule_count`, `agent_count`, fixed `agent_state_counts`, and
   `attention_count`.
@@ -178,6 +182,16 @@ Command payloads are:
   `active_executions`. State is `active` only for a running worker whose latest
   evaluation and next-occurrence projection succeeded; otherwise it is
   `offline`.
+
+## Project Data
+
+`project.list` discovers the same configured project suggestions used by the
+dashboard. Each project contains `name`, its canonical absolute `path`, the
+configured-root `group`, and zero-based `group_order`. `roots_configured` is
+false when the merged configuration has no project roots, distinguishing that
+state from configured roots that currently discover no projects. Recoverable
+scan problems and resource-limit notices are returned as human-readable strings
+in `warnings`; integrations must not parse warning text.
 
 ## Integration Data
 

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -13,6 +13,7 @@ use boomux::protocol::{
 };
 
 use crate::agent_attention_projection::AgentStateCounts;
+use crate::projects::Project;
 use crate::session_projection::{SessionOccurrence, SessionProjection};
 
 pub(crate) const SCHEMA: &str = "boomux.cli/v1";
@@ -90,6 +91,14 @@ pub(crate) struct WorkspaceSummary {
     pub(crate) agent_count: usize,
     pub(crate) agent_state_counts: AgentStateCounts,
     pub(crate) attention_count: usize,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ProjectData {
+    pub(crate) name: String,
+    pub(crate) path: String,
+    pub(crate) group: String,
+    pub(crate) group_order: usize,
 }
 
 #[derive(Serialize)]
@@ -325,6 +334,15 @@ pub(crate) fn shell(shell: &ShellSnapshot, workspace_name: Option<&str>) -> Shel
                 environment_has_run_id: run.environment_has_run_id,
             }
         }),
+    }
+}
+
+pub(crate) fn project(project: &Project) -> ProjectData {
+    ProjectData {
+        name: project.name.clone(),
+        path: project.path.display().to_string(),
+        group: project.group.clone(),
+        group_order: project.group_order,
     }
 }
 
@@ -670,6 +688,27 @@ mod tests {
     use super::*;
     use boomux::client::RemoteError;
     use boomux::protocol::AgentObservationSnapshot;
+
+    #[test]
+    fn project_json_uses_the_stable_cli_shape() {
+        let value = serde_json::to_value(project(&Project {
+            name: "boomux".into(),
+            path: "/home/user/Projects/boomux".into(),
+            group: "Projects".into(),
+            group_order: 1,
+        }))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "name": "boomux",
+                "path": "/home/user/Projects/boomux",
+                "group": "Projects",
+                "group_order": 1,
+            })
+        );
+    }
 
     #[test]
     fn agent_json_uses_the_stable_cli_shape() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,6 +376,11 @@ enum Commands {
     },
     /// Close a shell by name or shell ID
     Close { target: String },
+    /// Discover configured projects
+    Project {
+        #[command(subcommand)]
+        command: ProjectCommands,
+    },
     /// Manage workspaces
     Workspace {
         #[command(subcommand)]
@@ -469,6 +474,12 @@ enum Commands {
     },
     #[command(name = "__scheduled-runner", hide = true)]
     ScheduledRunner { schedule_id: String },
+}
+
+#[derive(Subcommand)]
+enum ProjectCommands {
+    /// List projects discovered from configured roots
+    List,
 }
 
 #[derive(Subcommand)]
@@ -1018,6 +1029,7 @@ command_keys! {
     Read => ("read", Json),
     Events => ("events", Json),
     Close => ("close", HumanOnly),
+    ProjectList => ("project.list", Json),
     WorkspaceList => ("workspace.list", Json),
     WorkspaceInspect => ("workspace.inspect", Json),
     Workspace => ("workspace", HumanOnly),
@@ -1078,6 +1090,9 @@ impl Cli {
             Some(Commands::Shells) => CommandKey::Shells,
             Some(Commands::Read { .. }) => CommandKey::Read,
             Some(Commands::Events { .. }) => CommandKey::Events,
+            Some(Commands::Project {
+                command: ProjectCommands::List,
+            }) => CommandKey::ProjectList,
             Some(Commands::Workspace {
                 command: WorkspaceCommands::List,
             }) => CommandKey::WorkspaceList,
@@ -1403,6 +1418,9 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             wait_ms,
         }) => read_events(after.as_deref(), limit, wait_ms, cli.json),
         Some(Commands::Close { target }) => close_shell(&target),
+        Some(Commands::Project {
+            command: ProjectCommands::List,
+        }) => list_projects(cli.json),
         Some(Commands::Workspace { command }) => {
             workspace_command(command, cli.json, cli.terminal.as_deref())
         }
@@ -3116,6 +3134,47 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
             .join(",")
     );
     println!("ERROR CODES\t{}", error_codes.join(","));
+    Ok(())
+}
+
+fn list_projects(json: bool) -> Result<(), Box<dyn Error>> {
+    let config = config::load()?;
+    let roots_configured = !config.projects.roots.is_empty();
+    let discovery = projects::discover(&config.projects);
+    if json {
+        let projects = discovery
+            .projects
+            .iter()
+            .map(cli_output::project)
+            .collect::<Vec<_>>();
+        return print_json(
+            CommandKey::ProjectList,
+            serde_json::json!({
+                "roots_configured": roots_configured,
+                "projects": projects,
+                "warnings": discovery.warnings,
+            }),
+        );
+    }
+
+    if !roots_configured {
+        println!("No project roots configured.");
+    } else if discovery.projects.is_empty() {
+        println!("No projects discovered.");
+    } else {
+        println!("GROUP\tNAME\tPATH");
+        for project in discovery.projects {
+            println!(
+                "{}\t{}\t{}",
+                project.group,
+                project.name,
+                project.path.display()
+            );
+        }
+    }
+    for warning in discovery.warnings {
+        eprintln!("warning: {warning}");
+    }
     Ok(())
 }
 
@@ -8875,6 +8934,7 @@ mod tests {
                 "shells",
                 "read",
                 "events",
+                "project.list",
                 "workspace.list",
                 "workspace.inspect",
                 "shell.inspect",
@@ -9072,6 +9132,7 @@ mod tests {
             "boomux events",
             "boomux close",
             "boomux open",
+            "boomux project list",
             "boomux workspace list",
             "boomux workspace create",
             "boomux workspace open",

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -10,6 +10,8 @@ mod handoff;
 mod launchers_integrations;
 #[path = "native_backend/notifications.rs"]
 mod notifications;
+#[path = "native_backend/project_discovery.rs"]
+mod project_discovery;
 #[path = "native_backend/protocol_control.rs"]
 mod protocol_control;
 #[path = "native_backend/schedules.rs"]

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -71,6 +71,7 @@ fn native_daemon_lifecycle() {
     let json_commands = capabilities["data"]["json_commands"].as_array().unwrap();
     for command in [
         "events",
+        "project.list",
         "agent.register",
         "agent.ensure",
         "agent.report",

--- a/tests/native_backend/project_discovery.rs
+++ b/tests/native_backend/project_discovery.rs
@@ -1,0 +1,103 @@
+use std::fs;
+use std::process::Command;
+
+use uuid::Uuid;
+
+#[test]
+fn project_list_is_local_and_has_a_stable_json_envelope() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-project-discovery-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let projects_root = root.join("Projects");
+    let project = projects_root.join("alpha");
+    let runtime = root.join("runtime");
+    let config_home = root.join("config-home");
+    fs::create_dir_all(project.join(".git")).unwrap();
+    fs::create_dir_all(&runtime).unwrap();
+    fs::create_dir_all(&config_home).unwrap();
+    let config = root.join("config.toml");
+    fs::write(
+        &config,
+        format!(
+            "[projects]\nroots = [{:?}, {:?}]\nmax_depth = 2\n",
+            projects_root.display().to_string(),
+            root.join("missing").display().to_string()
+        ),
+    )
+    .unwrap();
+
+    let command = || {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+        command
+            .env("BOOMUX_CONFIG", &config)
+            .env("HOME", &root)
+            .env("XDG_CONFIG_HOME", &config_home)
+            .env("XDG_RUNTIME_DIR", &runtime)
+            .env("XDG_STATE_HOME", root.join("state"));
+        command
+    };
+
+    let output = command()
+        .args(["project", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "project list failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["schema"], "boomux.cli/v1");
+    assert_eq!(value["command"], "project.list");
+    assert_eq!(value["data"]["roots_configured"], true);
+    assert_eq!(value["data"]["projects"].as_array().unwrap().len(), 1);
+    assert_eq!(value["data"]["projects"][0]["name"], "alpha");
+    assert_eq!(
+        value["data"]["projects"][0]["path"],
+        project.canonicalize().unwrap().display().to_string()
+    );
+    assert_eq!(value["data"]["projects"][0]["group"], "Projects");
+    assert_eq!(value["data"]["projects"][0]["group_order"], 0);
+    assert_eq!(value["data"]["warnings"].as_array().unwrap().len(), 1);
+    assert!(
+        value["data"]["warnings"][0]
+            .as_str()
+            .unwrap()
+            .contains("project root is not a directory")
+    );
+
+    let human = command().args(["project", "list"]).output().unwrap();
+    assert!(human.status.success());
+    let stdout = String::from_utf8(human.stdout).unwrap();
+    let stderr = String::from_utf8(human.stderr).unwrap();
+    assert!(stdout.contains("GROUP\tNAME\tPATH"));
+    assert!(stdout.contains("Projects\talpha\t"));
+    assert!(stderr.contains("warning: project root is not a directory"));
+
+    fs::write(&config, "").unwrap();
+    let empty = command()
+        .args(["project", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(empty.status.success());
+    let empty: serde_json::Value = serde_json::from_slice(&empty.stdout).unwrap();
+    assert_eq!(empty["data"]["roots_configured"], false);
+    assert_eq!(empty["data"]["projects"], serde_json::json!([]));
+    assert_eq!(empty["data"]["warnings"], serde_json::json!([]));
+
+    let capabilities = command().args(["capabilities", "--json"]).output().unwrap();
+    assert!(capabilities.status.success());
+    let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
+    assert!(
+        capabilities["data"]["json_commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|command| command == "project.list")
+    );
+    assert!(!runtime.join("boomux/daemon.sock").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
## Summary
- add passive `boomux project list` and stable `project.list` JSON output
- expose canonical project paths, configured-root groups/order, warnings, and root configuration state
- advertise the command through capabilities and document it for integrations

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --lib --bins --locked
- cargo test --test native_backend --locked -- --test-threads=1
- bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js
- git diff --check
- verified project listing does not start or contact the daemon