### PR TITLE
feat(cli): suggest generated shell names

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -565,6 +565,7 @@ workspace context or `--workspace`.
 ## Manage Shells
 
 ```console
+boomux shell suggest-name "<workspace-name-or-id>" --json
 boomux shell create "<workspace-name-or-id>"
 boomux shell create "<workspace-name-or-id>" --name "<name>" --cwd "/path"
 boomux shell create "<workspace-name-or-id>" --name "<name>" -- command arg
@@ -580,6 +581,12 @@ generate a unique lowercase `adjective-noun` shell name. A shell cannot close it
 Closing one shell terminates its process session and removes its retained
 terminal state, but durable Agent records remain in the workspace as historical
 occurrences.
+
+`shell suggest-name` returns `boomux.cli/v1` command `shell.suggest-name` with
+exact `workspace_id` and nonempty `name`, without creating or reserving a shell.
+Use it only as a UI suggestion. Creation can still fail with typed
+`already_exists` if another operation claims the name first; request another
+suggestion rather than changing or inferring a name.
 
 The contextual close shorthand is:
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | Create a generated workspace | `boomux .` |
 | Create or add to a named workspace | `boomux . --name feature-x` |
 | Create an empty workspace with a default directory | `boomux workspace create feature-x --cwd .` |
+| Suggest an unused shell name | `boomux shell suggest-name feature-x` |
 | Add a randomly named shell | `boomux shell create feature-x` |
 | Open the new shell in another terminal | `boomux . --name feature-x --new` |
 | Run one command | `boomux . --name feature-x --new -- lazygit` |
@@ -143,7 +144,10 @@ path as its default for later shells. With `--name`, it adds a shell to an
 existing exact-name workspace or creates a workspace with that default.
 Shells created without an explicit shell name receive a memorable lowercase
 `adjective-noun` name such as `quiet-otter`; that concrete name is retained like
-any explicit name.
+any explicit name. `shell suggest-name` exposes the same collision-aware naming
+for integrations without creating a shell. A suggestion is not reserved, so a
+later creation can still fail with `already_exists` if another operation claims
+the name first.
 `--terminal` implies `--new`. Terminal selection uses the CLI override, then
 Boomux configuration, then the normal `xdg-terminal-exec` policy.
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -51,6 +51,7 @@ The following commands support `--json`:
 - `boomux project list`
 - `boomux workspace list`
 - `boomux workspace inspect`
+- `boomux shell suggest-name <workspace-name-or-id>`
 - `boomux shell inspect`
 - `boomux launcher list`
 - `boomux launcher inspect`
@@ -113,6 +114,9 @@ Command payloads are:
 - `workspace.inspect`: one `workspace` object containing `id`, `name`, nullable
   `default_cwd`, and prompt-free `shells`, `launchers`, `schedules`, and `agents`
   arrays.
+- `shell.suggest-name`: exact resolved `workspace_id` plus a nonempty generated
+  `name` that does not match any shell name in that workspace at observation
+  time.
 - `shell.inspect`: one `shell` object.
 - `launcher.list`: workspace identity plus a `launchers` array.
 - `launcher.inspect`: one `launcher` object.
@@ -192,6 +196,16 @@ false when the merged configuration has no project roots, distinguishing that
 state from configured roots that currently discover no projects. Recoverable
 scan problems and resource-limit notices are returned as human-readable strings
 in `warnings`; integrations must not parse warning text.
+
+## Shell Name Suggestions
+
+`boomux shell suggest-name <workspace-name-or-id> --json` returns a lowercase
+`adjective-noun` suggestion using the same catalog and collision-exclusion
+algorithm as generated shell creation. The suggestion is not reserved. Another
+operation can claim it before creation, so a later explicit `shell create
+--name <suggestion>` can still fail with `already_exists`; callers must handle
+that typed error rather than assume the suggestion grants ownership. If every
+generated name is currently in use, suggestion fails with `already_exists`.
 
 ## Integration Data
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -548,6 +548,8 @@ enum LauncherCommands {
 
 #[derive(Subcommand)]
 enum ShellCommands {
+    /// Suggest an unused generated name without reserving it
+    SuggestName { workspace: String },
     /// Create a pending shell in a workspace
     Create {
         workspace: String,
@@ -1033,6 +1035,7 @@ command_keys! {
     WorkspaceList => ("workspace.list", Json),
     WorkspaceInspect => ("workspace.inspect", Json),
     Workspace => ("workspace", HumanOnly),
+    ShellSuggestName => ("shell.suggest-name", Json),
     ShellInspect => ("shell.inspect", Json),
     Shell => ("shell", HumanOnly),
     LauncherList => ("launcher.list", Json),
@@ -1099,6 +1102,9 @@ impl Cli {
             Some(Commands::Workspace {
                 command: WorkspaceCommands::Inspect { .. },
             }) => CommandKey::WorkspaceInspect,
+            Some(Commands::Shell {
+                command: ShellCommands::SuggestName { .. },
+            }) => CommandKey::ShellSuggestName,
             Some(Commands::Shell {
                 command: ShellCommands::Inspect { .. },
             }) => CommandKey::ShellInspect,
@@ -2455,19 +2461,13 @@ fn create_generated_shell(
     let mut rejected = BTreeSet::new();
     loop {
         let workspace = client.get_workspace(workspace_id)?;
-        let name = generated_names::random_excluding(
+        let name = generated_shell_name(
             workspace
                 .shells
                 .iter()
                 .map(|shell| shell.name.as_str())
                 .chain(rejected.iter().map(String::as_str)),
-        )
-        .ok_or_else(|| {
-            cli_output::failure(
-                "already_exists",
-                "all generated shell names are already in use",
-            )
-        })?;
+        )?;
         match client.create_shell(workspace_id, shell_spec(&name, cwd, command)) {
             Ok(shell) => return Ok(shell),
             Err(client::ClientError::Remote(error))
@@ -2478,6 +2478,17 @@ fn create_generated_shell(
             Err(error) => return Err(error.into()),
         }
     }
+}
+
+fn generated_shell_name<'a>(
+    unavailable: impl IntoIterator<Item = &'a str>,
+) -> Result<String, Box<dyn Error>> {
+    generated_names::random_excluding(unavailable).ok_or_else(|| {
+        cli_output::failure(
+            "already_exists",
+            "all generated shell names are already in use",
+        )
+    })
 }
 
 fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), Box<dyn Error>> {
@@ -3413,6 +3424,28 @@ fn workspace_command(
 fn shell_command(command: ShellCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     match command {
+        ShellCommands::SuggestName { workspace } => {
+            let snapshot = client.snapshot()?;
+            let workspace = resolve_workspace_target(&snapshot.workspaces, &workspace)?;
+            let name =
+                generated_shell_name(workspace.shells.iter().map(|shell| shell.name.as_str()))?;
+            if json {
+                return print_json(
+                    CommandKey::ShellSuggestName,
+                    serde_json::json!({
+                        "workspace_id": workspace.id,
+                        "name": name,
+                    }),
+                );
+            }
+            println!(
+                "Suggested shell name {name} for {} ({})",
+                workspace.name, workspace.id
+            );
+            println!(
+                "This suggestion is not reserved; shell creation can still fail if the name is already in use."
+            );
+        }
         ShellCommands::Create {
             workspace,
             name,
@@ -6814,6 +6847,7 @@ mod tests {
             vec!["boomux", "--json", "capabilities"],
             vec!["boomux", "list", "--json"],
             vec!["boomux", "workspace", "list", "--json"],
+            vec!["boomux", "shell", "suggest-name", "project", "--json"],
             vec![
                 "boomux",
                 "launcher",
@@ -6988,6 +7022,14 @@ mod tests {
                 && name == "tests"
                 && cwd.as_deref() == Some(Path::new("/tmp"))
                 && command == ["cargo", "test"]
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "shell", "suggest-name", "project"])
+                .unwrap()
+                .command,
+            Some(Commands::Shell {
+                command: ShellCommands::SuggestName { workspace }
+            }) if workspace == "project"
         ));
         assert!(matches!(
             Cli::try_parse_from(["boomux", "shell", "create", "project"])
@@ -7451,6 +7493,20 @@ mod tests {
         let (adjective, noun) = generated.split_once('-').unwrap();
         assert!(adjective.bytes().all(|byte| byte.is_ascii_lowercase()));
         assert!(noun.bytes().all(|byte| byte.is_ascii_lowercase()));
+    }
+
+    #[test]
+    fn generated_shell_name_exhaustion_is_typed() {
+        let mut names = Vec::new();
+        while let Some(name) = generated_names::random_excluding(names.iter().map(String::as_str)) {
+            names.push(name);
+        }
+
+        let error = generated_shell_name(names.iter().map(String::as_str)).unwrap_err();
+        assert_eq!(
+            cli_output::classify_for_test("shell.suggest-name", error.as_ref()),
+            "already_exists"
+        );
     }
 
     #[test]
@@ -8848,6 +8904,7 @@ mod tests {
     #[test]
     fn capabilities_advertise_phase_two_agent_integration_surface() {
         let json_commands = json_commands().collect::<Vec<_>>();
+        assert!(json_commands.contains(&"shell.suggest-name"));
         for command in [
             "agent.register",
             "agent.ensure",
@@ -8937,6 +8994,7 @@ mod tests {
                 "project.list",
                 "workspace.list",
                 "workspace.inspect",
+                "shell.suggest-name",
                 "shell.inspect",
                 "launcher.list",
                 "launcher.inspect",

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -18,3 +18,5 @@ mod protocol_control;
 mod schedules;
 #[path = "native_backend/shell_lifecycle.rs"]
 mod shell_lifecycle;
+#[path = "native_backend/shell_name_suggestion.rs"]
+mod shell_name_suggestion;

--- a/tests/native_backend/shell_name_suggestion.rs
+++ b/tests/native_backend/shell_name_suggestion.rs
@@ -1,0 +1,66 @@
+use std::collections::BTreeSet;
+
+use boomux::protocol::ShellSpec;
+
+use crate::support::{TestDaemon, assert_generated_name};
+
+#[test]
+fn shell_name_suggestion_is_stable_non_mutating_cli_data() {
+    let daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "suggestions",
+            vec![
+                ShellSpec::login("agile-badger", std::env::temp_dir()),
+                ShellSpec::login("quiet-otter", std::env::temp_dir()),
+            ],
+        )
+        .unwrap();
+    let before = workspace
+        .shells
+        .iter()
+        .map(|shell| (shell.id.clone(), shell.name.clone()))
+        .collect::<BTreeSet<_>>();
+
+    let output = daemon
+        .command()
+        .args(["shell", "suggest-name", "suggestions", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "shell name suggestion failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["schema"], "boomux.cli/v1");
+    assert_eq!(value["command"], "shell.suggest-name");
+    assert_eq!(value["data"]["workspace_id"], workspace.id);
+    assert_eq!(value["data"].as_object().unwrap().len(), 2);
+    let name = value["data"]["name"].as_str().unwrap();
+    assert!(!name.is_empty());
+    assert_generated_name(name);
+    assert!(!before.iter().any(|(_, current)| current == name));
+
+    let after = daemon
+        .client
+        .get_workspace(&workspace.id)
+        .unwrap()
+        .shells
+        .into_iter()
+        .map(|shell| (shell.id, shell.name))
+        .collect::<BTreeSet<_>>();
+    assert_eq!(after, before);
+
+    let human = daemon
+        .command()
+        .args(["shell", "suggest-name", &workspace.id])
+        .output()
+        .unwrap();
+    assert!(human.status.success());
+    let human = String::from_utf8(human.stdout).unwrap();
+    assert!(human.contains("Suggested shell name"));
+    assert!(human.contains(&workspace.id));
+    assert!(human.contains("not reserved"));
+}


### PR DESCRIPTION
## Summary
- add advertised `boomux shell suggest-name <workspace> --json` support
- reuse generated-name collision exclusion without creating or reserving a shell
- return the exact resolved workspace ID and generated name in the stable envelope
- document unreserved concurrency semantics and add native coverage

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --lib --bins --locked
- cargo test --test native_backend --locked -- --test-threads=1
- bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js
- git diff --check