### PR TITLE
feat(node): rekey identity after bounded drain

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@
 | `src/client.rs` | Daemon discovery/startup, protocol negotiation, typed management requests, and attachment setup |
 | `src/daemon.rs` | `DaemonService` coordination over durable registry, event-stream, shell-runtime, persistence, and handoff owners |
 | `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
-| `src/node_identity.rs` | Independent stable Node identity creation, validation, and atomic persistence |
+| `src/node_identity.rs` | Stable Node identity persistence, federation admission leases, and bounded rekey drain |
 | `src/federation.rs` | Independently versioned federation handshake and verified stdio daemon bridging |
 | `src/handoff.rs`, `src/fd_transfer.rs` | Graceful daemon replacement records and Unix descriptor transfer |
 | `src/attach.rs` | Terminal-side raw mode, control frames, live input/output, resize, focus, and reconnect handling |
@@ -826,8 +826,14 @@ handshake version 1 is emitted by the hidden `__federation-stdio` helper only
 after the helper's state-root identity matches the identity returned on the exact
 daemon socket subsequently used for inner protocol bytes. Protocol-28 peers keep
 stable identity queries but cannot open that channel. The SSH launcher/bootstrap,
-rekey admission, registration, and projection protocols remain unimplemented
-under #173.
+registration, and projection protocols remain unimplemented under #173.
+
+Protocol 30 adds expected-ID-conditional Node rekey. The daemon excludes restart,
+shutdown, and concurrent rekey transitions, closes federation admission, and
+atomically replaces `node.json` only after every admitted channel drains within
+the bound. Timeout returns `busy`, reopens admission, and preserves the old ID;
+rekey cannot be routed through a federation channel. A public owner-confirmation
+workflow remains pending.
 
 Cron day matching preserves syntactic wildcard origin: `*/n` is wildcard-origin,
 while numeric lists and ranges remain restricted even when they cover the full

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -6,9 +6,10 @@
 > epic [#173](https://github.com/gardnmi/boomux/issues/173). Current source and
 > compatibility tests remain authoritative for shipped behavior. Protocol 28
 > implements stable local Node identity; protocol 29, handshake version 1, and
-> the hidden stdio helper establish the verified same-socket bridge boundary. No
-> public remote Node command, SSH bootstrap, registration, or projection is
-> implemented yet.
+> the hidden stdio helper establish the verified same-socket bridge boundary.
+> Protocol 30 implements bounded expected-ID rekey admission, but its public
+> confirmation workflow remains pending. No public remote Node command, SSH
+> bootstrap, registration, or projection is implemented yet.
 
 ## Purpose
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -554,6 +554,15 @@ impl Client {
         }
     }
 
+    pub fn rekey_node(&self, expected_node_id: impl Into<String>) -> Result<String> {
+        match self.request(Request::RekeyNode {
+            expected_node_id: expected_node_id.into(),
+        })? {
+            Response::NodeIdentity { node_id } => Ok(node_id),
+            response => unexpected(response),
+        }
+    }
+
     pub fn shutdown(&self) -> Result<()> {
         expect_ok(self.request(Request::Shutdown)?, Response::Ok)?;
         for _ in 0..SHUTDOWN_ATTEMPTS {
@@ -1769,6 +1778,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
             reject_protocol(&listener, 28, 27);
             reject_protocol(&listener, 27, 26);
@@ -1919,7 +1929,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 29);
+            assert_eq!(request.version, 30);
             assert_eq!(request.message, Request::GetNodeIdentity);
             protocol::write_message(
                 &mut stream,
@@ -1933,6 +1943,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 27);
 
             let (mut stream, _) = listener.accept().unwrap();
@@ -1977,7 +1988,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 29);
+            assert_eq!(request.version, 30);
             assert_eq!(request.message, Request::OpenFederationChannel);
             protocol::write_message(
                 &mut stream,
@@ -1991,6 +2002,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
@@ -2163,6 +2175,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
             reject_protocol(&listener, 28, 27);
             reject_protocol(&listener, 27, 26);
@@ -2228,6 +2241,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
             reject_protocol(&listener, 28, 27);
             reject_protocol(&listener, 27, 26);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -28,7 +28,7 @@ use crate::desktop_notifications::{
 };
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
-use crate::node_identity::NodeIdentity;
+use crate::node_identity::{NodeIdentityLease, NodeIdentityManager};
 use crate::protocol::{
     self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
     AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
@@ -82,6 +82,8 @@ const MAX_EVENT_WAIT: Duration = Duration::from_secs(30);
 const TRANSITION_IDLE: u8 = 0;
 const TRANSITION_RESTART: u8 = 1;
 const TRANSITION_SHUTDOWN: u8 = 2;
+const TRANSITION_REKEY: u8 = 3;
+const NODE_REKEY_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NotificationSettings {
@@ -325,7 +327,7 @@ fn run_daemon(
     validate_notification_delivery_settings(&notification_settings)?;
     let live_handoff = committed.is_some();
     let mut registry = DaemonService::restore(store, live_handoff, transferred.events)?;
-    registry.node_identity = match NodeIdentity::load_or_create_from_environment() {
+    registry.node_identity = match NodeIdentityManager::load_or_create_from_environment() {
         Ok(identity) => Some(identity),
         Err(error) => {
             eprintln!("boomux: federation disabled: {error}");
@@ -890,7 +892,15 @@ fn handle_connection(
     transition: Arc<AtomicU8>,
     restart_sender: mpsc::Sender<RestartRequest>,
 ) -> io::Result<()> {
-    handle_connection_inner(stream, registry, shutdown, transition, restart_sender, true)
+    handle_connection_inner(
+        stream,
+        registry,
+        shutdown,
+        transition,
+        restart_sender,
+        true,
+        None,
+    )
 }
 
 fn handle_connection_inner(
@@ -900,6 +910,7 @@ fn handle_connection_inner(
     transition: Arc<AtomicU8>,
     restart_sender: mpsc::Sender<RestartRequest>,
     allow_federation_upgrade: bool,
+    federation_lease: Option<NodeIdentityLease>,
 ) -> io::Result<()> {
     stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
     let request: Envelope<Request> = protocol::read_message(&mut stream)?;
@@ -946,11 +957,22 @@ fn handle_connection_inner(
                 .into_response(),
             );
         };
+        let lease = match identity.admit() {
+            Ok(lease) => lease,
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                return send_response(
+                    &mut stream,
+                    response_version,
+                    DaemonError::from(error).into_response(),
+                );
+            }
+            Err(error) => return Err(error),
+        };
         send_response(
             &mut stream,
             response_version,
             Response::FederationChannel {
-                node_id: identity.id().to_owned(),
+                node_id: identity.id()?,
             },
         )?;
         stream.set_write_timeout(None)?;
@@ -961,7 +983,56 @@ fn handle_connection_inner(
             transition,
             restart_sender,
             false,
+            Some(lease),
         );
+    }
+
+    let _federation_lease = federation_lease;
+
+    if let Request::RekeyNode { expected_node_id } = &request.message {
+        if _federation_lease.is_some() {
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::validation("Node rekey cannot use a federation channel")
+                    .into_response(),
+            );
+        }
+        if transition
+            .compare_exchange(
+                TRANSITION_IDLE,
+                TRANSITION_REKEY,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::lifecycle(
+                    ErrorCode::Busy,
+                    "another daemon transition is already in progress",
+                )
+                .into_response(),
+            );
+        }
+        let response = match registry.node_identity.as_ref() {
+            Some(identity) => match identity.rekey(expected_node_id, NODE_REKEY_DRAIN_TIMEOUT) {
+                Ok(node_id) => Response::NodeIdentity { node_id },
+                Err(error) if error.kind() == io::ErrorKind::TimedOut => {
+                    DaemonError::lifecycle(ErrorCode::Busy, error.to_string()).into_response()
+                }
+                Err(error) => DaemonError::from(error).into_response(),
+            },
+            None => DaemonError::lifecycle(
+                ErrorCode::NodeIdentityUnavailable,
+                "Boomux Node identity is unavailable",
+            )
+            .into_response(),
+        };
+        transition.store(TRANSITION_IDLE, Ordering::Release);
+        return send_response(&mut stream, response_version, response);
     }
 
     if let Request::Attach {
@@ -1547,7 +1618,7 @@ fn scheduled_execution_response(
 }
 
 struct DaemonService {
-    node_identity: Option<NodeIdentity>,
+    node_identity: Option<Arc<NodeIdentityManager>>,
     durable: DurableRegistry,
     events: EventStream,
     runtimes: ShellRuntimeManager,
@@ -6965,18 +7036,19 @@ impl DaemonService {
             Request::GetNodeIdentity => self
                 .node_identity
                 .as_ref()
-                .map(|identity| Response::NodeIdentity {
-                    node_id: identity.id().to_owned(),
-                })
                 .ok_or_else(|| {
                     DaemonError::lifecycle(
                         ErrorCode::NodeIdentityUnavailable,
                         "Boomux Node identity is unavailable",
                     )
-                }),
+                })?
+                .id()
+                .map(|node_id| Response::NodeIdentity { node_id })
+                .map_err(DaemonError::from),
             Request::OpenFederationChannel => {
                 unreachable!("federation channel is handled before dispatch")
             }
+            Request::RekeyNode { .. } => unreachable!("Node rekey is handled before dispatch"),
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
                 unreachable!("restart is handled before dispatch")
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8977,7 +8977,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 29);
+        assert_eq!(protocol::PROTOCOL_VERSION, 30);
     }
 
     #[test]

--- a/src/node_identity.rs
+++ b/src/node_identity.rs
@@ -3,6 +3,8 @@ use std::io::{self, Read, Write};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -15,6 +17,22 @@ const MAX_NODE_IDENTITY_BYTES: u64 = 4 * 1024;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct NodeIdentity {
     id: String,
+}
+
+pub(crate) struct NodeIdentityManager {
+    path: PathBuf,
+    state: Mutex<NodeIdentityState>,
+    changed: Condvar,
+}
+
+struct NodeIdentityState {
+    identity: NodeIdentity,
+    admission_open: bool,
+    admitted: usize,
+}
+
+pub(crate) struct NodeIdentityLease {
+    manager: Arc<NodeIdentityManager>,
 }
 
 impl NodeIdentity {
@@ -36,6 +54,114 @@ impl NodeIdentity {
             Ok(identity) => Ok(identity),
             Err(error) if error.kind() == io::ErrorKind::NotFound => create(&path),
             Err(error) => Err(error),
+        }
+    }
+}
+
+impl NodeIdentityManager {
+    pub(crate) fn load_or_create_from_environment() -> io::Result<Arc<Self>> {
+        let path = state_directory_from_environment()?.join("node.json");
+        let identity = NodeIdentity::load_or_create_at(path.clone())?;
+        Ok(Arc::new(Self {
+            path,
+            state: Mutex::new(NodeIdentityState {
+                identity,
+                admission_open: true,
+                admitted: 0,
+            }),
+            changed: Condvar::new(),
+        }))
+    }
+
+    pub(crate) fn id(&self) -> io::Result<String> {
+        Ok(self.lock_state()?.identity.id.clone())
+    }
+
+    pub(crate) fn admit(self: &Arc<Self>) -> io::Result<NodeIdentityLease> {
+        let mut state = self.lock_state()?;
+        if !state.admission_open {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "Boomux Node federation admission is closed",
+            ));
+        }
+        state.admitted = state
+            .admitted
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("Node federation admission count overflow"))?;
+        drop(state);
+        Ok(NodeIdentityLease {
+            manager: Arc::clone(self),
+        })
+    }
+
+    pub(crate) fn rekey(&self, expected_node_id: &str, timeout: Duration) -> io::Result<String> {
+        let mut state = self.lock_state()?;
+        if state.identity.id != expected_node_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "current Node identity does not match the confirmed Node ID",
+            ));
+        }
+        if !state.admission_open {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "Boomux Node federation admission is already closed",
+            ));
+        }
+        state.admission_open = false;
+        let deadline = Instant::now() + timeout;
+        while state.admitted != 0 {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                state.admission_open = true;
+                self.changed.notify_all();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out draining active federation channels",
+                ));
+            };
+            let (next, wait) = self
+                .changed
+                .wait_timeout(state, remaining)
+                .map_err(|_| io::Error::other("Node identity lock is poisoned"))?;
+            state = next;
+            if wait.timed_out() && state.admitted != 0 {
+                state.admission_open = true;
+                self.changed.notify_all();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out draining active federation channels",
+                ));
+            }
+        }
+
+        let replacement = match replace(&self.path, expected_node_id) {
+            Ok(identity) => identity,
+            Err(error) => {
+                state.admission_open = true;
+                self.changed.notify_all();
+                return Err(error);
+            }
+        };
+        state.identity = replacement;
+        state.admission_open = true;
+        let node_id = state.identity.id.clone();
+        self.changed.notify_all();
+        Ok(node_id)
+    }
+
+    fn lock_state(&self) -> io::Result<std::sync::MutexGuard<'_, NodeIdentityState>> {
+        self.state
+            .lock()
+            .map_err(|_| io::Error::other("Node identity lock is poisoned"))
+    }
+}
+
+impl Drop for NodeIdentityLease {
+    fn drop(&mut self) {
+        if let Ok(mut state) = self.manager.state.lock() {
+            state.admitted = state.admitted.saturating_sub(1);
+            self.manager.changed.notify_all();
         }
     }
 }
@@ -163,6 +289,45 @@ fn create(path: &Path) -> io::Result<NodeIdentity> {
     result
 }
 
+fn replace(path: &Path, expected_node_id: &str) -> io::Result<NodeIdentity> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("Node identity path has no parent"))?;
+    secure_state_dir(parent)?;
+    let _lock = acquire_identity_lock(parent)?;
+    if load(path)?.id != expected_node_id {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "persisted Node identity changed before rekey",
+        ));
+    }
+    let identity = NodeIdentity {
+        id: Uuid::new_v4().to_string(),
+    };
+    let bytes = serde_json::to_vec_pretty(&PersistedNodeIdentity {
+        version: NODE_IDENTITY_VERSION,
+        node_id: identity.id.clone(),
+    })
+    .map_err(io::Error::other)?;
+    let temporary = parent.join(format!(".node-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)?;
+        let _ = File::open(parent).and_then(|directory| directory.sync_all());
+        Ok(identity)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -256,6 +421,37 @@ mod tests {
         fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
         let error = NodeIdentity::load_or_create_at(path.clone()).unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn rekey_drains_admission_and_preserves_old_identity_on_timeout() {
+        let path = test_path();
+        let identity = NodeIdentity::load_or_create_at(path.clone()).unwrap();
+        let manager = Arc::new(NodeIdentityManager {
+            path: path.clone(),
+            state: Mutex::new(NodeIdentityState {
+                identity: identity.clone(),
+                admission_open: true,
+                admitted: 0,
+            }),
+            changed: Condvar::new(),
+        });
+        let lease = manager.admit().unwrap();
+        let error = manager
+            .rekey(identity.id(), Duration::from_millis(1))
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(manager.id().unwrap(), identity.id());
+        assert_eq!(load(&path).unwrap(), identity);
+
+        drop(lease);
+        let replacement = manager
+            .rekey(identity.id(), Duration::from_secs(1))
+            .unwrap();
+        assert_ne!(replacement, identity.id());
+        assert_eq!(manager.id().unwrap(), replacement);
+        assert_eq!(load(&path).unwrap().id(), replacement);
         fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 29;
+pub const PROTOCOL_VERSION: u32 = 30;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -117,6 +117,7 @@ define_protocol_features! {
         "protocol_29",
         "federation_daemon_channel",
     ]),
+    NodeRekey => (30, "Node rekey", ["protocol_30", "node_rekey"]),
 }
 
 pub const DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 100;
@@ -932,6 +933,9 @@ pub enum Request {
     Ping,
     GetNodeIdentity,
     OpenFederationChannel,
+    RekeyNode {
+        expected_node_id: String,
+    },
     Restart,
     RestartWithNotificationConfig {
         notifications: NotificationDeliveryConfig,
@@ -1120,6 +1124,7 @@ impl Request {
         match self {
             Self::GetNodeIdentity => Some(ProtocolFeature::NodeIdentity),
             Self::OpenFederationChannel => Some(ProtocolFeature::FederationChannel),
+            Self::RekeyNode { .. } => Some(ProtocolFeature::NodeRekey),
             Self::WaitScheduledExecution { .. } => {
                 Some(ProtocolFeature::ScheduledExecutionObservation)
             }
@@ -1806,8 +1811,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_twenty_nine_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 29);
+    fn protocol_version_is_thirty_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 30);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -1841,6 +1846,13 @@ mod tests {
             serde_json::from_value::<Response>(encoded).unwrap(),
             response
         );
+
+        let request = Request::RekeyNode {
+            expected_node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+        };
+        let encoded = serde_json::to_value(&request).unwrap();
+        assert_eq!(encoded["request"], "rekey_node");
+        assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
     }
 
     #[test]
@@ -2165,6 +2177,12 @@ mod tests {
     #[test]
     fn request_feature_requirements_cover_all_groups() {
         let groups = vec![
+            (
+                30,
+                vec![Request::RekeyNode {
+                    expected_node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+                }],
+            ),
             (29, vec![Request::OpenFederationChannel]),
             (28, vec![Request::GetNodeIdentity]),
             (
@@ -2554,6 +2572,7 @@ mod tests {
             (27, &["protocol_27", "agent_schedule_editing"][..]),
             (28, &["protocol_28", "stable_node_identity"][..]),
             (29, &["protocol_29", "federation_daemon_channel"][..]),
+            (30, &["protocol_30", "node_rekey"][..]),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 29);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 30);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -118,6 +118,7 @@ fn native_daemon_lifecycle() {
         "protocol_27",
         "protocol_28",
         "protocol_29",
+        "protocol_30",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -152,7 +153,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 29"));
+    assert!(status_text.contains("running (protocol 30"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -912,7 +913,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 29);
+    assert_eq!(handshake.core_protocol_version, 30);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc
@@ -920,7 +921,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
 
     protocol::write_message(
         &mut stdin,
-        &protocol::Envelope::with_version(29, protocol::Request::Ping),
+        &protocol::Envelope::with_version(30, protocol::Request::Ping),
     )
     .unwrap();
     drop(stdin);
@@ -928,7 +929,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
         protocol::read_message(&mut stdout).unwrap();
     assert_eq!(
         response,
-        protocol::Envelope::with_version(29, protocol::Response::Pong)
+        protocol::Envelope::with_version(30, protocol::Response::Pong)
     );
     let output = child.wait_with_output().unwrap();
     assert!(
@@ -955,6 +956,35 @@ fn federation_helper_emits_no_handshake_for_a_mismatched_state_root() {
         String::from_utf8_lossy(&output.stderr)
             .contains("daemon Node identity does not match the helper state root")
     );
+}
+
+#[test]
+fn node_rekey_is_expected_identity_conditional_and_drains_federation_channels() {
+    let daemon = TestDaemon::start();
+    let original = daemon.client.node_identity().unwrap();
+    let channel = daemon.client.open_federation_channel().unwrap();
+
+    assert_remote_code(
+        &daemon.client.rekey_node(&original).unwrap_err(),
+        ErrorCode::Busy,
+    );
+    assert_eq!(daemon.client.node_identity().unwrap(), original);
+
+    drop(channel);
+    let replacement = daemon.client.rekey_node(&original).unwrap();
+    assert_ne!(replacement, original);
+    assert_eq!(daemon.client.node_identity().unwrap(), replacement);
+    assert_remote_code(
+        &daemon.client.rekey_node(&original).unwrap_err(),
+        ErrorCode::InvalidArgument,
+    );
+    assert_eq!(daemon.client.node_identity().unwrap(), replacement);
+
+    let identity: serde_json::Value = serde_json::from_slice(
+        &fs::read(daemon.runtime_dir.join("state/boomux/node.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(identity["node_id"], replacement);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add protocol 30 expected-ID-conditional Node rekey
- hold admission leases through complete federation requests and reject routed rekey
- close admission and atomically replace `node.json` only after a bounded channel drain
- preserve the old identity and reopen admission when drain fails

## Stack

- GitHub stack #190
- depends on #189
- third implementation slice of #175

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked node_rekey -- --test-threads=1`

Part of #175

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
