### PR TITLE
feat(remote): discover remote platforms and binaries

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@
 | `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
 | `src/node_identity.rs` | Stable Node identity persistence, federation admission leases, and bounded rekey drain |
 | `src/federation.rs` | Independently versioned federation handshake and verified stdio daemon bridging |
-| `src/ssh_bootstrap.rs` | Validated SSH targets, fixed helper command construction, and private invocation configuration |
+| `src/ssh_bootstrap.rs` | Validated SSH targets, private invocation configuration, and bounded fixed remote discovery probes |
 | `src/handoff.rs`, `src/fd_transfer.rs` | Graceful daemon replacement records and Unix descriptor transfer |
 | `src/attach.rs` | Terminal-side raw mode, control frames, live input/output, resize, focus, and reconnect handling |
 | `src/terminal.rs` | Selection and launch of native terminal windows through `xdg-terminal-exec` |

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::env;
 #[cfg(test)]
 use std::ffi::{OsStr, OsString};
@@ -13,11 +14,105 @@ use uuid::Uuid;
 const MAX_SSH_TARGET_BYTES: usize = 1024;
 const MAX_REMOTE_EXECUTABLE_BYTES: usize = 4096;
 const MAX_CONTROL_PATH_BYTES: usize = 100;
+const MAX_PROBE_OUTPUT_BYTES: usize = 64 * 1024;
+const MAX_DISCOVERED_EXECUTABLES: usize = 32;
+const PLATFORM_PROBE_PREFIX: &[u8] = b"boomux-platform-v1";
+const EXECUTABLE_PROBE_PREFIX: &[u8] = b"boomux-executables-v1";
+
+pub const PLATFORM_PROBE_COMMAND: &str = "os=$(uname -s) || exit; arch=$(uname -m) || exit; printf 'boomux-platform-v1\\0%s\\0%s\\0' \"$os\" \"$arch\"";
+pub const EXECUTABLE_PROBE_COMMAND: &str = "printf 'boomux-executables-v1\\0'; path=$(command -v boomux 2>/dev/null || true); for candidate in \"$path\" /usr/local/bin/boomux /usr/bin/boomux /opt/homebrew/bin/boomux /home/linuxbrew/.linuxbrew/bin/boomux \"$HOME/.local/bin/boomux\" \"$HOME/.local/share/mise/shims/boomux\" \"$HOME/.nix-profile/bin/boomux\" /run/current-system/sw/bin/boomux; do case \"$candidate\" in /*) [ -f \"$candidate\" ] && [ -x \"$candidate\" ] && printf '%s\\0' \"$candidate\" ;; esac; done";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SshAuthenticationMode {
     Interactive,
     Batch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteProbe {
+    Platform,
+    Executables,
+}
+
+impl RemoteProbe {
+    pub const fn command(self) -> &'static str {
+        match self {
+            Self::Platform => PLATFORM_PROBE_COMMAND,
+            Self::Executables => EXECUTABLE_PROBE_COMMAND,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteOperatingSystem {
+    Linux,
+    MacOs,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteArchitecture {
+    X86_64,
+    Aarch64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemotePlatform {
+    pub operating_system: RemoteOperatingSystem,
+    pub architecture: RemoteArchitecture,
+}
+
+impl RemotePlatform {
+    pub fn parse_probe(output: &[u8]) -> io::Result<Self> {
+        let fields = parse_nul_fields(output, PLATFORM_PROBE_PREFIX)?;
+        if fields.len() != 2 {
+            return Err(invalid_probe(
+                "platform probe returned an invalid field count",
+            ));
+        }
+        let operating_system = match fields[0] {
+            b"Linux" => RemoteOperatingSystem::Linux,
+            b"Darwin" => RemoteOperatingSystem::MacOs,
+            _ => return Err(invalid_probe("remote operating system is unsupported")),
+        };
+        let architecture = match fields[1] {
+            b"x86_64" | b"amd64" => RemoteArchitecture::X86_64,
+            b"aarch64" | b"arm64" => RemoteArchitecture::Aarch64,
+            _ => return Err(invalid_probe("remote architecture is unsupported")),
+        };
+        Ok(Self {
+            operating_system,
+            architecture,
+        })
+    }
+
+    pub const fn release_target(self) -> Option<&'static str> {
+        match (self.operating_system, self.architecture) {
+            (RemoteOperatingSystem::Linux, RemoteArchitecture::X86_64) => {
+                Some("x86_64-unknown-linux-gnu")
+            }
+            _ => None,
+        }
+    }
+}
+
+pub fn parse_executable_probe(output: &[u8]) -> io::Result<Vec<RemoteExecutable>> {
+    let fields = parse_nul_fields(output, EXECUTABLE_PROBE_PREFIX)?;
+    if fields.len() > MAX_DISCOVERED_EXECUTABLES {
+        return Err(invalid_probe(
+            "executable probe returned too many candidates",
+        ));
+    }
+    let mut seen = HashSet::new();
+    let mut executables = Vec::new();
+    for field in fields {
+        let value = std::str::from_utf8(field)
+            .map_err(|_| invalid_probe("executable probe returned non-UTF-8 data"))?;
+        let executable = RemoteExecutable::parse(value.to_owned())?;
+        if seen.insert(executable.0.clone()) {
+            executables.push(executable);
+        }
+    }
+    Ok(executables)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -136,6 +231,28 @@ impl SshInvocation {
         command
     }
 
+    pub fn prepare_probe(
+        target: SshTarget,
+        probe: RemoteProbe,
+        authentication: SshAuthenticationMode,
+    ) -> io::Result<Self> {
+        let socket_path = crate::client::socket_path()?;
+        let runtime_directory = socket_path
+            .parent()
+            .ok_or_else(|| io::Error::other("Boomux runtime socket has no parent"))?;
+        let user_config = env::var_os("HOME")
+            .filter(|home| !home.is_empty())
+            .map(PathBuf::from)
+            .map(|home| home.join(".ssh/config"));
+        Self::prepare_command_at(
+            runtime_directory,
+            user_config.as_deref(),
+            target,
+            probe.command().to_owned(),
+            authentication,
+        )
+    }
+
     pub fn config_path(&self) -> &Path {
         &self.config_path
     }
@@ -149,6 +266,25 @@ impl SshInvocation {
         user_config: Option<&Path>,
         target: SshTarget,
         executable: RemoteExecutable,
+        authentication: SshAuthenticationMode,
+    ) -> io::Result<Self> {
+        Self::prepare_command_at(
+            runtime_directory,
+            user_config,
+            target,
+            format!(
+                "{} __federation-stdio",
+                quote_posix_shell(executable.as_str())
+            ),
+            authentication,
+        )
+    }
+
+    fn prepare_command_at(
+        runtime_directory: &Path,
+        user_config: Option<&Path>,
+        target: SshTarget,
+        remote_command: String,
         authentication: SshAuthenticationMode,
     ) -> io::Result<Self> {
         secure_runtime_directory(runtime_directory)?;
@@ -191,10 +327,7 @@ impl SshInvocation {
             config_path,
             control_path,
             target,
-            remote_command: format!(
-                "{} __federation-stdio",
-                quote_posix_shell(executable.as_str())
-            ),
+            remote_command,
             authentication,
         })
     }
@@ -263,6 +396,29 @@ fn validate_option_path(path: &Path, label: &str) -> io::Result<()> {
 fn effective_uid() -> u32 {
     // `geteuid` has no arguments, pointers, or caller safety requirements.
     unsafe { libc::geteuid() }
+}
+
+fn parse_nul_fields<'a>(output: &'a [u8], prefix: &[u8]) -> io::Result<Vec<&'a [u8]>> {
+    if output.len() > MAX_PROBE_OUTPUT_BYTES {
+        return Err(invalid_probe("remote probe output exceeds the size limit"));
+    }
+    let mut fields = output.split(|byte| *byte == 0);
+    if fields.next() != Some(prefix) {
+        return Err(invalid_probe("remote probe returned an invalid header"));
+    }
+    let mut values = fields.collect::<Vec<_>>();
+    if values.last() != Some(&&b""[..]) {
+        return Err(invalid_probe("remote probe output is not NUL terminated"));
+    }
+    values.pop();
+    if values.iter().any(|value| value.is_empty()) {
+        return Err(invalid_probe("remote probe returned an empty field"));
+    }
+    Ok(values)
+}
+
+fn invalid_probe(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
 }
 
 #[cfg(test)]
@@ -371,6 +527,69 @@ mod tests {
                 .windows(2)
                 .any(|pair| pair == ["-o", "BatchMode=yes"])
         );
+        drop(invocation);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn parses_supported_platforms_and_current_release_matrix() {
+        let linux = RemotePlatform::parse_probe(b"boomux-platform-v1\0Linux\0x86_64\0").unwrap();
+        assert_eq!(linux.operating_system, RemoteOperatingSystem::Linux);
+        assert_eq!(linux.architecture, RemoteArchitecture::X86_64);
+        assert_eq!(linux.release_target(), Some("x86_64-unknown-linux-gnu"));
+
+        let mac = RemotePlatform::parse_probe(b"boomux-platform-v1\0Darwin\0arm64\0").unwrap();
+        assert_eq!(mac.operating_system, RemoteOperatingSystem::MacOs);
+        assert_eq!(mac.architecture, RemoteArchitecture::Aarch64);
+        assert_eq!(mac.release_target(), None);
+
+        for invalid in [
+            &b"wrong\0Linux\0x86_64\0"[..],
+            &b"boomux-platform-v1\0Plan9\0x86_64\0"[..],
+            &b"boomux-platform-v1\0Linux\0mips\0"[..],
+            &b"boomux-platform-v1\0Linux\0x86_64"[..],
+        ] {
+            assert_eq!(
+                RemotePlatform::parse_probe(invalid).unwrap_err().kind(),
+                io::ErrorKind::InvalidData
+            );
+        }
+    }
+
+    #[test]
+    fn parses_bounded_unique_absolute_executable_candidates() {
+        let candidates = parse_executable_probe(
+            b"boomux-executables-v1\0/usr/bin/boomux\0/opt/boomux/bin/boomux\0/usr/bin/boomux\0",
+        )
+        .unwrap();
+        assert_eq!(
+            candidates
+                .iter()
+                .map(RemoteExecutable::as_str)
+                .collect::<Vec<_>>(),
+            ["/usr/bin/boomux", "/opt/boomux/bin/boomux"]
+        );
+        assert_eq!(
+            parse_executable_probe(b"boomux-executables-v1\0relative/boomux\0")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn probe_invocations_use_only_fixed_remote_commands() {
+        let runtime = runtime_directory();
+        let invocation = SshInvocation::prepare_command_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            RemoteProbe::Platform.command().to_owned(),
+            SshAuthenticationMode::Interactive,
+        )
+        .unwrap();
+        let arguments = command_arguments(&invocation.command());
+        assert_eq!(arguments.last().unwrap(), PLATFORM_PROBE_COMMAND);
         drop(invocation);
         fs::remove_dir_all(runtime).unwrap();
     }


### PR DESCRIPTION
## Summary

- define fixed remote platform and executable discovery commands without user interpolation
- parse bounded NUL-delimited probe output with strict headers and field counts
- normalize supported Linux/macOS and x86-64/ARM64 platform values
- discover and deduplicate absolute PATH, direct, Homebrew, mise, and Nix candidates
- expose only the currently published Linux x86-64 release target

## Stack

- GitHub stack #190
- depends on #193
- sixth implementation slice of #175

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --locked ssh_bootstrap --no-fail-fast`

Part of #175

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
