### PR TITLE
feat(node): synchronize remote projections

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,7 @@
 | `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
 | `src/node_identity.rs` | Stable Node identity persistence, federation admission leases, and bounded rekey drain |
 | `src/node_registration.rs` | Independently versioned remote Node registrations, identity pinning, admission drain, validation, and atomic storage |
+| `src/node_projection.rs` | Disposable owner-only remote projection cache, deterministic bounds, health, generation CAS, quarantine, and atomic storage |
 | `src/federation.rs` | Independently versioned federation handshake and verified stdio daemon bridging |
 | `src/ssh_bootstrap.rs` | Validated SSH targets, private invocation configuration, deadline-bound remote discovery, and helper compatibility selection |
 | `src/handoff.rs`, `src/fd_transfer.rs` | Graceful daemon replacement records and Unix descriptor transfer |
@@ -59,8 +60,8 @@
   accepted federation boundary: one owning Node remains authoritative, SSH is a
   route, and local cached projections never authorize mutation or lifecycle
   inference. Ad hoc bootstrap and verified transport are implemented; durable
-  durable registration is implemented; projection and routed management remain
-  tracked by #173.
+  registration and background reduced projection synchronization are
+  implemented; routed management remains tracked by #173.
 
 ## Product Boundary
 
@@ -101,8 +102,9 @@ Public `boomux --remote TARGET` performs ad hoc bootstrap only. It
 discovers and verifies a compatible helper, or interactively installs one before
 opening and pinging a daemon-bound stdio channel. Explicit `boomux node add
 ALIAS TARGET` and revision-conditional registration management persist an
-identity-pinned route separately; neither mode creates a projection or routes
-dashboard or resource-management operations yet.
+identity-pinned route separately. A registration starts one noninteractive
+projection worker; routed dashboard and resource-management operations are not
+yet implemented.
 
 ## Components
 
@@ -546,6 +548,13 @@ changes reset the evaluation frontier to commit time. Exact no-ops do not persis
 or publish, active executions retain captured revisions, and update events remain
 prompt-free. Protocol-26 peers filter update events without rewinding cursors.
 The durable representation is unchanged, so state schema remains 12.
+Protocol 32 adds owner projection synchronization. One transition-frontier cut
+returns an explicitly reduced snapshot, scheduler health, at most 1,000 newest
+executions (all nonterminal records first), a remote stream cursor, and at most
+256 reduced resumable transitions. Expired, replaced, or overlong cursors return
+a baseline with no historical transition evidence. Protocol-31 and older event
+readers filter local `node_projection_changed` invalidations while retaining the
+unfiltered cursor. The authoritative state schema remains 12.
 Protocol-25 lists are daemon-bounded, newest-first pages with explicit limit and
 truncation. The request limit is optional on the wire; protocol 25 defaults it to
 100 and clamps it to 1 through 1,000, while protocol-23 and protocol-24 requests

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -36,6 +36,8 @@ Protocol 25 adds positive durable execution revisions, bounded execution-list
 metadata, and exact revision-aware execution waits.
 Protocol 26 adds exact-run attachment, and protocol 27 adds optimistic paused
 schedule-definition updates with prompt-free update events.
+Protocol 32 adds owner-side reduced Node projection cuts and the local
+`node_projection_changed` cache invalidation event.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns
@@ -109,6 +111,7 @@ The event vocabulary is:
 - `agent_schedule_created`, `agent_schedule_updated`, `agent_schedule_paused`,
   `agent_schedule_resumed`, `agent_schedule_removed`
 - `scheduled_execution_created`, `scheduled_execution_changed`
+- `node_projection_changed`
 - `handoff_completed`
 
 Output events carry run identity and the latest output revision, not raw PTY
@@ -195,6 +198,11 @@ replaying or stalling the stream.
 Protocol-24 and older clients ignore the additive execution revision and bounded
 list metadata. Their existing record/event filtering remains unchanged. In all
 versions the returned cursor advances across hidden execution events.
+
+Protocol-31 and older clients do not receive `node_projection_changed`; their
+cursor still advances across the invalidation. A projection cut resumes only
+when every remote event through its captured cursor fits within 256 records;
+otherwise it returns a fresh reduced baseline and no transition history.
 
 Manual final eligibility, claim creation, shell/run binding, and runner spawn are
 serialized against Agent activity mutations. A protocol-23 client therefore

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -9,9 +9,10 @@
 > the hidden stdio helper establish the verified same-socket bridge boundary.
 > Protocol 30 and local `boomux node rekey` implement bounded expected-ID rekey
 > with exact interactive confirmation. Protocol 31 and registration schema 1
-> implement explicit identity-pinned registration management. Public `boomux
-> --remote TARGET` remains ad hoc; projection and routed resource operations are
-> not yet implemented.
+> implement explicit identity-pinned registration management. Protocol 32 and
+> Node-cache schema 1 implement bounded background reduced projections. Public
+> `boomux --remote TARGET` remains ad hoc; routed resource operations are not yet
+> implemented.
 
 ## Purpose
 
@@ -206,6 +207,15 @@ state from loading or persisting. Node identity, registrations, and cache each
 use owner-only directories, bounded schemas, atomic replacement, and explicit
 validation.
 
+Node-cache schema 1 is `node-cache.json` beside, but independent from,
+`state.json`, `node.json`, and `node_registrations.json`. It is owner-only,
+atomically replaced, and capped at 4 MiB and 128 Nodes. Per Node it accepts at
+most 1,024 Workspaces, 4,096 Shells, 4,096 launchers, 4,096 Agents, 1,024
+Schedules, 1,000 executions, and 96 capability identifiers of at most 128 bytes.
+Names and identifiers in reduced collections are capped at 256 bytes. An invalid
+cache is renamed to `node-cache.corrupt-<uuid>.json` when possible and otherwise
+discarded in memory; it never blocks authoritative state startup.
+
 ## Synchronization And Events
 
 The local coordinator maintains at most one synchronization writer and one
@@ -254,6 +264,11 @@ reconnects and revalidates identity.
 Background connection retries are bounded and use backoff with jitter.
 Authentication, identity, and unsupported-version failures stop aggressive
 retry and remain actionable Node health rather than generic Agent failure.
+The implementation uses two-second bounded discovery and handshake operations,
+a two-second projection-response deadline, one-second event-wakeup waits,
+and exponential retry from one through sixty seconds plus deterministic
+sub-second jitter. Authentication, identity, and unsupported states retry no
+faster than sixty seconds plus jitter.
 
 The federation lock order is: daemon transition, Node mutation gate, Node
 persistence gate, local event-stream transition frontier, then Node

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,12 +16,12 @@ use std::time::Duration;
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
     AgentScheduleSnapshot, AgentScheduleSpec, AgentScheduleUpdate, DaemonEvent, Envelope,
-    ErrorCode, EventCursor, FocusedTerminalSnapshot, NodeRegistrationSnapshot,
-    NotificationDeliveryConfig, Request, Response, ScheduledExecutionScheduleProjection,
-    ScheduledExecutionSnapshot, ScheduledOccurrence, ScheduledRunnerResult, ShellSnapshot,
-    ShellSpec, ShellStatus, Snapshot, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan,
-    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
-    WorkspaceLauncherSpec, WorkspaceSnapshot,
+    ErrorCode, EventCursor, FocusedTerminalSnapshot, NodeProjectionHealth,
+    NodeRegistrationSnapshot, NotificationDeliveryConfig, Request, Response,
+    ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot, ScheduledOccurrence,
+    ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
+    TerminalPreviewLine, TerminalPreviewSpan, TerminalProfile, UnixEnvironment,
+    UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
 const CONNECT_ATTEMPTS: usize = 40;
@@ -591,6 +591,18 @@ impl Client {
         self.node_registration_response(Request::GetNodeRegistration {
             selector: selector.into(),
         })
+    }
+
+    pub fn node_projection_health(
+        &self,
+        selector: impl Into<String>,
+    ) -> Result<NodeProjectionHealth> {
+        match self.request(Request::GetNodeProjectionHealth {
+            selector: selector.into(),
+        })? {
+            Response::NodeProjectionHealth { health } => Ok(health),
+            response => unexpected(response),
+        }
     }
 
     pub fn rename_node_registration(
@@ -1852,6 +1864,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
@@ -2004,7 +2017,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 31);
+            assert_eq!(request.version, 32);
             assert_eq!(request.message, Request::GetNodeIdentity);
             protocol::write_message(
                 &mut stream,
@@ -2018,6 +2031,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 27);
@@ -2064,7 +2078,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 31);
+            assert_eq!(request.version, 32);
             assert_eq!(request.message, Request::OpenFederationChannel);
             protocol::write_message(
                 &mut stream,
@@ -2078,6 +2092,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
@@ -2107,7 +2122,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 31);
+            assert_eq!(request.version, 32);
             assert_eq!(request.message, Request::ListNodeRegistrations);
             protocol::write_message(
                 &mut stream,
@@ -2120,6 +2135,7 @@ mod tests {
                 ),
             )
             .unwrap();
+            reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
@@ -2292,6 +2308,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);
@@ -2359,6 +2376,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
             reject_protocol(&listener, 29, 28);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -29,6 +29,7 @@ use crate::desktop_notifications::{
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::node_identity::{NodeIdentityLease, NodeIdentityManager};
+use crate::node_projection::NodeProjectionCache;
 use crate::node_registration::NodeRegistrationManager;
 use crate::protocol::{
     self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
@@ -36,14 +37,18 @@ use crate::protocol::{
     AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSnapshot, AgentScheduleSpec,
     AgentScheduleState, AgentScheduleTrigger, AgentScheduleUpdate, AgentState, AttachFrame,
     DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot,
-    NotificationDeliveryConfig, Request, Response, ScheduledExecutionDispatchKind,
-    ScheduledExecutionOutcome, ScheduledExecutionReason, ScheduledExecutionScheduleProjection,
-    ScheduledExecutionSnapshot, ScheduledExecutionState, ScheduledOccurrence,
-    ScheduledRunnerResult, SchedulerHealth, SchedulerState, ShellOwner, ShellRunExitReason,
-    ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
-    TerminalProfile, UnixEnvironment, UnixEnvironmentVariable, WorkspaceLauncherSnapshot,
-    WorkspaceLauncherSpec, WorkspaceSnapshot,
+    NodeProjectionAgent, NodeProjectionAttention, NodeProjectionExecution, NodeProjectionLauncher,
+    NodeProjectionSchedule, NodeProjectionShell, NodeProjectionSnapshot, NodeProjectionSync,
+    NodeProjectionSyncMode, NodeProjectionTransition, NodeProjectionTransitionKind,
+    NodeProjectionWorkspace, NotificationDeliveryConfig, Request, Response,
+    ScheduledExecutionDispatchKind, ScheduledExecutionOutcome, ScheduledExecutionReason,
+    ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot, ScheduledExecutionState,
+    ScheduledOccurrence, ScheduledRunnerResult, SchedulerHealth, SchedulerState, ShellOwner,
+    ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
+    TerminalPreview, TerminalProfile, UnixEnvironment, UnixEnvironmentVariable,
+    WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
+use crate::ssh_bootstrap::{self, RemoteBootstrapPlan, SshAuthenticationMode, SshTarget};
 use crate::state_store::{
     PersistedAgentInstance, PersistedAgentSchedule, PersistedScheduledExecution, PersistedShell,
     PersistedShellRun, PersistedState, PersistedWorkspace, PersistedWorkspaceLauncher, StateStore,
@@ -341,6 +346,7 @@ fn run_daemon(
         eprintln!("boomux: Node registration routing disabled: {reason}");
     }
     registry.node_registrations = Some(registrations);
+    registry.node_projection_cache = Some(NodeProjectionCache::load_from_environment());
     registry.startup_environment = capture_current_environment();
     registry.configure_scheduler_clock()?;
     registry.notification_settings = notification_settings.clone();
@@ -407,6 +413,7 @@ fn run_daemon(
             .map_err(|error| io::Error::other(error.to_string()))?;
     }
     registry.start_scheduler()?;
+    registry.start_node_projection_workers()?;
     let shutdown = Arc::new(AtomicBool::new(false));
     let transition = Arc::new(AtomicU8::new(TRANSITION_IDLE));
     let (restart_sender, restart_receiver) = mpsc::channel::<RestartRequest>();
@@ -432,6 +439,7 @@ fn run_daemon(
         match restart_receiver.try_recv() {
             Ok(request) => {
                 registry.stop_scheduler()?;
+                registry.stop_node_projection_workers()?;
                 let result = launch_replacement(
                     &listener,
                     &daemon_lock,
@@ -445,6 +453,7 @@ fn run_daemon(
                 } else {
                     transition.store(TRANSITION_IDLE, Ordering::Release);
                     registry.start_scheduler()?;
+                    registry.start_node_projection_workers()?;
                 }
                 let _ = request.reply.send(result);
                 continue;
@@ -489,6 +498,7 @@ fn run_daemon(
         let _ = handler.join();
     }
     registry.stop_scheduler()?;
+    registry.stop_node_projection_workers()?;
     let result = if handed_off {
         socket_cleanup.disarm();
         Ok(())
@@ -1086,6 +1096,7 @@ fn handle_connection_inner(
             );
         }
         registry.stop_scheduler()?;
+        registry.stop_node_projection_workers()?;
         return match registry.shutdown() {
             Ok(()) => {
                 shutdown.store(true, Ordering::Release);
@@ -1094,6 +1105,7 @@ fn handle_connection_inner(
             Err(error) => {
                 transition.store(TRANSITION_IDLE, Ordering::Release);
                 let _ = registry.start_scheduler();
+                let _ = registry.start_node_projection_workers();
                 send_response(
                     &mut stream,
                     response_version,
@@ -1270,6 +1282,11 @@ fn response_for_version_with_schedule_shells(
     schedule_shell_ids: &HashSet<String>,
 ) -> Response {
     let mut response = response;
+    if !protocol::ProtocolFeature::NodeProjectionSync.is_supported_by(version)
+        && let Response::Events { events, .. } = &mut response
+    {
+        events.retain(|event| !matches!(event.kind, DaemonEventKind::NodeProjectionChanged { .. }));
+    }
     if !protocol::ProtocolFeature::ScheduledExecutionObservation.is_supported_by(version) {
         match &mut response {
             Response::ScheduledExecution {
@@ -1653,6 +1670,7 @@ fn scheduled_execution_response(
 struct DaemonService {
     node_identity: Option<Arc<NodeIdentityManager>>,
     node_registrations: Option<NodeRegistrationManager>,
+    node_projection_cache: Option<NodeProjectionCache>,
     durable: DurableRegistry,
     events: EventStream,
     runtimes: ShellRuntimeManager,
@@ -1663,6 +1681,7 @@ struct DaemonService {
     cold_recovery_executions: Vec<ScheduledExecutionSnapshot>,
     startup_environment: UnixEnvironment,
     scheduler: SchedulerWorker,
+    node_projection_workers: NodeProjectionWorkers,
     clock: Mutex<Arc<dyn SchedulerClock>>,
     #[cfg(test)]
     fail_after_mutation: AtomicBool,
@@ -1833,6 +1852,12 @@ struct SchedulerWorkerState {
     running: bool,
     healthy: bool,
     handle: Option<thread::JoinHandle<()>>,
+}
+
+#[derive(Default)]
+struct NodeProjectionWorkers {
+    stop: Arc<AtomicBool>,
+    handles: Mutex<HashMap<String, thread::JoinHandle<()>>>,
 }
 
 struct DurableRegistry {
@@ -2601,6 +2626,177 @@ impl EventStream {
             Self::append_batch_locked(events, vec![kind]);
         }
     }
+}
+
+fn projection_transitions(
+    state: &EventStreamState,
+    after: Option<&EventCursor>,
+    through: &EventCursor,
+) -> (NodeProjectionSyncMode, Vec<NodeProjectionTransition>) {
+    let Some(after) = after else {
+        return (NodeProjectionSyncMode::Baseline, Vec::new());
+    };
+    let earliest = state
+        .events
+        .front()
+        .map_or(state.latest_id, |event| event.id.saturating_sub(1));
+    if after.stream_id != state.stream_id
+        || after.event_id < earliest
+        || after.event_id > through.event_id
+    {
+        return (NodeProjectionSyncMode::Baseline, Vec::new());
+    }
+    let events = state
+        .events
+        .iter()
+        .filter(|event| event.id > after.event_id && event.id <= through.event_id)
+        .collect::<Vec<_>>();
+    if events.len() > usize::from(protocol::MAX_NODE_PROJECTION_TRANSITIONS) {
+        return (NodeProjectionSyncMode::Baseline, Vec::new());
+    }
+    let transitions = events
+        .into_iter()
+        .filter_map(reduce_projection_transition)
+        .collect();
+    (NodeProjectionSyncMode::Resumed, transitions)
+}
+
+fn reduce_projection_transition(event: &DaemonEvent) -> Option<NodeProjectionTransition> {
+    let kind = match &event.kind {
+        DaemonEventKind::WorkspaceCreated { workspace_id, .. }
+        | DaemonEventKind::WorkspaceRenamed { workspace_id, .. }
+        | DaemonEventKind::WorkspaceClosed { workspace_id } => {
+            NodeProjectionTransitionKind::Workspace {
+                workspace_id: workspace_id.clone(),
+            }
+        }
+        DaemonEventKind::ShellCreated {
+            workspace_id,
+            shell_id,
+            ..
+        }
+        | DaemonEventKind::ShellRenamed {
+            workspace_id,
+            shell_id,
+            ..
+        }
+        | DaemonEventKind::RunStarted {
+            workspace_id,
+            shell_id,
+            ..
+        }
+        | DaemonEventKind::OutputChanged {
+            workspace_id,
+            shell_id,
+            ..
+        }
+        | DaemonEventKind::RunExited {
+            workspace_id,
+            shell_id,
+            ..
+        } => NodeProjectionTransitionKind::Shell {
+            workspace_id: workspace_id.clone(),
+            shell_id: shell_id.clone(),
+        },
+        DaemonEventKind::ShellClosed {
+            workspace_id: Some(workspace_id),
+            shell_id,
+        } => NodeProjectionTransitionKind::Shell {
+            workspace_id: workspace_id.clone(),
+            shell_id: shell_id.clone(),
+        },
+        DaemonEventKind::ShellClosed {
+            workspace_id: None, ..
+        } => return None,
+        DaemonEventKind::LauncherCreated {
+            workspace_id,
+            launcher_id,
+            ..
+        }
+        | DaemonEventKind::LauncherRenamed {
+            workspace_id,
+            launcher_id,
+            ..
+        }
+        | DaemonEventKind::LauncherRemoved {
+            workspace_id,
+            launcher_id,
+        } => NodeProjectionTransitionKind::Launcher {
+            workspace_id: workspace_id.clone(),
+            launcher_id: launcher_id.clone(),
+        },
+        DaemonEventKind::AgentRegistered {
+            workspace_id,
+            agent,
+            ..
+        }
+        | DaemonEventKind::AgentStateChanged {
+            workspace_id,
+            agent,
+            ..
+        }
+        | DaemonEventKind::AgentCompleted {
+            workspace_id,
+            agent,
+            ..
+        }
+        | DaemonEventKind::AgentAttentionAcknowledged {
+            workspace_id,
+            agent,
+            ..
+        } => NodeProjectionTransitionKind::Agent {
+            workspace_id: workspace_id.clone(),
+            agent_id: agent.id.clone(),
+            revision: agent.observation.revision,
+        },
+        DaemonEventKind::AgentScheduleCreated {
+            workspace_id,
+            schedule,
+        }
+        | DaemonEventKind::AgentSchedulePaused {
+            workspace_id,
+            schedule,
+        }
+        | DaemonEventKind::AgentScheduleResumed {
+            workspace_id,
+            schedule,
+        }
+        | DaemonEventKind::AgentScheduleUpdated {
+            workspace_id,
+            schedule,
+        } => NodeProjectionTransitionKind::Schedule {
+            workspace_id: workspace_id.clone(),
+            schedule_id: schedule.id.clone(),
+            revision: Some(schedule.revision),
+        },
+        DaemonEventKind::AgentScheduleRemoved {
+            workspace_id,
+            schedule_id,
+        } => NodeProjectionTransitionKind::Schedule {
+            workspace_id: workspace_id.clone(),
+            schedule_id: schedule_id.clone(),
+            revision: None,
+        },
+        DaemonEventKind::ScheduledExecutionCreated {
+            workspace_id,
+            execution,
+        }
+        | DaemonEventKind::ScheduledExecutionChanged {
+            workspace_id,
+            execution,
+        } => NodeProjectionTransitionKind::Execution {
+            workspace_id: workspace_id.clone(),
+            execution_id: execution.id.clone(),
+            revision: execution.revision,
+        },
+        DaemonEventKind::HandoffCompleted => NodeProjectionTransitionKind::HandoffCompleted,
+        DaemonEventKind::NodeProjectionChanged { .. } => return None,
+    };
+    Some(NodeProjectionTransition {
+        event_id: event.id,
+        at_ms: event.at_ms,
+        kind,
+    })
 }
 
 impl DurableRegistry {
@@ -4209,6 +4405,94 @@ impl DurableRegistry {
         })
     }
 
+    fn node_projection(
+        &self,
+        node_id: String,
+        scheduler: SchedulerHealth,
+    ) -> io::Result<NodeProjectionSnapshot> {
+        let (workspaces, shells, launchers, agents, schedules) = {
+            let state = lock(&self.state)?;
+            (
+                state.workspaces.values().cloned().collect::<Vec<_>>(),
+                state.shells.values().cloned().collect::<Vec<_>>(),
+                state.launchers.values().cloned().collect::<Vec<_>>(),
+                state.agents.values().cloned().collect::<Vec<_>>(),
+                state.schedules.values().cloned().collect::<Vec<_>>(),
+            )
+        };
+        let mut projected_workspaces = Vec::with_capacity(workspaces.len());
+        for workspace in workspaces {
+            let item_count = lock(&workspace.shell_ids)?.len()
+                + lock(&workspace.launcher_ids)?.len()
+                + lock(&workspace.schedule_ids)?.len();
+            let agent_ids = lock(&workspace.agent_ids)?.clone();
+            let attention_count = agents
+                .iter()
+                .filter(|agent| agent_ids.contains(&agent.id))
+                .filter_map(|agent| lock(&agent.state).ok())
+                .filter(|state| state.attention.is_some())
+                .count();
+            projected_workspaces.push(NodeProjectionWorkspace {
+                id: workspace.id.clone(),
+                name: lock(&workspace.name)?.clone(),
+                item_count: u32::try_from(item_count).unwrap_or(u32::MAX),
+                attention_count: u32::try_from(attention_count).unwrap_or(u32::MAX),
+            });
+        }
+        let mut projected_shells = shells
+            .iter()
+            .map(|shell| shell.node_projection())
+            .collect::<io::Result<Vec<_>>>()?;
+        let mut projected_launchers = launchers
+            .iter()
+            .map(|launcher| launcher.node_projection())
+            .collect::<io::Result<Vec<_>>>()?;
+        let mut projected_agents = agents
+            .iter()
+            .map(|agent| agent.node_projection())
+            .collect::<io::Result<Vec<_>>>()?;
+        let mut projected_schedules = schedules
+            .iter()
+            .map(|schedule| schedule.node_projection())
+            .collect::<io::Result<Vec<_>>>()?;
+        let mut executions = Vec::new();
+        for schedule in schedules {
+            for execution in lock(&schedule.executions)?.iter() {
+                executions.push(execution.node_projection()?);
+            }
+        }
+        executions.sort_by(|left, right| {
+            left.state
+                .is_terminal()
+                .cmp(&right.state.is_terminal())
+                .then_with(|| {
+                    right
+                        .requested_at_ms
+                        .cmp(&left.requested_at_ms)
+                        .then_with(|| left.id.cmp(&right.id))
+                })
+        });
+        let execution_limit = usize::from(protocol::MAX_NODE_PROJECTION_EXECUTIONS);
+        let executions_truncated = executions.len() > execution_limit;
+        executions.truncate(execution_limit);
+        projected_workspaces.sort_by(|left, right| left.id.cmp(&right.id));
+        projected_shells.sort_by(|left, right| left.id.cmp(&right.id));
+        projected_launchers.sort_by(|left, right| left.id.cmp(&right.id));
+        projected_agents.sort_by(|left, right| left.id.cmp(&right.id));
+        projected_schedules.sort_by(|left, right| left.id.cmp(&right.id));
+        Ok(NodeProjectionSnapshot {
+            node_id,
+            workspaces: projected_workspaces,
+            shells: projected_shells,
+            launchers: projected_launchers,
+            agents: projected_agents,
+            schedules: projected_schedules,
+            executions,
+            executions_truncated,
+            scheduler,
+        })
+    }
+
     fn shells(&self) -> io::Result<Vec<Arc<Shell>>> {
         Ok(lock(&self.state)?.shells.values().cloned().collect())
     }
@@ -5006,6 +5290,7 @@ impl Default for DaemonService {
         Self {
             node_identity: None,
             node_registrations: None,
+            node_projection_cache: None,
             durable: DurableRegistry {
                 state: Mutex::new(DurableState::default()),
                 store: None,
@@ -5026,6 +5311,7 @@ impl Default for DaemonService {
             cold_recovery_executions: Vec::new(),
             startup_environment: capture_current_environment(),
             scheduler: SchedulerWorker::default(),
+            node_projection_workers: NodeProjectionWorkers::default(),
             clock: Mutex::new(Arc::new(SystemSchedulerClock)),
             #[cfg(test)]
             fail_after_mutation: AtomicBool::new(false),
@@ -5798,6 +6084,279 @@ fn scheduler_retry_delay(consecutive_failures: u32) -> Duration {
         .min(SCHEDULER_RETRY_MAX)
 }
 
+fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
+    let mut failures = 0_u32;
+    loop {
+        let Some(service) = service.upgrade() else {
+            return;
+        };
+        if service.node_projection_workers.stop.load(Ordering::Acquire) {
+            return;
+        }
+        let registration = match service.node_registrations().and_then(|registrations| {
+            registrations
+                .inspect(&node_id)
+                .map_err(node_registration_error)
+        }) {
+            Ok(registration) => registration,
+            Err(_) => return,
+        };
+        let (after, expected_generation) = match service.node_projection_cache().and_then(|cache| {
+            cache
+                .cursor_and_generation(&registration)
+                .map_err(DaemonError::from)
+        }) {
+            Ok(value) => value,
+            Err(error) => {
+                eprintln!("boomux: could not inspect Node projection cache: {error}");
+                return;
+            }
+        };
+        let admitted = service
+            .node_registrations()
+            .and_then(|registrations| {
+                registrations
+                    .admit(&registration)
+                    .map_err(node_registration_error)
+            })
+            .unwrap_or(false);
+        if !admitted {
+            if interruptible_node_sleep(&service, Duration::from_millis(100)) {
+                return;
+            }
+            continue;
+        }
+        let attempt_at_ms = unix_time_ms();
+        let result = fetch_node_projection(&registration, after);
+        let mut published_generation = None;
+        match result {
+            Ok((sync, capabilities)) => {
+                let commit = service.node_registrations().and_then(|registrations| {
+                    registrations
+                        .with_current(&registration, || {
+                            service
+                                .node_projection_cache
+                                .as_ref()
+                                .ok_or_else(|| {
+                                    io::Error::other("Node projection cache unavailable")
+                                })?
+                                .commit_projection(
+                                    &registration,
+                                    expected_generation,
+                                    sync.cursor,
+                                    sync.projection,
+                                    capabilities,
+                                    attempt_at_ms,
+                                )
+                        })
+                        .map_err(node_registration_error)
+                });
+                if let Ok(Some(Some(generation))) = commit {
+                    published_generation = Some(generation);
+                    failures = 0;
+                } else if let Err(error) = commit {
+                    eprintln!("boomux: could not commit Node projection: {error}");
+                }
+            }
+            Err((health, error)) => {
+                failures = failures.saturating_add(1);
+                let delay = node_projection_retry_delay(&node_id, failures, health);
+                let retry_at_ms = attempt_at_ms
+                    .saturating_add(u64::try_from(delay.as_millis()).unwrap_or(u64::MAX));
+                let commit = service.node_registrations().and_then(|registrations| {
+                    registrations
+                        .with_current(&registration, || {
+                            service
+                                .node_projection_cache
+                                .as_ref()
+                                .ok_or_else(|| {
+                                    io::Error::other("Node projection cache unavailable")
+                                })?
+                                .mark_health(
+                                    &registration,
+                                    expected_generation,
+                                    health,
+                                    attempt_at_ms,
+                                    Some(retry_at_ms),
+                                )
+                        })
+                        .map_err(node_registration_error)
+                });
+                if let Ok(Some(Some(generation))) = commit {
+                    published_generation = Some(generation);
+                } else if let Err(error) = commit {
+                    eprintln!("boomux: could not commit Node projection health: {error}");
+                }
+                if failures == 1 {
+                    eprintln!(
+                        "boomux: Node projection sync for {} failed: {error}",
+                        registration.alias
+                    );
+                }
+            }
+        }
+        service
+            .node_registrations()
+            .map(|registrations| registrations.release(&registration))
+            .ok();
+        if let Some(cache_generation) = published_generation {
+            let _ = service.events.publish_runtime_batch(vec![
+                DaemonEventKind::NodeProjectionChanged {
+                    node_id: registration.node_id.clone(),
+                    cache_generation,
+                },
+            ]);
+        }
+        let delay = if failures == 0 {
+            Duration::from_secs(1)
+        } else {
+            node_projection_retry_delay(
+                &node_id,
+                failures,
+                service
+                    .node_projection_cache()
+                    .and_then(|cache| cache.health(&registration).map_err(DaemonError::from))
+                    .map(|health| health.code)
+                    .unwrap_or(crate::protocol::NodeProjectionHealthCode::Unreachable),
+            )
+        };
+        if interruptible_node_sleep(&service, delay) {
+            return;
+        }
+    }
+}
+
+fn fetch_node_projection(
+    registration: &crate::protocol::NodeRegistrationSnapshot,
+    after: Option<EventCursor>,
+) -> Result<(NodeProjectionSync, Vec<String>), (crate::protocol::NodeProjectionHealthCode, io::Error)>
+{
+    use crate::protocol::NodeProjectionHealthCode;
+    let target = SshTarget::parse(registration.target.clone())
+        .map_err(|error| (NodeProjectionHealthCode::Unreachable, error))?;
+    let helper = match ssh_bootstrap::plan_remote_bootstrap(
+        target.clone(),
+        SshAuthenticationMode::Batch,
+        Duration::from_secs(2),
+    ) {
+        Ok(RemoteBootstrapPlan::Ready(helper)) => helper,
+        Ok(RemoteBootstrapPlan::Install(_)) => {
+            return Err((
+                NodeProjectionHealthCode::Unsupported,
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "remote helper requires installation",
+                ),
+            ));
+        }
+        Err(error) => return Err((classify_node_sync_error(&error), error)),
+    };
+    if helper.handshake.node_id != registration.node_id {
+        return Err((
+            NodeProjectionHealthCode::IdentityChanged,
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "remote Node identity changed",
+            ),
+        ));
+    }
+    let version = helper.handshake.core_protocol_version;
+    if !protocol::ProtocolFeature::NodeProjectionSync.is_supported_by(version) {
+        return Err((
+            NodeProjectionHealthCode::Unsupported,
+            io::Error::new(
+                io::ErrorKind::Unsupported,
+                "remote Node does not support projection synchronization",
+            ),
+        ));
+    }
+    let mut remote = ssh_bootstrap::connect_remote(
+        target,
+        helper,
+        SshAuthenticationMode::Batch,
+        Duration::from_secs(2),
+    )
+    .map_err(|error| (classify_node_sync_error(&error), error))?;
+    let sync = remote
+        .node_projection_sync(after, Duration::from_secs(2))
+        .map_err(|error| (classify_node_sync_error(&error), error))?;
+    if sync.projection.node_id != registration.node_id {
+        return Err((
+            NodeProjectionHealthCode::IdentityChanged,
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "projection owner identity changed",
+            ),
+        ));
+    }
+    let capabilities = protocol::ProtocolFeature::ALL
+        .iter()
+        .copied()
+        .filter(|feature| feature.is_supported_by(version))
+        .flat_map(protocol::ProtocolFeature::capability_names)
+        .copied()
+        .map(str::to_owned)
+        .collect();
+    Ok((sync, capabilities))
+}
+
+fn classify_node_sync_error(error: &io::Error) -> crate::protocol::NodeProjectionHealthCode {
+    use crate::protocol::NodeProjectionHealthCode;
+    if error.kind() == io::ErrorKind::Unsupported {
+        NodeProjectionHealthCode::Unsupported
+    } else if error.kind() == io::ErrorKind::PermissionDenied
+        || error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("authentication")
+    {
+        NodeProjectionHealthCode::AuthenticationRequired
+    } else {
+        NodeProjectionHealthCode::Unreachable
+    }
+}
+
+fn node_projection_retry_delay(
+    node_id: &str,
+    failures: u32,
+    health: crate::protocol::NodeProjectionHealthCode,
+) -> Duration {
+    use crate::protocol::NodeProjectionHealthCode;
+    let base = if matches!(
+        health,
+        NodeProjectionHealthCode::AuthenticationRequired
+            | NodeProjectionHealthCode::IdentityChanged
+            | NodeProjectionHealthCode::IdentityConflict
+            | NodeProjectionHealthCode::Unsupported
+    ) {
+        60_u64
+    } else {
+        1_u64
+            .checked_shl(failures.saturating_sub(1).min(6))
+            .unwrap_or(60)
+            .min(60)
+    };
+    let jitter = node_id.bytes().fold(u64::from(failures), |value, byte| {
+        value.wrapping_mul(33).wrapping_add(u64::from(byte))
+    }) % 1_000;
+    Duration::from_millis(base.saturating_mul(1_000).saturating_add(jitter))
+}
+
+fn interruptible_node_sleep(service: &DaemonService, duration: Duration) -> bool {
+    let deadline = Instant::now() + duration;
+    while Instant::now() < deadline {
+        if service.node_projection_workers.stop.load(Ordering::Acquire) {
+            return true;
+        }
+        thread::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_millis(100)),
+        );
+    }
+    false
+}
+
 fn resume_identity(
     agent: &AgentInstance,
     shell: &Shell,
@@ -5847,6 +6406,15 @@ impl DaemonService {
             DaemonError::lifecycle(
                 ErrorCode::NodeRegistrationUnavailable,
                 "Boomux Node registrations are unavailable",
+            )
+        })
+    }
+
+    fn node_projection_cache(&self) -> DaemonResult<&NodeProjectionCache> {
+        self.node_projection_cache.as_ref().ok_or_else(|| {
+            DaemonError::lifecycle(
+                ErrorCode::NodeRegistrationUnavailable,
+                "Boomux Node projection cache is unavailable",
             )
         })
     }
@@ -5914,6 +6482,66 @@ impl DaemonService {
                 .spawn(move || scheduler_worker(service))?,
         );
         self.scheduler.changed.notify_all();
+        Ok(())
+    }
+
+    fn start_node_projection_workers(self: &Arc<Self>) -> io::Result<()> {
+        self.node_projection_workers
+            .stop
+            .store(false, Ordering::Release);
+        let registrations = self
+            .node_registrations
+            .as_ref()
+            .ok_or_else(|| io::Error::other("Node registrations unavailable"))?;
+        let registrations = match registrations.list() {
+            Ok(registrations) => registrations,
+            Err(error) => {
+                eprintln!("boomux: Node projection synchronization disabled: {error}");
+                return Ok(());
+            }
+        };
+        for registration in registrations {
+            self.start_node_projection_worker(registration.node_id)?;
+        }
+        Ok(())
+    }
+
+    fn start_node_projection_worker(self: &Arc<Self>, node_id: String) -> io::Result<()> {
+        let mut handles = lock(&self.node_projection_workers.handles)?;
+        if handles
+            .get(&node_id)
+            .is_some_and(|handle| !handle.is_finished())
+        {
+            return Ok(());
+        }
+        if let Some(handle) = handles.remove(&node_id) {
+            let _ = handle.join();
+        }
+        let service = Arc::downgrade(self);
+        let worker_node_id = node_id.clone();
+        let handle = thread::Builder::new()
+            .name(format!("boomux-node-sync-{node_id}"))
+            .spawn(move || node_projection_worker(service, worker_node_id))?;
+        handles.insert(node_id, handle);
+        Ok(())
+    }
+
+    fn stop_node_projection_workers(&self) -> io::Result<()> {
+        self.node_projection_workers
+            .stop
+            .store(true, Ordering::Release);
+        let handles = {
+            let mut handles = lock(&self.node_projection_workers.handles)?;
+            handles
+                .drain()
+                .map(|(_, handle)| handle)
+                .collect::<Vec<_>>()
+        };
+        for handle in handles {
+            handle
+                .join()
+                .map_err(|_| io::Error::other("Node projection worker panicked"))?;
+        }
         Ok(())
     }
 
@@ -6104,6 +6732,13 @@ impl DaemonService {
         request: Request,
         response_version: u32,
     ) -> DaemonResult<Response> {
+        if matches!(request, Request::AddNodeRegistration { .. }) {
+            let response = self.dispatch(request)?;
+            if let Response::NodeRegistration { registration } = &response {
+                self.start_node_projection_worker(registration.node_id.clone())?;
+            }
+            return Ok(response);
+        }
         if let Request::ListScheduledExecutions {
             workspace_id,
             schedule_id,
@@ -7137,22 +7772,44 @@ impl DaemonService {
                 target,
                 node_id,
                 expected_revision,
-            } => self
-                .node_registrations()?
-                .retarget(
-                    &selector,
-                    target,
-                    &node_id,
-                    expected_revision,
-                    NODE_REGISTRATION_DRAIN_TIMEOUT,
-                )
-                .map(|registration| Response::NodeRegistration { registration })
-                .map_err(node_registration_error),
-            Request::ForgetNodeRegistration { selector } => self
-                .node_registrations()?
-                .forget(&selector, NODE_REGISTRATION_DRAIN_TIMEOUT)
-                .map(|registration| Response::NodeRegistration { registration })
-                .map_err(node_registration_error),
+            } => {
+                let registration = self
+                    .node_registrations()?
+                    .retarget(
+                        &selector,
+                        target,
+                        &node_id,
+                        expected_revision,
+                        NODE_REGISTRATION_DRAIN_TIMEOUT,
+                    )
+                    .map_err(node_registration_error)?;
+                if let Err(error) = self.node_projection_cache()?.remove(&registration.node_id) {
+                    eprintln!("boomux: could not remove disposable Node projection: {error}");
+                }
+                Ok(Response::NodeRegistration { registration })
+            }
+            Request::ForgetNodeRegistration { selector } => {
+                let registration = self
+                    .node_registrations()?
+                    .forget(&selector, NODE_REGISTRATION_DRAIN_TIMEOUT)
+                    .map_err(node_registration_error)?;
+                if let Err(error) = self.node_projection_cache()?.remove(&registration.node_id) {
+                    eprintln!("boomux: could not remove disposable Node projection: {error}");
+                }
+                Ok(Response::NodeRegistration { registration })
+            }
+            Request::SyncNodeProjection { after, wait_ms } => Ok(Response::NodeProjectionSync {
+                sync: self.node_projection_sync(after, wait_ms)?,
+            }),
+            Request::GetNodeProjectionHealth { selector } => {
+                let registration = self
+                    .node_registrations()?
+                    .inspect(&selector)
+                    .map_err(node_registration_error)?;
+                Ok(Response::NodeProjectionHealth {
+                    health: self.node_projection_cache()?.health(&registration)?,
+                })
+            }
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
                 unreachable!("restart is handled before dispatch")
             }
@@ -7947,6 +8604,7 @@ impl DaemonService {
         let registry = Self {
             node_identity: None,
             node_registrations: None,
+            node_projection_cache: None,
             durable: DurableRegistry {
                 state: Mutex::new(state),
                 store: Some(store),
@@ -7967,6 +8625,7 @@ impl DaemonService {
             cold_recovery_executions,
             startup_environment: capture_current_environment(),
             scheduler: SchedulerWorker::default(),
+            node_projection_workers: NodeProjectionWorkers::default(),
             clock: Mutex::new(Arc::new(SystemSchedulerClock)),
             #[cfg(test)]
             fail_after_mutation: AtomicBool::new(false),
@@ -8843,6 +9502,64 @@ impl DaemonService {
                 .unwrap_or(u16::MAX),
         });
         Ok(snapshot)
+    }
+
+    fn node_projection_sync(
+        &self,
+        after: Option<EventCursor>,
+        wait_ms: u32,
+    ) -> DaemonResult<NodeProjectionSync> {
+        if let Some(cursor) = &after
+            && wait_ms != 0
+        {
+            match self
+                .events
+                .read_after(cursor, 1, wait_ms, || self.runtimes.is_stopping())
+            {
+                Ok(_) => {}
+                Err(DaemonError::Lifecycle {
+                    code: ErrorCode::CursorExpired,
+                    ..
+                }) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        let transaction = self.events.transaction()?;
+        let cursor = transaction.cursor();
+        let (mode, transitions) =
+            projection_transitions(&transaction.events, after.as_ref(), &cursor);
+        let node_id = self.node_identity()?.id()?;
+        let scheduler = self.scheduler_health()?;
+        let projection = self.durable.node_projection(node_id, scheduler)?;
+        Ok(NodeProjectionSync {
+            mode,
+            cursor,
+            projection,
+            transitions,
+        })
+    }
+
+    fn scheduler_health(&self) -> io::Result<SchedulerHealth> {
+        let active = self.scheduler.state.lock().ok().is_some_and(|scheduler| {
+            scheduler.running
+                && scheduler.healthy
+                && scheduler
+                    .handle
+                    .as_ref()
+                    .is_some_and(|handle| !handle.is_finished())
+        });
+        Ok(SchedulerHealth {
+            state: if active {
+                SchedulerState::Active
+            } else {
+                SchedulerState::Offline
+            },
+            max_concurrent: self
+                .notification_settings
+                .max_scheduled_execution_concurrency,
+            active_executions: u16::try_from(self.durable.active_scheduled_execution_count()?)
+                .unwrap_or(u16::MAX),
+        })
     }
 
     fn schedule_shell_ids_for_downgrade(&self) -> io::Result<HashSet<String>> {
@@ -9824,6 +10541,37 @@ impl Workspace {
 }
 
 impl AgentSchedule {
+    fn node_projection(&self) -> io::Result<NodeProjectionSchedule> {
+        let state = lock(&self.state)?;
+        let next_occurrence = if state.state == AgentScheduleState::Enabled {
+            Some(ScheduledOccurrence {
+                trigger_revision: state.trigger_revision,
+                scheduled_at_ms: crate::scheduling::CronSchedule::compile(
+                    &state.trigger.cron,
+                    &state.trigger.timezone,
+                )
+                .and_then(|cron| cron.next_after_ms(state.evaluation_frontier_ms))
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?,
+            })
+        } else {
+            None
+        };
+        Ok(NodeProjectionSchedule {
+            id: self.id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            name: state.name.clone(),
+            integration: self.integration.clone(),
+            state: state.state,
+            trigger: state.trigger.clone(),
+            revision: state.revision,
+            prompt_revision: state.prompt_revision,
+            trigger_revision: state.trigger_revision,
+            created_at_ms: self.created_at_ms,
+            updated_at_ms: state.updated_at_ms,
+            next_occurrence,
+        })
+    }
+
     fn from_persisted(workspace_id: &str, saved: PersistedAgentSchedule) -> Self {
         let schedule_id = saved.id.clone();
         Self {
@@ -9952,6 +10700,30 @@ impl AgentSchedule {
 }
 
 impl ScheduledExecution {
+    fn node_projection(&self) -> io::Result<NodeProjectionExecution> {
+        let state = lock(&self.state)?;
+        Ok(NodeProjectionExecution {
+            id: self.id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            schedule_id: self.schedule_id.clone(),
+            revision: state.revision,
+            state: state.state,
+            dispatch_kind: self.dispatch_kind,
+            schedule_revision: self.schedule_revision,
+            prompt_revision: self.prompt_revision,
+            trigger_revision: self.trigger_revision,
+            requested_at_ms: self.requested_at_ms,
+            scheduled_at_ms: self.scheduled_at_ms,
+            started_at_ms: state.started_at_ms,
+            ended_at_ms: state.ended_at_ms,
+            reason: state.reason,
+            outcome: state.outcome.clone(),
+            shell_id: state.shell_id.clone(),
+            run_id: state.run_id.clone(),
+            agent_id: state.agent_id.clone(),
+        })
+    }
+
     fn from_persisted(
         workspace_id: &str,
         schedule_id: &str,
@@ -10055,6 +10827,14 @@ impl ScheduledExecution {
 }
 
 impl WorkspaceLauncher {
+    fn node_projection(&self) -> io::Result<NodeProjectionLauncher> {
+        Ok(NodeProjectionLauncher {
+            id: self.id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            name: lock(&self.name)?.clone(),
+        })
+    }
+
     fn snapshot(&self) -> io::Result<WorkspaceLauncherSnapshot> {
         Ok(WorkspaceLauncherSnapshot {
             id: self.id.clone(),
@@ -10067,6 +10847,31 @@ impl WorkspaceLauncher {
 }
 
 impl AgentInstance {
+    fn node_projection(&self) -> io::Result<NodeProjectionAgent> {
+        let state = lock(&self.state)?;
+        Ok(NodeProjectionAgent {
+            id: self.id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            shell_id: self.shell_id.clone(),
+            run_id: self.run_id.clone(),
+            name: self.name.clone(),
+            integration: self.integration.clone(),
+            state: state.observation.state,
+            observation_revision: state.observation.revision,
+            observed_at_ms: state.observation.observed_at_ms,
+            started_at_ms: self.started_at_ms,
+            ended_at_ms: state.ended_at_ms,
+            attention: state
+                .attention
+                .as_ref()
+                .map(|attention| NodeProjectionAttention {
+                    reason: attention.reason,
+                    observation_revision: attention.observation.revision,
+                    observed_at_ms: attention.observation.observed_at_ms,
+                }),
+        })
+    }
+
     fn from_persisted(workspace_id: &str, saved: PersistedAgentInstance) -> Self {
         Self {
             id: saved.id,
@@ -10127,6 +10932,39 @@ impl AgentInstance {
 }
 
 impl Shell {
+    fn node_projection(&self) -> io::Result<NodeProjectionShell> {
+        let (status, run_id, generation, started_at_ms, ended_at_ms) =
+            match &*lock(&self.lifecycle)? {
+                ShellLifecycle::Pending => (ShellStatus::Pending, None, None, None, None),
+                ShellLifecycle::Running { run, .. } => (
+                    ShellStatus::Running,
+                    Some(run.id.clone()),
+                    Some(run.generation),
+                    Some(run.started_at_ms),
+                    lock(&run.ended)?.as_ref().map(|end| end.ended_at_ms),
+                ),
+                ShellLifecycle::Exited { code, run, .. } => (
+                    ShellStatus::Exited { code: *code },
+                    Some(run.id.clone()),
+                    Some(run.generation),
+                    Some(run.started_at_ms),
+                    lock(&run.ended)?.as_ref().map(|end| end.ended_at_ms),
+                ),
+                ShellLifecycle::Closed => return Err(not_found("shell", &self.id)),
+            };
+        Ok(NodeProjectionShell {
+            id: self.id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            name: lock(&self.name)?.clone(),
+            owner: self.owner.clone(),
+            status,
+            run_id,
+            generation,
+            started_at_ms,
+            ended_at_ms,
+        })
+    }
+
     fn snapshot(&self) -> io::Result<ShellSnapshot> {
         let (status, run, runtime) = match &*lock(&self.lifecycle)? {
             ShellLifecycle::Pending => (ShellStatus::Pending, None, None),
@@ -14829,6 +15667,72 @@ mod tests {
         };
         assert_eq!(cursor, current_cursor);
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn protocol_thirty_one_filters_projection_invalidation_without_rewinding_cursor() {
+        let cursor = EventCursor {
+            stream_id: Uuid::new_v4().to_string(),
+            event_id: 4,
+        };
+        let response = response_for_version(
+            Response::Events {
+                stream_id: cursor.stream_id.clone(),
+                cursor: cursor.clone(),
+                snapshot: None,
+                events: vec![DaemonEvent {
+                    id: 4,
+                    at_ms: 10,
+                    kind: DaemonEventKind::NodeProjectionChanged {
+                        node_id: Uuid::from_u128(2).to_string(),
+                        cache_generation: 3,
+                    },
+                }],
+            },
+            31,
+        );
+        let Response::Events {
+            cursor: filtered_cursor,
+            events,
+            ..
+        } = response
+        else {
+            panic!("expected events");
+        };
+        assert_eq!(filtered_cursor, cursor);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn projection_cut_resumes_exactly_or_reseeds_on_stream_expiry() {
+        let events = EventStream::new();
+        let baseline = events.transaction().unwrap().cursor();
+        events
+            .publish(DaemonEventKind::WorkspaceCreated {
+                workspace_id: "workspace-1".into(),
+                name: "private-name-is-not-copied-into-transition".into(),
+            })
+            .unwrap();
+        let transaction = events.transaction().unwrap();
+        let through = transaction.cursor();
+        let (mode, transitions) =
+            projection_transitions(&transaction.events, Some(&baseline), &through);
+        assert_eq!(mode, NodeProjectionSyncMode::Resumed);
+        assert!(matches!(
+            transitions.as_slice(),
+            [NodeProjectionTransition {
+                kind: NodeProjectionTransitionKind::Workspace { workspace_id },
+                ..
+            }] if workspace_id == "workspace-1"
+        ));
+        let expired = EventCursor {
+            stream_id: Uuid::new_v4().to_string(),
+            event_id: baseline.event_id,
+        };
+        let (mode, transitions) =
+            projection_transitions(&transaction.events, Some(&expired), &through);
+        assert_eq!(mode, NodeProjectionSyncMode::Baseline);
+        assert!(transitions.is_empty());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod federation;
 mod handoff;
 pub mod integrations;
 mod node_identity;
+mod node_projection;
 mod node_registration;
 pub mod protocol;
 pub mod scheduling;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1647,26 +1647,81 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
             print_node_registration(CommandKey::NodeAdd, &registration, json)
         }
         NodeCommands::List => {
-            let registrations = client::connect_or_start()?.node_registrations()?;
+            let client = client::connect_or_start()?;
+            let registrations = client.node_registrations()?;
+            let projection_supported =
+                client.supports(protocol::ProtocolFeature::NodeProjectionSync)?;
             if json {
-                print_json(CommandKey::NodeList, serde_json::to_value(registrations)?)
+                let rows = registrations
+                    .into_iter()
+                    .map(|registration| {
+                        let mut value = serde_json::to_value(registration)?;
+                        if projection_supported {
+                            let health = client.node_projection_health(
+                                value["node_id"].as_str().expect("Node ID is a string"),
+                            )?;
+                            value
+                                .as_object_mut()
+                                .expect("registration serializes as an object")
+                                .insert("projection".into(), serde_json::to_value(health)?);
+                        }
+                        Ok::<_, Box<dyn Error>>(value)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                print_json(CommandKey::NodeList, serde_json::to_value(rows)?)
             } else {
-                println!("ALIAS\tTARGET\tNODE ID\tREVISION");
+                println!("ALIAS\tTARGET\tNODE ID\tREVISION\tPROJECTION");
                 for registration in registrations {
+                    let health = projection_supported
+                        .then(|| client.node_projection_health(&registration.node_id))
+                        .transpose()?;
                     println!(
-                        "{}\t{}\t{}\t{}",
+                        "{}\t{}\t{}\t{}\t{}",
                         registration.alias,
                         registration.target,
                         registration.node_id,
-                        registration.revision
+                        registration.revision,
+                        health
+                            .map(|health| format!("{:?}", health.code).to_ascii_lowercase())
+                            .unwrap_or_else(|| "unsupported".into()),
                     );
                 }
                 Ok(())
             }
         }
         NodeCommands::Inspect { selector } => {
-            let registration = client::connect_or_start()?.node_registration(selector)?;
-            print_node_registration(CommandKey::NodeInspect, &registration, json)
+            let client = client::connect_or_start()?;
+            let registration = client.node_registration(selector)?;
+            let health = client
+                .supports(protocol::ProtocolFeature::NodeProjectionSync)?
+                .then(|| client.node_projection_health(&registration.node_id))
+                .transpose()?;
+            if json {
+                let mut value = serde_json::to_value(&registration)?;
+                if let Some(health) = health {
+                    value
+                        .as_object_mut()
+                        .expect("registration serializes as an object")
+                        .insert("projection".into(), serde_json::to_value(health)?);
+                }
+                print_json(CommandKey::NodeInspect, value)
+            } else {
+                print_node_registration(CommandKey::NodeInspect, &registration, false)?;
+                if let Some(health) = health {
+                    println!(
+                        "Projection: {}",
+                        format!("{:?}", health.code).to_ascii_lowercase()
+                    );
+                    println!("Projection stale: {}", health.stale);
+                    println!("Cache generation: {}", health.cache_generation);
+                    if let (Some(stream_id), Some(cursor)) = (health.stream_id, health.cursor) {
+                        println!("Remote cursor: {stream_id}:{cursor}");
+                    }
+                } else {
+                    println!("Projection: unsupported");
+                }
+                Ok(())
+            }
         }
         NodeCommands::Rename {
             selector,
@@ -9286,7 +9341,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 31);
+        assert_eq!(protocol::PROTOCOL_VERSION, 32);
     }
 
     #[test]

--- a/src/node_projection.rs
+++ b/src/node_projection.rs
@@ -1,0 +1,547 @@
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::protocol::{
+    EventCursor, NodeProjectionHealth, NodeProjectionHealthCode, NodeProjectionSnapshot,
+    NodeRegistrationSnapshot,
+};
+use crate::state_store::{effective_uid, secure_state_dir, state_directory_from_environment};
+
+const NODE_CACHE_VERSION: u32 = 1;
+const MAX_CACHE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_NODES: usize = 128;
+const MAX_WORKSPACES_PER_NODE: usize = 1_024;
+const MAX_SHELLS_PER_NODE: usize = 4_096;
+const MAX_LAUNCHERS_PER_NODE: usize = 4_096;
+const MAX_AGENTS_PER_NODE: usize = 4_096;
+const MAX_SCHEDULES_PER_NODE: usize = 1_024;
+const MAX_CAPABILITIES: usize = 96;
+const MAX_CAPABILITY_BYTES: usize = 128;
+const MAX_NAME_BYTES: usize = 256;
+
+pub(crate) struct NodeProjectionCache {
+    path: PathBuf,
+    state: Mutex<CacheState>,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CacheState {
+    version: u32,
+    nodes: Vec<CachedNode>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CachedNode {
+    node_id: String,
+    registration_revision: u64,
+    tombstone_epoch: u64,
+    generation: u64,
+    health: NodeProjectionHealthCode,
+    last_attempt_at_ms: Option<u64>,
+    last_success_at_ms: Option<u64>,
+    retry_at_ms: Option<u64>,
+    capabilities: Vec<String>,
+    cursor: Option<EventCursor>,
+    projection: Option<NodeProjectionSnapshot>,
+}
+
+impl NodeProjectionCache {
+    pub(crate) fn load_from_environment() -> Self {
+        let path = state_directory_from_environment()
+            .map(|directory| directory.join("node-cache.json"))
+            .unwrap_or_default();
+        Self::load_at(path)
+    }
+
+    fn load_at(path: PathBuf) -> Self {
+        let mut state = match load(&path) {
+            Ok(state) => state,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => empty_state(),
+            Err(error) => {
+                if !path.as_os_str().is_empty() {
+                    quarantine(&path);
+                }
+                eprintln!("boomux: discarded invalid disposable Node cache: {error}");
+                empty_state()
+            }
+        };
+        let mut changed = false;
+        for node in &mut state.nodes {
+            if node.health == NodeProjectionHealthCode::Online {
+                node.health = NodeProjectionHealthCode::Stale;
+                changed = true;
+            }
+        }
+        if changed && let Err(error) = save(&path, &state) {
+            eprintln!("boomux: could not mark recovered Node projections stale: {error}");
+        }
+        Self {
+            path,
+            state: Mutex::new(state),
+        }
+    }
+
+    pub(crate) fn health(
+        &self,
+        registration: &NodeRegistrationSnapshot,
+    ) -> io::Result<NodeProjectionHealth> {
+        let state = self.lock()?;
+        Ok(state
+            .nodes
+            .iter()
+            .find(|node| node.node_id == registration.node_id)
+            .filter(|node| node.tombstone_epoch == registration.tombstone_epoch)
+            .map(CachedNode::health_snapshot)
+            .unwrap_or_else(unobserved_health))
+    }
+
+    pub(crate) fn cursor_and_generation(
+        &self,
+        registration: &NodeRegistrationSnapshot,
+    ) -> io::Result<(Option<EventCursor>, u64)> {
+        let state = self.lock()?;
+        Ok(state
+            .nodes
+            .iter()
+            .find(|node| {
+                node.node_id == registration.node_id
+                    && node.tombstone_epoch == registration.tombstone_epoch
+            })
+            .map(|node| (node.cursor.clone(), node.generation))
+            .unwrap_or((None, 0)))
+    }
+
+    pub(crate) fn commit_projection(
+        &self,
+        registration: &NodeRegistrationSnapshot,
+        expected_generation: u64,
+        cursor: EventCursor,
+        projection: NodeProjectionSnapshot,
+        capabilities: Vec<String>,
+        now_ms: u64,
+    ) -> io::Result<Option<u64>> {
+        validate_projection(&projection)?;
+        validate_capabilities(&capabilities)?;
+        if projection.node_id != registration.node_id {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "projection owner does not match the pinned Node identity",
+            ));
+        }
+        let mut state = self.lock()?;
+        let current = state
+            .nodes
+            .iter()
+            .position(|node| node.node_id == registration.node_id);
+        let actual_generation = current
+            .filter(|index| state.nodes[*index].tombstone_epoch == registration.tombstone_epoch)
+            .map_or(0, |index| state.nodes[index].generation);
+        if actual_generation != expected_generation {
+            return Ok(None);
+        }
+        let generation = expected_generation
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("Node cache generation exhausted"))?;
+        let replacement = CachedNode {
+            node_id: registration.node_id.clone(),
+            registration_revision: registration.revision,
+            tombstone_epoch: registration.tombstone_epoch,
+            generation,
+            health: NodeProjectionHealthCode::Online,
+            last_attempt_at_ms: Some(now_ms),
+            last_success_at_ms: Some(now_ms),
+            retry_at_ms: None,
+            capabilities,
+            cursor: Some(cursor),
+            projection: Some(projection),
+        };
+        let mut next = state.clone();
+        match current {
+            Some(index) => next.nodes[index] = replacement,
+            None if next.nodes.len() < MAX_NODES => next.nodes.push(replacement),
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Node cache registration limit reached",
+                ));
+            }
+        }
+        sort_nodes(&mut next);
+        save(&self.path, &next)?;
+        *state = next;
+        Ok(Some(generation))
+    }
+
+    pub(crate) fn mark_health(
+        &self,
+        registration: &NodeRegistrationSnapshot,
+        expected_generation: u64,
+        health: NodeProjectionHealthCode,
+        attempt_at_ms: u64,
+        retry_at_ms: Option<u64>,
+    ) -> io::Result<Option<u64>> {
+        let mut state = self.lock()?;
+        let current = state
+            .nodes
+            .iter()
+            .position(|node| node.node_id == registration.node_id);
+        let actual_generation = current
+            .filter(|index| state.nodes[*index].tombstone_epoch == registration.tombstone_epoch)
+            .map_or(0, |index| state.nodes[index].generation);
+        if actual_generation != expected_generation {
+            return Ok(None);
+        }
+        let generation = expected_generation
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("Node cache generation exhausted"))?;
+        let mut replacement = current.map_or_else(
+            || CachedNode {
+                node_id: registration.node_id.clone(),
+                registration_revision: registration.revision,
+                tombstone_epoch: registration.tombstone_epoch,
+                generation,
+                health,
+                last_attempt_at_ms: Some(attempt_at_ms),
+                last_success_at_ms: None,
+                retry_at_ms,
+                capabilities: Vec::new(),
+                cursor: None,
+                projection: None,
+            },
+            |index| state.nodes[index].clone(),
+        );
+        replacement.registration_revision = registration.revision;
+        replacement.tombstone_epoch = registration.tombstone_epoch;
+        replacement.generation = generation;
+        replacement.health = health;
+        replacement.last_attempt_at_ms = Some(attempt_at_ms);
+        replacement.retry_at_ms = retry_at_ms;
+        let mut next = state.clone();
+        match current {
+            Some(index) => next.nodes[index] = replacement,
+            None if next.nodes.len() < MAX_NODES => next.nodes.push(replacement),
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Node cache limit reached",
+                ));
+            }
+        }
+        sort_nodes(&mut next);
+        save(&self.path, &next)?;
+        *state = next;
+        Ok(Some(generation))
+    }
+
+    pub(crate) fn remove(&self, node_id: &str) -> io::Result<bool> {
+        let mut state = self.lock()?;
+        let mut next = state.clone();
+        next.nodes.retain(|node| node.node_id != node_id);
+        if next.nodes.len() == state.nodes.len() {
+            return Ok(false);
+        }
+        save(&self.path, &next)?;
+        *state = next;
+        Ok(true)
+    }
+
+    fn lock(&self) -> io::Result<std::sync::MutexGuard<'_, CacheState>> {
+        self.state
+            .lock()
+            .map_err(|_| io::Error::other("Node cache lock is poisoned"))
+    }
+}
+
+impl CachedNode {
+    fn health_snapshot(&self) -> NodeProjectionHealth {
+        NodeProjectionHealth {
+            code: self.health,
+            stale: self.health != NodeProjectionHealthCode::Online,
+            cache_generation: self.generation,
+            stream_id: self.cursor.as_ref().map(|cursor| cursor.stream_id.clone()),
+            cursor: self.cursor.as_ref().map(|cursor| cursor.event_id),
+            last_attempt_at_ms: self.last_attempt_at_ms,
+            last_success_at_ms: self.last_success_at_ms,
+            retry_at_ms: self.retry_at_ms,
+            capabilities: self.capabilities.clone(),
+        }
+    }
+}
+
+fn unobserved_health() -> NodeProjectionHealth {
+    NodeProjectionHealth {
+        code: NodeProjectionHealthCode::Unobserved,
+        stale: true,
+        cache_generation: 0,
+        stream_id: None,
+        cursor: None,
+        last_attempt_at_ms: None,
+        last_success_at_ms: None,
+        retry_at_ms: None,
+        capabilities: Vec::new(),
+    }
+}
+
+fn empty_state() -> CacheState {
+    CacheState {
+        version: NODE_CACHE_VERSION,
+        nodes: Vec::new(),
+    }
+}
+
+fn validate_projection(projection: &NodeProjectionSnapshot) -> io::Result<()> {
+    if Uuid::parse_str(&projection.node_id).is_err()
+        || projection.workspaces.len() > MAX_WORKSPACES_PER_NODE
+        || projection.shells.len() > MAX_SHELLS_PER_NODE
+        || projection.launchers.len() > MAX_LAUNCHERS_PER_NODE
+        || projection.agents.len() > MAX_AGENTS_PER_NODE
+        || projection.schedules.len() > MAX_SCHEDULES_PER_NODE
+        || projection.executions.len()
+            > usize::from(crate::protocol::MAX_NODE_PROJECTION_EXECUTIONS)
+    {
+        return Err(invalid("Node projection exceeds its structural bounds"));
+    }
+    let mut ids = HashSet::new();
+    for workspace in &projection.workspaces {
+        validate_name(&workspace.id)?;
+        validate_name(&workspace.name)?;
+        if !ids.insert(("workspace", workspace.id.as_str())) {
+            return Err(invalid("Node projection contains duplicate workspace IDs"));
+        }
+    }
+    for name in projection
+        .shells
+        .iter()
+        .map(|item| item.name.as_str())
+        .chain(projection.launchers.iter().map(|item| item.name.as_str()))
+        .chain(projection.agents.iter().map(|item| item.name.as_str()))
+        .chain(projection.schedules.iter().map(|item| item.name.as_str()))
+    {
+        validate_name(name)?;
+    }
+    Ok(())
+}
+
+fn validate_name(value: &str) -> io::Result<()> {
+    if value.is_empty() || value.len() > MAX_NAME_BYTES || value.chars().any(char::is_control) {
+        Err(invalid(
+            "Node projection contains an invalid bounded string",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_capabilities(capabilities: &[String]) -> io::Result<()> {
+    if capabilities.len() > MAX_CAPABILITIES
+        || capabilities.iter().any(|capability| {
+            capability.is_empty()
+                || capability.len() > MAX_CAPABILITY_BYTES
+                || !capability
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+        })
+    {
+        return Err(invalid("Node projection capabilities exceed their bounds"));
+    }
+    Ok(())
+}
+
+fn load(path: &Path) -> io::Result<CacheState> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.uid() != effective_uid() || metadata.mode() & 0o077 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Node cache is not an owner-only regular file",
+        ));
+    }
+    if metadata.len() > MAX_CACHE_BYTES {
+        return Err(invalid("Node cache exceeds the file-size bound"));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.read_to_end(&mut bytes)?;
+    let state: CacheState =
+        serde_json::from_slice(&bytes).map_err(|error| invalid(error.to_string()))?;
+    if state.version != NODE_CACHE_VERSION || state.nodes.len() > MAX_NODES {
+        return Err(invalid("unsupported or oversized Node cache"));
+    }
+    let mut node_ids = HashSet::new();
+    for node in &state.nodes {
+        if !node_ids.insert(node.node_id.as_str()) || node.generation == 0 {
+            return Err(invalid(
+                "Node cache contains duplicate or invalid generations",
+            ));
+        }
+        validate_capabilities(&node.capabilities)?;
+        if let Some(projection) = &node.projection {
+            if projection.node_id != node.node_id {
+                return Err(invalid("Node cache projection identity mismatch"));
+            }
+            validate_projection(projection)?;
+        }
+    }
+    Ok(state)
+}
+
+fn save(path: &Path, state: &CacheState) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("Node cache path has no parent"))?;
+    secure_state_dir(parent)?;
+    let bytes = serde_json::to_vec_pretty(state).map_err(io::Error::other)?;
+    if bytes.len() as u64 > MAX_CACHE_BYTES {
+        return Err(invalid("Node cache exceeds the file-size bound"));
+    }
+    let temporary = parent.join(format!(".node-cache-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)?;
+        let _ = File::open(parent).and_then(|directory| directory.sync_all());
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn quarantine(path: &Path) {
+    let Some(parent) = path.parent() else { return };
+    let quarantine = parent.join(format!("node-cache.corrupt-{}.json", Uuid::new_v4()));
+    let _ = fs::rename(path, quarantine);
+}
+
+fn sort_nodes(state: &mut CacheState) {
+    state
+        .nodes
+        .sort_by(|left, right| left.node_id.cmp(&right.node_id));
+}
+
+fn invalid(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{SchedulerHealth, SchedulerState};
+
+    fn projection(node_id: String) -> NodeProjectionSnapshot {
+        NodeProjectionSnapshot {
+            node_id,
+            workspaces: Vec::new(),
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: Vec::new(),
+            schedules: Vec::new(),
+            executions: Vec::new(),
+            executions_truncated: false,
+            scheduler: SchedulerHealth {
+                state: SchedulerState::Active,
+                max_concurrent: 4,
+                active_executions: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn reduced_cache_rejects_rich_and_corrupt_payloads() {
+        let projection = projection(Uuid::from_u128(2).to_string());
+        let json = serde_json::to_value(&projection).unwrap();
+        for private in [
+            "cwd",
+            "command",
+            "prompt",
+            "evidence",
+            "environment",
+            "external_session_id",
+            "runner_token",
+        ] {
+            assert!(!json.to_string().contains(private));
+        }
+        let mut rich = json;
+        rich.as_object_mut()
+            .unwrap()
+            .insert("prompt".into(), serde_json::json!("secret"));
+        assert!(serde_json::from_value::<NodeProjectionSnapshot>(rich).is_err());
+    }
+
+    #[test]
+    fn cache_commit_is_generation_conditional_and_corruption_is_quarantined() {
+        let root = std::env::temp_dir().join(format!("boomux-node-cache-{}", Uuid::new_v4()));
+        let path = root.join("boomux/node-cache.json");
+        let node_id = Uuid::from_u128(2).to_string();
+        let registration = NodeRegistrationSnapshot {
+            alias: "work".into(),
+            target: "work.example".into(),
+            node_id: node_id.clone(),
+            revision: 1,
+            tombstone_epoch: 0,
+        };
+        let cache = NodeProjectionCache::load_at(path.clone());
+        assert_eq!(
+            cache
+                .commit_projection(
+                    &registration,
+                    0,
+                    EventCursor {
+                        stream_id: Uuid::new_v4().to_string(),
+                        event_id: 7
+                    },
+                    projection(node_id),
+                    vec!["protocol_32".into()],
+                    10,
+                )
+                .unwrap(),
+            Some(1)
+        );
+        assert_eq!(
+            cache
+                .mark_health(&registration, 0, NodeProjectionHealthCode::Stale, 11, None)
+                .unwrap(),
+            None
+        );
+        drop(cache);
+        assert_eq!(
+            NodeProjectionCache::load_at(path.clone())
+                .health(&registration)
+                .unwrap()
+                .cursor,
+            Some(7)
+        );
+
+        fs::write(&path, b"not-json").unwrap();
+        let discarded = NodeProjectionCache::load_at(path.clone());
+        assert_eq!(
+            discarded.health(&registration).unwrap().code,
+            NodeProjectionHealthCode::Unobserved
+        );
+        assert!(fs::read_dir(path.parent().unwrap()).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with("node-cache.corrupt-")
+        }));
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/node_registration.rs
+++ b/src/node_registration.rs
@@ -120,6 +120,67 @@ impl NodeRegistrationManager {
         Ok(find(state, selector)?.snapshot.clone())
     }
 
+    pub(crate) fn with_current<T>(
+        &self,
+        expected: &NodeRegistrationSnapshot,
+        operation: impl FnOnce() -> io::Result<T>,
+    ) -> io::Result<Option<T>> {
+        let state = self.lock_state()?;
+        let state = available(&state)?;
+        let Some(registration) = state
+            .registrations
+            .iter()
+            .find(|registration| registration.snapshot.node_id == expected.node_id)
+        else {
+            return Ok(None);
+        };
+        if registration.snapshot.revision != expected.revision
+            || registration.snapshot.tombstone_epoch != expected.tombstone_epoch
+            || registration.snapshot.target != expected.target
+            || !registration.admission_open
+        {
+            return Ok(None);
+        }
+        operation().map(Some)
+    }
+
+    pub(crate) fn admit(&self, expected: &NodeRegistrationSnapshot) -> io::Result<bool> {
+        let mut state = self.lock_state()?;
+        let state = available_mut(&mut state)?;
+        let Some(registration) = state
+            .registrations
+            .iter_mut()
+            .find(|registration| registration.snapshot.node_id == expected.node_id)
+        else {
+            return Ok(false);
+        };
+        if registration.snapshot.revision != expected.revision
+            || registration.snapshot.tombstone_epoch != expected.tombstone_epoch
+            || !registration.admission_open
+        {
+            return Ok(false);
+        }
+        registration.admitted = registration
+            .admitted
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("Node registration admission exhausted"))?;
+        Ok(true)
+    }
+
+    pub(crate) fn release(&self, expected: &NodeRegistrationSnapshot) {
+        if let Ok(mut state) = self.state.lock()
+            && let Ok(state) = available_mut(&mut state)
+            && let Some(registration) = state
+                .registrations
+                .iter_mut()
+                .find(|registration| registration.snapshot.node_id == expected.node_id)
+            && registration.snapshot.revision == expected.revision
+        {
+            registration.admitted = registration.admitted.saturating_sub(1);
+            self.changed.notify_all();
+        }
+    }
+
     pub(crate) fn add(
         &self,
         alias: String,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 31;
+pub const PROTOCOL_VERSION: u32 = 32;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -123,11 +123,18 @@ define_protocol_features! {
         "node_registration_management",
         "pinned_node_identity",
     ]),
+    NodeProjectionSync => (32, "Node projection synchronization", [
+        "protocol_32",
+        "node_projection_sync",
+        "bounded_remote_node_projections",
+    ]),
 }
 
 pub const DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 100;
 pub const MAX_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 1_000;
 pub const MAX_SCHEDULED_EXECUTION_SCHEDULE_PROJECTIONS: u16 = 100;
+pub const MAX_NODE_PROJECTION_EXECUTIONS: u16 = 1_000;
+pub const MAX_NODE_PROJECTION_TRANSITIONS: u16 = 256;
 
 pub fn protocol_capabilities() -> impl Iterator<Item = &'static str> {
     ProtocolFeature::ALL
@@ -243,6 +250,221 @@ pub struct NodeRegistrationSnapshot {
     pub node_id: String,
     pub revision: u64,
     pub tombstone_epoch: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeProjectionHealthCode {
+    Unobserved,
+    Online,
+    Reconnecting,
+    Stale,
+    Unreachable,
+    AuthenticationRequired,
+    IdentityChanged,
+    IdentityConflict,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionHealth {
+    pub code: NodeProjectionHealthCode,
+    pub stale: bool,
+    pub cache_generation: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_attempt_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_success_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_at_ms: Option<u64>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionWorkspace {
+    pub id: String,
+    pub name: String,
+    pub item_count: u32,
+    pub attention_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionShell {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+    pub owner: ShellOwner,
+    pub status: ShellStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionLauncher {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionAttention {
+    pub reason: AgentAttentionReason,
+    pub observation_revision: u64,
+    pub observed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionAgent {
+    pub id: String,
+    pub workspace_id: String,
+    pub shell_id: String,
+    pub run_id: String,
+    pub name: String,
+    pub integration: String,
+    pub state: AgentState,
+    pub observation_revision: u64,
+    pub observed_at_ms: u64,
+    pub started_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention: Option<NodeProjectionAttention>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionSchedule {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+    pub integration: String,
+    pub state: AgentScheduleState,
+    pub trigger: AgentScheduleTrigger,
+    pub revision: u64,
+    pub prompt_revision: u64,
+    pub trigger_revision: u64,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_occurrence: Option<ScheduledOccurrence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionExecution {
+    pub id: String,
+    pub workspace_id: String,
+    pub schedule_id: String,
+    pub revision: u64,
+    pub state: ScheduledExecutionState,
+    pub dispatch_kind: ScheduledExecutionDispatchKind,
+    pub schedule_revision: u64,
+    pub prompt_revision: u64,
+    pub trigger_revision: u64,
+    pub requested_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduled_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<ScheduledExecutionReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<ScheduledExecutionOutcome>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionSnapshot {
+    pub node_id: String,
+    pub workspaces: Vec<NodeProjectionWorkspace>,
+    pub shells: Vec<NodeProjectionShell>,
+    pub launchers: Vec<NodeProjectionLauncher>,
+    pub agents: Vec<NodeProjectionAgent>,
+    pub schedules: Vec<NodeProjectionSchedule>,
+    pub executions: Vec<NodeProjectionExecution>,
+    pub executions_truncated: bool,
+    pub scheduler: SchedulerHealth,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "transition", rename_all = "snake_case", deny_unknown_fields)]
+pub enum NodeProjectionTransitionKind {
+    Workspace {
+        workspace_id: String,
+    },
+    Shell {
+        workspace_id: String,
+        shell_id: String,
+    },
+    Launcher {
+        workspace_id: String,
+        launcher_id: String,
+    },
+    Agent {
+        workspace_id: String,
+        agent_id: String,
+        revision: u64,
+    },
+    Schedule {
+        workspace_id: String,
+        schedule_id: String,
+        revision: Option<u64>,
+    },
+    Execution {
+        workspace_id: String,
+        execution_id: String,
+        revision: u64,
+    },
+    HandoffCompleted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionTransition {
+    pub event_id: u64,
+    pub at_ms: u64,
+    pub kind: NodeProjectionTransitionKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeProjectionSyncMode {
+    Baseline,
+    Resumed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeProjectionSync {
+    pub mode: NodeProjectionSyncMode,
+    pub cursor: EventCursor,
+    pub projection: NodeProjectionSnapshot,
+    pub transitions: Vec<NodeProjectionTransition>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -822,6 +1044,10 @@ pub enum DaemonEventKind {
         workspace_id: String,
         execution: ScheduledExecutionSnapshot,
     },
+    NodeProjectionChanged {
+        node_id: String,
+        cache_generation: u64,
+    },
     HandoffCompleted,
 }
 
@@ -974,6 +1200,15 @@ pub enum Request {
         expected_revision: u64,
     },
     ForgetNodeRegistration {
+        selector: String,
+    },
+    SyncNodeProjection {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        after: Option<EventCursor>,
+        #[serde(default)]
+        wait_ms: u32,
+    },
+    GetNodeProjectionHealth {
         selector: String,
     },
     Restart,
@@ -1171,6 +1406,9 @@ impl Request {
             | Self::RenameNodeRegistration { .. }
             | Self::RetargetNodeRegistration { .. }
             | Self::ForgetNodeRegistration { .. } => Some(ProtocolFeature::NodeRegistration),
+            Self::SyncNodeProjection { .. } | Self::GetNodeProjectionHealth { .. } => {
+                Some(ProtocolFeature::NodeProjectionSync)
+            }
             Self::WaitScheduledExecution { .. } => {
                 Some(ProtocolFeature::ScheduledExecutionObservation)
             }
@@ -1282,6 +1520,12 @@ pub enum Response {
     },
     NodeRegistrations {
         registrations: Vec<NodeRegistrationSnapshot>,
+    },
+    NodeProjectionSync {
+        sync: NodeProjectionSync,
+    },
+    NodeProjectionHealth {
+        health: NodeProjectionHealth,
     },
     Snapshot {
         snapshot: Snapshot,
@@ -1863,8 +2107,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_thirty_one_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 31);
+    fn protocol_version_is_thirty_two_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 32);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -1962,6 +2206,60 @@ mod tests {
                 response
             );
         }
+    }
+
+    #[test]
+    fn node_projection_sync_is_protocol_thirty_two_and_privacy_allowlisted() {
+        let request = Request::SyncNodeProjection {
+            after: Some(EventCursor {
+                stream_id: "stream".into(),
+                event_id: 9,
+            }),
+            wait_ms: 1_000,
+        };
+        assert_eq!(
+            request.required_feature(),
+            Some(ProtocolFeature::NodeProjectionSync)
+        );
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(&request).unwrap()).unwrap(),
+            request
+        );
+
+        let projection = NodeProjectionSnapshot {
+            node_id: uuid::Uuid::from_u128(2).to_string(),
+            workspaces: Vec::new(),
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: Vec::new(),
+            schedules: Vec::new(),
+            executions: Vec::new(),
+            executions_truncated: false,
+            scheduler: SchedulerHealth {
+                state: SchedulerState::Active,
+                max_concurrent: 4,
+                active_executions: 0,
+            },
+        };
+        let mut encoded = serde_json::to_value(projection).unwrap();
+        let serialized = encoded.to_string();
+        for private in [
+            "cwd",
+            "command",
+            "terminal",
+            "prompt",
+            "evidence",
+            "environment",
+            "external_session_id",
+            "runner_token",
+        ] {
+            assert!(!serialized.contains(private));
+        }
+        encoded
+            .as_object_mut()
+            .unwrap()
+            .insert("prompt".into(), serde_json::json!("private"));
+        assert!(serde_json::from_value::<NodeProjectionSnapshot>(encoded).is_err());
     }
 
     #[test]
@@ -2716,6 +3014,14 @@ mod tests {
                     "protocol_31",
                     "node_registration_management",
                     "pinned_node_identity",
+                ][..],
+            ),
+            (
+                32,
+                &[
+                    "protocol_32",
+                    "node_projection_sync",
+                    "bounded_remote_node_projections",
                 ][..],
             ),
         ];

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -5,6 +5,7 @@ use std::fs::{self, OpenOptions};
 use std::io::{self, Read, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::io::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
@@ -150,6 +151,120 @@ impl RemoteConnection {
             ))
         }
     }
+
+    pub(crate) fn node_projection_sync(
+        &mut self,
+        after: Option<protocol::EventCursor>,
+        timeout: Duration,
+    ) -> io::Result<protocol::NodeProjectionSync> {
+        let version = self.handshake.core_protocol_version;
+        if !protocol::ProtocolFeature::NodeProjectionSync.is_supported_by(version) {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "remote Node does not support projection synchronization",
+            ));
+        }
+        let wait_ms = if after.is_some() { 1_000 } else { 0 };
+        protocol::write_message(
+            self.stdin.as_mut().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "remote channel closed")
+            })?,
+            &Envelope::with_version(version, Request::SyncNodeProjection { after, wait_ms }),
+        )?;
+        let response: Envelope<Response> = read_message_with_deadline(&mut self.stdout, timeout)?;
+        if response.version != version {
+            return Err(invalid_probe("remote projection response version mismatch"));
+        }
+        match response.message {
+            Response::NodeProjectionSync { sync } => Ok(sync),
+            Response::Error { message, .. } => Err(io::Error::other(message)),
+            _ => Err(invalid_probe(
+                "remote helper returned an invalid projection response",
+            )),
+        }
+    }
+}
+
+fn read_message_with_deadline<T: serde::de::DeserializeOwned>(
+    reader: &mut (impl Read + AsRawFd),
+    timeout: Duration,
+) -> io::Result<T> {
+    if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "response deadline is outside the supported bound",
+        ));
+    }
+    let fd = reader.as_raw_fd();
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    let deadline = Instant::now() + timeout;
+    let result = (|| {
+        let mut length = [0_u8; 4];
+        read_exact_with_deadline(reader, fd, &mut length, deadline)?;
+        let length = u32::from_be_bytes(length) as usize;
+        if length > protocol::MAX_CONTROL_FRAME {
+            return Err(invalid_probe("remote control frame exceeds the size limit"));
+        }
+        let mut bytes = vec![0; length];
+        read_exact_with_deadline(reader, fd, &mut bytes, deadline)?;
+        serde_json::from_slice(&bytes).map_err(io::Error::other)
+    })();
+    let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
+    result
+}
+
+fn read_exact_with_deadline(
+    reader: &mut impl Read,
+    fd: i32,
+    mut bytes: &mut [u8],
+    deadline: Instant,
+) -> io::Result<()> {
+    while !bytes.is_empty() {
+        match reader.read(bytes) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "remote channel closed",
+                ));
+            }
+            Ok(count) => bytes = &mut bytes[count..],
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "remote response timed out",
+                    ));
+                }
+                let mut descriptor = libc::pollfd {
+                    fd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                };
+                let milliseconds =
+                    i32::try_from(remaining.as_millis().min(i32::MAX as u128)).unwrap_or(i32::MAX);
+                let status = unsafe { libc::poll(&mut descriptor, 1, milliseconds) };
+                if status == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "remote response timed out",
+                    ));
+                }
+                if status == -1 {
+                    let error = io::Error::last_os_error();
+                    if error.kind() != io::ErrorKind::Interrupted {
+                        return Err(error);
+                    }
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
 }
 
 impl Drop for RemoteConnection {

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 31);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 32);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -120,7 +120,10 @@ fn native_daemon_lifecycle() {
         "protocol_29",
         "protocol_30",
         "protocol_31",
+        "protocol_32",
         "node_registration_management",
+        "node_projection_sync",
+        "bounded_remote_node_projections",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -155,7 +158,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 31"));
+    assert!(status_text.contains("running (protocol 32"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -915,7 +918,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 31);
+    assert_eq!(handshake.core_protocol_version, 32);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 use boomux::client::{ClientError, RemoteError};
 use boomux::protocol::ErrorCode;
@@ -11,6 +13,18 @@ use crate::support::TestDaemon;
 
 fn node_id(value: u128) -> String {
     Uuid::from_u128(value).to_string()
+}
+
+fn contains_json_key(value: &serde_json::Value, key: &str) -> bool {
+    match value {
+        serde_json::Value::Object(values) => {
+            values.contains_key(key) || values.values().any(|value| contains_json_key(value, key))
+        }
+        serde_json::Value::Array(values) => {
+            values.iter().any(|value| contains_json_key(value, key))
+        }
+        _ => false,
+    }
 }
 
 #[test]
@@ -76,7 +90,10 @@ fn fake_ssh(directory: &Path) {
     use boomux::federation::{
         FEDERATION_VERSION, FederationConnectionMode, FederationHandshake, write_handshake,
     };
-    use boomux::protocol::{self, Envelope, Request, Response};
+    use boomux::protocol::{
+        self, Envelope, EventCursor, NodeProjectionSnapshot, NodeProjectionSync,
+        NodeProjectionSyncMode, Response, SchedulerHealth, SchedulerState,
+    };
 
     let handshake = FederationHandshake {
         version: FEDERATION_VERSION,
@@ -87,26 +104,55 @@ fn fake_ssh(directory: &Path) {
     };
     let mut handshake_bytes = Vec::new();
     write_handshake(&mut handshake_bytes, &handshake).unwrap();
-    let mut request = Vec::new();
+    let mut ping = Vec::new();
     protocol::write_message(
-        &mut request,
-        &Envelope::with_version(protocol::PROTOCOL_VERSION, Request::Ping),
-    )
-    .unwrap();
-    let mut response = Vec::new();
-    protocol::write_message(
-        &mut response,
+        &mut ping,
         &Envelope::with_version(protocol::PROTOCOL_VERSION, Response::Pong),
     )
     .unwrap();
+    let mut sync = Vec::new();
+    protocol::write_message(
+        &mut sync,
+        &Envelope::with_version(
+            protocol::PROTOCOL_VERSION,
+            Response::NodeProjectionSync {
+                sync: NodeProjectionSync {
+                    mode: NodeProjectionSyncMode::Baseline,
+                    cursor: EventCursor {
+                        stream_id: Uuid::from_u128(20).to_string(),
+                        event_id: 0,
+                    },
+                    projection: NodeProjectionSnapshot {
+                        node_id: node_id(2),
+                        workspaces: Vec::new(),
+                        shells: Vec::new(),
+                        launchers: Vec::new(),
+                        agents: Vec::new(),
+                        schedules: Vec::new(),
+                        executions: Vec::new(),
+                        executions_truncated: false,
+                        scheduler: SchedulerHealth {
+                            state: SchedulerState::Active,
+                            max_concurrent: 4,
+                            active_executions: 0,
+                        },
+                    },
+                    transitions: Vec::new(),
+                },
+            },
+        ),
+    )
+    .unwrap();
+    fs::write(directory.join("pong.bin"), ping).unwrap();
+    fs::write(directory.join("sync.bin"), sync).unwrap();
     let ssh = directory.join("ssh");
     fs::write(
         &ssh,
         format!(
-            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") {}; dd bs=1 count={} of=/dev/null 2>/dev/null; {} ;;\n  *) exit 64 ;;\nesac\n",
+            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") {}; python3 -c 'import json,struct,sys; data=sys.stdin.buffer.read(struct.unpack(\">I\",sys.stdin.buffer.read(4))[0]); request=json.loads(data)[\"message\"][\"request\"]; path=sys.argv[1] if request==\"ping\" else sys.argv[2]; sys.stdout.buffer.write(open(path,\"rb\").read())' \"{}\" \"{}\" ;;\n  *) exit 64 ;;\nesac\n",
             shell_printf(&handshake_bytes),
-            request.len(),
-            shell_printf(&response),
+            directory.join("pong.bin").display(),
+            directory.join("sync.bin").display(),
         ),
     )
     .unwrap();
@@ -149,6 +195,40 @@ fn cli_add_and_retarget_pin_verified_identity_without_persisting_helper_path() {
     assert_eq!(list["data"][0]["node_id"], node_id(2));
     let revision = list["data"][0]["revision"].as_u64().unwrap();
 
+    let mut online = None;
+    let mut last_inspect = None;
+    for _ in 0..200 {
+        let inspect = command(&directory)
+            .args(["node", "inspect", "work", "--json"])
+            .output()
+            .unwrap();
+        assert!(inspect.status.success());
+        let inspect: serde_json::Value = serde_json::from_slice(&inspect.stdout).unwrap();
+        if inspect["data"]["projection"]["code"] == "online" {
+            online = Some(inspect);
+            break;
+        }
+        last_inspect = Some(inspect);
+        thread::sleep(Duration::from_millis(25));
+    }
+    let online = online
+        .unwrap_or_else(|| panic!("background projection did not become online: {last_inspect:?}"));
+    assert_eq!(online["data"]["projection"]["cursor"], 0);
+    let cache: serde_json::Value =
+        serde_json::from_slice(&fs::read(directory.join("state/boomux/node-cache.json")).unwrap())
+            .unwrap();
+    for private in [
+        "cwd",
+        "command",
+        "prompt",
+        "evidence",
+        "environment",
+        "external_session_id",
+        "runner_token",
+    ] {
+        assert!(!contains_json_key(&cache, private));
+    }
+
     let retarget = command(&directory)
         .args([
             "node",
@@ -169,6 +249,23 @@ fn cli_add_and_retarget_pin_verified_identity_without_persisting_helper_path() {
         fs::read_to_string(directory.join("state/boomux/node_registrations.json")).unwrap();
     assert!(persisted.contains("otherbox"));
     assert!(!persisted.contains("/remote/boomux"));
+
+    let restart = command(&directory)
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(restart.status.success());
+    let inspect = command(&directory)
+        .args(["node", "inspect", "work", "--json"])
+        .output()
+        .unwrap();
+    assert!(inspect.status.success());
+    let inspect: serde_json::Value = serde_json::from_slice(&inspect.stdout).unwrap();
+    assert!(
+        inspect["data"]["projection"]["cache_generation"]
+            .as_u64()
+            .is_some_and(|generation| generation > 0)
+    );
 
     let stop = command(&directory)
         .args(["daemon", "stop"])


### PR DESCRIPTION
## Summary

- add protocol 32 privacy-allowlisted owner projection synchronization
- persist bounded disposable projections in independent `node-cache.json`
- atomically commit projection, cursor, health, capabilities, and generation with registration CAS
- run one bounded noninteractive pinned-identity worker per registration
- preserve stale cache across disconnect and quarantine invalid disposable cache data
- publish projection invalidation only after cache persistence and filter it for older clients
- drain workers across graceful handoff without transferring SSH state

## Stack

- GitHub stack #190
- depends on #198
- implements #177

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`

Closes #177

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
