### PR TITLE
feat(node): persist stable node identity

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@
 | `src/client.rs` | Daemon discovery/startup, protocol negotiation, typed management requests, and attachment setup |
 | `src/daemon.rs` | `DaemonService` coordination over durable registry, event-stream, shell-runtime, persistence, and handoff owners |
 | `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
+| `src/node_identity.rs` | Independent stable Node identity creation, validation, and atomic persistence |
 | `src/handoff.rs`, `src/fd_transfer.rs` | Graceful daemon replacement records and Unix descriptor transfer |
 | `src/attach.rs` | Terminal-side raw mode, control frames, live input/output, resize, focus, and reconnect handling |
 | `src/terminal.rs` | Selection and launch of native terminal windows through `xdg-terminal-exec` |
@@ -811,12 +812,17 @@ Protocol 27 adds paused, revision-conditional schedule definition updates and
 prompt-free `agent_schedule_updated` events. Protocol-26 peers filter those
 events while advancing their cursor. State schema remains 12.
 
-Remote Node federation is tracked by #173 and has no assigned shipped protocol,
-state, or handoff version. Its compatibility contract requires older clients to
-retain local-only meaning, a separately versioned pre-protocol SSH identity
-handshake, and explicit schemas for Node identity, registrations, and disposable
-projection cache. A future implementation must update this protocol history only
-when those exact source versions are established.
+Protocol 28 and Node identity schema 1 establish the stable local Node ID used by
+future federation. The daemon creates owner-only `node.json` independently from
+authoritative `state.json`, preserves malformed or future identity files while
+disabling federation, and exposes the identity through the version-gated
+`GetNodeIdentity` request. Cold restart and graceful handoff read the same file;
+the identity is not transferred in the handoff manifest. State schema remains 12.
+Protocol-27 peers remain local-only and cannot query Node identity.
+
+The SSH federation handshake, transport, registration, and projection protocols
+remain unimplemented under #173. Their separately versioned schemas and protocol
+history entries are added only when the corresponding source versions land.
 
 Cron day matching preserves syntactic wildcard origin: `*/n` is wildcard-origin,
 while numeric lists and ranges remain restricted even when they cover the full

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -4,8 +4,9 @@
 > defines the authority, identity, privacy, compatibility, and failure semantics
 > delivered by [#174](https://github.com/gardnmi/boomux/issues/174) under tracking
 > epic [#173](https://github.com/gardnmi/boomux/issues/173). Current source and
-> compatibility tests remain authoritative for shipped behavior. No remote Node
-> command or protocol capability is implemented until its delivery issue lands.
+> compatibility tests remain authoritative for shipped behavior. Protocol 28
+> implements only stable local Node identity and its daemon query; no remote Node
+> command, SSH transport, registration, or projection is implemented yet.
 
 ## Purpose
 

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -678,6 +678,7 @@ fn protocol_error_code(code: ErrorCode) -> &'static str {
         ErrorCode::RunChanged => "run_changed",
         ErrorCode::RevisionAhead => "revision_ahead",
         ErrorCode::IdempotencyExpired => "idempotency_expired",
+        ErrorCode::NodeIdentityUnavailable => "node_identity_unavailable",
         ErrorCode::Internal => "internal",
         ErrorCode::Unknown => "unknown",
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -528,6 +528,13 @@ impl Client {
         expect_ok(self.request(Request::Ping)?, Response::Pong)
     }
 
+    pub fn node_identity(&self) -> Result<String> {
+        match self.request(Request::GetNodeIdentity)? {
+            Response::NodeIdentity { node_id } => Ok(node_id),
+            response => unexpected(response),
+        }
+    }
+
     pub fn shutdown(&self) -> Result<()> {
         expect_ok(self.request(Request::Shutdown)?, Response::Ok)?;
         for _ in 0..SHUTDOWN_ATTEMPTS {
@@ -1577,7 +1584,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 27);
+            assert_eq!(request.version, protocol::PROTOCOL_VERSION);
             let Request::UpdateAgentSchedule {
                 schedule_id,
                 expected_revision,
@@ -1592,7 +1599,7 @@ mod tests {
             protocol::write_message(
                 &mut stream,
                 &Envelope::with_version(
-                    27,
+                    protocol::PROTOCOL_VERSION,
                     Response::AgentSchedule {
                         schedule: AgentScheduleSnapshot {
                             id: schedule_id,
@@ -1743,6 +1750,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 28, 27);
             reject_protocol(&listener, 27, 26);
             reject_protocol(&listener, 26, 25);
             reject_protocol(&listener, 25, 24);
@@ -1877,6 +1885,62 @@ mod tests {
             error,
             ClientError::Protocol(ProtocolError::UnsupportedVersion(ref message))
                 if message == "daemon does not support Agent wait"
+        ));
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn node_identity_requires_protocol_twenty_eight() {
+        let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 28);
+            assert_eq!(request.message, Request::GetNodeIdentity);
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    27,
+                    Response::Error {
+                        message: "Node identity requires protocol 28".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 28);
+            assert_eq!(request.message, Request::Ping);
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    27,
+                    Response::Error {
+                        message: "protocol 28 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 27);
+            assert_eq!(request.message, Request::Ping);
+            protocol::write_message(&mut stream, &Envelope::with_version(27, Response::Pong))
+                .unwrap();
+        });
+
+        let client = Client::from_socket_path(socket);
+        assert!(matches!(
+            client.node_identity(),
+            Err(ClientError::Protocol(ProtocolError::UnsupportedVersion(_)))
         ));
         server.join().unwrap();
         fs::remove_dir_all(directory).unwrap();
@@ -2036,6 +2100,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 28, 27);
             reject_protocol(&listener, 27, 26);
             reject_protocol(&listener, 26, 25);
             reject_protocol(&listener, 25, 24);
@@ -2099,6 +2164,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 28, 27);
             reject_protocol(&listener, 27, 26);
             reject_protocol(&listener, 26, 25);
             reject_protocol(&listener, 25, 24);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -28,6 +28,7 @@ use crate::desktop_notifications::{
 };
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
+use crate::node_identity::NodeIdentity;
 use crate::protocol::{
     self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
     AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
@@ -324,6 +325,13 @@ fn run_daemon(
     validate_notification_delivery_settings(&notification_settings)?;
     let live_handoff = committed.is_some();
     let mut registry = DaemonService::restore(store, live_handoff, transferred.events)?;
+    registry.node_identity = match NodeIdentity::load_or_create_from_environment() {
+        Ok(identity) => Some(identity),
+        Err(error) => {
+            eprintln!("boomux: federation disabled: {error}");
+            None
+        }
+    };
     registry.startup_environment = capture_current_environment();
     registry.configure_scheduler_clock()?;
     registry.notification_settings = notification_settings.clone();
@@ -1491,6 +1499,7 @@ fn scheduled_execution_response(
 }
 
 struct DaemonService {
+    node_identity: Option<NodeIdentity>,
     durable: DurableRegistry,
     events: EventStream,
     runtimes: ShellRuntimeManager,
@@ -4842,6 +4851,7 @@ struct DurableState {
 impl Default for DaemonService {
     fn default() -> Self {
         Self {
+            node_identity: None,
             durable: DurableRegistry {
                 state: Mutex::new(DurableState::default()),
                 store: None,
@@ -6904,6 +6914,18 @@ impl DaemonService {
         .transpose()?;
         match request {
             Request::Ping => Ok(Response::Pong),
+            Request::GetNodeIdentity => self
+                .node_identity
+                .as_ref()
+                .map(|identity| Response::NodeIdentity {
+                    node_id: identity.id().to_owned(),
+                })
+                .ok_or_else(|| {
+                    DaemonError::lifecycle(
+                        ErrorCode::NodeIdentityUnavailable,
+                        "Boomux Node identity is unavailable",
+                    )
+                }),
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
                 unreachable!("restart is handled before dispatch")
             }
@@ -7696,6 +7718,7 @@ impl DaemonService {
         let store = Arc::new(store);
         let persistence_writer = PersistenceWriter::start(Arc::clone(&store));
         let registry = Self {
+            node_identity: None,
             durable: DurableRegistry {
                 state: Mutex::new(state),
                 store: Some(store),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod desktop_notifications;
 mod fd_transfer;
 mod handoff;
 pub mod integrations;
+mod node_identity;
 pub mod protocol;
 pub mod scheduling;
 mod state_store;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8969,7 +8969,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 27);
+        assert_eq!(protocol::PROTOCOL_VERSION, 28);
     }
 
     #[test]

--- a/src/node_identity.rs
+++ b/src/node_identity.rs
@@ -1,0 +1,261 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::state_store::{effective_uid, secure_state_dir, state_directory_from_environment};
+
+const NODE_IDENTITY_VERSION: u32 = 1;
+const MAX_NODE_IDENTITY_BYTES: u64 = 4 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NodeIdentity {
+    id: String,
+}
+
+impl NodeIdentity {
+    pub(crate) fn load_or_create_from_environment() -> io::Result<Self> {
+        Self::load_or_create_at(state_directory_from_environment()?.join("node.json"))
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn load_or_create_at(path: PathBuf) -> io::Result<Self> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| io::Error::other("Node identity path has no parent"))?;
+        secure_state_dir(parent)?;
+        let _lock = acquire_identity_lock(parent)?;
+        match load(&path) {
+            Ok(identity) => Ok(identity),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => create(&path),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedNodeIdentity {
+    version: u32,
+    node_id: String,
+}
+
+fn acquire_identity_lock(parent: &Path) -> io::Result<File> {
+    let path = parent.join("node.lock");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(&path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.uid() != effective_uid() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Boomux Node identity lock is not an owned regular file",
+        ));
+    }
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+    // The file remains open while `flock` is held and the call takes no pointers.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(file)
+}
+
+fn load(path: &Path) -> io::Result<NodeIdentity> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.uid() != effective_uid() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Boomux Node identity is not an owned regular file",
+        ));
+    }
+    if metadata.mode() & 0o077 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Boomux Node identity is not owner-only",
+        ));
+    }
+    if metadata.len() > MAX_NODE_IDENTITY_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux Node identity exceeds the size limit",
+        ));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.read_to_end(&mut bytes)?;
+    let persisted: PersistedNodeIdentity = serde_json::from_slice(&bytes).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("could not parse Boomux Node identity: {error}"),
+        )
+    })?;
+    if persisted.version != NODE_IDENTITY_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported Boomux Node identity version {}; expected {NODE_IDENTITY_VERSION}",
+                persisted.version
+            ),
+        ));
+    }
+    let parsed = Uuid::parse_str(&persisted.node_id).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux Node identity contains an invalid Node ID",
+        )
+    })?;
+    if parsed.to_string() != persisted.node_id {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux Node identity contains a noncanonical Node ID",
+        ));
+    }
+    Ok(NodeIdentity {
+        id: persisted.node_id,
+    })
+}
+
+fn create(path: &Path) -> io::Result<NodeIdentity> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("Node identity path has no parent"))?;
+    let identity = NodeIdentity {
+        id: Uuid::new_v4().to_string(),
+    };
+    let bytes = serde_json::to_vec_pretty(&PersistedNodeIdentity {
+        version: NODE_IDENTITY_VERSION,
+        node_id: identity.id.clone(),
+    })
+    .map_err(io::Error::other)?;
+    let temporary = parent.join(format!(".node-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        match fs::hard_link(&temporary, path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => return load(path),
+            Err(error) => return Err(error),
+        }
+        let _ = File::open(parent).and_then(|directory| directory.sync_all());
+        Ok(identity)
+    })();
+    let _ = fs::remove_file(&temporary);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    fn test_path() -> PathBuf {
+        std::env::temp_dir()
+            .join(format!("boomux-node-{}", Uuid::new_v4()))
+            .join("boomux/node.json")
+    }
+
+    #[test]
+    fn creates_and_reloads_one_owner_only_identity() {
+        let path = test_path();
+        let first = NodeIdentity::load_or_create_at(path.clone()).unwrap();
+        let second = NodeIdentity::load_or_create_at(path.clone()).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(fs::symlink_metadata(&path).unwrap().mode() & 0o777, 0o600);
+        assert_eq!(
+            fs::symlink_metadata(path.parent().unwrap()).unwrap().mode() & 0o777,
+            0o700
+        );
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn concurrent_creation_returns_one_identity() {
+        let path = test_path();
+        let barrier = Arc::new(Barrier::new(8));
+        let handles = (0..8)
+            .map(|_| {
+                let path = path.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    NodeIdentity::load_or_create_at(path).unwrap()
+                })
+            })
+            .collect::<Vec<_>>();
+        let identities = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect::<Vec<_>>();
+        assert!(identities.iter().all(|identity| identity == &identities[0]));
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn malformed_identity_is_preserved() {
+        let path = test_path();
+        secure_state_dir(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"not-json").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let error = NodeIdentity::load_or_create_at(path.clone()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(fs::read(&path).unwrap(), b"not-json");
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn unsupported_identity_is_preserved() {
+        let path = test_path();
+        secure_state_dir(path.parent().unwrap()).unwrap();
+        let bytes = serde_json::to_vec(&PersistedNodeIdentity {
+            version: NODE_IDENTITY_VERSION + 1,
+            node_id: Uuid::new_v4().to_string(),
+        })
+        .unwrap();
+        fs::write(&path, &bytes).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let error = NodeIdentity::load_or_create_at(path.clone()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(fs::read(&path).unwrap(), bytes);
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn rejects_non_owner_only_identity() {
+        let path = test_path();
+        secure_state_dir(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            serde_json::to_vec(&PersistedNodeIdentity {
+                version: NODE_IDENTITY_VERSION,
+                node_id: Uuid::new_v4().to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        let error = NodeIdentity::load_or_create_at(path.clone()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 27;
+pub const PROTOCOL_VERSION: u32 = 28;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -108,6 +108,10 @@ define_protocol_features! {
     AgentScheduleEditing => (27, "agent schedule editing", [
         "protocol_27",
         "agent_schedule_editing",
+    ]),
+    NodeIdentity => (28, "Node identity", [
+        "protocol_28",
+        "stable_node_identity",
     ]),
 }
 
@@ -670,6 +674,7 @@ pub enum ErrorCode {
     RunChanged,
     RevisionAhead,
     IdempotencyExpired,
+    NodeIdentityUnavailable,
     Internal,
     #[serde(other)]
     Unknown,
@@ -921,6 +926,7 @@ impl ShellSpec {
 #[serde(tag = "request", rename_all = "snake_case")]
 pub enum Request {
     Ping,
+    GetNodeIdentity,
     Restart,
     RestartWithNotificationConfig {
         notifications: NotificationDeliveryConfig,
@@ -1107,6 +1113,7 @@ pub enum Request {
 impl Request {
     pub fn required_feature(&self) -> Option<ProtocolFeature> {
         match self {
+            Self::GetNodeIdentity => Some(ProtocolFeature::NodeIdentity),
             Self::WaitScheduledExecution { .. } => {
                 Some(ProtocolFeature::ScheduledExecutionObservation)
             }
@@ -1207,6 +1214,9 @@ impl Request {
 #[serde(tag = "response", rename_all = "snake_case")]
 pub enum Response {
     Pong,
+    NodeIdentity {
+        node_id: String,
+    },
     Snapshot {
         snapshot: Snapshot,
     },
@@ -1787,9 +1797,29 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_twenty_seven_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 27);
+    fn protocol_version_is_twenty_eight_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 28);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
+    }
+
+    #[test]
+    fn node_identity_messages_round_trip() {
+        let request = serde_json::to_value(Request::GetNodeIdentity).unwrap();
+        assert_eq!(request["request"], "get_node_identity");
+        assert_eq!(
+            serde_json::from_value::<Request>(request).unwrap(),
+            Request::GetNodeIdentity
+        );
+
+        let response = Response::NodeIdentity {
+            node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+        };
+        let encoded = serde_json::to_value(&response).unwrap();
+        assert_eq!(encoded["response"], "node_identity");
+        assert_eq!(
+            serde_json::from_value::<Response>(encoded).unwrap(),
+            response
+        );
     }
 
     #[test]
@@ -2114,6 +2144,7 @@ mod tests {
     #[test]
     fn request_feature_requirements_cover_all_groups() {
         let groups = vec![
+            (28, vec![Request::GetNodeIdentity]),
             (
                 25,
                 vec![Request::WaitScheduledExecution {
@@ -2499,6 +2530,7 @@ mod tests {
             ),
             (26, &["protocol_26", "exact_run_attachment"][..]),
             (27, &["protocol_27", "agent_schedule_editing"][..]),
+            (28, &["protocol_28", "stable_node_identity"][..]),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -1078,7 +1078,7 @@ fn unix_time_ms() -> u64 {
         .unwrap_or(u64::MAX)
 }
 
-pub(crate) fn lock_path_from_environment() -> io::Result<PathBuf> {
+pub(crate) fn state_directory_from_environment() -> io::Result<PathBuf> {
     let root = match env::var_os("XDG_STATE_HOME").filter(|path| !path.is_empty()) {
         Some(path) => PathBuf::from(path),
         None => PathBuf::from(
@@ -1093,10 +1093,14 @@ pub(crate) fn lock_path_from_environment() -> io::Result<PathBuf> {
             "XDG_STATE_HOME must be an absolute path",
         ));
     }
-    Ok(root.join("boomux/daemon.lock"))
+    Ok(root.join("boomux"))
 }
 
-fn secure_state_dir(path: &Path) -> io::Result<()> {
+pub(crate) fn lock_path_from_environment() -> io::Result<PathBuf> {
+    Ok(state_directory_from_environment()?.join("daemon.lock"))
+}
+
+pub(crate) fn secure_state_dir(path: &Path) -> io::Result<()> {
     fs::create_dir_all(path)?;
     let metadata = fs::symlink_metadata(path)?;
     if !metadata.is_dir() || metadata.uid() != effective_uid() {
@@ -1108,7 +1112,7 @@ fn secure_state_dir(path: &Path) -> io::Result<()> {
     fs::set_permissions(path, fs::Permissions::from_mode(0o700))
 }
 
-fn effective_uid() -> u32 {
+pub(crate) fn effective_uid() -> u32 {
     // `geteuid` has no arguments, pointers, or caller safety requirements.
     unsafe { libc::geteuid() }
 }

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::os::unix::fs::{PermissionsExt, symlink};
+use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
 use std::os::unix::net::UnixStream;
 use std::process::{Command, Stdio};
 use std::thread;
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 27);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 28);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -115,7 +115,10 @@ fn native_daemon_lifecycle() {
         "protocol_24",
         "protocol_25",
         "protocol_26",
+        "protocol_27",
+        "protocol_28",
         "exact_run_attachment",
+        "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
         "bounded_scheduled_execution_history",
         "scheduled_execution_notifications",
@@ -148,7 +151,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 27"));
+    assert!(status_text.contains("running (protocol 28"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -807,6 +810,58 @@ fn native_daemon_lifecycle() {
     assert!(daemon.client.snapshot().unwrap().workspaces.is_empty());
 
     daemon.stop_with_cli();
+}
+
+#[test]
+fn node_identity_is_owner_only_and_survives_cold_and_graceful_restart() {
+    let mut daemon = TestDaemon::start();
+    let node_id = daemon.client.node_identity().unwrap();
+    assert_eq!(Uuid::parse_str(&node_id).unwrap().to_string(), node_id);
+
+    let path = daemon.runtime_dir.join("state/boomux/node.json");
+    let metadata = fs::symlink_metadata(&path).unwrap();
+    assert!(metadata.is_file());
+    assert_eq!(metadata.mode() & 0o777, 0o600);
+
+    let restart = daemon
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "daemon restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    assert_eq!(daemon.client.node_identity().unwrap(), node_id);
+
+    daemon.stop_with_cli();
+    daemon.restart();
+    assert_eq!(daemon.client.node_identity().unwrap(), node_id);
+}
+
+#[test]
+fn malformed_node_identity_disables_federation_without_blocking_local_daemon() {
+    let daemon = TestDaemon::start_with(|_, runtime_dir| {
+        let directory = runtime_dir.join("state/boomux");
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(directory.join("node.json"), b"not-json").unwrap();
+        fs::set_permissions(
+            directory.join("node.json"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+    });
+
+    daemon.client.ping().unwrap();
+    assert_remote_code(
+        &daemon.client.node_identity().unwrap_err(),
+        ErrorCode::NodeIdentityUnavailable,
+    );
+    assert_eq!(
+        fs::read(daemon.runtime_dir.join("state/boomux/node.json")).unwrap(),
+        b"not-json"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- persist one stable owner-only Node ID in independently versioned `node.json`
- add protocol 28 Node identity negotiation and a typed unavailable failure
- preserve local daemon operation when identity storage is malformed or unsupported
- prove identity stability across cold restart and graceful handoff

## Stack

- depends on #187
- first implementation slice of #175

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`

Part of #175
