### PR TITLE
feat(remote): add verified federation stdio bridge

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@
 | `src/daemon.rs` | `DaemonService` coordination over durable registry, event-stream, shell-runtime, persistence, and handoff owners |
 | `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
 | `src/node_identity.rs` | Independent stable Node identity creation, validation, and atomic persistence |
+| `src/federation.rs` | Independently versioned federation handshake and verified stdio daemon bridging |
 | `src/handoff.rs`, `src/fd_transfer.rs` | Graceful daemon replacement records and Unix descriptor transfer |
 | `src/attach.rs` | Terminal-side raw mode, control frames, live input/output, resize, focus, and reconnect handling |
 | `src/terminal.rs` | Selection and launch of native terminal windows through `xdg-terminal-exec` |
@@ -813,16 +814,20 @@ prompt-free `agent_schedule_updated` events. Protocol-26 peers filter those
 events while advancing their cursor. State schema remains 12.
 
 Protocol 28 and Node identity schema 1 establish the stable local Node ID used by
-future federation. The daemon creates owner-only `node.json` independently from
+federation. The daemon creates owner-only `node.json` independently from
 authoritative `state.json`, preserves malformed or future identity files while
-disabling federation, and exposes the identity through the version-gated
-`GetNodeIdentity` request. Cold restart and graceful handoff read the same file;
-the identity is not transferred in the handoff manifest. State schema remains 12.
-Protocol-27 peers remain local-only and cannot query Node identity.
+disabling federation, and exposes the identity through a version-gated query.
+Cold restart and graceful handoff read the same file; the identity is not
+transferred in the handoff manifest. State schema remains 12. Protocol-27 peers
+remain local-only and cannot query Node identity.
 
-The SSH federation handshake, transport, registration, and projection protocols
-remain unimplemented under #173. Their separately versioned schemas and protocol
-history entries are added only when the corresponding source versions land.
+Protocol 29 adds the same-socket `OpenFederationChannel` request. Federation
+handshake version 1 is emitted by the hidden `__federation-stdio` helper only
+after the helper's state-root identity matches the identity returned on the exact
+daemon socket subsequently used for inner protocol bytes. Protocol-28 peers keep
+stable identity queries but cannot open that channel. The SSH launcher/bootstrap,
+rekey admission, registration, and projection protocols remain unimplemented
+under #173.
 
 Cron day matching preserves syntactic wildcard origin: `*/n` is wildcard-origin,
 while numeric lists and ranges remain restricted even when they cover the full

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -5,8 +5,10 @@
 > delivered by [#174](https://github.com/gardnmi/boomux/issues/174) under tracking
 > epic [#173](https://github.com/gardnmi/boomux/issues/173). Current source and
 > compatibility tests remain authoritative for shipped behavior. Protocol 28
-> implements only stable local Node identity and its daemon query; no remote Node
-> command, SSH transport, registration, or projection is implemented yet.
+> implements stable local Node identity; protocol 29, handshake version 1, and
+> the hidden stdio helper establish the verified same-socket bridge boundary. No
+> public remote Node command, SSH bootstrap, registration, or projection is
+> implemented yet.
 
 ## Purpose
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -159,6 +159,13 @@ pub struct Attachment {
 }
 
 #[derive(Debug)]
+pub struct FederationChannel {
+    pub stream: UnixStream,
+    pub protocol_version: u32,
+    pub node_id: String,
+}
+
+#[derive(Debug)]
 pub struct OutputState {
     pub bytes: Vec<u8>,
     pub run_id: Option<String>,
@@ -531,6 +538,18 @@ impl Client {
     pub fn node_identity(&self) -> Result<String> {
         match self.request(Request::GetNodeIdentity)? {
             Response::NodeIdentity { node_id } => Ok(node_id),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn open_federation_channel(&self) -> Result<FederationChannel> {
+        let (stream, protocol_version, response) = self.send(Request::OpenFederationChannel)?;
+        match response {
+            Response::FederationChannel { node_id } => Ok(FederationChannel {
+                stream,
+                protocol_version,
+                node_id,
+            }),
             response => unexpected(response),
         }
     }
@@ -1750,6 +1769,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 29, 28);
             reject_protocol(&listener, 28, 27);
             reject_protocol(&listener, 27, 26);
             reject_protocol(&listener, 26, 25);
@@ -1899,7 +1919,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 28);
+            assert_eq!(request.version, 29);
             assert_eq!(request.message, Request::GetNodeIdentity);
             protocol::write_message(
                 &mut stream,
@@ -1912,6 +1932,8 @@ mod tests {
                 ),
             )
             .unwrap();
+
+            reject_protocol(&listener, 29, 27);
 
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
@@ -1940,6 +1962,47 @@ mod tests {
         let client = Client::from_socket_path(socket);
         assert!(matches!(
             client.node_identity(),
+            Err(ClientError::Protocol(ProtocolError::UnsupportedVersion(_)))
+        ));
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn federation_channel_requires_protocol_twenty_nine() {
+        let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 29);
+            assert_eq!(request.message, Request::OpenFederationChannel);
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    28,
+                    Response::Error {
+                        message: "federation channel requires protocol 29".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+
+            reject_protocol(&listener, 29, 28);
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 28);
+            assert_eq!(request.message, Request::Ping);
+            protocol::write_message(&mut stream, &Envelope::with_version(28, Response::Pong))
+                .unwrap();
+        });
+
+        let client = Client::from_socket_path(socket);
+        assert!(matches!(
+            client.open_federation_channel(),
             Err(ClientError::Protocol(ProtocolError::UnsupportedVersion(_)))
         ));
         server.join().unwrap();
@@ -2100,6 +2163,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 29, 28);
             reject_protocol(&listener, 28, 27);
             reject_protocol(&listener, 27, 26);
             reject_protocol(&listener, 26, 25);
@@ -2164,6 +2228,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 29, 28);
             reject_protocol(&listener, 28, 27);
             reject_protocol(&listener, 27, 26);
             reject_protocol(&listener, 26, 25);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -884,11 +884,22 @@ fn select_replacement_executable(current: PathBuf, argument_zero: Option<PathBuf
 }
 
 fn handle_connection(
+    stream: UnixStream,
+    registry: Arc<DaemonService>,
+    shutdown: Arc<AtomicBool>,
+    transition: Arc<AtomicU8>,
+    restart_sender: mpsc::Sender<RestartRequest>,
+) -> io::Result<()> {
+    handle_connection_inner(stream, registry, shutdown, transition, restart_sender, true)
+}
+
+fn handle_connection_inner(
     mut stream: UnixStream,
     registry: Arc<DaemonService>,
     shutdown: Arc<AtomicBool>,
     transition: Arc<AtomicU8>,
     restart_sender: mpsc::Sender<RestartRequest>,
+    allow_federation_upgrade: bool,
 ) -> io::Result<()> {
     stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
     let request: Envelope<Request> = protocol::read_message(&mut stream)?;
@@ -913,6 +924,43 @@ fn handle_connection(
             &mut stream,
             response_version,
             DaemonError::protocol(unsupported_request_message(feature)).into_response(),
+        );
+    }
+
+    if matches!(&request.message, Request::OpenFederationChannel) {
+        if !allow_federation_upgrade {
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::validation("federation channel is already open").into_response(),
+            );
+        }
+        let Some(identity) = registry.node_identity.as_ref() else {
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::lifecycle(
+                    ErrorCode::NodeIdentityUnavailable,
+                    "Boomux Node identity is unavailable",
+                )
+                .into_response(),
+            );
+        };
+        send_response(
+            &mut stream,
+            response_version,
+            Response::FederationChannel {
+                node_id: identity.id().to_owned(),
+            },
+        )?;
+        stream.set_write_timeout(None)?;
+        return handle_connection_inner(
+            stream,
+            registry,
+            shutdown,
+            transition,
+            restart_sender,
+            false,
         );
     }
 
@@ -6926,6 +6974,9 @@ impl DaemonService {
                         "Boomux Node identity is unavailable",
                     )
                 }),
+            Request::OpenFederationChannel => {
+                unreachable!("federation channel is handled before dispatch")
+            }
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
                 unreachable!("restart is handled before dispatch")
             }

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -1,0 +1,197 @@
+use std::error::Error;
+use std::io::{self, Read, Write};
+use std::net::Shutdown;
+use std::thread;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::client;
+use crate::node_identity::NodeIdentity;
+
+const FEDERATION_MAGIC: &[u8; 8] = b"BOOMUXF1";
+pub const FEDERATION_VERSION: u32 = 1;
+const MAX_HANDSHAKE_BYTES: usize = 4 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FederationConnectionMode {
+    AdHoc,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FederationHandshake {
+    pub version: u32,
+    pub node_id: String,
+    pub helper_version: String,
+    pub core_protocol_version: u32,
+    pub connection_mode: FederationConnectionMode,
+}
+
+pub fn write_handshake(writer: &mut impl Write, handshake: &FederationHandshake) -> io::Result<()> {
+    validate_handshake(handshake)?;
+    let bytes = serde_json::to_vec(handshake).map_err(io::Error::other)?;
+    if bytes.len() > MAX_HANDSHAKE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "federation handshake exceeds the size limit",
+        ));
+    }
+    writer.write_all(FEDERATION_MAGIC)?;
+    writer.write_all(&(bytes.len() as u32).to_be_bytes())?;
+    writer.write_all(&bytes)?;
+    writer.flush()
+}
+
+pub fn read_handshake(reader: &mut impl Read) -> io::Result<FederationHandshake> {
+    let mut magic = [0; FEDERATION_MAGIC.len()];
+    reader.read_exact(&mut magic)?;
+    if &magic != FEDERATION_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid federation handshake header",
+        ));
+    }
+    let mut length = [0; 4];
+    reader.read_exact(&mut length)?;
+    let length = u32::from_be_bytes(length) as usize;
+    if length == 0 || length > MAX_HANDSHAKE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid federation handshake length",
+        ));
+    }
+    let mut bytes = vec![0; length];
+    reader.read_exact(&mut bytes)?;
+    let handshake: FederationHandshake = serde_json::from_slice(&bytes).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid federation handshake: {error}"),
+        )
+    })?;
+    validate_handshake(&handshake)?;
+    Ok(handshake)
+}
+
+fn validate_handshake(handshake: &FederationHandshake) -> io::Result<()> {
+    if handshake.version != FEDERATION_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported federation handshake version {}; expected {FEDERATION_VERSION}",
+                handshake.version
+            ),
+        ));
+    }
+    let node_id = Uuid::parse_str(&handshake.node_id).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "federation handshake contains an invalid Node ID",
+        )
+    })?;
+    if node_id.to_string() != handshake.node_id {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "federation handshake contains a noncanonical Node ID",
+        ));
+    }
+    if handshake.helper_version.is_empty() || handshake.helper_version.len() > 128 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "federation handshake contains an invalid helper version",
+        ));
+    }
+    Ok(())
+}
+
+pub fn run_stdio_helper() -> Result<(), Box<dyn Error>> {
+    let expected_identity = NodeIdentity::load_or_create_from_environment()?;
+    let client = client::connect_or_start()?;
+    let channel = client.open_federation_channel()?;
+    if channel.node_id != expected_identity.id() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "daemon Node identity does not match the helper state root",
+        )
+        .into());
+    }
+
+    let handshake = FederationHandshake {
+        version: FEDERATION_VERSION,
+        node_id: channel.node_id,
+        helper_version: env!("CARGO_PKG_VERSION").into(),
+        core_protocol_version: channel.protocol_version,
+        connection_mode: FederationConnectionMode::AdHoc,
+    };
+    let mut stdout = io::stdout().lock();
+    write_handshake(&mut stdout, &handshake)?;
+
+    let mut daemon_writer = channel.stream.try_clone()?;
+    thread::Builder::new()
+        .name("boomux-federation-input".into())
+        .spawn(move || {
+            let _ = io::copy(&mut io::stdin().lock(), &mut daemon_writer);
+            let _ = daemon_writer.shutdown(Shutdown::Write);
+        })?;
+
+    let mut daemon_reader = channel.stream;
+    io::copy(&mut daemon_reader, &mut stdout)?;
+    stdout.flush()?;
+    let _ = daemon_reader.shutdown(Shutdown::Both);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn handshake() -> FederationHandshake {
+        FederationHandshake {
+            version: FEDERATION_VERSION,
+            node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            helper_version: "1.2.3".into(),
+            core_protocol_version: 29,
+            connection_mode: FederationConnectionMode::AdHoc,
+        }
+    }
+
+    #[test]
+    fn handshake_round_trips() {
+        let expected = handshake();
+        let mut bytes = Vec::new();
+        write_handshake(&mut bytes, &expected).unwrap();
+        assert_eq!(read_handshake(&mut bytes.as_slice()).unwrap(), expected);
+    }
+
+    #[test]
+    fn handshake_accepts_unknown_additive_fields() {
+        let mut value = serde_json::to_value(handshake()).unwrap();
+        value["future"] = serde_json::json!({ "enabled": true });
+        let body = serde_json::to_vec(&value).unwrap();
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(FEDERATION_MAGIC);
+        bytes.extend_from_slice(&(body.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(&body);
+        assert_eq!(read_handshake(&mut bytes.as_slice()).unwrap(), handshake());
+    }
+
+    #[test]
+    fn handshake_rejects_wrong_version_and_oversized_frames() {
+        let mut invalid = handshake();
+        invalid.version += 1;
+        assert_eq!(
+            write_handshake(&mut Vec::new(), &invalid)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(FEDERATION_MAGIC);
+        bytes.extend_from_slice(&((MAX_HANDSHAKE_BYTES + 1) as u32).to_be_bytes());
+        assert_eq!(
+            read_handshake(&mut bytes.as_slice()).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod client;
 pub mod daemon;
 mod desktop_notifications;
 mod fd_transfer;
+pub mod federation;
 mod handoff;
 pub mod integrations;
 mod node_identity;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use boomux::protocol::{
     ShellSpec, ShellStatus, Snapshot, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
     WorkspaceSnapshot,
 };
-use boomux::{attach, client, daemon, protocol};
+use boomux::{attach, client, daemon, federation, protocol};
 
 use crate::integration_management::{
     InstallOutcome, ensure_safe_directory, install_asset_at, regular_file_matches,
@@ -474,6 +474,8 @@ enum Commands {
     },
     #[command(name = "__scheduled-runner", hide = true)]
     ScheduledRunner { schedule_id: String },
+    #[command(name = "__federation-stdio", hide = true)]
+    FederationStdio,
 }
 
 #[derive(Subcommand)]
@@ -1250,6 +1252,7 @@ impl Cli {
             Some(Commands::Prompt) => CommandKey::Prompt,
             Some(Commands::Attach { .. }) => CommandKey::Attach,
             Some(Commands::ScheduledRunner { .. }) => CommandKey::Attach,
+            Some(Commands::FederationStdio) => CommandKey::Attach,
         }
     }
 }
@@ -1376,6 +1379,10 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::ScheduledRunner { schedule_id }) => {
             return scheduled_runner(schedule_id).map(CliExit::Child);
         }
+        Some(Commands::FederationStdio) => {
+            federation::run_stdio_helper()?;
+            return Ok(CliExit::Success);
+        }
         _ => {}
     }
 
@@ -1467,6 +1474,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Daemon { command }) => daemon_control(command, cli.json),
         Some(Commands::Attach { .. }) => unreachable!(),
         Some(Commands::ScheduledRunner { .. }) => unreachable!(),
+        Some(Commands::FederationStdio) => unreachable!(),
         None => dashboard(cli.terminal.as_deref()),
     };
     result?;
@@ -8969,7 +8977,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 28);
+        assert_eq!(protocol::PROTOCOL_VERSION, 29);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 28;
+pub const PROTOCOL_VERSION: u32 = 29;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -112,6 +112,10 @@ define_protocol_features! {
     NodeIdentity => (28, "Node identity", [
         "protocol_28",
         "stable_node_identity",
+    ]),
+    FederationChannel => (29, "federation daemon channel", [
+        "protocol_29",
+        "federation_daemon_channel",
     ]),
 }
 
@@ -927,6 +931,7 @@ impl ShellSpec {
 pub enum Request {
     Ping,
     GetNodeIdentity,
+    OpenFederationChannel,
     Restart,
     RestartWithNotificationConfig {
         notifications: NotificationDeliveryConfig,
@@ -1114,6 +1119,7 @@ impl Request {
     pub fn required_feature(&self) -> Option<ProtocolFeature> {
         match self {
             Self::GetNodeIdentity => Some(ProtocolFeature::NodeIdentity),
+            Self::OpenFederationChannel => Some(ProtocolFeature::FederationChannel),
             Self::WaitScheduledExecution { .. } => {
                 Some(ProtocolFeature::ScheduledExecutionObservation)
             }
@@ -1215,6 +1221,9 @@ impl Request {
 pub enum Response {
     Pong,
     NodeIdentity {
+        node_id: String,
+    },
+    FederationChannel {
         node_id: String,
     },
     Snapshot {
@@ -1797,8 +1806,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_twenty_eight_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 28);
+    fn protocol_version_is_twenty_nine_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 29);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -1816,6 +1825,18 @@ mod tests {
         };
         let encoded = serde_json::to_value(&response).unwrap();
         assert_eq!(encoded["response"], "node_identity");
+        assert_eq!(
+            serde_json::from_value::<Response>(encoded).unwrap(),
+            response
+        );
+
+        let request = serde_json::to_value(Request::OpenFederationChannel).unwrap();
+        assert_eq!(request["request"], "open_federation_channel");
+        let response = Response::FederationChannel {
+            node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+        };
+        let encoded = serde_json::to_value(&response).unwrap();
+        assert_eq!(encoded["response"], "federation_channel");
         assert_eq!(
             serde_json::from_value::<Response>(encoded).unwrap(),
             response
@@ -2144,6 +2165,7 @@ mod tests {
     #[test]
     fn request_feature_requirements_cover_all_groups() {
         let groups = vec![
+            (29, vec![Request::OpenFederationChannel]),
             (28, vec![Request::GetNodeIdentity]),
             (
                 25,
@@ -2531,6 +2553,7 @@ mod tests {
             (26, &["protocol_26", "exact_run_attachment"][..]),
             (27, &["protocol_27", "agent_schedule_editing"][..]),
             (28, &["protocol_28", "stable_node_identity"][..]),
+            (29, &["protocol_29", "federation_daemon_channel"][..]),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 28);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 29);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -117,6 +117,7 @@ fn native_daemon_lifecycle() {
         "protocol_26",
         "protocol_27",
         "protocol_28",
+        "protocol_29",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -151,7 +152,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 28"));
+    assert!(status_text.contains("running (protocol 29"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -861,6 +862,98 @@ fn malformed_node_identity_disables_federation_without_blocking_local_daemon() {
     assert_eq!(
         fs::read(daemon.runtime_dir.join("state/boomux/node.json")).unwrap(),
         b"not-json"
+    );
+}
+
+#[test]
+fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
+    let daemon = TestDaemon::start();
+    let node_id = daemon.client.node_identity().unwrap();
+
+    let mut stream = UnixStream::connect(daemon.client.socket_path()).unwrap();
+    protocol::write_message(
+        &mut stream,
+        &protocol::Envelope::with_version(29, protocol::Request::OpenFederationChannel),
+    )
+    .unwrap();
+    let response: protocol::Envelope<protocol::Response> =
+        protocol::read_message(&mut stream).unwrap();
+    assert_eq!(
+        response,
+        protocol::Envelope::with_version(
+            29,
+            protocol::Response::FederationChannel {
+                node_id: node_id.clone(),
+            },
+        )
+    );
+    protocol::write_message(
+        &mut stream,
+        &protocol::Envelope::with_version(29, protocol::Request::Ping),
+    )
+    .unwrap();
+    let response: protocol::Envelope<protocol::Response> =
+        protocol::read_message(&mut stream).unwrap();
+    assert_eq!(
+        response,
+        protocol::Envelope::with_version(29, protocol::Response::Pong)
+    );
+
+    let mut child = daemon
+        .command()
+        .arg("__federation-stdio")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = child.stdout.take().unwrap();
+    let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
+    assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
+    assert_eq!(handshake.node_id, node_id);
+    assert_eq!(handshake.core_protocol_version, 29);
+    assert_eq!(
+        handshake.connection_mode,
+        boomux::federation::FederationConnectionMode::AdHoc
+    );
+
+    protocol::write_message(
+        &mut stdin,
+        &protocol::Envelope::with_version(29, protocol::Request::Ping),
+    )
+    .unwrap();
+    drop(stdin);
+    let response: protocol::Envelope<protocol::Response> =
+        protocol::read_message(&mut stdout).unwrap();
+    assert_eq!(
+        response,
+        protocol::Envelope::with_version(29, protocol::Response::Pong)
+    );
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "federation helper failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn federation_helper_emits_no_handshake_for_a_mismatched_state_root() {
+    let daemon = TestDaemon::start();
+    let mismatched_state = daemon.runtime_dir.join("mismatched-state");
+    let output = daemon
+        .command()
+        .arg("__federation-stdio")
+        .env("XDG_STATE_HOME", &mismatched_state)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("daemon Node identity does not match the helper state root")
     );
 }
 


### PR DESCRIPTION
## Summary

- add protocol 29 same-socket federation channel setup with protocol-28 downgrade behavior
- emit an independently versioned handshake only after helper and daemon identities match
- add the hidden `__federation-stdio` helper for bounded byte-for-byte daemon bridging
- prove identity mismatch emits neither a handshake nor inner protocol bytes

## Stack

- depends on #188
- second implementation slice of #175

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked federation_helper -- --test-threads=1`

Part of #175
