### PR TITLE
feat(node): manage owner-evaluated schedules

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,8 @@ Protocol 35 adds Node-qualified native-terminal attachment and owner-environment
 startup for remote pending and exited Shells.
 Protocol 36 adds closed typed Node host services and owner-executed exact Agent
 Session resume.
+Protocol 37 adds Node-qualified remote Agent Schedule creation and bounded
+Scheduled Execution observation without adding local scheduler authority.
 
 ## Components
 
@@ -614,6 +616,14 @@ and observed asset states still match. Exact Session resume resolves the opaque
 projected ID and constructs cwd/argv on the owner, then relays bounded attachment
 frames to a local native terminal without creating a Workspace or Shell. Host
 service responses do not update Node projection cache or publish events.
+Protocol 37 extends the closed routed operation union with owner-side Schedule
+creation and bounded execution list/wait reads. Remote creation resolves the
+Workspace through a fresh owner read, validates cwd and any continuation Session
+through protocol-36 owner host services, and sends the prompt only in the
+transient owner mutation request. Creation is not retried after channel loss;
+run-now remains the only Schedule write retried, using the unchanged dispatch
+key. The local scheduler never evaluates, dispatches, or retries remote work.
+
 Protocol-25 lists are daemon-bounded, newest-first pages with explicit limit and
 truncation. The request limit is optional on the wire; protocol 25 defaults it to
 100 and clamps it to 1 through 1,000, while protocol-23 and protocol-24 requests

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -75,6 +75,12 @@ unsupported owners fail visibly and are never emulated against local PATH,
 configuration, catalogs, or filesystems. Responses are live and transient and do
 not update the cached Node projection.
 
+Protocol 37 advertises `remote_agent_schedule_management` and
+`remote_scheduled_execution_observation`. Schedule and execution commands accept
+`--node SELECTOR`; their JSON adds exact `node_id`. Remote Schedule list is the
+prompt-free reduced projection and includes Node freshness, health, observation
+time, and scheduler health. Exact reads and all mutations are live owner-routed.
+
 That passive command advertises only what the installed local CLI can speak and
 never reports negotiated state for a registered Node. Implemented `node.list`
 and `node.inspect` return registration data only. Future combined projection data
@@ -329,6 +335,8 @@ Protocol 36 adds `protocol_36`, `typed_node_host_services`,
 `remote_project_discovery`, `remote_launcher_invocation`,
 `remote_integration_management`, `remote_agent_session_catalog`, and
 `remote_exact_session_resume`.
+Protocol 37 adds `protocol_37`, `remote_agent_schedule_management`, and
+`remote_scheduled_execution_observation`.
 
 Node snapshot health is `unobserved`, `online`, `reconnecting`, `stale`,
 `unreachable`, `authentication_required`, `identity_changed`,
@@ -560,6 +568,11 @@ Schedule management commands require negotiated daemon protocol 22. `schedule
 run` and every `execution` command require protocol 23. Unsupported commands
 return `unsupported_version` rather than presenting empty data.
 `execution wait` specifically requires protocol 25.
+Node-qualified Schedule and execution commands require protocol 37 on the local
+coordinator and owner. Remote JSON responses add exact `node_id`; remote list
+presentation also reports Node freshness and per-Node scheduler health. Remote
+create reads prompt files locally once, validates cwd and continuation Session on
+the owner, and never stores the prompt in the presenting Node's projection.
 
 Only `schedule.inspect` adds `prompt`. Prompts are intentionally absent from
 list, create, pause, resume, remove, run, execution records, capabilities,

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -38,6 +38,9 @@ Protocol 26 adds exact-run attachment, and protocol 27 adds optimistic paused
 schedule-definition updates with prompt-free update events.
 Protocol 32 adds owner-side reduced Node projection cuts and the local
 `node_projection_changed` cache invalidation event.
+Protocol 37 adds remote Schedule management and execution observation without a
+new event kind: owner events remain owner-local and the presenting Node receives
+only its existing projection invalidation.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -16,6 +16,8 @@
 > reads and guarded management operations. Protocol 35 implements Node-qualified
 > native-terminal PTY attachment and owner-environment remote startup. Protocol
 > 36 implements closed typed owner host services and exact Agent Session resume.
+> Protocol 37 implements Node-qualified remote Schedule creation, management,
+> execution observation, and presentation.
 > Public `boomux --remote TARGET`
 > remains ad hoc.
 
@@ -443,6 +445,21 @@ when it recovers and projects the resulting durable decision. Another Node canno
 substitute its context or continue an external Agent Session implicitly. Future
 failover requires a separate explicit placement and portability contract; the
 initial model neither promises nor emulates it.
+
+Protocol 37 exposes prompt-free projected Schedule and bounded execution state
+only for presentation. Exact inspection, creation, editing, run-now, pause,
+resume, removal, execution list/inspect/wait/cancel, and Open all use a fresh
+identity-verified owner channel. Remote creation validates cwd and an optional
+opaque continuation Session on the owner before committing. Prompt content is
+transient routing input and is never added to the Node cache, projection events,
+notifications, or routing diagnostics. A lost create response is
+`outcome_unknown`; only run-now retries, with its exact durable dispatch key.
+
+Starting and Active Open re-fetches the exact execution, Shell, run, and
+ownership links before launching protocol-35 Node attachment with the
+protocol-26 expected run. Terminal Open freshly resolves the exact linked Agent
+occurrence and uses protocol-36 owner Session resume. Neither path restarts the
+schedule-owned Shell or chooses a later run or Session.
 
 ## Attention And Notifications
 

--- a/docs/scheduled-agent-work.md
+++ b/docs/scheduled-agent-work.md
@@ -51,7 +51,8 @@ The identities remain separate:
 
 ### Accepted Remote Node Ownership
 
-Remote Node federation is not yet implemented. When it ships, a Schedule belongs
+Remote Node federation is implemented for Schedule presentation and management.
+A Schedule belongs
 to the same Node as its owning Workspace and only that Node evaluates its
 trigger, advances its occurrence frontier, admits concurrency, resolves its
 filesystem and integration, or starts its Scheduled Executions. Local projection
@@ -64,6 +65,15 @@ missed-occurrence policy after recovery and reports the durable result; another
 Node cannot synthesize that decision, substitute its environment, or continue
 its external Agent Session. Any future failover requires a separate explicit
 placement and portability contract. See [`remote-nodes.md`](remote-nodes.md).
+
+Protocol 37 routes exact remote Schedule and Scheduled Execution operations to
+the owner. Reduced projected state remains presentation-only. Remote creation
+uses owner-side path and continuation Session validation; prompt content crosses
+only the explicit transient request and never enters the presenting Node cache,
+events, notifications, or diagnostics. Starting and Active Open attaches to the
+freshly revalidated exact run, while terminal Open resumes the freshly resolved
+exact owner Session. Neither operation restarts the reusable schedule Shell or
+selects a newer identity.
 
 ## Schedule-Owned Shell
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1958,7 +1958,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, 36, 34);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2115,7 +2116,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 36);
+            assert_eq!(request.version, protocol::PROTOCOL_VERSION);
             assert_eq!(request.message, Request::GetNodeIdentity);
             protocol::write_message(
                 &mut stream,
@@ -2129,7 +2130,8 @@ mod tests {
             )
             .unwrap();
 
-            reject_protocol(&listener, 36, 34);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2180,7 +2182,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 36);
+            assert_eq!(request.version, protocol::PROTOCOL_VERSION);
             assert_eq!(request.message, Request::OpenFederationChannel);
             protocol::write_message(
                 &mut stream,
@@ -2194,7 +2196,8 @@ mod tests {
             )
             .unwrap();
 
-            reject_protocol(&listener, 36, 34);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2228,7 +2231,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 36);
+            assert_eq!(request.version, protocol::PROTOCOL_VERSION);
             assert_eq!(request.message, Request::ListNodeRegistrations);
             protocol::write_message(
                 &mut stream,
@@ -2241,7 +2244,8 @@ mod tests {
                 ),
             )
             .unwrap();
-            reject_protocol(&listener, 36, 34);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2418,7 +2422,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, 36, 34);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);
@@ -2490,7 +2495,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, 36, 34);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
             reject_protocol(&listener, 33, 32);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1710,6 +1710,8 @@ fn operation_is_read(operation: &RoutedOperation) -> bool {
             | RoutedOperation::GetAgent { .. }
             | RoutedOperation::GetAgentSchedule { .. }
             | RoutedOperation::GetScheduledExecution { .. }
+            | RoutedOperation::ListScheduledExecutions { .. }
+            | RoutedOperation::WaitScheduledExecution { .. }
     )
 }
 
@@ -1732,6 +1734,24 @@ fn routed_result(response: Response) -> Result<RoutedOperationResult, Box<Respon
             execution,
             next_occurrence,
         }),
+        Response::ScheduledExecutions {
+            executions,
+            limit,
+            truncated,
+            schedules,
+            schedule_limit,
+            schedules_truncated,
+        } => Ok(RoutedOperationResult::ScheduledExecutions {
+            executions,
+            limit,
+            truncated,
+            schedules,
+            schedule_limit,
+            schedules_truncated,
+        }),
+        Response::ScheduledExecutionWait { execution, changed } => {
+            Ok(RoutedOperationResult::ScheduledExecutionWait { execution, changed })
+        }
         Response::AgentAttentionAcknowledged { agent, changed } => {
             Ok(RoutedOperationResult::AgentAttentionAcknowledged { agent, changed })
         }
@@ -1871,6 +1891,15 @@ fn send_registered_node_request(
     registration: &crate::protocol::NodeRegistrationSnapshot,
     request: Request,
 ) -> io::Result<Response> {
+    send_registered_node_request_with_timeout(registration, request, Duration::from_secs(2), None)
+}
+
+fn send_registered_node_request_with_timeout(
+    registration: &crate::protocol::NodeRegistrationSnapshot,
+    request: Request,
+    response_timeout: Duration,
+    route_feature: Option<protocol::ProtocolFeature>,
+) -> io::Result<Response> {
     let target = SshTarget::parse(registration.target.clone())?;
     let helper = match ssh_bootstrap::plan_remote_bootstrap(
         target.clone(),
@@ -1891,7 +1920,7 @@ fn send_registered_node_request(
             "remote Node identity changed",
         ));
     }
-    if let Some(feature) = request.required_feature()
+    if let Some(feature) = route_feature.or_else(|| request.required_feature())
         && !feature.is_supported_by(helper.handshake.core_protocol_version)
     {
         return Err(io::Error::new(
@@ -1905,7 +1934,26 @@ fn send_registered_node_request(
         SshAuthenticationMode::Batch,
         Duration::from_secs(2),
     )?;
-    remote.request(request, Duration::from_secs(2))
+    remote.request(request, response_timeout)
+}
+
+fn routed_response_timeout(operation: &RoutedOperation) -> Duration {
+    match operation {
+        RoutedOperation::WaitScheduledExecution { wait_ms, .. } => {
+            Duration::from_millis(u64::from(*wait_ms)).saturating_add(Duration::from_secs(2))
+        }
+        _ => Duration::from_secs(2),
+    }
+}
+
+fn routed_owner_feature(operation: &RoutedOperation) -> Option<protocol::ProtocolFeature> {
+    matches!(
+        operation,
+        RoutedOperation::CreateAgentSchedule { .. }
+            | RoutedOperation::ListScheduledExecutions { .. }
+            | RoutedOperation::WaitScheduledExecution { .. }
+    )
+    .then_some(protocol::ProtocolFeature::RemoteSchedules)
 }
 
 fn require_guard(actual: u64, expected: u64, resource: &str) -> DaemonResult<()> {
@@ -7427,9 +7475,21 @@ impl DaemonService {
             }
             Err(error) => return node_registration_error(error).into_response(),
         }
-        let mut result = send_registered_node_request(&registration, operation.owner_request());
+        let response_timeout = routed_response_timeout(&operation);
+        let owner_feature = routed_owner_feature(&operation);
+        let mut result = send_registered_node_request_with_timeout(
+            &registration,
+            operation.owner_request(),
+            response_timeout,
+            owner_feature,
+        );
         if result.is_err() && operation.is_retryable() {
-            result = send_registered_node_request(&registration, operation.owner_request());
+            result = send_registered_node_request_with_timeout(
+                &registration,
+                operation.owner_request(),
+                response_timeout,
+                owner_feature,
+            );
         }
         let proven = if result.is_err() && !operation.is_retryable() {
             operation.ambiguity_probe().and_then(|probe| {

--- a/src/dashboard_projection.rs
+++ b/src/dashboard_projection.rs
@@ -116,6 +116,68 @@ pub(crate) fn project_schedules(
     schedules
 }
 
+pub(crate) fn project_remote_executions(
+    executions: &[ScheduledExecutionSnapshot],
+) -> Vec<ExecutionView> {
+    executions
+        .iter()
+        .map(|execution| ExecutionView {
+            id: execution.id.clone(),
+            state: match execution.state {
+                ScheduledExecutionState::Skipped => ExecutionDisplayState::Skipped,
+                ScheduledExecutionState::Claimed => ExecutionDisplayState::Claimed,
+                ScheduledExecutionState::Starting => ExecutionDisplayState::Starting,
+                ScheduledExecutionState::Active => ExecutionDisplayState::Active,
+                ScheduledExecutionState::DispatchFailed => ExecutionDisplayState::DispatchFailed,
+                ScheduledExecutionState::Exited => ExecutionDisplayState::Exited,
+                ScheduledExecutionState::Cancelled => ExecutionDisplayState::Cancelled,
+                ScheduledExecutionState::Interrupted => ExecutionDisplayState::Interrupted,
+            },
+            reason: execution.reason.map(|reason| match reason {
+                ScheduledExecutionReason::Overlap => ExecutionReasonDisplay::Overlap,
+                ScheduledExecutionReason::ActiveSession => ExecutionReasonDisplay::ActiveSession,
+                ScheduledExecutionReason::WorkspaceCapacity => {
+                    ExecutionReasonDisplay::WorkspaceCapacity
+                }
+                ScheduledExecutionReason::GlobalCapacity => ExecutionReasonDisplay::GlobalCapacity,
+                ScheduledExecutionReason::Missed => ExecutionReasonDisplay::Missed,
+                ScheduledExecutionReason::PausedRace => ExecutionReasonDisplay::PausedRace,
+                ScheduledExecutionReason::InvalidTarget => ExecutionReasonDisplay::InvalidTarget,
+                ScheduledExecutionReason::RunnerStartFailed => {
+                    ExecutionReasonDisplay::RunnerStartFailed
+                }
+                ScheduledExecutionReason::HostSpawnFailed => {
+                    ExecutionReasonDisplay::HostSpawnFailed
+                }
+                ScheduledExecutionReason::CancelledByUser => {
+                    ExecutionReasonDisplay::CancelledByUser
+                }
+                ScheduledExecutionReason::ColdDaemonRecovery => {
+                    ExecutionReasonDisplay::ColdDaemonRecovery
+                }
+                ScheduledExecutionReason::RunnerExitedWithoutReport => {
+                    ExecutionReasonDisplay::RunnerExitedWithoutReport
+                }
+                ScheduledExecutionReason::DaemonShutdown => ExecutionReasonDisplay::DaemonShutdown,
+            }),
+            outcome: execution.outcome.as_ref().map(|outcome| match outcome {
+                ScheduledExecutionOutcome::ExitCode { code } => {
+                    ExecutionOutcomeDisplay::ExitCode(*code)
+                }
+                ScheduledExecutionOutcome::Signal { signal } => {
+                    ExecutionOutcomeDisplay::Signal(*signal)
+                }
+            }),
+            requested_at_ms: execution.requested_at_ms,
+            shell_id: execution.shell_id.clone(),
+            run_id: execution.run_id.clone(),
+            agent_id: execution.agent_id.clone(),
+            agent_state: None,
+            session_id: None,
+        })
+        .collect()
+}
+
 fn execution_view(
     workspace: &WorkspaceSnapshot,
     sessions: &[SessionProjection],
@@ -525,7 +587,7 @@ pub(crate) fn project_remote_node(
                     && node
                         .observed_capabilities
                         .iter()
-                        .any(|capability| capability == "guarded_remote_management"),
+                        .any(|capability| capability == "remote_agent_schedule_management"),
                 id: schedule.id.clone(),
                 workspace_id: schedule.workspace_id.clone(),
                 workspace: workspace.into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -766,30 +766,45 @@ enum ScheduleCommands {
     List {
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Inspect a schedule, including its private prompt
     Inspect {
         target: String,
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Mark a schedule paused in durable management state
     Pause {
         target: String,
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Enable future timed dispatch; run-now is independent
     Resume {
         target: String,
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Remove an inactive schedule and its persisted prompt
     Remove {
         target: String,
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Dispatch one execution now, including while paused
     Run {
@@ -798,7 +813,24 @@ enum ScheduleCommands {
         workspace: Option<String>,
         #[arg(long, value_name = "UUID")]
         idempotency_key: Option<Uuid>,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
+}
+
+impl ScheduleCommands {
+    fn node(&self) -> Option<&str> {
+        match self {
+            Self::Create(arguments) => arguments.node.as_deref(),
+            Self::List { node, .. }
+            | Self::Inspect { node, .. }
+            | Self::Pause { node, .. }
+            | Self::Resume { node, .. }
+            | Self::Remove { node, .. }
+            | Self::Run { node, .. } => node.as_deref(),
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -815,9 +847,17 @@ enum ExecutionCommands {
             value_parser = clap::value_parser!(u16).range(1..=protocol::MAX_SCHEDULED_EXECUTION_LIST_LIMIT as i64)
         )]
         limit: u16,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Inspect one execution by exact ID
-    Inspect { execution_id: String },
+    Inspect {
+        execution_id: String,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
     /// Wait for an exact execution revision to advance
     Wait {
         execution_id: String,
@@ -825,11 +865,36 @@ enum ExecutionCommands {
         after_revision: u64,
         #[arg(long, default_value_t = 30_000)]
         wait_ms: u32,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
     },
     /// Open an execution's exact active run or linked Agent Session
-    Open { execution_id: String },
+    Open {
+        execution_id: String,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
     /// Cancel one nonterminal execution by exact ID
-    Cancel { execution_id: String },
+    Cancel {
+        execution_id: String,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
+}
+
+impl ExecutionCommands {
+    fn node(&self) -> Option<&str> {
+        match self {
+            Self::List { node, .. }
+            | Self::Inspect { node, .. }
+            | Self::Wait { node, .. }
+            | Self::Open { node, .. }
+            | Self::Cancel { node, .. } => node.as_deref(),
+        }
+    }
 }
 
 #[derive(Args)]
@@ -900,6 +965,9 @@ struct ScheduleCreateArgs {
     /// Record consent for future timed dispatch
     #[arg(long)]
     enabled: bool,
+    /// Exact registered Node alias or Node ID
+    #[arg(long)]
+    node: Option<String>,
 }
 
 #[derive(Args)]
@@ -2598,6 +2666,7 @@ fn dashboard(
                         .map_err(|error| error.to_string())
                 } else {
                     open_remote_scheduled_execution(&client, &execution_id, terminal.as_deref())
+                        .map(|opened| opened.message)
                         .map_err(|error| error.to_string())
                 };
                 tui::DashboardEvent::OperationCompleted(result)
@@ -2641,24 +2710,50 @@ fn dashboard(
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::LoadScheduleHistory { schedule_id, limit } => {
-                let result = local_dashboard_inner(&schedule_id, &local_node_id).and_then(|id| {
-                    refresh
-                        .load_schedule_history(&client, id, limit)
-                        .map(|(_, truncated)| {
-                            let schedules = dashboard_projection::project_schedules(
-                                refresh.snapshot(),
-                                &refresh.executions(),
-                                refresh.history_truncated,
-                                &refresh.scoped_history,
-                            );
-                            let executions = schedules
-                                .into_iter()
-                                .find(|schedule| schedule.id == schedule_id.inner_id)
-                                .map_or_else(Vec::new, |schedule| schedule.executions);
-                            (executions, truncated)
-                        })
-                        .map_err(|error| error.to_string())
-                });
+                let result =
+                    if schedule_id.node_id == local_node_id || schedule_id.node_id.is_empty() {
+                        refresh
+                            .load_schedule_history(&client, &schedule_id.inner_id, limit)
+                            .map(|(_, truncated)| {
+                                let schedules = dashboard_projection::project_schedules(
+                                    refresh.snapshot(),
+                                    &refresh.executions(),
+                                    refresh.history_truncated,
+                                    &refresh.scoped_history,
+                                );
+                                let executions = schedules
+                                    .into_iter()
+                                    .find(|schedule| schedule.id == schedule_id.inner_id)
+                                    .map_or_else(Vec::new, |schedule| schedule.executions);
+                                (executions, truncated)
+                            })
+                            .map_err(|error| error.to_string())
+                    } else {
+                        client
+                            .route_node_operation(
+                                &schedule_id.node_id,
+                                protocol::RoutedOperation::ListScheduledExecutions {
+                                    workspace_id: None,
+                                    schedule_id: Some(schedule_id.inner_id.clone()),
+                                    limit,
+                                },
+                            )
+                            .map_err(|error| error.to_string())
+                            .and_then(|result| match result {
+                                protocol::RoutedOperationResult::ScheduledExecutions {
+                                    executions,
+                                    truncated,
+                                    ..
+                                } => Ok((
+                                    dashboard_projection::project_remote_executions(&executions),
+                                    truncated,
+                                )),
+                                _ => Err(
+                                    "remote Node returned an unexpected execution history response"
+                                        .into(),
+                                ),
+                            })
+                    };
                 tui::DashboardEvent::ScheduleHistoryCompleted {
                     schedule_id,
                     result,
@@ -3148,7 +3243,7 @@ fn open_remote_scheduled_execution(
     client: &client::Client,
     execution_id: &protocol::QualifiedIdentity,
     terminal: Option<&str>,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<OpenedScheduledExecution, Box<dyn Error>> {
     let execution =
         routed_dashboard_execution(client, execution_id, "").map_err(io::Error::other)?;
     let target = scheduled_execution_open_target(&execution)
@@ -3174,10 +3269,14 @@ fn open_remote_scheduled_execution(
                 registration.alias, session.workspace_name, session.integration,
             ),
         )?;
-        return Ok(format!(
-            "Opened exact {} Agent Session for execution {} on Node {}",
-            session.integration, execution.id, registration.alias,
-        ));
+        return Ok(OpenedScheduledExecution {
+            message: format!(
+                "Opened exact {} Agent Session for execution {} on Node {}",
+                session.integration, execution.id, registration.alias,
+            ),
+            execution,
+            target: "session",
+        });
     }
     let ScheduledExecutionOpenTarget::Run { shell_id, run_id } = target else {
         unreachable!("session targets return after opening")
@@ -3207,10 +3306,14 @@ fn open_remote_scheduled_execution(
         ),
         true,
     )?;
-    Ok(format!(
-        "Opened exact execution {} from schedule {} on Node {}",
-        execution.id, execution.schedule_id, registration.alias
-    ))
+    Ok(OpenedScheduledExecution {
+        message: format!(
+            "Opened exact execution {} from schedule {} on Node {}",
+            execution.id, execution.schedule_id, registration.alias
+        ),
+        execution,
+        target: "run",
+    })
 }
 
 fn validate_dashboard_execution_open(
@@ -5682,10 +5785,13 @@ fn remote_session_command(
 
 fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
+    if let Some(node) = command.node().map(str::to_owned) {
+        return remote_schedule_command(&client, command, &node, json);
+    }
     validate_schedule_protocol(client.protocol_version()?)?;
     match command {
         ScheduleCommands::Create(arguments) => create_schedule(&client, *arguments, json),
-        ScheduleCommands::List { workspace } => {
+        ScheduleCommands::List { workspace, .. } => {
             let snapshot = client.snapshot()?;
             let selected = workspace
                 .as_deref()
@@ -5747,7 +5853,9 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
             }
             Ok(())
         }
-        ScheduleCommands::Inspect { target, workspace } => {
+        ScheduleCommands::Inspect {
+            target, workspace, ..
+        } => {
             let snapshot = client.snapshot()?;
             let schedule = resolve_cli_schedule(&snapshot, &target, workspace.as_deref())?;
             let workspace_name = schedule_workspace_name(&snapshot, schedule);
@@ -5767,7 +5875,9 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
             print_schedule_inspection(&inspection.schedule, workspace_name, &inspection.prompt);
             Ok(())
         }
-        ScheduleCommands::Pause { target, workspace } => {
+        ScheduleCommands::Pause {
+            target, workspace, ..
+        } => {
             let snapshot = client.snapshot()?;
             let schedule = resolve_cli_schedule(&snapshot, &target, workspace.as_deref())?;
             let workspace_name = schedule_workspace_name(&snapshot, schedule).map(str::to_owned);
@@ -5783,7 +5893,9 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
             }
             Ok(())
         }
-        ScheduleCommands::Resume { target, workspace } => {
+        ScheduleCommands::Resume {
+            target, workspace, ..
+        } => {
             let snapshot = client.snapshot()?;
             let schedule = resolve_cli_schedule(&snapshot, &target, workspace.as_deref())?;
             let workspace_name = schedule_workspace_name(&snapshot, schedule).map(str::to_owned);
@@ -5802,7 +5914,9 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
             }
             Ok(())
         }
-        ScheduleCommands::Remove { target, workspace } => {
+        ScheduleCommands::Remove {
+            target, workspace, ..
+        } => {
             let snapshot = client.snapshot()?;
             let schedule = resolve_cli_schedule(&snapshot, &target, workspace.as_deref())?;
             let removed =
@@ -5825,6 +5939,7 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
             target,
             workspace,
             idempotency_key,
+            ..
         } => {
             let feature = protocol::ProtocolFeature::ScheduledExecutions;
             if !feature.is_supported_by(client.protocol_version()?) {
@@ -5847,12 +5962,444 @@ fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn
     }
 }
 
+fn remote_node_projection(
+    client: &client::Client,
+    selector: &str,
+) -> Result<(protocol::NodeRegistrationSnapshot, protocol::CombinedNode), Box<dyn Error>> {
+    let registration = client.node_registration(selector)?;
+    let mut nodes = client
+        .combined_node_snapshot(Some(registration.node_id.clone()))?
+        .nodes;
+    let node = nodes.pop().ok_or_else(|| {
+        cli_output::failure(
+            "not_found",
+            "registered Node has no combined projection entry",
+        )
+    })?;
+    Ok((registration, node))
+}
+
+fn remote_workspace_from_projection(
+    client: &client::Client,
+    node: &protocol::CombinedNode,
+    target: &str,
+) -> Result<protocol::WorkspaceSnapshot, Box<dyn Error>> {
+    let projection = node.remote_projection.as_ref().ok_or_else(|| {
+        cli_output::failure("not_found", "remote Node has no projected workspace state")
+    })?;
+    let matches = projection
+        .workspaces
+        .iter()
+        .filter(|workspace| workspace.id == target || workspace.name == target)
+        .collect::<Vec<_>>();
+    let [workspace] = matches.as_slice() else {
+        return Err(cli_output::failure(
+            if matches.is_empty() {
+                "not_found"
+            } else {
+                "ambiguous_target"
+            },
+            format!("remote workspace target did not resolve uniquely: {target}"),
+        ));
+    };
+    match client.route_node_operation(
+        &node.node_id,
+        protocol::RoutedOperation::GetWorkspace {
+            workspace_id: workspace.id.clone(),
+        },
+    )? {
+        protocol::RoutedOperationResult::Workspace { workspace } => Ok(workspace),
+        _ => Err("remote Node returned an unexpected workspace response".into()),
+    }
+}
+
+fn remote_schedule_inspection(
+    client: &client::Client,
+    node: &protocol::CombinedNode,
+    target: &str,
+    workspace: Option<&str>,
+) -> Result<protocol::AgentScheduleInspection, Box<dyn Error>> {
+    let schedule_id = if uuid::Uuid::parse_str(target).is_ok() {
+        target.to_owned()
+    } else {
+        let workspace = workspace.ok_or_else(|| {
+            cli_output::failure(
+                "invalid_argument",
+                "remote schedule names require --workspace; exact schedule IDs do not",
+            )
+        })?;
+        let workspace = remote_workspace_from_projection(client, node, workspace)?;
+        let matches = workspace
+            .schedules
+            .iter()
+            .filter(|schedule| schedule.name == target)
+            .collect::<Vec<_>>();
+        let [schedule] = matches.as_slice() else {
+            return Err(cli_output::failure(
+                if matches.is_empty() {
+                    "not_found"
+                } else {
+                    "ambiguous_target"
+                },
+                format!("remote schedule target did not resolve uniquely: {target}"),
+            ));
+        };
+        schedule.id.clone()
+    };
+    match client.route_node_operation(
+        &node.node_id,
+        protocol::RoutedOperation::GetAgentSchedule { schedule_id },
+    )? {
+        protocol::RoutedOperationResult::AgentScheduleInspection { inspection } => Ok(inspection),
+        _ => Err("remote Node returned an unexpected schedule response".into()),
+    }
+}
+
+fn remote_schedule_command(
+    client: &client::Client,
+    command: ScheduleCommands,
+    selector: &str,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let feature = protocol::ProtocolFeature::RemoteSchedules;
+    if !client.supports(feature)? {
+        return Err(cli_output::failure(
+            "unsupported_version",
+            format!(
+                "remote Schedule management requires local daemon protocol {}",
+                feature.minimum_version()
+            ),
+        ));
+    }
+    let (registration, node) = remote_node_projection(client, selector)?;
+    match command {
+        ScheduleCommands::List { workspace, .. } => {
+            let projection = node.remote_projection.as_ref().ok_or_else(|| {
+                cli_output::failure("not_found", "remote Node has no projected Schedule state")
+            })?;
+            let workspace_id = workspace
+                .as_deref()
+                .map(|target| remote_workspace_from_projection(client, &node, target))
+                .transpose()?
+                .map(|workspace| workspace.id);
+            let schedules = projection
+                .schedules
+                .iter()
+                .filter(|schedule| {
+                    workspace_id
+                        .as_deref()
+                        .is_none_or(|workspace_id| schedule.workspace_id == workspace_id)
+                })
+                .map(|schedule| {
+                    let workspace_name = projection
+                        .workspaces
+                        .iter()
+                        .find(|workspace| workspace.id == schedule.workspace_id)
+                        .map(|workspace| workspace.name.as_str());
+                    serde_json::json!({
+                        "node_id": node.node_id,
+                        "id": schedule.id,
+                        "workspace_id": schedule.workspace_id,
+                        "workspace_name": workspace_name,
+                        "name": schedule.name,
+                        "integration": schedule.integration,
+                        "cron": schedule.trigger.cron,
+                        "timezone": schedule.trigger.timezone,
+                        "state": cli_output::schedule_state(schedule.state),
+                        "revision": schedule.revision,
+                        "prompt_revision": schedule.prompt_revision,
+                        "trigger_revision": schedule.trigger_revision,
+                        "created_at_ms": schedule.created_at_ms,
+                        "updated_at_ms": schedule.updated_at_ms,
+                        "next_occurrence": schedule.next_occurrence,
+                    })
+                })
+                .collect::<Vec<_>>();
+            if json {
+                return print_json(
+                    CommandKey::ScheduleList,
+                    serde_json::json!({
+                        "node_id": registration.node_id,
+                        "node_alias": registration.alias,
+                        "health": node.health,
+                        "current": node.current,
+                        "stale": node.stale,
+                        "observed_at_ms": node.observed_at_ms,
+                        "scheduler": node.scheduler,
+                        "schedules": schedules,
+                    }),
+                );
+            }
+            println!(
+                "NODE\tWORKSPACE\tNAME\tSCHEDULE ID\tSTATE\tINTEGRATION\tTRIGGER\tTIMEZONE\tNEXT OCCURRENCE MS"
+            );
+            for schedule in &projection.schedules {
+                if workspace_id
+                    .as_deref()
+                    .is_some_and(|workspace_id| schedule.workspace_id != workspace_id)
+                {
+                    continue;
+                }
+                let workspace_name = projection
+                    .workspaces
+                    .iter()
+                    .find(|workspace| workspace.id == schedule.workspace_id)
+                    .map_or("unknown", |workspace| workspace.name.as_str());
+                println!(
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    registration.alias,
+                    workspace_name,
+                    schedule.name,
+                    schedule.id,
+                    cli_output::schedule_state(schedule.state),
+                    schedule.integration,
+                    schedule.trigger.cron,
+                    schedule.trigger.timezone,
+                    schedule
+                        .next_occurrence
+                        .as_ref()
+                        .map(|value| value.scheduled_at_ms.to_string())
+                        .unwrap_or_else(|| "-".into()),
+                );
+            }
+            println!(
+                "Node {} is {:?}; scheduler {:?} ({}/{} active)",
+                registration.alias,
+                node.health,
+                node.scheduler.state,
+                node.scheduler.active_executions,
+                node.scheduler.max_concurrent
+            );
+            Ok(())
+        }
+        ScheduleCommands::Create(arguments) => {
+            let workspace = remote_workspace_from_projection(client, &node, &arguments.workspace)?;
+            let name = cli_name(arguments.name, "schedule")?;
+            let resolved = client.route_node_host_service(
+                &node.node_id,
+                protocol::HostServiceOperation::ResolveDirectory {
+                    path: arguments.cwd,
+                },
+            )?;
+            let protocol::HostServiceResult::Directory { path: cwd } = resolved else {
+                return Err("remote Node returned an unexpected directory response".into());
+            };
+            let prompt = schedule_prompt(arguments.prompt, arguments.prompt_file.as_deref())?;
+            let cron = schedule_cron(
+                arguments.cron.as_deref(),
+                arguments.every.as_deref(),
+                arguments.daily.as_deref(),
+                arguments.weekdays.as_deref(),
+                arguments.weekly.as_deref(),
+            )?;
+            let timezone = arguments
+                .timezone
+                .as_deref()
+                .map(boomux::scheduling::canonicalize_timezone)
+                .transpose()?
+                .map_or_else(boomux::scheduling::resolve_system_timezone, Ok)?;
+            let integration = schedule_integration(&arguments.integration)?;
+            let session = if let Some(session_id) = arguments.continue_session.as_deref() {
+                let result = client.route_node_host_service(
+                    &node.node_id,
+                    protocol::HostServiceOperation::InspectAgentSession {
+                        session_id: session_id.to_owned(),
+                    },
+                )?;
+                let protocol::HostServiceResult::AgentSession { session } = result else {
+                    return Err("remote Node returned an unexpected Agent Session response".into());
+                };
+                if session.summary.workspace_id != workspace.id
+                    || session.summary.integration != integration.key
+                {
+                    return Err(cli_output::failure(
+                        "invalid_argument",
+                        "continued session must belong to the selected owner Workspace and integration",
+                    ));
+                }
+                let external_session_id = session.summary.external_session_id.ok_or_else(|| {
+                    cli_output::failure(
+                        "invalid_argument",
+                        "continued projected session has no canonical external session ID",
+                    )
+                })?;
+                boomux::scheduling::validate_external_session_id(&external_session_id)?;
+                AgentScheduleSession::Continue {
+                    external_session_id,
+                }
+            } else {
+                AgentScheduleSession::Fresh
+            };
+            let spec = AgentScheduleSpec {
+                name,
+                cwd,
+                integration: integration.key.into(),
+                prompt,
+                session,
+                trigger: AgentScheduleTrigger { cron, timezone },
+                state: if arguments.enabled {
+                    AgentScheduleState::Enabled
+                } else {
+                    AgentScheduleState::Paused
+                },
+                overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            };
+            let schedule = match client.route_node_operation(
+                &node.node_id,
+                protocol::RoutedOperation::CreateAgentSchedule {
+                    workspace_id: workspace.id.clone(),
+                    spec,
+                },
+            )? {
+                protocol::RoutedOperationResult::AgentSchedule { schedule } => schedule,
+                _ => return Err("remote Node returned an unexpected create response".into()),
+            };
+            if json {
+                return print_json(
+                    CommandKey::ScheduleCreate,
+                    serde_json::json!({
+                        "node_id": registration.node_id,
+                        "schedule": cli_output::schedule(&schedule, Some(&workspace.name)),
+                    }),
+                );
+            }
+            println!(
+                "Created {} schedule {} ({}) on Node {}",
+                cli_output::schedule_state(schedule.state),
+                schedule.name,
+                schedule.id,
+                registration.alias
+            );
+            Ok(())
+        }
+        ScheduleCommands::Inspect {
+            target, workspace, ..
+        } => {
+            let inspection =
+                remote_schedule_inspection(client, &node, &target, workspace.as_deref())?;
+            if json {
+                return print_json(
+                    CommandKey::ScheduleInspect,
+                    serde_json::json!({
+                        "node_id": registration.node_id,
+                        "schedule": cli_output::schedule_inspection(
+                            &inspection.schedule,
+                            None,
+                            &inspection.prompt,
+                        ),
+                    }),
+                );
+            }
+            println!("Node: {}", registration.alias);
+            print_schedule_inspection(&inspection.schedule, None, &inspection.prompt);
+            Ok(())
+        }
+        ScheduleCommands::Pause {
+            ref target,
+            ref workspace,
+            ..
+        }
+        | ScheduleCommands::Resume {
+            ref target,
+            ref workspace,
+            ..
+        }
+        | ScheduleCommands::Remove {
+            ref target,
+            ref workspace,
+            ..
+        }
+        | ScheduleCommands::Run {
+            ref target,
+            ref workspace,
+            ..
+        } => {
+            let inspection =
+                remote_schedule_inspection(client, &node, target, workspace.as_deref())?;
+            let (key, operation) = match command {
+                ScheduleCommands::Pause { .. } => (
+                    CommandKey::SchedulePause,
+                    protocol::RoutedOperation::PauseAgentSchedule {
+                        schedule_id: inspection.schedule.id.clone(),
+                        expected_revision: inspection.schedule.revision,
+                    },
+                ),
+                ScheduleCommands::Resume { .. } => (
+                    CommandKey::ScheduleResume,
+                    protocol::RoutedOperation::ResumeAgentSchedule {
+                        schedule_id: inspection.schedule.id.clone(),
+                        expected_revision: inspection.schedule.revision,
+                    },
+                ),
+                ScheduleCommands::Remove { .. } => (
+                    CommandKey::ScheduleRemove,
+                    protocol::RoutedOperation::RemoveAgentSchedule {
+                        schedule_id: inspection.schedule.id.clone(),
+                        expected_revision: inspection.schedule.revision,
+                    },
+                ),
+                ScheduleCommands::Run {
+                    idempotency_key, ..
+                } => (
+                    CommandKey::ScheduleRun,
+                    protocol::RoutedOperation::RunAgentSchedule {
+                        schedule_id: inspection.schedule.id.clone(),
+                        dispatch_key: idempotency_key.unwrap_or_else(Uuid::new_v4).to_string(),
+                    },
+                ),
+                _ => unreachable!(),
+            };
+            let result = client.route_node_operation(&node.node_id, operation)?;
+            match result {
+                protocol::RoutedOperationResult::AgentSchedule { schedule } => {
+                    print_schedule_mutation(key, &schedule, None, json)
+                }
+                protocol::RoutedOperationResult::ScheduledExecution { execution, .. } => {
+                    if json {
+                        print_json(
+                            key,
+                            serde_json::json!({
+                                "node_id": registration.node_id,
+                                "execution": cli_output::execution(&execution),
+                            }),
+                        )
+                    } else {
+                        print_execution(key, &execution, false)
+                    }
+                }
+                protocol::RoutedOperationResult::Ok if key == CommandKey::ScheduleRemove => {
+                    if json {
+                        print_json(
+                            key,
+                            serde_json::json!({
+                                "node_id": registration.node_id,
+                                "removed": true,
+                                "schedule": cli_output::schedule(&inspection.schedule, None),
+                            }),
+                        )
+                    } else {
+                        println!(
+                            "Removed schedule {} on Node {}",
+                            inspection.schedule.name, registration.alias
+                        );
+                        Ok(())
+                    }
+                }
+                _ => Err("remote Node returned an unexpected Schedule response".into()),
+            }
+        }
+    }
+}
+
 fn execution_command(
     command: ExecutionCommands,
     json: bool,
     terminal: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
+    if let Some(node) = command.node().map(str::to_owned) {
+        return remote_execution_command(&client, command, &node, json, terminal);
+    }
     let feature = protocol::ProtocolFeature::ScheduledExecutions;
     if !feature.is_supported_by(client.protocol_version()?) {
         return Err(cli_output::failure(
@@ -5868,6 +6415,7 @@ fn execution_command(
             workspace,
             schedule,
             limit,
+            ..
         } => {
             let snapshot = client.snapshot()?;
             let workspace = workspace
@@ -5956,7 +6504,7 @@ fn execution_command(
             }
             Ok(())
         }
-        ExecutionCommands::Inspect { execution_id } => {
+        ExecutionCommands::Inspect { execution_id, .. } => {
             let inspection = client.inspect_scheduled_execution(execution_id)?;
             if json {
                 return print_json(
@@ -5981,6 +6529,7 @@ fn execution_command(
             execution_id,
             after_revision,
             wait_ms,
+            ..
         } => {
             let waited = client.wait_scheduled_execution(execution_id, after_revision, wait_ms)?;
             if json {
@@ -5995,7 +6544,7 @@ fn execution_command(
             println!("Changed: {}", waited.changed);
             print_execution(CommandKey::ExecutionWait, &waited.execution, false)
         }
-        ExecutionCommands::Open { execution_id } => {
+        ExecutionCommands::Open { execution_id, .. } => {
             let opened = open_scheduled_execution(&client, &execution_id, terminal)?;
             if json {
                 return print_json(
@@ -6009,10 +6558,213 @@ fn execution_command(
             println!("{}", opened.message);
             Ok(())
         }
-        ExecutionCommands::Cancel { execution_id } => {
+        ExecutionCommands::Cancel { execution_id, .. } => {
             let execution = client.cancel_scheduled_execution(execution_id)?;
             print_execution(CommandKey::ExecutionCancel, &execution, json)
         }
+    }
+}
+
+fn remote_execution_command(
+    client: &client::Client,
+    command: ExecutionCommands,
+    selector: &str,
+    json: bool,
+    terminal: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    let feature = protocol::ProtocolFeature::RemoteSchedules;
+    if !client.supports(feature)? {
+        return Err(cli_output::failure(
+            "unsupported_version",
+            format!(
+                "remote Scheduled Execution management requires local daemon protocol {}",
+                feature.minimum_version()
+            ),
+        ));
+    }
+    let (registration, node) = remote_node_projection(client, selector)?;
+    match command {
+        ExecutionCommands::List {
+            workspace,
+            schedule,
+            limit,
+            ..
+        } => {
+            let workspace = workspace
+                .as_deref()
+                .map(|target| remote_workspace_from_projection(client, &node, target))
+                .transpose()?;
+            let schedule_id = schedule
+                .as_deref()
+                .map(|target| {
+                    remote_schedule_inspection(
+                        client,
+                        &node,
+                        target,
+                        workspace.as_ref().map(|workspace| workspace.id.as_str()),
+                    )
+                    .map(|inspection| inspection.schedule.id)
+                })
+                .transpose()?;
+            let result = client.route_node_operation(
+                &node.node_id,
+                protocol::RoutedOperation::ListScheduledExecutions {
+                    workspace_id: workspace.map(|workspace| workspace.id),
+                    schedule_id,
+                    limit,
+                },
+            )?;
+            let protocol::RoutedOperationResult::ScheduledExecutions {
+                executions,
+                limit,
+                truncated,
+                schedules,
+                schedule_limit,
+                schedules_truncated,
+            } = result
+            else {
+                return Err("remote Node returned an unexpected execution list response".into());
+            };
+            if json {
+                return print_json(
+                    CommandKey::ExecutionList,
+                    serde_json::json!({
+                        "node_id": registration.node_id,
+                        "executions": executions.iter().map(cli_output::execution).collect::<Vec<_>>(),
+                        "limit": limit,
+                        "truncated": truncated,
+                        "schedule_limit": schedule_limit,
+                        "schedules_truncated": schedules_truncated,
+                        "schedules": schedules,
+                    }),
+                );
+            }
+            println!(
+                "NODE\tSTATE\tREASON/OUTCOME\tEXECUTION ID\tSCHEDULE ID\tREQUESTED\tAGENT ID\tSHELL/RUN"
+            );
+            for execution in executions {
+                println!(
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}/{}",
+                    registration.alias,
+                    execution_state(&execution),
+                    execution_result_label(&execution),
+                    execution.id,
+                    execution.schedule_id,
+                    execution.requested_at_ms,
+                    execution.agent_id.as_deref().unwrap_or("-"),
+                    execution.shell_id.as_deref().unwrap_or("-"),
+                    execution.run_id.as_deref().unwrap_or("-"),
+                );
+            }
+            Ok(())
+        }
+        ExecutionCommands::Inspect { execution_id, .. } => {
+            let execution = routed_remote_execution(client, &node.node_id, &execution_id)?;
+            if json {
+                return print_json(
+                    CommandKey::ExecutionInspect,
+                    serde_json::json!({
+                        "node_id": registration.node_id,
+                        "execution": cli_output::execution(&execution),
+                    }),
+                );
+            }
+            println!("Node: {}", registration.alias);
+            print_execution(CommandKey::ExecutionInspect, &execution, false)
+        }
+        ExecutionCommands::Wait {
+            execution_id,
+            after_revision,
+            wait_ms,
+            ..
+        } => {
+            let result = client.route_node_operation(
+                &node.node_id,
+                protocol::RoutedOperation::WaitScheduledExecution {
+                    execution_id,
+                    after_revision,
+                    wait_ms,
+                },
+            )?;
+            let protocol::RoutedOperationResult::ScheduledExecutionWait { execution, changed } =
+                result
+            else {
+                return Err("remote Node returned an unexpected execution wait response".into());
+            };
+            if json {
+                return print_json(
+                    CommandKey::ExecutionWait,
+                    serde_json::json!({
+                        "node_id": registration.node_id,
+                        "changed": changed,
+                        "execution": cli_output::execution(&execution),
+                    }),
+                );
+            }
+            println!("Node: {}", registration.alias);
+            println!("Changed: {changed}");
+            print_execution(CommandKey::ExecutionWait, &execution, false)
+        }
+        ExecutionCommands::Cancel { execution_id, .. } => {
+            let execution = routed_remote_execution(client, &node.node_id, &execution_id)?;
+            let result = client.route_node_operation(
+                &node.node_id,
+                protocol::RoutedOperation::CancelScheduledExecution {
+                    execution_id,
+                    expected_revision: execution.revision,
+                },
+            )?;
+            let protocol::RoutedOperationResult::ScheduledExecution { execution, .. } = result
+            else {
+                return Err("remote Node returned an unexpected cancellation response".into());
+            };
+            if json {
+                return print_json(
+                    CommandKey::ExecutionCancel,
+                    serde_json::json!({
+                        "node_id": registration.node_id,
+                        "execution": cli_output::execution(&execution),
+                    }),
+                );
+            }
+            println!("Node: {}", registration.alias);
+            print_execution(CommandKey::ExecutionCancel, &execution, false)
+        }
+        ExecutionCommands::Open { execution_id, .. } => {
+            let opened = open_remote_scheduled_execution(
+                client,
+                &protocol::QualifiedIdentity::new(&node.node_id, execution_id),
+                terminal,
+            )?;
+            if json {
+                return print_json(
+                    CommandKey::ExecutionOpen,
+                    serde_json::json!({
+                        "node_id": registration.node_id,
+                        "execution": cli_output::execution(&opened.execution),
+                        "target": opened.target,
+                    }),
+                );
+            }
+            println!("{}", opened.message);
+            Ok(())
+        }
+    }
+}
+
+fn routed_remote_execution(
+    client: &client::Client,
+    node_id: &str,
+    execution_id: &str,
+) -> Result<ScheduledExecutionSnapshot, Box<dyn Error>> {
+    match client.route_node_operation(
+        node_id,
+        protocol::RoutedOperation::GetScheduledExecution {
+            execution_id: execution_id.to_owned(),
+        },
+    )? {
+        protocol::RoutedOperationResult::ScheduledExecution { execution, .. } => Ok(execution),
+        _ => Err("remote Node returned an unexpected execution response".into()),
     }
 }
 
@@ -10847,7 +11599,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 36);
+        assert_eq!(protocol::PROTOCOL_VERSION, 37);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 36;
+pub const PROTOCOL_VERSION: u32 = 37;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -155,6 +155,11 @@ define_protocol_features! {
         "remote_integration_management",
         "remote_agent_session_catalog",
         "remote_exact_session_resume",
+    ]),
+    RemoteSchedules => (37, "remote Schedule management", [
+        "protocol_37",
+        "remote_agent_schedule_management",
+        "remote_scheduled_execution_observation",
     ]),
 }
 
@@ -1214,6 +1219,10 @@ pub enum ErrorCode {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
 pub enum RoutedOperation {
+    CreateAgentSchedule {
+        workspace_id: String,
+        spec: AgentScheduleSpec,
+    },
     GetWorkspace {
         workspace_id: String,
     },
@@ -1231,6 +1240,19 @@ pub enum RoutedOperation {
     },
     GetScheduledExecution {
         execution_id: String,
+    },
+    ListScheduledExecutions {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        schedule_id: Option<String>,
+        limit: u16,
+    },
+    WaitScheduledExecution {
+        execution_id: String,
+        after_revision: u64,
+        #[serde(default)]
+        wait_ms: u32,
     },
     RenameWorkspace {
         workspace_id: String,
@@ -1297,6 +1319,7 @@ pub enum RoutedOperation {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RoutedGuard {
+    None,
     ExactId,
     ResourceRevision,
     ResourceRevisionAndRun,
@@ -1322,16 +1345,22 @@ impl RoutedOperation {
     pub const fn classification(&self) -> RoutedOperationClass {
         use RoutedAmbiguity::{ReadAndProve, RetrySameRequest};
         use RoutedGuard::{
-            AttentionObservationRevision, DispatchKey, ExactId, ExecutionRevision,
+            AttentionObservationRevision, DispatchKey, ExactId, ExecutionRevision, None,
             ResourceRevision, ResourceRevisionAndRun, ScheduleRevision,
         };
         match self {
+            Self::CreateAgentSchedule { .. } => RoutedOperationClass {
+                guard: None,
+                ambiguity: ReadAndProve,
+            },
             Self::GetWorkspace { .. }
             | Self::GetShell { .. }
             | Self::GetLauncher { .. }
             | Self::GetAgent { .. }
             | Self::GetAgentSchedule { .. }
-            | Self::GetScheduledExecution { .. } => RoutedOperationClass {
+            | Self::GetScheduledExecution { .. }
+            | Self::ListScheduledExecutions { .. }
+            | Self::WaitScheduledExecution { .. } => RoutedOperationClass {
                 guard: ExactId,
                 ambiguity: RetrySameRequest,
             },
@@ -1410,6 +1439,9 @@ impl RoutedOperation {
 
     pub fn owner_request(&self) -> Request {
         match self.clone() {
+            Self::CreateAgentSchedule { workspace_id, spec } => {
+                Request::CreateAgentSchedule { workspace_id, spec }
+            }
             Self::GetWorkspace { workspace_id } => Request::GetWorkspace { workspace_id },
             Self::GetShell { shell_id } => Request::GetShell { shell_id },
             Self::GetLauncher { launcher_id } => Request::GetLauncher { launcher_id },
@@ -1418,6 +1450,24 @@ impl RoutedOperation {
             Self::GetScheduledExecution { execution_id } => {
                 Request::GetScheduledExecution { execution_id }
             }
+            Self::ListScheduledExecutions {
+                workspace_id,
+                schedule_id,
+                limit,
+            } => Request::ListScheduledExecutions {
+                workspace_id,
+                schedule_id,
+                limit: Some(limit),
+            },
+            Self::WaitScheduledExecution {
+                execution_id,
+                after_revision,
+                wait_ms,
+            } => Request::WaitScheduledExecution {
+                execution_id,
+                after_revision,
+                wait_ms,
+            },
             Self::RenameWorkspace {
                 workspace_id,
                 name,
@@ -2099,6 +2149,13 @@ impl Request {
                 Some(ProtocolFeature::NodeProjectionSync)
             }
             Self::GetCombinedNodeSnapshot { .. } => Some(ProtocolFeature::CombinedNodeSnapshot),
+            Self::RouteNodeOperation {
+                operation:
+                    RoutedOperation::CreateAgentSchedule { .. }
+                    | RoutedOperation::ListScheduledExecutions { .. }
+                    | RoutedOperation::WaitScheduledExecution { .. },
+                ..
+            } => Some(ProtocolFeature::RemoteSchedules),
             Self::RouteNodeOperation { .. }
             | Self::GuardedCancelScheduledExecution { .. }
             | Self::GuardedRenameWorkspace { .. }
@@ -2361,6 +2418,18 @@ pub enum RoutedOperationResult {
         execution: ScheduledExecutionSnapshot,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         next_occurrence: Option<ScheduledOccurrence>,
+    },
+    ScheduledExecutions {
+        executions: Vec<ScheduledExecutionSnapshot>,
+        limit: u16,
+        truncated: bool,
+        schedules: Vec<ScheduledExecutionScheduleProjection>,
+        schedule_limit: u16,
+        schedules_truncated: bool,
+    },
+    ScheduledExecutionWait {
+        execution: ScheduledExecutionSnapshot,
+        changed: bool,
     },
     AgentAttentionAcknowledged {
         agent: AgentInstanceSnapshot,
@@ -2861,8 +2930,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_thirty_six_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 36);
+    fn protocol_version_is_thirty_seven_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 37);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -3076,6 +3145,63 @@ mod tests {
                 "operation": "shutdown"
             }))
             .is_err()
+        );
+    }
+
+    #[test]
+    fn protocol_thirty_seven_routes_remote_schedule_reads_without_broadening_retries() {
+        let create = RoutedOperation::CreateAgentSchedule {
+            workspace_id: "workspace-1".into(),
+            spec: AgentScheduleSpec {
+                name: "review".into(),
+                cwd: "/owner/work".into(),
+                integration: "opencode".into(),
+                prompt: "PRIVATE ROUTED PROMPT".into(),
+                session: AgentScheduleSession::Fresh,
+                trigger: AgentScheduleTrigger {
+                    cron: "0 2 * * *".into(),
+                    timezone: "UTC".into(),
+                },
+                state: AgentScheduleState::Paused,
+                overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            },
+        };
+        let request = Request::RouteNodeOperation {
+            node_id: "node-1".into(),
+            operation: create.clone(),
+        };
+        assert_eq!(
+            request.required_feature(),
+            Some(ProtocolFeature::RemoteSchedules)
+        );
+        assert!(!create.is_retryable());
+        assert!(format!("{create:?}").contains("<redacted>"));
+        assert!(!format!("{create:?}").contains("PRIVATE ROUTED PROMPT"));
+
+        let list = RoutedOperation::ListScheduledExecutions {
+            workspace_id: None,
+            schedule_id: Some("schedule-1".into()),
+            limit: 100,
+        };
+        assert!(list.is_retryable());
+        assert_eq!(
+            serde_json::from_value::<RoutedOperation>(serde_json::to_value(&list).unwrap())
+                .unwrap(),
+            list
+        );
+        assert!(
+            RoutedOperation::RunAgentSchedule {
+                schedule_id: "schedule-1".into(),
+                dispatch_key: "dispatch-1".into(),
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutedOperation::CancelScheduledExecution {
+                execution_id: "execution-1".into(),
+                expected_revision: 4,
+            }
+            .is_retryable()
         );
     }
 
@@ -3775,6 +3901,17 @@ mod tests {
                     },
                 ],
             ),
+            (
+                37,
+                vec![Request::RouteNodeOperation {
+                    node_id: "node-1".into(),
+                    operation: RoutedOperation::WaitScheduledExecution {
+                        execution_id: "execution-1".into(),
+                        after_revision: 1,
+                        wait_ms: 10,
+                    },
+                }],
+            ),
         ];
 
         for (expected, requests) in groups {
@@ -3925,6 +4062,14 @@ mod tests {
                     "remote_integration_management",
                     "remote_agent_session_catalog",
                     "remote_exact_session_resume",
+                ][..],
+            ),
+            (
+                37,
+                &[
+                    "protocol_37",
+                    "remote_agent_schedule_management",
+                    "remote_scheduled_execution_observation",
                 ][..],
             ),
         ];

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5024,11 +5024,30 @@ fn render_schedules(frame: &mut Frame, area: Rect, app: &mut App) {
             }))
         })
         .collect();
-    let health = match app.scheduling {
-        SchedulingView::Unsupported { .. } => "unsupported".into(),
-        SchedulingView::Active { active, maximum } => format!("active {active}/{maximum}"),
-        SchedulingView::Offline { active, maximum } => format!("offline {active}/{maximum}"),
-    };
+    let health = app
+        .selected_schedule()
+        .and_then(|schedule| {
+            app.nodes
+                .iter()
+                .find(|node| node.id == schedule.node_id)
+                .map(|node| {
+                    format!(
+                        "{} {} {}/{}",
+                        node.alias,
+                        match node.scheduler.state {
+                            boomux::protocol::SchedulerState::Active => "active",
+                            boomux::protocol::SchedulerState::Offline => "offline",
+                        },
+                        node.scheduler.active_executions,
+                        node.scheduler.max_concurrent,
+                    )
+                })
+        })
+        .unwrap_or_else(|| match app.scheduling {
+            SchedulingView::Unsupported { .. } => "unsupported".into(),
+            SchedulingView::Active { active, maximum } => format!("active {active}/{maximum}"),
+            SchedulingView::Offline { active, maximum } => format!("offline {active}/{maximum}"),
+        });
     let table = Table::new(rows, widths)
         .header(Row::new(headers).style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
         .column_spacing(1)

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -22,6 +22,8 @@ mod remote_attachment;
 mod remote_bootstrap;
 #[path = "native_backend/remote_host_services.rs"]
 mod remote_host_services;
+#[path = "native_backend/remote_schedules.rs"]
+mod remote_schedules;
 #[path = "native_backend/schedules.rs"]
 mod schedules;
 #[path = "native_backend/shell_lifecycle.rs"]

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 36);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 37);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -126,6 +126,7 @@ fn native_daemon_lifecycle() {
         "protocol_34",
         "protocol_35",
         "protocol_36",
+        "protocol_37",
         "node_registration_management",
         "node_projection_sync",
         "bounded_remote_node_projections",
@@ -141,6 +142,8 @@ fn native_daemon_lifecycle() {
         "remote_integration_management",
         "remote_agent_session_catalog",
         "remote_exact_session_resume",
+        "remote_agent_schedule_management",
+        "remote_scheduled_execution_observation",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -175,7 +178,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 36"));
+    assert!(status_text.contains("running (protocol 37"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -935,7 +938,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 36);
+    assert_eq!(handshake.core_protocol_version, 37);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc

--- a/tests/native_backend/remote_schedules.rs
+++ b/tests/native_backend/remote_schedules.rs
@@ -1,0 +1,477 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use boomux::protocol::{
+    AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSpec, AgentScheduleState,
+    AgentScheduleTrigger, QualifiedIdentity, RoutedOperation, RoutedOperationResult,
+    ScheduledExecutionReason, ScheduledExecutionState,
+};
+use uuid::Uuid;
+
+use crate::support::{TestDaemon, process_exists, profile, wait_until};
+
+fn install_fake_ssh(directory: &Path, owner: &TestDaemon) {
+    let ssh = directory.join("ssh");
+    fs::write(
+        &ssh,
+        format!(
+            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}\\0' ;;\n  *__federation-stdio*) exec env XDG_RUNTIME_DIR='{}' XDG_STATE_HOME='{}' '{}' __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
+            owner.executable.display(),
+            owner.executable.display(),
+            owner.runtime_dir.display(),
+            owner.runtime_dir.join("state").display(),
+            owner.executable.display(),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+fn schedule_spec(cwd: &Path, prompt: &str, state: AgentScheduleState) -> AgentScheduleSpec {
+    AgentScheduleSpec {
+        name: "remote-review".into(),
+        cwd: cwd.into(),
+        integration: "opencode".into(),
+        prompt: prompt.into(),
+        session: AgentScheduleSession::Fresh,
+        trigger: AgentScheduleTrigger {
+            cron: "* * * * *".into(),
+            timezone: "UTC".into(),
+        },
+        state,
+        overlap_policy: AgentScheduleOverlapPolicy::Skip,
+    }
+}
+
+fn create_clock(clock: &Path, generation: u64, now_ms: u64) {
+    fs::create_dir_all(clock.parent().unwrap()).unwrap();
+    fs::set_permissions(clock.parent().unwrap(), fs::Permissions::from_mode(0o700)).unwrap();
+    fs::create_dir(clock).unwrap();
+    fs::set_permissions(clock, fs::Permissions::from_mode(0o700)).unwrap();
+    write_tick(clock, generation, now_ms);
+}
+
+fn write_tick(clock: &Path, generation: u64, now_ms: u64) {
+    let tick = clock.join("tick");
+    fs::write(&tick, format!("{generation} {now_ms}")).unwrap();
+    fs::set_permissions(tick, fs::Permissions::from_mode(0o600)).unwrap();
+}
+
+fn wait_for_tick(clock: &Path, generation: u64) {
+    wait_until(
+        || {
+            fs::read_to_string(clock.join("ack"))
+                .is_ok_and(|value| value.trim() == generation.to_string())
+        },
+        "owner scheduler did not acknowledge deterministic tick",
+    );
+}
+
+fn assert_tree_omits(path: &Path, private: &str) {
+    if !path.exists() {
+        return;
+    }
+    for entry in fs::read_dir(path).unwrap() {
+        let entry = entry.unwrap();
+        let file_type = entry.file_type().unwrap();
+        if file_type.is_dir() {
+            assert_tree_omits(&entry.path(), private);
+        } else if file_type.is_file()
+            && let Ok(bytes) = fs::read(entry.path())
+        {
+            assert!(!String::from_utf8_lossy(&bytes).contains(private));
+        }
+    }
+}
+
+#[test]
+fn remote_execution_stays_owner_bound_across_local_stop_and_both_handoffs() {
+    let mut owner = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let host = bin.join("opencode");
+        fs::write(
+            &host,
+            "#!/bin/sh\nprintf '%s' \"$$\" > \"$BOOMUX_REMOTE_SCHEDULE_PID\"\nexec sleep 30\n",
+        )
+        .unwrap();
+        fs::set_permissions(&host, fs::Permissions::from_mode(0o700)).unwrap();
+        command
+            .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+            .env(
+                "BOOMUX_REMOTE_SCHEDULE_PID",
+                runtime_dir.join("schedule-pid"),
+            );
+    });
+    let owner_id = owner.client.node_identity().unwrap();
+    let mut local = TestDaemon::start_with(|command, runtime_dir| {
+        install_fake_ssh(runtime_dir, &owner);
+        command.env("PATH", format!("{}:/usr/bin:/bin", runtime_dir.display()));
+    });
+    local
+        .client
+        .add_node_registration("owner", "fake-owner", &owner_id)
+        .unwrap();
+    let workspace = owner
+        .client
+        .create_workspace("remote-scheduled", Vec::new())
+        .unwrap();
+    wait_until(
+        || {
+            local
+                .client
+                .combined_node_snapshot(Some(owner_id.clone()))
+                .is_ok_and(|snapshot| {
+                    snapshot.nodes[0]
+                        .remote_projection
+                        .as_ref()
+                        .is_some_and(|projection| {
+                            projection
+                                .workspaces
+                                .iter()
+                                .any(|value| value.id == workspace.id)
+                        })
+                })
+        },
+        "local projection did not observe owner workspace",
+    );
+    let cli_private = "PRIVATE REMOTE CLI CREATE PROMPT";
+    let cli_create = local
+        .command()
+        .args([
+            "schedule",
+            "create",
+            "cli-created",
+            "--workspace",
+            &workspace.id,
+            "--cwd",
+            owner.runtime_dir.to_str().unwrap(),
+            "--integration",
+            "opencode",
+            "--prompt",
+            cli_private,
+            "--cron",
+            "0 2 * * *",
+            "--timezone",
+            "UTC",
+            "--node",
+            "owner",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        cli_create.status.success(),
+        "{}",
+        String::from_utf8_lossy(&cli_create.stderr)
+    );
+    assert!(!String::from_utf8_lossy(&cli_create.stdout).contains(cli_private));
+    let cli_create: serde_json::Value = serde_json::from_slice(&cli_create.stdout).unwrap();
+    assert_eq!(cli_create["data"]["node_id"], owner_id);
+    let cli_schedule_id = cli_create["data"]["schedule"]["id"].as_str().unwrap();
+    assert_eq!(
+        owner
+            .client
+            .get_agent_schedule(cli_schedule_id)
+            .unwrap()
+            .prompt,
+        cli_private
+    );
+    let private = "PRIVATE REMOTE SCHEDULE PROMPT";
+    let schedule = match local
+        .client
+        .route_node_operation(
+            &owner_id,
+            RoutedOperation::CreateAgentSchedule {
+                workspace_id: workspace.id.clone(),
+                spec: schedule_spec(&owner.runtime_dir, private, AgentScheduleState::Paused),
+            },
+        )
+        .unwrap()
+    {
+        RoutedOperationResult::AgentSchedule { schedule } => schedule,
+        result => panic!("unexpected create result: {result:?}"),
+    };
+    assert!(local.client.snapshot().unwrap().workspaces.is_empty());
+    assert!(
+        !serde_json::to_string(&local.client.combined_node_snapshot(None).unwrap())
+            .unwrap()
+            .contains(private)
+    );
+    assert_tree_omits(&local.runtime_dir, private);
+    assert_tree_omits(&local.runtime_dir, cli_private);
+
+    let dispatch_key = Uuid::new_v4().to_string();
+    let execution = match local
+        .client
+        .route_node_operation(
+            &owner_id,
+            RoutedOperation::RunAgentSchedule {
+                schedule_id: schedule.id.clone(),
+                dispatch_key: dispatch_key.clone(),
+            },
+        )
+        .unwrap()
+    {
+        RoutedOperationResult::ScheduledExecution { execution, .. } => execution,
+        result => panic!("unexpected run result: {result:?}"),
+    };
+    let duplicate = local
+        .client
+        .route_node_operation(
+            &owner_id,
+            RoutedOperation::RunAgentSchedule {
+                schedule_id: schedule.id.clone(),
+                dispatch_key,
+            },
+        )
+        .unwrap();
+    assert!(matches!(
+        duplicate,
+        RoutedOperationResult::ScheduledExecution { execution: ref value, .. }
+            if value.id == execution.id
+    ));
+    let cli_inspect = local
+        .command()
+        .args([
+            "execution",
+            "inspect",
+            &execution.id,
+            "--node",
+            "owner",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(cli_inspect.status.success());
+    assert!(!String::from_utf8_lossy(&cli_inspect.stdout).contains(private));
+    let cli_inspect: serde_json::Value = serde_json::from_slice(&cli_inspect.stdout).unwrap();
+    assert_eq!(cli_inspect["data"]["node_id"], owner_id);
+    assert_eq!(cli_inspect["data"]["execution"]["id"], execution.id);
+    let pid_path = owner.runtime_dir.join("schedule-pid");
+    wait_until(|| pid_path.is_file(), "owner did not start scheduled host");
+    let pid = fs::read_to_string(&pid_path)
+        .unwrap()
+        .parse::<libc::pid_t>()
+        .unwrap();
+    wait_until(
+        || {
+            owner
+                .client
+                .get_scheduled_execution(&execution.id)
+                .is_ok_and(|value| value.state == ScheduledExecutionState::Active)
+        },
+        "owner execution did not become active",
+    );
+
+    local.stop_with_cli();
+    assert!(process_exists(pid));
+    assert_eq!(
+        owner
+            .client
+            .get_scheduled_execution(&execution.id)
+            .unwrap()
+            .state,
+        ScheduledExecutionState::Active
+    );
+    let local_path = format!("{}:/usr/bin:/bin", local.runtime_dir.display());
+    local.restart_with(|command| {
+        command.env("PATH", local_path);
+    });
+
+    let local_restart = local
+        .command()
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", local.runtime_dir.display()),
+        )
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(local_restart.status.success());
+    assert!(process_exists(pid));
+    let owner_restart = owner
+        .command()
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(owner_restart.status.success());
+    assert!(process_exists(pid));
+    let current = owner.client.get_scheduled_execution(&execution.id).unwrap();
+    assert_eq!(current.state, ScheduledExecutionState::Active);
+    assert_eq!(current.run_id, execution.run_id);
+
+    let exact_run = current.run_id.clone().unwrap();
+    let exact_shell = current.shell_id.clone().unwrap();
+    let attachment = local
+        .client
+        .attach_node(
+            QualifiedIdentity::new(&owner_id, &exact_shell),
+            true,
+            false,
+            Some(exact_run.clone()),
+            profile(),
+        )
+        .unwrap();
+    drop(attachment);
+
+    let page = local
+        .client
+        .route_node_operation(
+            &owner_id,
+            RoutedOperation::ListScheduledExecutions {
+                workspace_id: Some(workspace.id),
+                schedule_id: Some(schedule.id),
+                limit: 10,
+            },
+        )
+        .unwrap();
+    assert!(matches!(
+        page,
+        RoutedOperationResult::ScheduledExecutions { ref executions, .. }
+            if executions.iter().any(|value| value.id == execution.id)
+    ));
+    let waited = local
+        .client
+        .route_node_operation(
+            &owner_id,
+            RoutedOperation::WaitScheduledExecution {
+                execution_id: execution.id.clone(),
+                after_revision: current.revision,
+                wait_ms: 0,
+            },
+        )
+        .unwrap();
+    assert!(matches!(
+        waited,
+        RoutedOperationResult::ScheduledExecutionWait {
+            changed: false,
+            execution: ref value,
+        } if value.id == execution.id
+    ));
+    assert!(
+        local
+            .client
+            .route_node_operation(
+                &owner_id,
+                RoutedOperation::CancelScheduledExecution {
+                    execution_id: execution.id.clone(),
+                    expected_revision: current.revision - 1,
+                },
+            )
+            .is_err()
+    );
+    assert!(process_exists(pid));
+    let cancelled = local
+        .client
+        .route_node_operation(
+            &owner_id,
+            RoutedOperation::CancelScheduledExecution {
+                execution_id: execution.id.clone(),
+                expected_revision: current.revision,
+            },
+        )
+        .unwrap();
+    assert!(matches!(
+        cancelled,
+        RoutedOperationResult::ScheduledExecution { execution: ref value, .. }
+            if value.state == ScheduledExecutionState::Cancelled
+    ));
+    wait_until(
+        || !process_exists(pid),
+        "owner cancellation did not stop exact host PID",
+    );
+    assert!(
+        local
+            .client
+            .attach_node(
+                QualifiedIdentity::new(&owner_id, exact_shell),
+                true,
+                false,
+                Some(exact_run),
+                profile(),
+            )
+            .is_err()
+    );
+    local.stop_with_cli();
+    owner.stop_with_cli();
+}
+
+#[test]
+fn remote_cold_restart_alone_applies_missed_policy_without_local_spawn() {
+    const BASE_MS: u64 = 1_767_225_600_000;
+    let mut owner = TestDaemon::start_with(|command, runtime_dir| {
+        let clock = runtime_dir.join("boomux/remote-scheduler-clock");
+        create_clock(&clock, 1, BASE_MS);
+        command
+            .env("BOOMUX_NATIVE_TEST_CLOCK", &clock)
+            .env("PATH", "/nonexistent");
+    });
+    let clock = owner.runtime_dir.join("boomux/remote-scheduler-clock");
+    wait_for_tick(&clock, 1);
+    let owner_id = owner.client.node_identity().unwrap();
+    let mut local = TestDaemon::start_with(|command, runtime_dir| {
+        install_fake_ssh(runtime_dir, &owner);
+        command.env("PATH", format!("{}:/usr/bin:/bin", runtime_dir.display()));
+    });
+    local
+        .client
+        .add_node_registration("owner", "fake-owner", &owner_id)
+        .unwrap();
+    let workspace = owner
+        .client
+        .create_workspace("remote-missed", Vec::new())
+        .unwrap();
+    let schedule = match local
+        .client
+        .route_node_operation(
+            &owner_id,
+            RoutedOperation::CreateAgentSchedule {
+                workspace_id: workspace.id,
+                spec: schedule_spec(
+                    &owner.runtime_dir,
+                    "PRIVATE MISSED PROMPT",
+                    AgentScheduleState::Enabled,
+                ),
+            },
+        )
+        .unwrap()
+    {
+        RoutedOperationResult::AgentSchedule { schedule } => schedule,
+        result => panic!("unexpected create result: {result:?}"),
+    };
+    owner.crash();
+    write_tick(&clock, 2, BASE_MS + 180_000);
+    let restart_clock = clock.clone();
+    owner.restart_with(|command| {
+        command
+            .env("BOOMUX_NATIVE_TEST_CLOCK", restart_clock)
+            .env("PATH", "/nonexistent");
+    });
+    wait_for_tick(&clock, 2);
+
+    let result = local
+        .client
+        .route_node_operation(
+            &owner_id,
+            RoutedOperation::ListScheduledExecutions {
+                workspace_id: None,
+                schedule_id: Some(schedule.id),
+                limit: 10,
+            },
+        )
+        .unwrap();
+    let RoutedOperationResult::ScheduledExecutions { executions, .. } = result else {
+        panic!("unexpected execution list response");
+    };
+    assert_eq!(executions.len(), 1);
+    assert_eq!(executions[0].state, ScheduledExecutionState::Skipped);
+    assert_eq!(executions[0].reason, Some(ScheduledExecutionReason::Missed));
+    assert_eq!(executions[0].scheduled_at_ms, Some(BASE_MS + 60_000));
+    assert_eq!(executions[0].coalesced_through_ms, Some(BASE_MS + 180_000));
+    assert!(local.client.snapshot().unwrap().workspaces.is_empty());
+    assert_tree_omits(&local.runtime_dir, "PRIVATE MISSED PROMPT");
+    local.stop_with_cli();
+    owner.stop_with_cli();
+}


### PR DESCRIPTION
## Summary

- add protocol 37 Node-qualified remote Schedule and execution workflows
- keep reduced projections presentation-only and route private inspection to owners
- validate cwd and continuation Sessions on the owning Node
- preserve transient prompt privacy across create, inspect, and edit
- retain guarded ambiguity handling and exact dispatch-key retries
- open active executions by exact run and terminal executions by exact owner Session
- preserve owner-only evaluation, concurrency, recovery, and missed-occurrence policy

## Stack

- GitHub stack #190
- depends on #203
- implements #182

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`

Closes #182

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
