### PR TITLE
feat(node): require interactive rekey confirmation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -832,8 +832,10 @@ Protocol 30 adds expected-ID-conditional Node rekey. The daemon excludes restart
 shutdown, and concurrent rekey transitions, closes federation admission, and
 atomically replaces `node.json` only after every admitted channel drains within
 the bound. Timeout returns `busy`, reopens admission, and preserves the old ID;
-rekey cannot be routed through a federation channel. A public owner-confirmation
-workflow remains pending.
+rekey cannot be routed through a federation channel. `boomux node rekey` is a
+local human-only workflow: it refuses noninteractive input and requires the
+operator to type the exact current Node ID before sending the conditional
+request.
 
 Cron day matching preserves syntactic wildcard origin: `*/n` is wildcard-origin,
 while numeric lists and ranges remain restricted even when they cover the full

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -76,6 +76,10 @@ process-starting, destructive, integration-management, Schedule, and
 exact-attachment support. The full compatibility and privacy rules are defined
 in [`remote-nodes.md`](remote-nodes.md).
 
+`boomux node rekey` is an implemented local identity-administration command. It
+requires an interactive terminal and exact current-ID confirmation, and does not
+support `--json`; it cannot be routed through federation.
+
 The following commands support `--json`:
 
 - `boomux capabilities`

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -7,8 +7,8 @@
 > compatibility tests remain authoritative for shipped behavior. Protocol 28
 > implements stable local Node identity; protocol 29, handshake version 1, and
 > the hidden stdio helper establish the verified same-socket bridge boundary.
-> Protocol 30 implements bounded expected-ID rekey admission, but its public
-> confirmation workflow remains pending. No public remote Node command, SSH
+> Protocol 30 and local `boomux node rekey` implement bounded expected-ID rekey
+> with exact interactive confirmation. No public remote access command, SSH
 > bootstrap, registration, or projection is implemented yet.
 
 ## Purpose

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::ffi::OsString;
 use std::fmt::Write as _;
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, IsTerminal, Read};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::os::unix::process::{CommandExt, ExitStatusExt};
 use std::path::{Path, PathBuf};
@@ -386,6 +386,11 @@ enum Commands {
         #[command(subcommand)]
         command: WorkspaceCommands,
     },
+    /// Manage this Boomux Node identity
+    Node {
+        #[command(subcommand)]
+        command: NodeCommands,
+    },
     /// Manage shells
     Shell {
         #[command(subcommand)]
@@ -482,6 +487,12 @@ enum Commands {
 enum ProjectCommands {
     /// List projects discovered from configured roots
     List,
+}
+
+#[derive(Subcommand)]
+enum NodeCommands {
+    /// Assign this authority a new Node ID after exact confirmation
+    Rekey,
 }
 
 #[derive(Subcommand)]
@@ -1037,6 +1048,7 @@ command_keys! {
     WorkspaceList => ("workspace.list", Json),
     WorkspaceInspect => ("workspace.inspect", Json),
     Workspace => ("workspace", HumanOnly),
+    NodeRekey => ("node.rekey", HumanOnly),
     ShellSuggestName => ("shell.suggest-name", Json),
     ShellInspect => ("shell.inspect", Json),
     Shell => ("shell", HumanOnly),
@@ -1104,6 +1116,9 @@ impl Cli {
             Some(Commands::Workspace {
                 command: WorkspaceCommands::Inspect { .. },
             }) => CommandKey::WorkspaceInspect,
+            Some(Commands::Node {
+                command: NodeCommands::Rekey,
+            }) => CommandKey::NodeRekey,
             Some(Commands::Shell {
                 command: ShellCommands::SuggestName { .. },
             }) => CommandKey::ShellSuggestName,
@@ -1437,6 +1452,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Workspace { command }) => {
             workspace_command(command, cli.json, cli.terminal.as_deref())
         }
+        Some(Commands::Node { command }) => node_command(command),
         Some(Commands::Shell { command }) => shell_command(command, cli.json),
         Some(Commands::Launcher { command }) => launcher_command(command, cli.json),
         Some(Commands::Agent {
@@ -1479,6 +1495,46 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
     };
     result?;
     Ok(CliExit::Success)
+}
+
+fn node_command(command: NodeCommands) -> Result<(), Box<dyn Error>> {
+    match command {
+        NodeCommands::Rekey => rekey_node(),
+    }
+}
+
+fn rekey_node() -> Result<(), Box<dyn Error>> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "node rekey requires an interactive terminal",
+        )
+        .into());
+    }
+    let client = client::connect()?;
+    let current = client.node_identity()?;
+    println!("Current Node ID: {current}");
+    println!("Rekey changes the federated identity of every resource owned by this Node.");
+    print!("Type the current Node ID to continue: ");
+    io::Write::flush(&mut io::stdout())?;
+    let mut confirmation = String::new();
+    io::stdin().read_line(&mut confirmation)?;
+    validate_rekey_confirmation(&current, &confirmation)?;
+    let replacement = client.rekey_node(&current)?;
+    println!("Rekeyed Boomux Node: {current} -> {replacement}");
+    println!("Existing remote registrations must forget and add this Node again.");
+    Ok(())
+}
+
+fn validate_rekey_confirmation(expected: &str, confirmation: &str) -> io::Result<()> {
+    if confirmation.trim_end_matches(['\r', '\n']) == expected {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Node rekey confirmation did not match the current Node ID",
+        ))
+    }
 }
 
 fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Error>> {
@@ -6828,6 +6884,27 @@ mod tests {
                 ..
             }) if run_id == "r1"
         ));
+    }
+
+    #[test]
+    fn parses_node_rekey_and_requires_exact_confirmation() {
+        let cli = Cli::try_parse_from(["boomux", "node", "rekey"]).unwrap();
+        assert!(matches!(
+            cli.command.as_ref(),
+            Some(Commands::Node {
+                command: NodeCommands::Rekey
+            })
+        ));
+        assert_eq!(cli.command_descriptor().key, "node.rekey");
+
+        let node_id = "550e8400-e29b-41d4-a716-446655440000";
+        validate_rekey_confirmation(node_id, &format!("{node_id}\n")).unwrap();
+        assert_eq!(
+            validate_rekey_confirmation(node_id, "550e8400-e29b-41d4-a716-446655440001\n")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
     }
 
     #[test]

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -962,6 +962,20 @@ fn federation_helper_emits_no_handshake_for_a_mismatched_state_root() {
 fn node_rekey_is_expected_identity_conditional_and_drains_federation_channels() {
     let daemon = TestDaemon::start();
     let original = daemon.client.node_identity().unwrap();
+
+    let noninteractive = daemon
+        .command()
+        .args(["node", "rekey"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!noninteractive.status.success());
+    assert!(
+        String::from_utf8_lossy(&noninteractive.stderr)
+            .contains("node rekey requires an interactive terminal")
+    );
+    assert_eq!(daemon.client.node_identity().unwrap(), original);
+
     let channel = daemon.client.open_federation_channel().unwrap();
 
     assert_remote_code(


### PR DESCRIPTION
## Summary

- add the local human-only `boomux node rekey` command
- refuse noninteractive execution and require typing the exact current Node ID
- preserve protocol-side expected-ID and bounded-drain safeguards
- keep rekey outside JSON and remote federation routing

## Stack

- GitHub stack #190
- depends on #191
- fourth implementation slice of #175

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --bin boomux --locked parses_node_rekey_and_requires_exact_confirmation`
- `cargo test --test native_backend --locked node_rekey -- --test-threads=1`

Part of #175

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
