### PR TITLE
feat(node): persist remote registrations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@
 | `src/daemon.rs` | `DaemonService` coordination over durable registry, event-stream, shell-runtime, persistence, and handoff owners |
 | `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
 | `src/node_identity.rs` | Stable Node identity persistence, federation admission leases, and bounded rekey drain |
+| `src/node_registration.rs` | Independently versioned remote Node registrations, identity pinning, admission drain, validation, and atomic storage |
 | `src/federation.rs` | Independently versioned federation handshake and verified stdio daemon bridging |
 | `src/ssh_bootstrap.rs` | Validated SSH targets, private invocation configuration, deadline-bound remote discovery, and helper compatibility selection |
 | `src/handoff.rs`, `src/fd_transfer.rs` | Graceful daemon replacement records and Unix descriptor transfer |
@@ -58,7 +59,8 @@
   accepted federation boundary: one owning Node remains authoritative, SSH is a
   route, and local cached projections never authorize mutation or lifecycle
   inference. Ad hoc bootstrap and verified transport are implemented; durable
-  registration, projection, and routed management remain tracked by #173.
+  durable registration is implemented; projection and routed management remain
+  tracked by #173.
 
 ## Product Boundary
 
@@ -95,10 +97,12 @@ not expose a TCP listener or the local daemon socket. Remote work continues when
 the SSH bridge or local presentation disconnects. The complete accepted contract
 and deferred behavior are in [`remote-nodes.md`](remote-nodes.md).
 
-Public `boomux --remote TARGET` currently performs ad hoc bootstrap only. It
+Public `boomux --remote TARGET` performs ad hoc bootstrap only. It
 discovers and verifies a compatible helper, or interactively installs one before
-opening and pinging a daemon-bound stdio channel. It creates no registration or
-projection and does not yet route dashboard or management operations.
+opening and pinging a daemon-bound stdio channel. Explicit `boomux node add
+ALIAS TARGET` and revision-conditional registration management persist an
+identity-pinned route separately; neither mode creates a projection or routes
+dashboard or resource-management operations yet.
 
 ## Components
 
@@ -844,6 +848,20 @@ local human-only workflow: it refuses noninteractive input and requires the
 operator to type the exact current Node ID before sending the conditional
 request.
 
+Protocol 31 and Node registration schema 1 add explicit `node add`, `list`,
+`inspect`, `rename`, `retarget`, and `forget`. Registration records contain only
+the bounded local alias, exact SSH target, pinned Node ID, monotonic registration
+revision, and tombstone epoch in owner-only `node_registrations.json`; discovered
+helper paths and credentials are never persisted. Add and retarget use the
+authenticated protocol-29 bootstrap before commit. Retarget must prove the
+existing pinned identity and rename/retarget require the exact current revision.
+Forget performs only a local prepare/drain/commit and cannot contact or stop the
+remote authority. Malformed, future-version, oversized, or insecure registration
+files are preserved and disable registration routing while the local durable
+registry remains available. State schema remains 12, and the federation
+handshake continues to describe its transport as `ad_hoc` without assigning that
+field durable registration semantics.
+
 Cron day matching preserves syntactic wildcard origin: `*/n` is wildcard-origin,
 while numeric lists and ranges remain restricted even when they cover the full
 field. Trigger acceptance proves at least one occurrence across a Gregorian
@@ -907,15 +925,16 @@ by PTY readers. Shell close, workspace close, and shutdown use one lifecycle
 transaction policy: prepare every runtime stop, finalize visible lifecycle
 changes, apply the operation-specific durable removal, persist, then publish.
 
-The accepted remote federation coordinator remains outside this core durable
+The remote federation coordinator remains outside this core durable
 order. Its order is daemon transition, Node mutation gate, Node persistence gate,
 local `EventStream` transition frontier, then Node registry/cache state. It never
 acquires core durable, shell lifecycle, runtime, or terminal locks and never
 retains a federation lock during SSH I/O. A copied registration revision is
 revalidated only after network work and before an atomic cache or registration
-commit. Notification qualification and delivery occur after every federation and
-event lock is released. This is an accepted future invariant; each federation
-delivery issue must preserve the applicable part as the coordinator is built.
+commit. Registration changes atomically persist before replacing their in-memory
+generation. Notification qualification and delivery occur after every federation
+and event lock is released. Later federation delivery issues must preserve the
+applicable order as the coordinator is extended.
 
 Failure at any stage restores removed entities and exhaustively compensates every
 stopped shell. Already-running processes cannot be resurrected, so their

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -43,17 +43,17 @@ delivery diagnostic and does not support `--json`.
 
 ### Accepted Remote Node Compatibility
 
-Remote Node federation is an accepted, unimplemented extension tracked by #173.
-No current `boomux.cli/v1` command implies remote behavior. When the capability
-ships, it must be advertised explicitly by `capabilities`; clients must not infer
-support from a CLI or daemon version string.
+Remote Node federation is an incremental extension tracked by #173. Protocol 31
+advertises registration management explicitly; clients must not infer support
+from a CLI or daemon version string. Registration commands manage local routes
+only and do not imply projected reads or routed resource mutation.
 
 That passive command advertises only what the installed local CLI can speak and
-never reports negotiated state for a registered Node. Future `node.list`,
-`node.inspect`, and combined projection data carry each Node's observed protocol,
-capabilities, health, and observation time after contacting only the local
-daemon. Integrations must keep static CLI support distinct from per-Node runtime
-support.
+never reports negotiated state for a registered Node. Implemented `node.list`
+and `node.inspect` return registration data only. Future combined projection data
+will carry each Node's observed protocol, capabilities, health, and observation
+time after contacting only the local daemon. Integrations must keep static CLI
+support, registration data, and per-Node runtime support distinct.
 
 Existing unqualified commands and JSON methods retain local-Node meaning and
 local-only result sets. Older clients continue to receive only local resources.
@@ -90,6 +90,12 @@ The following commands support `--json`:
 - `boomux project list`
 - `boomux workspace list`
 - `boomux workspace inspect`
+- `boomux node add`
+- `boomux node list`
+- `boomux node inspect`
+- `boomux node rename`
+- `boomux node retarget`
+- `boomux node forget`
 - `boomux shell suggest-name <workspace-name-or-id>`
 - `boomux shell inspect`
 - `boomux launcher list`
@@ -125,7 +131,8 @@ The following commands support `--json`:
 - `boomux integration verify <opencode|pi>`
 - `boomux daemon status`
 
-JSON mutations are deliberately narrow. Agent register, ensure, and report;
+JSON mutations are deliberately narrow. Node registration add, rename, retarget,
+and forget; Agent register, ensure, and report;
 attention acknowledgment; schedule create, pause, resume, remove, and run;
 execution open and cancellation; and
 integration install and uninstall support the contract. Other mutation commands
@@ -153,6 +160,11 @@ Command payloads are:
 - `workspace.inspect`: one `workspace` object containing `id`, `name`, nullable
   `default_cwd`, and prompt-free `shells`, `launchers`, `schedules`, and `agents`
   arrays.
+- `node.list`: an alias-then-Node-ID ordered array of registration objects.
+- `node.add`, `node.inspect`, `node.rename`, `node.retarget`, and `node.forget`:
+  one registration object with `alias`, exact `target`, pinned `node_id`,
+  `revision`, and `tombstone_epoch`. Add and retarget verify the SSH route before
+  the local mutation; forget performs no SSH operation.
 - `shell.suggest-name`: exact resolved `workspace_id` plus a nonempty generated
   `name` that does not match any shell name in that workspace at observation
   time.

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -8,10 +8,10 @@
 > implements stable local Node identity; protocol 29, handshake version 1, and
 > the hidden stdio helper establish the verified same-socket bridge boundary.
 > Protocol 30 and local `boomux node rekey` implement bounded expected-ID rekey
-> with exact interactive confirmation. Public `boomux --remote TARGET` now
-> provides ad hoc SSH discovery, consent-gated bootstrap, and verified protocol
-> connectivity. Registration, projection, and routed operations are not yet
-> implemented.
+> with exact interactive confirmation. Protocol 31 and registration schema 1
+> implement explicit identity-pinned registration management. Public `boomux
+> --remote TARGET` remains ad hoc; projection and routed resource operations are
+> not yet implemented.
 
 ## Purpose
 
@@ -97,6 +97,14 @@ projection storage. Registration alone is read-only authority: process starts,
 destructive changes, integration installation, Schedule enablement, and remote
 daemon management retain their existing explicit user authorization. Boomux
 never scans SSH configuration and automatically connects to every alias.
+
+The implemented registration CLI is `boomux node add ALIAS TARGET`, `node list`,
+`node inspect`, revision-conditional `node rename` and `node retarget`, and `node
+forget`. Add and retarget complete verified bootstrap before submitting a
+registration mutation to the local daemon. The selected helper path is
+connection-local and is rediscovered on every later connection; it is not a
+registration field. The federation handshake's current `ad_hoc` mode remains a
+transport property and is not reinterpreted as registration persistence.
 
 Interactive setup can use normal OpenSSH authentication and confirmation. It can
 discover or install a compatible remote Boomux binary only after showing the
@@ -418,6 +426,12 @@ Introducing them cannot silently reinterpret authoritative `state.json`. If a
 later implementation places any Node field in that durable representation, it
 must bump `STATE_VERSION` and provide the ordinary explicit migration and cold
 recovery evidence.
+
+Registration schema 1 is stored in owner-only `node_registrations.json` beside,
+but independently from, `state.json` and `node.json`. It stores only alias,
+target, pinned Node ID, registration revision, and tombstone epoch. Atomic
+replacement fsyncs the new file before rename; records, aliases, targets, and
+file size are bounded and list order is deterministic by alias then Node ID.
 
 Every durable federation schema retains its immediately previous representation
 and migrates it explicitly under the appropriate owner lock before advertising

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -679,6 +679,9 @@ fn protocol_error_code(code: ErrorCode) -> &'static str {
         ErrorCode::RevisionAhead => "revision_ahead",
         ErrorCode::IdempotencyExpired => "idempotency_expired",
         ErrorCode::NodeIdentityUnavailable => "node_identity_unavailable",
+        ErrorCode::NodeRegistrationUnavailable => "node_registration_unavailable",
+        ErrorCode::NodeIdentityChanged => "node_identity_changed",
+        ErrorCode::RevisionChanged => "revision_changed",
         ErrorCode::Internal => "internal",
         ErrorCode::Unknown => "unknown",
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,11 +16,12 @@ use std::time::Duration;
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
     AgentScheduleSnapshot, AgentScheduleSpec, AgentScheduleUpdate, DaemonEvent, Envelope,
-    ErrorCode, EventCursor, FocusedTerminalSnapshot, NotificationDeliveryConfig, Request, Response,
-    ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot, ScheduledOccurrence,
-    ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
-    TerminalPreviewLine, TerminalPreviewSpan, TerminalProfile, UnixEnvironment,
-    UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    ErrorCode, EventCursor, FocusedTerminalSnapshot, NodeRegistrationSnapshot,
+    NotificationDeliveryConfig, Request, Response, ScheduledExecutionScheduleProjection,
+    ScheduledExecutionSnapshot, ScheduledOccurrence, ScheduledRunnerResult, ShellSnapshot,
+    ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan,
+    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
+    WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -559,6 +560,79 @@ impl Client {
             expected_node_id: expected_node_id.into(),
         })? {
             Response::NodeIdentity { node_id } => Ok(node_id),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn add_node_registration(
+        &self,
+        alias: impl Into<String>,
+        target: impl Into<String>,
+        node_id: impl Into<String>,
+    ) -> Result<NodeRegistrationSnapshot> {
+        self.node_registration_response(Request::AddNodeRegistration {
+            alias: alias.into(),
+            target: target.into(),
+            node_id: node_id.into(),
+        })
+    }
+
+    pub fn node_registrations(&self) -> Result<Vec<NodeRegistrationSnapshot>> {
+        match self.request(Request::ListNodeRegistrations)? {
+            Response::NodeRegistrations { registrations } => Ok(registrations),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn node_registration(
+        &self,
+        selector: impl Into<String>,
+    ) -> Result<NodeRegistrationSnapshot> {
+        self.node_registration_response(Request::GetNodeRegistration {
+            selector: selector.into(),
+        })
+    }
+
+    pub fn rename_node_registration(
+        &self,
+        selector: impl Into<String>,
+        alias: impl Into<String>,
+        expected_revision: u64,
+    ) -> Result<NodeRegistrationSnapshot> {
+        self.node_registration_response(Request::RenameNodeRegistration {
+            selector: selector.into(),
+            alias: alias.into(),
+            expected_revision,
+        })
+    }
+
+    pub fn retarget_node_registration(
+        &self,
+        selector: impl Into<String>,
+        target: impl Into<String>,
+        node_id: impl Into<String>,
+        expected_revision: u64,
+    ) -> Result<NodeRegistrationSnapshot> {
+        self.node_registration_response(Request::RetargetNodeRegistration {
+            selector: selector.into(),
+            target: target.into(),
+            node_id: node_id.into(),
+            expected_revision,
+        })
+    }
+
+    pub fn forget_node_registration(
+        &self,
+        selector: impl Into<String>,
+    ) -> Result<NodeRegistrationSnapshot> {
+        self.node_registration_response(Request::ForgetNodeRegistration {
+            selector: selector.into(),
+        })
+    }
+
+    fn node_registration_response(&self, request: Request) -> Result<NodeRegistrationSnapshot> {
+        match self.request(request)? {
+            Response::NodeRegistration { registration } => Ok(registration),
             response => unexpected(response),
         }
     }
@@ -1778,6 +1852,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
             reject_protocol(&listener, 28, 27);
@@ -1929,7 +2004,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 30);
+            assert_eq!(request.version, 31);
             assert_eq!(request.message, Request::GetNodeIdentity);
             protocol::write_message(
                 &mut stream,
@@ -1943,6 +2018,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 27);
 
@@ -1988,7 +2064,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 30);
+            assert_eq!(request.version, 31);
             assert_eq!(request.message, Request::OpenFederationChannel);
             protocol::write_message(
                 &mut stream,
@@ -2002,6 +2078,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
             let (mut stream, _) = listener.accept().unwrap();
@@ -2015,6 +2092,46 @@ mod tests {
         let client = Client::from_socket_path(socket);
         assert!(matches!(
             client.open_federation_channel(),
+            Err(ClientError::Protocol(ProtocolError::UnsupportedVersion(_)))
+        ));
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn node_registration_requires_protocol_thirty_one() {
+        let directory = env::temp_dir().join(format!("boomux-client-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 31);
+            assert_eq!(request.message, Request::ListNodeRegistrations);
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    30,
+                    Response::Error {
+                        message: "Node registration management requires protocol 31".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+            reject_protocol(&listener, 31, 30);
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 30);
+            assert_eq!(request.message, Request::Ping);
+            protocol::write_message(&mut stream, &Envelope::with_version(30, Response::Pong))
+                .unwrap();
+        });
+
+        let client = Client::from_socket_path(socket);
+        assert!(matches!(
+            client.node_registrations(),
             Err(ClientError::Protocol(ProtocolError::UnsupportedVersion(_)))
         ));
         server.join().unwrap();
@@ -2175,6 +2292,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
             reject_protocol(&listener, 28, 27);
@@ -2241,6 +2359,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
             reject_protocol(&listener, 28, 27);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -29,6 +29,7 @@ use crate::desktop_notifications::{
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::node_identity::{NodeIdentityLease, NodeIdentityManager};
+use crate::node_registration::NodeRegistrationManager;
 use crate::protocol::{
     self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
     AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
@@ -84,6 +85,7 @@ const TRANSITION_RESTART: u8 = 1;
 const TRANSITION_SHUTDOWN: u8 = 2;
 const TRANSITION_REKEY: u8 = 3;
 const NODE_REKEY_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
+const NODE_REGISTRATION_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NotificationSettings {
@@ -334,6 +336,11 @@ fn run_daemon(
             None
         }
     };
+    let registrations = NodeRegistrationManager::load_from_environment();
+    if let Some(reason) = registrations.unavailable_reason()? {
+        eprintln!("boomux: Node registration routing disabled: {reason}");
+    }
+    registry.node_registrations = Some(registrations);
     registry.startup_environment = capture_current_environment();
     registry.configure_scheduler_clock()?;
     registry.notification_settings = notification_settings.clone();
@@ -1226,6 +1233,32 @@ fn unsupported_request_message(feature: protocol::ProtocolFeature) -> String {
     )
 }
 
+fn node_registration_error(error: io::Error) -> DaemonError {
+    if error.kind() == io::ErrorKind::Unsupported {
+        return DaemonError::lifecycle(ErrorCode::NodeRegistrationUnavailable, error.to_string());
+    }
+    if error.kind() == io::ErrorKind::PermissionDenied
+        && error.to_string().contains("different Boomux Node identity")
+    {
+        return DaemonError::lifecycle(ErrorCode::NodeIdentityChanged, error.to_string());
+    }
+    if error.kind() == io::ErrorKind::InvalidInput
+        && error.to_string().contains("registration revision changed")
+    {
+        return DaemonError::lifecycle(ErrorCode::RevisionChanged, error.to_string());
+    }
+    if error.kind() == io::ErrorKind::TimedOut {
+        return DaemonError::lifecycle(ErrorCode::Busy, error.to_string());
+    }
+    if matches!(
+        error.kind(),
+        io::ErrorKind::PermissionDenied | io::ErrorKind::Other
+    ) {
+        return DaemonError::persistence(error);
+    }
+    DaemonError::from(error)
+}
+
 #[cfg(test)]
 fn response_for_version(response: Response, version: u32) -> Response {
     response_for_version_with_schedule_shells(response, version, &HashSet::new())
@@ -1619,6 +1652,7 @@ fn scheduled_execution_response(
 
 struct DaemonService {
     node_identity: Option<Arc<NodeIdentityManager>>,
+    node_registrations: Option<NodeRegistrationManager>,
     durable: DurableRegistry,
     events: EventStream,
     runtimes: ShellRuntimeManager,
@@ -4971,6 +5005,7 @@ impl Default for DaemonService {
     fn default() -> Self {
         Self {
             node_identity: None,
+            node_registrations: None,
             durable: DurableRegistry {
                 state: Mutex::new(DurableState::default()),
                 store: None,
@@ -5798,6 +5833,24 @@ fn resume_identity(
 }
 
 impl DaemonService {
+    fn node_identity(&self) -> DaemonResult<&Arc<NodeIdentityManager>> {
+        self.node_identity.as_ref().ok_or_else(|| {
+            DaemonError::lifecycle(
+                ErrorCode::NodeIdentityUnavailable,
+                "Boomux Node identity is unavailable",
+            )
+        })
+    }
+
+    fn node_registrations(&self) -> DaemonResult<&NodeRegistrationManager> {
+        self.node_registrations.as_ref().ok_or_else(|| {
+            DaemonError::lifecycle(
+                ErrorCode::NodeRegistrationUnavailable,
+                "Boomux Node registrations are unavailable",
+            )
+        })
+    }
+
     fn clock_now_ms(&self) -> u64 {
         lock(&self.clock)
             .map(|clock| clock.now_ms())
@@ -7049,6 +7102,57 @@ impl DaemonService {
                 unreachable!("federation channel is handled before dispatch")
             }
             Request::RekeyNode { .. } => unreachable!("Node rekey is handled before dispatch"),
+            Request::AddNodeRegistration {
+                alias,
+                target,
+                node_id,
+            } => {
+                let local_node_id = self.node_identity()?.id()?;
+                self.node_registrations()?
+                    .add(alias, target, node_id, &local_node_id)
+                    .map(|registration| Response::NodeRegistration { registration })
+                    .map_err(node_registration_error)
+            }
+            Request::ListNodeRegistrations => self
+                .node_registrations()?
+                .list()
+                .map(|registrations| Response::NodeRegistrations { registrations })
+                .map_err(node_registration_error),
+            Request::GetNodeRegistration { selector } => self
+                .node_registrations()?
+                .inspect(&selector)
+                .map(|registration| Response::NodeRegistration { registration })
+                .map_err(node_registration_error),
+            Request::RenameNodeRegistration {
+                selector,
+                alias,
+                expected_revision,
+            } => self
+                .node_registrations()?
+                .rename(&selector, alias, expected_revision)
+                .map(|registration| Response::NodeRegistration { registration })
+                .map_err(node_registration_error),
+            Request::RetargetNodeRegistration {
+                selector,
+                target,
+                node_id,
+                expected_revision,
+            } => self
+                .node_registrations()?
+                .retarget(
+                    &selector,
+                    target,
+                    &node_id,
+                    expected_revision,
+                    NODE_REGISTRATION_DRAIN_TIMEOUT,
+                )
+                .map(|registration| Response::NodeRegistration { registration })
+                .map_err(node_registration_error),
+            Request::ForgetNodeRegistration { selector } => self
+                .node_registrations()?
+                .forget(&selector, NODE_REGISTRATION_DRAIN_TIMEOUT)
+                .map(|registration| Response::NodeRegistration { registration })
+                .map_err(node_registration_error),
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
                 unreachable!("restart is handled before dispatch")
             }
@@ -7842,6 +7946,7 @@ impl DaemonService {
         let persistence_writer = PersistenceWriter::start(Arc::clone(&store));
         let registry = Self {
             node_identity: None,
+            node_registrations: None,
             durable: DurableRegistry {
                 state: Mutex::new(state),
                 store: Some(store),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod federation;
 mod handoff;
 pub mod integrations;
 mod node_identity;
+mod node_registration;
 pub mod protocol;
 pub mod scheduling;
 pub mod ssh_bootstrap;

--- a/src/main.rs
+++ b/src/main.rs
@@ -495,6 +495,28 @@ enum ProjectCommands {
 
 #[derive(Subcommand)]
 enum NodeCommands {
+    /// Verify and persist a remote Boomux Node route
+    Add { alias: String, target: String },
+    /// List registered remote Nodes
+    List,
+    /// Inspect a registered remote Node by alias or exact Node ID
+    Inspect { selector: String },
+    /// Rename a registered remote Node alias at an exact revision
+    Rename {
+        selector: String,
+        alias: String,
+        #[arg(long)]
+        revision: u64,
+    },
+    /// Verify and replace a registered SSH route at an exact revision
+    Retarget {
+        selector: String,
+        target: String,
+        #[arg(long)]
+        revision: u64,
+    },
+    /// Forget a registration without contacting the remote Node
+    Forget { selector: String },
     /// Assign this authority a new Node ID after exact confirmation
     Rekey,
 }
@@ -1052,6 +1074,12 @@ command_keys! {
     WorkspaceList => ("workspace.list", Json),
     WorkspaceInspect => ("workspace.inspect", Json),
     Workspace => ("workspace", HumanOnly),
+    NodeAdd => ("node.add", Json),
+    NodeList => ("node.list", Json),
+    NodeInspect => ("node.inspect", Json),
+    NodeRename => ("node.rename", Json),
+    NodeRetarget => ("node.retarget", Json),
+    NodeForget => ("node.forget", Json),
     NodeRekey => ("node.rekey", HumanOnly),
     ShellSuggestName => ("shell.suggest-name", Json),
     ShellInspect => ("shell.inspect", Json),
@@ -1120,6 +1148,24 @@ impl Cli {
             Some(Commands::Workspace {
                 command: WorkspaceCommands::Inspect { .. },
             }) => CommandKey::WorkspaceInspect,
+            Some(Commands::Node {
+                command: NodeCommands::Add { .. },
+            }) => CommandKey::NodeAdd,
+            Some(Commands::Node {
+                command: NodeCommands::List,
+            }) => CommandKey::NodeList,
+            Some(Commands::Node {
+                command: NodeCommands::Inspect { .. },
+            }) => CommandKey::NodeInspect,
+            Some(Commands::Node {
+                command: NodeCommands::Rename { .. },
+            }) => CommandKey::NodeRename,
+            Some(Commands::Node {
+                command: NodeCommands::Retarget { .. },
+            }) => CommandKey::NodeRetarget,
+            Some(Commands::Node {
+                command: NodeCommands::Forget { .. },
+            }) => CommandKey::NodeForget,
             Some(Commands::Node {
                 command: NodeCommands::Rekey,
             }) => CommandKey::NodeRekey,
@@ -1473,7 +1519,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Workspace { command }) => {
             workspace_command(command, cli.json, cli.terminal.as_deref())
         }
-        Some(Commands::Node { command }) => node_command(command),
+        Some(Commands::Node { command }) => node_command(command, cli.json),
         Some(Commands::Shell { command }) => shell_command(command, cli.json),
         Some(Commands::Launcher { command }) => launcher_command(command, cli.json),
         Some(Commands::Agent {
@@ -1519,10 +1565,27 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
 }
 
 fn remote_connect(target: &str) -> Result<(), Box<dyn Error>> {
+    let mut connection = verified_remote_connection(target, true)?;
+    connection.ping()?;
+    println!(
+        "Connected to Boomux Node {} (protocol {}, helper {}, {})",
+        connection.handshake.node_id,
+        connection.handshake.core_protocol_version,
+        connection.handshake.helper_version,
+        connection.executable.as_str(),
+    );
+    Ok(())
+}
+
+fn verified_remote_connection(
+    target: &str,
+    allow_interactive_install: bool,
+) -> Result<ssh_bootstrap::RemoteConnection, Box<dyn Error>> {
     const TIMEOUT: Duration = Duration::from_secs(120);
 
     let target = ssh_bootstrap::SshTarget::parse(target)?;
-    let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
+    let interactive =
+        allow_interactive_install && io::stdin().is_terminal() && io::stdout().is_terminal();
     let authentication = if interactive {
         ssh_bootstrap::SshAuthenticationMode::Interactive
     } else {
@@ -1554,27 +1617,114 @@ fn remote_connect(target: &str) -> Result<(), Box<dyn Error>> {
                 }
             );
             if !confirm_setup("Install Boomux on this remote target?")? {
-                println!("No changes made.");
-                return Ok(());
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "remote Boomux installation was not authorized",
+                )
+                .into());
             }
             ssh_bootstrap::install_remote(&plan, authentication, TIMEOUT)?
         }
     };
-    let mut connection = ssh_bootstrap::connect_remote(target, helper, authentication, TIMEOUT)?;
-    connection.ping()?;
-    println!(
-        "Connected to Boomux Node {} (protocol {}, helper {}, {})",
-        connection.handshake.node_id,
-        connection.handshake.core_protocol_version,
-        connection.handshake.helper_version,
-        connection.executable.as_str(),
-    );
-    Ok(())
+    Ok(ssh_bootstrap::connect_remote(
+        target,
+        helper,
+        authentication,
+        TIMEOUT,
+    )?)
 }
 
-fn node_command(command: NodeCommands) -> Result<(), Box<dyn Error>> {
+fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>> {
     match command {
+        NodeCommands::Add { alias, target } => {
+            let mut remote = verified_remote_connection(&target, !json)?;
+            remote.ping()?;
+            let registration = client::connect_or_start()?.add_node_registration(
+                alias,
+                target,
+                remote.handshake.node_id.clone(),
+            )?;
+            print_node_registration(CommandKey::NodeAdd, &registration, json)
+        }
+        NodeCommands::List => {
+            let registrations = client::connect_or_start()?.node_registrations()?;
+            if json {
+                print_json(CommandKey::NodeList, serde_json::to_value(registrations)?)
+            } else {
+                println!("ALIAS\tTARGET\tNODE ID\tREVISION");
+                for registration in registrations {
+                    println!(
+                        "{}\t{}\t{}\t{}",
+                        registration.alias,
+                        registration.target,
+                        registration.node_id,
+                        registration.revision
+                    );
+                }
+                Ok(())
+            }
+        }
+        NodeCommands::Inspect { selector } => {
+            let registration = client::connect_or_start()?.node_registration(selector)?;
+            print_node_registration(CommandKey::NodeInspect, &registration, json)
+        }
+        NodeCommands::Rename {
+            selector,
+            alias,
+            revision,
+        } => {
+            let registration =
+                client::connect_or_start()?.rename_node_registration(selector, alias, revision)?;
+            print_node_registration(CommandKey::NodeRename, &registration, json)
+        }
+        NodeCommands::Retarget {
+            selector,
+            target,
+            revision,
+        } => {
+            let local = client::connect_or_start()?;
+            let current = local.node_registration(&selector)?;
+            if current.revision != revision {
+                return Err(cli_output::failure(
+                    "revision_changed",
+                    format!(
+                        "Node registration revision changed: expected {revision}, current {}",
+                        current.revision
+                    ),
+                ));
+            }
+            let mut remote = verified_remote_connection(&target, !json)?;
+            remote.ping()?;
+            let registration = local.retarget_node_registration(
+                selector,
+                target,
+                remote.handshake.node_id.clone(),
+                revision,
+            )?;
+            print_node_registration(CommandKey::NodeRetarget, &registration, json)
+        }
+        NodeCommands::Forget { selector } => {
+            let registration = client::connect_or_start()?.forget_node_registration(selector)?;
+            print_node_registration(CommandKey::NodeForget, &registration, json)
+        }
         NodeCommands::Rekey => rekey_node(),
+    }
+}
+
+fn print_node_registration(
+    command: CommandKey,
+    registration: &protocol::NodeRegistrationSnapshot,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    if json {
+        print_json(command, serde_json::to_value(registration)?)
+    } else {
+        println!("Alias: {}", registration.alias);
+        println!("Target: {}", registration.target);
+        println!("Node ID: {}", registration.node_id);
+        println!("Revision: {}", registration.revision);
+        println!("Tombstone epoch: {}", registration.tombstone_epoch);
+        Ok(())
     }
 }
 
@@ -3234,6 +3384,10 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "run_changed",
         "revision_ahead",
         "idempotency_expired",
+        "node_identity_unavailable",
+        "node_registration_unavailable",
+        "node_identity_changed",
+        "revision_changed",
         "context_required",
         "ambiguous_target",
         "unsupported_integration",
@@ -9111,6 +9265,9 @@ mod tests {
             "desktop_notifications",
             "sound_notifications",
             "integration_management",
+            "protocol_31",
+            "node_registration_management",
+            "pinned_node_identity",
         ] {
             assert!(
                 NON_PROTOCOL_FEATURES.contains(&feature)
@@ -9129,7 +9286,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 30);
+        assert_eq!(protocol::PROTOCOL_VERSION, 31);
     }
 
     #[test]
@@ -9154,6 +9311,12 @@ mod tests {
                 "project.list",
                 "workspace.list",
                 "workspace.inspect",
+                "node.add",
+                "node.list",
+                "node.inspect",
+                "node.rename",
+                "node.retarget",
+                "node.forget",
                 "shell.suggest-name",
                 "shell.inspect",
                 "launcher.list",

--- a/src/node_registration.rs
+++ b/src/node_registration.rs
@@ -1,0 +1,786 @@
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+#[cfg(test)]
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::{Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::protocol::NodeRegistrationSnapshot;
+use crate::ssh_bootstrap::SshTarget;
+use crate::state_store::{effective_uid, secure_state_dir, state_directory_from_environment};
+
+const REGISTRATION_VERSION: u32 = 1;
+const MAX_REGISTRATION_BYTES: u64 = 128 * 1024;
+const MAX_REGISTRATIONS: usize = 128;
+const MAX_ALIAS_BYTES: usize = 128;
+
+pub(crate) struct NodeRegistrationManager {
+    path: PathBuf,
+    state: Mutex<ManagerState>,
+    changed: Condvar,
+}
+
+enum ManagerState {
+    Available(RegistrationState),
+    Unavailable(String),
+}
+
+#[derive(Clone)]
+struct RegistrationState {
+    revision: u64,
+    tombstone_epoch: u64,
+    registrations: Vec<Registration>,
+}
+
+#[derive(Clone)]
+struct Registration {
+    snapshot: NodeRegistrationSnapshot,
+    admission_open: bool,
+    admitted: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedRegistrations {
+    version: u32,
+    revision: u64,
+    tombstone_epoch: u64,
+    registrations: Vec<NodeRegistrationSnapshot>,
+}
+
+impl NodeRegistrationManager {
+    pub(crate) fn load_from_environment() -> Self {
+        match state_directory_from_environment() {
+            Ok(directory) => Self::load_at(directory.join("node_registrations.json")),
+            Err(error) => Self::unavailable(PathBuf::new(), error),
+        }
+    }
+
+    fn load_at(path: PathBuf) -> Self {
+        match load(&path) {
+            Ok(state) => Self {
+                path,
+                state: Mutex::new(ManagerState::Available(state)),
+                changed: Condvar::new(),
+            },
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Self {
+                path,
+                state: Mutex::new(ManagerState::Available(RegistrationState {
+                    revision: 0,
+                    tombstone_epoch: 0,
+                    registrations: Vec::new(),
+                })),
+                changed: Condvar::new(),
+            },
+            Err(error) => Self::unavailable(path, error),
+        }
+    }
+
+    fn unavailable(path: PathBuf, error: io::Error) -> Self {
+        Self {
+            path,
+            state: Mutex::new(ManagerState::Unavailable(error.to_string())),
+            changed: Condvar::new(),
+        }
+    }
+
+    pub(crate) fn unavailable_reason(&self) -> io::Result<Option<String>> {
+        let state = self.lock_state()?;
+        Ok(match &*state {
+            ManagerState::Available(_) => None,
+            ManagerState::Unavailable(reason) => Some(reason.clone()),
+        })
+    }
+
+    pub(crate) fn list(&self) -> io::Result<Vec<NodeRegistrationSnapshot>> {
+        let state = self.lock_state()?;
+        let state = available(&state)?;
+        let mut registrations = state
+            .registrations
+            .iter()
+            .map(|registration| registration.snapshot.clone())
+            .collect::<Vec<_>>();
+        registrations.sort_by(|left, right| {
+            left.alias
+                .cmp(&right.alias)
+                .then_with(|| left.node_id.cmp(&right.node_id))
+        });
+        Ok(registrations)
+    }
+
+    pub(crate) fn inspect(&self, selector: &str) -> io::Result<NodeRegistrationSnapshot> {
+        let state = self.lock_state()?;
+        let state = available(&state)?;
+        Ok(find(state, selector)?.snapshot.clone())
+    }
+
+    pub(crate) fn add(
+        &self,
+        alias: String,
+        target: String,
+        node_id: String,
+        local_node_id: &str,
+    ) -> io::Result<NodeRegistrationSnapshot> {
+        validate_alias(&alias)?;
+        validate_target(&target)?;
+        validate_node_id(&node_id)?;
+        if node_id == local_node_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "a Boomux Node cannot register itself",
+            ));
+        }
+        let mut state = self.lock_state()?;
+        let current = available_mut(&mut state)?;
+        if let Some(existing) = current.registrations.iter().find(|registration| {
+            registration.snapshot.alias == alias
+                || registration.snapshot.target == target
+                || registration.snapshot.node_id == node_id
+        }) {
+            if existing.snapshot.alias == alias
+                && existing.snapshot.target == target
+                && existing.snapshot.node_id == node_id
+            {
+                return Ok(existing.snapshot.clone());
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "Node alias, target, or Node ID is already registered",
+            ));
+        }
+        if current.registrations.len() >= MAX_REGISTRATIONS {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "registered Node limit reached",
+            ));
+        }
+        let revision = next(current.revision, "registration revision")?;
+        let snapshot = NodeRegistrationSnapshot {
+            alias,
+            target,
+            node_id,
+            revision,
+            tombstone_epoch: current.tombstone_epoch,
+        };
+        let mut replacement = current.clone();
+        replacement.revision = revision;
+        replacement.registrations.push(Registration {
+            snapshot: snapshot.clone(),
+            admission_open: true,
+            admitted: 0,
+        });
+        save(&self.path, &replacement)?;
+        *current = replacement;
+        Ok(snapshot)
+    }
+
+    pub(crate) fn rename(
+        &self,
+        selector: &str,
+        alias: String,
+        expected_revision: u64,
+    ) -> io::Result<NodeRegistrationSnapshot> {
+        validate_alias(&alias)?;
+        let mut state = self.lock_state()?;
+        let current = available_mut(&mut state)?;
+        let index = find_index(current, selector)?;
+        require_revision(&current.registrations[index], expected_revision)?;
+        if current.registrations[index].snapshot.alias == alias {
+            return Ok(current.registrations[index].snapshot.clone());
+        }
+        if current
+            .registrations
+            .iter()
+            .enumerate()
+            .any(|(other, registration)| other != index && registration.snapshot.alias == alias)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "Node alias is already registered",
+            ));
+        }
+        let revision = next(current.revision, "registration revision")?;
+        let mut replacement = current.clone();
+        replacement.revision = revision;
+        replacement.registrations[index].snapshot.alias = alias;
+        replacement.registrations[index].snapshot.revision = revision;
+        save(&self.path, &replacement)?;
+        let snapshot = replacement.registrations[index].snapshot.clone();
+        *current = replacement;
+        Ok(snapshot)
+    }
+
+    pub(crate) fn retarget(
+        &self,
+        selector: &str,
+        target: String,
+        verified_node_id: &str,
+        expected_revision: u64,
+        timeout: Duration,
+    ) -> io::Result<NodeRegistrationSnapshot> {
+        validate_target(&target)?;
+        validate_node_id(verified_node_id)?;
+        self.prepare_drain_commit(selector, expected_revision, timeout, |state, index| {
+            if state.registrations[index].snapshot.node_id != verified_node_id {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "new SSH target resolved to a different Boomux Node identity",
+                ));
+            }
+            if state.registrations[index].snapshot.target == target {
+                return Ok(state.registrations[index].snapshot.clone());
+            }
+            if state
+                .registrations
+                .iter()
+                .enumerate()
+                .any(|(other, registration)| {
+                    other != index && registration.snapshot.target == target
+                })
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "SSH target is already registered",
+                ));
+            }
+            let revision = next(state.revision, "registration revision")?;
+            state.revision = revision;
+            state.registrations[index].snapshot.target = target;
+            state.registrations[index].snapshot.revision = revision;
+            Ok(state.registrations[index].snapshot.clone())
+        })
+    }
+
+    pub(crate) fn forget(
+        &self,
+        selector: &str,
+        timeout: Duration,
+    ) -> io::Result<NodeRegistrationSnapshot> {
+        let expected_revision = self.inspect(selector)?.revision;
+        self.prepare_drain_commit(selector, expected_revision, timeout, |state, index| {
+            let tombstone_epoch = next(state.tombstone_epoch, "registration tombstone epoch")?;
+            state.tombstone_epoch = tombstone_epoch;
+            let mut removed = state.registrations.remove(index).snapshot;
+            removed.tombstone_epoch = tombstone_epoch;
+            Ok(removed)
+        })
+    }
+
+    fn prepare_drain_commit(
+        &self,
+        selector: &str,
+        expected_revision: u64,
+        timeout: Duration,
+        mutate: impl FnOnce(&mut RegistrationState, usize) -> io::Result<NodeRegistrationSnapshot>,
+    ) -> io::Result<NodeRegistrationSnapshot> {
+        let mut state = self.lock_state()?;
+        let current = available_mut(&mut state)?;
+        let index = find_index(current, selector)?;
+        require_revision(&current.registrations[index], expected_revision)?;
+        if !current.registrations[index].admission_open {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "Node registration change is already in progress",
+            ));
+        }
+        current.registrations[index].admission_open = false;
+        let deadline = Instant::now() + timeout;
+        loop {
+            let current = available_mut(&mut state)?;
+            let index = find_index(current, selector)?;
+            require_revision(&current.registrations[index], expected_revision)?;
+            if current.registrations[index].admitted == 0 {
+                break;
+            }
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                current.registrations[index].admission_open = true;
+                self.changed.notify_all();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out draining active Node registration operations",
+                ));
+            };
+            let (next_state, wait) = self
+                .changed
+                .wait_timeout(state, remaining)
+                .map_err(|_| io::Error::other("Node registration lock is poisoned"))?;
+            state = next_state;
+            if wait.timed_out() {
+                let current = available_mut(&mut state)?;
+                let index = find_index(current, selector)?;
+                current.registrations[index].admission_open = true;
+                self.changed.notify_all();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out draining active Node registration operations",
+                ));
+            }
+        }
+
+        let current = available_mut(&mut state)?;
+        let index = find_index(current, selector)?;
+        let mut replacement = current.clone();
+        let result = match mutate(&mut replacement, index) {
+            Ok(result) => result,
+            Err(error) => {
+                current.registrations[index].admission_open = true;
+                self.changed.notify_all();
+                return Err(error);
+            }
+        };
+        if let Some(registration) = replacement.registrations.get_mut(index) {
+            registration.admission_open = true;
+        }
+        if let Err(error) = save(&self.path, &replacement) {
+            current.registrations[index].admission_open = true;
+            self.changed.notify_all();
+            return Err(error);
+        }
+        *current = replacement;
+        self.changed.notify_all();
+        Ok(result)
+    }
+
+    fn lock_state(&self) -> io::Result<std::sync::MutexGuard<'_, ManagerState>> {
+        self.state
+            .lock()
+            .map_err(|_| io::Error::other("Node registration lock is poisoned"))
+    }
+
+    #[cfg(test)]
+    fn admit_for_test(&self, selector: &str) -> io::Result<()> {
+        let mut state = self.lock_state()?;
+        let registration = find_mut(available_mut(&mut state)?, selector)?;
+        if !registration.admission_open {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "admission closed",
+            ));
+        }
+        registration.admitted += 1;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn release_for_test(&self, selector: &str) {
+        if let Ok(mut state) = self.state.lock()
+            && let Ok(registration) =
+                available_mut(&mut state).and_then(|state| find_mut(state, selector))
+        {
+            registration.admitted = registration.admitted.saturating_sub(1);
+            self.changed.notify_all();
+        }
+    }
+}
+
+fn available(state: &ManagerState) -> io::Result<&RegistrationState> {
+    match state {
+        ManagerState::Available(state) => Ok(state),
+        ManagerState::Unavailable(reason) => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("Node registration routing is disabled: {reason}"),
+        )),
+    }
+}
+
+fn available_mut(state: &mut ManagerState) -> io::Result<&mut RegistrationState> {
+    match state {
+        ManagerState::Available(state) => Ok(state),
+        ManagerState::Unavailable(reason) => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("Node registration routing is disabled: {reason}"),
+        )),
+    }
+}
+
+fn find<'a>(state: &'a RegistrationState, selector: &str) -> io::Result<&'a Registration> {
+    state
+        .registrations
+        .iter()
+        .find(|registration| {
+            registration.snapshot.alias == selector || registration.snapshot.node_id == selector
+        })
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Node registration not found"))
+}
+
+#[cfg(test)]
+fn find_mut<'a>(
+    state: &'a mut RegistrationState,
+    selector: &str,
+) -> io::Result<&'a mut Registration> {
+    state
+        .registrations
+        .iter_mut()
+        .find(|registration| {
+            registration.snapshot.alias == selector || registration.snapshot.node_id == selector
+        })
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Node registration not found"))
+}
+
+fn find_index(state: &RegistrationState, selector: &str) -> io::Result<usize> {
+    state
+        .registrations
+        .iter()
+        .position(|registration| {
+            registration.snapshot.alias == selector || registration.snapshot.node_id == selector
+        })
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Node registration not found"))
+}
+
+fn require_revision(registration: &Registration, expected: u64) -> io::Result<()> {
+    if registration.snapshot.revision == expected {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Node registration revision changed: expected {expected}, current {}",
+                registration.snapshot.revision
+            ),
+        ))
+    }
+}
+
+fn validate_alias(alias: &str) -> io::Result<()> {
+    if alias.is_empty()
+        || alias.len() > MAX_ALIAS_BYTES
+        || alias.chars().any(char::is_control)
+        || alias.chars().any(char::is_whitespace)
+        || Uuid::parse_str(alias).is_ok_and(|id| id.to_string() == alias)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Node alias must be bounded, nonempty, whitespace-free, and not a canonical Node ID",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_target(target: &str) -> io::Result<()> {
+    SshTarget::parse(target.to_owned()).map(|_| ())
+}
+
+fn validate_node_id(node_id: &str) -> io::Result<()> {
+    let parsed = Uuid::parse_str(node_id)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid Node ID"))?;
+    if parsed.to_string() != node_id {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Node ID must use canonical UUID syntax",
+        ));
+    }
+    Ok(())
+}
+
+fn next(value: u64, label: &str) -> io::Result<u64> {
+    value
+        .checked_add(1)
+        .ok_or_else(|| io::Error::other(format!("{label} exhausted")))
+}
+
+fn load(path: &Path) -> io::Result<RegistrationState> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.uid() != effective_uid() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Boomux Node registration store is not an owned regular file",
+        ));
+    }
+    if metadata.mode() & 0o077 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Boomux Node registration store is not owner-only",
+        ));
+    }
+    if metadata.len() > MAX_REGISTRATION_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux Node registration store exceeds the size limit",
+        ));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.read_to_end(&mut bytes)?;
+    let persisted: PersistedRegistrations = serde_json::from_slice(&bytes).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("could not parse Boomux Node registrations: {error}"),
+        )
+    })?;
+    if persisted.version != REGISTRATION_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported Boomux Node registration version {}; expected {REGISTRATION_VERSION}",
+                persisted.version
+            ),
+        ));
+    }
+    validate_persisted(persisted)
+}
+
+fn validate_persisted(persisted: PersistedRegistrations) -> io::Result<RegistrationState> {
+    if persisted.registrations.len() > MAX_REGISTRATIONS {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux Node registration store contains too many registrations",
+        ));
+    }
+    let mut aliases = HashSet::new();
+    let mut targets = HashSet::new();
+    let mut node_ids = HashSet::new();
+    let mut registrations = Vec::with_capacity(persisted.registrations.len());
+    for snapshot in persisted.registrations {
+        validate_alias(&snapshot.alias).map_err(invalid_persisted)?;
+        validate_target(&snapshot.target).map_err(invalid_persisted)?;
+        validate_node_id(&snapshot.node_id).map_err(invalid_persisted)?;
+        if snapshot.revision == 0
+            || snapshot.revision > persisted.revision
+            || snapshot.tombstone_epoch > persisted.tombstone_epoch
+            || !aliases.insert(snapshot.alias.clone())
+            || !targets.insert(snapshot.target.clone())
+            || !node_ids.insert(snapshot.node_id.clone())
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Boomux Node registration store contains invalid or duplicate data",
+            ));
+        }
+        registrations.push(Registration {
+            snapshot,
+            admission_open: true,
+            admitted: 0,
+        });
+    }
+    Ok(RegistrationState {
+        revision: persisted.revision,
+        tombstone_epoch: persisted.tombstone_epoch,
+        registrations,
+    })
+}
+
+fn invalid_persisted(error: io::Error) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn save(path: &Path, state: &RegistrationState) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("Node registration path has no parent"))?;
+    secure_state_dir(parent)?;
+    let persisted = PersistedRegistrations {
+        version: REGISTRATION_VERSION,
+        revision: state.revision,
+        tombstone_epoch: state.tombstone_epoch,
+        registrations: state
+            .registrations
+            .iter()
+            .map(|registration| registration.snapshot.clone())
+            .collect(),
+    };
+    let bytes = serde_json::to_vec_pretty(&persisted).map_err(io::Error::other)?;
+    if bytes.len() as u64 > MAX_REGISTRATION_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux Node registrations exceed the size limit",
+        ));
+    }
+    let temporary = parent.join(format!(".node-registrations-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)?;
+        let _ = File::open(parent).and_then(|directory| directory.sync_all());
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    fn path() -> PathBuf {
+        std::env::temp_dir()
+            .join(format!("boomux-registration-{}", Uuid::new_v4()))
+            .join("boomux/node_registrations.json")
+    }
+
+    fn node_id(value: u128) -> String {
+        Uuid::from_u128(value).to_string()
+    }
+
+    #[test]
+    fn registration_lifecycle_is_bounded_deterministic_and_persistent() {
+        let path = path();
+        let manager = NodeRegistrationManager::load_at(path.clone());
+        let local = node_id(1);
+        let second = manager
+            .add("zeta".into(), "z.example".into(), node_id(2), &local)
+            .unwrap();
+        let first = manager
+            .add("alpha".into(), "a.example".into(), node_id(3), &local)
+            .unwrap();
+        assert_eq!(manager.list().unwrap()[0].alias, "alpha");
+        assert_eq!(
+            manager
+                .add("alpha".into(), "a.example".into(), node_id(3), &local)
+                .unwrap(),
+            first
+        );
+        assert_eq!(
+            manager
+                .add("other".into(), "z.example".into(), node_id(4), &local)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::AlreadyExists
+        );
+        assert_eq!(
+            manager
+                .add("self".into(), "self.example".into(), local.clone(), &local)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        let renamed = manager
+            .rename("zeta", "beta".into(), second.revision)
+            .unwrap();
+        assert!(renamed.revision > second.revision);
+        drop(manager);
+
+        let restored = NodeRegistrationManager::load_at(path.clone());
+        assert_eq!(restored.inspect("beta").unwrap(), renamed);
+        let removed = restored.forget("beta", Duration::from_millis(10)).unwrap();
+        assert!(removed.tombstone_epoch > second.tombstone_epoch);
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn retarget_requires_the_pinned_identity_and_rolls_back_failed_drain() {
+        let path = path();
+        let manager = std::sync::Arc::new(NodeRegistrationManager::load_at(path.clone()));
+        let local = node_id(1);
+        let registration = manager
+            .add("work".into(), "old".into(), node_id(2), &local)
+            .unwrap();
+        assert_eq!(
+            manager
+                .retarget(
+                    "work",
+                    "new".into(),
+                    &node_id(3),
+                    registration.revision,
+                    Duration::from_millis(10),
+                )
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(manager.inspect("work").unwrap().target, "old");
+
+        manager.admit_for_test("work").unwrap();
+        let error = manager
+            .retarget(
+                "work",
+                "new".into(),
+                &node_id(2),
+                registration.revision,
+                Duration::from_millis(1),
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        manager.release_for_test("work");
+        let changed = manager
+            .retarget(
+                "work",
+                "new".into(),
+                &node_id(2),
+                registration.revision,
+                Duration::from_secs(1),
+            )
+            .unwrap();
+        assert_eq!(changed.target, "new");
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn malformed_future_and_insecure_files_are_preserved_and_disable_routing() {
+        for (bytes, mode) in [
+            (b"not-json".to_vec(), 0o600),
+            (
+                serde_json::to_vec(&serde_json::json!({
+                    "version": 99,
+                    "revision": 0,
+                    "tombstone_epoch": 0,
+                    "registrations": []
+                }))
+                .unwrap(),
+                0o600,
+            ),
+            (
+                serde_json::to_vec(&serde_json::json!({
+                    "version": 1,
+                    "revision": 0,
+                    "tombstone_epoch": 0,
+                    "registrations": []
+                }))
+                .unwrap(),
+                0o644,
+            ),
+        ] {
+            let path = path();
+            secure_state_dir(path.parent().unwrap()).unwrap();
+            fs::write(&path, &bytes).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(mode)).unwrap();
+            let manager = NodeRegistrationManager::load_at(path.clone());
+            assert!(manager.list().is_err());
+            assert_eq!(fs::read(&path).unwrap(), bytes);
+            fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+        }
+    }
+
+    #[test]
+    fn drain_can_complete_after_an_admitted_operation_releases() {
+        let path = path();
+        let manager = std::sync::Arc::new(NodeRegistrationManager::load_at(path.clone()));
+        let registration = manager
+            .add("work".into(), "old".into(), node_id(2), &node_id(1))
+            .unwrap();
+        manager.admit_for_test("work").unwrap();
+        let released = std::sync::Arc::clone(&manager);
+        let worker = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            released.release_for_test("work");
+        });
+        let changed = manager
+            .retarget(
+                "work",
+                "new".into(),
+                &node_id(2),
+                registration.revision,
+                Duration::from_secs(1),
+            )
+            .unwrap();
+        worker.join().unwrap();
+        assert_eq!(changed.target, "new");
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 30;
+pub const PROTOCOL_VERSION: u32 = 31;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -118,6 +118,11 @@ define_protocol_features! {
         "federation_daemon_channel",
     ]),
     NodeRekey => (30, "Node rekey", ["protocol_30", "node_rekey"]),
+    NodeRegistration => (31, "Node registration management", [
+        "protocol_31",
+        "node_registration_management",
+        "pinned_node_identity",
+    ]),
 }
 
 pub const DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 100;
@@ -229,6 +234,15 @@ pub struct FocusedTerminalSnapshot {
     pub workspace_id: String,
     pub shell_id: String,
     pub run_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeRegistrationSnapshot {
+    pub alias: String,
+    pub target: String,
+    pub node_id: String,
+    pub revision: u64,
+    pub tombstone_epoch: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -680,6 +694,9 @@ pub enum ErrorCode {
     RevisionAhead,
     IdempotencyExpired,
     NodeIdentityUnavailable,
+    NodeRegistrationUnavailable,
+    NodeIdentityChanged,
+    RevisionChanged,
     Internal,
     #[serde(other)]
     Unknown,
@@ -936,6 +953,29 @@ pub enum Request {
     RekeyNode {
         expected_node_id: String,
     },
+    AddNodeRegistration {
+        alias: String,
+        target: String,
+        node_id: String,
+    },
+    ListNodeRegistrations,
+    GetNodeRegistration {
+        selector: String,
+    },
+    RenameNodeRegistration {
+        selector: String,
+        alias: String,
+        expected_revision: u64,
+    },
+    RetargetNodeRegistration {
+        selector: String,
+        target: String,
+        node_id: String,
+        expected_revision: u64,
+    },
+    ForgetNodeRegistration {
+        selector: String,
+    },
     Restart,
     RestartWithNotificationConfig {
         notifications: NotificationDeliveryConfig,
@@ -1125,6 +1165,12 @@ impl Request {
             Self::GetNodeIdentity => Some(ProtocolFeature::NodeIdentity),
             Self::OpenFederationChannel => Some(ProtocolFeature::FederationChannel),
             Self::RekeyNode { .. } => Some(ProtocolFeature::NodeRekey),
+            Self::AddNodeRegistration { .. }
+            | Self::ListNodeRegistrations
+            | Self::GetNodeRegistration { .. }
+            | Self::RenameNodeRegistration { .. }
+            | Self::RetargetNodeRegistration { .. }
+            | Self::ForgetNodeRegistration { .. } => Some(ProtocolFeature::NodeRegistration),
             Self::WaitScheduledExecution { .. } => {
                 Some(ProtocolFeature::ScheduledExecutionObservation)
             }
@@ -1230,6 +1276,12 @@ pub enum Response {
     },
     FederationChannel {
         node_id: String,
+    },
+    NodeRegistration {
+        registration: NodeRegistrationSnapshot,
+    },
+    NodeRegistrations {
+        registrations: Vec<NodeRegistrationSnapshot>,
     },
     Snapshot {
         snapshot: Snapshot,
@@ -1811,8 +1863,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_thirty_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 30);
+    fn protocol_version_is_thirty_one_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 31);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -1853,6 +1905,63 @@ mod tests {
         let encoded = serde_json::to_value(&request).unwrap();
         assert_eq!(encoded["request"], "rekey_node");
         assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
+    }
+
+    #[test]
+    fn node_registration_messages_round_trip() {
+        let registration = NodeRegistrationSnapshot {
+            alias: "work".into(),
+            target: "user@work.example".into(),
+            node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            revision: 3,
+            tombstone_epoch: 1,
+        };
+        for request in [
+            Request::AddNodeRegistration {
+                alias: registration.alias.clone(),
+                target: registration.target.clone(),
+                node_id: registration.node_id.clone(),
+            },
+            Request::ListNodeRegistrations,
+            Request::GetNodeRegistration {
+                selector: registration.alias.clone(),
+            },
+            Request::RenameNodeRegistration {
+                selector: registration.alias.clone(),
+                alias: "office".into(),
+                expected_revision: 3,
+            },
+            Request::RetargetNodeRegistration {
+                selector: registration.alias.clone(),
+                target: "new.example".into(),
+                node_id: registration.node_id.clone(),
+                expected_revision: 3,
+            },
+            Request::ForgetNodeRegistration {
+                selector: registration.alias.clone(),
+            },
+        ] {
+            let encoded = serde_json::to_value(&request).unwrap();
+            assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
+            assert_eq!(
+                request.required_feature(),
+                Some(ProtocolFeature::NodeRegistration)
+            );
+        }
+        for response in [
+            Response::NodeRegistration {
+                registration: registration.clone(),
+            },
+            Response::NodeRegistrations {
+                registrations: vec![registration.clone()],
+            },
+        ] {
+            let encoded = serde_json::to_value(&response).unwrap();
+            assert_eq!(
+                serde_json::from_value::<Response>(encoded).unwrap(),
+                response
+            );
+        }
     }
 
     #[test]
@@ -2177,6 +2286,34 @@ mod tests {
     #[test]
     fn request_feature_requirements_cover_all_groups() {
         let groups = vec![
+            (
+                31,
+                vec![
+                    Request::AddNodeRegistration {
+                        alias: "work".into(),
+                        target: "work.example".into(),
+                        node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+                    },
+                    Request::ListNodeRegistrations,
+                    Request::GetNodeRegistration {
+                        selector: "work".into(),
+                    },
+                    Request::RenameNodeRegistration {
+                        selector: "work".into(),
+                        alias: "office".into(),
+                        expected_revision: 1,
+                    },
+                    Request::RetargetNodeRegistration {
+                        selector: "work".into(),
+                        target: "new.example".into(),
+                        node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+                        expected_revision: 1,
+                    },
+                    Request::ForgetNodeRegistration {
+                        selector: "work".into(),
+                    },
+                ],
+            ),
             (
                 30,
                 vec![Request::RekeyNode {
@@ -2573,6 +2710,14 @@ mod tests {
             (28, &["protocol_28", "stable_node_identity"][..]),
             (29, &["protocol_29", "federation_daemon_channel"][..]),
             (30, &["protocol_30", "node_rekey"][..]),
+            (
+                31,
+                &[
+                    "protocol_31",
+                    "node_registration_management",
+                    "pinned_node_identity",
+                ][..],
+            ),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -8,6 +8,8 @@ mod daemon_lifecycle;
 mod handoff;
 #[path = "native_backend/launchers_integrations.rs"]
 mod launchers_integrations;
+#[path = "native_backend/node_registration.rs"]
+mod node_registration;
 #[path = "native_backend/notifications.rs"]
 mod notifications;
 #[path = "native_backend/project_discovery.rs"]

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 30);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 31);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -119,6 +119,8 @@ fn native_daemon_lifecycle() {
         "protocol_28",
         "protocol_29",
         "protocol_30",
+        "protocol_31",
+        "node_registration_management",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -153,7 +155,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 30"));
+    assert!(status_text.contains("running (protocol 31"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -913,7 +915,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 30);
+    assert_eq!(handshake.core_protocol_version, 31);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -1,0 +1,179 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use boomux::client::{ClientError, RemoteError};
+use boomux::protocol::ErrorCode;
+use uuid::Uuid;
+
+use crate::support::TestDaemon;
+
+fn node_id(value: u128) -> String {
+    Uuid::from_u128(value).to_string()
+}
+
+#[test]
+fn registrations_survive_cold_recovery_outside_authoritative_state() {
+    let mut daemon = TestDaemon::start();
+    let local = daemon.client.node_identity().unwrap();
+    let registration = daemon
+        .client
+        .add_node_registration("work", "work.example", node_id(2))
+        .unwrap();
+    assert_ne!(registration.node_id, local);
+    let state_path = daemon.runtime_dir.join("state/boomux/state.json");
+    if state_path.exists() {
+        assert!(
+            !fs::read_to_string(&state_path)
+                .unwrap()
+                .contains("work.example")
+        );
+    }
+    daemon.crash();
+    daemon.restart();
+
+    assert_eq!(
+        daemon.client.node_registration("work").unwrap(),
+        registration
+    );
+    assert_eq!(daemon.client.snapshot().unwrap().workspaces.len(), 0);
+}
+
+#[test]
+fn malformed_registration_store_preserves_local_daemon_operation() {
+    let mut daemon = TestDaemon::start();
+    daemon.crash();
+    let path = daemon
+        .runtime_dir
+        .join("state/boomux/node_registrations.json");
+    fs::write(&path, b"not-json").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    daemon.restart();
+
+    daemon.client.ping().unwrap();
+    daemon.client.snapshot().unwrap();
+    let error = daemon.client.node_registrations().unwrap_err();
+    assert!(matches!(
+        error,
+        ClientError::Remote(RemoteError {
+            code: Some(ErrorCode::NodeRegistrationUnavailable),
+            ..
+        })
+    ));
+    assert_eq!(fs::read(&path).unwrap(), b"not-json");
+}
+
+fn shell_printf(bytes: &[u8]) -> String {
+    let escaped = bytes
+        .iter()
+        .map(|byte| format!("\\{byte:03o}"))
+        .collect::<String>();
+    format!("printf '{escaped}'")
+}
+
+fn fake_ssh(directory: &Path) {
+    use boomux::federation::{
+        FEDERATION_VERSION, FederationConnectionMode, FederationHandshake, write_handshake,
+    };
+    use boomux::protocol::{self, Envelope, Request, Response};
+
+    let handshake = FederationHandshake {
+        version: FEDERATION_VERSION,
+        node_id: node_id(2),
+        helper_version: env!("CARGO_PKG_VERSION").into(),
+        core_protocol_version: protocol::PROTOCOL_VERSION,
+        connection_mode: FederationConnectionMode::AdHoc,
+    };
+    let mut handshake_bytes = Vec::new();
+    write_handshake(&mut handshake_bytes, &handshake).unwrap();
+    let mut request = Vec::new();
+    protocol::write_message(
+        &mut request,
+        &Envelope::with_version(protocol::PROTOCOL_VERSION, Request::Ping),
+    )
+    .unwrap();
+    let mut response = Vec::new();
+    protocol::write_message(
+        &mut response,
+        &Envelope::with_version(protocol::PROTOCOL_VERSION, Response::Pong),
+    )
+    .unwrap();
+    let ssh = directory.join("ssh");
+    fs::write(
+        &ssh,
+        format!(
+            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") {}; dd bs=1 count={} of=/dev/null 2>/dev/null; {} ;;\n  *) exit 64 ;;\nesac\n",
+            shell_printf(&handshake_bytes),
+            request.len(),
+            shell_printf(&response),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+fn command(directory: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+    command
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"));
+    command
+}
+
+#[test]
+fn cli_add_and_retarget_pin_verified_identity_without_persisting_helper_path() {
+    let id = Uuid::new_v4().simple().to_string();
+    let directory = std::env::temp_dir().join(format!("bx-n-{}-{}", std::process::id(), &id[..8]));
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_ssh(&directory);
+
+    let add = command(&directory)
+        .args(["node", "add", "work", "workbox"])
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "node add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let list = command(&directory)
+        .args(["node", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let list: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(list["data"][0]["node_id"], node_id(2));
+    let revision = list["data"][0]["revision"].as_u64().unwrap();
+
+    let retarget = command(&directory)
+        .args([
+            "node",
+            "retarget",
+            "work",
+            "otherbox",
+            "--revision",
+            &revision.to_string(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        retarget.status.success(),
+        "node retarget failed: {}",
+        String::from_utf8_lossy(&retarget.stderr)
+    );
+    let persisted =
+        fs::read_to_string(directory.join("state/boomux/node_registrations.json")).unwrap();
+    assert!(persisted.contains("otherbox"));
+    assert!(!persisted.contains("/remote/boomux"));
+
+    let stop = command(&directory)
+        .args(["daemon", "stop"])
+        .output()
+        .unwrap();
+    assert!(stop.status.success());
+    fs::remove_dir_all(directory).unwrap();
+}


### PR DESCRIPTION
## Summary

- persist bounded owner-only remote Node registrations outside authoritative state
- add protocol 31 registration management and stable CLI/JSON commands
- verify Node identity before add and retarget while rediscovering ephemeral helper paths
- enforce duplicate, self-registration, revision, and tombstone invariants
- drain admitted operations before retarget and forget with rollback on timeout
- preserve malformed registration data while leaving local operation available

## Stack

- GitHub stack #190
- depends on #197
- implements #176

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- focused serial native registration, bootstrap, and protocol-control tests

Closes #176

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
