### PR TITLE
feat(node): combine federated dashboard views

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,9 @@ opening and pinging a daemon-bound stdio channel. Explicit `boomux node add
 ALIAS TARGET` and revision-conditional registration management persist an
 identity-pinned route separately. A registration starts one noninteractive
 projection worker; routed dashboard and resource-management operations are not
-yet implemented.
+yet implemented. Protocol 33 exposes cached projections through the separately
+named combined Node snapshot and dashboard while existing snapshot and list
+operations remain local-only; remote mutation remains unavailable.
 
 ## Components
 
@@ -555,6 +557,13 @@ executions (all nonterminal records first), a remote stream cursor, and at most
 a baseline with no historical transition evidence. Protocol-31 and older event
 readers filter local `node_projection_changed` invalidations while retaining the
 unfiltered cursor. The authoritative state schema remains 12.
+Protocol 33 adds one local-daemon combined snapshot request. It returns the rich
+authoritative local snapshot and bounded reduced registered-Node projections
+with alias, ownership, stable health, freshness, observation time, observed
+protocol capabilities, and per-Node scheduler health. Dashboard model identity
+and effects use `(node_id, inner_id)`; remote rows never enter local Git, host
+catalog, path, preview, or mutation paths. Protocol-32 and older clients cannot
+request this response and retain local-only behavior.
 Protocol-25 lists are daemon-bounded, newest-first pages with explicit limit and
 truncation. The request limit is optional on the wire; protocol 25 defaults it to
 100 and clamps it to 1 through 1,000, while protocol-23 and protocol-24 requests

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -48,6 +48,10 @@ advertises registration management explicitly; clients must not infer support
 from a CLI or daemon version string. Registration commands manage local routes
 only and do not imply projected reads or routed resource mutation.
 
+Protocol 33 advertises the separately named `node.snapshot` combined read. It
+contacts only the local daemon and never changes the local-only meaning of any
+existing snapshot or list operation.
+
 That passive command advertises only what the installed local CLI can speak and
 never reports negotiated state for a registered Node. Implemented `node.list`
 and `node.inspect` return registration data only. Future combined projection data
@@ -93,6 +97,7 @@ The following commands support `--json`:
 - `boomux node add`
 - `boomux node list`
 - `boomux node inspect`
+- `boomux node snapshot [SELECTOR]`
 - `boomux node rename`
 - `boomux node retarget`
 - `boomux node forget`
@@ -165,6 +170,16 @@ Command payloads are:
   one registration object with `alias`, exact `target`, pinned `node_id`,
   `revision`, and `tombstone_epoch`. Add and retarget verify the SSH route before
   the local mutation; forget performs no SSH operation.
+- `node.snapshot`: a `nodes` array containing the authoritative rich local Node
+  and bounded reduced cached remote Nodes. `SELECTOR` is an exact Node ID or
+  local alias; omission returns the all-Node overview. The local Node has alias
+  `local`. A selector matching both that alias and a registration returns typed
+  `ambiguous_target`; exact Node IDs disambiguate. Entries contain `node_id`,
+  `alias`, `local`, `health`, `current`, `stale`, `observed_at_ms`, nullable
+  `observed_protocol_version`, `observed_capabilities`, `scheduler`, and nullable
+  `local_snapshot` and `remote_projection` payloads. Every resource `id` and
+  relationship ID in those payloads is `{ "node_id": "...", "inner_id":
+  "..." }`; inner IDs are unchanged and must not be routed without their Node.
 - `shell.suggest-name`: exact resolved `workspace_id` plus a nonempty generated
   `name` that does not match any shell name in that workspace at observation
   time.
@@ -278,6 +293,16 @@ Protocol 27 adds `protocol_27` and `agent_schedule_editing` for paused,
 revision-conditional schedule-definition updates. Update responses and events
 remain prompt-free; exact inspection is still the only response that discloses
 the current prompt.
+Protocol 32 adds `protocol_32`, `node_projection_sync`, and
+`bounded_remote_node_projections`. Protocol 33 adds `protocol_33`,
+`combined_node_snapshot`, and `node_qualified_dashboard`.
+
+Node snapshot health is `unobserved`, `online`, `reconnecting`, `stale`,
+`unreachable`, `authentication_required`, `identity_changed`,
+`identity_conflict`, or `unsupported`. `current` is true only for a live
+identity-verified observation. Cached rows remain visible when stale, but cached
+state never authorizes terminal reads, private inspection, Schedule controls, or
+mutation. Scheduler health is reported independently for every Node.
 
 ## Execution Data
 

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -11,8 +11,9 @@
 > with exact interactive confirmation. Protocol 31 and registration schema 1
 > implement explicit identity-pinned registration management. Protocol 32 and
 > Node-cache schema 1 implement bounded background reduced projections. Public
-> `boomux --remote TARGET` remains ad hoc; routed resource operations are not yet
-> implemented.
+> Protocol 33 adds the local-daemon combined Node snapshot and federated
+> dashboard. Public `boomux --remote TARGET` remains ad hoc; routed resource
+> operations are not yet implemented.
 
 ## Purpose
 
@@ -287,6 +288,17 @@ JSON methods retain their local-only result sets; federation does not append
 remote rows to a legacy array. Exact private reads, terminal reads, waits, and
 every mutation require a live verified channel to the owning Node.
 
+The implemented surface is `boomux node snapshot [SELECTOR]`. It emits a rich
+authoritative local projection and reduced remote projections with structurally
+qualified resource identities. The dashboard consumes the same request, keeps
+stale rows visible, exposes all-Node and exact-Node filtering, and never passes
+remote records to local Git, host-session catalog, path, terminal-preview, or
+mutation code. Remote actions remain disabled in this slice.
+After successful ad hoc `--remote TARGET` verification, Boomux focuses the
+matching Node in the local dashboard when that Node is already registered and
+the local daemon supports the combined view; otherwise the ad hoc connection
+retains its existing connection-only result.
+
 Boomux never queues an offline mutation. Before forwarding, it resolves explicit
 Node context, verifies the pinned identity, negotiates the remote core protocol,
 and revalidates the exact target where the operation requires it. Exact IDs,
@@ -412,6 +424,11 @@ and mutate only local resources; unsupported Node fields and projection events
 are filtered while their ordinary local cursors retain current semantics. CLI
 JSON additions remain capability-gated, node-qualified, and additive within the
 stable schema. A client never infers federation support from a version string.
+
+Protocol-32 and older clients cannot request the combined snapshot and continue
+to receive only local resources from every legacy surface. Protocol 33 adds no
+new event kind; protocol-31 filtering of `node_projection_changed` remains the
+event compatibility boundary.
 
 Federation has three independent compatibility boundaries:
 

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -681,6 +681,7 @@ fn protocol_error_code(code: ErrorCode) -> &'static str {
         ErrorCode::NodeIdentityUnavailable => "node_identity_unavailable",
         ErrorCode::NodeRegistrationUnavailable => "node_registration_unavailable",
         ErrorCode::NodeIdentityChanged => "node_identity_changed",
+        ErrorCode::AmbiguousTarget => "ambiguous_target",
         ErrorCode::RevisionChanged => "revision_changed",
         ErrorCode::Internal => "internal",
         ErrorCode::Unknown => "unknown",

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,8 +15,8 @@ use std::time::Duration;
 
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
-    AgentScheduleSnapshot, AgentScheduleSpec, AgentScheduleUpdate, DaemonEvent, Envelope,
-    ErrorCode, EventCursor, FocusedTerminalSnapshot, NodeProjectionHealth,
+    AgentScheduleSnapshot, AgentScheduleSpec, AgentScheduleUpdate, CombinedNodeSnapshot,
+    DaemonEvent, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot, NodeProjectionHealth,
     NodeRegistrationSnapshot, NotificationDeliveryConfig, Request, Response,
     ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot, ScheduledOccurrence,
     ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
@@ -601,6 +601,13 @@ impl Client {
             selector: selector.into(),
         })? {
             Response::NodeProjectionHealth { health } => Ok(health),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn combined_node_snapshot(&self, selector: Option<String>) -> Result<CombinedNodeSnapshot> {
+        match self.request(Request::GetCombinedNodeSnapshot { selector })? {
+            Response::CombinedNodeSnapshot { snapshot } => Ok(snapshot),
             response => unexpected(response),
         }
     }
@@ -1864,6 +1871,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
@@ -2017,7 +2025,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 32);
+            assert_eq!(request.version, 33);
             assert_eq!(request.message, Request::GetNodeIdentity);
             protocol::write_message(
                 &mut stream,
@@ -2031,6 +2039,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
@@ -2078,7 +2087,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 32);
+            assert_eq!(request.version, 33);
             assert_eq!(request.message, Request::OpenFederationChannel);
             protocol::write_message(
                 &mut stream,
@@ -2092,6 +2101,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
@@ -2122,7 +2132,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 32);
+            assert_eq!(request.version, 33);
             assert_eq!(request.message, Request::ListNodeRegistrations);
             protocol::write_message(
                 &mut stream,
@@ -2135,6 +2145,7 @@ mod tests {
                 ),
             )
             .unwrap();
+            reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             let (mut stream, _) = listener.accept().unwrap();
@@ -2308,6 +2319,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);
@@ -2376,6 +2388,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
             reject_protocol(&listener, 30, 29);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6419,6 +6419,111 @@ impl DaemonService {
         })
     }
 
+    fn combined_node_snapshot(
+        &self,
+        selector: Option<&str>,
+    ) -> DaemonResult<crate::protocol::CombinedNodeSnapshot> {
+        use crate::protocol::{
+            CombinedNode, CombinedNodeSnapshot, NodeProjectionHealthCode, SchedulerHealth,
+            SchedulerState,
+        };
+
+        let local_node_id = self.node_identity()?.id()?;
+        let registrations = self
+            .node_registrations()?
+            .list()
+            .map_err(node_registration_error)?;
+        let local_selected = selector.is_none()
+            || selector.is_some_and(|value| value == "local" || value == local_node_id);
+        let remote_selected = registrations
+            .iter()
+            .filter(|registration| {
+                selector.is_none()
+                    || selector.is_some_and(|value| {
+                        value == registration.alias || value == registration.node_id
+                    })
+            })
+            .collect::<Vec<_>>();
+        if selector == Some("local") && !remote_selected.is_empty() {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::AmbiguousTarget,
+                "combined Node selector 'local' matches the local Node and a registered alias; use an exact Node ID",
+            ));
+        }
+        if !local_selected && remote_selected.is_empty() {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::NotFound,
+                "Node selector not found",
+            ));
+        }
+
+        let mut nodes = Vec::with_capacity(usize::from(local_selected) + remote_selected.len());
+        if local_selected {
+            let snapshot = self.snapshot()?;
+            let scheduler = snapshot.scheduler.clone().unwrap_or(SchedulerHealth {
+                state: SchedulerState::Offline,
+                max_concurrent: 0,
+                active_executions: 0,
+            });
+            nodes.push(CombinedNode {
+                node_id: local_node_id,
+                alias: "local".into(),
+                local: true,
+                health: NodeProjectionHealthCode::Online,
+                current: true,
+                stale: false,
+                observed_at_ms: unix_time_ms(),
+                observed_protocol_version: Some(protocol::PROTOCOL_VERSION),
+                observed_capabilities: protocol::protocol_capabilities()
+                    .map(str::to_owned)
+                    .collect(),
+                scheduler,
+                local_snapshot: Some(snapshot),
+                remote_projection: None,
+            });
+        }
+        for registration in remote_selected {
+            let view = self.node_projection_cache()?.view(registration)?;
+            let scheduler = view
+                .projection
+                .as_ref()
+                .map(|projection| projection.scheduler.clone())
+                .unwrap_or(SchedulerHealth {
+                    state: SchedulerState::Offline,
+                    max_concurrent: 0,
+                    active_executions: 0,
+                });
+            let observed_protocol_version = view
+                .health
+                .capabilities
+                .iter()
+                .filter_map(|capability| capability.strip_prefix("protocol_")?.parse().ok())
+                .max();
+            nodes.push(CombinedNode {
+                node_id: registration.node_id.clone(),
+                alias: registration.alias.clone(),
+                local: false,
+                health: view.health.code,
+                current: !view.health.stale,
+                stale: view.health.stale,
+                observed_at_ms: view.health.last_success_at_ms.unwrap_or(0),
+                observed_protocol_version,
+                observed_capabilities: view.health.capabilities,
+                scheduler,
+                local_snapshot: None,
+                remote_projection: view.projection,
+            });
+        }
+        nodes.sort_by(|left, right| {
+            right
+                .local
+                .cmp(&left.local)
+                .then_with(|| left.alias.cmp(&right.alias))
+                .then_with(|| left.node_id.cmp(&right.node_id))
+        });
+        Ok(CombinedNodeSnapshot { nodes })
+    }
+
     fn clock_now_ms(&self) -> u64 {
         lock(&self.clock)
             .map(|clock| clock.now_ms())
@@ -7810,6 +7915,9 @@ impl DaemonService {
                     health: self.node_projection_cache()?.health(&registration)?,
                 })
             }
+            Request::GetCombinedNodeSnapshot { selector } => Ok(Response::CombinedNodeSnapshot {
+                snapshot: self.combined_node_snapshot(selector.as_deref())?,
+            }),
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
                 unreachable!("restart is handled before dispatch")
             }

--- a/src/dashboard_projection.rs
+++ b/src/dashboard_projection.rs
@@ -14,10 +14,29 @@ use crate::session_projection::{self, SessionProjection};
 use crate::tui::{
     AgentAuthorityDisplay, AgentDisplayState, AgentSessionRunView, AgentSessionView,
     AgentShellView, AgentView, AttentionReason, ExecutionDisplayState, ExecutionOutcomeDisplay,
-    ExecutionReasonDisplay, ExecutionView, LauncherView, ScheduleDisplayState, ScheduleItemView,
-    ScheduleView, TerminalKind, TerminalRunView, TerminalView, WorkspaceAttentionView,
-    WorkspaceItemView, WorkspaceView,
+    ExecutionReasonDisplay, ExecutionView, LauncherView, NodeView, ScheduleDisplayState,
+    ScheduleItemView, ScheduleView, TerminalKind, TerminalRunView, TerminalView,
+    WorkspaceAttentionView, WorkspaceItemView, WorkspaceView,
 };
+
+fn local_node_placeholder() -> NodeView {
+    NodeView {
+        id: String::new(),
+        alias: "local".into(),
+        local: true,
+        health: boomux::protocol::NodeProjectionHealthCode::Online,
+        current: true,
+        stale: false,
+        observed_at_ms: 0,
+        observed_protocol_version: None,
+        observed_capabilities: Vec::new(),
+        scheduler: boomux::protocol::SchedulerHealth {
+            state: boomux::protocol::SchedulerState::Offline,
+            max_concurrent: 0,
+            active_executions: 0,
+        },
+    }
+}
 
 #[cfg(test)]
 pub(crate) fn project(
@@ -57,6 +76,9 @@ pub(crate) fn project_schedules(
                     .filter(|execution| !execution.state.is_active())
                     .count();
                 ScheduleView {
+                    node_id: String::new(),
+                    node_alias: "local".into(),
+                    actionable: true,
                     id: schedule.id.clone(),
                     workspace_id: workspace.id.clone(),
                     workspace: workspace.name.clone(),
@@ -243,6 +265,293 @@ pub(crate) fn project_with_sessions(
         .collect()
 }
 
+pub(crate) fn project_remote_node(
+    node: &boomux::protocol::CombinedNode,
+) -> (Vec<WorkspaceView>, Vec<ScheduleView>) {
+    let Some(projection) = node.remote_projection.as_ref() else {
+        return (Vec::new(), Vec::new());
+    };
+    let node_view = NodeView {
+        id: node.node_id.clone(),
+        alias: node.alias.clone(),
+        local: false,
+        health: node.health,
+        current: node.current,
+        stale: node.stale,
+        observed_at_ms: node.observed_at_ms,
+        observed_protocol_version: node.observed_protocol_version,
+        observed_capabilities: node.observed_capabilities.clone(),
+        scheduler: node.scheduler.clone(),
+    };
+    let mut workspaces = projection
+        .workspaces
+        .iter()
+        .map(|workspace| {
+            let mut agent_state_counts =
+                crate::agent_attention_projection::AgentStateCounts::default();
+            for agent in projection
+                .agents
+                .iter()
+                .filter(|agent| agent.workspace_id == workspace.id)
+            {
+                match agent.state {
+                    AgentState::Unknown => agent_state_counts.unknown += 1,
+                    AgentState::Working => agent_state_counts.working += 1,
+                    AgentState::Blocked => agent_state_counts.blocked += 1,
+                    AgentState::Idle => agent_state_counts.idle += 1,
+                    AgentState::Inactive => agent_state_counts.inactive += 1,
+                    AgentState::Done => agent_state_counts.done += 1,
+                }
+            }
+            let mut items = Vec::new();
+            for shell in projection
+                .shells
+                .iter()
+                .filter(|shell| shell.workspace_id == workspace.id)
+            {
+                if matches!(shell.owner, boomux::protocol::ShellOwner::Schedule { .. }) {
+                    continue;
+                }
+                let terminal = TerminalView {
+                    id: shell.id.clone(),
+                    name: shell.name.clone(),
+                    status: match shell.status {
+                        ShellStatus::Pending => "pending",
+                        ShellStatus::Running => "running",
+                        ShellStatus::Exited { .. } => "exited",
+                    }
+                    .into(),
+                    directory: "remote path unavailable".into(),
+                    repository: String::new(),
+                    branch: String::new(),
+                    git_state: String::new(),
+                    worktree: String::new(),
+                    foreground_process: None,
+                    kind: TerminalKind::Shell,
+                    command: String::new(),
+                    argv: Vec::new(),
+                    run: shell.run_id.as_ref().map(|run_id| TerminalRunView {
+                        id: run_id.clone(),
+                        generation: shell.generation.unwrap_or(0),
+                        started_at_ms: shell.started_at_ms.unwrap_or(0),
+                        ended_at_ms: shell.ended_at_ms,
+                        exit_reason: None,
+                        output_revision: 0,
+                    }),
+                };
+                let agent = shell.run_id.as_deref().and_then(|run_id| {
+                    projection
+                        .agents
+                        .iter()
+                        .filter(|agent| {
+                            agent.shell_id == shell.id
+                                && agent.run_id == run_id
+                                && !matches!(agent.state, AgentState::Inactive | AgentState::Done)
+                        })
+                        .max_by_key(|agent| (agent.observed_at_ms, &agent.id))
+                });
+                if let Some(agent) = agent {
+                    items.push(WorkspaceItemView::AgentShell(AgentShellView {
+                        shell: terminal,
+                        agent: Some(AgentView {
+                            id: agent.id.clone(),
+                            state: agent.state.into(),
+                            integration: agent.integration.clone(),
+                            external_session_id: None,
+                            authority: AgentAuthorityDisplay::DaemonLifecycle,
+                            confidence: 0,
+                            evidence: "cached reduced observation".into(),
+                            updated_at_ms: agent.observed_at_ms,
+                            root_branch: String::new(),
+                            root_worktree: String::new(),
+                        }),
+                        schedule_id: None,
+                    }));
+                } else {
+                    items.push(WorkspaceItemView::Shell(terminal));
+                }
+            }
+            items.extend(
+                projection
+                    .launchers
+                    .iter()
+                    .filter(|launcher| launcher.workspace_id == workspace.id)
+                    .map(|launcher| {
+                        WorkspaceItemView::Launcher(LauncherView {
+                            id: launcher.id.clone(),
+                            name: launcher.name.clone(),
+                            directory: "remote path unavailable".into(),
+                            repository: String::new(),
+                            branch: String::new(),
+                            git_state: String::new(),
+                            worktree: String::new(),
+                            command: "cached definition".into(),
+                            argv: Vec::new(),
+                        })
+                    }),
+            );
+            items.extend(
+                projection
+                    .schedules
+                    .iter()
+                    .filter(|schedule| schedule.workspace_id == workspace.id)
+                    .map(|schedule| {
+                        WorkspaceItemView::Schedule(ScheduleItemView {
+                            id: schedule.id.clone(),
+                            name: schedule.name.clone(),
+                            integration: schedule.integration.clone(),
+                            state: match schedule.state {
+                                AgentScheduleState::Paused => ScheduleDisplayState::Paused,
+                                AgentScheduleState::Enabled => ScheduleDisplayState::Enabled,
+                            },
+                            friendly_trigger: friendly_trigger(&schedule.trigger.cron),
+                        })
+                    }),
+            );
+            WorkspaceView {
+                node: node_view.clone(),
+                id: workspace.id.clone(),
+                name: workspace.name.clone(),
+                default_cwd: None,
+                items,
+                sessions: Vec::new(),
+                agent_state_counts,
+                attention_count: workspace.attention_count as usize,
+                attention: Vec::new(),
+            }
+        })
+        .collect::<Vec<_>>();
+    workspaces.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let mut schedules = projection
+        .schedules
+        .iter()
+        .map(|schedule| {
+            let workspace = projection
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.id == schedule.workspace_id)
+                .map_or("unknown", |workspace| workspace.name.as_str());
+            let mut executions = projection
+                .executions
+                .iter()
+                .filter(|execution| execution.schedule_id == schedule.id)
+                .map(|execution| ExecutionView {
+                    id: execution.id.clone(),
+                    state: match execution.state {
+                        ScheduledExecutionState::Skipped => ExecutionDisplayState::Skipped,
+                        ScheduledExecutionState::Claimed => ExecutionDisplayState::Claimed,
+                        ScheduledExecutionState::Starting => ExecutionDisplayState::Starting,
+                        ScheduledExecutionState::Active => ExecutionDisplayState::Active,
+                        ScheduledExecutionState::DispatchFailed => {
+                            ExecutionDisplayState::DispatchFailed
+                        }
+                        ScheduledExecutionState::Exited => ExecutionDisplayState::Exited,
+                        ScheduledExecutionState::Cancelled => ExecutionDisplayState::Cancelled,
+                        ScheduledExecutionState::Interrupted => ExecutionDisplayState::Interrupted,
+                    },
+                    reason: execution.reason.map(|reason| match reason {
+                        ScheduledExecutionReason::Overlap => ExecutionReasonDisplay::Overlap,
+                        ScheduledExecutionReason::ActiveSession => {
+                            ExecutionReasonDisplay::ActiveSession
+                        }
+                        ScheduledExecutionReason::WorkspaceCapacity => {
+                            ExecutionReasonDisplay::WorkspaceCapacity
+                        }
+                        ScheduledExecutionReason::GlobalCapacity => {
+                            ExecutionReasonDisplay::GlobalCapacity
+                        }
+                        ScheduledExecutionReason::Missed => ExecutionReasonDisplay::Missed,
+                        ScheduledExecutionReason::PausedRace => ExecutionReasonDisplay::PausedRace,
+                        ScheduledExecutionReason::InvalidTarget => {
+                            ExecutionReasonDisplay::InvalidTarget
+                        }
+                        ScheduledExecutionReason::RunnerStartFailed => {
+                            ExecutionReasonDisplay::RunnerStartFailed
+                        }
+                        ScheduledExecutionReason::HostSpawnFailed => {
+                            ExecutionReasonDisplay::HostSpawnFailed
+                        }
+                        ScheduledExecutionReason::CancelledByUser => {
+                            ExecutionReasonDisplay::CancelledByUser
+                        }
+                        ScheduledExecutionReason::ColdDaemonRecovery => {
+                            ExecutionReasonDisplay::ColdDaemonRecovery
+                        }
+                        ScheduledExecutionReason::RunnerExitedWithoutReport => {
+                            ExecutionReasonDisplay::RunnerExitedWithoutReport
+                        }
+                        ScheduledExecutionReason::DaemonShutdown => {
+                            ExecutionReasonDisplay::DaemonShutdown
+                        }
+                    }),
+                    outcome: execution.outcome.as_ref().map(|outcome| match outcome {
+                        ScheduledExecutionOutcome::ExitCode { code } => {
+                            ExecutionOutcomeDisplay::ExitCode(*code)
+                        }
+                        ScheduledExecutionOutcome::Signal { signal } => {
+                            ExecutionOutcomeDisplay::Signal(*signal)
+                        }
+                    }),
+                    requested_at_ms: execution.requested_at_ms,
+                    shell_id: execution.shell_id.clone(),
+                    run_id: execution.run_id.clone(),
+                    agent_id: execution.agent_id.clone(),
+                    agent_state: execution.agent_id.as_deref().and_then(|agent_id| {
+                        projection
+                            .agents
+                            .iter()
+                            .find(|agent| agent.id == agent_id)
+                            .map(|agent| agent.state.into())
+                    }),
+                    session_id: None,
+                })
+                .collect::<Vec<_>>();
+            executions.sort_by(|left, right| {
+                right
+                    .requested_at_ms
+                    .cmp(&left.requested_at_ms)
+                    .then_with(|| right.id.cmp(&left.id))
+            });
+            ScheduleView {
+                node_id: node.node_id.clone(),
+                node_alias: node.alias.clone(),
+                actionable: false,
+                id: schedule.id.clone(),
+                workspace_id: schedule.workspace_id.clone(),
+                workspace: workspace.into(),
+                name: schedule.name.clone(),
+                integration: schedule.integration.clone(),
+                state: match schedule.state {
+                    AgentScheduleState::Paused => ScheduleDisplayState::Paused,
+                    AgentScheduleState::Enabled => ScheduleDisplayState::Enabled,
+                },
+                friendly_trigger: friendly_trigger(&schedule.trigger.cron),
+                next_occurrence_ms: schedule
+                    .next_occurrence
+                    .as_ref()
+                    .map(|value| value.scheduled_at_ms),
+                executions,
+                history_truncated: projection.executions_truncated,
+                possible_pruning_boundary: projection.executions_truncated,
+                history_scoped: true,
+                history_complete: !projection.executions_truncated,
+            }
+        })
+        .collect::<Vec<_>>();
+    schedules.sort_by(|left, right| {
+        left.workspace
+            .cmp(&right.workspace)
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    (workspaces, schedules)
+}
+
 fn project_workspace(
     workspace: &WorkspaceSnapshot,
     git_cache: &mut git::Cache,
@@ -424,6 +733,7 @@ fn project_workspace(
         })
     });
     WorkspaceView {
+        node: local_node_placeholder(),
         id: workspace.id.clone(),
         name: workspace.name.clone(),
         default_cwd: workspace

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,6 +501,8 @@ enum NodeCommands {
     List,
     /// Inspect a registered remote Node by alias or exact Node ID
     Inspect { selector: String },
+    /// Show the combined Node-qualified local and cached remote projection
+    Snapshot { selector: Option<String> },
     /// Rename a registered remote Node alias at an exact revision
     Rename {
         selector: String,
@@ -1077,6 +1079,7 @@ command_keys! {
     NodeAdd => ("node.add", Json),
     NodeList => ("node.list", Json),
     NodeInspect => ("node.inspect", Json),
+    NodeSnapshot => ("node.snapshot", Json),
     NodeRename => ("node.rename", Json),
     NodeRetarget => ("node.retarget", Json),
     NodeForget => ("node.forget", Json),
@@ -1157,6 +1160,9 @@ impl Cli {
             Some(Commands::Node {
                 command: NodeCommands::Inspect { .. },
             }) => CommandKey::NodeInspect,
+            Some(Commands::Node {
+                command: NodeCommands::Snapshot { .. },
+            }) => CommandKey::NodeSnapshot,
             Some(Commands::Node {
                 command: NodeCommands::Rename { .. },
             }) => CommandKey::NodeRename,
@@ -1425,7 +1431,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             )
             .into());
         }
-        remote_connect(target)?;
+        remote_connect(target, cli.terminal.as_deref())?;
         return Ok(CliExit::Success);
     }
     match cli.command.as_ref() {
@@ -1488,7 +1494,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
     }
 
     let result = match cli.command {
-        Some(Commands::Ui) => dashboard(cli.terminal.as_deref()),
+        Some(Commands::Ui) => dashboard(cli.terminal.as_deref(), None),
         Some(Commands::Doctor) => doctor(cli.terminal.as_deref()),
         Some(Commands::Capabilities) => capabilities(cli.json),
         Some(Commands::List) => list_shells(cli.json),
@@ -1558,13 +1564,13 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Attach { .. }) => unreachable!(),
         Some(Commands::ScheduledRunner { .. }) => unreachable!(),
         Some(Commands::FederationStdio) => unreachable!(),
-        None => dashboard(cli.terminal.as_deref()),
+        None => dashboard(cli.terminal.as_deref(), None),
     };
     result?;
     Ok(CliExit::Success)
 }
 
-fn remote_connect(target: &str) -> Result<(), Box<dyn Error>> {
+fn remote_connect(target: &str, terminal: Option<&str>) -> Result<(), Box<dyn Error>> {
     let mut connection = verified_remote_connection(target, true)?;
     connection.ping()?;
     println!(
@@ -1574,6 +1580,20 @@ fn remote_connect(target: &str) -> Result<(), Box<dyn Error>> {
         connection.handshake.helper_version,
         connection.executable.as_str(),
     );
+    let node_id = connection.handshake.node_id.clone();
+    drop(connection);
+    if let Ok(local) = client::connect_or_start()
+        && local.node_registrations().is_ok_and(|registrations| {
+            registrations
+                .iter()
+                .any(|registration| registration.node_id == node_id)
+        })
+        && local
+            .supports(protocol::ProtocolFeature::CombinedNodeSnapshot)
+            .unwrap_or(false)
+    {
+        dashboard(terminal, Some(node_id))?;
+    }
     Ok(())
 }
 
@@ -1723,6 +1743,47 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
                 Ok(())
             }
         }
+        NodeCommands::Snapshot { selector } => {
+            let snapshot = client::connect_or_start()?.combined_node_snapshot(selector)?;
+            if json {
+                let nodes = snapshot
+                    .nodes
+                    .into_iter()
+                    .map(node_snapshot_json)
+                    .collect::<Result<Vec<_>, _>>()?;
+                print_json(
+                    CommandKey::NodeSnapshot,
+                    serde_json::json!({ "nodes": nodes }),
+                )
+            } else {
+                println!("ALIAS\tOWNERSHIP\tHEALTH\tCURRENT\tOBSERVED\tWORKSPACES\tSCHEDULER");
+                for node in snapshot.nodes {
+                    let workspace_count = node
+                        .local_snapshot
+                        .as_ref()
+                        .map(|snapshot| snapshot.workspaces.len())
+                        .or_else(|| {
+                            node.remote_projection
+                                .as_ref()
+                                .map(|projection| projection.workspaces.len())
+                        })
+                        .unwrap_or(0);
+                    println!(
+                        "{}\t{}\t{}\t{}\t{}\t{}\t{} {}/{}",
+                        node.alias,
+                        if node.local { "local" } else { "remote" },
+                        format!("{:?}", node.health).to_ascii_lowercase(),
+                        node.current,
+                        node.observed_at_ms,
+                        workspace_count,
+                        format!("{:?}", node.scheduler.state).to_ascii_lowercase(),
+                        node.scheduler.active_executions,
+                        node.scheduler.max_concurrent,
+                    );
+                }
+                Ok(())
+            }
+        }
         NodeCommands::Rename {
             selector,
             alias,
@@ -1764,6 +1825,75 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
         }
         NodeCommands::Rekey => rekey_node(),
     }
+}
+
+fn node_snapshot_json(node: protocol::CombinedNode) -> Result<serde_json::Value, Box<dyn Error>> {
+    let protocol::CombinedNode {
+        node_id,
+        alias,
+        local,
+        health,
+        current,
+        stale,
+        observed_at_ms,
+        observed_protocol_version,
+        observed_capabilities,
+        scheduler,
+        local_snapshot,
+        remote_projection,
+    } = node;
+    let qualify = |value| qualify_resource_identities(value, &node_id);
+    Ok(serde_json::json!({
+        "node_id": node_id,
+        "alias": alias,
+        "local": local,
+        "health": health,
+        "current": current,
+        "stale": stale,
+        "observed_at_ms": observed_at_ms,
+        "observed_protocol_version": observed_protocol_version,
+        "observed_capabilities": observed_capabilities,
+        "scheduler": scheduler,
+        "local_snapshot": local_snapshot.map(serde_json::to_value).transpose()?.map(qualify),
+        "remote_projection": remote_projection.map(serde_json::to_value).transpose()?.map(qualify),
+    }))
+}
+
+fn qualify_resource_identities(mut value: serde_json::Value, node_id: &str) -> serde_json::Value {
+    const ID_FIELDS: &[&str] = &[
+        "id",
+        "workspace_id",
+        "shell_id",
+        "run_id",
+        "launcher_id",
+        "agent_id",
+        "schedule_id",
+        "execution_id",
+        "owner_schedule_id",
+    ];
+    match &mut value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                *value = qualify_resource_identities(value.take(), node_id);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            for (key, value) in object {
+                if ID_FIELDS.contains(&key.as_str()) {
+                    if let Some(inner_id) = value.as_str() {
+                        *value = serde_json::to_value(protocol::QualifiedIdentity::new(
+                            node_id, inner_id,
+                        ))
+                        .expect("qualified identity serializes");
+                    }
+                } else {
+                    *value = qualify_resource_identities(value.take(), node_id);
+                }
+            }
+        }
+        _ => {}
+    }
+    value
 }
 
 fn print_node_registration(
@@ -1884,14 +2014,19 @@ fn effective_terminal(override_entry: Option<&str>) -> Result<Option<String>, Bo
     Ok(config::load()?.terminal)
 }
 
-fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
+fn dashboard(
+    terminal_override: Option<&str>,
+    initial_node_filter: Option<String>,
+) -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
     let launch_cwd = resolve_directory(Path::new("."))?;
     let client = client::connect_or_start()?;
+    let local_node_id = client.node_identity()?;
     let mut git_cache = git::Cache::default();
     let mut title_cache = host_session_titles::Cache::default();
     let mut refresh = DashboardRefresh::baseline(&client)?;
     let snapshot = refresh.snapshot().clone();
+    let combined = combined_node_snapshot_for_dashboard(&client)?;
     let config = config::load()?;
     let terminal = terminal_override
         .map(str::to_owned)
@@ -1914,8 +2049,17 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
         roots_configured,
     };
 
+    let mut initial_state = dashboard_state(
+        snapshot,
+        combined,
+        &refresh,
+        &mut git_cache,
+        &mut title_cache,
+        false,
+    );
+    initial_state.initial_node_filter = initial_node_filter;
     tui::run(
-        dashboard_state(snapshot, &refresh, &mut git_cache, &mut title_cache, false),
+        initial_state,
         config.dashboard.follow_focused_terminal,
         project_context,
         true,
@@ -1925,13 +2069,21 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 let result = refresh.check(&client).map_err(|error| error.to_string());
                 match result {
                     Ok(Some((snapshot, reset_focus_revision))) => {
-                        tui::DashboardEvent::RefreshCompleted(Ok(dashboard_state(
-                            snapshot,
-                            &refresh,
-                            &mut git_cache,
-                            &mut title_cache,
-                            reset_focus_revision,
-                        )))
+                        match combined_node_snapshot_for_dashboard(&client) {
+                            Ok(combined) => {
+                                tui::DashboardEvent::RefreshCompleted(Ok(dashboard_state(
+                                    snapshot,
+                                    combined,
+                                    &refresh,
+                                    &mut git_cache,
+                                    &mut title_cache,
+                                    reset_focus_revision,
+                                )))
+                            }
+                            Err(error) => {
+                                tui::DashboardEvent::RefreshCompleted(Err(error.to_string()))
+                            }
+                        }
                     }
                     Ok(None) => tui::DashboardEvent::UpdateCheckCompleted,
                     Err(error) => tui::DashboardEvent::RefreshCompleted(Err(error)),
@@ -1939,8 +2091,9 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             }
             tui::DashboardEffect::RestoreWorkspace(workspace_id) => {
                 let result = (|| {
+                    let workspace_id = local_dashboard_inner(&workspace_id, &local_node_id)?;
                     let workspace = client
-                        .get_workspace(&workspace_id)
+                        .get_workspace(workspace_id)
                         .map_err(|error| error.to_string())?;
                     open_workspace(&workspace, terminal.as_deref())
                         .map_err(|error| error.to_string())?;
@@ -1956,6 +2109,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             tui::DashboardEffect::Open(target) => {
                 let result = dispatch_dashboard_open(
                     &target,
+                    &local_node_id,
                     |shell_id| {
                         open_dashboard_shell(&client, shell_id, terminal.as_deref())
                             .map_err(|error| error.to_string())
@@ -1980,6 +2134,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             tui::DashboardEffect::Close(target) => {
                 let result = (|| match &target {
                     tui::CloseTarget::Workspace(workspace_id) => {
+                        let workspace_id = local_dashboard_inner(workspace_id, &local_node_id)?;
                         let name = client
                             .get_workspace(workspace_id)
                             .map(|workspace| workspace.name)
@@ -1992,6 +2147,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                         ))
                     }
                     tui::CloseTarget::Shell(shell_id) => {
+                        let shell_id = local_dashboard_inner(shell_id, &local_node_id)?;
                         let name = client
                             .get_shell(shell_id)
                             .map(|shell| shell.name)
@@ -2002,6 +2158,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                         Ok(format!("Closed shell {name}"))
                     }
                     tui::CloseTarget::Launcher(launcher_id) => {
+                        let launcher_id = local_dashboard_inner(launcher_id, &local_node_id)?;
                         let name = client
                             .get_launcher(launcher_id)
                             .map(|launcher| launcher.name)
@@ -2028,25 +2185,30 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
             }
             tui::DashboardEffect::CreateShell(workspace_id) => {
                 tui::DashboardEvent::OperationCompleted(
-                    create_dashboard_shell(&client, &workspace_id, &launch_cwd)
-                        .map_err(|error| error.to_string()),
+                    local_dashboard_inner(&workspace_id, &local_node_id).and_then(|workspace_id| {
+                        create_dashboard_shell(&client, workspace_id, &launch_cwd)
+                            .map_err(|error| error.to_string())
+                    }),
                 )
             }
             tui::DashboardEffect::Rename { target, name } => {
                 let result = (|| match &target {
                     tui::RenameTarget::Workspace(workspace_id) => {
+                        let workspace_id = local_dashboard_inner(workspace_id, &local_node_id)?;
                         client
                             .rename_workspace(workspace_id, &name)
                             .map_err(|error| error.to_string())?;
                         Ok(format!("Renamed workspace to {name}"))
                     }
                     tui::RenameTarget::Shell(shell_id) => {
+                        let shell_id = local_dashboard_inner(shell_id, &local_node_id)?;
                         client
                             .rename_shell(shell_id, &name)
                             .map_err(|error| error.to_string())?;
                         Ok(format!("Renamed shell to {name}"))
                     }
                     tui::RenameTarget::Launcher(launcher_id) => {
+                        let launcher_id = local_dashboard_inner(launcher_id, &local_node_id)?;
                         client
                             .rename_launcher(launcher_id, &name)
                             .map_err(|error| error.to_string())?;
@@ -2062,6 +2224,8 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                         .map_err(|error| error.to_string())?;
                     Ok(dashboard_state(
                         snapshot,
+                        combined_node_snapshot_for_dashboard(&client)
+                            .map_err(|error| error.to_string())?,
                         &refresh,
                         &mut git_cache,
                         &mut title_cache,
@@ -2071,41 +2235,48 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 tui::DashboardEvent::RefreshCompleted(result)
             }
             tui::DashboardEffect::RunSchedule(schedule_id) => {
-                let result = run_dashboard_schedule(&client, &schedule_id);
+                let result = local_dashboard_inner(&schedule_id, &local_node_id)
+                    .and_then(|id| run_dashboard_schedule(&client, id));
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::PauseSchedule(schedule_id) => {
-                let result = client
-                    .pause_agent_schedule(&schedule_id)
-                    .map(|schedule| format!("Paused schedule {}", schedule.name))
-                    .map_err(|error| error.to_string());
+                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
+                    client
+                        .pause_agent_schedule(id)
+                        .map(|schedule| format!("Paused schedule {}", schedule.name))
+                        .map_err(|error| error.to_string())
+                });
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::ResumeSchedule(schedule_id) => {
-                let result = client
-                    .resume_agent_schedule(&schedule_id)
-                    .map(|schedule| {
-                        format!(
-                            "Enabled schedule {} for future timed dispatch",
-                            schedule.name
-                        )
-                    })
-                    .map_err(|error| error.to_string());
+                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
+                    client
+                        .resume_agent_schedule(id)
+                        .map(|schedule| {
+                            format!(
+                                "Enabled schedule {} for future timed dispatch",
+                                schedule.name
+                            )
+                        })
+                        .map_err(|error| error.to_string())
+                });
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::LoadScheduleEditor { schedule_id } => {
-                let result = client
-                    .get_agent_schedule(&schedule_id)
-                    .map(|inspection| tui::ScheduleEditInspection {
-                        schedule_id: inspection.schedule.id,
-                        name: inspection.schedule.name,
-                        cron: inspection.schedule.trigger.cron,
-                        timezone: inspection.schedule.trigger.timezone,
-                        prompt: inspection.prompt,
-                        revision: inspection.schedule.revision,
-                        paused: inspection.schedule.state == AgentScheduleState::Paused,
-                    })
-                    .map_err(|error| error.to_string());
+                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
+                    client
+                        .get_agent_schedule(id)
+                        .map(|inspection| tui::ScheduleEditInspection {
+                            schedule_id: schedule_id.clone(),
+                            name: inspection.schedule.name,
+                            cron: inspection.schedule.trigger.cron,
+                            timezone: inspection.schedule.trigger.timezone,
+                            prompt: inspection.prompt,
+                            revision: inspection.schedule.revision,
+                            paused: inspection.schedule.state == AgentScheduleState::Paused,
+                        })
+                        .map_err(|error| error.to_string())
+                });
                 tui::DashboardEvent::ScheduleEditorLoaded {
                     schedule_id,
                     result,
@@ -2116,71 +2287,81 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 expected_revision,
                 update,
             } => {
-                let result = client
-                    .update_agent_schedule(
-                        &schedule_id,
-                        expected_revision,
-                        AgentScheduleUpdate {
-                            name: update.name,
-                            prompt: update.prompt,
-                            trigger: AgentScheduleTrigger {
-                                cron: update.cron,
-                                timezone: update.timezone,
+                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
+                    client
+                        .update_agent_schedule(
+                            id,
+                            expected_revision,
+                            AgentScheduleUpdate {
+                                name: update.name,
+                                prompt: update.prompt,
+                                trigger: AgentScheduleTrigger {
+                                    cron: update.cron,
+                                    timezone: update.timezone,
+                                },
                             },
-                        },
-                    )
-                    .map(|schedule| format!("Updated schedule {}", schedule.name))
-                    .map_err(|error| error.to_string());
+                        )
+                        .map(|schedule| format!("Updated schedule {}", schedule.name))
+                        .map_err(|error| error.to_string())
+                });
                 tui::DashboardEvent::ScheduleEditorSaved {
                     schedule_id,
                     result,
                 }
             }
             tui::DashboardEffect::CancelExecution(execution_id) => {
-                let result = cancel_dashboard_execution(&client, &execution_id);
+                let result = local_dashboard_inner(&execution_id, &local_node_id)
+                    .and_then(|id| cancel_dashboard_execution(&client, id));
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::OpenScheduledExecution { execution_id } => {
-                let result = open_scheduled_execution(&client, &execution_id, terminal.as_deref())
-                    .map(|opened| opened.message)
-                    .map_err(|error| error.to_string());
+                let result = local_dashboard_inner(&execution_id, &local_node_id).and_then(|id| {
+                    open_scheduled_execution(&client, id, terminal.as_deref())
+                        .map(|opened| opened.message)
+                        .map_err(|error| error.to_string())
+                });
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::RemoveSchedule(schedule_id) => {
+                let schedule_inner = local_dashboard_inner(&schedule_id, &local_node_id);
                 let name = refresh
                     .snapshot()
                     .workspaces
                     .iter()
                     .flat_map(|workspace| &workspace.schedules)
-                    .find(|schedule| schedule.id == schedule_id)
+                    .find(|schedule| schedule_inner.as_ref().is_ok_and(|id| schedule.id == **id))
                     .map_or_else(|| "schedule".into(), |schedule| schedule.name.clone());
-                let result = client
-                    .remove_agent_schedule(&schedule_id)
+                let result = schedule_inner.and_then(|id| {
+                    client
+                    .remove_agent_schedule(id)
                     .map(|()| {
                         format!(
                             "Removed schedule {name}, its persisted prompt, and retained history"
                         )
                     })
-                    .map_err(|error| error.to_string());
+                    .map_err(|error| error.to_string())
+                });
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::LoadScheduleHistory { schedule_id, limit } => {
-                let result = refresh
-                    .load_schedule_history(&client, &schedule_id, limit)
-                    .map(|(_, truncated)| {
-                        let schedules = dashboard_projection::project_schedules(
-                            refresh.snapshot(),
-                            &refresh.executions(),
-                            refresh.history_truncated,
-                            &refresh.scoped_history,
-                        );
-                        let executions = schedules
-                            .into_iter()
-                            .find(|schedule| schedule.id == schedule_id)
-                            .map_or_else(Vec::new, |schedule| schedule.executions);
-                        (executions, truncated)
-                    })
-                    .map_err(|error| error.to_string());
+                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
+                    refresh
+                        .load_schedule_history(&client, id, limit)
+                        .map(|(_, truncated)| {
+                            let schedules = dashboard_projection::project_schedules(
+                                refresh.snapshot(),
+                                &refresh.executions(),
+                                refresh.history_truncated,
+                                &refresh.scoped_history,
+                            );
+                            let executions = schedules
+                                .into_iter()
+                                .find(|schedule| schedule.id == schedule_id.inner_id)
+                                .map_or_else(Vec::new, |schedule| schedule.executions);
+                            (executions, truncated)
+                        })
+                        .map_err(|error| error.to_string())
+                });
                 tui::DashboardEvent::ScheduleHistoryCompleted {
                     schedule_id,
                     result,
@@ -2191,10 +2372,12 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 run_id,
                 output_revision,
             } => tui::DashboardEvent::TerminalPreviewCompleted {
-                output: client
-                    .read_shell_preview(&shell_id, READ_BYTES, 500)
-                    .map_err(|error| error.to_string()),
-                shell_id,
+                output: local_dashboard_inner(&shell_id, &local_node_id).and_then(|id| {
+                    client
+                        .read_shell_preview(id, READ_BYTES, 500)
+                        .map_err(|error| error.to_string())
+                }),
+                shell_id: shell_id.inner_id,
                 run_id,
                 output_revision,
             },
@@ -2205,6 +2388,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
 
 fn dashboard_state(
     snapshot: Snapshot,
+    combined: Option<protocol::CombinedNodeSnapshot>,
     refresh: &DashboardRefresh,
     git_cache: &mut git::Cache,
     title_cache: &mut host_session_titles::Cache,
@@ -2245,7 +2429,7 @@ fn dashboard_state(
             },
         }
     };
-    let schedules = if schedules_supported {
+    let mut schedules = if schedules_supported {
         dashboard_projection::project_schedules(
             &snapshot,
             &refresh.executions(),
@@ -2255,7 +2439,63 @@ fn dashboard_state(
     } else {
         Vec::new()
     };
+    let mut nodes = Vec::new();
+    if let Some(combined) = combined {
+        for node in combined.nodes {
+            let node_view = tui::NodeView {
+                id: node.node_id.clone(),
+                alias: node.alias.clone(),
+                local: node.local,
+                health: node.health,
+                current: node.current,
+                stale: node.stale,
+                observed_at_ms: node.observed_at_ms,
+                observed_protocol_version: node.observed_protocol_version,
+                observed_capabilities: node.observed_capabilities.clone(),
+                scheduler: node.scheduler.clone(),
+            };
+            if node.local {
+                for workspace in &mut workspaces {
+                    workspace.node = node_view.clone();
+                }
+                for schedule in &mut schedules {
+                    schedule.node_id = node.node_id.clone();
+                    schedule.node_alias = node.alias.clone();
+                    schedule.actionable = node.current && !node.stale;
+                }
+            } else {
+                let (mut remote_workspaces, mut remote_schedules) =
+                    dashboard_projection::project_remote_node(&node);
+                workspaces.append(&mut remote_workspaces);
+                schedules.append(&mut remote_schedules);
+            }
+            nodes.push(node_view);
+        }
+    }
+    if nodes.is_empty() {
+        nodes.extend(
+            workspaces
+                .iter()
+                .map(|workspace| workspace.node.clone())
+                .take(1),
+        );
+    }
+    workspaces.sort_by(|left, right| {
+        left.node
+            .alias
+            .cmp(&right.node.alias)
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    schedules.sort_by(|left, right| {
+        left.node_alias
+            .cmp(&right.node_alias)
+            .then_with(|| left.workspace.cmp(&right.workspace))
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.id.cmp(&right.id))
+    });
     tui::DashboardState {
+        nodes,
         workspaces,
         schedules,
         scheduling,
@@ -2265,6 +2505,17 @@ fn dashboard_state(
             .is_supported_by(refresh.negotiated_protocol),
         focused_terminal: snapshot.focused_terminal.map(focused_terminal_view),
         reset_focus_revision,
+        initial_node_filter: None,
+    }
+}
+
+fn combined_node_snapshot_for_dashboard(
+    client: &client::Client,
+) -> Result<Option<protocol::CombinedNodeSnapshot>, client::ClientError> {
+    if client.supports(protocol::ProtocolFeature::CombinedNodeSnapshot)? {
+        client.combined_node_snapshot(None).map(Some)
+    } else {
+        Ok(None)
     }
 }
 
@@ -2278,6 +2529,7 @@ fn focused_terminal_view(focused: protocol::FocusedTerminalSnapshot) -> tui::Foc
 
 fn dispatch_dashboard_open<S, L>(
     target: &tui::OpenTarget,
+    local_node_id: &str,
     mut open_shell: S,
     mut launch: L,
 ) -> Result<String, String>
@@ -2286,11 +2538,30 @@ where
     L: FnMut(&str, &str) -> Result<String, String>,
 {
     match target {
-        tui::OpenTarget::Shell(shell_id) => open_shell(shell_id),
+        tui::OpenTarget::Shell(shell_id) => {
+            open_shell(local_dashboard_inner(shell_id, local_node_id)?)
+        }
         tui::OpenTarget::Launcher {
             workspace_id,
             launcher_id,
-        } => launch(workspace_id, launcher_id),
+        } => launch(
+            local_dashboard_inner(workspace_id, local_node_id)?,
+            local_dashboard_inner(launcher_id, local_node_id)?,
+        ),
+    }
+}
+
+fn local_dashboard_inner<'a>(
+    identity: &'a protocol::QualifiedIdentity,
+    local_node_id: &str,
+) -> Result<&'a str, String> {
+    if identity.node_id == local_node_id || identity.node_id.is_empty() {
+        Ok(&identity.inner_id)
+    } else {
+        Err(format!(
+            "remote Node {} is read-only in this Boomux version",
+            identity.node_id
+        ))
     }
 }
 
@@ -7192,6 +7463,35 @@ mod tests {
     }
 
     #[test]
+    fn node_snapshot_is_separate_json_command_with_structural_identities() {
+        let cli = Cli::try_parse_from(["boomux", "--json", "node", "snapshot", "work"]).unwrap();
+        assert!(matches!(
+            cli.command.as_ref(),
+            Some(Commands::Node {
+                command: NodeCommands::Snapshot {
+                    selector: Some(selector)
+                }
+            }) if selector == "work"
+        ));
+        assert_eq!(cli.command_descriptor().key, "node.snapshot");
+
+        let qualified = qualify_resource_identities(
+            serde_json::json!({
+                "id": "resource",
+                "workspace_id": "workspace",
+                "external_session_id": "private-host-id"
+            }),
+            "node",
+        );
+        assert_eq!(
+            qualified["id"],
+            serde_json::json!({"node_id": "node", "inner_id": "resource"})
+        );
+        assert_eq!(qualified["workspace_id"]["node_id"], "node");
+        assert_eq!(qualified["external_session_id"], "private-host-id");
+    }
+
+    #[test]
     fn accepts_path_options_and_named_subcommands() {
         let cli = Cli::try_parse_from(["boomux", ".", "--name", "feature", "--new"]).unwrap();
         assert_eq!(cli.name.as_deref(), Some("feature"));
@@ -7983,6 +8283,22 @@ mod tests {
     #[test]
     fn enriches_from_the_newest_available_session_directory() {
         let mut views = vec![tui::WorkspaceView {
+            node: tui::NodeView {
+                id: String::new(),
+                alias: "local".into(),
+                local: true,
+                health: protocol::NodeProjectionHealthCode::Online,
+                current: true,
+                stale: false,
+                observed_at_ms: 0,
+                observed_protocol_version: None,
+                observed_capabilities: Vec::new(),
+                scheduler: protocol::SchedulerHealth {
+                    state: protocol::SchedulerState::Active,
+                    max_concurrent: 4,
+                    active_executions: 0,
+                },
+            },
             id: "w1".into(),
             name: "project".into(),
             default_cwd: None,
@@ -8439,6 +8755,7 @@ mod tests {
                 workspace_id: "w1".into(),
                 launcher_id: "l1".into(),
             },
+            "",
             |_| {
                 shell_calls += 1;
                 Ok("shell".into())
@@ -9341,7 +9658,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 32);
+        assert_eq!(protocol::PROTOCOL_VERSION, 33);
     }
 
     #[test]
@@ -9369,6 +9686,7 @@ mod tests {
                 "node.add",
                 "node.list",
                 "node.inspect",
+                "node.snapshot",
                 "node.rename",
                 "node.retarget",
                 "node.forget",

--- a/src/node_projection.rs
+++ b/src/node_projection.rs
@@ -12,6 +12,12 @@ use crate::protocol::{
     EventCursor, NodeProjectionHealth, NodeProjectionHealthCode, NodeProjectionSnapshot,
     NodeRegistrationSnapshot,
 };
+
+#[derive(Clone)]
+pub(crate) struct NodeProjectionView {
+    pub(crate) health: NodeProjectionHealth,
+    pub(crate) projection: Option<NodeProjectionSnapshot>,
+}
 use crate::state_store::{effective_uid, secure_state_dir, state_directory_from_environment};
 
 const NODE_CACHE_VERSION: u32 = 1;
@@ -102,6 +108,26 @@ impl NodeProjectionCache {
             .filter(|node| node.tombstone_epoch == registration.tombstone_epoch)
             .map(CachedNode::health_snapshot)
             .unwrap_or_else(unobserved_health))
+    }
+
+    pub(crate) fn view(
+        &self,
+        registration: &NodeRegistrationSnapshot,
+    ) -> io::Result<NodeProjectionView> {
+        let state = self.lock()?;
+        Ok(state
+            .nodes
+            .iter()
+            .find(|node| node.node_id == registration.node_id)
+            .filter(|node| node.tombstone_epoch == registration.tombstone_epoch)
+            .map(|node| NodeProjectionView {
+                health: node.health_snapshot(),
+                projection: node.projection.clone(),
+            })
+            .unwrap_or_else(|| NodeProjectionView {
+                health: unobserved_health(),
+                projection: None,
+            }))
     }
 
     pub(crate) fn cursor_and_generation(
@@ -542,6 +568,42 @@ mod tests {
                 .to_string_lossy()
                 .starts_with("node-cache.corrupt-")
         }));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cache_view_preserves_every_stable_health_code() {
+        let root = std::env::temp_dir().join(format!("boomux-node-health-{}", Uuid::new_v4()));
+        let path = root.join("boomux/node-cache.json");
+        let registration = NodeRegistrationSnapshot {
+            alias: "work".into(),
+            target: "work.example".into(),
+            node_id: Uuid::from_u128(2).to_string(),
+            revision: 1,
+            tombstone_epoch: 0,
+        };
+        let cache = NodeProjectionCache::load_at(path);
+        let mut generation = 0;
+        for code in [
+            NodeProjectionHealthCode::Unobserved,
+            NodeProjectionHealthCode::Online,
+            NodeProjectionHealthCode::Reconnecting,
+            NodeProjectionHealthCode::Stale,
+            NodeProjectionHealthCode::Unreachable,
+            NodeProjectionHealthCode::AuthenticationRequired,
+            NodeProjectionHealthCode::IdentityChanged,
+            NodeProjectionHealthCode::IdentityConflict,
+            NodeProjectionHealthCode::Unsupported,
+        ] {
+            generation = cache
+                .mark_health(&registration, generation, code, generation + 1, None)
+                .unwrap()
+                .unwrap();
+            let view = cache.view(&registration).unwrap();
+            assert_eq!(view.health.code, code);
+            assert_eq!(view.health.stale, code != NodeProjectionHealthCode::Online);
+            assert!(view.projection.is_none());
+        }
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 32;
+pub const PROTOCOL_VERSION: u32 = 33;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -128,6 +128,11 @@ define_protocol_features! {
         "node_projection_sync",
         "bounded_remote_node_projections",
     ]),
+    CombinedNodeSnapshot => (33, "combined Node snapshot", [
+        "protocol_33",
+        "combined_node_snapshot",
+        "node_qualified_dashboard",
+    ]),
 }
 
 pub const DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 100;
@@ -250,6 +255,40 @@ pub struct NodeRegistrationSnapshot {
     pub node_id: String,
     pub revision: u64,
     pub tombstone_epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QualifiedIdentity {
+    pub node_id: String,
+    pub inner_id: String,
+}
+
+impl QualifiedIdentity {
+    pub fn new(node_id: impl Into<String>, inner_id: impl Into<String>) -> Self {
+        Self {
+            node_id: node_id.into(),
+            inner_id: inner_id.into(),
+        }
+    }
+}
+
+impl From<&str> for QualifiedIdentity {
+    fn from(inner_id: &str) -> Self {
+        Self::new("", inner_id)
+    }
+}
+
+impl PartialEq<str> for QualifiedIdentity {
+    fn eq(&self, other: &str) -> bool {
+        self.inner_id == other
+    }
+}
+
+impl PartialEq<&str> for QualifiedIdentity {
+    fn eq(&self, other: &&str) -> bool {
+        self.inner_id == *other
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -465,6 +504,33 @@ pub struct NodeProjectionSync {
     pub cursor: EventCursor,
     pub projection: NodeProjectionSnapshot,
     pub transitions: Vec<NodeProjectionTransition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CombinedNodeSnapshot {
+    pub nodes: Vec<CombinedNode>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CombinedNode {
+    pub node_id: String,
+    pub alias: String,
+    pub local: bool,
+    pub health: NodeProjectionHealthCode,
+    pub current: bool,
+    pub stale: bool,
+    pub observed_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_protocol_version: Option<u32>,
+    #[serde(default)]
+    pub observed_capabilities: Vec<String>,
+    pub scheduler: SchedulerHealth,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_snapshot: Option<Snapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_projection: Option<NodeProjectionSnapshot>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -918,6 +984,7 @@ pub enum ErrorCode {
     NodeIdentityUnavailable,
     NodeRegistrationUnavailable,
     NodeIdentityChanged,
+    AmbiguousTarget,
     RevisionChanged,
     Internal,
     #[serde(other)]
@@ -1211,6 +1278,10 @@ pub enum Request {
     GetNodeProjectionHealth {
         selector: String,
     },
+    GetCombinedNodeSnapshot {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        selector: Option<String>,
+    },
     Restart,
     RestartWithNotificationConfig {
         notifications: NotificationDeliveryConfig,
@@ -1409,6 +1480,7 @@ impl Request {
             Self::SyncNodeProjection { .. } | Self::GetNodeProjectionHealth { .. } => {
                 Some(ProtocolFeature::NodeProjectionSync)
             }
+            Self::GetCombinedNodeSnapshot { .. } => Some(ProtocolFeature::CombinedNodeSnapshot),
             Self::WaitScheduledExecution { .. } => {
                 Some(ProtocolFeature::ScheduledExecutionObservation)
             }
@@ -1526,6 +1598,9 @@ pub enum Response {
     },
     NodeProjectionHealth {
         health: NodeProjectionHealth,
+    },
+    CombinedNodeSnapshot {
+        snapshot: CombinedNodeSnapshot,
     },
     Snapshot {
         snapshot: Snapshot,
@@ -2107,8 +2182,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_thirty_two_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 32);
+    fn protocol_version_is_thirty_three_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 33);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -2260,6 +2335,33 @@ mod tests {
             .unwrap()
             .insert("prompt".into(), serde_json::json!("private"));
         assert!(serde_json::from_value::<NodeProjectionSnapshot>(encoded).is_err());
+    }
+
+    #[test]
+    fn combined_node_snapshot_is_protocol_thirty_three_and_round_trips() {
+        let request = Request::GetCombinedNodeSnapshot {
+            selector: Some("work".into()),
+        };
+        assert_eq!(
+            request.required_feature(),
+            Some(ProtocolFeature::CombinedNodeSnapshot)
+        );
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(&request).unwrap()).unwrap(),
+            request
+        );
+        let response = Response::CombinedNodeSnapshot {
+            snapshot: CombinedNodeSnapshot { nodes: Vec::new() },
+        };
+        assert_eq!(
+            serde_json::from_value::<Response>(serde_json::to_value(&response).unwrap()).unwrap(),
+            response
+        );
+        let identity = QualifiedIdentity::new("node", "resource");
+        assert_eq!(
+            serde_json::to_value(identity).unwrap(),
+            serde_json::json!({"node_id": "node", "inner_id": "resource"})
+        );
     }
 
     #[test]
@@ -2584,6 +2686,10 @@ mod tests {
     #[test]
     fn request_feature_requirements_cover_all_groups() {
         let groups = vec![
+            (
+                33,
+                vec![Request::GetCombinedNodeSnapshot { selector: None }],
+            ),
             (
                 31,
                 vec![
@@ -3022,6 +3128,14 @@ mod tests {
                     "protocol_32",
                     "node_projection_sync",
                     "bounded_remote_node_projections",
+                ][..],
+            ),
+            (
+                33,
+                &[
+                    "protocol_33",
+                    "combined_node_snapshot",
+                    "node_qualified_dashboard",
                 ][..],
             ),
         ];

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -18,7 +18,10 @@ use ratatui::widgets::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::agent_attention_projection::AgentStateCounts;
-use crate::protocol::{TerminalColor, TerminalPreview, TerminalPreviewLine, TerminalStyle};
+use crate::protocol::{
+    NodeProjectionHealthCode, QualifiedIdentity, SchedulerHealth, TerminalColor, TerminalPreview,
+    TerminalPreviewLine, TerminalStyle,
+};
 
 const BASE: Color = Color::Reset;
 const OVERLAY: Color = Color::DarkGray;
@@ -139,7 +142,23 @@ fn smoke_word_lines(stage: usize) -> Vec<Line<'static>> {
         .collect()
 }
 
+#[derive(Clone)]
+pub(crate) struct NodeView {
+    pub(crate) id: String,
+    pub(crate) alias: String,
+    pub(crate) local: bool,
+    pub(crate) health: NodeProjectionHealthCode,
+    pub(crate) current: bool,
+    pub(crate) stale: bool,
+    pub(crate) observed_at_ms: u64,
+    pub(crate) observed_protocol_version: Option<u32>,
+    pub(crate) observed_capabilities: Vec<String>,
+    pub(crate) scheduler: SchedulerHealth,
+}
+
+#[derive(Clone)]
 pub(crate) struct WorkspaceView {
+    pub(crate) node: NodeView,
     pub(crate) id: String,
     pub(crate) name: String,
     pub(crate) default_cwd: Option<String>,
@@ -151,6 +170,7 @@ pub(crate) struct WorkspaceView {
 }
 
 pub(crate) struct DashboardState {
+    pub(crate) nodes: Vec<NodeView>,
     pub(crate) workspaces: Vec<WorkspaceView>,
     pub(crate) schedules: Vec<ScheduleView>,
     pub(crate) scheduling: SchedulingView,
@@ -158,10 +178,11 @@ pub(crate) struct DashboardState {
     pub(crate) schedule_editing: bool,
     pub(crate) focused_terminal: Option<FocusedTerminalView>,
     pub(crate) reset_focus_revision: bool,
+    pub(crate) initial_node_filter: Option<String>,
 }
 
 pub(crate) struct ScheduleEditInspection {
-    pub(crate) schedule_id: String,
+    pub(crate) schedule_id: QualifiedIdentity,
     pub(crate) name: String,
     pub(crate) cron: String,
     pub(crate) timezone: String,
@@ -208,6 +229,9 @@ pub(crate) enum SchedulingView {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ScheduleView {
+    pub(crate) node_id: String,
+    pub(crate) node_alias: String,
+    pub(crate) actionable: bool,
     pub(crate) id: String,
     pub(crate) workspace_id: String,
     pub(crate) workspace: String,
@@ -221,6 +245,12 @@ pub(crate) struct ScheduleView {
     pub(crate) possible_pruning_boundary: bool,
     pub(crate) history_scoped: bool,
     pub(crate) history_complete: bool,
+}
+
+impl ScheduleView {
+    fn qualify(&self, inner_id: impl Into<String>) -> QualifiedIdentity {
+        QualifiedIdentity::new(self.node_id.clone(), inner_id)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -333,6 +363,7 @@ pub(crate) struct FocusedTerminalView {
     pub(crate) shell_id: String,
 }
 
+#[derive(Clone)]
 pub(crate) struct WorkspaceAttentionView {
     pub(crate) agent_id: String,
     pub(crate) shell_id: String,
@@ -342,6 +373,7 @@ pub(crate) struct WorkspaceAttentionView {
     pub(crate) observed_at_ms: u64,
 }
 
+#[derive(Clone)]
 pub(crate) struct AgentSessionView {
     pub(crate) id: String,
     pub(crate) label: String,
@@ -354,12 +386,14 @@ pub(crate) struct AgentSessionView {
     pub(crate) runs: Vec<AgentSessionRunView>,
 }
 
+#[derive(Clone)]
 pub(crate) struct AgentSessionRunView {
     pub(crate) agent_id: String,
     pub(crate) shell_name: Option<String>,
     pub(crate) directory: Option<PathBuf>,
 }
 
+#[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum WorkspaceItemView {
     Shell(TerminalView),
@@ -368,6 +402,7 @@ pub(crate) enum WorkspaceItemView {
     Schedule(ScheduleItemView),
 }
 
+#[derive(Clone)]
 pub(crate) struct ScheduleItemView {
     pub(crate) id: String,
     pub(crate) name: String,
@@ -376,6 +411,7 @@ pub(crate) struct ScheduleItemView {
     pub(crate) friendly_trigger: String,
 }
 
+#[derive(Clone)]
 pub(crate) struct AgentShellView {
     pub(crate) shell: TerminalView,
     pub(crate) agent: Option<AgentView>,
@@ -390,6 +426,7 @@ impl AgentShellView {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct AgentView {
     pub(crate) id: String,
     pub(crate) state: AgentDisplayState,
@@ -403,6 +440,7 @@ pub(crate) struct AgentView {
     pub(crate) root_worktree: String,
 }
 
+#[derive(Clone)]
 pub(crate) struct LauncherView {
     pub(crate) id: String,
     pub(crate) name: String,
@@ -430,6 +468,7 @@ pub(crate) struct ProjectContext {
     pub(crate) roots_configured: bool,
 }
 
+#[derive(Clone)]
 pub(crate) struct TerminalView {
     pub(crate) id: String,
     pub(crate) name: String,
@@ -446,6 +485,7 @@ pub(crate) struct TerminalView {
     pub(crate) run: Option<TerminalRunView>,
 }
 
+#[derive(Clone)]
 pub(crate) struct TerminalRunView {
     pub(crate) id: String,
     pub(crate) generation: u64,
@@ -485,6 +525,14 @@ impl TerminalView {
 }
 
 impl WorkspaceView {
+    fn qualify(&self, inner_id: impl Into<String>) -> QualifiedIdentity {
+        QualifiedIdentity::new(self.node.id.clone(), inner_id)
+    }
+
+    fn actionable(&self) -> bool {
+        self.node.local && self.node.current && !self.node.stale
+    }
+
     fn shell_count(&self) -> usize {
         self.items
             .iter()
@@ -690,42 +738,42 @@ impl AttentionReason {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum DashboardEffect {
     Quit,
-    RestoreWorkspace(String),
+    RestoreWorkspace(QualifiedIdentity),
     Open(OpenTarget),
     Close(CloseTarget),
     CreateWorkspace {
         name: String,
         default_cwd: Option<PathBuf>,
     },
-    CreateShell(String),
+    CreateShell(QualifiedIdentity),
     Rename {
         target: RenameTarget,
         name: String,
     },
     CheckForUpdates,
     Refresh,
-    RunSchedule(String),
-    PauseSchedule(String),
-    ResumeSchedule(String),
-    CancelExecution(String),
+    RunSchedule(QualifiedIdentity),
+    PauseSchedule(QualifiedIdentity),
+    ResumeSchedule(QualifiedIdentity),
+    CancelExecution(QualifiedIdentity),
     OpenScheduledExecution {
-        execution_id: String,
+        execution_id: QualifiedIdentity,
     },
-    RemoveSchedule(String),
+    RemoveSchedule(QualifiedIdentity),
     LoadScheduleHistory {
-        schedule_id: String,
+        schedule_id: QualifiedIdentity,
         limit: u16,
     },
     LoadScheduleEditor {
-        schedule_id: String,
+        schedule_id: QualifiedIdentity,
     },
     UpdateSchedule {
-        schedule_id: String,
+        schedule_id: QualifiedIdentity,
         expected_revision: u64,
         update: ScheduleEditUpdate,
     },
     ReadTerminalPreview {
-        shell_id: String,
+        shell_id: QualifiedIdentity,
         run_id: Option<String>,
         output_revision: u64,
     },
@@ -742,15 +790,15 @@ pub(crate) enum DashboardEvent {
     OperationCompleted(Result<String, String>),
     RefreshCompleted(Result<DashboardState, String>),
     ScheduleHistoryCompleted {
-        schedule_id: String,
+        schedule_id: QualifiedIdentity,
         result: Result<(Vec<ExecutionView>, bool), String>,
     },
     ScheduleEditorLoaded {
-        schedule_id: String,
+        schedule_id: QualifiedIdentity,
         result: Result<ScheduleEditInspection, String>,
     },
     ScheduleEditorSaved {
-        schedule_id: String,
+        schedule_id: QualifiedIdentity,
         result: Result<String, String>,
     },
     TextPasted(String),
@@ -776,7 +824,10 @@ where
 }
 
 struct App {
+    nodes: Vec<NodeView>,
+    all_workspaces: Vec<WorkspaceView>,
     workspaces: Vec<WorkspaceView>,
+    all_schedules: Vec<ScheduleView>,
     schedules: Vec<ScheduleView>,
     scheduling: SchedulingView,
     exact_run_attachment: bool,
@@ -796,6 +847,7 @@ struct App {
     follow_focused_terminal: bool,
     selection_pinned: bool,
     observed_focus_revision: Option<u64>,
+    node_filter: Option<String>,
 }
 
 struct TerminalPreviewState {
@@ -855,8 +907,8 @@ fn shortcut_tab(key: char) -> Option<PrimaryTab> {
 
 #[derive(Clone)]
 struct ItemIdentity {
-    workspace_id: String,
-    item_id: String,
+    workspace_id: QualifiedIdentity,
+    item_id: QualifiedIdentity,
     kind: ItemIdentityKind,
 }
 
@@ -869,27 +921,27 @@ enum ItemIdentityKind {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum OpenTarget {
-    Shell(String),
+    Shell(QualifiedIdentity),
     Launcher {
-        workspace_id: String,
-        launcher_id: String,
+        workspace_id: QualifiedIdentity,
+        launcher_id: QualifiedIdentity,
     },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum RenameTarget {
-    Workspace(String),
-    Shell(String),
-    Launcher(String),
+    Workspace(QualifiedIdentity),
+    Shell(QualifiedIdentity),
+    Launcher(QualifiedIdentity),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum CloseTarget {
-    Workspace(String),
-    Shell(String),
-    Launcher(String),
-    Schedule(String),
-    Execution(String),
+    Workspace(QualifiedIdentity),
+    Shell(QualifiedIdentity),
+    Launcher(QualifiedIdentity),
+    Schedule(QualifiedIdentity),
+    Execution(QualifiedIdentity),
 }
 
 impl RenameTarget {
@@ -912,7 +964,7 @@ enum Mode {
 }
 
 struct ScheduleEditor {
-    schedule_id: String,
+    schedule_id: QualifiedIdentity,
     expected_revision: u64,
     field: ScheduleEditorField,
     preset: ScheduleTriggerPreset,
@@ -1295,7 +1347,7 @@ enum PaletteCommand {
     CreateWorkspace,
     ShowHelp,
     Workspace {
-        workspace_id: String,
+        workspace_id: QualifiedIdentity,
         action: WorkspacePaletteAction,
     },
     Item {
@@ -1303,12 +1355,12 @@ enum PaletteCommand {
         action: ItemPaletteAction,
     },
     Attention {
-        workspace_id: String,
-        shell_id: String,
-        agent_id: String,
+        workspace_id: QualifiedIdentity,
+        shell_id: QualifiedIdentity,
+        agent_id: QualifiedIdentity,
     },
     Schedule {
-        schedule_id: String,
+        schedule_id: QualifiedIdentity,
         action: SchedulePaletteAction,
     },
 }
@@ -1492,6 +1544,9 @@ impl CommandPalette {
                 (WorkspacePaletteAction::Rename, PaletteActionGroup::Rename),
                 (WorkspacePaletteAction::Close, PaletteActionGroup::Close),
             ] {
+                if !workspace.actionable() && !matches!(action, WorkspacePaletteAction::GoTo) {
+                    continue;
+                }
                 entries.push(PaletteEntry {
                     action_group,
                     kind_group: if matches!(action, WorkspacePaletteAction::AddShell) {
@@ -1511,7 +1566,7 @@ impl CommandPalette {
                     ),
                     keywords: workspace_keywords.clone(),
                     command: PaletteCommand::Workspace {
-                        workspace_id: workspace.id.clone(),
+                        workspace_id: workspace.qualify(&workspace.id),
                         action,
                     },
                 });
@@ -1526,8 +1581,8 @@ impl CommandPalette {
                     continue;
                 }
                 let identity = ItemIdentity {
-                    workspace_id: workspace.id.clone(),
-                    item_id: item.id().to_owned(),
+                    workspace_id: workspace.qualify(&workspace.id),
+                    item_id: workspace.qualify(item.id()),
                     kind: if kind == ItemKind::Launcher {
                         ItemIdentityKind::Launcher
                     } else {
@@ -1556,6 +1611,9 @@ impl CommandPalette {
                     (ItemPaletteAction::Rename, PaletteActionGroup::Rename),
                     (ItemPaletteAction::Close, PaletteActionGroup::Close),
                 ] {
+                    if !workspace.actionable() && !matches!(action, ItemPaletteAction::GoTo) {
+                        continue;
+                    }
                     entries.push(PaletteEntry {
                         action_group,
                         kind_group,
@@ -1603,9 +1661,9 @@ impl CommandPalette {
                             attention.shell_id
                         ),
                         command: PaletteCommand::Attention {
-                            workspace_id: workspace.id.clone(),
-                            shell_id: attention.shell_id.clone(),
-                            agent_id: attention.agent_id.clone(),
+                            workspace_id: workspace.qualify(&workspace.id),
+                            shell_id: workspace.qualify(&attention.shell_id),
+                            agent_id: workspace.qualify(&attention.agent_id),
                         },
                     },
                 ));
@@ -1655,6 +1713,9 @@ impl CommandPalette {
                     "remove with confirmation",
                 ),
             ] {
+                if !schedule.actionable && !matches!(action, SchedulePaletteAction::GoTo) {
+                    continue;
+                }
                 entries.push(PaletteEntry {
                     action_group,
                     kind_group: PaletteKindGroup::Schedules,
@@ -1662,7 +1723,7 @@ impl CommandPalette {
                     detail: detail.into(),
                     keywords: keywords.clone(),
                     command: PaletteCommand::Schedule {
-                        schedule_id: schedule.id.clone(),
+                        schedule_id: schedule.qualify(&schedule.id),
                         action,
                     },
                 });
@@ -1680,7 +1741,7 @@ impl CommandPalette {
                     detail: execution_summary(execution),
                     keywords: format!("schedule notice failed skipped missed blocked {keywords}"),
                     command: PaletteCommand::Schedule {
-                        schedule_id: schedule.id.clone(),
+                        schedule_id: schedule.qualify(&schedule.id),
                         action: SchedulePaletteAction::SelectExecution(execution.id.clone()),
                     },
                 });
@@ -1697,7 +1758,7 @@ impl CommandPalette {
                     .first()
                     .map_or(PaletteCommand::ShowHelp, |schedule| {
                         PaletteCommand::Schedule {
-                            schedule_id: schedule.id.clone(),
+                            schedule_id: schedule.qualify(&schedule.id),
                             action: SchedulePaletteAction::GoTo,
                         }
                     }),
@@ -1837,8 +1898,20 @@ impl App {
                 item_state.select(Some(0));
             }
         }
+        let nodes = workspaces.iter().fold(Vec::new(), |mut nodes, workspace| {
+            if !nodes
+                .iter()
+                .any(|node: &NodeView| node.id == workspace.node.id)
+            {
+                nodes.push(workspace.node.clone());
+            }
+            nodes
+        });
         Self {
+            nodes,
+            all_workspaces: workspaces.clone(),
             workspaces,
+            all_schedules: Vec::new(),
             schedules: Vec::new(),
             scheduling: SchedulingView::Unsupported {
                 required_protocol: 22,
@@ -1861,7 +1934,63 @@ impl App {
             follow_focused_terminal: false,
             selection_pinned: false,
             observed_focus_revision: None,
+            node_filter: None,
         }
+    }
+
+    fn cycle_node_filter(&mut self) {
+        if self.nodes.is_empty() {
+            return;
+        }
+        let filter = match self
+            .node_filter
+            .as_ref()
+            .and_then(|id| self.nodes.iter().position(|node| &node.id == id))
+        {
+            None => Some(self.nodes[0].id.clone()),
+            Some(index) if index + 1 < self.nodes.len() => Some(self.nodes[index + 1].id.clone()),
+            Some(_) => None,
+        };
+        self.set_node_filter(filter);
+    }
+
+    fn set_node_filter(&mut self, filter: Option<String>) {
+        self.node_filter = filter.filter(|id| self.nodes.iter().any(|node| &node.id == id));
+        let workspaces = self
+            .all_workspaces
+            .iter()
+            .filter(|workspace| {
+                self.node_filter
+                    .as_ref()
+                    .is_none_or(|node_id| workspace.node.id == *node_id)
+            })
+            .cloned()
+            .collect();
+        let schedules = self
+            .all_schedules
+            .iter()
+            .filter(|schedule| {
+                self.node_filter
+                    .as_ref()
+                    .is_none_or(|node_id| schedule.node_id == *node_id)
+            })
+            .cloned()
+            .collect();
+        self.replace_workspaces(workspaces);
+        self.replace_schedules(schedules);
+        self.message = Some(Message {
+            text: self.node_filter.as_ref().map_or_else(
+                || "Showing all Nodes".into(),
+                |id| {
+                    let node = self.nodes.iter().find(|node| &node.id == id);
+                    format!(
+                        "Showing Node {}",
+                        node.map_or(id.as_str(), |node| &node.alias)
+                    )
+                },
+            ),
+            error: false,
+        });
     }
 
     fn enable_focus_following(&mut self, focused_terminal: Option<&FocusedTerminalView>) {
@@ -1889,7 +2018,7 @@ impl App {
         let Some(workspace_index) = self
             .workspaces
             .iter()
-            .position(|workspace| workspace.id == focused.workspace_id)
+            .position(|workspace| workspace.node.local && workspace.id == focused.workspace_id)
         else {
             return;
         };
@@ -1974,7 +2103,7 @@ impl App {
         self.selected_schedule()
             .filter(|schedule| !schedule.history_scoped)
             .map(|schedule| DashboardEffect::LoadScheduleHistory {
-                schedule_id: schedule.id.clone(),
+                schedule_id: schedule.qualify(&schedule.id),
                 limit: 100,
             })
     }
@@ -2243,12 +2372,10 @@ impl App {
         self.message = None;
     }
 
-    fn select_workspace(&mut self, workspace_id: &str, focus: Focus) -> bool {
-        let Some(index) = self
-            .workspaces
-            .iter()
-            .position(|workspace| workspace.id == workspace_id)
-        else {
+    fn select_workspace(&mut self, workspace_id: &QualifiedIdentity, focus: Focus) -> bool {
+        let Some(index) = self.workspaces.iter().position(|workspace| {
+            workspace.node.id == workspace_id.node_id && workspace.id == workspace_id.inner_id
+        }) else {
             self.message = Some(Message {
                 text: "workspace is no longer available".into(),
                 error: true,
@@ -2263,11 +2390,10 @@ impl App {
     }
 
     fn select_item_identity(&mut self, identity: &ItemIdentity) -> bool {
-        let Some(workspace_index) = self
-            .workspaces
-            .iter()
-            .position(|workspace| workspace.id == identity.workspace_id)
-        else {
+        let Some(workspace_index) = self.workspaces.iter().position(|workspace| {
+            workspace.node.id == identity.workspace_id.node_id
+                && workspace.id == identity.workspace_id.inner_id
+        }) else {
             self.message = Some(Message {
                 text: "item workspace is no longer available".into(),
                 error: true,
@@ -2294,12 +2420,10 @@ impl App {
         true
     }
 
-    fn select_schedule_id(&mut self, schedule_id: &str) -> bool {
-        let Some(index) = self
-            .schedules
-            .iter()
-            .position(|schedule| schedule.id == schedule_id)
-        else {
+    fn select_schedule_id(&mut self, schedule_id: &QualifiedIdentity) -> bool {
+        let Some(index) = self.schedules.iter().position(|schedule| {
+            schedule.node_id == schedule_id.node_id && schedule.id == schedule_id.inner_id
+        }) else {
             self.message = Some(Message {
                 text: "schedule is no longer available".into(),
                 error: true,
@@ -2356,10 +2480,13 @@ impl App {
 
     fn request_rename(&mut self) -> Option<DashboardEffect> {
         let schedule_id = if self.primary_tab == PrimaryTab::Schedules {
-            self.selected_schedule().map(|schedule| schedule.id.clone())
+            self.selected_schedule()
+                .map(|schedule| schedule.qualify(&schedule.id))
         } else {
             match self.selected_item() {
-                Some(WorkspaceItemView::Schedule(schedule)) => Some(schedule.id.clone()),
+                Some(WorkspaceItemView::Schedule(schedule)) => self
+                    .selected_item_workspace()
+                    .map(|workspace| workspace.qualify(&schedule.id)),
                 _ => None,
             }
         };
@@ -2387,18 +2514,21 @@ impl App {
             return None;
         }
         let target = if self.primary_tab != PrimaryTab::Workspaces {
-            self.selected_item()
-                .filter(|item| item.ordinary_visible())
-                .and_then(item_rename_target)
+            self.selected_item_workspace()
+                .filter(|workspace| workspace.actionable())
+                .zip(self.selected_item().filter(|item| item.ordinary_visible()))
+                .and_then(|(workspace, item)| item_rename_target(workspace, item))
         } else {
             match self.focus {
                 Focus::Workspaces => self
                     .selected()
-                    .map(|workspace| RenameTarget::Workspace(workspace.id.clone())),
+                    .filter(|workspace| workspace.actionable())
+                    .map(|workspace| RenameTarget::Workspace(workspace.qualify(&workspace.id))),
                 Focus::Items => self
-                    .selected_item()
-                    .filter(|item| item.ordinary_visible())
-                    .and_then(item_rename_target),
+                    .selected()
+                    .filter(|workspace| workspace.actionable())
+                    .zip(self.selected_item().filter(|item| item.ordinary_visible()))
+                    .and_then(|(workspace, item)| item_rename_target(workspace, item)),
             }
         };
         if let Some(target) = target {
@@ -2429,7 +2559,10 @@ impl App {
                 None
             }
             Focus::Items => {
-                let workspace_id = self.selected().map(|workspace| workspace.id.clone())?;
+                let workspace_id = self
+                    .selected()
+                    .filter(|workspace| workspace.actionable())
+                    .map(|workspace| workspace.qualify(&workspace.id))?;
                 Some(DashboardEffect::CreateShell(workspace_id))
             }
         }
@@ -2453,7 +2586,8 @@ impl App {
             return None;
         }
         self.selected()
-            .map(|workspace| DashboardEffect::RestoreWorkspace(workspace.id.clone()))
+            .filter(|workspace| workspace.actionable())
+            .map(|workspace| DashboardEffect::RestoreWorkspace(workspace.qualify(&workspace.id)))
     }
 
     fn open_selected_item(&self) -> Option<DashboardEffect> {
@@ -2461,17 +2595,20 @@ impl App {
         {
             return None;
         }
-        let workspace_id = self
+        let workspace = self
             .selected_item_workspace()
-            .map(|workspace| workspace.id.clone())?;
+            .filter(|workspace| workspace.actionable())?;
+        let workspace_id = workspace.qualify(&workspace.id);
         let target = self.selected_item().and_then(|item| match item {
-            WorkspaceItemView::Shell(shell) => Some(OpenTarget::Shell(shell.id.clone())),
+            WorkspaceItemView::Shell(shell) => {
+                Some(OpenTarget::Shell(workspace.qualify(&shell.id)))
+            }
             WorkspaceItemView::AgentShell(agent_shell) => {
-                Some(OpenTarget::Shell(agent_shell.shell.id.clone()))
+                Some(OpenTarget::Shell(workspace.qualify(&agent_shell.shell.id)))
             }
             WorkspaceItemView::Launcher(launcher) => Some(OpenTarget::Launcher {
                 workspace_id,
-                launcher_id: launcher.id.clone(),
+                launcher_id: workspace.qualify(&launcher.id),
             }),
             WorkspaceItemView::Schedule(_) => None,
         })?;
@@ -2480,7 +2617,9 @@ impl App {
 
     fn activate_selected_item(&mut self) -> Option<DashboardEffect> {
         let schedule_id = match self.selected_item() {
-            Some(WorkspaceItemView::Schedule(schedule)) => Some(schedule.id.clone()),
+            Some(WorkspaceItemView::Schedule(schedule)) => self
+                .selected_item_workspace()
+                .map(|workspace| workspace.qualify(&schedule.id)),
             _ => None,
         };
         if let Some(schedule_id) = schedule_id {
@@ -2494,30 +2633,38 @@ impl App {
 
     fn request_close(&mut self) {
         if self.primary_tab == PrimaryTab::Schedules {
-            self.pending_close = self.selected_schedule().map(|schedule| PendingClose {
-                target: CloseTarget::Schedule(schedule.id.clone()),
-                name: schedule.name.clone(),
-                shell_count: 0,
-                launcher_count: 0,
-            });
+            self.pending_close = self
+                .selected_schedule()
+                .filter(|schedule| schedule.actionable)
+                .map(|schedule| PendingClose {
+                    target: CloseTarget::Schedule(schedule.qualify(&schedule.id)),
+                    name: schedule.name.clone(),
+                    shell_count: 0,
+                    launcher_count: 0,
+                });
             return;
         }
         self.pending_close = if self.primary_tab != PrimaryTab::Workspaces {
-            self.selected_item()
-                .filter(|item| item.ordinary_visible())
-                .map(item_pending_close)
+            self.selected_item_workspace()
+                .filter(|workspace| workspace.actionable())
+                .zip(self.selected_item().filter(|item| item.ordinary_visible()))
+                .map(|(workspace, item)| item_pending_close(workspace, item))
         } else {
             match self.focus {
-                Focus::Workspaces => self.selected().map(|workspace| PendingClose {
-                    target: CloseTarget::Workspace(workspace.id.clone()),
-                    name: workspace.name.clone(),
-                    shell_count: workspace.process_count(),
-                    launcher_count: workspace.launcher_count(),
-                }),
+                Focus::Workspaces => self
+                    .selected()
+                    .filter(|workspace| workspace.actionable())
+                    .map(|workspace| PendingClose {
+                        target: CloseTarget::Workspace(workspace.qualify(&workspace.id)),
+                        name: workspace.name.clone(),
+                        shell_count: workspace.process_count(),
+                        launcher_count: workspace.launcher_count(),
+                    }),
                 Focus::Items => self
-                    .selected_item()
-                    .filter(|item| item.ordinary_visible())
-                    .map(item_pending_close),
+                    .selected()
+                    .filter(|workspace| workspace.actionable())
+                    .zip(self.selected_item().filter(|item| item.ordinary_visible()))
+                    .map(|(workspace, item)| item_pending_close(workspace, item)),
             }
         };
     }
@@ -2535,7 +2682,7 @@ impl App {
         }
     }
 
-    fn request_cancel_execution(&mut self, execution_id: String, label: String) {
+    fn request_cancel_execution(&mut self, execution_id: QualifiedIdentity, label: String) {
         self.pending_close = Some(PendingClose {
             target: CloseTarget::Execution(execution_id),
             name: label,
@@ -2573,11 +2720,10 @@ impl App {
                 result,
             } => match result {
                 Ok((executions, truncated)) => {
-                    if let Some(schedule) = self
-                        .schedules
-                        .iter_mut()
-                        .find(|schedule| schedule.id == schedule_id)
-                    {
+                    if let Some(schedule) = self.schedules.iter_mut().find(|schedule| {
+                        schedule.node_id == schedule_id.node_id
+                            && schedule.id == schedule_id.inner_id
+                    }) {
                         schedule.executions = executions;
                         schedule.history_truncated = truncated;
                         schedule.history_scoped = true;
@@ -2713,6 +2859,7 @@ impl App {
                 };
             }
             KeyCode::Char('r') => return Some(DashboardEffect::Refresh),
+            KeyCode::Char('n') => self.cycle_node_filter(),
             KeyCode::Char('[') if self.primary_tab == PrimaryTab::Schedules => {
                 self.cycle_execution(false);
             }
@@ -2722,17 +2869,19 @@ impl App {
             KeyCode::Char('u') if self.primary_tab == PrimaryTab::Schedules => {
                 return self
                     .selected_schedule()
-                    .map(|schedule| DashboardEffect::RunSchedule(schedule.id.clone()));
+                    .filter(|schedule| schedule.actionable)
+                    .map(|schedule| DashboardEffect::RunSchedule(schedule.qualify(&schedule.id)));
             }
             KeyCode::Char('p') if self.primary_tab == PrimaryTab::Schedules => {
                 return self
                     .selected_schedule()
+                    .filter(|schedule| schedule.actionable)
                     .map(|schedule| match schedule.state {
                         ScheduleDisplayState::Paused => {
-                            DashboardEffect::ResumeSchedule(schedule.id.clone())
+                            DashboardEffect::ResumeSchedule(schedule.qualify(&schedule.id))
                         }
                         ScheduleDisplayState::Enabled => {
-                            DashboardEffect::PauseSchedule(schedule.id.clone())
+                            DashboardEffect::PauseSchedule(schedule.qualify(&schedule.id))
                         }
                     });
             }
@@ -2742,8 +2891,11 @@ impl App {
                     .filter(|execution| execution.state.is_active())
                     .cloned()
                 {
+                    let node_id = self
+                        .selected_schedule()
+                        .map(|schedule| schedule.node_id.clone())?;
                     self.request_cancel_execution(
-                        execution.id.clone(),
+                        QualifiedIdentity::new(node_id, &execution.id),
                         format!("execution {}", short_id(&execution.id)),
                     );
                 }
@@ -2776,8 +2928,31 @@ impl App {
     fn apply_refresh(&mut self, result: Result<DashboardState, String>) {
         match result {
             Ok(state) => {
-                self.replace_workspaces(state.workspaces);
-                self.replace_schedules(state.schedules);
+                self.nodes = state.nodes;
+                self.all_workspaces = state.workspaces;
+                self.all_schedules = state.schedules;
+                let workspaces = self
+                    .all_workspaces
+                    .iter()
+                    .filter(|workspace| {
+                        self.node_filter
+                            .as_ref()
+                            .is_none_or(|node_id| workspace.node.id == *node_id)
+                    })
+                    .cloned()
+                    .collect();
+                let schedules = self
+                    .all_schedules
+                    .iter()
+                    .filter(|schedule| {
+                        self.node_filter
+                            .as_ref()
+                            .is_none_or(|node_id| schedule.node_id == *node_id)
+                    })
+                    .cloned()
+                    .collect();
+                self.replace_workspaces(workspaces);
+                self.replace_schedules(schedules);
                 self.scheduling = state.scheduling;
                 self.exact_run_attachment = state.exact_run_attachment;
                 self.schedule_editing = state.schedule_editing;
@@ -2794,9 +2969,12 @@ impl App {
         let selected = if self.primary_tab == PrimaryTab::Workspaces && self.focus != Focus::Items {
             None
         } else {
+            let workspace = self
+                .selected_item_workspace()
+                .filter(|workspace| workspace.actionable())?;
             self.selected_item().and_then(|item| match item {
                 WorkspaceItemView::Shell(shell) if shell.kind == TerminalKind::Shell => Some((
-                    shell.id.clone(),
+                    workspace.qualify(&shell.id),
                     shell.run.as_ref().map(|run| run.id.clone()),
                     shell.run.as_ref().map_or(0, |run| run.output_revision),
                 )),
@@ -2811,7 +2989,7 @@ impl App {
             return None;
         };
         if self.terminal_preview.as_ref().is_some_and(|preview| {
-            preview.shell_id == shell_id
+            preview.shell_id == shell_id.inner_id
                 && preview.run_id == run_id
                 && preview.output_revision == output_revision
                 && preview.output.is_ok()
@@ -2913,12 +3091,18 @@ impl App {
     }
 
     fn replace_workspaces(&mut self, workspaces: Vec<WorkspaceView>) {
-        let selected_id = self.selected().map(|workspace| workspace.id.clone());
+        let selected_id = self
+            .selected()
+            .map(|workspace| workspace.qualify(&workspace.id));
         let selected_item = self.workspace_item_identity();
         let selected_global_item = self.global_item_identity();
         let previous_index = self.selected_index().unwrap_or(0);
         let selected_index = selected_id
-            .and_then(|id| workspaces.iter().position(|workspace| workspace.id == id))
+            .and_then(|id| {
+                workspaces.iter().position(|workspace| {
+                    workspace.node.id == id.node_id && workspace.id == id.inner_id
+                })
+            })
             .or_else(|| (!workspaces.is_empty()).then(|| previous_index.min(workspaces.len() - 1)));
 
         self.workspaces = workspaces;
@@ -2947,13 +3131,19 @@ impl App {
     }
 
     fn replace_schedules(&mut self, schedules: Vec<ScheduleView>) {
-        let selected = self.selected_schedule().map(|schedule| schedule.id.clone());
+        let selected = self
+            .selected_schedule()
+            .map(|schedule| schedule.qualify(&schedule.id));
         let previous = self.global_state.selected().unwrap_or(0);
         self.schedules = schedules;
         if self.primary_tab == PrimaryTab::Schedules {
             self.global_state.select(
                 selected
-                    .and_then(|id| self.schedules.iter().position(|schedule| schedule.id == id))
+                    .and_then(|id| {
+                        self.schedules.iter().position(|schedule| {
+                            schedule.node_id == id.node_id && schedule.id == id.inner_id
+                        })
+                    })
                     .or_else(|| {
                         (!self.schedules.is_empty())
                             .then_some(previous.min(self.schedules.len() - 1))
@@ -2964,6 +3154,10 @@ impl App {
     }
 
     fn open_selected_schedule_link(&mut self) -> Option<DashboardEffect> {
+        let node_id = self
+            .selected_schedule()
+            .filter(|schedule| schedule.actionable)
+            .map(|schedule| schedule.node_id.clone())?;
         let execution = self.selected_execution()?.clone();
         if execution.state.is_active() && !self.exact_run_attachment {
             self.message = Some(Message {
@@ -2974,14 +3168,17 @@ impl App {
             return None;
         }
         Some(DashboardEffect::OpenScheduledExecution {
-            execution_id: execution.id,
+            execution_id: QualifiedIdentity::new(node_id, execution.id),
         })
     }
 
-    fn select_agent_id(&mut self, agent_id: &str) -> bool {
+    fn select_agent_id(&mut self, agent_id: &QualifiedIdentity) -> bool {
         let Some((workspace_index, item_index)) = self.workspaces.iter().enumerate().find_map(|(workspace_index, workspace)| {
+            if workspace.node.id != agent_id.node_id {
+                return None;
+            }
             workspace.items.iter().enumerate().find_map(|(item_index, item)| {
-                matches!(item, WorkspaceItemView::AgentShell(agent) if agent.agent.as_ref().is_some_and(|agent| agent.id == agent_id))
+                matches!(item, WorkspaceItemView::AgentShell(agent) if agent.agent.as_ref().is_some_and(|agent| agent.id == agent_id.inner_id))
                     .then_some((workspace_index, item_index))
             })
         }) else {
@@ -3020,7 +3217,8 @@ impl App {
                 .is_some_and(|(workspace, item)| {
                     let workspace = &self.workspaces[workspace];
                     item_matches(&workspace.items[item], identity)
-                        && workspace.id == identity.workspace_id
+                        && workspace.node.id == identity.workspace_id.node_id
+                        && workspace.id == identity.workspace_id.inner_id
                 })
         })
     }
@@ -3034,8 +3232,8 @@ fn item_identity(workspace: &WorkspaceView, item: &WorkspaceItemView) -> ItemIde
         WorkspaceItemView::Schedule(schedule) => (schedule.id.clone(), ItemIdentityKind::Schedule),
     };
     ItemIdentity {
-        workspace_id: workspace.id.clone(),
-        item_id,
+        workspace_id: workspace.qualify(&workspace.id),
+        item_id: workspace.qualify(item_id),
         kind,
     }
 }
@@ -3043,51 +3241,55 @@ fn item_identity(workspace: &WorkspaceView, item: &WorkspaceItemView) -> ItemIde
 fn item_matches(item: &WorkspaceItemView, identity: &ItemIdentity) -> bool {
     match item {
         WorkspaceItemView::Shell(shell) => {
-            identity.kind == ItemIdentityKind::Shell && shell.id == identity.item_id
+            identity.kind == ItemIdentityKind::Shell && shell.id == identity.item_id.inner_id
         }
         WorkspaceItemView::AgentShell(agent) => {
-            identity.kind == ItemIdentityKind::Shell && agent.shell.id == identity.item_id
+            identity.kind == ItemIdentityKind::Shell && agent.shell.id == identity.item_id.inner_id
         }
         WorkspaceItemView::Launcher(launcher) => {
-            identity.kind == ItemIdentityKind::Launcher && launcher.id == identity.item_id
+            identity.kind == ItemIdentityKind::Launcher && launcher.id == identity.item_id.inner_id
         }
         WorkspaceItemView::Schedule(schedule) => {
-            identity.kind == ItemIdentityKind::Schedule && schedule.id == identity.item_id
+            identity.kind == ItemIdentityKind::Schedule && schedule.id == identity.item_id.inner_id
         }
     }
 }
 
-fn item_rename_target(item: &WorkspaceItemView) -> Option<RenameTarget> {
+fn item_rename_target(workspace: &WorkspaceView, item: &WorkspaceItemView) -> Option<RenameTarget> {
     match item {
-        WorkspaceItemView::Shell(shell) => Some(RenameTarget::Shell(shell.id.clone())),
-        WorkspaceItemView::AgentShell(agent) => Some(RenameTarget::Shell(agent.shell.id.clone())),
-        WorkspaceItemView::Launcher(launcher) => Some(RenameTarget::Launcher(launcher.id.clone())),
+        WorkspaceItemView::Shell(shell) => Some(RenameTarget::Shell(workspace.qualify(&shell.id))),
+        WorkspaceItemView::AgentShell(agent) => {
+            Some(RenameTarget::Shell(workspace.qualify(&agent.shell.id)))
+        }
+        WorkspaceItemView::Launcher(launcher) => {
+            Some(RenameTarget::Launcher(workspace.qualify(&launcher.id)))
+        }
         WorkspaceItemView::Schedule(_) => None,
     }
 }
 
-fn item_pending_close(item: &WorkspaceItemView) -> PendingClose {
+fn item_pending_close(workspace: &WorkspaceView, item: &WorkspaceItemView) -> PendingClose {
     match item {
         WorkspaceItemView::Shell(shell) => PendingClose {
-            target: CloseTarget::Shell(shell.id.clone()),
+            target: CloseTarget::Shell(workspace.qualify(&shell.id)),
             name: shell.name.clone(),
             shell_count: 1,
             launcher_count: 0,
         },
         WorkspaceItemView::AgentShell(agent) => PendingClose {
-            target: CloseTarget::Shell(agent.shell.id.clone()),
+            target: CloseTarget::Shell(workspace.qualify(&agent.shell.id)),
             name: agent.shell.name.clone(),
             shell_count: 1,
             launcher_count: 0,
         },
         WorkspaceItemView::Launcher(launcher) => PendingClose {
-            target: CloseTarget::Launcher(launcher.id.clone()),
+            target: CloseTarget::Launcher(workspace.qualify(&launcher.id)),
             name: launcher.name.clone(),
             shell_count: 0,
             launcher_count: 1,
         },
         WorkspaceItemView::Schedule(schedule) => PendingClose {
-            target: CloseTarget::Schedule(schedule.id.clone()),
+            target: CloseTarget::Schedule(workspace.qualify(&schedule.id)),
             name: schedule.name.clone(),
             shell_count: 0,
             launcher_count: 0,
@@ -3108,7 +3310,12 @@ pub(crate) fn run<B: DashboardBackend>(
         return Err(error);
     }
     let mut app = App::new(state.workspaces, project_context);
+    app.nodes = state.nodes;
+    app.all_schedules = state.schedules.clone();
     app.schedules = state.schedules;
+    if state.initial_node_filter.is_some() {
+        app.set_node_filter(state.initial_node_filter);
+    }
     app.scheduling = state.scheduling;
     app.exact_run_attachment = state.exact_run_attachment;
     app.schedule_editing = state.schedule_editing;
@@ -4501,6 +4708,22 @@ fn centered_rect(area: Rect, width_percent: u16, height_percent: u16) -> Rect {
     horizontal
 }
 
+fn workspace_display_name(workspace: &WorkspaceView) -> String {
+    if workspace.node.local {
+        return workspace.name.clone();
+    }
+    let health = format!("{:?}", workspace.node.health).to_ascii_lowercase();
+    let freshness = if workspace.node.stale || !workspace.node.current {
+        " stale"
+    } else {
+        ""
+    };
+    format!(
+        "[{} {health}{freshness}] {}",
+        workspace.node.alias, workspace.name
+    )
+}
+
 fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
     if area.width < 100 {
         let spans = PrimaryTab::ALL
@@ -4518,6 +4741,17 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                 ]
             })
             .collect::<Vec<_>>();
+        let filter = app.node_filter.as_ref().map_or("all", |id| {
+            app.nodes
+                .iter()
+                .find(|node| &node.id == id)
+                .map_or("unknown", |node| node.alias.as_str())
+        });
+        let mut spans = spans;
+        spans.push(Span::styled(
+            format!(" NODE:{filter}"),
+            Style::new().fg(YELLOW),
+        ));
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
         return;
     }
@@ -4567,6 +4801,25 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                 ]
             }),
     );
+    spans.push(Span::styled(" NODES: ", Style::new().fg(SUBTEXT)));
+    for node in &app.nodes {
+        spans.push(Span::styled(
+            format!(
+                "{}({}) {}/{} sched:{}/{} p{} obs:{} caps:{}  ",
+                node.alias,
+                if node.local { "local" } else { "remote" },
+                format!("{:?}", node.health).to_ascii_lowercase(),
+                if node.stale { "stale" } else { "current" },
+                format!("{:?}", node.scheduler.state).to_ascii_lowercase(),
+                node.scheduler.active_executions,
+                node.observed_protocol_version
+                    .map_or_else(|| "?".into(), |version| version.to_string()),
+                node.observed_at_ms,
+                node.observed_capabilities.len(),
+            ),
+            Style::new().fg(if node.stale { YELLOW } else { GREEN }),
+        ));
+    }
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
@@ -4590,7 +4843,7 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
     } else {
         app.workspaces
             .iter()
-            .map(|workspace| Row::new([Cell::from(workspace.name.as_str())]))
+            .map(|workspace| Row::new([Cell::from(workspace_display_name(workspace))]))
             .collect()
     };
     let table = Table::new(rows, [Constraint::Min(8)])
@@ -4697,13 +4950,21 @@ fn render_schedules(frame: &mut Frame, area: Rect, app: &mut App) {
                     },
                     occurrence_recency,
                 );
-                let mut values = vec![schedule.name.clone()];
+                let mut values = vec![if schedule.node_alias == "local" {
+                    schedule.name.clone()
+                } else {
+                    format!("[{}] {}", schedule.node_alias, schedule.name)
+                }];
                 if show_trigger {
                     values.push(schedule.friendly_trigger.clone());
                 }
                 values.extend([next, last, schedule.state.label().into()]);
                 if show_workspace {
-                    values.push(schedule.workspace.clone());
+                    values.push(if schedule.node_alias == "local" {
+                        schedule.workspace.clone()
+                    } else {
+                        format!("[{}] {}", schedule.node_alias, schedule.workspace)
+                    });
                 }
                 if show_integration {
                     values.push(schedule.integration.clone());
@@ -4916,7 +5177,7 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                     Some([
                         agent.state().label().to_owned(),
                         updated,
-                        workspace.name.clone(),
+                        workspace_display_name(workspace),
                         agent.shell.name.clone(),
                         task.to_owned(),
                         branch,
@@ -4961,7 +5222,7 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                             .run
                             .as_ref()
                             .map_or_else(|| "-".into(), |run| format!("#{}", run.generation)),
-                        workspace.name.clone(),
+                        workspace_display_name(workspace),
                         shell.name.clone(),
                         shell.kind.label().into(),
                         shell.process().into(),
@@ -5013,7 +5274,7 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                     .iter()
                     .filter(move |item| item.kind() == kind)
                     .map(move |item| {
-                        let mut cells = vec![Cell::from(workspace.name.clone())];
+                        let mut cells = vec![Cell::from(workspace_display_name(workspace))];
                         match item {
                             WorkspaceItemView::Shell(shell) => cells.extend([
                                 Cell::from(shell.name.clone()),
@@ -6391,6 +6652,22 @@ mod tests {
 
     fn workspace(id: &str, name: &str) -> WorkspaceView {
         WorkspaceView {
+            node: NodeView {
+                id: String::new(),
+                alias: "local".into(),
+                local: true,
+                health: NodeProjectionHealthCode::Online,
+                current: true,
+                stale: false,
+                observed_at_ms: 0,
+                observed_protocol_version: None,
+                observed_capabilities: Vec::new(),
+                scheduler: SchedulerHealth {
+                    state: crate::protocol::SchedulerState::Active,
+                    max_concurrent: 4,
+                    active_executions: 0,
+                },
+            },
             id: id.into(),
             name: name.into(),
             default_cwd: None,
@@ -6498,6 +6775,9 @@ mod tests {
 
     fn schedule_view() -> ScheduleView {
         ScheduleView {
+            node_id: String::new(),
+            node_alias: "local".into(),
+            actionable: true,
             id: "schedule-1".into(),
             workspace_id: "w1".into(),
             workspace: "boomux".into(),
@@ -6511,6 +6791,79 @@ mod tests {
             possible_pruning_boundary: false,
             history_scoped: false,
             history_complete: true,
+        }
+    }
+
+    #[test]
+    fn qualified_selection_and_actions_do_not_cross_colliding_nodes() {
+        let mut local = workspace("same-workspace", "same");
+        local.node.id = "00000000-0000-0000-0000-000000000001".into();
+        let mut remote = local.clone();
+        remote.node.id = "00000000-0000-0000-0000-000000000002".into();
+        remote.node.alias = "work".into();
+        remote.node.local = false;
+        remote.node.current = false;
+        remote.node.stale = true;
+        remote.node.health = NodeProjectionHealthCode::Stale;
+        let mut app = App::new(vec![local.clone(), remote.clone()], project_context());
+        app.workspace_state.select(Some(1));
+        app.item_state.select(Some(0));
+
+        app.replace_workspaces(vec![remote, local]);
+
+        assert_eq!(
+            app.selected().unwrap().node.id,
+            "00000000-0000-0000-0000-000000000002"
+        );
+        assert_eq!(app.selected_item().unwrap().id(), "term_1");
+        assert_eq!(app.restore_selected(), None);
+        assert_eq!(app.open_selected_item(), None);
+        app.request_close();
+        assert!(app.pending_close.is_none());
+
+        app.cycle_node_filter();
+        assert_eq!(app.workspaces.len(), 1);
+        assert_eq!(app.workspaces[0].node.alias, "local");
+        app.cycle_node_filter();
+        assert_eq!(app.workspaces.len(), 1);
+        assert_eq!(app.workspaces[0].node.alias, "work");
+        app.cycle_node_filter();
+        assert_eq!(app.workspaces.len(), 2);
+    }
+
+    #[test]
+    fn every_remote_health_code_is_unmistakable_wide_and_compact() {
+        for health in [
+            NodeProjectionHealthCode::Unobserved,
+            NodeProjectionHealthCode::Online,
+            NodeProjectionHealthCode::Reconnecting,
+            NodeProjectionHealthCode::Stale,
+            NodeProjectionHealthCode::Unreachable,
+            NodeProjectionHealthCode::AuthenticationRequired,
+            NodeProjectionHealthCode::IdentityChanged,
+            NodeProjectionHealthCode::IdentityConflict,
+            NodeProjectionHealthCode::Unsupported,
+        ] {
+            let mut remote = workspace("same-workspace", "same");
+            remote.node.id = "00000000-0000-0000-0000-000000000002".into();
+            remote.node.alias = "work".into();
+            remote.node.local = false;
+            remote.node.health = health;
+            remote.node.current = health == NodeProjectionHealthCode::Online;
+            remote.node.stale = health != NodeProjectionHealthCode::Online;
+            let mut wide = App::new(vec![remote.clone()], project_context());
+            let mut compact = App::new(vec![remote], project_context());
+            let label = format!("{:?}", health).to_ascii_lowercase();
+            let wide = rendered_text(&mut wide, 180, 24);
+            let compact = rendered_text(&mut compact, 60, 20);
+            assert!(
+                wide.contains(&format!("work(remote) {label}")),
+                "{health:?}: {wide}"
+            );
+            assert!(
+                compact.contains(&format!("[work {label}")),
+                "{health:?}: {compact}"
+            );
         }
     }
 
@@ -6583,9 +6936,9 @@ mod tests {
         else {
             return;
         };
-        let output = read(&shell_id);
+        let output = read(&shell_id.inner_id);
         app.update(DashboardEvent::TerminalPreviewCompleted {
-            shell_id,
+            shell_id: shell_id.inner_id,
             run_id,
             output_revision,
             output,

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 32);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 33);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -72,6 +72,7 @@ fn native_daemon_lifecycle() {
     for command in [
         "events",
         "project.list",
+        "node.snapshot",
         "agent.register",
         "agent.ensure",
         "agent.report",
@@ -121,9 +122,12 @@ fn native_daemon_lifecycle() {
         "protocol_30",
         "protocol_31",
         "protocol_32",
+        "protocol_33",
         "node_registration_management",
         "node_projection_sync",
         "bounded_remote_node_projections",
+        "combined_node_snapshot",
+        "node_qualified_dashboard",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -158,7 +162,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 32"));
+    assert!(status_text.contains("running (protocol 33"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -918,7 +922,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 32);
+    assert_eq!(handshake.core_protocol_version, 33);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -55,6 +55,31 @@ fn registrations_survive_cold_recovery_outside_authoritative_state() {
 }
 
 #[test]
+fn combined_snapshot_is_separate_and_local_alias_ambiguity_is_typed() {
+    let daemon = TestDaemon::start();
+    daemon
+        .client
+        .add_node_registration("local", "other.example", node_id(3))
+        .unwrap();
+    let combined = daemon.client.combined_node_snapshot(None).unwrap();
+    assert_eq!(combined.nodes.len(), 2);
+    assert!(combined.nodes.iter().any(|node| node.local));
+    assert!(combined.nodes.iter().any(|node| !node.local));
+
+    let error = daemon
+        .client
+        .combined_node_snapshot(Some("local".into()))
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        ClientError::Remote(RemoteError {
+            code: Some(ErrorCode::AmbiguousTarget),
+            ..
+        })
+    ));
+}
+
+#[test]
 fn malformed_registration_store_preserves_local_daemon_operation() {
     let mut daemon = TestDaemon::start();
     daemon.crash();
@@ -91,8 +116,9 @@ fn fake_ssh(directory: &Path) {
         FEDERATION_VERSION, FederationConnectionMode, FederationHandshake, write_handshake,
     };
     use boomux::protocol::{
-        self, Envelope, EventCursor, NodeProjectionSnapshot, NodeProjectionSync,
-        NodeProjectionSyncMode, Response, SchedulerHealth, SchedulerState,
+        self, Envelope, EventCursor, NodeProjectionShell, NodeProjectionSnapshot,
+        NodeProjectionSync, NodeProjectionSyncMode, NodeProjectionWorkspace, Response,
+        SchedulerHealth, SchedulerState, ShellOwner, ShellStatus,
     };
 
     let handshake = FederationHandshake {
@@ -124,8 +150,23 @@ fn fake_ssh(directory: &Path) {
                     },
                     projection: NodeProjectionSnapshot {
                         node_id: node_id(2),
-                        workspaces: Vec::new(),
-                        shells: Vec::new(),
+                        workspaces: vec![NodeProjectionWorkspace {
+                            id: "shared-workspace".into(),
+                            name: "shared".into(),
+                            item_count: 1,
+                            attention_count: 0,
+                        }],
+                        shells: vec![NodeProjectionShell {
+                            id: "shared-shell".into(),
+                            workspace_id: "shared-workspace".into(),
+                            name: "shared".into(),
+                            owner: ShellOwner::User,
+                            status: ShellStatus::Running,
+                            run_id: Some("shared-run".into()),
+                            generation: Some(1),
+                            started_at_ms: Some(1),
+                            ended_at_ms: None,
+                        }],
                         launchers: Vec::new(),
                         agents: Vec::new(),
                         schedules: Vec::new(),
@@ -214,6 +255,38 @@ fn cli_add_and_retarget_pin_verified_identity_without_persisting_helper_path() {
     let online = online
         .unwrap_or_else(|| panic!("background projection did not become online: {last_inspect:?}"));
     assert_eq!(online["data"]["projection"]["cursor"], 0);
+    let combined = command(&directory)
+        .args(["node", "snapshot", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        combined.status.success(),
+        "node snapshot failed: {}",
+        String::from_utf8_lossy(&combined.stderr)
+    );
+    let combined: serde_json::Value = serde_json::from_slice(&combined.stdout).unwrap();
+    assert_eq!(combined["command"], "node.snapshot");
+    assert_eq!(combined["data"]["nodes"].as_array().unwrap().len(), 2);
+    let remote = combined["data"]["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|node| node["alias"] == "work")
+        .unwrap();
+    assert_eq!(remote["health"], "online");
+    assert_eq!(remote["current"], true);
+    assert_eq!(
+        remote["remote_projection"]["workspaces"][0]["id"]["node_id"],
+        node_id(2)
+    );
+    assert_eq!(
+        remote["remote_projection"]["workspaces"][0]["id"]["inner_id"],
+        "shared-workspace"
+    );
+    assert_eq!(
+        remote["remote_projection"]["shells"][0]["workspace_id"]["inner_id"],
+        "shared-workspace"
+    );
     let cache: serde_json::Value =
         serde_json::from_slice(&fs::read(directory.join("state/boomux/node-cache.json")).unwrap())
             .unwrap();


### PR DESCRIPTION
## Summary

- add protocol 33 combined Node-qualified snapshots and `node snapshot`
- preserve existing local-only list and snapshot contracts
- use structural `(node_id, inner_id)` identities throughout dashboard selection and effects
- combine rich local state with reduced remote cache without local host inspection
- render Node ownership, health, freshness, capabilities, and per-Node scheduler health
- retain stale rows while disabling owner-dependent actions
- support all-Node overview, Node filtering, and collision-safe selection

## Stack

- GitHub stack #190
- depends on #199
- implements #178

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`

Closes #178

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
