### PR TITLE
fix(opencode): clear stale child errors on root work

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -664,7 +664,10 @@ ID as `external_session_id`; child and subagent events aggregate into that one
 root agent instance. Busy/active work, chat, tools, compaction, and resolved
 prompts map to `working`; outstanding permission or question requests and
 session errors map to `blocked`; only root idle maps to `idle`. Blockers are
-tracked as a set, and errors remain latched until later work is observed. Only
+tracked as a set. Errors remain latched until their session resumes or is
+deleted; later root work clears every root-aggregate error latch because it
+demonstrates aggregate recovery, but does not clear outstanding permission or
+question blockers. Only
 explicit root `session.deleted` maps to `done`: child deletion and process or
 shell exit do not complete the instance. Once the derived state is `working`,
 later chat, tool, and compaction evidence is coalesced until a meaningful state

--- a/integrations/opencode/boomux.js
+++ b/integrations/opencode/boomux.js
@@ -216,7 +216,8 @@ function reduce(state, action, isRootEvent) {
       next = "blocked";
       break;
     case "working":
-      state.errors.delete(action.sessionID);
+      if (isRootEvent) state.errors.clear();
+      else state.errors.delete(action.sessionID);
       next = isBlocked(state) ? "blocked" : "working";
       break;
     case "idle":

--- a/integrations/opencode/boomux.test.js
+++ b/integrations/opencode/boomux.test.js
@@ -362,7 +362,7 @@ describe("root aggregation", () => {
     expect(calls[3][calls[3].indexOf("--state") + 1]).toBe("working");
   });
 
-  test("child deletion clears its latched error", async () => {
+  test("root work clears a latched child error", async () => {
     const calls = [];
     const lifecycle = createLifecycle({
       client: { session: { get: async () => {} } },
@@ -391,13 +391,88 @@ describe("root aggregation", () => {
       event("session.status", { sessionID: "root", status: "busy" }),
     );
     expect(calls).toHaveLength(2);
-    expect(calls[1][calls[1].indexOf("--state") + 1]).toBe("blocked");
+    expect(calls[1][calls[1].indexOf("--state") + 1]).toBe("working");
     await lifecycle.enqueue(
       event("session.deleted", { info: { id: "child", parentID: "root" } }),
     );
 
+    expect(calls).toHaveLength(2);
+  });
+
+  test("child deletion clears its latched error", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: { session: { get: async () => {} } },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return successfulEnsure();
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    await lifecycle.enqueue(
+      event("session.created", { info: { id: "child", parentID: "root" } }),
+    );
+    calls.length = 0;
+
+    await lifecycle.enqueue(
+      event("session.error", {
+        sessionID: "child",
+        error: { message: "child failed" },
+      }),
+    );
+    await lifecycle.enqueue(
+      event("session.deleted", { info: { id: "child", parentID: "root" } }),
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1][calls[1].indexOf("--state") + 1]).toBe("working");
+  });
+
+  test("root work clears errors without clearing an outstanding prompt", async () => {
+    const calls = [];
+    const lifecycle = createLifecycle({
+      client: { session: { get: async () => {} } },
+      env,
+      run: async (argv) => {
+        calls.push(argv);
+        return successfulEnsure();
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    await lifecycle.enqueue(
+      event("session.created", { info: { id: "child", parentID: "root" } }),
+    );
+    calls.length = 0;
+
+    await lifecycle.enqueue(
+      event("session.error", {
+        sessionID: "child",
+        error: { message: "child failed" },
+      }),
+    );
+    await lifecycle.enqueue(
+      event("permission.asked", {
+        sessionID: "child",
+        id: "permission-1",
+      }),
+    );
+    await lifecycle.enqueue(
+      event("session.status", { sessionID: "root", status: "busy" }),
+    );
+
     expect(calls).toHaveLength(3);
-    expect(calls[2][calls[2].indexOf("--state") + 1]).toBe("working");
+    expect(calls[2][calls[2].indexOf("--state") + 1]).toBe("blocked");
+    await lifecycle.enqueue(
+      event("permission.replied", {
+        sessionID: "child",
+        requestID: "permission-1",
+      }),
+    );
+    expect(calls).toHaveLength(4);
+    expect(calls[3][calls[3].indexOf("--state") + 1]).toBe("working");
   });
 });
 


### PR DESCRIPTION
## Summary

- clear latched root and child session errors when fresh root activity proves the aggregate OpenCode session recovered
- preserve outstanding permission and question blockers during root activity
- retain child-session deletion as an independent error-recovery path
- document the aggregate error-latch semantics and add combined-state regression coverage

## Root Cause

An interrupted retained subagent emitted `session.error`. Later root `busy` and tool events were classified as working, but only cleared errors for their own session ID. The retained child error therefore kept the root Agent blocked indefinitely unless OpenCode later deleted or resumed that exact child session.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`