### PR TITLE
feat(remote): bootstrap ad hoc SSH access

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,7 +57,8 @@
 - **Remote Node authority:** [`remote-nodes.md`](remote-nodes.md) defines the
   accepted federation boundary: one owning Node remains authoritative, SSH is a
   route, and local cached projections never authorize mutation or lifecycle
-  inference. Implementation is tracked by #173 and is not yet shipped.
+  inference. Ad hoc bootstrap and verified transport are implemented; durable
+  registration, projection, and routed management remain tracked by #173.
 
 ## Product Boundary
 
@@ -80,8 +81,8 @@ persistence across attachment disconnects, naming, grouping, and orchestration.
 
 ### Accepted Federation Boundary
 
-Remote Node federation is an accepted but not yet implemented extension of this
-product boundary. A remote daemon, not a local SSH process, owns its remote PTYs,
+Remote Node federation extends this product boundary incrementally. A remote
+daemon, not a local SSH process, owns its remote PTYs,
 processes, Workspaces, and runtime identities. The local daemon can later retain
 a bounded prompt-free projection for its TUI, CLI integrations, and desktop
 presentation, but that projection remains separate from the authoritative local
@@ -93,6 +94,11 @@ ordinary negotiated daemon protocol stream to the remote Unix socket. It does
 not expose a TCP listener or the local daemon socket. Remote work continues when
 the SSH bridge or local presentation disconnects. The complete accepted contract
 and deferred behavior are in [`remote-nodes.md`](remote-nodes.md).
+
+Public `boomux --remote TARGET` currently performs ad hoc bootstrap only. It
+discovers and verifies a compatible helper, or interactively installs one before
+opening and pinging a daemon-bound stdio channel. It creates no registration or
+projection and does not yet route dashboard or management operations.
 
 ## Components
 

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -1,6 +1,6 @@
 # Remote Node Federation
 
-> **Status: Accepted design contract; implementation pending.** This document
+> **Status: Accepted design contract; implementation in progress.** This document
 > defines the authority, identity, privacy, compatibility, and failure semantics
 > delivered by [#174](https://github.com/gardnmi/boomux/issues/174) under tracking
 > epic [#173](https://github.com/gardnmi/boomux/issues/173). Current source and
@@ -8,8 +8,10 @@
 > implements stable local Node identity; protocol 29, handshake version 1, and
 > the hidden stdio helper establish the verified same-socket bridge boundary.
 > Protocol 30 and local `boomux node rekey` implement bounded expected-ID rekey
-> with exact interactive confirmation. No public remote access command, SSH
-> bootstrap, registration, or projection is implemented yet.
+> with exact interactive confirmation. Public `boomux --remote TARGET` now
+> provides ad hoc SSH discovery, consent-gated bootstrap, and verified protocol
+> connectivity. Registration, projection, and routed operations are not yet
+> implemented.
 
 ## Purpose
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use boomux::protocol::{
     ShellSpec, ShellStatus, Snapshot, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec,
     WorkspaceSnapshot,
 };
-use boomux::{attach, client, daemon, federation, protocol};
+use boomux::{attach, client, daemon, federation, protocol, ssh_bootstrap};
 
 use crate::integration_management::{
     InstallOutcome, ensure_safe_directory, install_asset_at, regular_file_matches,
@@ -316,6 +316,10 @@ struct Cli {
     /// Emit the stable boomux.cli/v1 JSON envelope
     #[arg(long, global = true)]
     json: bool,
+
+    /// Connect ad hoc to one Boomux Node through OpenSSH
+    #[arg(long, value_name = "TARGET")]
+    remote: Option<String>,
 
     /// Open or create a persistent terminal in this directory
     #[arg(value_name = "PATH")]
@@ -1361,6 +1365,23 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         )
         .into());
     }
+    if let Some(target) = cli.remote.as_deref() {
+        if cli.json
+            || cli.path.is_some()
+            || cli.command.is_some()
+            || cli.name.is_some()
+            || cli.new_window
+            || !cli.startup_command.is_empty()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "--remote currently accepts only an SSH target; remote management and dashboard routing are delivered separately",
+            )
+            .into());
+        }
+        remote_connect(target)?;
+        return Ok(CliExit::Success);
+    }
     match cli.command.as_ref() {
         Some(Commands::Daemon {
             command: DaemonCommands::Run,
@@ -1495,6 +1516,60 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
     };
     result?;
     Ok(CliExit::Success)
+}
+
+fn remote_connect(target: &str) -> Result<(), Box<dyn Error>> {
+    const TIMEOUT: Duration = Duration::from_secs(120);
+
+    let target = ssh_bootstrap::SshTarget::parse(target)?;
+    let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
+    let authentication = if interactive {
+        ssh_bootstrap::SshAuthenticationMode::Interactive
+    } else {
+        ssh_bootstrap::SshAuthenticationMode::Batch
+    };
+    let helper = match ssh_bootstrap::plan_remote_bootstrap(
+        target.clone(),
+        authentication,
+        TIMEOUT,
+    )? {
+        ssh_bootstrap::RemoteBootstrapPlan::Ready(helper) => helper,
+        ssh_bootstrap::RemoteBootstrapPlan::Install(_plan) if !interactive => {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "remote Boomux installation is required, but noninteractive --remote never modifies remote software",
+            )
+            .into());
+        }
+        ssh_bootstrap::RemoteBootstrapPlan::Install(plan) => {
+            println!("Remote target: {}", plan.target.as_str());
+            println!("Install source: {}", plan.source.description());
+            println!("Install destination: {}", plan.destination.as_str());
+            println!(
+                "Process impact: {}",
+                if plan.may_restart_daemon {
+                    "the daemon may be gracefully restarted only if the installed helper cannot connect to the running daemon"
+                } else {
+                    "a detached daemon may be started; no running daemon will be restarted for a release-version difference"
+                }
+            );
+            if !confirm_setup("Install Boomux on this remote target?")? {
+                println!("No changes made.");
+                return Ok(());
+            }
+            ssh_bootstrap::install_remote(&plan, authentication, TIMEOUT)?
+        }
+    };
+    let mut connection = ssh_bootstrap::connect_remote(target, helper, authentication, TIMEOUT)?;
+    connection.ping()?;
+    println!(
+        "Connected to Boomux Node {} (protocol {}, helper {}, {})",
+        connection.handshake.node_id,
+        connection.handshake.core_protocol_version,
+        connection.handshake.helper_version,
+        connection.executable.as_str(),
+    );
+    Ok(())
 }
 
 fn node_command(command: NodeCommands) -> Result<(), Box<dyn Error>> {

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -7,11 +7,12 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::federation::FederationHandshake;
@@ -27,9 +28,15 @@ const MAX_PROBE_TIMEOUT: Duration = Duration::from_secs(120);
 const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const PLATFORM_PROBE_PREFIX: &[u8] = b"boomux-platform-v1";
 const EXECUTABLE_PROBE_PREFIX: &[u8] = b"boomux-executables-v1";
+const INSTALL_DESTINATION_PROBE_PREFIX: &[u8] = b"boomux-install-destination-v1";
+const MAX_RELEASE_BYTES: u64 = 128 * 1024 * 1024;
+const REMOTE_INSTALL_COMMAND: &str = "set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; umask 077; directory=$HOME/.local/bin; destination=$directory/boomux; mkdir -p \"$directory\"; temporary=$(mktemp \"$directory/.boomux.XXXXXXXX\"); trap 'rm -f \"$temporary\"' EXIT HUP INT TERM; cat > \"$temporary\"; chmod 755 \"$temporary\"; mv -f \"$temporary\" \"$destination\"; trap - EXIT HUP INT TERM";
+const REMOTE_RESTART_COMMAND: &str =
+    "case \"$HOME\" in /*) exec \"$HOME/.local/bin/boomux\" daemon restart ;; *) exit 1 ;; esac";
 
 pub const PLATFORM_PROBE_COMMAND: &str = "os=$(uname -s) || exit; arch=$(uname -m) || exit; printf 'boomux-platform-v1\\0%s\\0%s\\0' \"$os\" \"$arch\"";
 pub const EXECUTABLE_PROBE_COMMAND: &str = "printf 'boomux-executables-v1\\0'; path=$(command -v boomux 2>/dev/null || true); for candidate in \"$path\" /usr/local/bin/boomux /usr/bin/boomux /opt/homebrew/bin/boomux /home/linuxbrew/.linuxbrew/bin/boomux \"$HOME/.local/bin/boomux\" \"$HOME/.local/share/mise/shims/boomux\" \"$HOME/.nix-profile/bin/boomux\" /run/current-system/sw/bin/boomux; do case \"$candidate\" in /*) [ -f \"$candidate\" ] && [ -x \"$candidate\" ] && printf '%s\\0' \"$candidate\" ;; esac; done";
+pub const INSTALL_DESTINATION_PROBE_COMMAND: &str = "case \"$HOME\" in /*) printf 'boomux-install-destination-v1\\0%s\\0' \"$HOME/.local/bin/boomux\" ;; *) exit 1 ;; esac";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SshAuthenticationMode {
@@ -41,6 +48,7 @@ pub enum SshAuthenticationMode {
 pub enum RemoteProbe {
     Platform,
     Executables,
+    InstallDestination,
 }
 
 impl RemoteProbe {
@@ -48,6 +56,7 @@ impl RemoteProbe {
         match self {
             Self::Platform => PLATFORM_PROBE_COMMAND,
             Self::Executables => EXECUTABLE_PROBE_COMMAND,
+            Self::InstallDestination => INSTALL_DESTINATION_PROBE_COMMAND,
         }
     }
 }
@@ -74,12 +83,83 @@ pub struct RemotePlatform {
 pub struct RemoteDiscovery {
     pub platform: RemotePlatform,
     pub executables: Vec<RemoteExecutable>,
+    pub install_destination: RemoteExecutable,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompatibleRemoteHelper {
     pub executable: RemoteExecutable,
     pub handshake: FederationHandshake,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteInstallSource {
+    CurrentBinary(PathBuf),
+    Release { target: &'static str, tag: String },
+}
+
+impl RemoteInstallSource {
+    pub fn description(&self) -> String {
+        match self {
+            Self::CurrentBinary(path) => format!("current binary {}", path.display()),
+            Self::Release { target, tag } => {
+                format!("checksum-verified GitHub release {tag} for {target}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteInstallPlan {
+    pub target: SshTarget,
+    pub destination: RemoteExecutable,
+    pub source: RemoteInstallSource,
+    pub may_restart_daemon: bool,
+}
+
+pub enum RemoteBootstrapPlan {
+    Ready(CompatibleRemoteHelper),
+    Install(RemoteInstallPlan),
+}
+
+pub struct RemoteConnection {
+    child: Child,
+    pid: i32,
+    stdin: Option<ChildStdin>,
+    stdout: ChildStdout,
+    stderr_reader: Option<BoundedReader>,
+    pub executable: RemoteExecutable,
+    pub handshake: FederationHandshake,
+}
+
+impl RemoteConnection {
+    pub fn ping(&mut self) -> io::Result<()> {
+        let version = self.handshake.core_protocol_version;
+        protocol::write_message(
+            self.stdin.as_mut().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "remote channel closed")
+            })?,
+            &Envelope::with_version(version, Request::Ping),
+        )?;
+        let response: Envelope<Response> = protocol::read_message(&mut self.stdout)?;
+        if response.version == version && response.message == Response::Pong {
+            Ok(())
+        } else {
+            Err(invalid_probe(
+                "remote helper returned an invalid ping response",
+            ))
+        }
+    }
+}
+
+impl Drop for RemoteConnection {
+    fn drop(&mut self) {
+        self.stdin.take();
+        let _ = kill_process_group(self.pid, &mut self.child);
+        if let Some(reader) = self.stderr_reader.take() {
+            let _ = join_bounded_reader(reader);
+        }
+    }
 }
 
 impl RemotePlatform {
@@ -114,6 +194,38 @@ impl RemotePlatform {
             _ => None,
         }
     }
+
+    fn matches_local(self) -> bool {
+        matches!(
+            (
+                self.operating_system,
+                self.architecture,
+                env::consts::OS,
+                env::consts::ARCH
+            ),
+            (
+                RemoteOperatingSystem::Linux,
+                RemoteArchitecture::X86_64,
+                "linux",
+                "x86_64"
+            ) | (
+                RemoteOperatingSystem::Linux,
+                RemoteArchitecture::Aarch64,
+                "linux",
+                "aarch64"
+            ) | (
+                RemoteOperatingSystem::MacOs,
+                RemoteArchitecture::X86_64,
+                "macos",
+                "x86_64"
+            ) | (
+                RemoteOperatingSystem::MacOs,
+                RemoteArchitecture::Aarch64,
+                "macos",
+                "aarch64"
+            )
+        )
+    }
 }
 
 pub fn parse_executable_probe(output: &[u8]) -> io::Result<Vec<RemoteExecutable>> {
@@ -134,6 +246,18 @@ pub fn parse_executable_probe(output: &[u8]) -> io::Result<Vec<RemoteExecutable>
         }
     }
     Ok(executables)
+}
+
+pub fn parse_install_destination_probe(output: &[u8]) -> io::Result<RemoteExecutable> {
+    let fields = parse_nul_fields(output, INSTALL_DESTINATION_PROBE_PREFIX)?;
+    if fields.len() != 1 {
+        return Err(invalid_probe(
+            "install destination probe returned an invalid field count",
+        ));
+    }
+    let value = std::str::from_utf8(fields[0])
+        .map_err(|_| invalid_probe("install destination probe returned non-UTF-8 data"))?;
+    RemoteExecutable::parse(value.to_owned())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -413,6 +537,333 @@ pub fn discover_remote(
     )
 }
 
+pub fn plan_remote_bootstrap(
+    target: SshTarget,
+    authentication: SshAuthenticationMode,
+    timeout: Duration,
+) -> io::Result<RemoteBootstrapPlan> {
+    let discovery = discover_remote(target.clone(), authentication, timeout)?;
+    if let Ok(helper) = find_compatible_remote_helper(
+        target.clone(),
+        &discovery.executables,
+        authentication,
+        timeout,
+    ) {
+        return Ok(RemoteBootstrapPlan::Ready(helper));
+    }
+    let source = select_install_source(discovery.platform)?;
+    Ok(RemoteBootstrapPlan::Install(RemoteInstallPlan {
+        target,
+        destination: discovery.install_destination,
+        source,
+        may_restart_daemon: !discovery.executables.is_empty(),
+    }))
+}
+
+pub fn install_remote(
+    plan: &RemoteInstallPlan,
+    authentication: SshAuthenticationMode,
+    timeout: Duration,
+) -> io::Result<CompatibleRemoteHelper> {
+    let binary = load_install_source(&plan.source)?;
+    let invocation =
+        prepare_fixed_invocation(plan.target.clone(), REMOTE_INSTALL_COMMAND, authentication)?;
+    run_streaming_command(invocation.command(), binary, timeout)?;
+
+    let candidates = [plan.destination.clone()];
+    match find_compatible_remote_helper(plan.target.clone(), &candidates, authentication, timeout) {
+        Ok(helper) => Ok(helper),
+        Err(first_error) if plan.may_restart_daemon => {
+            let restart = prepare_fixed_invocation(
+                plan.target.clone(),
+                REMOTE_RESTART_COMMAND,
+                authentication,
+            )?;
+            run_bounded_command(restart.command(), timeout).map_err(|_| first_error)?;
+            find_compatible_remote_helper(plan.target.clone(), &candidates, authentication, timeout)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub fn connect_remote(
+    target: SshTarget,
+    helper: CompatibleRemoteHelper,
+    authentication: SshAuthenticationMode,
+    timeout: Duration,
+) -> io::Result<RemoteConnection> {
+    if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SSH connection timeout is outside the supported bound",
+        ));
+    }
+    let invocation = SshInvocation::prepare(target, helper.executable.clone(), authentication)?;
+    let mut command = invocation.command();
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command.spawn()?;
+    let pid = i32::try_from(child.id()).map_err(|error| {
+        let _ = child.kill();
+        let _ = child.wait();
+        io::Error::other(format!("child PID overflow: {error}"))
+    })?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::other("SSH helper stdin was not captured"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("SSH helper stdout was not captured"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("SSH helper stderr was not captured"))?;
+    let stderr_reader = match spawn_bounded_reader(stderr, MAX_PROBE_STDERR_BYTES, "stderr") {
+        Ok(reader) => reader,
+        Err(error) => {
+            let _ = kill_process_group(pid, &mut child);
+            return Err(error);
+        }
+    };
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let handshake_worker = match thread::Builder::new()
+        .name("boomux-ssh-handshake".into())
+        .spawn(move || {
+            let mut stdout = stdout;
+            let result = crate::federation::read_handshake(&mut stdout);
+            let _ = sender.send((result, stdout));
+        }) {
+        Ok(worker) => worker,
+        Err(error) => {
+            let _ = kill_process_group(pid, &mut child);
+            let _ = join_bounded_reader(stderr_reader);
+            return Err(error);
+        }
+    };
+    let received = receiver.recv_timeout(timeout);
+    let (handshake, stdout) = match received {
+        Ok((result, stdout)) => (result, stdout),
+        Err(_) => {
+            let _ = kill_process_group(pid, &mut child);
+            handshake_worker
+                .join()
+                .map_err(|_| io::Error::other("SSH handshake worker panicked"))?;
+            let _ = join_bounded_reader(stderr_reader);
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "SSH helper handshake timed out",
+            ));
+        }
+    };
+    handshake_worker
+        .join()
+        .map_err(|_| io::Error::other("SSH handshake worker panicked"))?;
+    let handshake = match handshake {
+        Ok(handshake) => handshake,
+        Err(error) => {
+            let _ = kill_process_group(pid, &mut child);
+            let _ = join_bounded_reader(stderr_reader);
+            return Err(error);
+        }
+    };
+    if let Err(error) = validate_live_handshake(&helper.handshake, &handshake) {
+        let _ = kill_process_group(pid, &mut child);
+        let _ = join_bounded_reader(stderr_reader);
+        return Err(error);
+    }
+    Ok(RemoteConnection {
+        child,
+        pid,
+        stdin: Some(stdin),
+        stdout,
+        stderr_reader: Some(stderr_reader),
+        executable: helper.executable,
+        handshake,
+    })
+}
+
+fn validate_live_handshake(
+    expected: &FederationHandshake,
+    actual: &FederationHandshake,
+) -> io::Result<()> {
+    if !(protocol::MIN_PROTOCOL_VERSION..=protocol::PROTOCOL_VERSION)
+        .contains(&actual.core_protocol_version)
+    {
+        return Err(invalid_probe(
+            "remote helper reported an incompatible core protocol",
+        ));
+    }
+    if actual.node_id != expected.node_id {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "remote helper identity changed after bootstrap",
+        ));
+    }
+    Ok(())
+}
+
+fn prepare_fixed_invocation(
+    target: SshTarget,
+    command: &'static str,
+    authentication: SshAuthenticationMode,
+) -> io::Result<SshInvocation> {
+    let socket_path = crate::client::socket_path()?;
+    let runtime_directory = socket_path
+        .parent()
+        .ok_or_else(|| io::Error::other("Boomux runtime socket has no parent"))?;
+    let user_config = env::var_os("HOME")
+        .filter(|home| !home.is_empty())
+        .map(PathBuf::from)
+        .map(|home| home.join(".ssh/config"));
+    SshInvocation::prepare_command_at(
+        runtime_directory,
+        user_config.as_deref(),
+        target,
+        command.to_owned(),
+        authentication,
+    )
+}
+
+fn select_install_source(platform: RemotePlatform) -> io::Result<RemoteInstallSource> {
+    if platform.matches_local() {
+        return Ok(RemoteInstallSource::CurrentBinary(env::current_exe()?));
+    }
+    let target = platform.release_target().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::Unsupported,
+            "no Boomux release asset supports the remote platform",
+        )
+    })?;
+    Ok(RemoteInstallSource::Release {
+        target,
+        tag: format!("v{}", env!("CARGO_PKG_VERSION")),
+    })
+}
+
+fn load_install_source(source: &RemoteInstallSource) -> io::Result<Vec<u8>> {
+    match source {
+        RemoteInstallSource::CurrentBinary(path) => read_bounded_file(path),
+        RemoteInstallSource::Release { target, tag } => download_release_binary(target, tag),
+    }
+}
+
+fn read_bounded_file(path: &Path) -> io::Result<Vec<u8>> {
+    let metadata = fs::metadata(path)?;
+    if !metadata.is_file() || metadata.len() == 0 || metadata.len() > MAX_RELEASE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux install source is not a bounded regular file",
+        ));
+    }
+    fs::read(path)
+}
+
+fn download_release_binary(target: &str, tag: &str) -> io::Result<Vec<u8>> {
+    let socket_path = crate::client::socket_path()?;
+    let parent = socket_path
+        .parent()
+        .ok_or_else(|| io::Error::other("Boomux runtime socket has no parent"))?;
+    secure_runtime_directory(parent)?;
+    let directory = parent.join(format!("release-{}", Uuid::new_v4()));
+    fs::create_dir(&directory)?;
+    fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
+    let result = (|| {
+        let archive_name = format!("boomux-{tag}-{target}.tar.gz");
+        let archive = directory.join(&archive_name);
+        let checksum = directory.join(format!("{archive_name}.sha256"));
+        let base = format!("https://github.com/gardnmi/boomux/releases/download/{tag}");
+        for (url, destination, maximum_size) in [
+            (
+                format!("{base}/{archive_name}"),
+                &archive,
+                MAX_RELEASE_BYTES,
+            ),
+            (format!("{base}/{archive_name}.sha256"), &checksum, 1024),
+        ] {
+            let status = Command::new("curl")
+                .args([
+                    "--fail",
+                    "--location",
+                    "--silent",
+                    "--show-error",
+                    "--output",
+                ])
+                .arg(destination)
+                .arg("--max-filesize")
+                .arg(maximum_size.to_string())
+                .arg(url)
+                .status()?;
+            if !status.success() {
+                return Err(io::Error::other("could not download Boomux release asset"));
+            }
+        }
+        if fs::metadata(&archive)?.len() > MAX_RELEASE_BYTES {
+            return Err(invalid_probe(
+                "Boomux release archive exceeds the size limit",
+            ));
+        }
+        verify_release_checksum(&archive, &checksum, &archive_name)?;
+        let member = format!("boomux-{tag}-{target}/boomux");
+        let status = Command::new("tar")
+            .args(["-xzf"])
+            .arg(&archive)
+            .args(["-C"])
+            .arg(&directory)
+            .arg(&member)
+            .status()?;
+        if !status.success() {
+            return Err(io::Error::other("could not extract Boomux release asset"));
+        }
+        read_bounded_file(&directory.join(member))
+    })();
+    let _ = fs::remove_dir_all(&directory);
+    result
+}
+
+fn verify_release_checksum(archive: &Path, checksum: &Path, archive_name: &str) -> io::Result<()> {
+    let checksum = fs::read_to_string(checksum)?;
+    if checksum.len() > 1024 {
+        return Err(invalid_probe(
+            "Boomux release checksum exceeds the size limit",
+        ));
+    }
+    let mut fields = checksum.split_ascii_whitespace();
+    let expected = fields
+        .next()
+        .filter(|value| value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .ok_or_else(|| invalid_probe("Boomux release checksum is invalid"))?;
+    let name = fields
+        .next()
+        .map(|value| value.trim_start_matches('*'))
+        .ok_or_else(|| invalid_probe("Boomux release checksum has no filename"))?;
+    if name != archive_name || fields.next().is_some() {
+        return Err(invalid_probe(
+            "Boomux release checksum names an unexpected asset",
+        ));
+    }
+    let mut file = fs::File::open(archive)?;
+    let mut digest = Sha256::new();
+    io::copy(&mut file, &mut digest)?;
+    let actual = format!("{:x}", digest.finalize());
+    if actual != expected.to_ascii_lowercase() {
+        return Err(invalid_probe("Boomux release checksum did not match"));
+    }
+    Ok(())
+}
+
 pub fn find_compatible_remote_helper(
     target: SshTarget,
     executables: &[RemoteExecutable],
@@ -518,9 +969,12 @@ fn discover_remote_at(
     };
     let platform = RemotePlatform::parse_probe(&run(RemoteProbe::Platform)?.stdout)?;
     let executables = parse_executable_probe(&run(RemoteProbe::Executables)?.stdout)?;
+    let install_destination =
+        parse_install_destination_probe(&run(RemoteProbe::InstallDestination)?.stdout)?;
     Ok(RemoteDiscovery {
         platform,
         executables,
+        install_destination,
     })
 }
 
@@ -683,6 +1137,76 @@ fn run_bounded_command(mut command: Command, timeout: Duration) -> io::Result<Ss
         return Err(io::Error::other("SSH probe exited unsuccessfully"));
     }
     Ok(SshProbeOutput { stdout, stderr })
+}
+
+fn run_streaming_command(
+    mut command: Command,
+    input: Vec<u8>,
+    timeout: Duration,
+) -> io::Result<()> {
+    if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SSH install timeout is outside the supported bound",
+        ));
+    }
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command.spawn()?;
+    let pid = i32::try_from(child.id()).map_err(|_| io::Error::other("child PID overflow"))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::other("SSH install stdin was not captured"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("SSH install stderr was not captured"))?;
+    let stderr_reader = spawn_bounded_reader(stderr, MAX_PROBE_STDERR_BYTES, "stderr")?;
+    let writer = thread::Builder::new()
+        .name("boomux-ssh-install-input".into())
+        .spawn(move || stdin.write_all(&input))?;
+    let deadline = Instant::now().checked_add(timeout).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "SSH install timeout overflow")
+    })?;
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break Some(status);
+        }
+        if Instant::now() >= deadline {
+            kill_process_group(pid, &mut child)?;
+            break None;
+        }
+        thread::sleep(CHILD_POLL_INTERVAL);
+    };
+    writer
+        .join()
+        .map_err(|_| io::Error::other("SSH install input worker panicked"))??;
+    let (_, stderr_truncated) = join_bounded_reader(stderr_reader)?;
+    if status.is_none() {
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "SSH install timed out",
+        ));
+    }
+    if stderr_truncated {
+        return Err(invalid_probe("SSH install stderr exceeds the size limit"));
+    }
+    if !status.expect("checked above").success() {
+        return Err(io::Error::other("remote Boomux install failed"));
+    }
+    Ok(())
 }
 
 fn run_helper_probe_command(
@@ -1003,6 +1527,21 @@ mod tests {
                 .kind(),
             io::ErrorKind::InvalidInput
         );
+
+        assert_eq!(
+            parse_install_destination_probe(
+                b"boomux-install-destination-v1\0/home/person/.local/bin/boomux\0"
+            )
+            .unwrap()
+            .as_str(),
+            "/home/person/.local/bin/boomux"
+        );
+        assert_eq!(
+            parse_install_destination_probe(b"boomux-install-destination-v1\0relative/boomux\0")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
     }
 
     #[test]
@@ -1137,6 +1676,29 @@ mod tests {
     }
 
     #[test]
+    fn live_handshake_pins_identity_but_allows_compatible_version_changes() {
+        let expected = FederationHandshake {
+            version: FEDERATION_VERSION,
+            node_id: Uuid::new_v4().to_string(),
+            helper_version: "0.17.0".into(),
+            core_protocol_version: protocol::MIN_PROTOCOL_VERSION,
+            connection_mode: FederationConnectionMode::AdHoc,
+        };
+        let mut changed = expected.clone();
+        changed.helper_version = "0.18.0".into();
+        changed.core_protocol_version = protocol::PROTOCOL_VERSION;
+        validate_live_handshake(&expected, &changed).unwrap();
+
+        changed.node_id = Uuid::new_v4().to_string();
+        assert_eq!(
+            validate_live_handshake(&expected, &changed)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+    }
+
+    #[test]
     fn helper_selection_skips_incompatible_discovered_executables() {
         let runtime = runtime_directory();
         fs::create_dir_all(&runtime).unwrap();
@@ -1211,7 +1773,7 @@ mod tests {
         fs::write(
             &ssh,
             format!(
-                "#!/bin/sh\nprintf 'call\\0' >> {quoted_log}\nfor arg do printf '%s\\0' \"$arg\" >> {quoted_log}; done\nprintf 'end\\0' >> {quoted_log}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/usr/bin/boomux\\0/opt/homebrew/bin/boomux\\0' ;;\n  *) exit 64 ;;\nesac\n"
+                "#!/bin/sh\nprintf 'call\\0' >> {quoted_log}\nfor arg do printf '%s\\0' \"$arg\" >> {quoted_log}; done\nprintf 'end\\0' >> {quoted_log}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/usr/bin/boomux\\0/opt/homebrew/bin/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/person/.local/bin/boomux\\0' ;;\n  *) exit 64 ;;\nesac\n"
             ),
         )
         .unwrap();
@@ -1241,6 +1803,10 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["/usr/bin/boomux", "/opt/homebrew/bin/boomux"]
         );
+        assert_eq!(
+            discovery.install_destination.as_str(),
+            "/home/person/.local/bin/boomux"
+        );
 
         let arguments = fs::read(&log).unwrap();
         let fields = arguments
@@ -1248,16 +1814,17 @@ mod tests {
             .filter(|field| !field.is_empty())
             .map(|field| std::str::from_utf8(field).unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(fields.iter().filter(|field| **field == "call").count(), 2);
+        assert_eq!(fields.iter().filter(|field| **field == "call").count(), 3);
         assert_eq!(
             fields
                 .iter()
                 .filter(|field| **field == "user@workbox")
                 .count(),
-            2
+            3
         );
         assert!(fields.contains(&PLATFORM_PROBE_COMMAND));
         assert!(fields.contains(&EXECUTABLE_PROBE_COMMAND));
+        assert!(fields.contains(&INSTALL_DESTINATION_PROBE_COMMAND));
         assert_eq!(
             fs::read_dir(&runtime)
                 .unwrap()
@@ -1267,5 +1834,80 @@ mod tests {
             0
         );
         fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn fixed_install_command_streams_private_executable_and_replaces_atomically() {
+        let directory = runtime_directory();
+        fs::create_dir_all(directory.join(".local/bin")).unwrap();
+        let destination = directory.join(".local/bin/boomux");
+        fs::write(&destination, b"previous").unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", REMOTE_INSTALL_COMMAND])
+            .env("HOME", &directory);
+        run_streaming_command(command, b"replacement".to_vec(), Duration::from_secs(1)).unwrap();
+        assert_eq!(fs::read(&destination).unwrap(), b"replacement");
+        assert_eq!(fs::metadata(&destination).unwrap().mode() & 0o777, 0o755);
+        assert!(
+            fs::read_dir(directory.join(".local/bin"))
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| !entry.file_name().to_string_lossy().starts_with(".boomux."))
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn failed_streamed_install_leaves_previous_binary_usable() {
+        let directory = runtime_directory();
+        fs::create_dir_all(directory.join("bin")).unwrap();
+        let destination = directory.join("bin/boomux");
+        fs::write(&destination, b"previous").unwrap();
+        let temporary = directory.join("bin/.boomux.test");
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "set -eu; trap 'rm -f \"$TEMPORARY\"' EXIT; cat > \"$TEMPORARY\"; false; mv -f \"$TEMPORARY\" \"$DESTINATION\"",
+        ]);
+        command
+            .env("TEMPORARY", &temporary)
+            .env("DESTINATION", &destination);
+        assert!(
+            run_streaming_command(command, b"replacement".to_vec(), Duration::from_secs(1))
+                .is_err()
+        );
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        assert!(!temporary.exists());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn release_checksum_requires_exact_asset_name_and_digest() {
+        let directory = runtime_directory();
+        fs::create_dir_all(&directory).unwrap();
+        let archive = directory.join("asset.tar.gz");
+        let checksum = directory.join("asset.tar.gz.sha256");
+        fs::write(&archive, b"archive").unwrap();
+        let digest = format!("{:x}", Sha256::digest(b"archive"));
+        fs::write(&checksum, format!("{digest}  asset.tar.gz\n")).unwrap();
+        verify_release_checksum(&archive, &checksum, "asset.tar.gz").unwrap();
+
+        fs::write(&checksum, format!("{digest}  another.tar.gz\n")).unwrap();
+        assert_eq!(
+            verify_release_checksum(&archive, &checksum, "asset.tar.gz")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        fs::write(&checksum, format!("{}  asset.tar.gz\n", "0".repeat(64))).unwrap();
+        assert_eq!(
+            verify_release_checksum(&archive, &checksum, "asset.tar.gz")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -14,6 +14,8 @@ mod notifications;
 mod project_discovery;
 #[path = "native_backend/protocol_control.rs"]
 mod protocol_control;
+#[path = "native_backend/remote_bootstrap.rs"]
+mod remote_bootstrap;
 #[path = "native_backend/schedules.rs"]
 mod schedules;
 #[path = "native_backend/shell_lifecycle.rs"]

--- a/tests/native_backend/remote_bootstrap.rs
+++ b/tests/native_backend/remote_bootstrap.rs
@@ -1,0 +1,153 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use boomux::federation::{
+    FEDERATION_VERSION, FederationConnectionMode, FederationHandshake, write_handshake,
+};
+use boomux::protocol::{self, Envelope, Request, Response};
+use uuid::Uuid;
+
+fn shell_printf(bytes: &[u8]) -> String {
+    let escaped = bytes
+        .iter()
+        .map(|byte| format!("\\{byte:03o}"))
+        .collect::<String>();
+    format!("printf '{escaped}'")
+}
+
+fn fake_ssh(
+    directory: &Path,
+    executables: &str,
+    disconnect_second_helper: bool,
+) -> std::path::PathBuf {
+    let handshake = FederationHandshake {
+        version: FEDERATION_VERSION,
+        node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+        helper_version: env!("CARGO_PKG_VERSION").into(),
+        core_protocol_version: protocol::PROTOCOL_VERSION,
+        connection_mode: FederationConnectionMode::AdHoc,
+    };
+    let mut handshake_bytes = Vec::new();
+    write_handshake(&mut handshake_bytes, &handshake).unwrap();
+    let mut request = Vec::new();
+    protocol::write_message(
+        &mut request,
+        &Envelope::with_version(protocol::PROTOCOL_VERSION, Request::Ping),
+    )
+    .unwrap();
+    let mut response = Vec::new();
+    protocol::write_message(
+        &mut response,
+        &Envelope::with_version(protocol::PROTOCOL_VERSION, Response::Pong),
+    )
+    .unwrap();
+    let log = directory.join("ssh.log");
+    let count = directory.join("helper.count");
+    let ssh = directory.join("ssh");
+    let helper = if disconnect_second_helper {
+        format!(
+            "count=0; [ ! -f '{}' ] || count=$(cat '{}'); count=$((count + 1)); printf '%s' \"$count\" > '{}'; {}; dd bs=1 count={} of=/dev/null 2>/dev/null; [ \"$count\" -lt 2 ] && {}",
+            count.display(),
+            count.display(),
+            count.display(),
+            shell_printf(&handshake_bytes),
+            request.len(),
+            shell_printf(&response),
+        )
+    } else {
+        format!(
+            "{}; dd bs=1 count={} of=/dev/null 2>/dev/null; {}",
+            shell_printf(&handshake_bytes),
+            request.len(),
+            shell_printf(&response),
+        )
+    };
+    fs::write(
+        &ssh,
+        format!(
+            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\nprintf '%s\\n' \"$last\" >> '{}'\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") {} ;;\n  *) exit 64 ;;\nesac\n",
+            log.display(),
+            executables,
+            helper,
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+    ssh
+}
+
+fn command(directory: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+    command
+        .args(["--remote", "workbox"])
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"));
+    command
+}
+
+fn test_directory() -> std::path::PathBuf {
+    let id = Uuid::new_v4().simple().to_string();
+    std::env::temp_dir().join(format!("bx-r-{}-{}", std::process::id(), &id[..8]))
+}
+
+#[test]
+fn public_remote_uses_verified_stdio_protocol_channel() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_ssh(&directory, "/remote/boomux\\0", false);
+
+    let output = command(&directory).output().unwrap();
+    assert!(
+        output.status.success(),
+        "remote command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Connected to Boomux Node 550e8400-e29b-41d4-a716-446655440000"));
+    let log = fs::read_to_string(directory.join("ssh.log")).unwrap();
+    assert_eq!(log.matches("__federation-stdio").count(), 2);
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn noninteractive_remote_refuses_install_without_modification() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_ssh(&directory, "", false);
+
+    let output = command(&directory).output().unwrap();
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("noninteractive --remote never modifies remote software")
+    );
+    let log = fs::read_to_string(directory.join("ssh.log")).unwrap();
+    assert_eq!(log.lines().count(), 3);
+    assert!(!log.contains("mktemp"));
+    assert!(!log.contains("daemon restart"));
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn remote_disconnect_after_handshake_fails_without_hanging() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_ssh(&directory, "/remote/boomux\\0", true);
+
+    let output = command(&directory).output().unwrap();
+    assert!(!output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("Connected to Boomux Node"));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("failed to fill whole buffer"),
+        "unexpected disconnect error: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    fs::remove_dir_all(directory).unwrap();
+}


### PR DESCRIPTION
## Summary

- add public ad hoc `boomux --remote TARGET` bootstrap and verified connectivity
- prefer compatible installed helpers without restart solely for release differences
- refuse remote modification in noninteractive mode and preview interactive impact
- copy a matching local binary or checksum-verify a supported release asset
- stream installation through a private temporary file and atomically replace it
- revalidate Node identity before opening the live daemon protocol channel
- add hermetic fake-SSH native coverage for connection, refusal, and disconnect

## Stack

- GitHub stack #190
- depends on #196
- completes the implementation scope of #175

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend remote_bootstrap --locked -- --test-threads=1`

Closes #175

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
