### PR TITLE
feat(node): route owner host services

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,6 +109,8 @@ operations remain local-only. Protocol 34 adds closed typed exact-Node private
 reads and guarded management; unclassified mutation remains unavailable.
 Protocol 35 adds Node-qualified native-terminal attachment and owner-environment
 startup for remote pending and exited Shells.
+Protocol 36 adds closed typed Node host services and owner-executed exact Agent
+Session resume.
 
 ## Components
 
@@ -601,6 +603,17 @@ arbitrary `UnixEnvironment`; old wire values default it off. Remote handoff
 attachment and drops the old SSH bridge; the replacement discovers and verifies
 a fresh helper channel. No SSH child, remote PTY descriptor, process, cursor, or
 reconstruction state enters the handoff manifest.
+Protocol 36 adds `HostServiceOperation`, `RouteNodeHostService`, and separate
+streamed Agent Session resume requests. The closed union contains bounded project
+discovery, owner-side directory resolution, Shell name suggestion, exact stored
+launcher invocation, integration status and preview-bound mutation, verification,
+and bounded Agent Session list/inspect/resolve. It cannot represent arbitrary
+command execution. Remote integration previews are transient owner memory: commit
+consumes one opaque token only while its Node-local action, force policy, paths,
+and observed asset states still match. Exact Session resume resolves the opaque
+projected ID and constructs cwd/argv on the owner, then relays bounded attachment
+frames to a local native terminal without creating a Workspace or Shell. Host
+service responses do not update Node projection cache or publish events.
 Protocol-25 lists are daemon-bounded, newest-first pages with explicit limit and
 truncation. The request limit is optional on the wire; protocol 25 defaults it to
 100 and clamps it to 1 through 1,000, while protocol-23 and protocol-24 requests

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -67,6 +67,14 @@ registered Node, the title includes its alias, and the hidden attachment carries
 the exact qualified identity. It does not add a JSON method or change legacy
 unqualified `open` semantics.
 
+Protocol 36 advertises `typed_node_host_services` and separate capabilities for
+remote project discovery, launcher invocation, integration management, Agent
+Session catalogs, and exact Session resume. Commands with `--node SELECTOR`
+resolve one registered Node and require its live verified protocol-36 service;
+unsupported owners fail visibly and are never emulated against local PATH,
+configuration, catalogs, or filesystems. Responses are live and transient and do
+not update the cached Node projection.
+
 That passive command advertises only what the installed local CLI can speak and
 never reports negotiated state for a registered Node. Implemented `node.list`
 and `node.inspect` return registration data only. Future combined projection data
@@ -172,8 +180,10 @@ Command payloads are:
 - `list`: a `shells` array.
 - `shells`: workspace identity plus a `shells` array.
 - `project.list`: `roots_configured`, a `projects` array, and a `warnings`
-  array. This command reads local configuration and the filesystem without
-  starting or contacting the daemon.
+  array. Without `--node` this command reads local configuration and the
+  filesystem without starting or contacting the daemon. With `--node`, the same
+  bounded discovery runs on the verified owner and contacts the local routing
+  daemon.
 - `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`,
   `launcher_count`, `schedule_count`, `agent_count`, fixed `agent_state_counts`, and
   `attention_count`.
@@ -315,6 +325,10 @@ Protocol 34 adds `protocol_34`, `typed_exact_node_routing`, and
 `guarded_remote_management`.
 Protocol 35 adds `protocol_35`, `remote_pty_attachment`, and
 `owner_environment_attachment`.
+Protocol 36 adds `protocol_36`, `typed_node_host_services`,
+`remote_project_discovery`, `remote_launcher_invocation`,
+`remote_integration_management`, `remote_agent_session_catalog`, and
+`remote_exact_session_resume`.
 
 Node snapshot health is `unobserved`, `online`, `reconnecting`, `stale`,
 `unreachable`, `authentication_required`, `identity_changed`,
@@ -524,6 +538,11 @@ exact ID returned by `session.list` resolves; external IDs, descriptions, shell
 IDs, and Agent IDs never resolve through `session.inspect`.
 All session commands require a negotiated daemon protocol of at least 12 and return
 `unsupported_version` before projection against an older daemon.
+`session list`, `session inspect`, and human-only `session resume` accept
+`--node SELECTOR` under protocol 36. Remote JSON responses add the exact
+`node_id`. Resume opens a local native terminal but resolves the opaque ID and
+executes the integration argv only on the owner; it creates no ordinary
+Workspace or Shell.
 
 ## Schedule Data
 

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -14,7 +14,9 @@
 > Protocol 33 adds the local-daemon combined Node snapshot and federated
 > dashboard. Protocol 34 and state schema 13 implement typed exact-Node private
 > reads and guarded management operations. Protocol 35 implements Node-qualified
-> native-terminal PTY attachment and owner-environment remote startup. Public `boomux --remote TARGET`
+> native-terminal PTY attachment and owner-environment remote startup. Protocol
+> 36 implements closed typed owner host services and exact Agent Session resume.
+> Public `boomux --remote TARGET`
 > remains ad hoc.
 
 ## Purpose
@@ -292,6 +294,22 @@ revision, verifies the pinned identity and protocol capability before sending
 the owner request, performs SSH I/O outside locks, and revalidates the
 registration before returning. Routed responses never update projection cache.
 
+Protocol 36 adds a separate closed host-service union. It routes bounded project
+discovery, directory validation/resolution, Shell-name suggestion, exact stored
+Workspace launcher invocation, integration status/preview/install/verify/remove,
+and bounded Agent Session list/inspect/resolve. It has no executable-and-arguments
+request and cannot run a caller-supplied command. Launchers are selected by exact
+Workspace and launcher IDs, then their stored cwd and argv execute directly on
+the owner. Integration commits consume an owner-held expiring preview token and
+fail if action, force policy, target path, or observed file state changed.
+
+Exact remote Agent Session resume is a distinct streaming request. The owner
+freshly resolves the opaque projected Session ID, validates owner cwd, builds the
+integration descriptor's exact argv, and owns the unmanaged PTY and child. The
+presenting Node launches only its native terminal and relays bounded attachment
+frames. No ordinary Workspace/Shell row, transcript, prompt, environment,
+credential, stderr capture, cache update, or event is created.
+
 | Operation | Owner guard | Automatic retry | Ambiguity read and exact postcondition |
 | --- | --- | --- | --- |
 | Workspace/Shell/launcher/Agent/Schedule/execution inspect | Exact ID on a fresh verified channel | Yes; read-only | Not applicable |
@@ -498,7 +516,9 @@ requires protocol 35. Release-version differences never authorize restarting a
 compatible remote daemon.
 
 Node identity, registrations, and projections use explicit independent schemas.
-Introducing them cannot silently reinterpret authoritative `state.json`. If a
+Introducing them cannot silently reinterpret authoritative `state.json`.
+Protocol-36 host-service previews and resumed unmanaged PTYs are transient and
+require no state or Node-cache schema change. If a
 later implementation places any Node field in that durable representation, it
 must bump `STATE_VERSION` and provide the ordinary explicit migration and cold
 recovery evidence.

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -205,6 +205,38 @@ pub fn run(
     result
 }
 
+pub fn run_agent_session(
+    session_id: &str,
+    node_id: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let profile = terminal_profile()?;
+    let mut size = (
+        profile.rows,
+        profile.cols,
+        profile.pixel_width,
+        profile.pixel_height,
+    );
+    let client = client::connect_or_start()?;
+    let attachment = client.resume_agent_session(node_id, session_id, profile)?;
+    let _raw_mode = RawMode::enter()?;
+    let mut stdin = io::stdin().lock();
+    let mut stdout = io::stdout().lock();
+    let mut input = [0; 16 * 1024];
+    let mut focus = FocusTracking::default();
+    stdout.write_all(&attachment.reconstruction)?;
+    stdout.flush()?;
+    let mut stream = attachment.stream;
+    let _ = pump_attachment(
+        &mut stream,
+        &mut stdin,
+        &mut stdout,
+        &mut input,
+        &mut size,
+        &mut focus,
+    )?;
+    Ok(())
+}
+
 fn reconnect(
     client: &client::Client,
     shell_id: &str,

--- a/src/client.rs
+++ b/src/client.rs
@@ -626,6 +626,30 @@ impl Client {
         }
     }
 
+    pub fn host_service(
+        &self,
+        operation: crate::protocol::HostServiceOperation,
+    ) -> Result<crate::protocol::HostServiceResult> {
+        match self.request(Request::HostService { operation })? {
+            Response::HostService { result } => Ok(result),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn route_node_host_service(
+        &self,
+        node_id: impl Into<String>,
+        operation: crate::protocol::HostServiceOperation,
+    ) -> Result<crate::protocol::HostServiceResult> {
+        match self.request(Request::RouteNodeHostService {
+            node_id: node_id.into(),
+            operation,
+        })? {
+            Response::HostService { result } => Ok(result),
+            response => unexpected(response),
+        }
+    }
+
     pub fn rename_node_registration(
         &self,
         selector: impl Into<String>,
@@ -1465,6 +1489,28 @@ impl Client {
         attachment_from_response(stream, protocol_version, response)
     }
 
+    pub fn resume_agent_session(
+        &self,
+        node_id: Option<&str>,
+        session_id: impl Into<String>,
+        profile: TerminalProfile,
+    ) -> Result<Attachment> {
+        let session_id = session_id.into();
+        let request = match node_id {
+            Some(node_id) => Request::ResumeNodeAgentSession {
+                node_id: node_id.to_owned(),
+                session_id,
+                profile,
+            },
+            None => Request::ResumeAgentSession {
+                session_id,
+                profile,
+            },
+        };
+        let (stream, protocol_version, response) = self.send(request)?;
+        attachment_from_response(stream, protocol_version, response)
+    }
+
     fn attach_with_restart(
         &self,
         shell_id: String,
@@ -1912,6 +1958,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 36, 34);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2068,7 +2115,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 35);
+            assert_eq!(request.version, 36);
             assert_eq!(request.message, Request::GetNodeIdentity);
             protocol::write_message(
                 &mut stream,
@@ -2082,6 +2129,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 36, 34);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2132,7 +2180,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 35);
+            assert_eq!(request.version, 36);
             assert_eq!(request.message, Request::OpenFederationChannel);
             protocol::write_message(
                 &mut stream,
@@ -2146,6 +2194,7 @@ mod tests {
             )
             .unwrap();
 
+            reject_protocol(&listener, 36, 34);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2179,7 +2228,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 35);
+            assert_eq!(request.version, 36);
             assert_eq!(request.message, Request::ListNodeRegistrations);
             protocol::write_message(
                 &mut stream,
@@ -2192,6 +2241,7 @@ mod tests {
                 ),
             )
             .unwrap();
+            reject_protocol(&listener, 36, 34);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2368,6 +2418,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 36, 34);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2439,6 +2490,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
+            reject_protocol(&listener, 36, 34);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -28,6 +28,7 @@ use crate::desktop_notifications::{
 };
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
+use crate::host_services::{self, PreparedIntegrationMutation};
 use crate::node_identity::{NodeIdentityLease, NodeIdentityManager};
 use crate::node_projection::NodeProjectionCache;
 use crate::node_registration::NodeRegistrationManager;
@@ -37,7 +38,8 @@ use crate::protocol::{
     AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSnapshot, AgentScheduleSpec,
     AgentScheduleState, AgentScheduleTrigger, AgentScheduleUpdate, AgentState, AttachFrame,
     DaemonEvent, DaemonEventKind, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot,
-    NodeProjectionAgent, NodeProjectionAttention, NodeProjectionExecution, NodeProjectionLauncher,
+    HostIntegrationMutationPreview, HostServiceOperation, HostServiceResult, NodeProjectionAgent,
+    NodeProjectionAttention, NodeProjectionExecution, NodeProjectionLauncher,
     NodeProjectionSchedule, NodeProjectionShell, NodeProjectionSnapshot, NodeProjectionSync,
     NodeProjectionSyncMode, NodeProjectionTransition, NodeProjectionTransitionKind,
     NodeProjectionWorkspace, NotificationDeliveryConfig, Request, Response, RoutedOperation,
@@ -72,6 +74,8 @@ const MAX_TERMINAL_HISTORY_BYTES: usize = 256 * 1024;
 const MAX_TERMINAL_ENV_VALUE: usize = 256;
 const MAX_NAME_BYTES: usize = 256;
 const MAX_AGENT_EVIDENCE_BYTES: usize = 4 * 1024;
+const MAX_HOST_SERVICE_PREVIEWS: usize = 64;
+const HOST_SERVICE_PREVIEW_TTL: Duration = Duration::from_secs(300);
 const MAX_TERMINAL_ROWS: u16 = 1_000;
 pub const MAX_SCHEDULED_EXECUTION_CONCURRENCY: u16 = 64;
 const MAX_TERMINAL_COLS: u16 = 1_000;
@@ -1072,6 +1076,29 @@ fn handle_connection_inner(
         );
     }
 
+    if let Request::ResumeNodeAgentSession {
+        node_id,
+        session_id,
+        profile,
+    } = request.message
+    {
+        return registry.handle_remote_session_resume(
+            stream,
+            response_version,
+            &node_id,
+            &session_id,
+            profile,
+        );
+    }
+
+    if let Request::ResumeAgentSession {
+        session_id,
+        profile,
+    } = request.message
+    {
+        return registry.handle_session_resume(stream, response_version, &session_id, profile);
+    }
+
     if let Request::Attach {
         shell_id,
         takeover,
@@ -1864,12 +1891,12 @@ fn send_registered_node_request(
             "remote Node identity changed",
         ));
     }
-    if !protocol::ProtocolFeature::GuardedNodeRouting
-        .is_supported_by(helper.handshake.core_protocol_version)
+    if let Some(feature) = request.required_feature()
+        && !feature.is_supported_by(helper.handshake.core_protocol_version)
     {
         return Err(io::Error::new(
             io::ErrorKind::Unsupported,
-            "remote Node does not support guarded routing",
+            format!("remote Node does not support {}", feature.requirement()),
         ));
     }
     let mut remote = ssh_bootstrap::connect_remote(
@@ -1932,6 +1959,7 @@ struct DaemonService {
     events: EventStream,
     runtimes: ShellRuntimeManager,
     remote_attachments: RemoteAttachmentManager,
+    host_service_previews: Mutex<HashMap<String, HostServicePreview>>,
     mutation_lock: Mutex<()>,
     schedule_dispatch_lock: Mutex<()>,
     notification_settings: NotificationDeliverySettings,
@@ -1943,6 +1971,11 @@ struct DaemonService {
     clock: Mutex<Arc<dyn SchedulerClock>>,
     #[cfg(test)]
     fail_after_mutation: AtomicBool,
+}
+
+struct HostServicePreview {
+    created_at: Instant,
+    prepared: PreparedIntegrationMutation,
 }
 
 #[derive(Default)]
@@ -5698,6 +5731,7 @@ impl Default for DaemonService {
                 stopping: AtomicBool::new(false),
             },
             remote_attachments: RemoteAttachmentManager::default(),
+            host_service_previews: Mutex::new(HashMap::new()),
             mutation_lock: Mutex::new(()),
             schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
@@ -6816,6 +6850,315 @@ impl DaemonService {
         })
     }
 
+    fn handle_session_resume(
+        &self,
+        mut stream: UnixStream,
+        response_version: u32,
+        session_id: &str,
+        profile: TerminalProfile,
+    ) -> io::Result<()> {
+        if let Err(error) = validate_terminal_profile(&profile) {
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::from(error).into_response(),
+            );
+        }
+        let snapshot = match self.snapshot() {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                return send_response(
+                    &mut stream,
+                    response_version,
+                    DaemonError::from(error).into_response(),
+                );
+            }
+        };
+        let plan = match host_services::prepare_session_resume(&snapshot, session_id) {
+            Ok(plan) => plan,
+            Err(error) => {
+                return send_response(
+                    &mut stream,
+                    response_version,
+                    DaemonError::from(error).into_response(),
+                );
+            }
+        };
+        let (executable, arguments) = plan.argv.split_first().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "session resume argv is empty")
+        })?;
+        let pty = native_pty_system()
+            .openpty(PtySize {
+                rows: profile.rows,
+                cols: profile.cols,
+                pixel_width: profile.pixel_width,
+                pixel_height: profile.pixel_height,
+            })
+            .map_err(io::Error::other)?;
+        let master = Arc::new(PtyMaster::duplicate(pty.master.as_ref())?);
+        let mut reader = master.try_clone_reader()?;
+        let mut command = CommandBuilder::new(executable);
+        command.args(arguments);
+        command.cwd(&plan.cwd);
+        for name in ["TERM", "COLORTERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION"] {
+            command.env_remove(name);
+        }
+        for (name, value) in [
+            ("TERM", profile.term.as_deref()),
+            ("COLORTERM", profile.colorterm.as_deref()),
+            ("TERM_PROGRAM", profile.term_program.as_deref()),
+            (
+                "TERM_PROGRAM_VERSION",
+                profile.term_program_version.as_deref(),
+            ),
+        ] {
+            if let Some(value) = value {
+                command.env(name, value);
+            }
+        }
+        for name in [
+            "BOOMUX_WORKSPACE_ID",
+            "BOOMUX_WORKSPACE",
+            "BOOMUX_SHELL_ID",
+            "BOOMUX_SHELL_NAME",
+            "BOOMUX_RUN_ID",
+        ] {
+            command.env_remove(name);
+        }
+        let mut child = pty.slave.spawn_command(command).map_err(io::Error::other)?;
+        drop(pty.slave);
+        drop(pty.master);
+        send_response(
+            &mut stream,
+            response_version,
+            Response::Attached {
+                token: Uuid::new_v4().to_string(),
+                reconstruction: Vec::new(),
+                warning: None,
+            },
+        )?;
+        let mut output_stream = stream.try_clone()?;
+        output_stream.set_write_timeout(Some(RESPONSE_WRITE_TIMEOUT))?;
+        let output = thread::Builder::new()
+            .name(format!("session-resume-output-{session_id}"))
+            .spawn(move || -> io::Result<()> {
+                let mut bytes = vec![0; 16 * 1024];
+                loop {
+                    match reader.read(&mut bytes) {
+                        Ok(0) => break,
+                        Ok(count) => AttachFrame::Output(bytes[..count].to_vec())
+                            .write_to(&mut output_stream)?,
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                            thread::sleep(IO_RETRY_DELAY)
+                        }
+                        Err(error) if error.raw_os_error() == Some(libc::EIO) => break,
+                        Err(error) => return Err(error),
+                    }
+                }
+                let _ = AttachFrame::Detached.write_to(&mut output_stream);
+                let _ = output_stream.shutdown(std::net::Shutdown::Both);
+                Ok(())
+            })?;
+        let input_result = 'input: loop {
+            match AttachFrame::read_from(&mut stream) {
+                Ok(AttachFrame::Input(bytes)) => {
+                    let mut remaining = bytes.as_slice();
+                    while !remaining.is_empty() {
+                        match master.write(remaining) {
+                            Ok(0) => break,
+                            Ok(count) => remaining = &remaining[count..],
+                            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                                thread::sleep(IO_RETRY_DELAY)
+                            }
+                            Err(error) => break 'input Err(error),
+                        }
+                    }
+                }
+                Ok(AttachFrame::Resize {
+                    rows,
+                    cols,
+                    pixel_width,
+                    pixel_height,
+                }) => master.resize(PtySize {
+                    rows,
+                    cols,
+                    pixel_width,
+                    pixel_height,
+                })?,
+                Ok(AttachFrame::FocusGained) => {}
+                Ok(AttachFrame::Detached | AttachFrame::ReconnectAck) => break Ok(()),
+                Ok(AttachFrame::Output(_) | AttachFrame::Reconnect) => {
+                    break Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid client frame during Agent Session resume",
+                    ));
+                }
+                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => break Ok(()),
+                Err(error) => break Err(error),
+            }
+        };
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = stream.shutdown(std::net::Shutdown::Both);
+        let output_result = output
+            .join()
+            .map_err(|_| io::Error::other("session resume output thread panicked"))?;
+        input_result?;
+        output_result
+    }
+
+    fn handle_remote_session_resume(
+        &self,
+        mut stream: UnixStream,
+        response_version: u32,
+        node_id: &str,
+        session_id: &str,
+        profile: TerminalProfile,
+    ) -> io::Result<()> {
+        let registrations = match self.node_registrations() {
+            Ok(registrations) => registrations,
+            Err(error) => {
+                return send_response(&mut stream, response_version, error.into_response());
+            }
+        };
+        let registration = match registrations.inspect(node_id) {
+            Ok(registration) if registration.node_id == node_id => registration,
+            Ok(_) => {
+                return send_response(
+                    &mut stream,
+                    response_version,
+                    error_response(ErrorCode::NotFound, "exact Node registration not found"),
+                );
+            }
+            Err(error) => {
+                return send_response(
+                    &mut stream,
+                    response_version,
+                    node_registration_error(error).into_response(),
+                );
+            }
+        };
+        if !registrations.admit(&registration).unwrap_or(false) {
+            return send_response(
+                &mut stream,
+                response_version,
+                error_response(
+                    ErrorCode::RevisionChanged,
+                    "Node registration changed before session resume",
+                ),
+            );
+        }
+        let result = self.bridge_remote_session_resume(
+            &mut stream,
+            response_version,
+            &registration,
+            session_id,
+            profile,
+        );
+        registrations.release(&registration);
+        result
+    }
+
+    fn bridge_remote_session_resume(
+        &self,
+        stream: &mut UnixStream,
+        response_version: u32,
+        registration: &crate::protocol::NodeRegistrationSnapshot,
+        session_id: &str,
+        profile: TerminalProfile,
+    ) -> io::Result<()> {
+        let target = SshTarget::parse(registration.target.clone())?;
+        let helper = match ssh_bootstrap::plan_remote_bootstrap(
+            target.clone(),
+            SshAuthenticationMode::Batch,
+            HANDSHAKE_TIMEOUT,
+        )? {
+            RemoteBootstrapPlan::Ready(helper) => helper,
+            RemoteBootstrapPlan::Install(_) => {
+                return send_response(
+                    stream,
+                    response_version,
+                    error_response(
+                        ErrorCode::UnsupportedVersion,
+                        "remote helper requires installation",
+                    ),
+                );
+            }
+        };
+        if helper.handshake.node_id != registration.node_id {
+            return send_response(
+                stream,
+                response_version,
+                error_response(
+                    ErrorCode::NodeIdentityChanged,
+                    "remote Node identity changed",
+                ),
+            );
+        }
+        if !protocol::ProtocolFeature::NodeHostServices
+            .is_supported_by(helper.handshake.core_protocol_version)
+        {
+            return send_response(
+                stream,
+                response_version,
+                error_response(
+                    ErrorCode::UnsupportedVersion,
+                    "remote Node does not support exact Agent Session resume",
+                ),
+            );
+        }
+        let remote = ssh_bootstrap::connect_remote(
+            target,
+            helper,
+            SshAuthenticationMode::Batch,
+            HANDSHAKE_TIMEOUT,
+        )?;
+        let (response, mut remote_reader, mut remote_writer) = remote.open_attachment(
+            Request::ResumeAgentSession {
+                session_id: session_id.to_owned(),
+                profile,
+            },
+            HANDSHAKE_TIMEOUT,
+        )?;
+        if !matches!(response, Response::Attached { .. }) {
+            return send_response(stream, response_version, response);
+        }
+        send_response(stream, response_version, response)?;
+        let mut output_connection = stream.try_clone()?;
+        output_connection.set_write_timeout(Some(RESPONSE_WRITE_TIMEOUT))?;
+        let output = thread::Builder::new()
+            .name(format!("remote-session-resume-{session_id}"))
+            .spawn(move || -> io::Result<()> {
+                while let Ok(frame) = remote_reader.read_frame() {
+                    frame.write_to(&mut output_connection)?;
+                    if matches!(frame, AttachFrame::Detached) {
+                        break;
+                    }
+                }
+                let _ = output_connection.shutdown(std::net::Shutdown::Both);
+                Ok(())
+            })?;
+        let input_result = loop {
+            let frame = match AttachFrame::read_from(stream) {
+                Ok(frame) => frame,
+                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => break Ok(()),
+                Err(error) => break Err(error),
+            };
+            let closes = matches!(frame, AttachFrame::Detached);
+            remote_writer.write_frame(&frame, RESPONSE_WRITE_TIMEOUT)?;
+            if closes {
+                break Ok(());
+            }
+        };
+        drop(remote_writer);
+        let _ = stream.shutdown(std::net::Shutdown::Both);
+        let output_result = output
+            .join()
+            .map_err(|_| io::Error::other("remote session output thread panicked"))?;
+        input_result?;
+        output_result
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn handle_remote_attach(
         &self,
@@ -7139,6 +7482,236 @@ impl DaemonService {
         match routed_result(response) {
             Ok(result) => Response::RoutedNodeOperation { result },
             Err(response) => *response,
+        }
+    }
+
+    fn host_service(&self, operation: HostServiceOperation) -> DaemonResult<HostServiceResult> {
+        match operation {
+            HostServiceOperation::DiscoverProjects => Ok(HostServiceResult::Projects {
+                discovery: host_services::discover_projects().map_err(DaemonError::from)?,
+            }),
+            HostServiceOperation::ResolveDirectory { path } => Ok(HostServiceResult::Directory {
+                path: host_services::resolve_directory(&path).map_err(DaemonError::from)?,
+            }),
+            HostServiceOperation::SuggestShellName { workspace_id } => {
+                let workspace = self.workspace(&workspace_id)?.snapshot(&self.durable)?;
+                let name =
+                    host_services::suggest_shell_name(&workspace).map_err(DaemonError::from)?;
+                Ok(HostServiceResult::ShellName { workspace_id, name })
+            }
+            HostServiceOperation::InvokeLauncher {
+                workspace_id,
+                launcher_id,
+            } => {
+                let workspace = self.workspace(&workspace_id)?.snapshot(&self.durable)?;
+                let launcher = self.launcher(&launcher_id)?.snapshot()?;
+                host_services::invoke_launcher(&workspace, &launcher).map_err(DaemonError::from)?;
+                Ok(HostServiceResult::LauncherInvoked {
+                    workspace_id,
+                    launcher_id,
+                })
+            }
+            HostServiceOperation::IntegrationStatus { integration } => {
+                Ok(HostServiceResult::IntegrationStatus {
+                    integrations: host_services::integration_status(
+                        integration.as_deref(),
+                        &self.snapshot()?,
+                    )
+                    .map_err(DaemonError::from)?,
+                })
+            }
+            HostServiceOperation::PreviewIntegrationMutation {
+                action,
+                integrations,
+                force,
+            } => {
+                let prepared =
+                    host_services::prepare_integration_mutation(action, &integrations, force)
+                        .map_err(DaemonError::from)?;
+                let token = Uuid::new_v4().to_string();
+                let mut previews = lock(&self.host_service_previews)?;
+                previews
+                    .retain(|_, preview| preview.created_at.elapsed() < HOST_SERVICE_PREVIEW_TTL);
+                if previews.len() >= MAX_HOST_SERVICE_PREVIEWS {
+                    return Err(DaemonError::lifecycle(
+                        ErrorCode::Busy,
+                        "too many uncommitted integration previews",
+                    ));
+                }
+                previews.insert(
+                    token.clone(),
+                    HostServicePreview {
+                        created_at: Instant::now(),
+                        prepared: prepared.clone(),
+                    },
+                );
+                Ok(HostServiceResult::IntegrationMutationPreview {
+                    preview: HostIntegrationMutationPreview {
+                        token,
+                        action,
+                        force,
+                        plans: prepared.plans,
+                    },
+                })
+            }
+            HostServiceOperation::CommitIntegrationMutation { preview_token } => {
+                let preview = lock(&self.host_service_previews)?.remove(&preview_token);
+                let preview = preview.ok_or_else(|| {
+                    DaemonError::lifecycle(
+                        ErrorCode::NotFound,
+                        "integration preview is missing, expired, or already committed",
+                    )
+                })?;
+                if preview.created_at.elapsed() >= HOST_SERVICE_PREVIEW_TTL {
+                    return Err(DaemonError::lifecycle(
+                        ErrorCode::NotFound,
+                        "integration preview expired",
+                    ));
+                }
+                Ok(HostServiceResult::IntegrationMutation {
+                    integrations: host_services::commit_integration_mutation(&preview.prepared)
+                        .map_err(DaemonError::from)?,
+                })
+            }
+            HostServiceOperation::VerifyIntegration {
+                integration,
+                shell_id,
+                run_id,
+            } => Ok(HostServiceResult::IntegrationVerified {
+                agents: host_services::verify_integration(
+                    &self.snapshot()?,
+                    &integration,
+                    &shell_id,
+                    &run_id,
+                )
+                .map_err(DaemonError::from)?,
+                integration,
+                shell_id,
+                run_id,
+            }),
+            HostServiceOperation::ListAgentSessions { workspace_id } => {
+                let sessions = host_services::sessions(&self.snapshot()?)
+                    .into_iter()
+                    .filter(|session| {
+                        workspace_id
+                            .as_deref()
+                            .is_none_or(|workspace_id| session.workspace_id == workspace_id)
+                    })
+                    .map(|session| host_services::session_summary(&session))
+                    .collect();
+                Ok(HostServiceResult::AgentSessions { sessions })
+            }
+            HostServiceOperation::InspectAgentSession { session_id } => {
+                Ok(HostServiceResult::AgentSession {
+                    session: host_services::inspect_session(&self.snapshot()?, &session_id)
+                        .map_err(DaemonError::from)?,
+                })
+            }
+            HostServiceOperation::ResolveAgentSession {
+                workspace_id,
+                agent_id,
+            } => {
+                let matches = host_services::sessions(&self.snapshot()?)
+                    .into_iter()
+                    .filter(|session| {
+                        session.workspace_id == workspace_id
+                            && session
+                                .occurrences
+                                .iter()
+                                .any(|occurrence| occurrence.agent_id == agent_id)
+                    })
+                    .collect::<Vec<_>>();
+                let [session] = matches.as_slice() else {
+                    return Err(DaemonError::lifecycle(
+                        if matches.is_empty() {
+                            ErrorCode::NotFound
+                        } else {
+                            ErrorCode::AmbiguousTarget
+                        },
+                        "exact Agent occurrence did not resolve to one Agent Session",
+                    ));
+                };
+                Ok(HostServiceResult::ResolvedAgentSession {
+                    session: host_services::session_summary(session),
+                })
+            }
+        }
+    }
+
+    fn route_node_host_service(&self, node_id: &str, operation: HostServiceOperation) -> Response {
+        let registrations = match self.node_registrations() {
+            Ok(registrations) => registrations,
+            Err(error) => return error.into_response(),
+        };
+        let registration = match registrations.inspect(node_id) {
+            Ok(registration) if registration.node_id == node_id => registration,
+            Ok(_) => {
+                return error_response(ErrorCode::NotFound, "exact Node registration not found");
+            }
+            Err(error) => return node_registration_error(error).into_response(),
+        };
+        match registrations.admit(&registration) {
+            Ok(true) => {}
+            Ok(false) => {
+                return error_response(
+                    ErrorCode::RevisionChanged,
+                    "Node registration changed before routing",
+                );
+            }
+            Err(error) => return node_registration_error(error).into_response(),
+        }
+        let mutation = matches!(
+            operation,
+            HostServiceOperation::InvokeLauncher { .. }
+                | HostServiceOperation::CommitIntegrationMutation { .. }
+        );
+        let response = send_registered_node_request(
+            &registration,
+            Request::HostService {
+                operation: operation.clone(),
+            },
+        );
+        registrations.release(&registration);
+        let response = match response {
+            Ok(response) => response,
+            Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
+                return error_response(ErrorCode::NodeIdentityChanged, error.to_string());
+            }
+            Err(error) if error.kind() == io::ErrorKind::Unsupported => {
+                return error_response(ErrorCode::UnsupportedVersion, error.to_string());
+            }
+            Err(error) => {
+                return error_response(
+                    if mutation {
+                        ErrorCode::OutcomeUnknown
+                    } else {
+                        ErrorCode::Timeout
+                    },
+                    format!("Node host service lost its verified channel: {error}"),
+                );
+            }
+        };
+        let current = registrations
+            .with_current(&registration, || Ok(()))
+            .unwrap_or(None)
+            .is_some();
+        if !current {
+            return error_response(
+                if mutation {
+                    ErrorCode::OutcomeUnknown
+                } else {
+                    ErrorCode::RevisionChanged
+                },
+                "Node registration changed while the host service was in flight",
+            );
+        }
+        match response {
+            Response::HostService { result } => Response::HostService { result },
+            Response::Error { .. } => response,
+            _ => error_response(
+                ErrorCode::Internal,
+                "remote Node returned an unexpected host-service response",
+            ),
         }
     }
 
@@ -8651,6 +9224,12 @@ impl DaemonService {
             Request::RouteNodeOperation { node_id, operation } => {
                 Ok(self.route_node_operation(&node_id, operation))
             }
+            Request::HostService { operation } => Ok(Response::HostService {
+                result: self.host_service(operation)?,
+            }),
+            Request::RouteNodeHostService { node_id, operation } => {
+                Ok(self.route_node_host_service(&node_id, operation))
+            }
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
                 unreachable!("restart is handled before dispatch")
             }
@@ -9234,7 +9813,10 @@ impl DaemonService {
                     }],
                 ))
             }),
-            Request::Attach { .. } | Request::AttachNode { .. } => {
+            Request::Attach { .. }
+            | Request::AttachNode { .. }
+            | Request::ResumeAgentSession { .. }
+            | Request::ResumeNodeAgentSession { .. } => {
                 unreachable!("attach is handled before dispatch")
             }
         }
@@ -9584,6 +10166,7 @@ impl DaemonService {
                 stopping: AtomicBool::new(false),
             },
             remote_attachments: RemoteAttachmentManager::default(),
+            host_service_previews: Mutex::new(HashMap::new()),
             mutation_lock: Mutex::new(()),
             schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),

--- a/src/host_services.rs
+++ b/src/host_services.rs
@@ -1,0 +1,708 @@
+use std::collections::{BTreeSet, HashSet};
+use std::env;
+use std::fs;
+use std::io;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+
+use serde::Deserialize;
+
+use crate::generated_names;
+use crate::integration_management::{self, IntegrationId};
+use crate::protocol::{
+    AgentInstanceSnapshot, HostAgentSessionInspection, HostAgentSessionResumePlan,
+    HostAgentSessionSummary, HostIntegrationMutationResult, HostIntegrationPlan,
+    HostIntegrationStatus, HostProjectDiscovery, HostProjectSnapshot, HostServiceIntegrationAction,
+    MAX_HOST_SERVICE_PROJECTS, MAX_HOST_SERVICE_SESSIONS, MAX_HOST_SERVICE_WARNINGS, Snapshot,
+    WorkspaceLauncherSnapshot, WorkspaceSnapshot,
+};
+use crate::session_projection::{self, SessionProjection};
+
+const MAX_PROJECT_DIRECTORIES: usize = 10_000;
+const MAX_PROJECT_ENTRIES: usize = 50_000;
+const MAX_CATALOG_DIRECTORIES: usize = 8;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PreparedIntegrationMutation {
+    pub action: HostServiceIntegrationAction,
+    pub integrations: Vec<String>,
+    pub force: bool,
+    pub plans: Vec<HostIntegrationPlan>,
+}
+
+pub(crate) fn resolve_directory(path: &Path) -> io::Result<PathBuf> {
+    let path = if path.is_absolute() {
+        path.to_owned()
+    } else {
+        env::current_dir()?.join(path)
+    };
+    let path = path.canonicalize()?;
+    path.is_dir().then_some(path).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path is not an existing directory",
+        )
+    })
+}
+
+#[derive(Default, Deserialize)]
+struct ProjectConfigFile {
+    projects: Option<ProjectConfig>,
+}
+
+#[derive(Clone, Default, Deserialize)]
+struct ProjectConfig {
+    roots: Option<Vec<String>>,
+    max_depth: Option<usize>,
+}
+
+pub(crate) fn discover_projects() -> io::Result<HostProjectDiscovery> {
+    let mut config = ProjectConfig::default();
+    for path in project_config_paths() {
+        if !path.is_file() {
+            continue;
+        }
+        let parsed: ProjectConfigFile = toml::from_str(&fs::read_to_string(&path)?)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        if let Some(next) = parsed.projects {
+            if next.roots.is_some() {
+                config.roots = next.roots;
+            }
+            if next.max_depth.is_some() {
+                config.max_depth = next.max_depth;
+            }
+        }
+    }
+    let roots = config.roots.unwrap_or_default();
+    let roots_configured = !roots.is_empty();
+    let max_depth = config.max_depth.unwrap_or(3);
+    if !(1..=10).contains(&max_depth) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "projects.max_depth must be between 1 and 10",
+        ));
+    }
+    let mut projects = Vec::new();
+    let mut warnings = Vec::new();
+    let mut seen = HashSet::new();
+    let mut directories = 0;
+    let mut entries = 0;
+    for (group_order, configured) in roots.iter().enumerate() {
+        let root = expand_root(configured)?;
+        if !root.is_dir() {
+            push_warning(
+                &mut warnings,
+                format!("project root is not a directory: {}", root.display()),
+            );
+            continue;
+        }
+        let group = root.file_name().map_or_else(
+            || root.display().to_string(),
+            |name| name.to_string_lossy().into_owned(),
+        );
+        scan_projects(
+            &root,
+            0,
+            max_depth,
+            &group,
+            group_order,
+            &mut projects,
+            &mut seen,
+            &mut directories,
+            &mut entries,
+        );
+        if projects.len() >= MAX_HOST_SERVICE_PROJECTS
+            || directories >= MAX_PROJECT_DIRECTORIES
+            || entries >= MAX_PROJECT_ENTRIES
+        {
+            break;
+        }
+    }
+    if projects.len() >= MAX_HOST_SERVICE_PROJECTS {
+        push_warning(
+            &mut warnings,
+            format!("project scan stopped after {MAX_HOST_SERVICE_PROJECTS} projects"),
+        );
+    }
+    if directories >= MAX_PROJECT_DIRECTORIES {
+        push_warning(
+            &mut warnings,
+            format!("project scan stopped after {MAX_PROJECT_DIRECTORIES} directories"),
+        );
+    }
+    if entries >= MAX_PROJECT_ENTRIES {
+        push_warning(
+            &mut warnings,
+            format!("project scan stopped after {MAX_PROJECT_ENTRIES} filesystem entries"),
+        );
+    }
+    projects.sort_by(|left, right| {
+        left.group_order
+            .cmp(&right.group_order)
+            .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    Ok(HostProjectDiscovery {
+        roots_configured,
+        projects,
+        warnings,
+    })
+}
+
+fn project_config_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(path) = env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| {
+            env::var_os("HOME")
+                .map(PathBuf::from)
+                .filter(|path| path.is_absolute())
+                .map(|path| path.join(".config"))
+        })
+    {
+        paths.push(path.join("boomux/config.toml"));
+    }
+    if let Some(path) = env::var_os("BOOMUX_CONFIG").map(PathBuf::from) {
+        paths.push(path);
+    }
+    paths
+}
+
+fn expand_root(root: &str) -> io::Result<PathBuf> {
+    let path = if root == "~" {
+        owner_home()?
+    } else if let Some(relative) = root.strip_prefix("~/") {
+        owner_home()?.join(relative)
+    } else {
+        PathBuf::from(root)
+    };
+    path.is_absolute().then_some(path).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "project root must be absolute or start with ~",
+        )
+    })
+}
+
+fn owner_home() -> io::Result<PathBuf> {
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "HOME must be an absolute path"))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn scan_projects(
+    directory: &Path,
+    depth: usize,
+    max_depth: usize,
+    group: &str,
+    group_order: usize,
+    projects: &mut Vec<HostProjectSnapshot>,
+    seen: &mut HashSet<PathBuf>,
+    directories: &mut usize,
+    entries: &mut usize,
+) {
+    if *directories >= MAX_PROJECT_DIRECTORIES
+        || *entries >= MAX_PROJECT_ENTRIES
+        || projects.len() >= MAX_HOST_SERVICE_PROJECTS
+    {
+        return;
+    }
+    *directories += 1;
+    if directory.join(".git").exists() {
+        if let Ok(path) = directory.canonicalize()
+            && seen.insert(path.clone())
+        {
+            projects.push(HostProjectSnapshot {
+                name: path.file_name().map_or_else(
+                    || path.display().to_string(),
+                    |name| name.to_string_lossy().into_owned(),
+                ),
+                path,
+                group: group.to_owned(),
+                group_order,
+            });
+        }
+        return;
+    }
+    if depth >= max_depth {
+        return;
+    }
+    let Ok(read) = fs::read_dir(directory) else {
+        return;
+    };
+    let mut children = Vec::new();
+    for entry in read {
+        if *entries >= MAX_PROJECT_ENTRIES {
+            break;
+        }
+        *entries += 1;
+        let Ok(entry) = entry else { continue };
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if entry.file_type().is_ok_and(|kind| kind.is_dir())
+            && !name.starts_with('.')
+            && !matches!(name.as_ref(), "node_modules" | "target")
+        {
+            children.push(entry.path());
+        }
+    }
+    children.sort();
+    for child in children {
+        scan_projects(
+            &child,
+            depth + 1,
+            max_depth,
+            group,
+            group_order,
+            projects,
+            seen,
+            directories,
+            entries,
+        );
+    }
+}
+
+fn push_warning(warnings: &mut Vec<String>, warning: String) {
+    if warnings.len() < MAX_HOST_SERVICE_WARNINGS {
+        warnings.push(warning);
+    }
+}
+
+pub(crate) fn suggest_shell_name(workspace: &WorkspaceSnapshot) -> io::Result<String> {
+    generated_names::random_excluding(workspace.shells.iter().map(|shell| shell.name.as_str()))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "generated shell names are exhausted",
+            )
+        })
+}
+
+pub(crate) fn invoke_launcher(
+    workspace: &WorkspaceSnapshot,
+    launcher: &WorkspaceLauncherSnapshot,
+) -> io::Result<()> {
+    if launcher.workspace_id != workspace.id {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "launcher is not owned by workspace",
+        ));
+    }
+    let (executable, arguments) = launcher
+        .command
+        .split_first()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "launcher command is empty"))?;
+    let mut command = Command::new(executable);
+    command
+        .args(arguments)
+        .current_dir(&launcher.cwd)
+        .env("BOOMUX_WORKSPACE_ID", &workspace.id)
+        .env("BOOMUX_WORKSPACE", &workspace.name)
+        .env("BOOMUX_LAUNCHER_ID", &launcher.id)
+        .env("BOOMUX_LAUNCHER_NAME", &launcher.name)
+        .env_remove("BOOMUX_SHELL_ID")
+        .env_remove("BOOMUX_SHELL_NAME")
+        .env_remove("BOOMUX_RUN_ID")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command.spawn()?;
+    thread::Builder::new()
+        .name(format!("host-launcher-reaper-{}", launcher.id))
+        .spawn(move || {
+            let _ = child.wait();
+        })
+        .map_err(|error| io::Error::other(format!("could not start launcher reaper: {error}")))?;
+    Ok(())
+}
+
+fn integration_ids(requested: &[String]) -> io::Result<Vec<IntegrationId>> {
+    if requested.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "at least one integration is required",
+        ));
+    }
+    let mut seen = BTreeSet::new();
+    requested
+        .iter()
+        .map(|name| {
+            if !seen.insert(name.clone()) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "duplicate integration",
+                ));
+            }
+            name.parse()
+                .map_err(|message: String| io::Error::new(io::ErrorKind::InvalidInput, message))
+        })
+        .collect()
+}
+
+pub(crate) fn integration_status(
+    integration: Option<&str>,
+    snapshot: &Snapshot,
+) -> io::Result<Vec<HostIntegrationStatus>> {
+    let ids = match integration {
+        Some(name) => integration_ids(&[name.to_owned()])?,
+        None => IntegrationId::all().collect(),
+    };
+    let environment = integration_management::Environment::from_process();
+    Ok(ids
+        .into_iter()
+        .map(|id| integration_management::inspect(id, &environment, Some(snapshot)))
+        .map(|status| HostIntegrationStatus {
+            name: status.name.into(),
+            display_name: status.display_name.into(),
+            package: status.package.into(),
+            validated_version: status.validated_version.into(),
+            host_state: status.host.state.as_str().into(),
+            executable: status.host.executable,
+            version: status.host.version,
+            compatibility: status.host.compatibility.into(),
+            host_error: status.host.error,
+            asset_state: status.asset.state.as_str().into(),
+            path: status.asset.path,
+            asset_error: status.asset.error,
+            runtime_state: status.runtime.state.as_str().into(),
+            running_processes: status.runtime.running_processes,
+            tracked_processes: status.runtime.tracked_processes,
+            untracked_processes: status.runtime.untracked_processes,
+            recommended_action: recommended_action_name(status.recommended_action).into(),
+        })
+        .collect())
+}
+
+fn recommended_action_name(action: integration_management::RecommendedAction) -> &'static str {
+    use integration_management::RecommendedAction::*;
+    match action {
+        None => "none",
+        Install => "install",
+        Replace => "replace",
+        RestartHost => "restart_host",
+        InspectError => "inspect_error",
+    }
+}
+
+pub(crate) fn prepare_integration_mutation(
+    action: HostServiceIntegrationAction,
+    requested: &[String],
+    force: bool,
+) -> io::Result<PreparedIntegrationMutation> {
+    let ids = integration_ids(requested)?;
+    let environment = integration_management::Environment::from_process();
+    let plans = match action {
+        HostServiceIntegrationAction::Install => ids
+            .iter()
+            .copied()
+            .map(|id| integration_management::plan_install(id, &environment, force))
+            .map(|result| result.map_err(boxed_error))
+            .collect::<io::Result<Vec<_>>>()?
+            .into_iter()
+            .map(|plan| HostIntegrationPlan {
+                name: plan.name.into(),
+                current_state: plan.current_state.as_str().into(),
+                action: match plan.action {
+                    integration_management::InstallAction::Install => "install",
+                    integration_management::InstallAction::Replace => "replace",
+                    integration_management::InstallAction::Unchanged => "unchanged",
+                }
+                .into(),
+                path: plan.path,
+                restart_required: plan.restart_required,
+            })
+            .collect(),
+        HostServiceIntegrationAction::Uninstall => {
+            let mut plans = Vec::new();
+            for id in ids.iter().copied() {
+                integration_management::preflight_uninstall(id, &environment, force)
+                    .map_err(boxed_error)?;
+                let status =
+                    integration_management::inspect_without_host_probe(id, &environment, None);
+                plans.push(HostIntegrationPlan {
+                    name: status.name.into(),
+                    current_state: status.asset.state.as_str().into(),
+                    action: if status.asset.state == integration_management::AssetState::Missing {
+                        "unchanged"
+                    } else {
+                        "remove"
+                    }
+                    .into(),
+                    path: status.asset.path.ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "integration path is unavailable",
+                        )
+                    })?,
+                    restart_required: status.asset.state
+                        != integration_management::AssetState::Missing,
+                });
+            }
+            plans
+        }
+    };
+    Ok(PreparedIntegrationMutation {
+        action,
+        integrations: requested.to_vec(),
+        force,
+        plans,
+    })
+}
+
+pub(crate) fn commit_integration_mutation(
+    prepared: &PreparedIntegrationMutation,
+) -> io::Result<Vec<HostIntegrationMutationResult>> {
+    let current =
+        prepare_integration_mutation(prepared.action, &prepared.integrations, prepared.force)?;
+    if current != *prepared {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "integration target changed after preview; inspect and confirm again",
+        ));
+    }
+    let ids = integration_ids(&prepared.integrations)?;
+    let environment = integration_management::Environment::from_process();
+    match prepared.action {
+        HostServiceIntegrationAction::Install => ids
+            .into_iter()
+            .map(|id| integration_management::install(id, &environment, prepared.force))
+            .map(|result| {
+                let result = result.map_err(boxed_error)?;
+                Ok(HostIntegrationMutationResult {
+                    name: result.name.into(),
+                    result: match result.result {
+                        integration_management::InstallOutcome::Installed => "installed",
+                        integration_management::InstallOutcome::Replaced => "replaced",
+                        integration_management::InstallOutcome::Unchanged => "unchanged",
+                    }
+                    .into(),
+                    path: result.path,
+                    restart_required: result.restart_required,
+                })
+            })
+            .collect(),
+        HostServiceIntegrationAction::Uninstall => ids
+            .into_iter()
+            .map(|id| integration_management::uninstall(id, &environment, prepared.force))
+            .map(|result| {
+                let result = result.map_err(boxed_error)?;
+                Ok(HostIntegrationMutationResult {
+                    name: result.name.into(),
+                    result: match result.result {
+                        integration_management::UninstallOutcome::Removed => "removed",
+                        integration_management::UninstallOutcome::NotInstalled => "not_installed",
+                    }
+                    .into(),
+                    path: result.path,
+                    restart_required: result.restart_required,
+                })
+            })
+            .collect(),
+    }
+}
+
+fn boxed_error(error: Box<dyn std::error::Error>) -> io::Error {
+    if let Some(error) = error.downcast_ref::<io::Error>() {
+        return io::Error::new(error.kind(), error.to_string());
+    }
+    io::Error::other(error.to_string())
+}
+
+pub(crate) fn verify_integration(
+    snapshot: &Snapshot,
+    integration: &str,
+    shell_id: &str,
+    run_id: &str,
+) -> io::Result<Vec<AgentInstanceSnapshot>> {
+    let id = integration_ids(&[integration.to_owned()])?.remove(0);
+    let target = integration_management::VerificationTarget {
+        shell_id: shell_id.to_owned(),
+        run_id: run_id.to_owned(),
+    };
+    match integration_management::check_verification_target(snapshot, id, &target) {
+        integration_management::VerificationCheck::Verified { agents, .. } => Ok(agents),
+        integration_management::VerificationCheck::Pending => Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "integration has not reported authoritative lifecycle state",
+        )),
+        integration_management::VerificationCheck::Missing => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "integration host shell is not running",
+        )),
+        integration_management::VerificationCheck::RunChanged => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "integration host shell run changed",
+        )),
+    }
+}
+
+pub(crate) fn sessions(snapshot: &Snapshot) -> Vec<SessionProjection> {
+    let directories = workspace_directories(&snapshot.workspaces)
+        .into_iter()
+        .take(MAX_CATALOG_DIRECTORIES)
+        .collect::<Vec<_>>();
+    let catalog = thread::scope(|scope| {
+        directories
+            .into_iter()
+            .flat_map(|directory| {
+                crate::host_session_titles::catalog_integrations()
+                    .map(move |integration| (integration, directory.clone()))
+            })
+            .map(|(integration, directory)| {
+                scope.spawn(move || crate::host_session_titles::catalog(integration, &directory))
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .filter_map(|handle| handle.join().ok().flatten())
+            .flatten()
+            .collect::<Vec<_>>()
+    });
+    let mut sessions = session_projection::project_snapshot_with_catalog(snapshot, Some(&catalog));
+    sessions.truncate(MAX_HOST_SERVICE_SESSIONS);
+    sessions
+}
+
+fn workspace_directories(workspaces: &[WorkspaceSnapshot]) -> BTreeSet<PathBuf> {
+    workspaces
+        .iter()
+        .flat_map(|workspace| {
+            workspace
+                .default_cwd
+                .iter()
+                .cloned()
+                .chain(workspace.shells.iter().map(|shell| shell.cwd.clone()))
+                .chain(
+                    workspace
+                        .launchers
+                        .iter()
+                        .map(|launcher| launcher.cwd.clone()),
+                )
+                .chain(
+                    workspace
+                        .agents
+                        .iter()
+                        .filter_map(|agent| agent.cwd.clone()),
+                )
+        })
+        .collect()
+}
+
+pub(crate) fn session_summary(session: &SessionProjection) -> HostAgentSessionSummary {
+    HostAgentSessionSummary {
+        id: session.id.clone(),
+        workspace_id: session.workspace_id.clone(),
+        workspace_name: session.workspace_name.clone(),
+        description: session.description.clone(),
+        integration: session.integration.clone(),
+        external_session_id: session.external_session_id.clone(),
+        state: session.state,
+        state_is_current: session.state_is_current,
+        started_at_ms: session.started_at_ms,
+        last_at_ms: session.last_at_ms,
+        occurrence_count: session.occurrences.len(),
+    }
+}
+
+pub(crate) fn inspect_session(
+    snapshot: &Snapshot,
+    session_id: &str,
+) -> io::Result<HostAgentSessionInspection> {
+    let sessions = sessions(snapshot);
+    let session = session_projection::resolve_exact(&sessions, session_id).map_err(|error| {
+        io::Error::new(
+            match error {
+                session_projection::ResolveError::NotFound => io::ErrorKind::NotFound,
+                session_projection::ResolveError::DuplicateId => io::ErrorKind::InvalidData,
+            },
+            "exact Agent Session was not found",
+        )
+    })?;
+    let agent_ids = session
+        .occurrences
+        .iter()
+        .map(|occurrence| occurrence.agent_id.as_str())
+        .collect::<HashSet<_>>();
+    let occurrences = snapshot
+        .workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.agents)
+        .filter(|agent| agent_ids.contains(agent.id.as_str()))
+        .take(MAX_HOST_SERVICE_SESSIONS)
+        .cloned()
+        .collect();
+    Ok(HostAgentSessionInspection {
+        summary: session_summary(session),
+        source_cwd: session.source_cwd.clone(),
+        occurrences,
+    })
+}
+
+pub(crate) fn prepare_session_resume(
+    snapshot: &Snapshot,
+    session_id: &str,
+) -> io::Result<HostAgentSessionResumePlan> {
+    let sessions = sessions(snapshot);
+    let session = session_projection::resolve_exact(&sessions, session_id).map_err(|_| {
+        io::Error::new(io::ErrorKind::NotFound, "exact Agent Session was not found")
+    })?;
+    if session.state_is_current {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "Agent Session is already active",
+        ));
+    }
+    if session.state == crate::protocol::AgentState::Done {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Agent Session is permanently done",
+        ));
+    }
+    let external_id = session.external_session_id.as_deref().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Agent Session has no canonical external ID",
+        )
+    })?;
+    let descriptor = crate::integrations::by_key(&session.integration)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "unknown Agent integration"))?;
+    let resume = descriptor.resume.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::Unsupported,
+            "integration does not support session resume",
+        )
+    })?;
+    let cwd = resolve_directory(session.source_cwd.as_deref().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Agent Session has no retained working directory",
+        )
+    })?)?;
+    let argv = resume.command(&[], external_id).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "could not build exact resume argv",
+        )
+    })?;
+    Ok(HostAgentSessionResumePlan {
+        session_id: session.id.clone(),
+        workspace_id: session.workspace_id.clone(),
+        workspace_name: session.workspace_name.clone(),
+        integration: session.integration.clone(),
+        cwd,
+        argv,
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,28 @@
+extern crate self as boomux;
+
 pub mod attach;
 pub mod client;
 pub mod daemon;
 mod desktop_notifications;
 mod fd_transfer;
 pub mod federation;
+#[allow(dead_code)]
+mod generated_names;
 mod handoff;
+pub mod host_services;
+#[allow(dead_code)]
+mod host_session_source;
+#[allow(dead_code)]
+mod host_session_titles;
+#[allow(dead_code)]
+mod integration_management;
 pub mod integrations;
 mod node_identity;
 mod node_projection;
 mod node_registration;
 pub mod protocol;
 pub mod scheduling;
+mod session_projection;
 pub mod ssh_bootstrap;
 mod state_store;
 mod terminal_focus;

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,6 +488,12 @@ enum Commands {
     },
     #[command(name = "__scheduled-runner", hide = true)]
     ScheduledRunner { schedule_id: String },
+    #[command(name = "__resume-session", hide = true)]
+    ResumeSession {
+        session_id: String,
+        #[arg(long)]
+        node: Option<String>,
+    },
     #[command(name = "__federation-stdio", hide = true)]
     FederationStdio,
 }
@@ -495,7 +501,11 @@ enum Commands {
 #[derive(Subcommand)]
 enum ProjectCommands {
     /// List projects discovered from configured roots
-    List,
+    List {
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -539,7 +549,12 @@ enum WorkspaceCommands {
         cwd: Option<PathBuf>,
     },
     /// Open terminal windows and invoke launchers
-    Open { target: String },
+    Open {
+        target: String,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
     /// Show a workspace and its shells
     Inspect { target: String },
     /// Rename a workspace
@@ -576,6 +591,9 @@ enum LauncherCommands {
         target: String,
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Rename a launcher
     Rename {
@@ -595,7 +613,12 @@ enum LauncherCommands {
 #[derive(Subcommand)]
 enum ShellCommands {
     /// Suggest an unused generated name without reserving it
-    SuggestName { workspace: String },
+    SuggestName {
+        workspace: String,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
     /// Create a pending shell in a workspace
     Create {
         workspace: String,
@@ -714,10 +737,25 @@ enum SessionCommands {
     List {
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Show a projected session by exact opaque ID
     #[command(alias = "get")]
-    Inspect { session_id: String },
+    Inspect {
+        session_id: String,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
+    /// Resume one exact projected session in a native terminal
+    Resume {
+        session_id: String,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -974,6 +1012,8 @@ enum IntegrationCommands {
     /// Inspect host, asset, and runtime reporting status
     Status {
         integration: Option<integration_management::IntegrationId>,
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Install one integration or every bundled integration
     Install {
@@ -985,6 +1025,8 @@ enum IntegrationCommands {
         force: bool,
         #[arg(long)]
         dry_run: bool,
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Remove one integration or every bundled integration
     Uninstall {
@@ -994,6 +1036,8 @@ enum IntegrationCommands {
         all: bool,
         #[arg(long)]
         force: bool,
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Inspect, install, and explain verification for one integration
     Setup {
@@ -1004,6 +1048,8 @@ enum IntegrationCommands {
         /// Allow replacement of a modified integration asset
         #[arg(long)]
         force: bool,
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Verify authoritative lifecycle reporting in a running host shell
     Verify {
@@ -1012,6 +1058,8 @@ enum IntegrationCommands {
         shell: Option<String>,
         #[arg(long, default_value_t = 30_000)]
         wait_ms: u32,
+        #[arg(long)]
+        node: Option<String>,
     },
 }
 
@@ -1113,6 +1161,7 @@ command_keys! {
     IntegrationVerify => ("integration.verify", Json),
     SessionList => ("session.list", Json),
     SessionInspect => ("session.inspect", Json),
+    SessionResume => ("session.resume", HumanOnly),
     ScheduleCreate => ("schedule.create", Json),
     ScheduleList => ("schedule.list", Json),
     ScheduleInspect => ("schedule.inspect", Json),
@@ -1133,6 +1182,7 @@ command_keys! {
     DaemonStatus => ("daemon.status", Json),
     Daemon => ("daemon", HumanOnly),
     Attach => ("attach", HumanOnly),
+    ResumeSessionInternal => ("resume-session-internal", HumanOnly),
 }
 
 impl Cli {
@@ -1148,7 +1198,7 @@ impl Cli {
             Some(Commands::Read { .. }) => CommandKey::Read,
             Some(Commands::Events { .. }) => CommandKey::Events,
             Some(Commands::Project {
-                command: ProjectCommands::List,
+                command: ProjectCommands::List { .. },
             }) => CommandKey::ProjectList,
             Some(Commands::Workspace {
                 command: WorkspaceCommands::List,
@@ -1228,6 +1278,9 @@ impl Cli {
             Some(Commands::Session {
                 command: SessionCommands::Inspect { .. },
             }) => CommandKey::SessionInspect,
+            Some(Commands::Session {
+                command: SessionCommands::Resume { .. },
+            }) => CommandKey::SessionResume,
             Some(Commands::Schedule {
                 command: ScheduleCommands::Create(..),
             }) => CommandKey::ScheduleCreate,
@@ -1327,6 +1380,7 @@ impl Cli {
             Some(Commands::Open { .. }) => CommandKey::Open,
             Some(Commands::Prompt) => CommandKey::Prompt,
             Some(Commands::Attach { .. }) => CommandKey::Attach,
+            Some(Commands::ResumeSession { .. }) => CommandKey::ResumeSessionInternal,
             Some(Commands::ScheduledRunner { .. }) => CommandKey::Attach,
             Some(Commands::FederationStdio) => CommandKey::Attach,
         }
@@ -1474,6 +1528,10 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::ScheduledRunner { schedule_id }) => {
             return scheduled_runner(schedule_id).map(CliExit::Child);
         }
+        Some(Commands::ResumeSession { session_id, node }) => {
+            attach::run_agent_session(session_id, node.as_deref())?;
+            return Ok(CliExit::Success);
+        }
         Some(Commands::FederationStdio) => {
             federation::run_stdio_helper()?;
             return Ok(CliExit::Success);
@@ -1527,8 +1585,8 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         }) => read_events(after.as_deref(), limit, wait_ms, cli.json),
         Some(Commands::Close { target }) => close_shell(&target),
         Some(Commands::Project {
-            command: ProjectCommands::List,
-        }) => list_projects(cli.json),
+            command: ProjectCommands::List { node },
+        }) => list_projects(cli.json, node.as_deref()),
         Some(Commands::Workspace { command }) => {
             workspace_command(command, cli.json, cli.terminal.as_deref())
         }
@@ -1576,6 +1634,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Prompt) => print_prompt_label(),
         Some(Commands::Daemon { command }) => daemon_control(command, cli.json),
         Some(Commands::Attach { .. }) => unreachable!(),
+        Some(Commands::ResumeSession { .. }) => unreachable!(),
         Some(Commands::ScheduledRunner { .. }) => unreachable!(),
         Some(Commands::FederationStdio) => unreachable!(),
         None => dashboard(cli.terminal.as_deref(), None),
@@ -2134,14 +2193,30 @@ fn dashboard(
                         }
                     },
                     |workspace_id, launcher_id| {
-                        let workspace = client
-                            .get_workspace(workspace_id)
-                            .map_err(|error| error.to_string())?;
-                        let launcher = client
-                            .get_launcher(launcher_id)
-                            .map_err(|error| error.to_string())?;
-                        invoke_workspace_launcher(&workspace, &launcher)
-                            .map_err(|error| error.to_string())?;
+                        let workspace =
+                            routed_dashboard_workspace(&client, workspace_id, &local_node_id)?;
+                        let launcher =
+                            routed_dashboard_launcher(&client, launcher_id, &local_node_id)?;
+                        if launcher.workspace_id != workspace.id {
+                            return Err(
+                                "launcher ownership changed; refresh before invoking".into()
+                            );
+                        }
+                        if workspace_id.node_id == local_node_id || workspace_id.node_id.is_empty()
+                        {
+                            invoke_workspace_launcher(&workspace, &launcher)
+                                .map_err(|error| error.to_string())?;
+                        } else {
+                            client
+                                .route_node_host_service(
+                                    &workspace_id.node_id,
+                                    protocol::HostServiceOperation::InvokeLauncher {
+                                        workspace_id: workspace.id.clone(),
+                                        launcher_id: launcher.id.clone(),
+                                    },
+                                )
+                                .map_err(|error| error.to_string())?;
+                        }
                         Ok(format!(
                             "Launched {} from {}",
                             launcher.name, workspace.name
@@ -2751,23 +2826,25 @@ fn focused_terminal_view(focused: protocol::FocusedTerminalSnapshot) -> tui::Foc
 
 fn dispatch_dashboard_open<S, L>(
     target: &tui::OpenTarget,
-    local_node_id: &str,
+    _local_node_id: &str,
     mut open_shell: S,
     mut launch: L,
 ) -> Result<String, String>
 where
     S: FnMut(&protocol::QualifiedIdentity) -> Result<String, String>,
-    L: FnMut(&str, &str) -> Result<String, String>,
+    L: FnMut(&protocol::QualifiedIdentity, &protocol::QualifiedIdentity) -> Result<String, String>,
 {
     match target {
         tui::OpenTarget::Shell(shell_id) => open_shell(shell_id),
         tui::OpenTarget::Launcher {
             workspace_id,
             launcher_id,
-        } => launch(
-            local_dashboard_inner(workspace_id, local_node_id)?,
-            local_dashboard_inner(launcher_id, local_node_id)?,
-        ),
+        } => {
+            if workspace_id.node_id != launcher_id.node_id {
+                return Err("workspace and launcher belong to different Nodes".into());
+            }
+            launch(workspace_id, launcher_id)
+        }
     }
 }
 
@@ -3074,14 +3151,36 @@ fn open_remote_scheduled_execution(
 ) -> Result<String, Box<dyn Error>> {
     let execution =
         routed_dashboard_execution(client, execution_id, "").map_err(io::Error::other)?;
-    let ScheduledExecutionOpenTarget::Run { shell_id, run_id } =
-        scheduled_execution_open_target(&execution)
-            .map_err(|(code, message)| cli_output::failure(code, message))?
-    else {
-        return Err(cli_output::failure(
-            "unsupported_version",
-            "remote Scheduled Execution session resume is unavailable; only active exact runs can attach",
+    let target = scheduled_execution_open_target(&execution)
+        .map_err(|(code, message)| cli_output::failure(code, message))?;
+    if let ScheduledExecutionOpenTarget::Session { agent_id } = target {
+        let result = client.route_node_host_service(
+            &execution_id.node_id,
+            protocol::HostServiceOperation::ResolveAgentSession {
+                workspace_id: execution.workspace_id.clone(),
+                agent_id: agent_id.to_owned(),
+            },
+        )?;
+        let protocol::HostServiceResult::ResolvedAgentSession { session } = result else {
+            return Err("remote Node returned an unexpected Agent Session response".into());
+        };
+        let registration = client.node_registration(&execution_id.node_id)?;
+        terminal::open_agent_session(
+            terminal,
+            Some(&execution_id.node_id),
+            &session.id,
+            &format!(
+                "[{}] {} - {} session",
+                registration.alias, session.workspace_name, session.integration,
+            ),
+        )?;
+        return Ok(format!(
+            "Opened exact {} Agent Session for execution {} on Node {}",
+            session.integration, execution.id, registration.alias,
         ));
+    }
+    let ScheduledExecutionOpenTarget::Run { shell_id, run_id } = target else {
+        unreachable!("session targets return after opening")
     };
     let shell_identity = protocol::QualifiedIdentity::new(&execution_id.node_id, shell_id);
     let shell = routed_dashboard_shell(client, &shell_identity, "").map_err(io::Error::other)?;
@@ -3508,14 +3607,28 @@ fn generated_shell_name<'a>(
 }
 
 fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), Box<dyn Error>> {
+    let node = match &command {
+        IntegrationCommands::List => None,
+        IntegrationCommands::Status { node, .. }
+        | IntegrationCommands::Install { node, .. }
+        | IntegrationCommands::Uninstall { node, .. }
+        | IntegrationCommands::Setup { node, .. }
+        | IntegrationCommands::Verify { node, .. } => node.as_deref(),
+    };
+    if let Some(node) = node {
+        let client = client::connect_or_start()?;
+        let registration = client.node_registration(node)?;
+        return remote_integration_command(&client, &registration, command, json);
+    }
     match command {
         IntegrationCommands::List => list_integrations(json),
-        IntegrationCommands::Status { integration } => integration_status(integration, json),
+        IntegrationCommands::Status { integration, .. } => integration_status(integration, json),
         IntegrationCommands::Install {
             integration,
             all,
             force,
             dry_run,
+            ..
         } => {
             let integrations = if all {
                 integration_management::IntegrationId::all().collect()
@@ -3533,6 +3646,7 @@ fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), B
             integration,
             all,
             force,
+            ..
         } => {
             let integrations = if all {
                 integration_management::IntegrationId::all().collect()
@@ -3550,12 +3664,287 @@ fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), B
             integration,
             yes,
             force,
+            ..
         } => setup_integration(integration, yes, force),
         IntegrationCommands::Verify {
             integration,
             shell,
             wait_ms,
+            ..
         } => verify_integration(integration, shell.as_deref(), wait_ms, json),
+    }
+}
+
+fn remote_integration_command(
+    client: &client::Client,
+    registration: &protocol::NodeRegistrationSnapshot,
+    command: IntegrationCommands,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let names = |integration: Option<integration_management::IntegrationId>, all: bool| {
+        if all {
+            integration_management::IntegrationId::all()
+                .map(|id| id.spec().key.to_owned())
+                .collect::<Vec<_>>()
+        } else {
+            integration
+                .map(|id| vec![id.spec().key.to_owned()])
+                .unwrap_or_default()
+        }
+    };
+    match command {
+        IntegrationCommands::List => unreachable!(),
+        IntegrationCommands::Status { integration, .. } => {
+            let result = client.route_node_host_service(
+                &registration.node_id,
+                protocol::HostServiceOperation::IntegrationStatus {
+                    integration: integration.map(|id| id.spec().key.to_owned()),
+                },
+            )?;
+            let protocol::HostServiceResult::IntegrationStatus { integrations } = result else {
+                return Err("remote Node returned an unexpected integration status".into());
+            };
+            if json {
+                let integrations = integrations
+                    .into_iter()
+                    .map(|status| serde_json::json!({
+                        "name": status.name,
+                        "display_name": status.display_name,
+                        "package": status.package,
+                        "validated_version": status.validated_version,
+                        "host": { "state": status.host_state, "executable": status.executable, "version": status.version, "compatibility": status.compatibility, "error": status.host_error },
+                        "asset": { "state": status.asset_state, "path": status.path, "error": status.asset_error },
+                        "runtime": { "state": status.runtime_state, "running_processes": status.running_processes, "tracked_processes": status.tracked_processes, "untracked_processes": status.untracked_processes },
+                        "recommended_action": status.recommended_action,
+                    }))
+                    .collect::<Vec<_>>();
+                return print_json(
+                    CommandKey::IntegrationStatus,
+                    serde_json::json!({ "node_id": registration.node_id, "integrations": integrations }),
+                );
+            }
+            println!("Integration status on Node {}", registration.alias);
+            for status in integrations {
+                println!(
+                    "{}\t{}\t{}\t{}",
+                    status.display_name,
+                    status.host_state,
+                    status.asset_state,
+                    status.runtime_state
+                );
+            }
+        }
+        IntegrationCommands::Install {
+            integration,
+            all,
+            force,
+            dry_run,
+            ..
+        } => {
+            let requested = names(integration, all);
+            if requested.is_empty() {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    "integration install requires a name or --all",
+                ));
+            }
+            let preview = remote_integration_preview(
+                client,
+                registration,
+                protocol::HostServiceIntegrationAction::Install,
+                requested,
+                force,
+            )?;
+            if dry_run {
+                if json {
+                    return print_json(
+                        CommandKey::IntegrationInstall,
+                        serde_json::json!({ "node_id": registration.node_id, "dry_run": true, "integrations": preview.plans }),
+                    );
+                }
+                for plan in preview.plans {
+                    println!("Plan: {} {}", plan.action, plan.path);
+                }
+            } else {
+                remote_integration_commit(
+                    client,
+                    registration,
+                    preview.token,
+                    CommandKey::IntegrationInstall,
+                    json,
+                )?;
+            }
+        }
+        IntegrationCommands::Uninstall {
+            integration,
+            all,
+            force,
+            ..
+        } => {
+            let requested = names(integration, all);
+            if requested.is_empty() {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    "integration uninstall requires a name or --all",
+                ));
+            }
+            let preview = remote_integration_preview(
+                client,
+                registration,
+                protocol::HostServiceIntegrationAction::Uninstall,
+                requested,
+                force,
+            )?;
+            remote_integration_commit(
+                client,
+                registration,
+                preview.token,
+                CommandKey::IntegrationUninstall,
+                json,
+            )?;
+        }
+        IntegrationCommands::Setup {
+            integration,
+            yes,
+            force,
+            ..
+        } => {
+            let preview = remote_integration_preview(
+                client,
+                registration,
+                protocol::HostServiceIntegrationAction::Install,
+                vec![integration.spec().key.to_owned()],
+                force,
+            )?;
+            for plan in &preview.plans {
+                println!("Node: {}", registration.alias);
+                println!("Plan: {} {}", plan.action, plan.path);
+            }
+            if !yes && !confirm_setup("Apply this integration plan on the selected Node?")? {
+                println!("No changes made.");
+                return Ok(());
+            }
+            remote_integration_commit(
+                client,
+                registration,
+                preview.token,
+                CommandKey::IntegrationInstall,
+                false,
+            )?;
+        }
+        IntegrationCommands::Verify {
+            integration,
+            shell,
+            wait_ms,
+            ..
+        } => {
+            let shell_id = shell.ok_or_else(|| {
+                cli_output::failure(
+                    "context_required",
+                    "remote integration verify requires --shell with an exact ID",
+                )
+            })?;
+            let shell = match client.route_node_operation(
+                &registration.node_id,
+                protocol::RoutedOperation::GetShell {
+                    shell_id: shell_id.clone(),
+                },
+            )? {
+                protocol::RoutedOperationResult::Shell { shell } => shell,
+                _ => return Err("remote Node returned an unexpected shell response".into()),
+            };
+            let run_id = shell
+                .run
+                .as_ref()
+                .map(|run| run.id.clone())
+                .ok_or_else(|| {
+                    cli_output::failure("not_found", "remote integration shell has no active run")
+                })?;
+            let deadline = Instant::now() + Duration::from_millis(u64::from(wait_ms));
+            let agents = loop {
+                match client.route_node_host_service(
+                    &registration.node_id,
+                    protocol::HostServiceOperation::VerifyIntegration {
+                        integration: integration.spec().key.to_owned(),
+                        shell_id: shell_id.clone(),
+                        run_id: run_id.clone(),
+                    },
+                ) {
+                    Ok(protocol::HostServiceResult::IntegrationVerified { agents, .. }) => {
+                        break agents;
+                    }
+                    Ok(_) => {
+                        return Err(
+                            "remote Node returned an unexpected verification response".into()
+                        );
+                    }
+                    Err(_error) if Instant::now() < deadline => {
+                        thread::sleep(Duration::from_millis(100))
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            };
+            if json {
+                return print_json(
+                    CommandKey::IntegrationVerify,
+                    serde_json::json!({ "node_id": registration.node_id, "integration": integration.spec().key, "verified": true, "shell_id": shell_id, "run_id": run_id, "agents": agents }),
+                );
+            }
+            println!(
+                "Verified {} on Node {}",
+                integration.spec().display_name,
+                registration.alias
+            );
+        }
+    }
+    Ok(())
+}
+
+fn remote_integration_preview(
+    client: &client::Client,
+    registration: &protocol::NodeRegistrationSnapshot,
+    action: protocol::HostServiceIntegrationAction,
+    integrations: Vec<String>,
+    force: bool,
+) -> Result<protocol::HostIntegrationMutationPreview, Box<dyn Error>> {
+    let result = client.route_node_host_service(
+        &registration.node_id,
+        protocol::HostServiceOperation::PreviewIntegrationMutation {
+            action,
+            integrations,
+            force,
+        },
+    )?;
+    match result {
+        protocol::HostServiceResult::IntegrationMutationPreview { preview } => Ok(preview),
+        _ => Err("remote Node returned an unexpected integration preview".into()),
+    }
+}
+
+fn remote_integration_commit(
+    client: &client::Client,
+    registration: &protocol::NodeRegistrationSnapshot,
+    preview_token: String,
+    command: CommandKey,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let result = client.route_node_host_service(
+        &registration.node_id,
+        protocol::HostServiceOperation::CommitIntegrationMutation { preview_token },
+    )?;
+    let protocol::HostServiceResult::IntegrationMutation { integrations } = result else {
+        return Err("remote Node returned an unexpected integration mutation".into());
+    };
+    if json {
+        print_json(
+            command,
+            serde_json::json!({ "node_id": registration.node_id, "integrations": integrations }),
+        )
+    } else {
+        for result in integrations {
+            println!("{}: {} {}", result.name, result.result, result.path);
+        }
+        Ok(())
     }
 }
 
@@ -4168,7 +4557,51 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn list_projects(json: bool) -> Result<(), Box<dyn Error>> {
+fn list_projects(json: bool, node: Option<&str>) -> Result<(), Box<dyn Error>> {
+    if let Some(node) = node {
+        let client = client::connect_or_start()?;
+        let registration = client.node_registration(node)?;
+        let protocol::HostServiceResult::Projects { discovery } = client.route_node_host_service(
+            &registration.node_id,
+            protocol::HostServiceOperation::DiscoverProjects,
+        )?
+        else {
+            return Err("remote Node returned an unexpected project response".into());
+        };
+        if json {
+            return print_json(
+                CommandKey::ProjectList,
+                serde_json::json!({
+                    "node_id": registration.node_id,
+                    "roots_configured": discovery.roots_configured,
+                    "projects": discovery.projects,
+                    "warnings": discovery.warnings,
+                }),
+            );
+        }
+        if !discovery.roots_configured {
+            println!(
+                "No project roots configured on Node {}.",
+                registration.alias
+            );
+        } else if discovery.projects.is_empty() {
+            println!("No projects discovered on Node {}.", registration.alias);
+        } else {
+            println!("GROUP\tNAME\tPATH");
+            for project in discovery.projects {
+                println!(
+                    "{}\t{}\t{}",
+                    project.group,
+                    project.name,
+                    project.path.display()
+                );
+            }
+        }
+        for warning in discovery.warnings {
+            eprintln!("warning: {warning}");
+        }
+        return Ok(());
+    }
     let config = config::load()?;
     let roots_configured = !config.projects.roots.is_empty();
     let discovery = projects::discover(&config.projects);
@@ -4297,7 +4730,65 @@ fn workspace_command(
                 client.create_workspace_with_default_cwd(name, default_cwd, Vec::new())?;
             println!("Created workspace {} ({})", workspace.name, workspace.id);
         }
-        WorkspaceCommands::Open { target } => {
+        WorkspaceCommands::Open { target, node } => {
+            if let Some(node) = node {
+                let registration = client.node_registration(node)?;
+                let workspace = match client.route_node_operation(
+                    &registration.node_id,
+                    protocol::RoutedOperation::GetWorkspace {
+                        workspace_id: target.clone(),
+                    },
+                )? {
+                    protocol::RoutedOperationResult::Workspace { workspace } => workspace,
+                    _ => return Err("remote Node returned an unexpected workspace response".into()),
+                };
+                let terminal = effective_terminal(terminal_override)?;
+                let mut failures = Vec::new();
+                for launcher in &workspace.launchers {
+                    if let Err(error) = client.route_node_host_service(
+                        &registration.node_id,
+                        protocol::HostServiceOperation::InvokeLauncher {
+                            workspace_id: workspace.id.clone(),
+                            launcher_id: launcher.id.clone(),
+                        },
+                    ) {
+                        failures.push(format!("launcher {}: {error}", launcher.name));
+                    }
+                }
+                for shell in workspace
+                    .shells
+                    .iter()
+                    .filter(|shell| matches!(shell.owner, protocol::ShellOwner::User))
+                {
+                    if let Err(error) = terminal::open_remote(
+                        terminal.as_deref(),
+                        &registration.node_id,
+                        &shell.id,
+                        &format!(
+                            "[{}] {} - {}",
+                            registration.alias, workspace.name, shell.name
+                        ),
+                        true,
+                    ) {
+                        failures.push(format!("shell {}: {error}", shell.name));
+                    }
+                }
+                if !failures.is_empty() {
+                    return Err(io::Error::other(format!(
+                        "remote workspace opened with failures: {}",
+                        failures.join("; ")
+                    ))
+                    .into());
+                }
+                println!(
+                    "Opened {} launcher(s) and {} shell(s) for {} on Node {}",
+                    workspace.launchers.len(),
+                    workspace_user_shell_count(&workspace),
+                    workspace.name,
+                    registration.alias,
+                );
+                return Ok(());
+            }
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
             let terminal = effective_terminal(terminal_override)?;
@@ -4444,7 +4935,37 @@ fn workspace_command(
 fn shell_command(command: ShellCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     match command {
-        ShellCommands::SuggestName { workspace } => {
+        ShellCommands::SuggestName { workspace, node } => {
+            if let Some(node) = node {
+                let registration = client.node_registration(node)?;
+                let result = client.route_node_host_service(
+                    &registration.node_id,
+                    protocol::HostServiceOperation::SuggestShellName {
+                        workspace_id: workspace.clone(),
+                    },
+                )?;
+                let protocol::HostServiceResult::ShellName { workspace_id, name } = result else {
+                    return Err("remote Node returned an unexpected shell-name response".into());
+                };
+                if json {
+                    return print_json(
+                        CommandKey::ShellSuggestName,
+                        serde_json::json!({
+                            "node_id": registration.node_id,
+                            "workspace_id": workspace_id,
+                            "name": name,
+                        }),
+                    );
+                }
+                println!(
+                    "Suggested shell name {name} for {workspace_id} on Node {}",
+                    registration.alias
+                );
+                println!(
+                    "This suggestion is not reserved; shell creation can still fail if the name is already in use."
+                );
+                return Ok(());
+            }
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &workspace)?;
             let name =
@@ -4627,7 +5148,52 @@ fn launcher_command(command: LauncherCommands, json: bool) -> Result<(), Box<dyn
             println!("CWD\t{}", launcher.cwd.display());
             println!("COMMAND\t{}", launcher.command.join(" "));
         }
-        LauncherCommands::Invoke { target, workspace } => {
+        LauncherCommands::Invoke {
+            target,
+            workspace,
+            node,
+        } => {
+            if let Some(node) = node {
+                let registration = client.node_registration(node)?;
+                let launcher = match client.route_node_operation(
+                    &registration.node_id,
+                    protocol::RoutedOperation::GetLauncher {
+                        launcher_id: target.clone(),
+                    },
+                )? {
+                    protocol::RoutedOperationResult::Launcher { launcher } => launcher,
+                    _ => return Err("remote Node returned an unexpected launcher response".into()),
+                };
+                if let Some(workspace) = workspace.as_deref()
+                    && workspace != launcher.workspace_id
+                {
+                    return Err(cli_output::failure(
+                        "invalid_argument",
+                        "launcher is not owned by the requested workspace",
+                    ));
+                }
+                let workspace_snapshot = match client.route_node_operation(
+                    &registration.node_id,
+                    protocol::RoutedOperation::GetWorkspace {
+                        workspace_id: launcher.workspace_id.clone(),
+                    },
+                )? {
+                    protocol::RoutedOperationResult::Workspace { workspace } => workspace,
+                    _ => return Err("remote Node returned an unexpected workspace response".into()),
+                };
+                client.route_node_host_service(
+                    &registration.node_id,
+                    protocol::HostServiceOperation::InvokeLauncher {
+                        workspace_id: launcher.workspace_id.clone(),
+                        launcher_id: launcher.id.clone(),
+                    },
+                )?;
+                println!(
+                    "Launched {} from {} on Node {}",
+                    launcher.name, workspace_snapshot.name, registration.alias
+                );
+                return Ok(());
+            }
             let snapshot = client.snapshot()?;
             let launcher = resolve_cli_launcher(&snapshot, &target, workspace.as_deref())?;
             let workspace = snapshot
@@ -4895,9 +5461,18 @@ fn attention_command(command: AttentionCommands, json: bool) -> Result<(), Box<d
 fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     validate_session_protocol(client.protocol_version()?)?;
+    let selected_node = match &command {
+        SessionCommands::List { node, .. }
+        | SessionCommands::Inspect { node, .. }
+        | SessionCommands::Resume { node, .. } => node.as_deref(),
+    };
+    if let Some(node) = selected_node {
+        let registration = client.node_registration(node)?;
+        return remote_session_command(&client, &registration, command, json);
+    }
     let snapshot = client.snapshot()?;
     match command {
-        SessionCommands::List { workspace } => {
+        SessionCommands::List { workspace, .. } => {
             let selected_workspace = workspace
                 .as_deref()
                 .map(|target| resolve_workspace_target(&snapshot.workspaces, target))
@@ -4946,7 +5521,7 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
                 );
             }
         }
-        SessionCommands::Inspect { session_id } => {
+        SessionCommands::Inspect { session_id, .. } => {
             let catalog = discover_host_catalog(&snapshot.workspaces);
             let sessions =
                 session_projection::project_snapshot_with_catalog(&snapshot, Some(&catalog));
@@ -4972,6 +5547,134 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
                 );
             }
             print_session(session);
+        }
+        SessionCommands::Resume { session_id, .. } => {
+            let catalog = discover_host_catalog(&snapshot.workspaces);
+            let sessions =
+                session_projection::project_snapshot_with_catalog(&snapshot, Some(&catalog));
+            let session =
+                session_projection::resolve_exact(&sessions, &session_id).map_err(|_| {
+                    cli_output::failure("not_found", format!("session not found: {session_id}"))
+                })?;
+            let (cwd, command) = dashboard_session_resume_plan(session)
+                .map_err(|message| cli_output::failure("invalid_argument", message))?;
+            let terminal = effective_terminal(None)?;
+            terminal::open_command(
+                terminal.as_deref(),
+                &cwd,
+                &format!(
+                    "{} - {} session",
+                    session.workspace_name, session.integration
+                ),
+                &command,
+            )?;
+            println!("Opened exact {} Agent Session", session.integration);
+        }
+    }
+    Ok(())
+}
+
+fn remote_session_command(
+    client: &client::Client,
+    registration: &protocol::NodeRegistrationSnapshot,
+    command: SessionCommands,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    match command {
+        SessionCommands::List { workspace, .. } => {
+            let result = client.route_node_host_service(
+                &registration.node_id,
+                protocol::HostServiceOperation::ListAgentSessions {
+                    workspace_id: workspace,
+                },
+            )?;
+            let protocol::HostServiceResult::AgentSessions { sessions } = result else {
+                return Err("remote Node returned an unexpected session-list response".into());
+            };
+            if json {
+                return print_json(
+                    CommandKey::SessionList,
+                    serde_json::json!({ "node_id": registration.node_id, "sessions": sessions }),
+                );
+            }
+            println!(
+                "WORKSPACE\tDESCRIPTION\tSESSION ID\tINTEGRATION\tSTATE\tLAST ACTIVITY MS\tOCCURRENCES"
+            );
+            for session in sessions {
+                println!(
+                    "{}\t{}\t{}\t{}\t{} ({})\t{}\t{}",
+                    session.workspace_name,
+                    session.description,
+                    session.id,
+                    session.integration,
+                    cli_output::agent_state(session.state),
+                    if session.state_is_current {
+                        "current"
+                    } else {
+                        "last-known"
+                    },
+                    session.last_at_ms,
+                    session.occurrence_count,
+                );
+            }
+        }
+        SessionCommands::Inspect { session_id, .. } => {
+            let result = client.route_node_host_service(
+                &registration.node_id,
+                protocol::HostServiceOperation::InspectAgentSession { session_id },
+            )?;
+            let protocol::HostServiceResult::AgentSession { session } = result else {
+                return Err("remote Node returned an unexpected session response".into());
+            };
+            if json {
+                let mut value = serde_json::to_value(&session.summary)?;
+                let object = value
+                    .as_object_mut()
+                    .expect("session summary serializes as object");
+                object.insert(
+                    "source_cwd".into(),
+                    serde_json::to_value(&session.source_cwd)?,
+                );
+                object.insert(
+                    "occurrences".into(),
+                    serde_json::to_value(&session.occurrences)?,
+                );
+                return print_json(
+                    CommandKey::SessionInspect,
+                    serde_json::json!({ "node_id": registration.node_id, "session": value }),
+                );
+            }
+            println!("NODE\t{}", registration.alias);
+            println!("ID\t{}", session.summary.id);
+            println!("WORKSPACE\t{}", session.summary.workspace_name);
+            println!("DESCRIPTION\t{}", session.summary.description);
+            println!("INTEGRATION\t{}", session.summary.integration);
+            println!("OCCURRENCES\t{}", session.summary.occurrence_count);
+        }
+        SessionCommands::Resume { session_id, .. } => {
+            let result = client.route_node_host_service(
+                &registration.node_id,
+                protocol::HostServiceOperation::InspectAgentSession {
+                    session_id: session_id.clone(),
+                },
+            )?;
+            let protocol::HostServiceResult::AgentSession { session } = result else {
+                return Err("remote Node returned an unexpected session response".into());
+            };
+            let terminal = effective_terminal(None)?;
+            terminal::open_agent_session(
+                terminal.as_deref(),
+                Some(&registration.node_id),
+                &session_id,
+                &format!(
+                    "[{}] {} - {} session",
+                    registration.alias, session.summary.workspace_name, session.summary.integration,
+                ),
+            )?;
+            println!(
+                "Opened exact {} Agent Session on Node {}",
+                session.summary.integration, registration.alias
+            );
         }
     }
     Ok(())
@@ -8138,6 +8841,7 @@ mod tests {
                 command: LauncherCommands::Invoke {
                     target,
                     workspace: Some(workspace),
+                    ..
                 }
             }) if target == "editor" && workspace == "project"
         ));
@@ -8146,7 +8850,7 @@ mod tests {
                 .unwrap()
                 .command,
             Some(Commands::Workspace {
-                command: WorkspaceCommands::Open { target }
+                command: WorkspaceCommands::Open { target, .. }
             }) if target == "project"
         ));
         let cli = Cli::try_parse_from([
@@ -8173,7 +8877,7 @@ mod tests {
                 .unwrap()
                 .command,
             Some(Commands::Shell {
-                command: ShellCommands::SuggestName { workspace }
+                command: ShellCommands::SuggestName { workspace, .. }
             }) if workspace == "project"
         ));
         assert!(matches!(
@@ -8520,7 +9224,8 @@ mod tests {
             list.command,
             Some(Commands::Session {
                 command: SessionCommands::List {
-                    workspace: Some(workspace)
+                    workspace: Some(workspace),
+                    ..
                 }
             }) if workspace == "project"
         ));
@@ -9579,7 +10284,8 @@ mod tests {
             status.command,
             Some(Commands::Integration {
                 command: IntegrationCommands::Status {
-                    integration: Some(integration_management::IntegrationId::Pi)
+                    integration: Some(integration_management::IntegrationId::Pi),
+                    ..
                 }
             })
         ));
@@ -9596,6 +10302,7 @@ mod tests {
                     all: false,
                     force: true,
                     dry_run: false,
+                    ..
                 }
             })
         ));
@@ -9618,6 +10325,7 @@ mod tests {
                     all: false,
                     force: false,
                     dry_run: true,
+                    ..
                 }
             })
         ));
@@ -9639,6 +10347,7 @@ mod tests {
                     integration: Some(integration_management::IntegrationId::Opencode),
                     all: false,
                     force: true,
+                    ..
                 }
             })
         ));
@@ -9655,6 +10364,7 @@ mod tests {
                     integration: integration_management::IntegrationId::Pi,
                     yes: true,
                     force: true,
+                    ..
                 }
             })
         ));
@@ -9684,6 +10394,7 @@ mod tests {
                     integration: integration_management::IntegrationId::Opencode,
                     shell: Some(ref shell),
                     wait_ms: 0,
+                    ..
                 }
             }) if shell == "s1"
         ));
@@ -10136,7 +10847,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 35);
+        assert_eq!(protocol::PROTOCOL_VERSION, 36);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 35;
+pub const PROTOCOL_VERSION: u32 = 36;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -147,6 +147,15 @@ define_protocol_features! {
         "remote_pty_attachment",
         "owner_environment_attachment",
     ]),
+    NodeHostServices => (36, "Node host services", [
+        "protocol_36",
+        "typed_node_host_services",
+        "remote_project_discovery",
+        "remote_launcher_invocation",
+        "remote_integration_management",
+        "remote_agent_session_catalog",
+        "remote_exact_session_resume",
+    ]),
 }
 
 pub const DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 100;
@@ -154,6 +163,196 @@ pub const MAX_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 1_000;
 pub const MAX_SCHEDULED_EXECUTION_SCHEDULE_PROJECTIONS: u16 = 100;
 pub const MAX_NODE_PROJECTION_EXECUTIONS: u16 = 1_000;
 pub const MAX_NODE_PROJECTION_TRANSITIONS: u16 = 256;
+pub const MAX_HOST_SERVICE_PROJECTS: usize = 2_000;
+pub const MAX_HOST_SERVICE_WARNINGS: usize = 64;
+pub const MAX_HOST_SERVICE_SESSIONS: usize = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostServiceIntegrationAction {
+    Install,
+    Uninstall,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
+pub enum HostServiceOperation {
+    DiscoverProjects,
+    ResolveDirectory {
+        path: PathBuf,
+    },
+    SuggestShellName {
+        workspace_id: String,
+    },
+    InvokeLauncher {
+        workspace_id: String,
+        launcher_id: String,
+    },
+    IntegrationStatus {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        integration: Option<String>,
+    },
+    PreviewIntegrationMutation {
+        action: HostServiceIntegrationAction,
+        integrations: Vec<String>,
+        force: bool,
+    },
+    CommitIntegrationMutation {
+        preview_token: String,
+    },
+    VerifyIntegration {
+        integration: String,
+        shell_id: String,
+        run_id: String,
+    },
+    ListAgentSessions {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_id: Option<String>,
+    },
+    InspectAgentSession {
+        session_id: String,
+    },
+    ResolveAgentSession {
+        workspace_id: String,
+        agent_id: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostProjectSnapshot {
+    pub name: String,
+    pub path: PathBuf,
+    pub group: String,
+    pub group_order: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostProjectDiscovery {
+    pub roots_configured: bool,
+    pub projects: Vec<HostProjectSnapshot>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostIntegrationStatus {
+    pub name: String,
+    pub display_name: String,
+    pub package: String,
+    pub validated_version: String,
+    pub host_state: String,
+    pub executable: Option<String>,
+    pub version: Option<String>,
+    pub compatibility: String,
+    pub host_error: Option<String>,
+    pub asset_state: String,
+    pub path: Option<String>,
+    pub asset_error: Option<String>,
+    pub runtime_state: String,
+    pub running_processes: usize,
+    pub tracked_processes: usize,
+    pub untracked_processes: usize,
+    pub recommended_action: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostIntegrationPlan {
+    pub name: String,
+    pub current_state: String,
+    pub action: String,
+    pub path: String,
+    pub restart_required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostIntegrationMutationPreview {
+    pub token: String,
+    pub action: HostServiceIntegrationAction,
+    pub force: bool,
+    pub plans: Vec<HostIntegrationPlan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostIntegrationMutationResult {
+    pub name: String,
+    pub result: String,
+    pub path: String,
+    pub restart_required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostAgentSessionSummary {
+    pub id: String,
+    pub workspace_id: String,
+    pub workspace_name: String,
+    pub description: String,
+    pub integration: String,
+    pub external_session_id: Option<String>,
+    pub state: AgentState,
+    pub state_is_current: bool,
+    pub started_at_ms: u64,
+    pub last_at_ms: u64,
+    pub occurrence_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostAgentSessionInspection {
+    pub summary: HostAgentSessionSummary,
+    pub source_cwd: Option<PathBuf>,
+    pub occurrences: Vec<AgentInstanceSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostAgentSessionResumePlan {
+    pub session_id: String,
+    pub workspace_id: String,
+    pub workspace_name: String,
+    pub integration: String,
+    pub cwd: PathBuf,
+    pub argv: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case", deny_unknown_fields)]
+pub enum HostServiceResult {
+    Projects {
+        discovery: HostProjectDiscovery,
+    },
+    Directory {
+        path: PathBuf,
+    },
+    ShellName {
+        workspace_id: String,
+        name: String,
+    },
+    LauncherInvoked {
+        workspace_id: String,
+        launcher_id: String,
+    },
+    IntegrationStatus {
+        integrations: Vec<HostIntegrationStatus>,
+    },
+    IntegrationMutationPreview {
+        preview: HostIntegrationMutationPreview,
+    },
+    IntegrationMutation {
+        integrations: Vec<HostIntegrationMutationResult>,
+    },
+    IntegrationVerified {
+        integration: String,
+        shell_id: String,
+        run_id: String,
+        agents: Vec<AgentInstanceSnapshot>,
+    },
+    AgentSessions {
+        sessions: Vec<HostAgentSessionSummary>,
+    },
+    AgentSession {
+        session: HostAgentSessionInspection,
+    },
+    ResolvedAgentSession {
+        session: HostAgentSessionSummary,
+    },
+}
 
 pub fn protocol_capabilities() -> impl Iterator<Item = &'static str> {
     ProtocolFeature::ALL
@@ -1626,6 +1825,13 @@ pub enum Request {
         node_id: String,
         operation: RoutedOperation,
     },
+    HostService {
+        operation: HostServiceOperation,
+    },
+    RouteNodeHostService {
+        node_id: String,
+        operation: HostServiceOperation,
+    },
     Restart,
     RestartWithNotificationConfig {
         notifications: NotificationDeliveryConfig,
@@ -1866,6 +2072,15 @@ pub enum Request {
         expected_run_id: Option<String>,
         profile: TerminalProfile,
     },
+    ResumeAgentSession {
+        session_id: String,
+        profile: TerminalProfile,
+    },
+    ResumeNodeAgentSession {
+        node_id: String,
+        session_id: String,
+        profile: TerminalProfile,
+    },
 }
 
 impl Request {
@@ -1896,6 +2111,10 @@ impl Request {
             | Self::GuardedPauseAgentSchedule { .. }
             | Self::GuardedResumeAgentSchedule { .. }
             | Self::GuardedRemoveAgentSchedule { .. } => Some(ProtocolFeature::GuardedNodeRouting),
+            Self::HostService { .. }
+            | Self::RouteNodeHostService { .. }
+            | Self::ResumeAgentSession { .. }
+            | Self::ResumeNodeAgentSession { .. } => Some(ProtocolFeature::NodeHostServices),
             Self::AttachNode { .. }
             | Self::Attach {
                 owner_environment: true,
@@ -2024,6 +2243,9 @@ pub enum Response {
     },
     RoutedNodeOperation {
         result: RoutedOperationResult,
+    },
+    HostService {
+        result: HostServiceResult,
     },
     Snapshot {
         snapshot: Snapshot,
@@ -2639,8 +2861,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_thirty_five_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 35);
+    fn protocol_version_is_thirty_six_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 36);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -3532,6 +3754,27 @@ mod tests {
                     },
                 ],
             ),
+            (
+                36,
+                vec![
+                    Request::HostService {
+                        operation: HostServiceOperation::DiscoverProjects,
+                    },
+                    Request::RouteNodeHostService {
+                        node_id: "node-1".into(),
+                        operation: HostServiceOperation::DiscoverProjects,
+                    },
+                    Request::ResumeAgentSession {
+                        session_id: "session-1".into(),
+                        profile: test_profile(),
+                    },
+                    Request::ResumeNodeAgentSession {
+                        node_id: "node-1".into(),
+                        session_id: "session-1".into(),
+                        profile: test_profile(),
+                    },
+                ],
+            ),
         ];
 
         for (expected, requests) in groups {
@@ -3670,6 +3913,18 @@ mod tests {
                     "protocol_35",
                     "remote_pty_attachment",
                     "owner_environment_attachment",
+                ][..],
+            ),
+            (
+                36,
+                &[
+                    "protocol_36",
+                    "typed_node_host_services",
+                    "remote_project_discovery",
+                    "remote_launcher_invocation",
+                    "remote_integration_management",
+                    "remote_agent_session_catalog",
+                    "remote_exact_session_resume",
                 ][..],
             ),
         ];

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -111,6 +111,26 @@ pub(crate) fn open_command(
     )
 }
 
+pub(crate) fn open_agent_session(
+    desktop_entry: Option<&str>,
+    node_id: Option<&str>,
+    session_id: &str,
+    title: &str,
+) -> Result<(), Box<dyn Error>> {
+    let executable = attachment_executable()?;
+    let mut arguments = vec!["__resume-session".into(), session_id.into()];
+    if let Some(node_id) = node_id {
+        arguments.extend(["--node".into(), node_id.into()]);
+    }
+    launch(
+        desktop_entry,
+        title,
+        None,
+        executable.as_os_str(),
+        &arguments,
+    )
+}
+
 fn terminal_command_arguments(command: &[String]) -> Option<(&OsStr, Vec<OsString>)> {
     let (program, arguments) = command.split_first()?;
     (!program.is_empty()).then(|| {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -555,6 +555,17 @@ impl WorkspaceView {
                     .any(|capability| capability == "remote_pty_attachment"))
     }
 
+    fn launcher_invokable(&self) -> bool {
+        self.local_actionable()
+            || (self.node.current
+                && !self.node.stale
+                && self
+                    .node
+                    .observed_capabilities
+                    .iter()
+                    .any(|capability| capability == "typed_node_host_services"))
+    }
+
     fn shell_count(&self) -> usize {
         self.items
             .iter()
@@ -2627,10 +2638,12 @@ impl App {
                 .shell_attachable()
                 .then(|| OpenTarget::Shell(workspace.qualify(&agent_shell.shell.id))),
             WorkspaceItemView::Launcher(launcher) => {
-                workspace.local_actionable().then(|| OpenTarget::Launcher {
-                    workspace_id,
-                    launcher_id: workspace.qualify(&launcher.id),
-                })
+                workspace
+                    .launcher_invokable()
+                    .then(|| OpenTarget::Launcher {
+                        workspace_id,
+                        launcher_id: workspace.qualify(&launcher.id),
+                    })
             }
             WorkspaceItemView::Schedule(_) => None,
         })?;

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -20,6 +20,8 @@ mod protocol_control;
 mod remote_attachment;
 #[path = "native_backend/remote_bootstrap.rs"]
 mod remote_bootstrap;
+#[path = "native_backend/remote_host_services.rs"]
+mod remote_host_services;
 #[path = "native_backend/schedules.rs"]
 mod schedules;
 #[path = "native_backend/shell_lifecycle.rs"]

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 35);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 36);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -125,6 +125,7 @@ fn native_daemon_lifecycle() {
         "protocol_33",
         "protocol_34",
         "protocol_35",
+        "protocol_36",
         "node_registration_management",
         "node_projection_sync",
         "bounded_remote_node_projections",
@@ -134,6 +135,12 @@ fn native_daemon_lifecycle() {
         "guarded_remote_management",
         "remote_pty_attachment",
         "owner_environment_attachment",
+        "typed_node_host_services",
+        "remote_project_discovery",
+        "remote_launcher_invocation",
+        "remote_integration_management",
+        "remote_agent_session_catalog",
+        "remote_exact_session_resume",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -168,7 +175,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 35"));
+    assert!(status_text.contains("running (protocol 36"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -928,7 +935,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 35);
+    assert_eq!(handshake.core_protocol_version, 36);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc

--- a/tests/native_backend/remote_host_services.rs
+++ b/tests/native_backend/remote_host_services.rs
@@ -1,0 +1,281 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+use boomux::protocol::{
+    AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame,
+    HostServiceIntegrationAction, HostServiceOperation, HostServiceResult, ShellSpec,
+    WorkspaceLauncherSpec,
+};
+
+use crate::support::{TestDaemon, profile, wait_until};
+
+#[test]
+fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-host-services-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    let ssh_bin = root.join("ssh-bin");
+    let owner_bin = root.join("owner-bin");
+    let owner_projects = root.join("owner-projects");
+    let owner_config = root.join("owner-config.toml");
+    fs::create_dir_all(&ssh_bin).unwrap();
+    fs::create_dir_all(&owner_bin).unwrap();
+    fs::create_dir_all(owner_projects.join("remote-only/.git")).unwrap();
+    fs::write(
+        &owner_config,
+        format!(
+            "[projects]\nroots = [{}]\nmax_depth = 1\n",
+            toml::Value::String(owner_projects.display().to_string())
+        ),
+    )
+    .unwrap();
+    let output = root.join("owner-launcher-output");
+    let launcher = owner_bin.join("capture-launcher");
+    fs::write(
+        &launcher,
+        "#!/bin/sh\nprintf '%s\\n%s\\n%s\\n' \"$PWD\" \"$1\" \"$2\" > \"$3\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&launcher, fs::Permissions::from_mode(0o700)).unwrap();
+    let resume_output = root.join("owner-resume-output");
+    let pi = owner_bin.join("pi");
+    fs::write(
+        &pi,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n%s\\n%s\\n' \"$1\" \"$2\" \"$PWD\" > '{}'\nprintf 'owner resume\\n'\n",
+            resume_output.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&pi, fs::Permissions::from_mode(0o700)).unwrap();
+
+    let owner_path = format!("{}:/usr/bin:/bin", owner_bin.display());
+    let mut owner = TestDaemon::start_with(|command, _| {
+        command
+            .env("PATH", &owner_path)
+            .env("BOOMUX_CONFIG", &owner_config)
+            .env("HOME", root.join("owner-home"));
+    });
+    let owner_id = owner.client.node_identity().unwrap();
+
+    let ssh = ssh_bin.join("ssh");
+    fs::write(
+        &ssh,
+        format!(
+            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}\\0' ;;\n  *__federation-stdio*) exec env XDG_RUNTIME_DIR='{}' XDG_STATE_HOME='{}' '{}' __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
+            owner.executable.display(),
+            owner.executable.display(),
+            owner.runtime_dir.display(),
+            owner.runtime_dir.join("state").display(),
+            owner.executable.display(),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+
+    let local_path = format!("{}:/usr/bin:/bin", ssh_bin.display());
+    let mut local = TestDaemon::start_with(|command, _| {
+        command
+            .env("PATH", &local_path)
+            .env("HOME", root.join("local-home"));
+    });
+    local
+        .client
+        .add_node_registration("owner", "fake-owner", &owner_id)
+        .unwrap();
+
+    let workspace = owner
+        .client
+        .create_workspace("remote-host", Vec::new())
+        .unwrap();
+    let exact_argument = "$(touch local-pwned); semi; colon";
+    let stored_launcher = owner
+        .client
+        .create_launcher(
+            &workspace.id,
+            WorkspaceLauncherSpec {
+                name: "capture".into(),
+                cwd: owner_projects.join("remote-only"),
+                command: vec![
+                    launcher.display().to_string(),
+                    exact_argument.into(),
+                    "two words".into(),
+                    output.display().to_string(),
+                ],
+            },
+        )
+        .unwrap();
+
+    let projects = local
+        .client
+        .route_node_host_service(&owner_id, HostServiceOperation::DiscoverProjects)
+        .unwrap();
+    let HostServiceResult::Projects { discovery } = projects else {
+        panic!("unexpected project response");
+    };
+    assert_eq!(discovery.projects.len(), 1);
+    assert_eq!(discovery.projects[0].name, "remote-only");
+    assert!(discovery.projects[0].path.starts_with(&owner_projects));
+
+    let invoked = local
+        .client
+        .route_node_host_service(
+            &owner_id,
+            HostServiceOperation::InvokeLauncher {
+                workspace_id: workspace.id.clone(),
+                launcher_id: stored_launcher.id.clone(),
+            },
+        )
+        .unwrap();
+    assert!(matches!(invoked, HostServiceResult::LauncherInvoked { .. }));
+    wait_until(
+        || output.is_file(),
+        "owner-side launcher did not produce its output",
+    );
+    assert_eq!(
+        fs::read_to_string(&output).unwrap(),
+        format!(
+            "{}\n{}\ntwo words\n",
+            owner_projects.join("remote-only").display(),
+            exact_argument,
+        )
+    );
+    assert!(!root.join("local-pwned").exists());
+
+    let session_workspace = owner
+        .client
+        .create_workspace(
+            "remote-session",
+            vec![ShellSpec {
+                name: "pi".into(),
+                command: vec!["/bin/sh".into(), "-c".into(), "sleep 30".into()],
+                cwd: owner_projects.join("remote-only"),
+            }],
+        )
+        .unwrap();
+    let shell_id = session_workspace.shells[0].id.clone();
+    let owner_attachment = owner.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = owner.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+    let hostile_session_id = "pi-exact; touch local-session-pwned";
+    let agent = owner
+        .client
+        .ensure_agent(
+            &shell_id,
+            &run_id,
+            AgentRegistrationSpec {
+                name: "owner pi".into(),
+                integration: "pi".into(),
+                external_session_id: Some(hostile_session_id.into()),
+                report: AgentReport {
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "owner catalog".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    owner
+        .client
+        .report_agent(
+            &agent.id,
+            &run_id,
+            AgentReport {
+                state: AgentState::Inactive,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "owner shutdown".into(),
+                confidence: 100,
+            },
+        )
+        .unwrap();
+    let sessions = local
+        .client
+        .route_node_host_service(
+            &owner_id,
+            HostServiceOperation::ListAgentSessions {
+                workspace_id: Some(session_workspace.id.clone()),
+            },
+        )
+        .unwrap();
+    let HostServiceResult::AgentSessions { sessions } = sessions else {
+        panic!("unexpected Agent Session response");
+    };
+    assert_eq!(sessions.len(), 1);
+    let mut resumed = local
+        .client
+        .resume_agent_session(Some(&owner_id), &sessions[0].id, profile())
+        .unwrap();
+    let mut terminal_output = Vec::new();
+    loop {
+        match AttachFrame::read_from(&mut resumed.stream).unwrap() {
+            AttachFrame::Output(bytes) => terminal_output.extend(bytes),
+            AttachFrame::Detached => break,
+            _ => {}
+        }
+    }
+    assert!(String::from_utf8_lossy(&terminal_output).contains("owner resume"));
+    assert_eq!(
+        fs::read_to_string(&resume_output).unwrap(),
+        format!(
+            "--session\n{}\n{}\n",
+            hostile_session_id,
+            owner_projects.join("remote-only").display(),
+        )
+    );
+    assert!(!root.join("local-session-pwned").exists());
+    assert!(local.client.snapshot().unwrap().workspaces.is_empty());
+    drop(owner_attachment);
+
+    let preview = local
+        .client
+        .route_node_host_service(
+            &owner_id,
+            HostServiceOperation::PreviewIntegrationMutation {
+                action: HostServiceIntegrationAction::Install,
+                integrations: vec!["pi".into()],
+                force: false,
+            },
+        )
+        .unwrap();
+    let HostServiceResult::IntegrationMutationPreview { preview } = preview else {
+        panic!("unexpected integration preview response");
+    };
+    let pi_asset = root.join("owner-home/.pi/agent/extensions/boomux.js");
+    fs::create_dir_all(pi_asset.parent().unwrap()).unwrap();
+    fs::write(&pi_asset, "owner customization").unwrap();
+    assert!(
+        local
+            .client
+            .route_node_host_service(
+                &owner_id,
+                HostServiceOperation::CommitIntegrationMutation {
+                    preview_token: preview.token,
+                },
+            )
+            .is_err()
+    );
+    assert_eq!(fs::read_to_string(pi_asset).unwrap(), "owner customization");
+
+    let unsupported = boomux::protocol::Envelope::with_version(
+        35,
+        boomux::protocol::Request::HostService {
+            operation: HostServiceOperation::DiscoverProjects,
+        },
+    );
+    assert_eq!(
+        unsupported
+            .message
+            .required_feature()
+            .unwrap()
+            .minimum_version(),
+        36
+    );
+
+    local.stop_with_cli();
+    owner.stop_with_cli();
+    std::thread::sleep(Duration::from_millis(10));
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
## Summary

- add protocol 36 closed typed owner-host services
- resolve projects, paths, names, launchers, integrations, and Agent Sessions on the owning Node
- bind integration mutation commits to expiring preview tokens and observed file state
- execute exact launcher argv/cwd only on the owner
- resume exact opaque Agent Sessions through local presentation without local execution
- keep private host data transient and out of projections, persistence, and events
- fail unsupported remote services without local emulation

## Stack

- GitHub stack #190
- depends on #202
- implements #181

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`

Closes #181

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
