### PR TITLE
feat(node): route guarded remote operations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,10 +103,10 @@ discovers and verifies a compatible helper, or interactively installs one before
 opening and pinging a daemon-bound stdio channel. Explicit `boomux node add
 ALIAS TARGET` and revision-conditional registration management persist an
 identity-pinned route separately. A registration starts one noninteractive
-projection worker; routed dashboard and resource-management operations are not
-yet implemented. Protocol 33 exposes cached projections through the separately
+projection worker. Protocol 33 exposes cached projections through the separately
 named combined Node snapshot and dashboard while existing snapshot and list
-operations remain local-only; remote mutation remains unavailable.
+operations remain local-only. Protocol 34 adds closed typed exact-Node private
+reads and guarded management; unclassified mutation remains unavailable.
 
 ## Components
 
@@ -564,6 +564,18 @@ protocol capabilities, and per-Node scheduler health. Dashboard model identity
 and effects use `(node_id, inner_id)`; remote rows never enter local Git, host
 catalog, path, preview, or mutation paths. Protocol-32 and older clients cannot
 request this response and retain local-only behavior.
+Protocol 34 and state schema 13 add typed exact-Node routing. Workspace, Shell,
+and launcher snapshots carry positive durable revisions, and Workspace revision
+also guards membership. Schema 12 migrates explicitly by assigning revision 1.
+The routed operation union contains only fresh private exact reads, guarded
+rename/close/restart/remove, guarded Schedule pause/resume/update/remove,
+idempotent run-now, revision-guarded execution cancellation, and exact attention
+acknowledgment. Registration admission is revision-pinned across lock-free SSH
+I/O, identity and protocol are verified before owner request bytes, and routed
+responses never mutate projection cache. Only read-only operations and mutations
+with an owner-side durable idempotency key are retried; every other transport
+ambiguity performs an authoritative postcondition read and otherwise returns
+`outcome_unknown`.
 Protocol-25 lists are daemon-bounded, newest-first pages with explicit limit and
 truncation. The request limit is optional on the wire; protocol 25 defaults it to
 100 and clamps it to 1 through 1,000, while protocol-23 and protocol-24 requests

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -52,6 +52,14 @@ Protocol 33 advertises the separately named `node.snapshot` combined read. It
 contacts only the local daemon and never changes the local-only meaning of any
 existing snapshot or list operation.
 
+Protocol 34 advertises `typed_exact_node_routing` and
+`guarded_remote_management`. Dashboard effects carry structured Node-qualified
+identities, freshly inspect the owner before destructive confirmation, and use
+the resource revision, membership generation, run ID, Schedule/execution
+revision, observation revision, or dispatch key required by the operation.
+Stale Nodes and Nodes without the capability remain non-actionable. Existing
+unqualified CLI methods preserve local-only semantics.
+
 That passive command advertises only what the installed local CLI can speak and
 never reports negotiated state for a registered Node. Implemented `node.list`
 and `node.inspect` return registration data only. Future combined projection data
@@ -296,6 +304,8 @@ the current prompt.
 Protocol 32 adds `protocol_32`, `node_projection_sync`, and
 `bounded_remote_node_projections`. Protocol 33 adds `protocol_33`,
 `combined_node_snapshot`, and `node_qualified_dashboard`.
+Protocol 34 adds `protocol_34`, `typed_exact_node_routing`, and
+`guarded_remote_management`.
 
 Node snapshot health is `unobserved`, `online`, `reconnecting`, `stale`,
 `unreachable`, `authentication_required`, `identity_changed`,

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -12,8 +12,9 @@
 > implement explicit identity-pinned registration management. Protocol 32 and
 > Node-cache schema 1 implement bounded background reduced projections. Public
 > Protocol 33 adds the local-daemon combined Node snapshot and federated
-> dashboard. Public `boomux --remote TARGET` remains ad hoc; routed resource
-> operations are not yet implemented.
+> dashboard. Protocol 34 and state schema 13 implement typed exact-Node private
+> reads and guarded management operations. Public `boomux --remote TARGET`
+> remains ad hoc.
 
 ## Purpose
 
@@ -282,6 +283,32 @@ federation and event lock is released.
 
 ## Reads, Mutations, And Failure
 
+Protocol 34 routes one closed `RoutedOperation` union. It is not an arbitrary
+daemon-request envelope: creation, daemon stop/restart, Node rekey, integration
+mutation, launcher execution, attachment/session resume, and every unlisted
+request cannot be represented. The coordinator reserves the exact registration
+revision, verifies the pinned identity and protocol capability before sending
+the owner request, performs SSH I/O outside locks, and revalidates the
+registration before returning. Routed responses never update projection cache.
+
+| Operation | Owner guard | Automatic retry | Ambiguity read and exact postcondition |
+| --- | --- | --- | --- |
+| Workspace/Shell/launcher/Agent/Schedule/execution inspect | Exact ID on a fresh verified channel | Yes; read-only | Not applicable |
+| Rename Workspace/Shell/launcher | Durable resource revision | No | Exact inspect proves requested name and a later revision |
+| Close Workspace/Shell; remove launcher/Schedule | Durable resource or Schedule revision | No | Exact inspect returns typed `not_found` |
+| Restart exited Shell | Durable Shell revision and exact run ID | No | Exact inspect proves pending state, unchanged definition revision, and the confirmed retained run |
+| Pause/resume Schedule | Exact Schedule revision | No | Exact inspect proves requested state and a later revision |
+| Update paused Schedule | Exact Schedule revision | No | Private inspect proves the complete requested name, prompt, trigger, and later revision |
+| Run Schedule now | Durable dispatch key | Yes, with the same key | Dispatch-key record returns the same execution/run IDs |
+| Cancel execution | Exact execution revision and exact active run binding | No | Exact inspect proves a later `cancelled_by_user` revision |
+| Acknowledge attention | Exact raising observation revision; empty is idempotent | Yes, with the same revision | Returned Agent retains lifecycle revision and has no matching outstanding item |
+
+Any unproved ambiguous write returns `outcome_unknown`; conditional revisions
+alone never authorize blind replay. Workspace revisions also act as membership
+generations and advance when owned Shell, launcher, Agent, or Schedule membership
+changes. Schema 13 persists positive Workspace, Shell, and launcher revisions;
+the explicit schema-12 migration initializes each to 1.
+
 New explicitly Node-aware read-only views can use persisted remote projections
 and must expose their observation time and stale state. Existing commands and
 JSON methods retain their local-only result sets; federation does not append
@@ -293,7 +320,8 @@ authoritative local projection and reduced remote projections with structurally
 qualified resource identities. The dashboard consumes the same request, keeps
 stale rows visible, exposes all-Node and exact-Node filtering, and never passes
 remote records to local Git, host-session catalog, path, terminal-preview, or
-mutation code. Remote actions remain disabled in this slice.
+mutation code. Only tabled protocol-34 actions are enabled for a current,
+non-stale Node; local-only execution and presentation paths remain disabled.
 After successful ad hoc `--remote TARGET` verification, Boomux focuses the
 matching Node in the local dashboard when that Node is already registered and
 the local daemon supports the combined view; otherwise the ad hoc connection

--- a/src/agent_attention_projection.rs
+++ b/src/agent_attention_projection.rs
@@ -161,11 +161,13 @@ mod tests {
     fn workspace(agents: Vec<AgentInstanceSnapshot>) -> WorkspaceSnapshot {
         WorkspaceSnapshot {
             id: "w1".into(),
+            revision: 1,
             name: "project".into(),
             default_cwd: None,
             shells: vec![boomux::protocol::ShellSnapshot {
                 owner: boomux::protocol::ShellOwner::User,
                 id: "s1".into(),
+                revision: 1,
                 workspace_id: "w1".into(),
                 name: "shell".into(),
                 cwd: PathBuf::from("/tmp"),

--- a/src/cli_output.rs
+++ b/src/cli_output.rs
@@ -683,6 +683,7 @@ fn protocol_error_code(code: ErrorCode) -> &'static str {
         ErrorCode::NodeIdentityChanged => "node_identity_changed",
         ErrorCode::AmbiguousTarget => "ambiguous_target",
         ErrorCode::RevisionChanged => "revision_changed",
+        ErrorCode::OutcomeUnknown => "outcome_unknown",
         ErrorCode::Internal => "internal",
         ErrorCode::Unknown => "unknown",
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,10 +17,10 @@ use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
     AgentScheduleSnapshot, AgentScheduleSpec, AgentScheduleUpdate, CombinedNodeSnapshot,
     DaemonEvent, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot, NodeProjectionHealth,
-    NodeRegistrationSnapshot, NotificationDeliveryConfig, Request, Response,
-    ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot, ScheduledOccurrence,
-    ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
-    TerminalPreviewLine, TerminalPreviewSpan, TerminalProfile, UnixEnvironment,
+    NodeRegistrationSnapshot, NotificationDeliveryConfig, Request, Response, RoutedOperation,
+    RoutedOperationResult, ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot,
+    ScheduledOccurrence, ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
+    TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan, TerminalProfile, UnixEnvironment,
     UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 
@@ -608,6 +608,20 @@ impl Client {
     pub fn combined_node_snapshot(&self, selector: Option<String>) -> Result<CombinedNodeSnapshot> {
         match self.request(Request::GetCombinedNodeSnapshot { selector })? {
             Response::CombinedNodeSnapshot { snapshot } => Ok(snapshot),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn route_node_operation(
+        &self,
+        node_id: impl Into<String>,
+        operation: RoutedOperation,
+    ) -> Result<RoutedOperationResult> {
+        match self.request(Request::RouteNodeOperation {
+            node_id: node_id.into(),
+            operation,
+        })? {
+            Response::RoutedNodeOperation { result } => Ok(result),
             response => unexpected(response),
         }
     }
@@ -1871,6 +1885,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
@@ -2025,7 +2040,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 33);
+            assert_eq!(request.version, 34);
             assert_eq!(request.message, Request::GetNodeIdentity);
             protocol::write_message(
                 &mut stream,
@@ -2039,6 +2054,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
@@ -2087,7 +2103,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 33);
+            assert_eq!(request.version, 34);
             assert_eq!(request.message, Request::OpenFederationChannel);
             protocol::write_message(
                 &mut stream,
@@ -2101,6 +2117,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
@@ -2132,7 +2149,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 33);
+            assert_eq!(request.version, 34);
             assert_eq!(request.message, Request::ListNodeRegistrations);
             protocol::write_message(
                 &mut stream,
@@ -2145,6 +2162,7 @@ mod tests {
                 ),
             )
             .unwrap();
+            reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
@@ -2319,6 +2337,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);
@@ -2388,6 +2407,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
             reject_protocol(&listener, 31, 30);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -40,13 +40,13 @@ use crate::protocol::{
     NodeProjectionAgent, NodeProjectionAttention, NodeProjectionExecution, NodeProjectionLauncher,
     NodeProjectionSchedule, NodeProjectionShell, NodeProjectionSnapshot, NodeProjectionSync,
     NodeProjectionSyncMode, NodeProjectionTransition, NodeProjectionTransitionKind,
-    NodeProjectionWorkspace, NotificationDeliveryConfig, Request, Response,
-    ScheduledExecutionDispatchKind, ScheduledExecutionOutcome, ScheduledExecutionReason,
-    ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot, ScheduledExecutionState,
-    ScheduledOccurrence, ScheduledRunnerResult, SchedulerHealth, SchedulerState, ShellOwner,
-    ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
-    TerminalPreview, TerminalProfile, UnixEnvironment, UnixEnvironmentVariable,
-    WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    NodeProjectionWorkspace, NotificationDeliveryConfig, Request, Response, RoutedOperation,
+    RoutedOperationResult, ScheduledExecutionDispatchKind, ScheduledExecutionOutcome,
+    ScheduledExecutionReason, ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot,
+    ScheduledExecutionState, ScheduledOccurrence, ScheduledRunnerResult, SchedulerHealth,
+    SchedulerState, ShellOwner, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec,
+    ShellStatus, Snapshot, TerminalPreview, TerminalProfile, UnixEnvironment,
+    UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::ssh_bootstrap::{self, RemoteBootstrapPlan, SshAuthenticationMode, SshTarget};
 use crate::state_store::{
@@ -1199,6 +1199,9 @@ fn handle_connection_inner(
             | Request::PauseAgentSchedule { .. }
             | Request::ResumeAgentSchedule { .. }
             | Request::RemoveAgentSchedule { .. }
+            | Request::GuardedPauseAgentSchedule { .. }
+            | Request::GuardedResumeAgentSchedule { .. }
+            | Request::GuardedRemoveAgentSchedule { .. }
     );
     let response = match registry.dispatch_arc(request.message, response_version) {
         Ok(response) => response,
@@ -1649,6 +1652,238 @@ fn error_response(code: ErrorCode, message: impl Into<String>) -> Response {
     }
 }
 
+fn operation_is_read(operation: &RoutedOperation) -> bool {
+    matches!(
+        operation,
+        RoutedOperation::GetWorkspace { .. }
+            | RoutedOperation::GetShell { .. }
+            | RoutedOperation::GetLauncher { .. }
+            | RoutedOperation::GetAgent { .. }
+            | RoutedOperation::GetAgentSchedule { .. }
+            | RoutedOperation::GetScheduledExecution { .. }
+    )
+}
+
+fn routed_result(response: Response) -> Result<RoutedOperationResult, Box<Response>> {
+    match response {
+        Response::Workspace { workspace } => Ok(RoutedOperationResult::Workspace { workspace }),
+        Response::Shell { shell } => Ok(RoutedOperationResult::Shell { shell }),
+        Response::Launcher { launcher } => Ok(RoutedOperationResult::Launcher { launcher }),
+        Response::Agent { agent } => Ok(RoutedOperationResult::Agent { agent }),
+        Response::AgentSchedule { schedule } => {
+            Ok(RoutedOperationResult::AgentSchedule { schedule })
+        }
+        Response::AgentScheduleInspection { inspection } => {
+            Ok(RoutedOperationResult::AgentScheduleInspection { inspection })
+        }
+        Response::ScheduledExecution {
+            execution,
+            next_occurrence,
+        } => Ok(RoutedOperationResult::ScheduledExecution {
+            execution,
+            next_occurrence,
+        }),
+        Response::AgentAttentionAcknowledged { agent, changed } => {
+            Ok(RoutedOperationResult::AgentAttentionAcknowledged { agent, changed })
+        }
+        Response::Ok => Ok(RoutedOperationResult::Ok),
+        Response::Error { .. } => Err(Box::new(response)),
+        _ => Err(Box::new(error_response(
+            ErrorCode::Internal,
+            "remote Node returned an unexpected typed response",
+        ))),
+    }
+}
+
+fn routed_postcondition(operation: &RoutedOperation, response: &Response) -> bool {
+    match (operation, response) {
+        (
+            RoutedOperation::RenameWorkspace {
+                name,
+                expected_revision,
+                ..
+            },
+            Response::Workspace { workspace },
+        ) => workspace.name == *name && workspace.revision > *expected_revision,
+        (
+            RoutedOperation::RenameShell {
+                name,
+                expected_revision,
+                ..
+            },
+            Response::Shell { shell },
+        ) => shell.name == *name && shell.revision > *expected_revision,
+        (
+            RoutedOperation::RenameLauncher {
+                name,
+                expected_revision,
+                ..
+            },
+            Response::Launcher { launcher },
+        ) => launcher.name == *name && launcher.revision > *expected_revision,
+        (
+            RoutedOperation::CloseWorkspace { .. }
+            | RoutedOperation::CloseShell { .. }
+            | RoutedOperation::RemoveLauncher { .. }
+            | RoutedOperation::RemoveAgentSchedule { .. },
+            Response::Error {
+                code: Some(ErrorCode::NotFound),
+                ..
+            },
+        ) => true,
+        (
+            RoutedOperation::RestartShell {
+                expected_revision,
+                expected_run_id,
+                ..
+            },
+            Response::Shell { shell },
+        ) => {
+            shell.revision == *expected_revision
+                && shell.status == ShellStatus::Pending
+                && shell
+                    .run
+                    .as_ref()
+                    .is_some_and(|run| run.id == *expected_run_id)
+        }
+        (
+            RoutedOperation::PauseAgentSchedule {
+                expected_revision, ..
+            },
+            Response::AgentScheduleInspection { inspection },
+        ) => {
+            inspection.schedule.revision > *expected_revision
+                && inspection.schedule.state == AgentScheduleState::Paused
+        }
+        (
+            RoutedOperation::ResumeAgentSchedule {
+                expected_revision, ..
+            },
+            Response::AgentScheduleInspection { inspection },
+        ) => {
+            inspection.schedule.revision > *expected_revision
+                && inspection.schedule.state == AgentScheduleState::Enabled
+        }
+        (
+            RoutedOperation::UpdateAgentSchedule {
+                expected_revision,
+                update,
+                ..
+            },
+            Response::AgentScheduleInspection { inspection },
+        ) => {
+            inspection.schedule.revision > *expected_revision
+                && inspection.schedule.name == update.name
+                && inspection.schedule.trigger == update.trigger
+                && inspection.prompt == update.prompt
+        }
+        (
+            RoutedOperation::CancelScheduledExecution {
+                expected_revision, ..
+            },
+            Response::ScheduledExecution { execution, .. },
+        ) => {
+            execution.revision > *expected_revision
+                && execution.state == ScheduledExecutionState::Cancelled
+                && execution.reason == Some(ScheduledExecutionReason::CancelledByUser)
+        }
+        _ => false,
+    }
+}
+
+fn proven_routed_result(
+    operation: &RoutedOperation,
+    response: Response,
+) -> Option<RoutedOperationResult> {
+    if !routed_postcondition(operation, &response) {
+        return None;
+    }
+    match (operation, response) {
+        (
+            RoutedOperation::CloseWorkspace { .. }
+            | RoutedOperation::CloseShell { .. }
+            | RoutedOperation::RemoveLauncher { .. }
+            | RoutedOperation::RemoveAgentSchedule { .. },
+            Response::Error { .. },
+        ) => Some(RoutedOperationResult::Ok),
+        (
+            RoutedOperation::PauseAgentSchedule { .. }
+            | RoutedOperation::ResumeAgentSchedule { .. }
+            | RoutedOperation::UpdateAgentSchedule { .. },
+            Response::AgentScheduleInspection { inspection },
+        ) => Some(RoutedOperationResult::AgentSchedule {
+            schedule: inspection.schedule,
+        }),
+        (_, response) => routed_result(response).ok(),
+    }
+}
+
+fn send_registered_node_request(
+    registration: &crate::protocol::NodeRegistrationSnapshot,
+    request: Request,
+) -> io::Result<Response> {
+    let target = SshTarget::parse(registration.target.clone())?;
+    let helper = match ssh_bootstrap::plan_remote_bootstrap(
+        target.clone(),
+        SshAuthenticationMode::Batch,
+        Duration::from_secs(2),
+    )? {
+        RemoteBootstrapPlan::Ready(helper) => helper,
+        RemoteBootstrapPlan::Install(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "remote helper requires installation",
+            ));
+        }
+    };
+    if helper.handshake.node_id != registration.node_id {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "remote Node identity changed",
+        ));
+    }
+    if !protocol::ProtocolFeature::GuardedNodeRouting
+        .is_supported_by(helper.handshake.core_protocol_version)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "remote Node does not support guarded routing",
+        ));
+    }
+    let mut remote = ssh_bootstrap::connect_remote(
+        target,
+        helper,
+        SshAuthenticationMode::Batch,
+        Duration::from_secs(2),
+    )?;
+    remote.request(request, Duration::from_secs(2))
+}
+
+fn require_guard(actual: u64, expected: u64, resource: &str) -> DaemonResult<()> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(DaemonError::lifecycle(
+            ErrorCode::RevisionAhead,
+            format!("{resource} revision is {actual}; guarded operation supplied {expected}"),
+        ))
+    }
+}
+
+fn bump_revision(revision: &Mutex<u64>, resource: &str) -> io::Result<()> {
+    let mut revision = lock(revision)?;
+    *revision = revision
+        .checked_add(1)
+        .ok_or_else(|| io::Error::other(format!("{resource} revision exhausted")))?;
+    Ok(())
+}
+
+fn rollback_bump(revision: &Mutex<u64>) -> io::Result<()> {
+    let mut revision = lock(revision)?;
+    *revision = revision.saturating_sub(1).max(1);
+    Ok(())
+}
+
 fn scheduled_execution_response(
     execution: ScheduledExecutionSnapshot,
     response_version: u32,
@@ -1955,14 +2190,17 @@ enum DurableUndo {
     RenamedWorkspace {
         workspace: Arc<Workspace>,
         previous: String,
+        previous_revision: u64,
     },
     RenamedShell {
         shell: Arc<Shell>,
         previous: String,
+        previous_revision: u64,
     },
     RenamedLauncher {
         launcher: Arc<WorkspaceLauncher>,
         previous: String,
+        previous_revision: u64,
     },
     AgentState {
         agent: Arc<AgentInstance>,
@@ -3334,6 +3572,7 @@ impl DurableRegistry {
             .collect::<io::Result<Vec<_>>>()?;
         let workspace = Arc::new(Workspace {
             id: workspace_id.clone(),
+            revision: Mutex::new(1),
             name: Mutex::new(name.clone()),
             default_cwd,
             shell_ids: Mutex::new(shells.iter().map(|shell| shell.id.clone()).collect()),
@@ -3343,6 +3582,7 @@ impl DurableRegistry {
         });
         let snapshot = WorkspaceSnapshot {
             id: workspace_id.clone(),
+            revision: 1,
             name: name.clone(),
             default_cwd: workspace.default_cwd.clone(),
             shells: shells
@@ -3406,6 +3646,7 @@ impl DurableRegistry {
         }
         state.shells.insert(shell.id.clone(), Arc::clone(&shell));
         shell_ids.push(shell.id.clone());
+        bump_revision(&workspace.revision, "workspace")?;
         drop(shell_ids);
         drop(state);
         Ok((snapshot, DurableUndo::CreatedShell { workspace, shell }))
@@ -3419,6 +3660,7 @@ impl DurableRegistry {
         let workspace = self.workspace(&schedule.workspace_id)?;
         let shell = Arc::new(Shell {
             id: Uuid::new_v4().to_string(),
+            revision: Mutex::new(1),
             workspace_id: schedule.workspace_id.clone(),
             name: Mutex::new(format!("schedule-{}", &schedule.id[..8])),
             cwd: schedule.cwd.clone(),
@@ -3434,6 +3676,7 @@ impl DurableRegistry {
         let mut shell_ids = lock(&workspace.shell_ids)?;
         state.shells.insert(shell.id.clone(), Arc::clone(&shell));
         shell_ids.push(shell.id.clone());
+        bump_revision(&workspace.revision, "workspace")?;
         drop(shell_ids);
         drop(state);
         Ok((
@@ -3515,6 +3758,7 @@ impl DurableRegistry {
         let workspace = self.workspace(workspace_id)?;
         let launcher = Arc::new(WorkspaceLauncher {
             id: Uuid::new_v4().to_string(),
+            revision: Mutex::new(1),
             workspace_id: workspace_id.into(),
             name: Mutex::new(spec.name),
             cwd: spec.cwd,
@@ -3545,6 +3789,7 @@ impl DurableRegistry {
             .launchers
             .insert(launcher.id.clone(), Arc::clone(&launcher));
         launcher_ids.push(launcher.id.clone());
+        bump_revision(&workspace.revision, "workspace")?;
         drop(launcher_ids);
         drop(state);
         Ok((
@@ -3641,6 +3886,7 @@ impl DurableRegistry {
             .schedules
             .insert(schedule.id.clone(), Arc::clone(&schedule));
         schedule_ids.push(schedule.id.clone());
+        bump_revision(&workspace.revision, "workspace")?;
         drop(schedule_ids);
         drop(state);
         Ok((
@@ -3656,10 +3902,14 @@ impl DurableRegistry {
         &self,
         schedule_id: &str,
         next: AgentScheduleState,
+        expected_revision: Option<u64>,
         requested_at_ms: u64,
-    ) -> io::Result<(AgentScheduleSnapshot, Option<DurableUndo>)> {
+    ) -> DaemonResult<(AgentScheduleSnapshot, Option<DurableUndo>)> {
         let schedule = self.schedule(schedule_id)?;
         let mut state = lock(&schedule.state)?;
+        if let Some(expected) = expected_revision {
+            require_guard(state.revision, expected, "agent schedule")?;
+        }
         if state.state == next {
             return Ok((schedule.snapshot_from(&state)?, None));
         }
@@ -3854,13 +4104,23 @@ impl DurableRegistry {
                 format!("shell name already exists: {name}"),
             ));
         }
+        let mut revision = lock(&shell.revision)?;
         let mut current_name = lock(&shell.name)?;
         if *current_name == name {
             return Ok(None);
         }
+        let previous_revision = *revision;
+        *revision = revision
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("shell revision exhausted"))?;
         let previous = std::mem::replace(&mut *current_name, name);
         drop(current_name);
-        Ok(Some(DurableUndo::RenamedShell { shell, previous }))
+        drop(revision);
+        Ok(Some(DurableUndo::RenamedShell {
+            shell,
+            previous,
+            previous_revision,
+        }))
     }
 
     fn rename_launcher(&self, launcher_id: &str, name: String) -> io::Result<Option<DurableUndo>> {
@@ -3885,13 +4145,23 @@ impl DurableRegistry {
                 format!("workspace launcher name already exists: {name}"),
             ));
         }
+        let mut revision = lock(&launcher.revision)?;
         let mut current_name = lock(&launcher.name)?;
         if *current_name == name {
             return Ok(None);
         }
+        let previous_revision = *revision;
+        *revision = revision
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("workspace launcher revision exhausted"))?;
         let previous = std::mem::replace(&mut *current_name, name);
         drop(current_name);
-        Ok(Some(DurableUndo::RenamedLauncher { launcher, previous }))
+        drop(revision);
+        Ok(Some(DurableUndo::RenamedLauncher {
+            launcher,
+            previous,
+            previous_revision,
+        }))
     }
 
     fn rename_workspace(
@@ -3910,15 +4180,22 @@ impl DurableRegistry {
                 ));
             }
         }
+        let mut revision = lock(&workspace.revision)?;
         let mut current_name = lock(&workspace.name)?;
         if *current_name == name {
             return Ok(None);
         }
+        let previous_revision = *revision;
+        *revision = revision
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("workspace revision exhausted"))?;
         let previous = std::mem::replace(&mut *current_name, name);
         drop(current_name);
+        drop(revision);
         Ok(Some(DurableUndo::RenamedWorkspace {
             workspace,
             previous,
+            previous_revision,
         }))
     }
 
@@ -3990,6 +4267,7 @@ impl DurableRegistry {
         let mut agent_ids = lock(&workspace.agent_ids)?;
         state.agents.insert(agent.id.clone(), Arc::clone(&agent));
         agent_ids.push(agent.id.clone());
+        bump_revision(&workspace.revision, "workspace")?;
         drop(agent_ids);
         drop(lifecycle);
         drop(state);
@@ -4256,6 +4534,7 @@ impl DurableRegistry {
                     state.shells.remove(&shell.id);
                 }
                 lock(&workspace.shell_ids)?.retain(|id| id != &shell.id);
+                rollback_bump(&workspace.revision)?;
             }
             DurableUndo::CreatedLauncher {
                 workspace,
@@ -4270,6 +4549,7 @@ impl DurableRegistry {
                     state.launchers.remove(&launcher.id);
                 }
                 lock(&workspace.launcher_ids)?.retain(|id| id != &launcher.id);
+                rollback_bump(&workspace.revision)?;
             }
             DurableUndo::CreatedSchedule {
                 workspace,
@@ -4284,6 +4564,7 @@ impl DurableRegistry {
                     state.schedules.remove(&schedule.id);
                 }
                 lock(&workspace.schedule_ids)?.retain(|id| id != &schedule.id);
+                rollback_bump(&workspace.revision)?;
             }
             DurableUndo::RegisteredAgent { workspace, agent } => {
                 let mut state = lock(&self.state)?;
@@ -4295,16 +4576,31 @@ impl DurableRegistry {
                     state.agents.remove(&agent.id);
                 }
                 lock(&workspace.agent_ids)?.retain(|id| id != &agent.id);
+                rollback_bump(&workspace.revision)?;
             }
             DurableUndo::RenamedWorkspace {
                 workspace,
                 previous,
-            } => *lock(&workspace.name)? = previous,
-            DurableUndo::RenamedShell { shell, previous } => {
-                *lock(&shell.name)? = previous;
+                previous_revision,
+            } => {
+                *lock(&workspace.name)? = previous;
+                *lock(&workspace.revision)? = previous_revision;
             }
-            DurableUndo::RenamedLauncher { launcher, previous } => {
+            DurableUndo::RenamedShell {
+                shell,
+                previous,
+                previous_revision,
+            } => {
+                *lock(&shell.name)? = previous;
+                *lock(&shell.revision)? = previous_revision;
+            }
+            DurableUndo::RenamedLauncher {
+                launcher,
+                previous,
+                previous_revision,
+            } => {
                 *lock(&launcher.name)? = previous;
+                *lock(&launcher.revision)? = previous_revision;
             }
             DurableUndo::AgentState { agent, previous } => {
                 *lock(&agent.state)? = previous;
@@ -4333,6 +4629,7 @@ impl DurableRegistry {
                     .launchers
                     .insert(launcher.id.clone(), Arc::clone(&launcher));
                 lock(&workspace.launcher_ids)?.insert(index, launcher.id.clone());
+                rollback_bump(&workspace.revision)?;
             }
             DurableUndo::RemovedSchedule {
                 workspace,
@@ -4343,6 +4640,7 @@ impl DurableRegistry {
                     .schedules
                     .insert(schedule.id.clone(), Arc::clone(&schedule));
                 lock(&workspace.schedule_ids)?.insert(index, schedule.id.clone());
+                rollback_bump(&workspace.revision)?;
             }
             DurableUndo::RemovedShell {
                 workspace,
@@ -4353,6 +4651,7 @@ impl DurableRegistry {
                     .shells
                     .insert(shell.id.clone(), Arc::clone(&shell));
                 lock(&workspace.shell_ids)?.insert(index, shell.id.clone());
+                rollback_bump(&workspace.revision)?;
             }
             DurableUndo::RemovedWorkspace {
                 workspace,
@@ -4535,6 +4834,7 @@ impl DurableRegistry {
                 };
                 shells.push(PersistedShell {
                     id: shell.id.clone(),
+                    revision: *lock(&shell.revision)?,
                     name: lock(&shell.name)?.clone(),
                     cwd: shell.cwd.clone(),
                     command: shell.command.clone(),
@@ -4550,6 +4850,7 @@ impl DurableRegistry {
                 };
                 launchers.push(PersistedWorkspaceLauncher {
                     id: launcher.id.clone(),
+                    revision: *lock(&launcher.revision)?,
                     name: lock(&launcher.name)?.clone(),
                     cwd: launcher.cwd.clone(),
                     command: launcher.command.clone(),
@@ -4573,6 +4874,7 @@ impl DurableRegistry {
             }
             saved.workspaces.push(PersistedWorkspace {
                 id: workspace.id.clone(),
+                revision: *lock(&workspace.revision)?,
                 name: lock(&workspace.name)?.clone(),
                 default_cwd: workspace.default_cwd.clone(),
                 shells,
@@ -5321,6 +5623,7 @@ impl Default for DaemonService {
 
 struct Workspace {
     id: String,
+    revision: Mutex<u64>,
     name: Mutex<String>,
     default_cwd: Option<PathBuf>,
     shell_ids: Mutex<Vec<String>>,
@@ -5422,6 +5725,7 @@ struct AgentInstanceState {
 
 struct WorkspaceLauncher {
     id: String,
+    revision: Mutex<u64>,
     workspace_id: String,
     name: Mutex<String>,
     cwd: PathBuf,
@@ -5430,6 +5734,7 @@ struct WorkspaceLauncher {
 
 struct Shell {
     id: String,
+    revision: Mutex<u64>,
     workspace_id: String,
     name: Mutex<String>,
     cwd: PathBuf,
@@ -6417,6 +6722,86 @@ impl DaemonService {
                 "Boomux Node projection cache is unavailable",
             )
         })
+    }
+
+    fn route_node_operation(&self, node_id: &str, operation: RoutedOperation) -> Response {
+        let registrations = match self.node_registrations() {
+            Ok(registrations) => registrations,
+            Err(error) => return error.into_response(),
+        };
+        let registration = match registrations.inspect(node_id) {
+            Ok(registration) if registration.node_id == node_id => registration,
+            Ok(_) => {
+                return error_response(ErrorCode::NotFound, "exact Node registration not found");
+            }
+            Err(error) => return node_registration_error(error).into_response(),
+        };
+        match registrations.admit(&registration) {
+            Ok(true) => {}
+            Ok(false) => {
+                return error_response(
+                    ErrorCode::RevisionChanged,
+                    "Node registration changed before routing",
+                );
+            }
+            Err(error) => return node_registration_error(error).into_response(),
+        }
+        let mut result = send_registered_node_request(&registration, operation.owner_request());
+        if result.is_err() && operation.is_retryable() {
+            result = send_registered_node_request(&registration, operation.owner_request());
+        }
+        let proven = if result.is_err() && !operation.is_retryable() {
+            operation.ambiguity_probe().and_then(|probe| {
+                send_registered_node_request(&registration, probe)
+                    .ok()
+                    .and_then(|response| proven_routed_result(&operation, response))
+            })
+        } else {
+            None
+        };
+        registrations.release(&registration);
+        let response = match result {
+            Ok(response) => response,
+            Err(_) if proven.is_some() => Response::Ok,
+            Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
+                return error_response(ErrorCode::NodeIdentityChanged, error.to_string());
+            }
+            Err(error) if error.kind() == io::ErrorKind::Unsupported => {
+                return error_response(ErrorCode::UnsupportedVersion, error.to_string());
+            }
+            Err(error) => {
+                let code = if operation_is_read(&operation) {
+                    ErrorCode::Timeout
+                } else {
+                    ErrorCode::OutcomeUnknown
+                };
+                return error_response(
+                    code,
+                    format!("routed operation lost its verified channel: {error}"),
+                );
+            }
+        };
+        let current = registrations
+            .with_current(&registration, || Ok(()))
+            .unwrap_or(None)
+            .is_some();
+        if !current {
+            return error_response(
+                if operation_is_read(&operation) {
+                    ErrorCode::RevisionChanged
+                } else {
+                    ErrorCode::OutcomeUnknown
+                },
+                "Node registration changed while the routed operation was in flight",
+            );
+        }
+        if let Some(result) = proven {
+            return Response::RoutedNodeOperation { result };
+        }
+        match routed_result(response) {
+            Ok(result) => Response::RoutedNodeOperation { result },
+            Err(response) => *response,
+        }
     }
 
     fn combined_node_snapshot(
@@ -7584,12 +7969,19 @@ impl DaemonService {
         Ok(execution.snapshot()?)
     }
 
-    fn cancel_scheduled_execution(&self, execution_id: &str) -> DaemonResult<Response> {
+    fn cancel_scheduled_execution(
+        &self,
+        execution_id: &str,
+        expected_revision: Option<u64>,
+    ) -> DaemonResult<Response> {
         let _mutation = lock(&self.mutation_lock)?;
         self.ensure_running()?;
         self.flush_pending()?;
         let execution = self.durable.execution(execution_id)?;
         let current = execution.snapshot()?;
+        if let Some(expected) = expected_revision {
+            require_guard(current.revision, expected, "scheduled execution")?;
+        }
         if current.state.is_terminal() {
             return Ok(Response::ScheduledExecution {
                 execution: current,
@@ -7918,6 +8310,9 @@ impl DaemonService {
             Request::GetCombinedNodeSnapshot { selector } => Ok(Response::CombinedNodeSnapshot {
                 snapshot: self.combined_node_snapshot(selector.as_deref())?,
             }),
+            Request::RouteNodeOperation { node_id, operation } => {
+                Ok(self.route_node_operation(&node_id, operation))
+            }
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
                 unreachable!("restart is handled before dispatch")
             }
@@ -8088,8 +8483,12 @@ impl DaemonService {
                 unreachable!("schedule run is handled with the service Arc")
             }
             Request::CancelScheduledExecution { execution_id } => {
-                self.cancel_scheduled_execution(&execution_id)
+                self.cancel_scheduled_execution(&execution_id, None)
             }
+            Request::GuardedCancelScheduledExecution {
+                execution_id,
+                expected_revision,
+            } => self.cancel_scheduled_execution(&execution_id, Some(expected_revision)),
             Request::ResolveScheduledExecutionClaim {
                 schedule_id,
                 shell_id,
@@ -8333,10 +8732,32 @@ impl DaemonService {
                         .map(|()| Response::Ok))
                 })
             }
+            Request::GuardedRenameWorkspace {
+                workspace_id,
+                name,
+                expected_revision,
+            } => self.durable_mutation_outcome(|undo| {
+                let workspace = self.workspace(&workspace_id)?;
+                require_guard(*lock(&workspace.revision)?, expected_revision, "workspace")?;
+                let mutation = self.rename_workspace_mutation(undo, &workspace_id, name)?;
+                let workspace = self.workspace(&workspace_id)?.snapshot(&self.durable)?;
+                Ok(mutation.map(|()| Response::Workspace { workspace }))
+            }),
             Request::RenameShell { shell_id, name } => self.durable_mutation_outcome(|undo| {
                 Ok(self
                     .rename_shell_mutation(undo, &shell_id, name)?
                     .map(|()| Response::Ok))
+            }),
+            Request::GuardedRenameShell {
+                shell_id,
+                name,
+                expected_revision,
+            } => self.durable_mutation_outcome(|undo| {
+                let shell = self.shell(&shell_id)?;
+                require_guard(*lock(&shell.revision)?, expected_revision, "shell")?;
+                let mutation = self.rename_shell_mutation(undo, &shell_id, name)?;
+                let shell = self.shell(&shell_id)?.snapshot()?;
+                Ok(mutation.map(|()| Response::Shell { shell }))
             }),
             Request::RenameLauncher { launcher_id, name } => {
                 self.durable_mutation_outcome(|undo| {
@@ -8345,18 +8766,76 @@ impl DaemonService {
                         .map(|()| Response::Ok))
                 })
             }
+            Request::GuardedRenameLauncher {
+                launcher_id,
+                name,
+                expected_revision,
+            } => self.durable_mutation_outcome(|undo| {
+                let launcher = self.launcher(&launcher_id)?;
+                require_guard(
+                    *lock(&launcher.revision)?,
+                    expected_revision,
+                    "workspace launcher",
+                )?;
+                let mutation = self.rename_launcher_mutation(undo, &launcher_id, name)?;
+                let launcher = self.launcher(&launcher_id)?.snapshot()?;
+                Ok(mutation.map(|()| Response::Launcher { launcher }))
+            }),
             Request::CloseWorkspace { workspace_id } => {
                 self.close_workspace(&workspace_id)?;
+                Ok(Response::Ok)
+            }
+            Request::GuardedCloseWorkspace {
+                workspace_id,
+                expected_revision,
+            } => {
+                self.close_workspace_guarded(&workspace_id, Some(expected_revision))?;
                 Ok(Response::Ok)
             }
             Request::CloseShell { shell_id } => {
                 self.close_shell(&shell_id)?;
                 Ok(Response::Ok)
             }
+            Request::GuardedCloseShell {
+                shell_id,
+                expected_revision,
+            } => {
+                self.close_shell_guarded(&shell_id, Some(expected_revision))?;
+                Ok(Response::Ok)
+            }
             Request::RestartShell { shell_id } => Ok(Response::Shell {
                 shell: self.restart_shell(&shell_id)?,
             }),
+            Request::GuardedRestartShell {
+                shell_id,
+                expected_revision,
+                expected_run_id,
+            } => Ok(Response::Shell {
+                shell: self.restart_shell_guarded(
+                    &shell_id,
+                    Some((expected_revision, &expected_run_id)),
+                )?,
+            }),
             Request::RemoveLauncher { launcher_id } => self.durable_mutation(|undo| {
+                let launcher = self.remove_launcher_mutation(undo, &launcher_id)?;
+                Ok((
+                    Response::Ok,
+                    vec![DaemonEventKind::LauncherRemoved {
+                        workspace_id: launcher.workspace_id.clone(),
+                        launcher_id,
+                    }],
+                ))
+            }),
+            Request::GuardedRemoveLauncher {
+                launcher_id,
+                expected_revision,
+            } => self.durable_mutation(|undo| {
+                let launcher = self.launcher(&launcher_id)?;
+                require_guard(
+                    *lock(&launcher.revision)?,
+                    expected_revision,
+                    "workspace launcher",
+                )?;
                 let launcher = self.remove_launcher_mutation(undo, &launcher_id)?;
                 Ok((
                     Response::Ok,
@@ -8372,7 +8851,42 @@ impl DaemonService {
             Request::ResumeAgentSchedule { schedule_id } => {
                 self.change_schedule_state(&schedule_id, AgentScheduleState::Enabled)
             }
+            Request::GuardedPauseAgentSchedule {
+                schedule_id,
+                expected_revision,
+            } => self.change_schedule_state_guarded(
+                &schedule_id,
+                AgentScheduleState::Paused,
+                Some(expected_revision),
+            ),
+            Request::GuardedResumeAgentSchedule {
+                schedule_id,
+                expected_revision,
+            } => self.change_schedule_state_guarded(
+                &schedule_id,
+                AgentScheduleState::Enabled,
+                Some(expected_revision),
+            ),
             Request::RemoveAgentSchedule { schedule_id } => self.durable_mutation(|undo| {
+                let schedule = self.remove_schedule_mutation(undo, &schedule_id)?;
+                Ok((
+                    Response::Ok,
+                    vec![DaemonEventKind::AgentScheduleRemoved {
+                        workspace_id: schedule.workspace_id.clone(),
+                        schedule_id,
+                    }],
+                ))
+            }),
+            Request::GuardedRemoveAgentSchedule {
+                schedule_id,
+                expected_revision,
+            } => self.durable_mutation(|undo| {
+                let schedule = self.schedule(&schedule_id)?;
+                require_guard(
+                    schedule.snapshot()?.revision,
+                    expected_revision,
+                    "agent schedule",
+                )?;
                 let schedule = self.remove_schedule_mutation(undo, &schedule_id)?;
                 Ok((
                     Response::Ok,
@@ -8484,6 +8998,7 @@ impl DaemonService {
                 }
                 let shell = Arc::new(Shell {
                     id: saved_shell.id,
+                    revision: Mutex::new(saved_shell.revision),
                     workspace_id: saved_workspace.id.clone(),
                     name: Mutex::new(saved_shell.name),
                     cwd: saved_shell.cwd,
@@ -8518,6 +9033,7 @@ impl DaemonService {
                 }
                 let launcher = Arc::new(WorkspaceLauncher {
                     id: saved_launcher.id,
+                    revision: Mutex::new(saved_launcher.revision),
                     workspace_id: saved_workspace.id.clone(),
                     name: Mutex::new(saved_launcher.name),
                     cwd: saved_launcher.cwd,
@@ -8698,6 +9214,7 @@ impl DaemonService {
             }
             let workspace = Arc::new(Workspace {
                 id: saved_workspace.id.clone(),
+                revision: Mutex::new(saved_workspace.revision),
                 name: Mutex::new(saved_workspace.name),
                 default_cwd: saved_workspace.default_cwd,
                 shell_ids: Mutex::new(shell_ids),
@@ -10083,10 +10600,22 @@ impl DaemonService {
         schedule_id: &str,
         next: AgentScheduleState,
     ) -> DaemonResult<Response> {
+        self.change_schedule_state_guarded(schedule_id, next, None)
+    }
+
+    fn change_schedule_state_guarded(
+        &self,
+        schedule_id: &str,
+        next: AgentScheduleState,
+        expected_revision: Option<u64>,
+    ) -> DaemonResult<Response> {
         self.durable_mutation_outcome(|undo| {
-            let (schedule, record) =
-                self.durable
-                    .set_schedule_state_at(schedule_id, next, self.clock_now_ms())?;
+            let (schedule, record) = self.durable.set_schedule_state_at(
+                schedule_id,
+                next,
+                expected_revision,
+                self.clock_now_ms(),
+            )?;
             let Some(record) = record else {
                 return Ok(DurableMutation::Unchanged(Response::AgentSchedule {
                     schedule,
@@ -10292,6 +10821,7 @@ impl DaemonService {
             .ok_or_else(|| not_found("workspace launcher", launcher_id))?;
         state.launchers.remove(launcher_id);
         launcher_ids.remove(index);
+        bump_revision(&workspace.revision, "workspace")?;
         drop(launcher_ids);
         drop(state);
         let result = Arc::clone(&launcher);
@@ -10346,6 +10876,7 @@ impl DaemonService {
             .ok_or_else(|| not_found("agent schedule", schedule_id))?;
         state.schedules.remove(schedule_id);
         schedule_ids.remove(index);
+        bump_revision(&workspace.revision, "workspace")?;
         drop(schedule_ids);
         drop(state);
         let result = Arc::clone(&schedule);
@@ -10457,6 +10988,7 @@ impl DaemonService {
             .ok_or_else(|| not_found("shell", shell_id))?;
         state.shells.remove(shell_id);
         shell_ids.remove(index);
+        bump_revision(&workspace.revision, "workspace")?;
         drop(shell_ids);
         drop(state);
         Ok(DurableUndo::RemovedShell {
@@ -10517,6 +11049,14 @@ impl DaemonService {
     }
 
     fn close_shell(&self, shell_id: &str) -> DaemonResult<()> {
+        self.close_shell_guarded(shell_id, None)
+    }
+
+    fn close_shell_guarded(
+        &self,
+        shell_id: &str,
+        expected_revision: Option<u64>,
+    ) -> DaemonResult<()> {
         if !matches!(self.shell(shell_id)?.owner, ShellOwner::User) {
             return Err(DaemonError::lifecycle(
                 ErrorCode::Busy,
@@ -10525,7 +11065,13 @@ impl DaemonService {
         }
         self.lifecycle_transaction(
             false,
-            || Ok(vec![self.shell(shell_id)?]),
+            || {
+                let shell = self.shell(shell_id)?;
+                if let Some(expected) = expected_revision {
+                    require_guard(*lock(&shell.revision)?, expected, "shell")?;
+                }
+                Ok(vec![shell])
+            },
             |undo| {
                 undo.record(self.remove_shell_mutation(shell_id)?);
                 Ok(())
@@ -10540,10 +11086,21 @@ impl DaemonService {
     }
 
     fn close_workspace(&self, workspace_id: &str) -> DaemonResult<()> {
+        self.close_workspace_guarded(workspace_id, None)
+    }
+
+    fn close_workspace_guarded(
+        &self,
+        workspace_id: &str,
+        expected_revision: Option<u64>,
+    ) -> DaemonResult<()> {
         self.lifecycle_transaction(
             false,
             || {
                 let workspace = self.workspace(workspace_id)?;
+                if let Some(expected) = expected_revision {
+                    require_guard(*lock(&workspace.revision)?, expected, "workspace")?;
+                }
                 Ok(self.durable.workspace_shells(&workspace)?)
             },
             |undo| {
@@ -10559,9 +11116,27 @@ impl DaemonService {
     }
 
     fn restart_shell(&self, shell_id: &str) -> DaemonResult<ShellSnapshot> {
+        self.restart_shell_guarded(shell_id, None)
+    }
+
+    fn restart_shell_guarded(
+        &self,
+        shell_id: &str,
+        guard: Option<(u64, &str)>,
+    ) -> DaemonResult<ShellSnapshot> {
         let _mutation = lock(&self.mutation_lock)?;
         self.ensure_running()?;
         let shell = self.shell(shell_id)?;
+        if let Some((expected_revision, expected_run_id)) = guard {
+            require_guard(*lock(&shell.revision)?, expected_revision, "shell")?;
+            let current_run = shell.snapshot()?.run.map(|run| run.id);
+            if current_run.as_deref() != Some(expected_run_id) {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::RunChanged,
+                    "shell no longer has the confirmed run",
+                ));
+            }
+        }
         if !matches!(shell.owner, ShellOwner::User) {
             return Err(DaemonError::lifecycle(
                 ErrorCode::Busy,
@@ -10638,6 +11213,7 @@ impl Workspace {
             .collect::<io::Result<_>>()?;
         Ok(WorkspaceSnapshot {
             id: self.id.clone(),
+            revision: *lock(&self.revision)?,
             name: lock(&self.name)?.clone(),
             default_cwd: self.default_cwd.clone(),
             shells,
@@ -10946,6 +11522,7 @@ impl WorkspaceLauncher {
     fn snapshot(&self) -> io::Result<WorkspaceLauncherSnapshot> {
         Ok(WorkspaceLauncherSnapshot {
             id: self.id.clone(),
+            revision: *lock(&self.revision)?,
             workspace_id: self.workspace_id.clone(),
             name: lock(&self.name)?.clone(),
             command: self.command.clone(),
@@ -11096,6 +11673,7 @@ impl Shell {
         };
         Ok(ShellSnapshot {
             id: self.id.clone(),
+            revision: *lock(&self.revision)?,
             workspace_id: self.workspace_id.clone(),
             name: lock(&self.name)?.clone(),
             cwd: self.cwd.clone(),
@@ -11113,6 +11691,7 @@ fn create_pending_shell(workspace_id: &str, spec: ShellSpec) -> io::Result<Arc<S
     validate_cwd(&spec.cwd)?;
     Ok(Arc::new(Shell {
         id: Uuid::new_v4().to_string(),
+        revision: Mutex::new(1),
         workspace_id: workspace_id.to_owned(),
         name: Mutex::new(spec.name),
         cwd: spec.cwd,
@@ -14199,10 +14778,12 @@ mod tests {
         let mut persisted = PersistedState::default();
         persisted.workspaces = vec![PersistedWorkspace {
             id: workspace_id,
+            revision: 1,
             name: "continued".into(),
             default_cwd: None,
             shells: vec![PersistedShell {
                 id: shell_id.clone(),
+                revision: 1,
                 name: "scheduled".into(),
                 cwd: env::temp_dir(),
                 command: vec!["boomux".into()],
@@ -17999,6 +18580,7 @@ mod tests {
         };
         let workspace = WorkspaceSnapshot {
             id: "w1".into(),
+            revision: 1,
             name: "workspace".into(),
             default_cwd: None,
             shells: Vec::new(),
@@ -18138,6 +18720,7 @@ mod tests {
 
         let workspace = WorkspaceSnapshot {
             id: "w1".into(),
+            revision: 1,
             name: "workspace".into(),
             default_cwd: None,
             shells: Vec::new(),
@@ -18239,6 +18822,7 @@ mod tests {
             snapshot: Some(Snapshot {
                 workspaces: vec![WorkspaceSnapshot {
                     id: "w1".into(),
+                    revision: 1,
                     name: "workspace".into(),
                     default_cwd: None,
                     shells: Vec::new(),
@@ -18510,6 +19094,45 @@ mod tests {
     }
 
     #[test]
+    fn guarded_resource_mutations_reject_stale_revisions_without_changing_legacy_semantics() {
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace("guarded".into(), Vec::new())
+            .unwrap();
+        let stale = registry
+            .dispatch(Request::GuardedRenameWorkspace {
+                workspace_id: workspace.id.clone(),
+                name: "stale".into(),
+                expected_revision: workspace.revision + 1,
+            })
+            .unwrap_err();
+        assert_eq!(stale.wire_code(), ErrorCode::RevisionAhead);
+        assert_eq!(
+            registry
+                .workspace(&workspace.id)
+                .unwrap()
+                .snapshot(&registry.durable)
+                .unwrap()
+                .name,
+            "guarded"
+        );
+
+        registry
+            .dispatch(Request::RenameWorkspace {
+                workspace_id: workspace.id.clone(),
+                name: "legacy".into(),
+            })
+            .unwrap();
+        let current = registry
+            .workspace(&workspace.id)
+            .unwrap()
+            .snapshot(&registry.durable)
+            .unwrap();
+        assert_eq!(current.name, "legacy");
+        assert_eq!(current.revision, workspace.revision + 1);
+    }
+
+    #[test]
     fn workspace_snapshot_retains_default_cwd() {
         let registry = DaemonService::default();
         let cwd = env::temp_dir();
@@ -18525,6 +19148,7 @@ mod tests {
     fn protocol_eighteen_responses_hide_workspace_default_cwd() {
         let source_workspace = WorkspaceSnapshot {
             id: "w1".into(),
+            revision: 1,
             name: "project".into(),
             default_cwd: Some("/tmp/project".into()),
             shells: Vec::new(),

--- a/src/dashboard_projection.rs
+++ b/src/dashboard_projection.rs
@@ -520,7 +520,12 @@ pub(crate) fn project_remote_node(
             ScheduleView {
                 node_id: node.node_id.clone(),
                 node_alias: node.alias.clone(),
-                actionable: false,
+                actionable: node.current
+                    && !node.stale
+                    && node
+                        .observed_capabilities
+                        .iter()
+                        .any(|capability| capability == "guarded_remote_management"),
                 id: schedule.id.clone(),
                 workspace_id: schedule.workspace_id.clone(),
                 workspace: workspace.into(),
@@ -880,11 +885,13 @@ mod tests {
     fn workspace(command: Vec<String>) -> WorkspaceSnapshot {
         WorkspaceSnapshot {
             id: "workspace-1".into(),
+            revision: 1,
             name: "project".into(),
             default_cwd: Some(PathBuf::from("/tmp/project")),
             shells: vec![ShellSnapshot {
                 owner: boomux::protocol::ShellOwner::User,
                 id: "shell-1".into(),
+                revision: 1,
                 workspace_id: "workspace-1".into(),
                 name: "main".into(),
                 cwd: PathBuf::from("/tmp/project"),

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -1322,6 +1322,7 @@ mod tests {
         let shell = ShellSnapshot {
             owner: boomux::protocol::ShellOwner::User,
             id: "s1".into(),
+            revision: 1,
             workspace_id: "w1".into(),
             name: "shell".into(),
             cwd: "/repo".into(),
@@ -1340,6 +1341,7 @@ mod tests {
         };
         let mut workspace = WorkspaceSnapshot {
             id: "w1".into(),
+            revision: 1,
             name: "workspace".into(),
             default_cwd: None,
             shells: vec![shell],

--- a/src/main.rs
+++ b/src/main.rs
@@ -2134,38 +2134,68 @@ fn dashboard(
             tui::DashboardEffect::Close(target) => {
                 let result = (|| match &target {
                     tui::CloseTarget::Workspace(workspace_id) => {
-                        let workspace_id = local_dashboard_inner(workspace_id, &local_node_id)?;
-                        let name = client
-                            .get_workspace(workspace_id)
-                            .map(|workspace| workspace.name)
-                            .unwrap_or_else(|_| "workspace".into());
-                        client
-                            .close_workspace(workspace_id)
-                            .map_err(|error| error.to_string())?;
+                        let workspace =
+                            routed_dashboard_workspace(&client, workspace_id, &local_node_id)?;
+                        let name = workspace.name.clone();
+                        if workspace_id.node_id == local_node_id || workspace_id.node_id.is_empty()
+                        {
+                            client
+                                .close_workspace(&workspace_id.inner_id)
+                                .map_err(|error| error.to_string())?;
+                        } else {
+                            routed_dashboard_operation(
+                                &client,
+                                workspace_id,
+                                &local_node_id,
+                                protocol::RoutedOperation::CloseWorkspace {
+                                    workspace_id: workspace_id.inner_id.clone(),
+                                    expected_revision: workspace.revision,
+                                },
+                            )?;
+                        }
                         Ok(format!(
                             "Closed {name}, its launchers, shells, schedules, and persisted prompts"
                         ))
                     }
                     tui::CloseTarget::Shell(shell_id) => {
-                        let shell_id = local_dashboard_inner(shell_id, &local_node_id)?;
-                        let name = client
-                            .get_shell(shell_id)
-                            .map(|shell| shell.name)
-                            .unwrap_or_else(|_| "shell".into());
-                        client
-                            .close_shell(shell_id)
-                            .map_err(|error| error.to_string())?;
+                        let shell = routed_dashboard_shell(&client, shell_id, &local_node_id)?;
+                        let name = shell.name.clone();
+                        if shell_id.node_id == local_node_id || shell_id.node_id.is_empty() {
+                            client
+                                .close_shell(&shell_id.inner_id)
+                                .map_err(|error| error.to_string())?;
+                        } else {
+                            routed_dashboard_operation(
+                                &client,
+                                shell_id,
+                                &local_node_id,
+                                protocol::RoutedOperation::CloseShell {
+                                    shell_id: shell_id.inner_id.clone(),
+                                    expected_revision: shell.revision,
+                                },
+                            )?;
+                        }
                         Ok(format!("Closed shell {name}"))
                     }
                     tui::CloseTarget::Launcher(launcher_id) => {
-                        let launcher_id = local_dashboard_inner(launcher_id, &local_node_id)?;
-                        let name = client
-                            .get_launcher(launcher_id)
-                            .map(|launcher| launcher.name)
-                            .unwrap_or_else(|_| "launcher".into());
-                        client
-                            .remove_launcher(launcher_id)
-                            .map_err(|error| error.to_string())?;
+                        let launcher =
+                            routed_dashboard_launcher(&client, launcher_id, &local_node_id)?;
+                        let name = launcher.name.clone();
+                        if launcher_id.node_id == local_node_id || launcher_id.node_id.is_empty() {
+                            client
+                                .remove_launcher(&launcher_id.inner_id)
+                                .map_err(|error| error.to_string())?;
+                        } else {
+                            routed_dashboard_operation(
+                                &client,
+                                launcher_id,
+                                &local_node_id,
+                                protocol::RoutedOperation::RemoveLauncher {
+                                    launcher_id: launcher_id.inner_id.clone(),
+                                    expected_revision: launcher.revision,
+                                },
+                            )?;
+                        }
                         Ok(format!("Removed launcher {name}"))
                     }
                     tui::CloseTarget::Schedule(_) => {
@@ -2194,24 +2224,66 @@ fn dashboard(
             tui::DashboardEffect::Rename { target, name } => {
                 let result = (|| match &target {
                     tui::RenameTarget::Workspace(workspace_id) => {
-                        let workspace_id = local_dashboard_inner(workspace_id, &local_node_id)?;
-                        client
-                            .rename_workspace(workspace_id, &name)
-                            .map_err(|error| error.to_string())?;
+                        let workspace =
+                            routed_dashboard_workspace(&client, workspace_id, &local_node_id)?;
+                        if workspace_id.node_id == local_node_id || workspace_id.node_id.is_empty()
+                        {
+                            client
+                                .rename_workspace(&workspace_id.inner_id, &name)
+                                .map_err(|error| error.to_string())?;
+                        } else {
+                            routed_dashboard_operation(
+                                &client,
+                                workspace_id,
+                                &local_node_id,
+                                protocol::RoutedOperation::RenameWorkspace {
+                                    workspace_id: workspace_id.inner_id.clone(),
+                                    name: name.clone(),
+                                    expected_revision: workspace.revision,
+                                },
+                            )?;
+                        }
                         Ok(format!("Renamed workspace to {name}"))
                     }
                     tui::RenameTarget::Shell(shell_id) => {
-                        let shell_id = local_dashboard_inner(shell_id, &local_node_id)?;
-                        client
-                            .rename_shell(shell_id, &name)
-                            .map_err(|error| error.to_string())?;
+                        let shell = routed_dashboard_shell(&client, shell_id, &local_node_id)?;
+                        if shell_id.node_id == local_node_id || shell_id.node_id.is_empty() {
+                            client
+                                .rename_shell(&shell_id.inner_id, &name)
+                                .map_err(|error| error.to_string())?;
+                        } else {
+                            routed_dashboard_operation(
+                                &client,
+                                shell_id,
+                                &local_node_id,
+                                protocol::RoutedOperation::RenameShell {
+                                    shell_id: shell_id.inner_id.clone(),
+                                    name: name.clone(),
+                                    expected_revision: shell.revision,
+                                },
+                            )?;
+                        }
                         Ok(format!("Renamed shell to {name}"))
                     }
                     tui::RenameTarget::Launcher(launcher_id) => {
-                        let launcher_id = local_dashboard_inner(launcher_id, &local_node_id)?;
-                        client
-                            .rename_launcher(launcher_id, &name)
-                            .map_err(|error| error.to_string())?;
+                        let launcher =
+                            routed_dashboard_launcher(&client, launcher_id, &local_node_id)?;
+                        if launcher_id.node_id == local_node_id || launcher_id.node_id.is_empty() {
+                            client
+                                .rename_launcher(&launcher_id.inner_id, &name)
+                                .map_err(|error| error.to_string())?;
+                        } else {
+                            routed_dashboard_operation(
+                                &client,
+                                launcher_id,
+                                &local_node_id,
+                                protocol::RoutedOperation::RenameLauncher {
+                                    launcher_id: launcher_id.inner_id.clone(),
+                                    name: name.clone(),
+                                    expected_revision: launcher.revision,
+                                },
+                            )?;
+                        }
                         Ok(format!("Renamed launcher to {name}"))
                     }
                 })();
@@ -2235,48 +2307,114 @@ fn dashboard(
                 tui::DashboardEvent::RefreshCompleted(result)
             }
             tui::DashboardEffect::RunSchedule(schedule_id) => {
-                let result = local_dashboard_inner(&schedule_id, &local_node_id)
-                    .and_then(|id| run_dashboard_schedule(&client, id));
+                let result =
+                    if schedule_id.node_id == local_node_id || schedule_id.node_id.is_empty() {
+                        run_dashboard_schedule(&client, &schedule_id.inner_id)
+                    } else {
+                        (|| {
+                            routed_dashboard_schedule(&client, &schedule_id, &local_node_id)?;
+                            let dispatch_key = Uuid::new_v4().to_string();
+                            match routed_dashboard_operation(
+                                &client,
+                                &schedule_id,
+                                &local_node_id,
+                                protocol::RoutedOperation::RunAgentSchedule {
+                                    schedule_id: schedule_id.inner_id.clone(),
+                                    dispatch_key,
+                                },
+                            )? {
+                                protocol::RoutedOperationResult::ScheduledExecution {
+                                    execution,
+                                    ..
+                                } => Ok(format!("Started scheduled execution {}", execution.id)),
+                                _ => {
+                                    Err("remote Node returned an unexpected schedule run response"
+                                        .into())
+                                }
+                            }
+                        })()
+                    };
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::PauseSchedule(schedule_id) => {
-                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
-                    client
-                        .pause_agent_schedule(id)
-                        .map(|schedule| format!("Paused schedule {}", schedule.name))
-                        .map_err(|error| error.to_string())
-                });
+                let result = (|| {
+                    let inspection =
+                        routed_dashboard_schedule(&client, &schedule_id, &local_node_id)?;
+                    let schedule = if schedule_id.node_id == local_node_id
+                        || schedule_id.node_id.is_empty()
+                    {
+                        client
+                            .pause_agent_schedule(&schedule_id.inner_id)
+                            .map_err(|error| error.to_string())?
+                    } else {
+                        match routed_dashboard_operation(
+                            &client,
+                            &schedule_id,
+                            &local_node_id,
+                            protocol::RoutedOperation::PauseAgentSchedule {
+                                schedule_id: schedule_id.inner_id.clone(),
+                                expected_revision: inspection.schedule.revision,
+                            },
+                        )? {
+                            protocol::RoutedOperationResult::AgentSchedule { schedule } => schedule,
+                            _ => {
+                                return Err(
+                                    "remote Node returned an unexpected pause response".into()
+                                );
+                            }
+                        }
+                    };
+                    Ok(format!("Paused schedule {}", schedule.name))
+                })();
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::ResumeSchedule(schedule_id) => {
-                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
-                    client
-                        .resume_agent_schedule(id)
-                        .map(|schedule| {
-                            format!(
-                                "Enabled schedule {} for future timed dispatch",
-                                schedule.name
-                            )
-                        })
-                        .map_err(|error| error.to_string())
-                });
+                let result = (|| {
+                    let inspection =
+                        routed_dashboard_schedule(&client, &schedule_id, &local_node_id)?;
+                    let schedule = if schedule_id.node_id == local_node_id
+                        || schedule_id.node_id.is_empty()
+                    {
+                        client
+                            .resume_agent_schedule(&schedule_id.inner_id)
+                            .map_err(|error| error.to_string())?
+                    } else {
+                        match routed_dashboard_operation(
+                            &client,
+                            &schedule_id,
+                            &local_node_id,
+                            protocol::RoutedOperation::ResumeAgentSchedule {
+                                schedule_id: schedule_id.inner_id.clone(),
+                                expected_revision: inspection.schedule.revision,
+                            },
+                        )? {
+                            protocol::RoutedOperationResult::AgentSchedule { schedule } => schedule,
+                            _ => {
+                                return Err(
+                                    "remote Node returned an unexpected resume response".into()
+                                );
+                            }
+                        }
+                    };
+                    Ok(format!(
+                        "Enabled schedule {} for future timed dispatch",
+                        schedule.name
+                    ))
+                })();
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::LoadScheduleEditor { schedule_id } => {
-                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
-                    client
-                        .get_agent_schedule(id)
-                        .map(|inspection| tui::ScheduleEditInspection {
-                            schedule_id: schedule_id.clone(),
-                            name: inspection.schedule.name,
-                            cron: inspection.schedule.trigger.cron,
-                            timezone: inspection.schedule.trigger.timezone,
-                            prompt: inspection.prompt,
-                            revision: inspection.schedule.revision,
-                            paused: inspection.schedule.state == AgentScheduleState::Paused,
-                        })
-                        .map_err(|error| error.to_string())
-                });
+                let result = routed_dashboard_schedule(&client, &schedule_id, &local_node_id).map(
+                    |inspection| tui::ScheduleEditInspection {
+                        schedule_id: schedule_id.clone(),
+                        name: inspection.schedule.name,
+                        cron: inspection.schedule.trigger.cron,
+                        timezone: inspection.schedule.trigger.timezone,
+                        prompt: inspection.prompt,
+                        revision: inspection.schedule.revision,
+                        paused: inspection.schedule.state == AgentScheduleState::Paused,
+                    },
+                );
                 tui::DashboardEvent::ScheduleEditorLoaded {
                     schedule_id,
                     result,
@@ -2287,31 +2425,74 @@ fn dashboard(
                 expected_revision,
                 update,
             } => {
-                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
+                let definition = AgentScheduleUpdate {
+                    name: update.name,
+                    prompt: update.prompt,
+                    trigger: AgentScheduleTrigger {
+                        cron: update.cron,
+                        timezone: update.timezone,
+                    },
+                };
+                let result = if schedule_id.node_id == local_node_id
+                    || schedule_id.node_id.is_empty()
+                {
                     client
-                        .update_agent_schedule(
-                            id,
-                            expected_revision,
-                            AgentScheduleUpdate {
-                                name: update.name,
-                                prompt: update.prompt,
-                                trigger: AgentScheduleTrigger {
-                                    cron: update.cron,
-                                    timezone: update.timezone,
-                                },
-                            },
-                        )
+                        .update_agent_schedule(&schedule_id.inner_id, expected_revision, definition)
                         .map(|schedule| format!("Updated schedule {}", schedule.name))
                         .map_err(|error| error.to_string())
-                });
+                } else {
+                    routed_dashboard_operation(
+                        &client,
+                        &schedule_id,
+                        &local_node_id,
+                        protocol::RoutedOperation::UpdateAgentSchedule {
+                            schedule_id: schedule_id.inner_id.clone(),
+                            expected_revision,
+                            update: definition,
+                        },
+                    )
+                    .and_then(|result| match result {
+                        protocol::RoutedOperationResult::AgentSchedule { schedule } => {
+                            Ok(format!("Updated schedule {}", schedule.name))
+                        }
+                        _ => Err(
+                            "remote Node returned an unexpected schedule update response".into(),
+                        ),
+                    })
+                };
                 tui::DashboardEvent::ScheduleEditorSaved {
                     schedule_id,
                     result,
                 }
             }
             tui::DashboardEffect::CancelExecution(execution_id) => {
-                let result = local_dashboard_inner(&execution_id, &local_node_id)
-                    .and_then(|id| cancel_dashboard_execution(&client, id));
+                let result =
+                    if execution_id.node_id == local_node_id || execution_id.node_id.is_empty() {
+                        cancel_dashboard_execution(&client, &execution_id.inner_id)
+                    } else {
+                        (|| {
+                            let execution =
+                                routed_dashboard_execution(&client, &execution_id, &local_node_id)?;
+                            match routed_dashboard_operation(
+                                &client,
+                                &execution_id,
+                                &local_node_id,
+                                protocol::RoutedOperation::CancelScheduledExecution {
+                                    execution_id: execution_id.inner_id.clone(),
+                                    expected_revision: execution.revision,
+                                },
+                            )? {
+                                protocol::RoutedOperationResult::ScheduledExecution {
+                                    execution,
+                                    ..
+                                } => Ok(format!("Cancelled scheduled execution {}", execution.id)),
+                                _ => {
+                                    Err("remote Node returned an unexpected cancellation response"
+                                        .into())
+                                }
+                            }
+                        })()
+                    };
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::OpenScheduledExecution { execution_id } => {
@@ -2331,15 +2512,32 @@ fn dashboard(
                     .flat_map(|workspace| &workspace.schedules)
                     .find(|schedule| schedule_inner.as_ref().is_ok_and(|id| schedule.id == **id))
                     .map_or_else(|| "schedule".into(), |schedule| schedule.name.clone());
-                let result = schedule_inner.and_then(|id| {
-                    client
-                    .remove_agent_schedule(id)
-                    .map(|()| {
-                        format!(
-                            "Removed schedule {name}, its persisted prompt, and retained history"
-                        )
+                let result = if schedule_id.node_id == local_node_id
+                    || schedule_id.node_id.is_empty()
+                {
+                    schedule_inner.and_then(|id| {
+                        client
+                            .remove_agent_schedule(id)
+                            .map_err(|error| error.to_string())
                     })
-                    .map_err(|error| error.to_string())
+                } else {
+                    (|| {
+                        let inspection =
+                            routed_dashboard_schedule(&client, &schedule_id, &local_node_id)?;
+                        routed_dashboard_operation(
+                            &client,
+                            &schedule_id,
+                            &local_node_id,
+                            protocol::RoutedOperation::RemoveAgentSchedule {
+                                schedule_id: schedule_id.inner_id.clone(),
+                                expected_revision: inspection.schedule.revision,
+                            },
+                        )?;
+                        Ok(())
+                    })()
+                }
+                .map(|()| {
+                    format!("Removed schedule {name}, its persisted prompt, and retained history")
                 });
                 tui::DashboardEvent::OperationCompleted(result)
             }
@@ -2563,6 +2761,140 @@ fn local_dashboard_inner<'a>(
             identity.node_id
         ))
     }
+}
+
+fn routed_dashboard_workspace(
+    client: &client::Client,
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+) -> Result<protocol::WorkspaceSnapshot, String> {
+    if identity.node_id == local_node_id || identity.node_id.is_empty() {
+        return client
+            .get_workspace(&identity.inner_id)
+            .map_err(|error| error.to_string());
+    }
+    match client
+        .route_node_operation(
+            &identity.node_id,
+            protocol::RoutedOperation::GetWorkspace {
+                workspace_id: identity.inner_id.clone(),
+            },
+        )
+        .map_err(|error| error.to_string())?
+    {
+        protocol::RoutedOperationResult::Workspace { workspace } => Ok(workspace),
+        _ => Err("remote Node returned an unexpected workspace response".into()),
+    }
+}
+
+fn routed_dashboard_shell(
+    client: &client::Client,
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+) -> Result<protocol::ShellSnapshot, String> {
+    if identity.node_id == local_node_id || identity.node_id.is_empty() {
+        return client
+            .get_shell(&identity.inner_id)
+            .map_err(|error| error.to_string());
+    }
+    match client
+        .route_node_operation(
+            &identity.node_id,
+            protocol::RoutedOperation::GetShell {
+                shell_id: identity.inner_id.clone(),
+            },
+        )
+        .map_err(|error| error.to_string())?
+    {
+        protocol::RoutedOperationResult::Shell { shell } => Ok(shell),
+        _ => Err("remote Node returned an unexpected shell response".into()),
+    }
+}
+
+fn routed_dashboard_launcher(
+    client: &client::Client,
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+) -> Result<protocol::WorkspaceLauncherSnapshot, String> {
+    if identity.node_id == local_node_id || identity.node_id.is_empty() {
+        return client
+            .get_launcher(&identity.inner_id)
+            .map_err(|error| error.to_string());
+    }
+    match client
+        .route_node_operation(
+            &identity.node_id,
+            protocol::RoutedOperation::GetLauncher {
+                launcher_id: identity.inner_id.clone(),
+            },
+        )
+        .map_err(|error| error.to_string())?
+    {
+        protocol::RoutedOperationResult::Launcher { launcher } => Ok(launcher),
+        _ => Err("remote Node returned an unexpected launcher response".into()),
+    }
+}
+
+fn routed_dashboard_schedule(
+    client: &client::Client,
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+) -> Result<protocol::AgentScheduleInspection, String> {
+    if identity.node_id == local_node_id || identity.node_id.is_empty() {
+        return client
+            .get_agent_schedule(&identity.inner_id)
+            .map_err(|error| error.to_string());
+    }
+    match client
+        .route_node_operation(
+            &identity.node_id,
+            protocol::RoutedOperation::GetAgentSchedule {
+                schedule_id: identity.inner_id.clone(),
+            },
+        )
+        .map_err(|error| error.to_string())?
+    {
+        protocol::RoutedOperationResult::AgentScheduleInspection { inspection } => Ok(inspection),
+        _ => Err("remote Node returned an unexpected schedule response".into()),
+    }
+}
+
+fn routed_dashboard_execution(
+    client: &client::Client,
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+) -> Result<protocol::ScheduledExecutionSnapshot, String> {
+    if identity.node_id == local_node_id || identity.node_id.is_empty() {
+        return client
+            .get_scheduled_execution(&identity.inner_id)
+            .map_err(|error| error.to_string());
+    }
+    match client
+        .route_node_operation(
+            &identity.node_id,
+            protocol::RoutedOperation::GetScheduledExecution {
+                execution_id: identity.inner_id.clone(),
+            },
+        )
+        .map_err(|error| error.to_string())?
+    {
+        protocol::RoutedOperationResult::ScheduledExecution { execution, .. } => Ok(execution),
+        _ => Err("remote Node returned an unexpected execution response".into()),
+    }
+}
+
+fn routed_dashboard_operation(
+    client: &client::Client,
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+    operation: protocol::RoutedOperation,
+) -> Result<protocol::RoutedOperationResult, String> {
+    if identity.node_id == local_node_id || identity.node_id.is_empty() {
+        return Err("internal error: local operation was sent through Node routing".into());
+    }
+    client
+        .route_node_operation(&identity.node_id, operation)
+        .map_err(|error| error.to_string())
 }
 
 fn run_dashboard_schedule(client: &client::Client, schedule_id: &str) -> Result<String, String> {
@@ -6816,6 +7148,7 @@ mod tests {
         ShellSnapshot {
             owner: boomux::protocol::ShellOwner::User,
             id: id.into(),
+            revision: 1,
             workspace_id: workspace_id.into(),
             name: name.into(),
             cwd: PathBuf::from("/tmp/project"),
@@ -6837,6 +7170,7 @@ mod tests {
     fn workspace(id: &str, name: &str, shells: Vec<ShellSnapshot>) -> WorkspaceSnapshot {
         WorkspaceSnapshot {
             id: id.into(),
+            revision: 1,
             name: name.into(),
             default_cwd: None,
             shells,
@@ -6927,6 +7261,7 @@ mod tests {
     fn launcher(id: &str, workspace_id: &str, name: &str) -> WorkspaceLauncherSnapshot {
         WorkspaceLauncherSnapshot {
             id: id.into(),
+            revision: 1,
             workspace_id: workspace_id.into(),
             name: name.into(),
             cwd: PathBuf::from("/tmp/project"),
@@ -8989,6 +9324,7 @@ mod tests {
         workspace.launchers = vec![
             WorkspaceLauncherSnapshot {
                 id: "l1".into(),
+                revision: 1,
                 workspace_id: "w1".into(),
                 name: "missing".into(),
                 cwd: env::temp_dir(),
@@ -8996,6 +9332,7 @@ mod tests {
             },
             WorkspaceLauncherSnapshot {
                 id: "l2".into(),
+                revision: 1,
                 workspace_id: "w1".into(),
                 name: "later".into(),
                 cwd: env::temp_dir(),
@@ -9658,7 +9995,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 33);
+        assert_eq!(protocol::PROTOCOL_VERSION, 34);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 33;
+pub const PROTOCOL_VERSION: u32 = 34;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -132,6 +132,11 @@ define_protocol_features! {
         "protocol_33",
         "combined_node_snapshot",
         "node_qualified_dashboard",
+    ]),
+    GuardedNodeRouting => (34, "guarded Node routing", [
+        "protocol_34",
+        "typed_exact_node_routing",
+        "guarded_remote_management",
     ]),
 }
 
@@ -536,6 +541,8 @@ pub struct CombinedNode {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkspaceSnapshot {
     pub id: String,
+    #[serde(default)]
+    pub revision: u64,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_cwd: Option<PathBuf>,
@@ -905,6 +912,8 @@ pub struct WorkspaceLauncherSpec {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkspaceLauncherSnapshot {
     pub id: String,
+    #[serde(default)]
+    pub revision: u64,
     pub workspace_id: String,
     pub name: String,
     pub command: Vec<String>,
@@ -914,6 +923,8 @@ pub struct WorkspaceLauncherSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShellSnapshot {
     pub id: String,
+    #[serde(default)]
+    pub revision: u64,
     pub workspace_id: String,
     pub name: String,
     pub cwd: PathBuf,
@@ -986,9 +997,329 @@ pub enum ErrorCode {
     NodeIdentityChanged,
     AmbiguousTarget,
     RevisionChanged,
+    OutcomeUnknown,
     Internal,
     #[serde(other)]
     Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RoutedOperation {
+    GetWorkspace {
+        workspace_id: String,
+    },
+    GetShell {
+        shell_id: String,
+    },
+    GetLauncher {
+        launcher_id: String,
+    },
+    GetAgent {
+        agent_id: String,
+    },
+    GetAgentSchedule {
+        schedule_id: String,
+    },
+    GetScheduledExecution {
+        execution_id: String,
+    },
+    RenameWorkspace {
+        workspace_id: String,
+        name: String,
+        expected_revision: u64,
+    },
+    RenameShell {
+        shell_id: String,
+        name: String,
+        expected_revision: u64,
+    },
+    RenameLauncher {
+        launcher_id: String,
+        name: String,
+        expected_revision: u64,
+    },
+    CloseWorkspace {
+        workspace_id: String,
+        expected_revision: u64,
+    },
+    CloseShell {
+        shell_id: String,
+        expected_revision: u64,
+    },
+    RestartShell {
+        shell_id: String,
+        expected_revision: u64,
+        expected_run_id: String,
+    },
+    RemoveLauncher {
+        launcher_id: String,
+        expected_revision: u64,
+    },
+    PauseAgentSchedule {
+        schedule_id: String,
+        expected_revision: u64,
+    },
+    ResumeAgentSchedule {
+        schedule_id: String,
+        expected_revision: u64,
+    },
+    UpdateAgentSchedule {
+        schedule_id: String,
+        expected_revision: u64,
+        update: AgentScheduleUpdate,
+    },
+    RemoveAgentSchedule {
+        schedule_id: String,
+        expected_revision: u64,
+    },
+    RunAgentSchedule {
+        schedule_id: String,
+        dispatch_key: String,
+    },
+    CancelScheduledExecution {
+        execution_id: String,
+        expected_revision: u64,
+    },
+    AcknowledgeAgentAttention {
+        agent_id: String,
+        observation_revision: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoutedGuard {
+    ExactId,
+    ResourceRevision,
+    ResourceRevisionAndRun,
+    ScheduleRevision,
+    ExecutionRevision,
+    DispatchKey,
+    AttentionObservationRevision,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoutedAmbiguity {
+    RetrySameRequest,
+    ReadAndProve,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoutedOperationClass {
+    pub guard: RoutedGuard,
+    pub ambiguity: RoutedAmbiguity,
+}
+
+impl RoutedOperation {
+    pub const fn classification(&self) -> RoutedOperationClass {
+        use RoutedAmbiguity::{ReadAndProve, RetrySameRequest};
+        use RoutedGuard::{
+            AttentionObservationRevision, DispatchKey, ExactId, ExecutionRevision,
+            ResourceRevision, ResourceRevisionAndRun, ScheduleRevision,
+        };
+        match self {
+            Self::GetWorkspace { .. }
+            | Self::GetShell { .. }
+            | Self::GetLauncher { .. }
+            | Self::GetAgent { .. }
+            | Self::GetAgentSchedule { .. }
+            | Self::GetScheduledExecution { .. } => RoutedOperationClass {
+                guard: ExactId,
+                ambiguity: RetrySameRequest,
+            },
+            Self::RenameWorkspace { .. }
+            | Self::RenameShell { .. }
+            | Self::RenameLauncher { .. }
+            | Self::CloseWorkspace { .. }
+            | Self::CloseShell { .. }
+            | Self::RemoveLauncher { .. } => RoutedOperationClass {
+                guard: ResourceRevision,
+                ambiguity: ReadAndProve,
+            },
+            Self::RestartShell { .. } => RoutedOperationClass {
+                guard: ResourceRevisionAndRun,
+                ambiguity: ReadAndProve,
+            },
+            Self::PauseAgentSchedule { .. }
+            | Self::ResumeAgentSchedule { .. }
+            | Self::UpdateAgentSchedule { .. }
+            | Self::RemoveAgentSchedule { .. } => RoutedOperationClass {
+                guard: ScheduleRevision,
+                ambiguity: ReadAndProve,
+            },
+            Self::RunAgentSchedule { .. } => RoutedOperationClass {
+                guard: DispatchKey,
+                ambiguity: RetrySameRequest,
+            },
+            Self::CancelScheduledExecution { .. } => RoutedOperationClass {
+                guard: ExecutionRevision,
+                ambiguity: ReadAndProve,
+            },
+            Self::AcknowledgeAgentAttention { .. } => RoutedOperationClass {
+                guard: AttentionObservationRevision,
+                ambiguity: RetrySameRequest,
+            },
+        }
+    }
+
+    pub const fn is_retryable(&self) -> bool {
+        matches!(
+            self.classification().ambiguity,
+            RoutedAmbiguity::RetrySameRequest
+        )
+    }
+
+    pub fn ambiguity_probe(&self) -> Option<Request> {
+        match self {
+            Self::RenameWorkspace { workspace_id, .. }
+            | Self::CloseWorkspace { workspace_id, .. } => Some(Request::GetWorkspace {
+                workspace_id: workspace_id.clone(),
+            }),
+            Self::RenameShell { shell_id, .. }
+            | Self::CloseShell { shell_id, .. }
+            | Self::RestartShell { shell_id, .. } => Some(Request::GetShell {
+                shell_id: shell_id.clone(),
+            }),
+            Self::RenameLauncher { launcher_id, .. } | Self::RemoveLauncher { launcher_id, .. } => {
+                Some(Request::GetLauncher {
+                    launcher_id: launcher_id.clone(),
+                })
+            }
+            Self::PauseAgentSchedule { schedule_id, .. }
+            | Self::ResumeAgentSchedule { schedule_id, .. }
+            | Self::UpdateAgentSchedule { schedule_id, .. }
+            | Self::RemoveAgentSchedule { schedule_id, .. } => Some(Request::GetAgentSchedule {
+                schedule_id: schedule_id.clone(),
+            }),
+            Self::CancelScheduledExecution { execution_id, .. } => {
+                Some(Request::GetScheduledExecution {
+                    execution_id: execution_id.clone(),
+                })
+            }
+            _ => None,
+        }
+    }
+
+    pub fn owner_request(&self) -> Request {
+        match self.clone() {
+            Self::GetWorkspace { workspace_id } => Request::GetWorkspace { workspace_id },
+            Self::GetShell { shell_id } => Request::GetShell { shell_id },
+            Self::GetLauncher { launcher_id } => Request::GetLauncher { launcher_id },
+            Self::GetAgent { agent_id } => Request::GetAgent { agent_id },
+            Self::GetAgentSchedule { schedule_id } => Request::GetAgentSchedule { schedule_id },
+            Self::GetScheduledExecution { execution_id } => {
+                Request::GetScheduledExecution { execution_id }
+            }
+            Self::RenameWorkspace {
+                workspace_id,
+                name,
+                expected_revision,
+            } => Request::GuardedRenameWorkspace {
+                workspace_id,
+                name,
+                expected_revision,
+            },
+            Self::RenameShell {
+                shell_id,
+                name,
+                expected_revision,
+            } => Request::GuardedRenameShell {
+                shell_id,
+                name,
+                expected_revision,
+            },
+            Self::RenameLauncher {
+                launcher_id,
+                name,
+                expected_revision,
+            } => Request::GuardedRenameLauncher {
+                launcher_id,
+                name,
+                expected_revision,
+            },
+            Self::CloseWorkspace {
+                workspace_id,
+                expected_revision,
+            } => Request::GuardedCloseWorkspace {
+                workspace_id,
+                expected_revision,
+            },
+            Self::CloseShell {
+                shell_id,
+                expected_revision,
+            } => Request::GuardedCloseShell {
+                shell_id,
+                expected_revision,
+            },
+            Self::RestartShell {
+                shell_id,
+                expected_revision,
+                expected_run_id,
+            } => Request::GuardedRestartShell {
+                shell_id,
+                expected_revision,
+                expected_run_id,
+            },
+            Self::RemoveLauncher {
+                launcher_id,
+                expected_revision,
+            } => Request::GuardedRemoveLauncher {
+                launcher_id,
+                expected_revision,
+            },
+            Self::PauseAgentSchedule {
+                schedule_id,
+                expected_revision,
+            } => Request::GuardedPauseAgentSchedule {
+                schedule_id,
+                expected_revision,
+            },
+            Self::ResumeAgentSchedule {
+                schedule_id,
+                expected_revision,
+            } => Request::GuardedResumeAgentSchedule {
+                schedule_id,
+                expected_revision,
+            },
+            Self::UpdateAgentSchedule {
+                schedule_id,
+                expected_revision,
+                update,
+            } => Request::UpdateAgentSchedule {
+                schedule_id,
+                expected_revision,
+                update,
+            },
+            Self::RemoveAgentSchedule {
+                schedule_id,
+                expected_revision,
+            } => Request::GuardedRemoveAgentSchedule {
+                schedule_id,
+                expected_revision,
+            },
+            Self::RunAgentSchedule {
+                schedule_id,
+                dispatch_key,
+            } => Request::RunAgentSchedule {
+                schedule_id,
+                dispatch_key,
+            },
+            Self::CancelScheduledExecution {
+                execution_id,
+                expected_revision,
+            } => Request::GuardedCancelScheduledExecution {
+                execution_id,
+                expected_revision,
+            },
+            Self::AcknowledgeAgentAttention {
+                agent_id,
+                observation_revision,
+            } => Request::AcknowledgeAgentAttention {
+                agent_id,
+                observation_revision,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1282,6 +1613,10 @@ pub enum Request {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         selector: Option<String>,
     },
+    RouteNodeOperation {
+        node_id: String,
+        operation: RoutedOperation,
+    },
     Restart,
     RestartWithNotificationConfig {
         notifications: NotificationDeliveryConfig,
@@ -1360,6 +1695,10 @@ pub enum Request {
     CancelScheduledExecution {
         execution_id: String,
     },
+    GuardedCancelScheduledExecution {
+        execution_id: String,
+        expected_revision: u64,
+    },
     ResolveScheduledExecutionClaim {
         schedule_id: String,
         shell_id: String,
@@ -1423,34 +1762,78 @@ pub enum Request {
         workspace_id: String,
         name: String,
     },
+    GuardedRenameWorkspace {
+        workspace_id: String,
+        name: String,
+        expected_revision: u64,
+    },
     RenameShell {
         shell_id: String,
         name: String,
+    },
+    GuardedRenameShell {
+        shell_id: String,
+        name: String,
+        expected_revision: u64,
     },
     RenameLauncher {
         launcher_id: String,
         name: String,
     },
+    GuardedRenameLauncher {
+        launcher_id: String,
+        name: String,
+        expected_revision: u64,
+    },
     CloseWorkspace {
         workspace_id: String,
+    },
+    GuardedCloseWorkspace {
+        workspace_id: String,
+        expected_revision: u64,
     },
     CloseShell {
         shell_id: String,
     },
+    GuardedCloseShell {
+        shell_id: String,
+        expected_revision: u64,
+    },
     RestartShell {
         shell_id: String,
+    },
+    GuardedRestartShell {
+        shell_id: String,
+        expected_revision: u64,
+        expected_run_id: String,
     },
     RemoveLauncher {
         launcher_id: String,
     },
+    GuardedRemoveLauncher {
+        launcher_id: String,
+        expected_revision: u64,
+    },
     PauseAgentSchedule {
         schedule_id: String,
+    },
+    GuardedPauseAgentSchedule {
+        schedule_id: String,
+        expected_revision: u64,
     },
     ResumeAgentSchedule {
         schedule_id: String,
     },
+    GuardedResumeAgentSchedule {
+        schedule_id: String,
+        expected_revision: u64,
+    },
     RemoveAgentSchedule {
         schedule_id: String,
+    },
+    GuardedRemoveAgentSchedule {
+        schedule_id: String,
+        expected_revision: u64,
     },
     Attach {
         shell_id: String,
@@ -1481,6 +1864,18 @@ impl Request {
                 Some(ProtocolFeature::NodeProjectionSync)
             }
             Self::GetCombinedNodeSnapshot { .. } => Some(ProtocolFeature::CombinedNodeSnapshot),
+            Self::RouteNodeOperation { .. }
+            | Self::GuardedCancelScheduledExecution { .. }
+            | Self::GuardedRenameWorkspace { .. }
+            | Self::GuardedRenameShell { .. }
+            | Self::GuardedRenameLauncher { .. }
+            | Self::GuardedCloseWorkspace { .. }
+            | Self::GuardedCloseShell { .. }
+            | Self::GuardedRestartShell { .. }
+            | Self::GuardedRemoveLauncher { .. }
+            | Self::GuardedPauseAgentSchedule { .. }
+            | Self::GuardedResumeAgentSchedule { .. }
+            | Self::GuardedRemoveAgentSchedule { .. } => Some(ProtocolFeature::GuardedNodeRouting),
             Self::WaitScheduledExecution { .. } => {
                 Some(ProtocolFeature::ScheduledExecutionObservation)
             }
@@ -1602,6 +1997,9 @@ pub enum Response {
     CombinedNodeSnapshot {
         snapshot: CombinedNodeSnapshot,
     },
+    RoutedNodeOperation {
+        result: RoutedOperationResult,
+    },
     Snapshot {
         snapshot: Snapshot,
     },
@@ -1689,6 +2087,39 @@ pub enum Response {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         code: Option<ErrorCode>,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RoutedOperationResult {
+    Workspace {
+        workspace: WorkspaceSnapshot,
+    },
+    Shell {
+        shell: ShellSnapshot,
+    },
+    Launcher {
+        launcher: WorkspaceLauncherSnapshot,
+    },
+    Agent {
+        agent: AgentInstanceSnapshot,
+    },
+    AgentSchedule {
+        schedule: AgentScheduleSnapshot,
+    },
+    AgentScheduleInspection {
+        inspection: AgentScheduleInspection,
+    },
+    ScheduledExecution {
+        execution: ScheduledExecutionSnapshot,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        next_occurrence: Option<ScheduledOccurrence>,
+    },
+    AgentAttentionAcknowledged {
+        agent: AgentInstanceSnapshot,
+        changed: bool,
+    },
+    Ok,
 }
 
 fn default_event_limit() -> u16 {
@@ -2183,7 +2614,7 @@ mod tests {
 
     #[test]
     fn protocol_version_is_thirty_three_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 33);
+        assert_eq!(PROTOCOL_VERSION, 34);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -2361,6 +2792,42 @@ mod tests {
         assert_eq!(
             serde_json::to_value(identity).unwrap(),
             serde_json::json!({"node_id": "node", "inner_id": "resource"})
+        );
+    }
+
+    #[test]
+    fn protocol_thirty_four_routes_only_closed_typed_operations() {
+        let operation = RoutedOperation::RestartShell {
+            shell_id: "shell".into(),
+            expected_revision: 7,
+            expected_run_id: "run".into(),
+        };
+        let request = Request::RouteNodeOperation {
+            node_id: uuid::Uuid::from_u128(2).to_string(),
+            operation: operation.clone(),
+        };
+        assert_eq!(
+            request.required_feature(),
+            Some(ProtocolFeature::GuardedNodeRouting)
+        );
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(&request).unwrap()).unwrap(),
+            request
+        );
+        assert_eq!(
+            operation.owner_request(),
+            Request::GuardedRestartShell {
+                shell_id: "shell".into(),
+                expected_revision: 7,
+                expected_run_id: "run".into(),
+            }
+        );
+        assert!(!operation.is_retryable());
+        assert!(
+            serde_json::from_value::<RoutedOperation>(serde_json::json!({
+                "operation": "shutdown"
+            }))
+            .is_err()
         );
     }
 
@@ -3138,6 +3605,14 @@ mod tests {
                     "node_qualified_dashboard",
                 ][..],
             ),
+            (
+                34,
+                &[
+                    "protocol_34",
+                    "typed_exact_node_routing",
+                    "guarded_remote_management",
+                ][..],
+            ),
         ];
 
         let actual = ProtocolFeature::ALL
@@ -3368,6 +3843,7 @@ mod tests {
     fn protocol_six_client_ignores_additive_shell_snapshot_fields() {
         let snapshot = ShellSnapshot {
             id: "s1".into(),
+            revision: 1,
             workspace_id: "w1".into(),
             name: "shell".into(),
             cwd: "/tmp".into(),

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -360,6 +360,7 @@ mod tests {
         let shell = boomux::protocol::ShellSnapshot {
             owner: boomux::protocol::ShellOwner::User,
             id: "shell".into(),
+            revision: 1,
             workspace_id: id.into(),
             name: "agent".into(),
             cwd: "/tmp/project".into(),
@@ -378,6 +379,7 @@ mod tests {
         };
         WorkspaceSnapshot {
             id: id.into(),
+            revision: 1,
             name: format!("workspace-{id}"),
             default_cwd: None,
             shells: vec![shell],
@@ -567,6 +569,7 @@ mod tests {
             .launchers
             .push(boomux::protocol::WorkspaceLauncherSnapshot {
                 id: "launcher".into(),
+                revision: 1,
                 workspace_id: "launcher".into(),
                 name: "build".into(),
                 command: vec!["make".into()],
@@ -642,6 +645,7 @@ mod tests {
             .launchers
             .push(boomux::protocol::WorkspaceLauncherSnapshot {
                 id: "launcher".into(),
+                revision: 1,
                 workspace_id: "w1".into(),
                 name: "agent".into(),
                 command: vec!["opencode".into()],

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -134,6 +134,21 @@ pub struct RemoteConnection {
 }
 
 impl RemoteConnection {
+    pub(crate) fn request(&mut self, request: Request, timeout: Duration) -> io::Result<Response> {
+        let version = self.handshake.core_protocol_version;
+        protocol::write_message(
+            self.stdin.as_mut().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "remote channel closed")
+            })?,
+            &Envelope::with_version(version, request),
+        )?;
+        let response: Envelope<Response> = read_message_with_deadline(&mut self.stdout, timeout)?;
+        if response.version != version {
+            return Err(invalid_probe("remote response version mismatch"));
+        }
+        Ok(response.message)
+    }
+
     pub fn ping(&mut self) -> io::Result<()> {
         let version = self.handshake.core_protocol_version;
         protocol::write_message(

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -18,7 +18,8 @@ use crate::protocol::{
     ShellRunExitReason, TerminalProfile,
 };
 
-const STATE_VERSION: u32 = 12;
+const STATE_VERSION: u32 = 13;
+const VERSION_TWELVE_STATE_VERSION: u32 = 12;
 const VERSION_ELEVEN_STATE_VERSION: u32 = 11;
 const VERSION_TEN_STATE_VERSION: u32 = 10;
 const VERSION_NINE_STATE_VERSION: u32 = 9;
@@ -32,6 +33,10 @@ const VERSION_TWO_STATE_VERSION: u32 = 2;
 const LEGACY_STATE_VERSION: u32 = 1;
 const MAX_STATE_BYTES: u64 = 8 * 1024 * 1024;
 const DISPATCH_KEY_FILTER_BYTES: usize = 2048;
+
+const fn initial_revision() -> u64 {
+    1
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -53,6 +58,8 @@ impl Default for PersistedState {
 #[serde(deny_unknown_fields)]
 pub(crate) struct PersistedWorkspace {
     pub(crate) id: String,
+    #[serde(default = "initial_revision")]
+    pub(crate) revision: u64,
     pub(crate) name: String,
     pub(crate) default_cwd: Option<PathBuf>,
     pub(crate) shells: Vec<PersistedShell>,
@@ -171,6 +178,8 @@ pub(crate) struct PersistedAgentInstance {
 #[serde(deny_unknown_fields)]
 pub(crate) struct PersistedWorkspaceLauncher {
     pub(crate) id: String,
+    #[serde(default = "initial_revision")]
+    pub(crate) revision: u64,
     pub(crate) name: String,
     pub(crate) cwd: PathBuf,
     pub(crate) command: Vec<String>,
@@ -180,6 +189,8 @@ pub(crate) struct PersistedWorkspaceLauncher {
 #[serde(deny_unknown_fields)]
 pub(crate) struct PersistedShell {
     pub(crate) id: String,
+    #[serde(default = "initial_revision")]
+    pub(crate) revision: u64,
     pub(crate) name: String,
     pub(crate) cwd: PathBuf,
     pub(crate) command: Vec<String>,
@@ -586,7 +597,10 @@ impl StateStore {
             )
         })?;
         let (state, migrated) = match version.version {
-            STATE_VERSION => (parse_state(&bytes, &self.path)?, false),
+            STATE_VERSION => (parse_current_state(&bytes, &self.path)?, false),
+            VERSION_TWELVE_STATE_VERSION => {
+                (migrate_version_twelve_state(&bytes, &self.path)?, true)
+            }
             VERSION_ELEVEN_STATE_VERSION => {
                 (migrate_version_eleven_state(&bytes, &self.path)?, true)
             }
@@ -675,6 +689,32 @@ impl StateStore {
     }
 }
 
+fn migrate_version_twelve_state(bytes: &[u8], path: &Path) -> io::Result<PersistedState> {
+    let mut previous: serde_json::Value = parse_state(bytes, path)?;
+    previous["version"] = serde_json::Value::from(STATE_VERSION);
+    if let Some(workspaces) = previous["workspaces"].as_array_mut() {
+        for workspace in workspaces {
+            workspace["revision"] = serde_json::Value::from(1);
+            if let Some(shells) = workspace["shells"].as_array_mut() {
+                for shell in shells {
+                    shell["revision"] = serde_json::Value::from(1);
+                }
+            }
+            if let Some(launchers) = workspace["launchers"].as_array_mut() {
+                for launcher in launchers {
+                    launcher["revision"] = serde_json::Value::from(1);
+                }
+            }
+        }
+    }
+    serde_json::from_value(previous).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("could not migrate {}: {error}", path.display()),
+        )
+    })
+}
+
 fn migrate_version_eleven_state(bytes: &[u8], path: &Path) -> io::Result<PersistedState> {
     let mut previous: serde_json::Value = parse_state(bytes, path)?;
     previous["version"] = serde_json::Value::from(STATE_VERSION);
@@ -737,6 +777,59 @@ fn parse_state<T: for<'de> Deserialize<'de>>(bytes: &[u8], path: &Path) -> io::R
     })
 }
 
+fn parse_current_state(bytes: &[u8], path: &Path) -> io::Result<PersistedState> {
+    let value: serde_json::Value = parse_state(bytes, path)?;
+    let workspaces = value
+        .get("workspaces")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Boomux state has no workspace array",
+            )
+        })?;
+    for workspace in workspaces {
+        require_positive_revision(workspace, "workspace")?;
+        for shell in workspace
+            .get("shells")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            require_positive_revision(shell, "shell")?;
+        }
+        for launcher in workspace
+            .get("launchers")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            require_positive_revision(launcher, "workspace launcher")?;
+        }
+    }
+    serde_json::from_value(value).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("could not parse {}: {error}", path.display()),
+        )
+    })
+}
+
+fn require_positive_revision(value: &serde_json::Value, resource: &str) -> io::Result<()> {
+    if value
+        .get("revision")
+        .and_then(serde_json::Value::as_u64)
+        .is_some_and(|revision| revision > 0)
+    {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Boomux state contains a {resource} without a positive revision"),
+        ))
+    }
+}
+
 fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
     debug_assert_eq!(legacy.version, LEGACY_STATE_VERSION);
     let migrated_at_ms = unix_time_ms();
@@ -747,6 +840,7 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
             .into_iter()
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
+                revision: 1,
                 name: workspace.name,
                 default_cwd: None,
                 shells: workspace
@@ -754,6 +848,7 @@ fn migrate_legacy_state(legacy: LegacyPersistedState) -> PersistedState {
                     .into_iter()
                     .map(|shell| PersistedShell {
                         id: shell.id,
+                        revision: 1,
                         name: shell.name,
                         cwd: shell.cwd,
                         command: shell.command,
@@ -788,6 +883,7 @@ fn migrate_version_nine_state(previous: VersionNinePersistedState) -> PersistedS
             .into_iter()
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
+                revision: 1,
                 name: workspace.name,
                 default_cwd: workspace.default_cwd,
                 shells: workspace
@@ -795,6 +891,7 @@ fn migrate_version_nine_state(previous: VersionNinePersistedState) -> PersistedS
                     .into_iter()
                     .map(|shell| PersistedShell {
                         id: shell.id,
+                        revision: 1,
                         name: shell.name,
                         cwd: shell.cwd,
                         command: shell.command,
@@ -837,6 +934,7 @@ fn migrate_version_nine_state(previous: VersionNinePersistedState) -> PersistedS
 fn migrate_pre_ownership_shell(shell: PreOwnershipPersistedShell) -> PersistedShell {
     PersistedShell {
         id: shell.id,
+        revision: 1,
         name: shell.name,
         cwd: shell.cwd,
         command: shell.command,
@@ -854,6 +952,7 @@ fn migrate_version_eight_state(previous: VersionEightPersistedState) -> Persiste
             .into_iter()
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
+                revision: 1,
                 name: workspace.name,
                 default_cwd: workspace.default_cwd,
                 shells: workspace
@@ -878,6 +977,7 @@ fn migrate_version_seven_state(previous: VersionSevenPersistedState) -> Persiste
             .into_iter()
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
+                revision: 1,
                 name: workspace.name,
                 default_cwd: workspace.default_cwd,
                 shells: workspace
@@ -885,6 +985,7 @@ fn migrate_version_seven_state(previous: VersionSevenPersistedState) -> Persiste
                     .into_iter()
                     .map(|shell| PersistedShell {
                         id: shell.id,
+                        revision: 1,
                         name: shell.name,
                         cwd: shell.cwd,
                         command: shell.command,
@@ -919,6 +1020,7 @@ fn migrate_previous_state(previous: PreviousPersistedState) -> PersistedState {
             .into_iter()
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
+                revision: 1,
                 name: workspace.name,
                 default_cwd: None,
                 shells: workspace
@@ -943,6 +1045,7 @@ fn migrate_version_five_state(previous: VersionFivePersistedState) -> PersistedS
             .into_iter()
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
+                revision: 1,
                 name: workspace.name,
                 default_cwd: None,
                 shells: workspace
@@ -989,6 +1092,7 @@ fn migrate_version_four_state(previous: VersionFourPersistedState) -> PersistedS
                     .collect::<std::collections::HashMap<_, _>>();
                 PersistedWorkspace {
                     id: workspace.id,
+                    revision: 1,
                     name: workspace.name,
                     default_cwd: None,
                     shells: workspace
@@ -1030,6 +1134,7 @@ fn migrate_version_three_state(previous: VersionThreePersistedState) -> Persiste
             .into_iter()
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
+                revision: 1,
                 name: workspace.name,
                 default_cwd: None,
                 shells: workspace
@@ -1054,6 +1159,7 @@ fn migrate_version_two_state(previous: VersionTwoPersistedState) -> PersistedSta
             .into_iter()
             .map(|workspace| PersistedWorkspace {
                 id: workspace.id,
+                revision: 1,
                 name: workspace.name,
                 default_cwd: None,
                 shells: workspace
@@ -1130,10 +1236,12 @@ mod tests {
             version: STATE_VERSION,
             workspaces: vec![PersistedWorkspace {
                 id: Uuid::new_v4().to_string(),
+                revision: 1,
                 name: "saved".into(),
                 default_cwd: Some("/tmp/project".into()),
                 shells: vec![PersistedShell {
                     id: "shell-1".into(),
+                    revision: 1,
                     name: "agent".into(),
                     cwd: "/tmp/project".into(),
                     command: vec!["opencode".into()],
@@ -1162,12 +1270,14 @@ mod tests {
                 launchers: vec![
                     PersistedWorkspaceLauncher {
                         id: "launcher-1".into(),
+                        revision: 1,
                         name: "editor".into(),
                         cwd: "/tmp/project".into(),
                         command: vec!["editor".into(), "".into(), "two words".into()],
                     },
                     PersistedWorkspaceLauncher {
                         id: "launcher-2".into(),
+                        revision: 1,
                         name: "server".into(),
                         cwd: "/tmp/project/server".into(),
                         command: vec!["server".into()],
@@ -1410,7 +1520,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 12")
+                .contains("\"version\": 13")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1447,7 +1557,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 12")
+                .contains("\"version\": 13")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1460,6 +1570,7 @@ mod tests {
         let mut state = PersistedState::default();
         state.workspaces.push(PersistedWorkspace {
             id: Uuid::new_v4().to_string(),
+            revision: 1,
             name: "saved".into(),
             default_cwd: None,
             shells: Vec::new(),
@@ -1540,7 +1651,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 12")
+                .contains("\"version\": 13")
         );
 
         let mut version_eleven = serde_json::to_value(&migrated).unwrap();
@@ -1554,6 +1665,66 @@ mod tests {
         assert_eq!(
             migrated_eleven.workspaces[0].schedules[0].executions[0].revision,
             1
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn migrates_version_twelve_resource_revisions() {
+        let directory = env::temp_dir().join(format!("boomux-state-{}", Uuid::new_v4()));
+        let path = directory.join("boomux/state.json");
+        let state = PersistedState {
+            version: STATE_VERSION,
+            workspaces: vec![PersistedWorkspace {
+                id: "workspace".into(),
+                revision: 9,
+                name: "saved".into(),
+                default_cwd: None,
+                shells: vec![PersistedShell {
+                    id: "shell".into(),
+                    revision: 8,
+                    name: "main".into(),
+                    cwd: "/tmp".into(),
+                    command: Vec::new(),
+                    owner: ShellOwner::User,
+                    last_run: None,
+                }],
+                launchers: vec![PersistedWorkspaceLauncher {
+                    id: "launcher".into(),
+                    revision: 7,
+                    name: "build".into(),
+                    cwd: "/tmp".into(),
+                    command: vec!["true".into()],
+                }],
+                agents: Vec::new(),
+                schedules: Vec::new(),
+            }],
+        };
+        let mut value = serde_json::to_value(state).unwrap();
+        value["version"] = serde_json::Value::from(12);
+        value["workspaces"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("revision");
+        value["workspaces"][0]["shells"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("revision");
+        value["workspaces"][0]["launchers"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("revision");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, serde_json::to_vec(&value).unwrap()).unwrap();
+
+        let migrated = StateStore::at(path.clone()).load().unwrap().unwrap();
+        assert_eq!(migrated.workspaces[0].revision, 1);
+        assert_eq!(migrated.workspaces[0].shells[0].revision, 1);
+        assert_eq!(migrated.workspaces[0].launchers[0].revision, 1);
+        assert!(
+            fs::read_to_string(path)
+                .unwrap()
+                .contains("\"version\": 13")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1652,7 +1823,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 12")
+                .contains("\"version\": 13")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1708,7 +1879,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 12")
+                .contains("\"version\": 13")
         );
         assert!(migrated.workspaces[0].launchers.is_empty());
         assert!(migrated.workspaces[0].agents.is_empty());
@@ -1759,7 +1930,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 12")
+                .contains("\"version\": 13")
         );
         assert!(migrated.workspaces[0].agents.is_empty());
         assert!(migrated.workspaces[0].schedules.is_empty());
@@ -1799,7 +1970,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 12")
+                .contains("\"version\": 13")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1876,7 +2047,7 @@ mod tests {
         assert!(
             fs::read_to_string(&path)
                 .unwrap()
-                .contains("\"version\": 12")
+                .contains("\"version\": 13")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1912,7 +2083,7 @@ mod tests {
         assert!(migrated.workspaces[0].agents[0].attention.is_none());
         assert!(migrated.workspaces[0].schedules.is_empty());
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 12"));
+        assert!(saved.contains("\"version\": 13"));
         assert!(saved.contains("\"attention\": null"));
         fs::remove_dir_all(directory).unwrap();
     }
@@ -1945,7 +2116,7 @@ mod tests {
         assert!(!original.contains("default_cwd"));
         store.save(&migrated).unwrap();
         let saved = fs::read_to_string(&path).unwrap();
-        assert!(saved.contains("\"version\": 12"));
+        assert!(saved.contains("\"version\": 13"));
         assert!(saved.contains("\"default_cwd\": null"));
         fs::remove_dir_all(directory).unwrap();
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -530,6 +530,17 @@ impl WorkspaceView {
     }
 
     fn actionable(&self) -> bool {
+        self.node.current
+            && !self.node.stale
+            && (self.node.local
+                || self
+                    .node
+                    .observed_capabilities
+                    .iter()
+                    .any(|capability| capability == "guarded_remote_management"))
+    }
+
+    fn local_actionable(&self) -> bool {
         self.node.local && self.node.current && !self.node.stale
     }
 
@@ -2561,7 +2572,7 @@ impl App {
             Focus::Items => {
                 let workspace_id = self
                     .selected()
-                    .filter(|workspace| workspace.actionable())
+                    .filter(|workspace| workspace.local_actionable())
                     .map(|workspace| workspace.qualify(&workspace.id))?;
                 Some(DashboardEffect::CreateShell(workspace_id))
             }
@@ -2586,7 +2597,7 @@ impl App {
             return None;
         }
         self.selected()
-            .filter(|workspace| workspace.actionable())
+            .filter(|workspace| workspace.local_actionable())
             .map(|workspace| DashboardEffect::RestoreWorkspace(workspace.qualify(&workspace.id)))
     }
 
@@ -2597,7 +2608,7 @@ impl App {
         }
         let workspace = self
             .selected_item_workspace()
-            .filter(|workspace| workspace.actionable())?;
+            .filter(|workspace| workspace.local_actionable())?;
         let workspace_id = workspace.qualify(&workspace.id);
         let target = self.selected_item().and_then(|item| match item {
             WorkspaceItemView::Shell(shell) => {

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 33);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 34);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -123,11 +123,14 @@ fn native_daemon_lifecycle() {
         "protocol_31",
         "protocol_32",
         "protocol_33",
+        "protocol_34",
         "node_registration_management",
         "node_projection_sync",
         "bounded_remote_node_projections",
         "combined_node_snapshot",
         "node_qualified_dashboard",
+        "typed_exact_node_routing",
+        "guarded_remote_management",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -162,7 +165,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 33"));
+    assert!(status_text.contains("running (protocol 34"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -922,7 +925,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 33);
+    assert_eq!(handshake.core_protocol_version, 34);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -55,6 +55,28 @@ fn registrations_survive_cold_recovery_outside_authoritative_state() {
 }
 
 #[test]
+fn guarded_resource_revisions_survive_cold_recovery() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace("guarded", Vec::new())
+        .unwrap();
+    assert_eq!(workspace.revision, 1);
+    daemon
+        .client
+        .rename_workspace(&workspace.id, "guarded-renamed")
+        .unwrap();
+    let renamed = daemon.client.get_workspace(&workspace.id).unwrap();
+    assert_eq!(renamed.revision, 2);
+
+    daemon.crash();
+    daemon.restart();
+    let recovered = daemon.client.get_workspace(&workspace.id).unwrap();
+    assert_eq!(recovered.name, "guarded-renamed");
+    assert_eq!(recovered.revision, 2);
+}
+
+#[test]
 fn combined_snapshot_is_separate_and_local_alias_ambiguity_is_typed() {
     let daemon = TestDaemon::start();
     daemon
@@ -184,16 +206,38 @@ fn fake_ssh(directory: &Path) {
         ),
     )
     .unwrap();
+    let mut workspace = Vec::new();
+    protocol::write_message(
+        &mut workspace,
+        &Envelope::with_version(
+            protocol::PROTOCOL_VERSION,
+            Response::Workspace {
+                workspace: protocol::WorkspaceSnapshot {
+                    id: "shared-workspace".into(),
+                    revision: 7,
+                    name: "shared-private".into(),
+                    default_cwd: Some("/remote/private".into()),
+                    shells: Vec::new(),
+                    launchers: Vec::new(),
+                    agents: Vec::new(),
+                    schedules: Vec::new(),
+                },
+            },
+        ),
+    )
+    .unwrap();
     fs::write(directory.join("pong.bin"), ping).unwrap();
     fs::write(directory.join("sync.bin"), sync).unwrap();
+    fs::write(directory.join("workspace.bin"), workspace).unwrap();
     let ssh = directory.join("ssh");
     fs::write(
         &ssh,
         format!(
-            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") {}; python3 -c 'import json,struct,sys; data=sys.stdin.buffer.read(struct.unpack(\">I\",sys.stdin.buffer.read(4))[0]); request=json.loads(data)[\"message\"][\"request\"]; path=sys.argv[1] if request==\"ping\" else sys.argv[2]; sys.stdout.buffer.write(open(path,\"rb\").read())' \"{}\" \"{}\" ;;\n  *) exit 64 ;;\nesac\n",
+            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") {}; python3 -c 'import json,struct,sys; data=sys.stdin.buffer.read(struct.unpack(\">I\",sys.stdin.buffer.read(4))[0]); request=json.loads(data)[\"message\"][\"request\"]; paths={{\"ping\":sys.argv[1],\"sync_node_projection\":sys.argv[2],\"get_workspace\":sys.argv[3]}}; sys.stdout.buffer.write(open(paths[request],\"rb\").read())' \"{}\" \"{}\" \"{}\" ;;\n  *) exit 64 ;;\nesac\n",
             shell_printf(&handshake_bytes),
             directory.join("pong.bin").display(),
             directory.join("sync.bin").display(),
+            directory.join("workspace.bin").display(),
         ),
     )
     .unwrap();
@@ -255,6 +299,23 @@ fn cli_add_and_retarget_pin_verified_identity_without_persisting_helper_path() {
     let online = online
         .unwrap_or_else(|| panic!("background projection did not become online: {last_inspect:?}"));
     assert_eq!(online["data"]["projection"]["cursor"], 0);
+    let routed =
+        boomux::client::Client::from_socket_path(directory.join("runtime/boomux/daemon.sock"))
+            .route_node_operation(
+                node_id(2),
+                boomux::protocol::RoutedOperation::GetWorkspace {
+                    workspace_id: "shared-workspace".into(),
+                },
+            )
+            .unwrap();
+    let boomux::protocol::RoutedOperationResult::Workspace { workspace } = routed else {
+        panic!("expected routed workspace");
+    };
+    assert_eq!(workspace.revision, 7);
+    assert_eq!(
+        workspace.default_cwd.as_deref(),
+        Some(Path::new("/remote/private"))
+    );
     let combined = command(&directory)
         .args(["node", "snapshot", "--json"])
         .output()


### PR DESCRIPTION
## Summary

- add protocol 34 closed typed routing for exact registered Nodes
- add state schema 13 durable resource revisions with schema-12 migration
- enforce owner-side guards and preserve exact revisions, run IDs, and dispatch keys
- reserve and revalidate registration identity around lock-free network operations
- retry only reads and operations with the same proven idempotency key
- prove ambiguous postconditions or return `outcome_unknown` without replay
- keep unclassified remote operations disabled and legacy local behavior unchanged

## Stack

- GitHub stack #190
- depends on #200
- implements #179

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`

Closes #179

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
