### PR TITLE
feat(remote): attach owner-managed PTYs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,6 +107,8 @@ projection worker. Protocol 33 exposes cached projections through the separately
 named combined Node snapshot and dashboard while existing snapshot and list
 operations remain local-only. Protocol 34 adds closed typed exact-Node private
 reads and guarded management; unclassified mutation remains unavailable.
+Protocol 35 adds Node-qualified native-terminal attachment and owner-environment
+startup for remote pending and exited Shells.
 
 ## Components
 
@@ -244,6 +246,14 @@ available `workspace-N` name and publishes the generated workspace and shell as
 one operation. Concurrent requests retry name allocation rather than exposing
 an ungrouped shell.
 
+Protocol-35 owner-environment attachment is a mutually exclusive alternative to
+the client Unix environment. The owning daemon constructs startup from its own
+captured environment, then applies the validated terminal profile and
+authoritative Boomux identity. Node-qualified attachment never sends the
+presenting Node's environment. A protocol-34 owner can attach only an
+authoritatively preflighted running Shell; it cannot start or restart one
+remotely.
+
 ### Attachment
 
 `src/attach.rs` runs inside the selected terminal emulator. It enables raw mode,
@@ -287,6 +297,14 @@ the attachment handshake. While holding the ordinary attachment mutation and
 shell lifecycle boundary, the daemon returns `run_changed` unless the shell is
 currently running that exact run. It cannot restart or take over a later run.
 Ordinary shell attachments retain their existing restart behavior.
+
+Node-qualified opens still launch local `xdg-terminal-exec` presentation. Their
+hidden `__attach` command carries the exact owner Node ID and unchanged inner
+Shell ID. The local daemon opens one identity-verified SSH helper channel and
+relays bounded `AttachFrame` values; the remote daemon retains PTY, controller,
+focus, takeover, resize, reconstruction, and exact-run authority. Remote
+transport loss closes only the local attachment and does not synthesize Shell,
+Agent, or Scheduled Execution completion.
 
 No emulator-specific adapter or compositor window ID is required.
 Spawned terminal windows start in independent process sessions with null
@@ -576,6 +594,13 @@ responses never mutate projection cache. Only read-only operations and mutations
 with an owner-side durable idempotency key are retried; every other transport
 ambiguity performs an authoritative postcondition read and otherwise returns
 `outcome_unknown`.
+Protocol 35 adds `AttachNode` as a separate Node-qualified streaming request and
+adds the inner `Attach.owner_environment` mode. The mode is incompatible with an
+arbitrary `UnixEnvironment`; old wire values default it off. Remote handoff
+`Reconnect` frames pass through unchanged. Local handoff reconnects the local
+attachment and drops the old SSH bridge; the replacement discovers and verifies
+a fresh helper channel. No SSH child, remote PTY descriptor, process, cursor, or
+reconstruction state enters the handoff manifest.
 Protocol-25 lists are daemon-bounded, newest-first pages with explicit limit and
 truncation. The request limit is optional on the wire; protocol 25 defaults it to
 100 and clamps it to 1 through 1,000, while protocol-23 and protocol-24 requests

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -60,6 +60,13 @@ revision, observation revision, or dispatch key required by the operation.
 Stale Nodes and Nodes without the capability remain non-actionable. Existing
 unqualified CLI methods preserve local-only semantics.
 
+Protocol 35 advertises `remote_pty_attachment` and
+`owner_environment_attachment`. `boomux open SHELL --node SELECTOR` is a
+human-facing local presentation command: the selector resolves to an exact
+registered Node, the title includes its alias, and the hidden attachment carries
+the exact qualified identity. It does not add a JSON method or change legacy
+unqualified `open` semantics.
+
 That passive command advertises only what the installed local CLI can speak and
 never reports negotiated state for a registered Node. Implemented `node.list`
 and `node.inspect` return registration data only. Future combined projection data
@@ -306,6 +313,8 @@ Protocol 32 adds `protocol_32`, `node_projection_sync`, and
 `combined_node_snapshot`, and `node_qualified_dashboard`.
 Protocol 34 adds `protocol_34`, `typed_exact_node_routing`, and
 `guarded_remote_management`.
+Protocol 35 adds `protocol_35`, `remote_pty_attachment`, and
+`owner_environment_attachment`.
 
 Node snapshot health is `unobserved`, `online`, `reconnecting`, `stale`,
 `unreachable`, `authentication_required`, `identity_changed`,

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -71,8 +71,8 @@ ordinary cold recovery does not restore it.
 
 ## Accepted Remote Node Boundary
 
-Remote Node federation is not yet implemented. Under its accepted contract, a
-remote PTY descriptor, process handle, runtime, and reconstruction state remain
+Protocol 35 implements the accepted remote attachment boundary. A remote PTY
+descriptor, process handle, runtime, and reconstruction state remain
 owned by the remote daemon and never enter a local handoff manifest. Remote
 daemon replacement uses this existing descriptor-transfer protocol on the
 remote machine, and its attachment reconnect frames pass unchanged through the

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -13,7 +13,8 @@
 > Node-cache schema 1 implement bounded background reduced projections. Public
 > Protocol 33 adds the local-daemon combined Node snapshot and federated
 > dashboard. Protocol 34 and state schema 13 implement typed exact-Node private
-> reads and guarded management operations. Public `boomux --remote TARGET`
+> reads and guarded management operations. Protocol 35 implements Node-qualified
+> native-terminal PTY attachment and owner-environment remote startup. Public `boomux --remote TARGET`
 > remains ad hoc.
 
 ## Purpose
@@ -381,6 +382,15 @@ trusting the bridge to strip fields. Without the capability, a running remote
 Shell can remain attachable where otherwise compatible, but federation refuses
 to start or restart it and never sends the local attachment environment.
 
+Protocol 35 advertises `remote_pty_attachment` and
+`owner_environment_attachment`. `AttachNode` carries an exact
+`QualifiedIdentity`; the inner `Attach.owner_environment` flag defaults false
+for old peers and is rejected when an arbitrary `UnixEnvironment` is also
+present. Public `open --node SELECTOR` resolves through the local registration
+and launches local presentation with a Node-qualified title. The dashboard opens
+current remote Shell rows and active exact Scheduled Execution runs only when
+the observed owner capabilities include remote attachment.
+
 Remote graceful handoff sends its existing reconnect boundary through the
 bridge. Local graceful handoff asks the local attachment to reconnect and opens
 a fresh SSH stream after finalization. No remote PTY descriptor, process handle,
@@ -480,6 +490,12 @@ versions differ. Handshake round trips, old/new helper pairs, current/minimum
 federation-capable remote daemons, old local clients, response filtering, and
 cursor advancement all require mixed-version tests before capability
 advertisement.
+
+Protocol-34 owners are the attachment compatibility floor for registered
+running Shells because the coordinator performs a fresh exact Shell preflight
+through guarded routing. Starting a pending Shell or restarting an exited Shell
+requires protocol 35. Release-version differences never authorize restarting a
+compatible remote daemon.
 
 Node identity, registrations, and projections use explicit independent schemas.
 Introducing them cannot silently reinterpret authoritative `state.json`. If a

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -114,6 +114,7 @@ impl Drop for RawMode {
 
 pub fn run(
     shell_id: &str,
+    node_id: Option<&str>,
     takeover: bool,
     restart_exited: bool,
     expected_run_id: Option<&str>,
@@ -129,6 +130,7 @@ pub fn run(
     let mut attachment = attach_once(
         &client,
         shell_id,
+        node_id,
         takeover,
         restart_exited,
         expected_run_id,
@@ -182,7 +184,14 @@ pub fn run(
                 profile.pixel_width = pixel_width;
                 profile.pixel_height = pixel_height;
             }
-            attachment = reconnect(&client, shell_id, takeover, expected_run_id, &profile)?;
+            attachment = reconnect(
+                &client,
+                shell_id,
+                node_id,
+                takeover,
+                expected_run_id,
+                &profile,
+            )?;
         }
     })();
     if focus_reporting {
@@ -199,13 +208,22 @@ pub fn run(
 fn reconnect(
     client: &client::Client,
     shell_id: &str,
+    node_id: Option<&str>,
     takeover: bool,
     expected_run_id: Option<&str>,
     profile: &TerminalProfile,
 ) -> client::Result<client::Attachment> {
     let mut last_error = None;
     for _ in 0..RECONNECT_ATTEMPTS {
-        match attach_once(client, shell_id, takeover, false, expected_run_id, profile) {
+        match attach_once(
+            client,
+            shell_id,
+            node_id,
+            takeover,
+            false,
+            expected_run_id,
+            profile,
+        ) {
             Ok(attachment) => return Ok(attachment),
             Err(error) if exact_reconnect_error_is_permanent(expected_run_id, &error) => {
                 return Err(error);
@@ -236,11 +254,21 @@ fn exact_reconnect_error_is_permanent(
 fn attach_once(
     client: &client::Client,
     shell_id: &str,
+    node_id: Option<&str>,
     takeover: bool,
     restart_exited: bool,
     expected_run_id: Option<&str>,
     profile: &TerminalProfile,
 ) -> client::Result<client::Attachment> {
+    if let Some(node_id) = node_id {
+        return client.attach_node(
+            crate::protocol::QualifiedIdentity::new(node_id, shell_id),
+            takeover,
+            restart_exited,
+            expected_run_id.map(str::to_owned),
+            profile.clone(),
+        );
+    }
     if let Some(expected_run_id) = expected_run_id {
         return client.attach_exact_run_with_client_environment(
             shell_id,
@@ -455,6 +483,7 @@ mod tests {
         let error = reconnect(
             &client,
             "shell-1",
+            None,
             true,
             Some("run-1"),
             &TerminalProfile {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1447,6 +1447,24 @@ impl Client {
         )
     }
 
+    pub fn attach_node(
+        &self,
+        identity: protocol::QualifiedIdentity,
+        takeover: bool,
+        restart_exited: bool,
+        expected_run_id: Option<String>,
+        profile: TerminalProfile,
+    ) -> Result<Attachment> {
+        let (stream, protocol_version, response) = self.send(Request::AttachNode {
+            identity,
+            takeover,
+            restart_exited,
+            expected_run_id,
+            profile,
+        })?;
+        attachment_from_response(stream, protocol_version, response)
+    }
+
     fn attach_with_restart(
         &self,
         shell_id: String,
@@ -1463,21 +1481,30 @@ impl Client {
             expected_run_id,
             profile,
             environment,
+            owner_environment: false,
         })?;
-        match response {
-            Response::Attached {
-                token,
-                reconstruction,
-                warning,
-            } => Ok(Attachment {
-                stream,
-                protocol_version,
-                token,
-                reconstruction,
-                warning,
-            }),
-            other => unexpected(other),
-        }
+        attachment_from_response(stream, protocol_version, response)
+    }
+}
+
+fn attachment_from_response(
+    stream: UnixStream,
+    protocol_version: u32,
+    response: Response,
+) -> Result<Attachment> {
+    match response {
+        Response::Attached {
+            token,
+            reconstruction,
+            warning,
+        } => Ok(Attachment {
+            stream,
+            protocol_version,
+            token,
+            reconstruction,
+            warning,
+        }),
+        other => unexpected(other),
     }
 }
 
@@ -1885,6 +1912,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
@@ -2040,7 +2068,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 34);
+            assert_eq!(request.version, 35);
             assert_eq!(request.message, Request::GetNodeIdentity);
             protocol::write_message(
                 &mut stream,
@@ -2054,6 +2082,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
@@ -2103,7 +2132,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 34);
+            assert_eq!(request.version, 35);
             assert_eq!(request.message, Request::OpenFederationChannel);
             protocol::write_message(
                 &mut stream,
@@ -2117,6 +2146,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
@@ -2149,7 +2179,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 34);
+            assert_eq!(request.version, 35);
             assert_eq!(request.message, Request::ListNodeRegistrations);
             protocol::write_message(
                 &mut stream,
@@ -2162,6 +2192,7 @@ mod tests {
                 ),
             )
             .unwrap();
+            reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
@@ -2337,6 +2368,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);
@@ -2407,6 +2439,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
             reject_protocol(&listener, 32, 31);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -723,6 +723,7 @@ fn launch_replacement(
     registry.notify_output_waiters();
     let mut paused = Vec::new();
     let result = (|| {
+        registry.remote_attachments.quiesce()?;
         let shells = registry.durable.shells()?;
         let prepared = registry.runtimes.prepare_handoff(shells)?;
         paused = prepared.paused;
@@ -1052,6 +1053,25 @@ fn handle_connection_inner(
         return send_response(&mut stream, response_version, response);
     }
 
+    if let Request::AttachNode {
+        identity,
+        takeover,
+        restart_exited,
+        expected_run_id,
+        profile,
+    } = request.message
+    {
+        return registry.handle_remote_attach(
+            stream,
+            response_version,
+            identity,
+            takeover,
+            restart_exited,
+            expected_run_id,
+            profile,
+        );
+    }
+
     if let Request::Attach {
         shell_id,
         takeover,
@@ -1059,6 +1079,7 @@ fn handle_connection_inner(
         expected_run_id,
         profile,
         environment,
+        owner_environment,
     } = request.message
     {
         return registry.runtimes.handle_attach(
@@ -1072,6 +1093,7 @@ fn handle_connection_inner(
                 expected_run_id,
                 profile,
                 environment,
+                owner_environment,
             },
         );
     }
@@ -1909,6 +1931,7 @@ struct DaemonService {
     durable: DurableRegistry,
     events: EventStream,
     runtimes: ShellRuntimeManager,
+    remote_attachments: RemoteAttachmentManager,
     mutation_lock: Mutex<()>,
     schedule_dispatch_lock: Mutex<()>,
     notification_settings: NotificationDeliverySettings,
@@ -1920,6 +1943,74 @@ struct DaemonService {
     clock: Mutex<Arc<dyn SchedulerClock>>,
     #[cfg(test)]
     fail_after_mutation: AtomicBool,
+}
+
+#[derive(Default)]
+struct RemoteAttachmentManager {
+    controllers: Mutex<HashMap<String, RemoteAttachmentController>>,
+}
+
+struct RemoteAttachmentController {
+    connection: Arc<Mutex<UnixStream>>,
+    reconnect_ack: Option<SyncSender<()>>,
+}
+
+impl RemoteAttachmentManager {
+    fn insert(&self, token: String, connection: UnixStream) -> io::Result<()> {
+        lock(&self.controllers)?.insert(
+            token,
+            RemoteAttachmentController {
+                connection: Arc::new(Mutex::new(connection)),
+                reconnect_ack: None,
+            },
+        );
+        Ok(())
+    }
+
+    fn connection(&self, token: &str) -> io::Result<Option<Arc<Mutex<UnixStream>>>> {
+        Ok(lock(&self.controllers)?
+            .get(token)
+            .map(|controller| Arc::clone(&controller.connection)))
+    }
+
+    fn acknowledge(&self, token: &str) -> io::Result<bool> {
+        let acknowledge = lock(&self.controllers)?
+            .get_mut(token)
+            .and_then(|controller| controller.reconnect_ack.take());
+        if let Some(acknowledge) = acknowledge {
+            let _ = acknowledge.send(());
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn remove(&self, token: &str) {
+        if let Ok(mut controllers) = self.controllers.lock() {
+            controllers.remove(token);
+        }
+    }
+
+    fn quiesce(&self) -> io::Result<()> {
+        let mut acknowledgements = Vec::new();
+        {
+            let mut controllers = lock(&self.controllers)?;
+            for controller in controllers.values_mut() {
+                let (acknowledge, acknowledged) = mpsc::sync_channel(1);
+                controller.reconnect_ack = Some(acknowledge);
+                AttachFrame::Reconnect.write_to(&mut *lock(&controller.connection)?)?;
+                acknowledgements.push(acknowledged);
+            }
+        }
+        for acknowledged in acknowledgements {
+            acknowledged.recv_timeout(HANDSHAKE_TIMEOUT).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "remote attachment did not acknowledge local reconnect",
+                )
+            })?;
+        }
+        Ok(())
+    }
 }
 
 trait SchedulerClock: Send + Sync {
@@ -5606,6 +5697,7 @@ impl Default for DaemonService {
                 focus: Mutex::new(FocusState::default()),
                 stopping: AtomicBool::new(false),
             },
+            remote_attachments: RemoteAttachmentManager::default(),
             mutation_lock: Mutex::new(()),
             schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
@@ -6722,6 +6814,252 @@ impl DaemonService {
                 "Boomux Node projection cache is unavailable",
             )
         })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn handle_remote_attach(
+        &self,
+        mut stream: UnixStream,
+        response_version: u32,
+        identity: protocol::QualifiedIdentity,
+        takeover: bool,
+        restart_exited: bool,
+        expected_run_id: Option<String>,
+        profile: TerminalProfile,
+    ) -> io::Result<()> {
+        if identity.node_id.is_empty() || identity.inner_id.is_empty() {
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::validation("remote attachment requires an exact qualified identity")
+                    .into_response(),
+            );
+        }
+        if self
+            .node_identity()
+            .and_then(|node| node.id().map_err(DaemonError::from))
+            .is_ok_and(|node_id| node_id == identity.node_id)
+        {
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::validation("local shells must use the local attachment request")
+                    .into_response(),
+            );
+        }
+        if let Err(error) = validate_terminal_profile(&profile) {
+            return send_daemon_error(&mut stream, response_version, error.into());
+        }
+        let registrations = match self.node_registrations() {
+            Ok(registrations) => registrations,
+            Err(error) => {
+                return send_response(&mut stream, response_version, error.into_response());
+            }
+        };
+        let registration = match registrations.inspect(&identity.node_id) {
+            Ok(registration) if registration.node_id == identity.node_id => registration,
+            Ok(_) => {
+                return send_response(
+                    &mut stream,
+                    response_version,
+                    error_response(ErrorCode::NotFound, "exact Node registration not found"),
+                );
+            }
+            Err(error) => {
+                return send_response(
+                    &mut stream,
+                    response_version,
+                    node_registration_error(error).into_response(),
+                );
+            }
+        };
+        if !registrations.admit(&registration).unwrap_or(false) {
+            return send_response(
+                &mut stream,
+                response_version,
+                error_response(
+                    ErrorCode::RevisionChanged,
+                    "Node registration changed before attachment",
+                ),
+            );
+        }
+        let result = self.bridge_remote_attach(
+            &mut stream,
+            response_version,
+            &registration,
+            &identity.inner_id,
+            takeover,
+            restart_exited,
+            expected_run_id,
+            profile,
+        );
+        registrations.release(&registration);
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn bridge_remote_attach(
+        &self,
+        stream: &mut UnixStream,
+        response_version: u32,
+        registration: &crate::protocol::NodeRegistrationSnapshot,
+        shell_id: &str,
+        takeover: bool,
+        restart_exited: bool,
+        expected_run_id: Option<String>,
+        profile: TerminalProfile,
+    ) -> io::Result<()> {
+        let target = SshTarget::parse(registration.target.clone())?;
+        let helper = match ssh_bootstrap::plan_remote_bootstrap(
+            target.clone(),
+            SshAuthenticationMode::Batch,
+            HANDSHAKE_TIMEOUT,
+        )? {
+            RemoteBootstrapPlan::Ready(helper) => helper,
+            RemoteBootstrapPlan::Install(_) => {
+                return send_response(
+                    stream,
+                    response_version,
+                    error_response(
+                        ErrorCode::UnsupportedVersion,
+                        "remote helper requires installation",
+                    ),
+                );
+            }
+        };
+        if helper.handshake.node_id != registration.node_id {
+            return send_response(
+                stream,
+                response_version,
+                error_response(
+                    ErrorCode::NodeIdentityChanged,
+                    "remote Node identity changed",
+                ),
+            );
+        }
+        let remote_version = helper.handshake.core_protocol_version;
+        let owner_environment =
+            protocol::ProtocolFeature::RemotePtyAttachment.is_supported_by(remote_version);
+        if !owner_environment {
+            let shell = match send_registered_node_request(
+                registration,
+                Request::GetShell {
+                    shell_id: shell_id.to_owned(),
+                },
+            ) {
+                Ok(Response::Shell { shell }) => shell,
+                Ok(Response::Error { message, code }) => {
+                    return send_response(
+                        stream,
+                        response_version,
+                        Response::Error { message, code },
+                    );
+                }
+                Ok(_) => {
+                    return send_response(
+                        stream,
+                        response_version,
+                        error_response(ErrorCode::Internal, "remote shell preflight was invalid"),
+                    );
+                }
+                Err(error) => {
+                    return send_response(
+                        stream,
+                        response_version,
+                        error_response(ErrorCode::Timeout, error.to_string()),
+                    );
+                }
+            };
+            if shell.status != ShellStatus::Running {
+                return send_response(
+                    stream,
+                    response_version,
+                    error_response(
+                        ErrorCode::UnsupportedVersion,
+                        "remote pending or exited shell requires owner-environment attachment support",
+                    ),
+                );
+            }
+        }
+        let remote = ssh_bootstrap::connect_remote(
+            target,
+            helper,
+            SshAuthenticationMode::Batch,
+            HANDSHAKE_TIMEOUT,
+        )?;
+        let request = Request::Attach {
+            shell_id: shell_id.to_owned(),
+            takeover,
+            restart_exited: restart_exited && owner_environment,
+            expected_run_id,
+            profile,
+            environment: None,
+            owner_environment,
+        };
+        let (response, mut remote_reader, mut remote_writer) =
+            remote.open_attachment(request, HANDSHAKE_TIMEOUT)?;
+        let token = match &response {
+            Response::Attached { token, .. } => token.clone(),
+            _ => return send_response(stream, response_version, response),
+        };
+        send_response(stream, response_version, response)?;
+        let connection = stream.try_clone()?;
+        connection.set_write_timeout(Some(RESPONSE_WRITE_TIMEOUT))?;
+        self.remote_attachments.insert(token.clone(), connection)?;
+        let output_connection = self
+            .remote_attachments
+            .connection(&token)?
+            .ok_or_else(|| io::Error::other("remote attachment registration disappeared"))?;
+        let (reconnect_finished, reconnect_wait) = mpsc::sync_channel(1);
+        let output = thread::Builder::new()
+            .name(format!("boomux-remote-attachment-{shell_id}"))
+            .spawn(move || -> io::Result<()> {
+                let mut reconnect = false;
+                while let Ok(frame) = remote_reader.read_frame() {
+                    frame.write_to(&mut *lock(&output_connection)?)?;
+                    if matches!(frame, AttachFrame::Reconnect) {
+                        reconnect = true;
+                        let _ = reconnect_wait.recv_timeout(HANDSHAKE_TIMEOUT);
+                        break;
+                    }
+                    if matches!(frame, AttachFrame::Detached) {
+                        break;
+                    }
+                }
+                if !reconnect {
+                    let _ = lock(&output_connection)?.shutdown(std::net::Shutdown::Both);
+                }
+                Ok(())
+            })?;
+        let input_result = loop {
+            let frame = match AttachFrame::read_from(stream) {
+                Ok(frame) => frame,
+                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => break Ok(()),
+                Err(error) => break Err(error),
+            };
+            if matches!(frame, AttachFrame::ReconnectAck)
+                && self.remote_attachments.acknowledge(&token)?
+            {
+                let _ = reconnect_finished.try_send(());
+                break Ok(());
+            }
+            let closes = matches!(frame, AttachFrame::Detached | AttachFrame::ReconnectAck);
+            remote_writer.write_frame(&frame, RESPONSE_WRITE_TIMEOUT)?;
+            if closes {
+                if matches!(frame, AttachFrame::ReconnectAck) {
+                    let _ = reconnect_finished.try_send(());
+                }
+                break Ok(());
+            }
+        };
+        drop(remote_writer);
+        let _ = stream.shutdown(std::net::Shutdown::Both);
+        let output_result = output
+            .join()
+            .map_err(|_| io::Error::other("remote attachment output thread panicked"))?;
+        self.remote_attachments.remove(&token);
+        input_result?;
+        output_result
     }
 
     fn route_node_operation(&self, node_id: &str, operation: RoutedOperation) -> Response {
@@ -8896,7 +9234,9 @@ impl DaemonService {
                     }],
                 ))
             }),
-            Request::Attach { .. } => unreachable!("attach is handled before dispatch"),
+            Request::Attach { .. } | Request::AttachNode { .. } => {
+                unreachable!("attach is handled before dispatch")
+            }
         }
     }
 
@@ -9243,6 +9583,7 @@ impl DaemonService {
                 focus: Mutex::new(FocusState::default()),
                 stopping: AtomicBool::new(false),
             },
+            remote_attachments: RemoteAttachmentManager::default(),
             mutation_lock: Mutex::new(()),
             schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
@@ -12171,6 +12512,7 @@ struct AttachRequestOptions {
     expected_run_id: Option<String>,
     profile: TerminalProfile,
     environment: Option<UnixEnvironment>,
+    owner_environment: bool,
 }
 
 impl ShellRuntimeManager {
@@ -12188,6 +12530,7 @@ impl ShellRuntimeManager {
             expected_run_id,
             profile,
             environment,
+            owner_environment,
         } = options;
         if let Err(error) = validate_terminal_profile(&profile) {
             return send_daemon_error(&mut stream, response_version, error.into());
@@ -12196,6 +12539,16 @@ impl ShellRuntimeManager {
             && let Err(error) = validate_unix_environment(environment)
         {
             return send_daemon_error(&mut stream, response_version, error.into());
+        }
+        if owner_environment && environment.is_some() {
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::validation(
+                    "owner-environment attachment cannot include a Unix environment",
+                )
+                .into_response(),
+            );
         }
         let shell = match registry.shell(shell_id) {
             Ok(shell) => shell,
@@ -12324,7 +12677,11 @@ impl ShellRuntimeManager {
                         workspace_name: &workspace_name,
                         shell_name: &shell_name,
                         profile: &profile,
-                        environment: environment.as_ref(),
+                        environment: if owner_environment {
+                            Some(&registry.startup_environment)
+                        } else {
+                            environment.as_ref()
+                        },
                         recovery: RuntimeRecovery {
                             effective_command: resume_command.as_deref(),
                             history: restored_history.as_deref(),

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -135,8 +135,15 @@ pub fn run_stdio_helper() -> Result<(), Box<dyn Error>> {
         })?;
 
     let mut daemon_reader = channel.stream;
-    io::copy(&mut daemon_reader, &mut stdout)?;
-    stdout.flush()?;
+    let mut bytes = [0_u8; 16 * 1024];
+    loop {
+        let count = daemon_reader.read(&mut bytes)?;
+        if count == 0 {
+            break;
+        }
+        stdout.write_all(&bytes[..count])?;
+        stdout.flush()?;
+    }
     let _ = daemon_reader.shutdown(Shutdown::Both);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -458,6 +458,9 @@ enum Commands {
     /// Open a shell in a new terminal window
     Open {
         shell_id: String,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
         #[arg(long)]
         title: Option<String>,
         #[arg(long)]
@@ -474,6 +477,8 @@ enum Commands {
     #[command(name = "__attach", hide = true)]
     Attach {
         shell_id: String,
+        #[arg(long)]
+        node: Option<String>,
         #[arg(long)]
         takeover: bool,
         #[arg(long)]
@@ -1452,12 +1457,14 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         }
         Some(Commands::Attach {
             shell_id,
+            node,
             takeover,
             restart_exited,
             expected_run_id,
         }) => {
             attach::run(
                 shell_id,
+                node.as_deref(),
                 *takeover,
                 *restart_exited,
                 expected_run_id.as_deref(),
@@ -1553,11 +1560,18 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         }) => install_pi(force),
         Some(Commands::Open {
             shell_id,
+            node,
             title,
             takeover,
         }) => {
             let terminal = effective_terminal(cli.terminal.as_deref())?;
-            open_shell(&shell_id, title.as_deref(), takeover, terminal.as_deref())
+            open_shell(
+                &shell_id,
+                node.as_deref(),
+                title.as_deref(),
+                takeover,
+                terminal.as_deref(),
+            )
         }
         Some(Commands::Prompt) => print_prompt_label(),
         Some(Commands::Daemon { command }) => daemon_control(command, cli.json),
@@ -2111,8 +2125,13 @@ fn dashboard(
                     &target,
                     &local_node_id,
                     |shell_id| {
-                        open_dashboard_shell(&client, shell_id, terminal.as_deref())
-                            .map_err(|error| error.to_string())
+                        if shell_id.node_id == local_node_id || shell_id.node_id.is_empty() {
+                            open_dashboard_shell(&client, &shell_id.inner_id, terminal.as_deref())
+                                .map_err(|error| error.to_string())
+                        } else {
+                            open_dashboard_remote_shell(&client, shell_id, terminal.as_deref())
+                                .map_err(|error| error.to_string())
+                        }
                     },
                     |workspace_id, launcher_id| {
                         let workspace = client
@@ -2496,11 +2515,16 @@ fn dashboard(
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::OpenScheduledExecution { execution_id } => {
-                let result = local_dashboard_inner(&execution_id, &local_node_id).and_then(|id| {
-                    open_scheduled_execution(&client, id, terminal.as_deref())
+                let result = if execution_id.node_id == local_node_id
+                    || execution_id.node_id.is_empty()
+                {
+                    open_scheduled_execution(&client, &execution_id.inner_id, terminal.as_deref())
                         .map(|opened| opened.message)
                         .map_err(|error| error.to_string())
-                });
+                } else {
+                    open_remote_scheduled_execution(&client, &execution_id, terminal.as_deref())
+                        .map_err(|error| error.to_string())
+                };
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::RemoveSchedule(schedule_id) => {
@@ -2732,13 +2756,11 @@ fn dispatch_dashboard_open<S, L>(
     mut launch: L,
 ) -> Result<String, String>
 where
-    S: FnMut(&str) -> Result<String, String>,
+    S: FnMut(&protocol::QualifiedIdentity) -> Result<String, String>,
     L: FnMut(&str, &str) -> Result<String, String>,
 {
     match target {
-        tui::OpenTarget::Shell(shell_id) => {
-            open_shell(local_dashboard_inner(shell_id, local_node_id)?)
-        }
+        tui::OpenTarget::Shell(shell_id) => open_shell(shell_id),
         tui::OpenTarget::Launcher {
             workspace_id,
             launcher_id,
@@ -3045,6 +3067,53 @@ fn open_scheduled_execution(
     })
 }
 
+fn open_remote_scheduled_execution(
+    client: &client::Client,
+    execution_id: &protocol::QualifiedIdentity,
+    terminal: Option<&str>,
+) -> Result<String, Box<dyn Error>> {
+    let execution =
+        routed_dashboard_execution(client, execution_id, "").map_err(io::Error::other)?;
+    let ScheduledExecutionOpenTarget::Run { shell_id, run_id } =
+        scheduled_execution_open_target(&execution)
+            .map_err(|(code, message)| cli_output::failure(code, message))?
+    else {
+        return Err(cli_output::failure(
+            "unsupported_version",
+            "remote Scheduled Execution session resume is unavailable; only active exact runs can attach",
+        ));
+    };
+    let shell_identity = protocol::QualifiedIdentity::new(&execution_id.node_id, shell_id);
+    let shell = routed_dashboard_shell(client, &shell_identity, "").map_err(io::Error::other)?;
+    validate_dashboard_execution_open(&execution, &shell, shell_id, run_id)
+        .map_err(|message| cli_output::failure("busy", message))?;
+    let workspace = match client.route_node_operation(
+        &execution_id.node_id,
+        protocol::RoutedOperation::GetWorkspace {
+            workspace_id: execution.workspace_id.clone(),
+        },
+    )? {
+        protocol::RoutedOperationResult::Workspace { workspace } => workspace,
+        _ => return Err("remote Node returned an unexpected workspace response".into()),
+    };
+    let registration = client.node_registration(&execution_id.node_id)?;
+    terminal::open_remote_exact_run(
+        terminal,
+        &execution_id.node_id,
+        shell_id,
+        run_id,
+        &format!(
+            "[{}] {} - {}",
+            registration.alias, workspace.name, shell.name
+        ),
+        true,
+    )?;
+    Ok(format!(
+        "Opened exact execution {} from schedule {} on Node {}",
+        execution.id, execution.schedule_id, registration.alias
+    ))
+}
+
 fn validate_dashboard_execution_open(
     execution: &ScheduledExecutionSnapshot,
     shell: &ShellSnapshot,
@@ -3270,7 +3339,7 @@ fn open_directory(
             terminal,
         )
     } else {
-        Ok(attach::run(&shell.id, true, false, None)?)
+        Ok(attach::run(&shell.id, None, true, false, None)?)
     };
     if let Err(open_error) = open_result {
         let rollback = if created_workspace {
@@ -6578,6 +6647,47 @@ fn open_dashboard_shell(
     Ok(format!("Opened {} from {}", shell.name, workspace.name))
 }
 
+fn open_dashboard_remote_shell(
+    client: &client::Client,
+    identity: &protocol::QualifiedIdentity,
+    terminal: Option<&str>,
+) -> Result<String, Box<dyn Error>> {
+    let registration = client.node_registration(&identity.node_id)?;
+    let shell = routed_dashboard_shell(client, identity, "").map_err(io::Error::other)?;
+    if matches!(shell.owner, protocol::ShellOwner::Schedule { .. })
+        && shell.status != ShellStatus::Running
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "schedule-owned shell is attachable only while its execution is active",
+        )
+        .into());
+    }
+    let workspace = match client.route_node_operation(
+        &identity.node_id,
+        protocol::RoutedOperation::GetWorkspace {
+            workspace_id: shell.workspace_id.clone(),
+        },
+    )? {
+        protocol::RoutedOperationResult::Workspace { workspace } => workspace,
+        _ => return Err("remote Node returned an unexpected workspace response".into()),
+    };
+    terminal::open_remote(
+        terminal,
+        &identity.node_id,
+        &identity.inner_id,
+        &format!(
+            "[{}] {} - {}",
+            registration.alias, workspace.name, shell.name
+        ),
+        true,
+    )?;
+    Ok(format!(
+        "Opened {} from {} on Node {}",
+        shell.name, workspace.name, registration.alias
+    ))
+}
+
 fn open_workspace(
     workspace: &WorkspaceSnapshot,
     terminal: Option<&str>,
@@ -6669,11 +6779,42 @@ fn invoke_workspace_launcher(
 
 fn open_shell(
     shell_id: &str,
+    node: Option<&str>,
     title: Option<&str>,
     takeover: bool,
     terminal: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
+    if let Some(selector) = node {
+        let registration = client.node_registration(selector)?;
+        let identity = protocol::QualifiedIdentity::new(&registration.node_id, shell_id);
+        let shell = routed_dashboard_shell(&client, &identity, "").map_err(io::Error::other)?;
+        if matches!(shell.owner, protocol::ShellOwner::Schedule { .. })
+            && shell.status != ShellStatus::Running
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "schedule-owned shell is attachable only while its execution is active",
+            )
+            .into());
+        }
+        let workspace = match client.route_node_operation(
+            &registration.node_id,
+            protocol::RoutedOperation::GetWorkspace {
+                workspace_id: shell.workspace_id.clone(),
+            },
+        )? {
+            protocol::RoutedOperationResult::Workspace { workspace } => workspace,
+            _ => return Err("remote Node returned an unexpected workspace response".into()),
+        };
+        let title = title.map(str::to_owned).unwrap_or_else(|| {
+            format!(
+                "[{}] {} - {}",
+                registration.alias, workspace.name, shell.name
+            )
+        });
+        return terminal::open_remote(terminal, &registration.node_id, shell_id, &title, takeover);
+    }
     let shell = client.get_shell(shell_id)?;
     if matches!(shell.owner, protocol::ShellOwner::Schedule { .. })
         && shell.status != ShellStatus::Running
@@ -9995,7 +10136,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 34);
+        assert_eq!(protocol::PROTOCOL_VERSION, 35);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,10 +4,14 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 34;
+pub const PROTOCOL_VERSION: u32 = 35;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
 
 macro_rules! define_protocol_features {
     ($($variant:ident => ($version:literal, $requirement:literal, [$($capability:literal),* $(,)?])),* $(,)?) => {
@@ -137,6 +141,11 @@ define_protocol_features! {
         "protocol_34",
         "typed_exact_node_routing",
         "guarded_remote_management",
+    ]),
+    RemotePtyAttachment => (35, "remote PTY attachment", [
+        "protocol_35",
+        "remote_pty_attachment",
+        "owner_environment_attachment",
     ]),
 }
 
@@ -1845,6 +1854,17 @@ pub enum Request {
         profile: TerminalProfile,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         environment: Option<UnixEnvironment>,
+        #[serde(default, skip_serializing_if = "is_false")]
+        owner_environment: bool,
+    },
+    AttachNode {
+        identity: QualifiedIdentity,
+        takeover: bool,
+        #[serde(default)]
+        restart_exited: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expected_run_id: Option<String>,
+        profile: TerminalProfile,
     },
 }
 
@@ -1876,6 +1896,11 @@ impl Request {
             | Self::GuardedPauseAgentSchedule { .. }
             | Self::GuardedResumeAgentSchedule { .. }
             | Self::GuardedRemoveAgentSchedule { .. } => Some(ProtocolFeature::GuardedNodeRouting),
+            Self::AttachNode { .. }
+            | Self::Attach {
+                owner_environment: true,
+                ..
+            } => Some(ProtocolFeature::RemotePtyAttachment),
             Self::WaitScheduledExecution { .. } => {
                 Some(ProtocolFeature::ScheduledExecutionObservation)
             }
@@ -2428,6 +2453,7 @@ mod tests {
                     value: vec![0xff, 0xfe],
                 }],
             }),
+            owner_environment: false,
         });
         let mut bytes = Vec::new();
         write_message(&mut bytes, &value).unwrap();
@@ -2613,8 +2639,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_thirty_three_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 34);
+    fn protocol_version_is_thirty_five_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 35);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -3322,6 +3348,7 @@ mod tests {
                         expected_run_id: None,
                         profile: test_profile(),
                         environment: None,
+                        owner_environment: false,
                     },
                 ],
             ),
@@ -3404,6 +3431,7 @@ mod tests {
                         expected_run_id: None,
                         profile: test_profile(),
                         environment: None,
+                        owner_environment: false,
                     },
                 ],
             ),
@@ -3453,6 +3481,7 @@ mod tests {
                     environment: Some(UnixEnvironment {
                         variables: Vec::new(),
                     }),
+                    owner_environment: false,
                 }],
             ),
             (
@@ -3464,6 +3493,7 @@ mod tests {
                     expected_run_id: Some("r1".into()),
                     profile: test_profile(),
                     environment: None,
+                    owner_environment: false,
                 }],
             ),
             (
@@ -3480,6 +3510,27 @@ mod tests {
                         },
                     },
                 }],
+            ),
+            (
+                35,
+                vec![
+                    Request::Attach {
+                        shell_id: "s1".into(),
+                        takeover: true,
+                        restart_exited: true,
+                        expected_run_id: None,
+                        profile: test_profile(),
+                        environment: None,
+                        owner_environment: true,
+                    },
+                    Request::AttachNode {
+                        identity: QualifiedIdentity::new("node-1", "s1"),
+                        takeover: true,
+                        restart_exited: true,
+                        expected_run_id: None,
+                        profile: test_profile(),
+                    },
+                ],
             ),
         ];
 
@@ -3611,6 +3662,14 @@ mod tests {
                     "protocol_34",
                     "typed_exact_node_routing",
                     "guarded_remote_management",
+                ][..],
+            ),
+            (
+                35,
+                &[
+                    "protocol_35",
+                    "remote_pty_attachment",
+                    "owner_environment_attachment",
                 ][..],
             ),
         ];

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -17,7 +17,7 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::federation::FederationHandshake;
-use crate::protocol::{self, Envelope, Request, Response};
+use crate::protocol::{self, AttachFrame, Envelope, Request, Response};
 
 const MAX_SSH_TARGET_BYTES: usize = 1024;
 const MAX_REMOTE_EXECUTABLE_BYTES: usize = 4096;
@@ -133,7 +133,38 @@ pub struct RemoteConnection {
     pub handshake: FederationHandshake,
 }
 
+pub(crate) struct RemoteAttachmentReader {
+    child: Child,
+    pid: i32,
+    stdout: ChildStdout,
+    stderr_reader: Option<BoundedReader>,
+}
+
+pub(crate) struct RemoteAttachmentWriter(Option<ChildStdin>);
+
 impl RemoteConnection {
+    pub(crate) fn open_attachment(
+        mut self,
+        request: Request,
+        timeout: Duration,
+    ) -> io::Result<(Response, RemoteAttachmentReader, RemoteAttachmentWriter)> {
+        let response = self.request(request, timeout)?;
+        let mut this = std::mem::ManuallyDrop::new(self);
+        // Ownership moves to the attachment while suppressing RemoteConnection's
+        // process-group cleanup for the still-live channel.
+        let (reader, writer) = unsafe {
+            (
+                RemoteAttachmentReader {
+                    child: std::ptr::read(&this.child),
+                    pid: this.pid,
+                    stdout: std::ptr::read(&this.stdout),
+                    stderr_reader: this.stderr_reader.take(),
+                },
+                RemoteAttachmentWriter(this.stdin.take()),
+            )
+        };
+        Ok((response, reader, writer))
+    }
     pub(crate) fn request(&mut self, request: Request, timeout: Duration) -> io::Result<Response> {
         let version = self.handshake.core_protocol_version;
         protocol::write_message(
@@ -196,6 +227,96 @@ impl RemoteConnection {
             _ => Err(invalid_probe(
                 "remote helper returned an invalid projection response",
             )),
+        }
+    }
+}
+
+impl RemoteAttachmentReader {
+    pub(crate) fn read_frame(&mut self) -> io::Result<AttachFrame> {
+        AttachFrame::read_from(&mut self.stdout)
+    }
+
+    pub(crate) fn close(&mut self) {
+        let _ = kill_process_group(self.pid, &mut self.child);
+    }
+}
+
+impl RemoteAttachmentWriter {
+    pub(crate) fn write_frame(&mut self, frame: &AttachFrame, timeout: Duration) -> io::Result<()> {
+        if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "attachment write deadline is outside the supported bound",
+            ));
+        }
+        let stdin = self
+            .0
+            .as_mut()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "remote channel closed"))?;
+        let mut bytes = Vec::new();
+        frame.write_to(&mut bytes)?;
+        write_all_with_deadline(stdin, &bytes, timeout)
+    }
+}
+
+fn write_all_with_deadline(
+    writer: &mut (impl Write + AsRawFd),
+    mut bytes: &[u8],
+    timeout: Duration,
+) -> io::Result<()> {
+    let fd = writer.as_raw_fd();
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    let deadline = Instant::now() + timeout;
+    let result = (|| {
+        while !bytes.is_empty() {
+            match writer.write(bytes) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "remote channel closed",
+                    ));
+                }
+                Ok(count) => bytes = &bytes[count..],
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "remote attachment write timed out",
+                        ));
+                    }
+                    let mut descriptor = libc::pollfd {
+                        fd,
+                        events: libc::POLLOUT,
+                        revents: 0,
+                    };
+                    let milliseconds = i32::try_from(remaining.as_millis().min(i32::MAX as u128))
+                        .unwrap_or(i32::MAX);
+                    if unsafe { libc::poll(&mut descriptor, 1, milliseconds) } == 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "remote attachment write timed out",
+                        ));
+                    }
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        writer.flush()
+    })();
+    let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
+    result
+}
+
+impl Drop for RemoteAttachmentReader {
+    fn drop(&mut self) {
+        self.close();
+        if let Some(reader) = self.stderr_reader.take() {
+            let _ = join_bounded_reader(reader);
         }
     }
 }
@@ -598,7 +719,8 @@ impl SshInvocation {
         program: &OsStr,
     ) -> io::Result<Self> {
         secure_runtime_directory(runtime_directory)?;
-        let directory = runtime_directory.join(format!("ssh-{}", Uuid::new_v4()));
+        let nonce = Uuid::new_v4().simple().to_string();
+        let directory = runtime_directory.join(format!("ssh-{}", &nonce[..16]));
         fs::create_dir(&directory)?;
         fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
         let config_path = directory.join("config");

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -39,7 +39,24 @@ pub(crate) fn open(
     title: &str,
     takeover: bool,
 ) -> Result<(), Box<dyn Error>> {
-    open_with_expected_run(desktop_entry, shell_id, title, takeover, None)
+    open_with_expected_run(desktop_entry, shell_id, None, title, takeover, None)
+}
+
+pub(crate) fn open_remote(
+    desktop_entry: Option<&str>,
+    node_id: &str,
+    shell_id: &str,
+    title: &str,
+    takeover: bool,
+) -> Result<(), Box<dyn Error>> {
+    open_with_expected_run(
+        desktop_entry,
+        shell_id,
+        Some(node_id),
+        title,
+        takeover,
+        None,
+    )
 }
 
 pub(crate) fn open_exact_run(
@@ -52,6 +69,25 @@ pub(crate) fn open_exact_run(
     open_with_expected_run(
         desktop_entry,
         shell_id,
+        None,
+        title,
+        takeover,
+        Some(expected_run_id),
+    )
+}
+
+pub(crate) fn open_remote_exact_run(
+    desktop_entry: Option<&str>,
+    node_id: &str,
+    shell_id: &str,
+    expected_run_id: &str,
+    title: &str,
+    takeover: bool,
+) -> Result<(), Box<dyn Error>> {
+    open_with_expected_run(
+        desktop_entry,
+        shell_id,
+        Some(node_id),
         title,
         takeover,
         Some(expected_run_id),
@@ -88,12 +124,13 @@ fn terminal_command_arguments(command: &[String]) -> Option<(&OsStr, Vec<OsStrin
 fn open_with_expected_run(
     desktop_entry: Option<&str>,
     shell_id: &str,
+    node_id: Option<&str>,
     title: &str,
     takeover: bool,
     expected_run_id: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
     let executable = attachment_executable()?;
-    let mut arguments = attachment_arguments(shell_id, expected_run_id);
+    let mut arguments = attachment_arguments(shell_id, node_id, expected_run_id);
     if takeover {
         arguments.push("--takeover".into());
     }
@@ -160,8 +197,15 @@ fn launch(
     Ok(())
 }
 
-fn attachment_arguments(shell_id: &str, expected_run_id: Option<&str>) -> Vec<OsString> {
+fn attachment_arguments(
+    shell_id: &str,
+    node_id: Option<&str>,
+    expected_run_id: Option<&str>,
+) -> Vec<OsString> {
     let mut arguments = vec!["__attach".into(), shell_id.into()];
+    if let Some(node_id) = node_id {
+        arguments.extend(["--node".into(), node_id.into()]);
+    }
     if let Some(expected_run_id) = expected_run_id {
         arguments.extend(["--expected-run-id".into(), expected_run_id.into()]);
     } else {
@@ -313,16 +357,29 @@ mod tests {
     #[test]
     fn exact_run_attachment_arguments_never_enable_restart() {
         assert_eq!(
-            attachment_arguments("shell-1", Some("run-1")),
+            attachment_arguments("shell-1", None, Some("run-1")),
             ["__attach", "shell-1", "--expected-run-id", "run-1"]
                 .map(OsStr::new)
                 .map(OsStr::to_owned)
         );
         assert_eq!(
-            attachment_arguments("shell-1", None),
+            attachment_arguments("shell-1", None, None),
             ["__attach", "shell-1", "--restart-exited"]
                 .map(OsStr::new)
                 .map(OsStr::to_owned)
+        );
+        assert_eq!(
+            attachment_arguments("shell-1", Some("node-1"), Some("run-1")),
+            [
+                "__attach",
+                "shell-1",
+                "--node",
+                "node-1",
+                "--expected-run-id",
+                "run-1",
+            ]
+            .map(OsStr::new)
+            .map(OsStr::to_owned)
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -544,6 +544,17 @@ impl WorkspaceView {
         self.node.local && self.node.current && !self.node.stale
     }
 
+    fn shell_attachable(&self) -> bool {
+        self.local_actionable()
+            || (self.node.current
+                && !self.node.stale
+                && self
+                    .node
+                    .observed_capabilities
+                    .iter()
+                    .any(|capability| capability == "remote_pty_attachment"))
+    }
+
     fn shell_count(&self) -> usize {
         self.items
             .iter()
@@ -2606,21 +2617,21 @@ impl App {
         {
             return None;
         }
-        let workspace = self
-            .selected_item_workspace()
-            .filter(|workspace| workspace.local_actionable())?;
+        let workspace = self.selected_item_workspace()?;
         let workspace_id = workspace.qualify(&workspace.id);
         let target = self.selected_item().and_then(|item| match item {
-            WorkspaceItemView::Shell(shell) => {
-                Some(OpenTarget::Shell(workspace.qualify(&shell.id)))
+            WorkspaceItemView::Shell(shell) => workspace
+                .shell_attachable()
+                .then(|| OpenTarget::Shell(workspace.qualify(&shell.id))),
+            WorkspaceItemView::AgentShell(agent_shell) => workspace
+                .shell_attachable()
+                .then(|| OpenTarget::Shell(workspace.qualify(&agent_shell.shell.id))),
+            WorkspaceItemView::Launcher(launcher) => {
+                workspace.local_actionable().then(|| OpenTarget::Launcher {
+                    workspace_id,
+                    launcher_id: workspace.qualify(&launcher.id),
+                })
             }
-            WorkspaceItemView::AgentShell(agent_shell) => {
-                Some(OpenTarget::Shell(workspace.qualify(&agent_shell.shell.id)))
-            }
-            WorkspaceItemView::Launcher(launcher) => Some(OpenTarget::Launcher {
-                workspace_id,
-                launcher_id: workspace.qualify(&launcher.id),
-            }),
             WorkspaceItemView::Schedule(_) => None,
         })?;
         Some(DashboardEffect::Open(target))

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -16,6 +16,8 @@ mod notifications;
 mod project_discovery;
 #[path = "native_backend/protocol_control.rs"]
 mod protocol_control;
+#[path = "native_backend/remote_attachment.rs"]
+mod remote_attachment;
 #[path = "native_backend/remote_bootstrap.rs"]
 mod remote_bootstrap;
 #[path = "native_backend/schedules.rs"]

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 34);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 35);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -124,6 +124,7 @@ fn native_daemon_lifecycle() {
         "protocol_32",
         "protocol_33",
         "protocol_34",
+        "protocol_35",
         "node_registration_management",
         "node_projection_sync",
         "bounded_remote_node_projections",
@@ -131,6 +132,8 @@ fn native_daemon_lifecycle() {
         "node_qualified_dashboard",
         "typed_exact_node_routing",
         "guarded_remote_management",
+        "remote_pty_attachment",
+        "owner_environment_attachment",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -165,7 +168,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 34"));
+    assert!(status_text.contains("running (protocol 35"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -925,7 +928,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 34);
+    assert_eq!(handshake.core_protocol_version, 35);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc

--- a/tests/native_backend/remote_attachment.rs
+++ b/tests/native_backend/remote_attachment.rs
@@ -1,0 +1,201 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Stdio;
+
+use boomux::protocol::{AttachFrame, QualifiedIdentity, ShellSpec};
+
+use crate::support::{TestDaemon, contains, parse_pid, profile, read_until, wait_until};
+
+fn install_fake_ssh(
+    directory: &std::path::Path,
+    executable: &std::path::Path,
+    remote: &TestDaemon,
+) {
+    let ssh = directory.join("ssh");
+    fs::write(
+        &ssh,
+        format!(
+            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}/boomux\\0' ;;\n  *'__federation-stdio'*) exec env -i PATH=/usr/bin:/bin HOME={} XDG_RUNTIME_DIR={} XDG_STATE_HOME={} {} __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
+            executable.display(),
+            directory.display(),
+            directory.display(),
+            remote.runtime_dir.display(),
+            remote.runtime_dir.join("state").display(),
+            executable.display(),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+#[test]
+fn two_daemon_remote_attachment_keeps_environment_and_runtime_on_owner() {
+    let mut remote = TestDaemon::start_with(|command, _| {
+        command
+            .env("REMOTE_PRIVATE", "owner-only")
+            .env("TERM", "remote-daemon-term");
+    });
+    let workspace = remote
+        .client
+        .create_workspace(
+            "remote-workspace",
+            vec![ShellSpec {
+                name: "remote-shell".into(),
+                cwd: "/tmp".into(),
+                command: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    "printf 'pid=%s remote=%s local=%s term=%s\\n' \"$$\" \"$REMOTE_PRIVATE\" \"${LOCAL_PRIVATE-unset}\" \"$TERM\"; exec cat".into(),
+                ],
+            }],
+        )
+        .unwrap();
+    let shell = &workspace.shells[0];
+    let remote_node = remote.client.node_identity().unwrap();
+    let executable = remote.executable.clone();
+    let local = TestDaemon::start_with(|command, directory| {
+        install_fake_ssh(directory, &executable, &remote);
+        command
+            .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+            .env("LOCAL_PRIVATE", "must-not-cross-node");
+    });
+    local
+        .client
+        .add_node_registration("work", "fake-target", &remote_node)
+        .unwrap();
+
+    let mut attachment = local
+        .client
+        .attach_node(
+            QualifiedIdentity::new(&remote_node, &shell.id),
+            true,
+            true,
+            None,
+            profile(),
+        )
+        .unwrap();
+    let output = read_until(&mut attachment.stream, b"term=attachment-term");
+    assert!(contains(&output, b"remote=owner-only"));
+    assert!(contains(&output, b"local=unset"));
+    let pid = parse_pid(&output, "pid=").expect("remote shell PID");
+    let run_id = remote.client.get_shell(&shell.id).unwrap().run.unwrap().id;
+
+    AttachFrame::Resize {
+        rows: 40,
+        cols: 120,
+        pixel_width: 1200,
+        pixel_height: 800,
+    }
+    .write_to(&mut attachment.stream)
+    .unwrap();
+    AttachFrame::Input(b"remote-input\n".to_vec())
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut attachment.stream, b"remote-input"),
+        b"remote-input"
+    ));
+    drop(attachment);
+    wait_until(
+        || {
+            remote.client.get_shell(&shell.id).unwrap().status
+                == boomux::protocol::ShellStatus::Running
+        },
+        "SSH disconnect changed remote shell lifecycle",
+    );
+
+    let mut reattached = local
+        .client
+        .attach_node(
+            QualifiedIdentity::new(&remote_node, &shell.id),
+            true,
+            false,
+            None,
+            profile(),
+        )
+        .unwrap();
+    let restart = local
+        .command()
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", local.runtime_dir.display()),
+        )
+        .args(["daemon", "restart"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    assert_eq!(
+        AttachFrame::read_from(&mut reattached.stream).unwrap(),
+        AttachFrame::Reconnect
+    );
+    AttachFrame::ReconnectAck
+        .write_to(&mut reattached.stream)
+        .unwrap();
+    assert!(restart.wait_with_output().unwrap().status.success());
+    let mut after_handoff = local
+        .client
+        .attach_node(
+            QualifiedIdentity::new(&remote_node, &shell.id),
+            true,
+            false,
+            None,
+            profile(),
+        )
+        .unwrap();
+    AttachFrame::Input(b"after-local-handoff\n".to_vec())
+        .write_to(&mut after_handoff.stream)
+        .unwrap();
+    let output = read_until(&mut after_handoff.stream, b"after-local-handoff");
+    assert!(contains(&output, b"after-local-handoff"));
+    assert_eq!(
+        remote.client.get_shell(&shell.id).unwrap().run.unwrap().id,
+        run_id
+    );
+    assert!(crate::support::process_exists(pid));
+
+    let remote_restart = remote
+        .command()
+        .args(["daemon", "restart"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    assert_eq!(
+        AttachFrame::read_from(&mut after_handoff.stream).unwrap(),
+        AttachFrame::Reconnect
+    );
+    AttachFrame::ReconnectAck
+        .write_to(&mut after_handoff.stream)
+        .unwrap();
+    let remote_restart = remote_restart.wait_with_output().unwrap();
+    assert!(
+        remote_restart.status.success(),
+        "remote restart failed: {}",
+        String::from_utf8_lossy(&remote_restart.stderr)
+    );
+    let mut after_remote_handoff = local
+        .client
+        .attach_node(
+            QualifiedIdentity::new(&remote_node, &shell.id),
+            true,
+            false,
+            Some(run_id.clone()),
+            profile(),
+        )
+        .unwrap();
+    AttachFrame::Input(b"after-remote-handoff\n".to_vec())
+        .write_to(&mut after_remote_handoff.stream)
+        .unwrap();
+    assert!(contains(
+        &read_until(&mut after_remote_handoff.stream, b"after-remote-handoff"),
+        b"after-remote-handoff"
+    ));
+    assert_eq!(
+        remote.client.get_shell(&shell.id).unwrap().run.unwrap().id,
+        run_id
+    );
+    assert!(crate::support::process_exists(pid));
+
+    remote.stop_with_cli();
+}

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -840,6 +840,7 @@ fn attach_with_environment(
                 expected_run_id: None,
                 profile: profile(),
                 environment: Some(environment),
+                owner_environment: false,
             },
         ),
     )
@@ -861,4 +862,45 @@ fn attach_with_environment(
         },
         response => panic!("unexpected attach response: {response:?}"),
     }
+}
+
+#[test]
+fn owner_environment_attach_rejects_an_arbitrary_unix_environment() {
+    let daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace("owner-environment-exclusive", Vec::new())
+        .unwrap();
+    let shell = daemon
+        .client
+        .create_shell(&workspace.id, ShellSpec::login("exclusive", "/tmp"))
+        .unwrap();
+    let mut stream = UnixStream::connect(daemon.client.socket_path()).unwrap();
+    protocol::write_message(
+        &mut stream,
+        &protocol::Envelope::with_version(
+            protocol::PROTOCOL_VERSION,
+            protocol::Request::Attach {
+                shell_id: shell.id,
+                takeover: false,
+                restart_exited: false,
+                expected_run_id: None,
+                profile: profile(),
+                environment: Some(UnixEnvironment {
+                    variables: Vec::new(),
+                }),
+                owner_environment: true,
+            },
+        ),
+    )
+    .unwrap();
+    let response: protocol::Envelope<protocol::Response> =
+        protocol::read_message(&mut stream).unwrap();
+    assert!(matches!(
+        response.message,
+        protocol::Response::Error {
+            code: Some(ErrorCode::InvalidArgument),
+            ..
+        }
+    ));
 }


### PR DESCRIPTION
## Summary

- add protocol 35 Node-qualified remote PTY attachment
- enforce owner-environment startup without forwarding local Unix environments
- allow older peers only to attach already-running remote shells
- bridge bounded attachment frames over a verified SSH helper channel
- preserve exact-run attachment, takeover, resize, focus, and remote reconnect behavior
- reconnect through fresh SSH after local handoff without transferring remote runtime state
- keep SSH loss separate from authoritative remote lifecycle

## Stack

- GitHub stack #190
- depends on #201
- implements #180

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`

Closes #180

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
