### PR TITLE
feat(node): deliver remote attention notifications

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,10 @@ Protocol 36 adds closed typed Node host services and owner-executed exact Agent
 Session resume.
 Protocol 37 adds Node-qualified remote Agent Schedule creation and bounded
 Scheduled Execution observation without adding local scheduler authority.
+Remote notification presentation reuses protocol-32 atomic reduced transitions,
+so the core protocol remains 37. Node-cache schema 2 adds bounded local
+at-most-once individual and reconnect-digest claims with an explicit schema-1
+migration.
 
 ## Components
 
@@ -650,6 +654,19 @@ actually published, including after a failed first write and later pending flush
 The prior committed execution snapshot must be nonqualifying, so late Agent links
 and other revisions that retain the same terminal state and reason do not notify
 again.
+
+Registered remote Nodes use the same local desktop/sound sink only as presentation.
+After a protocol-32 projection and cursor are atomically persisted, the coordinator
+matches reduced Agent and execution transitions to exact revisions in that same
+cut. While continuously online, qualifying blocked/Done attention and enabled
+dispatch-failure/interruption categories enqueue individual requests with local
+Node alias and stable Node ID context. After a disconnect with a resumable cursor,
+all rows update but qualifying transitions become one bounded per-Node digest.
+Baseline reseeds never notify. Node-cache schema 2 persists at most 512 individual
+and 128 digest claims per Node before enqueue; crash and graceful replacement keep
+those frontiers but create a fresh notifier worker. Delivery, queue saturation,
+and sound/desktop failures remain fail-open and never acknowledge owner attention
+or infer lifecycle from transport, process, or output state.
 
 Protocol 7 adds a bounded in-memory daemon event journal and atomic output-state
 reads. Clients reconnect through stream UUID/event-ID cursors and recover from

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -41,6 +41,9 @@ Protocol 32 adds owner-side reduced Node projection cuts and the local
 Protocol 37 adds remote Schedule management and execution observation without a
 new event kind: owner events remain owner-local and the presenting Node receives
 only its existing projection invalidation.
+Remote notification presentation adds no protocol or event kind. It consumes the
+protocol-32 reduced transition batch at the projection-cache boundary and never
+copies owner events into the presenting Node's domain journal.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns
@@ -81,8 +84,8 @@ the durable registry remains the cold-recovery authority.
 
 ### Accepted Federation Rules
 
-Remote Node federation is not yet implemented, but its event boundary is fixed
-by [`remote-nodes.md`](remote-nodes.md). Each Node retains its own stream UUID,
+Remote Node federation keeps the event boundary defined by
+[`remote-nodes.md`](remote-nodes.md). Each Node retains its own stream UUID,
 event IDs, retention, baseline, and cursor authority. There is no cross-Node
 event order, and timestamps cannot be used to fabricate one.
 
@@ -100,6 +103,14 @@ baselines update presentation but emit neither historical notifications nor a
 reconnect digest because the expired stream cannot prove which transitions were
 unseen. Older clients remain local-only and do not receive federation
 invalidations when the future capability is filtered.
+
+For a resumable cursor, the presenting Node persists the complete reduced cut and
+then uses exact transition revisions only to claim local notification
+presentation. Continuous live synchronization can enqueue individual requests;
+recovery from stale health can enqueue one per-Node digest. Both paths persist
+bounded Node-cache schema-2 claims before enqueue. Cursor expiry, stream
+replacement, first baselines, and stale or duplicate revisions enqueue nothing.
+The resulting local `node_projection_changed` remains the only journal event.
 
 ## Events
 

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -10,7 +10,9 @@
 > Protocol 30 and local `boomux node rekey` implement bounded expected-ID rekey
 > with exact interactive confirmation. Protocol 31 and registration schema 1
 > implement explicit identity-pinned registration management. Protocol 32 and
-> Node-cache schema 1 implement bounded background reduced projections. Public
+> Node-cache schema 1 implement bounded background reduced projections. Node-cache
+> schema 2 adds local remote-notification and reconnect-digest claims without a
+> remote protocol change. Public
 > Protocol 33 adds the local-daemon combined Node snapshot and federated
 > dashboard. Protocol 34 and state schema 13 implement typed exact-Node private
 > reads and guarded management operations. Protocol 35 implements Node-qualified
@@ -214,7 +216,7 @@ state from loading or persisting. Node identity, registrations, and cache each
 use owner-only directories, bounded schemas, atomic replacement, and explicit
 validation.
 
-Node-cache schema 1 is `node-cache.json` beside, but independent from,
+Node-cache schema 2 is `node-cache.json` beside, but independent from,
 `state.json`, `node.json`, and `node_registrations.json`. It is owner-only,
 atomically replaced, and capped at 4 MiB and 128 Nodes. Per Node it accepts at
 most 1,024 Workspaces, 4,096 Shells, 4,096 launchers, 4,096 Agents, 1,024
@@ -222,6 +224,15 @@ Schedules, 1,000 executions, and 96 capability identifiers of at most 128 bytes.
 Names and identifiers in reduced collections are capped at 256 bytes. An invalid
 cache is renamed to `node-cache.corrupt-<uuid>.json` when possible and otherwise
 discarded in memory; it never blocks authoritative state startup.
+
+Schema 2 explicitly migrates schema 1 by retaining every cached Node generation,
+projection, cursor, capability, and health field and initializing empty local
+notification frontiers. Each Node retains at most 512 individual claims and 128
+digest claims. Individual claims contain only stream UUID, entity ID, positive
+observation or execution revision, typed category, and bounded typed reason;
+digest claims contain stream UUID, prior and through cursor IDs, and the sorted
+enabled category set. Claims are local presentation state and are removed with
+their registered Node cache.
 
 ## Synchronization And Events
 
@@ -489,6 +500,25 @@ frontier without turning it into remote attention authority.
 
 Notification failure is fail-open and cannot change remote lifecycle, attention,
 Schedule, or execution state.
+
+Classification consumes only protocol-32 reduced transitions and the projection
+from that same owner-side cut. An Agent transition qualifies only when its exact
+observation revision is the current blocked or Done row with matching outstanding
+attention. An execution transition qualifies only when its exact revision is a
+configured dispatch failure or cold-recovery interruption. Stale revisions,
+acknowledgments, disconnects, process or output changes, and unrelated transitions
+do not qualify. Because this evidence already exists in protocol 32, remote
+notification presentation adds no protocol version or capability.
+
+The coordinator first persists the complete projection and cursor. After that
+cache lock is released it classifies the reduced transition batch, atomically
+persists previously unseen claims, and releases all federation/cache locks before
+enqueueing delivery. A previously online valid-cursor response produces
+individual requests. A valid-cursor response after stale or unreachable health
+instead replaces those requests with one digest containing bounded category
+counts. A baseline from first observation, cursor expiry, or stream replacement
+never produces a digest. Local crash and graceful handoff reload the same claim
+frontiers; the live notifier queue and worker are not transferred.
 
 ## Compatibility And Migration
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,14 +23,17 @@ use uuid::Uuid;
 
 use crate::client;
 use crate::desktop_notifications::{
-    DesktopNotificationSink, DisabledNotificationSink, NotificationReason, NotificationRequest,
-    NotificationSink, category_enabled, test_delivery,
+    DesktopNotificationSink, DisabledNotificationSink, NotificationDigest, NotificationNodeContext,
+    NotificationReason, NotificationRequest, NotificationSink, category_enabled, test_delivery,
 };
 use crate::fd_transfer::send_descriptor;
 use crate::handoff;
 use crate::host_services::{self, PreparedIntegrationMutation};
 use crate::node_identity::{NodeIdentityLease, NodeIdentityManager};
-use crate::node_projection::NodeProjectionCache;
+use crate::node_projection::{
+    NodeProjectionCache, ProjectionCommit, RemoteDigestClaim, RemoteNotificationCategory,
+    RemoteNotificationClaim,
+};
 use crate::node_registration::NodeRegistrationManager;
 use crate::protocol::{
     self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
@@ -6608,6 +6611,7 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
         let attempt_at_ms = unix_time_ms();
         let result = fetch_node_projection(&registration, after);
         let mut published_generation = None;
+        let mut remote_notifications = Vec::new();
         match result {
             Ok((sync, capabilities)) => {
                 let commit = service.node_registrations().and_then(|registrations| {
@@ -6622,17 +6626,65 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
                                 .commit_projection(
                                     &registration,
                                     expected_generation,
-                                    sync.cursor,
-                                    sync.projection,
+                                    sync.cursor.clone(),
+                                    sync.projection.clone(),
                                     capabilities,
                                     attempt_at_ms,
                                 )
                         })
                         .map_err(node_registration_error)
                 });
-                if let Ok(Some(Some(generation))) = commit {
-                    published_generation = Some(generation);
+                if let Ok(Some(Some(commit))) = commit {
+                    published_generation = Some(commit.generation);
                     failures = 0;
+                    let (candidates, digest) = remote_notification_candidates(
+                        &registration,
+                        &sync,
+                        &commit,
+                        &service.notification_settings,
+                    );
+                    if !candidates.is_empty() || digest.is_some() {
+                        let claims = candidates
+                            .iter()
+                            .map(|candidate| candidate.claim.clone())
+                            .collect::<Vec<_>>();
+                        let claimed = service.node_registrations().and_then(|registrations| {
+                            registrations
+                                .with_current(&registration, || {
+                                    service
+                                        .node_projection_cache
+                                        .as_ref()
+                                        .ok_or_else(|| {
+                                            io::Error::other("Node projection cache unavailable")
+                                        })?
+                                        .claim_notifications(
+                                            &registration,
+                                            commit.generation,
+                                            &claims,
+                                            digest.as_ref().map(|digest| &digest.claim),
+                                        )
+                                })
+                                .map_err(node_registration_error)
+                        });
+                        match claimed {
+                            Ok(Some(Some((accepted, digest_accepted)))) => {
+                                remote_notifications.extend(
+                                    candidates.into_iter().zip(accepted).filter_map(
+                                        |(candidate, accepted)| {
+                                            accepted.then_some(candidate.request)
+                                        },
+                                    ),
+                                );
+                                if digest_accepted && let Some(digest) = digest {
+                                    remote_notifications.push(digest.request);
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(error) => {
+                                eprintln!("boomux: could not claim remote notification: {error}");
+                            }
+                        }
+                    }
                 } else if let Err(error) = commit {
                     eprintln!("boomux: could not commit Node projection: {error}");
                 }
@@ -6686,6 +6738,9 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
                 },
             ]);
         }
+        for notification in remote_notifications {
+            service.notification_sink.notify(notification);
+        }
         let delay = if failures == 0 {
             Duration::from_secs(1)
         } else {
@@ -6702,6 +6757,236 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
         if interruptible_node_sleep(&service, delay) {
             return;
         }
+    }
+}
+
+struct RemoteNotificationCandidate {
+    claim: RemoteNotificationClaim,
+    request: NotificationRequest,
+}
+
+struct RemoteDigestCandidate {
+    claim: RemoteDigestClaim,
+    request: NotificationRequest,
+}
+
+fn remote_notification_candidates(
+    registration: &crate::protocol::NodeRegistrationSnapshot,
+    sync: &NodeProjectionSync,
+    commit: &ProjectionCommit,
+    settings: &NotificationDeliverySettings,
+) -> (
+    Vec<RemoteNotificationCandidate>,
+    Option<RemoteDigestCandidate>,
+) {
+    if sync.mode != NodeProjectionSyncMode::Resumed {
+        return (Vec::new(), None);
+    }
+    let Some(prior) = commit.previous_cursor.as_ref().filter(|prior| {
+        prior.stream_id == sync.cursor.stream_id && prior.event_id <= sync.cursor.event_id
+    }) else {
+        return (Vec::new(), None);
+    };
+    let node = NotificationNodeContext {
+        alias: registration.alias.clone(),
+        node_id: registration.node_id.clone(),
+    };
+    let workspaces = sync
+        .projection
+        .workspaces
+        .iter()
+        .map(|workspace| (workspace.id.as_str(), workspace.name.as_str()))
+        .collect::<HashMap<_, _>>();
+    let shells = sync
+        .projection
+        .shells
+        .iter()
+        .map(|shell| (shell.id.as_str(), shell.name.as_str()))
+        .collect::<HashMap<_, _>>();
+    let schedules = sync
+        .projection
+        .schedules
+        .iter()
+        .map(|schedule| (schedule.id.as_str(), schedule.name.as_str()))
+        .collect::<HashMap<_, _>>();
+    let mut seen = HashSet::new();
+    let mut candidates = Vec::new();
+    for transition in &sync.transitions {
+        let candidate = match &transition.kind {
+            NodeProjectionTransitionKind::Agent {
+                workspace_id,
+                agent_id,
+                revision,
+            } => sync
+                .projection
+                .agents
+                .iter()
+                .find(|agent| agent.id == *agent_id && agent.observation_revision == *revision)
+                .and_then(|agent| {
+                    let attention = agent
+                        .attention
+                        .as_ref()
+                        .filter(|attention| attention.observation_revision == *revision)?;
+                    let category = match (agent.state, attention.reason) {
+                        (AgentState::Blocked, AgentAttentionReason::Blocked) => {
+                            RemoteNotificationCategory::AgentBlocked
+                        }
+                        (AgentState::Done, AgentAttentionReason::Completed) => {
+                            RemoteNotificationCategory::AgentCompleted
+                        }
+                        _ => return None,
+                    };
+                    let reason = remote_notification_reason(category);
+                    category_enabled(settings, reason).then(|| RemoteNotificationCandidate {
+                        claim: RemoteNotificationClaim {
+                            stream_id: sync.cursor.stream_id.clone(),
+                            entity_id: agent.id.clone(),
+                            revision: *revision,
+                            category,
+                            reason: remote_notification_reason_key(category).into(),
+                        },
+                        request: NotificationRequest {
+                            reason,
+                            agent: agent.name.clone(),
+                            workspace: workspaces
+                                .get(workspace_id.as_str())
+                                .copied()
+                                .unwrap_or(workspace_id)
+                                .into(),
+                            shell: shells
+                                .get(agent.shell_id.as_str())
+                                .copied()
+                                .unwrap_or(&agent.shell_id)
+                                .into(),
+                            node: Some(node.clone()),
+                            digest: None,
+                        },
+                    })
+                }),
+            NodeProjectionTransitionKind::Execution {
+                workspace_id,
+                execution_id,
+                revision,
+            } => sync
+                .projection
+                .executions
+                .iter()
+                .find(|execution| execution.id == *execution_id && execution.revision == *revision)
+                .and_then(|execution| {
+                    let category = match (execution.state, execution.reason) {
+                        (
+                            ScheduledExecutionState::DispatchFailed,
+                            Some(
+                                ScheduledExecutionReason::RunnerStartFailed
+                                | ScheduledExecutionReason::HostSpawnFailed,
+                            ),
+                        ) => RemoteNotificationCategory::ScheduledDispatchFailed,
+                        (
+                            ScheduledExecutionState::Interrupted,
+                            Some(ScheduledExecutionReason::ColdDaemonRecovery),
+                        ) => RemoteNotificationCategory::ScheduledInterrupted,
+                        _ => return None,
+                    };
+                    let reason = remote_notification_reason(category);
+                    category_enabled(settings, reason).then(|| RemoteNotificationCandidate {
+                        claim: RemoteNotificationClaim {
+                            stream_id: sync.cursor.stream_id.clone(),
+                            entity_id: execution.id.clone(),
+                            revision: *revision,
+                            category,
+                            reason: remote_notification_reason_key(category).into(),
+                        },
+                        request: NotificationRequest {
+                            reason,
+                            agent: schedules
+                                .get(execution.schedule_id.as_str())
+                                .copied()
+                                .unwrap_or(&execution.schedule_id)
+                                .into(),
+                            workspace: workspaces
+                                .get(workspace_id.as_str())
+                                .copied()
+                                .unwrap_or(workspace_id)
+                                .into(),
+                            shell: execution.id.clone(),
+                            node: Some(node.clone()),
+                            digest: None,
+                        },
+                    })
+                }),
+            _ => None,
+        };
+        if let Some(candidate) = candidate
+            && seen.insert(candidate.claim.clone())
+        {
+            candidates.push(candidate);
+        }
+    }
+    if commit.previous_health == Some(crate::protocol::NodeProjectionHealthCode::Online) {
+        return (candidates, None);
+    }
+    let mut enabled_categories = candidates
+        .iter()
+        .map(|candidate| candidate.claim.category)
+        .collect::<Vec<_>>();
+    enabled_categories.sort_unstable();
+    enabled_categories.dedup();
+    if enabled_categories.is_empty() {
+        return (Vec::new(), None);
+    }
+    let mut counts = NotificationDigest::default();
+    for candidate in &candidates {
+        let count = match candidate.claim.category {
+            RemoteNotificationCategory::AgentBlocked => &mut counts.blocked,
+            RemoteNotificationCategory::AgentCompleted => &mut counts.completed,
+            RemoteNotificationCategory::ScheduledDispatchFailed => {
+                &mut counts.scheduled_dispatch_failed
+            }
+            RemoteNotificationCategory::ScheduledInterrupted => &mut counts.scheduled_interrupted,
+        };
+        *count = count.saturating_add(1);
+    }
+    let reason = remote_notification_reason(enabled_categories[0]);
+    (
+        Vec::new(),
+        Some(RemoteDigestCandidate {
+            claim: RemoteDigestClaim {
+                stream_id: sync.cursor.stream_id.clone(),
+                prior_cursor: prior.event_id,
+                through_cursor: sync.cursor.event_id,
+                enabled_categories,
+            },
+            request: NotificationRequest {
+                reason,
+                agent: String::new(),
+                workspace: String::new(),
+                shell: String::new(),
+                node: Some(node),
+                digest: Some(counts),
+            },
+        }),
+    )
+}
+
+fn remote_notification_reason(category: RemoteNotificationCategory) -> NotificationReason {
+    match category {
+        RemoteNotificationCategory::AgentBlocked => NotificationReason::Blocked,
+        RemoteNotificationCategory::AgentCompleted => NotificationReason::Completed,
+        RemoteNotificationCategory::ScheduledDispatchFailed => {
+            NotificationReason::ScheduledDispatchFailed
+        }
+        RemoteNotificationCategory::ScheduledInterrupted => {
+            NotificationReason::ScheduledInterrupted
+        }
+    }
+}
+
+fn remote_notification_reason_key(category: RemoteNotificationCategory) -> &'static str {
+    match category {
+        RemoteNotificationCategory::AgentBlocked => "blocked",
+        RemoteNotificationCategory::AgentCompleted => "completed",
+        RemoteNotificationCategory::ScheduledDispatchFailed => "runner_or_host_spawn_failed",
+        RemoteNotificationCategory::ScheduledInterrupted => "cold_daemon_recovery",
     }
 }
 
@@ -10624,6 +10909,8 @@ impl DaemonService {
                 agent: agent.name.clone(),
                 workspace,
                 shell,
+                node: None,
+                digest: None,
             });
         }
         requests.extend(self.execution_notification_requests(kinds, committed_executions));
@@ -10671,6 +10958,8 @@ impl DaemonService {
                 agent: schedule,
                 workspace,
                 shell: execution.id.clone(),
+                node: None,
+                digest: None,
             });
         }
         requests
@@ -10716,6 +11005,8 @@ impl DaemonService {
                 agent: schedule,
                 workspace,
                 shell: execution.id,
+                node: None,
+                digest: None,
             });
         }
     }
@@ -17422,6 +17713,278 @@ mod tests {
             projection_transitions(&transaction.events, Some(&expired), &through);
         assert_eq!(mode, NodeProjectionSyncMode::Baseline);
         assert!(transitions.is_empty());
+    }
+
+    fn remote_notification_test_settings() -> NotificationDeliverySettings {
+        NotificationDeliverySettings {
+            desktop: NotificationSettings {
+                enabled: true,
+                blocked: true,
+                completed: true,
+                scheduled_dispatch_failed: true,
+                scheduled_interrupted: true,
+            },
+            ..Default::default()
+        }
+    }
+
+    fn remote_notification_projection(node_id: &str) -> NodeProjectionSnapshot {
+        NodeProjectionSnapshot {
+            node_id: node_id.into(),
+            workspaces: vec![NodeProjectionWorkspace {
+                id: "workspace-1".into(),
+                name: "project".into(),
+                item_count: 4,
+                attention_count: 2,
+            }],
+            shells: vec![NodeProjectionShell {
+                id: "shell-1".into(),
+                workspace_id: "workspace-1".into(),
+                name: "agent-shell".into(),
+                owner: ShellOwner::User,
+                status: ShellStatus::Running,
+                run_id: Some("run-1".into()),
+                generation: Some(1),
+                started_at_ms: Some(1),
+                ended_at_ms: None,
+            }],
+            launchers: Vec::new(),
+            agents: vec![
+                NodeProjectionAgent {
+                    id: "agent-blocked".into(),
+                    workspace_id: "workspace-1".into(),
+                    shell_id: "shell-1".into(),
+                    run_id: "run-1".into(),
+                    name: "blocked-agent".into(),
+                    integration: "test".into(),
+                    state: AgentState::Blocked,
+                    observation_revision: 2,
+                    observed_at_ms: 2,
+                    started_at_ms: 1,
+                    ended_at_ms: None,
+                    attention: Some(NodeProjectionAttention {
+                        reason: AgentAttentionReason::Blocked,
+                        observation_revision: 2,
+                        observed_at_ms: 2,
+                    }),
+                },
+                NodeProjectionAgent {
+                    id: "agent-done".into(),
+                    workspace_id: "workspace-1".into(),
+                    shell_id: "shell-1".into(),
+                    run_id: "run-1".into(),
+                    name: "done-agent".into(),
+                    integration: "test".into(),
+                    state: AgentState::Done,
+                    observation_revision: 4,
+                    observed_at_ms: 4,
+                    started_at_ms: 1,
+                    ended_at_ms: Some(4),
+                    attention: Some(NodeProjectionAttention {
+                        reason: AgentAttentionReason::Completed,
+                        observation_revision: 4,
+                        observed_at_ms: 4,
+                    }),
+                },
+            ],
+            schedules: vec![NodeProjectionSchedule {
+                id: "schedule-1".into(),
+                workspace_id: "workspace-1".into(),
+                name: "nightly".into(),
+                integration: "test".into(),
+                state: AgentScheduleState::Paused,
+                trigger: AgentScheduleTrigger {
+                    cron: "0 2 * * *".into(),
+                    timezone: "UTC".into(),
+                },
+                revision: 1,
+                prompt_revision: 1,
+                trigger_revision: 1,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+                next_occurrence: None,
+            }],
+            executions: vec![NodeProjectionExecution {
+                id: "execution-1".into(),
+                workspace_id: "workspace-1".into(),
+                schedule_id: "schedule-1".into(),
+                revision: 3,
+                state: ScheduledExecutionState::DispatchFailed,
+                dispatch_kind: ScheduledExecutionDispatchKind::Manual,
+                schedule_revision: 1,
+                prompt_revision: 1,
+                trigger_revision: 1,
+                requested_at_ms: 1,
+                scheduled_at_ms: None,
+                started_at_ms: None,
+                ended_at_ms: Some(3),
+                reason: Some(ScheduledExecutionReason::HostSpawnFailed),
+                outcome: None,
+                shell_id: None,
+                run_id: None,
+                agent_id: None,
+            }],
+            executions_truncated: false,
+            scheduler: SchedulerHealth {
+                state: SchedulerState::Active,
+                max_concurrent: 4,
+                active_executions: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn reduced_remote_transitions_classify_live_attention_and_one_reconnect_digest() {
+        let node_id = Uuid::from_u128(2).to_string();
+        let stream_id = Uuid::from_u128(3).to_string();
+        let registration = crate::protocol::NodeRegistrationSnapshot {
+            alias: "work".into(),
+            target: "work.example".into(),
+            node_id: node_id.clone(),
+            revision: 1,
+            tombstone_epoch: 0,
+        };
+        let sync = NodeProjectionSync {
+            mode: NodeProjectionSyncMode::Resumed,
+            cursor: EventCursor {
+                stream_id: stream_id.clone(),
+                event_id: 13,
+            },
+            projection: remote_notification_projection(&node_id),
+            transitions: vec![
+                NodeProjectionTransition {
+                    event_id: 11,
+                    at_ms: 11,
+                    kind: NodeProjectionTransitionKind::Agent {
+                        workspace_id: "workspace-1".into(),
+                        agent_id: "agent-blocked".into(),
+                        revision: 2,
+                    },
+                },
+                NodeProjectionTransition {
+                    event_id: 12,
+                    at_ms: 12,
+                    kind: NodeProjectionTransitionKind::Agent {
+                        workspace_id: "workspace-1".into(),
+                        agent_id: "agent-done".into(),
+                        revision: 4,
+                    },
+                },
+                NodeProjectionTransition {
+                    event_id: 13,
+                    at_ms: 13,
+                    kind: NodeProjectionTransitionKind::Execution {
+                        workspace_id: "workspace-1".into(),
+                        execution_id: "execution-1".into(),
+                        revision: 3,
+                    },
+                },
+            ],
+        };
+        let live = ProjectionCommit {
+            generation: 2,
+            previous_health: Some(crate::protocol::NodeProjectionHealthCode::Online),
+            previous_cursor: Some(EventCursor {
+                stream_id: stream_id.clone(),
+                event_id: 10,
+            }),
+        };
+        let (requests, digest) = remote_notification_candidates(
+            &registration,
+            &sync,
+            &live,
+            &remote_notification_test_settings(),
+        );
+        assert_eq!(requests.len(), 3);
+        assert!(digest.is_none());
+        assert_eq!(requests[0].request.reason, NotificationReason::Blocked);
+        assert_eq!(requests[1].request.reason, NotificationReason::Completed);
+        assert_eq!(
+            requests[2].request.reason,
+            NotificationReason::ScheduledDispatchFailed
+        );
+        assert_eq!(requests[0].request.node.as_ref().unwrap().alias, "work");
+
+        let reconnect = ProjectionCommit {
+            previous_health: Some(crate::protocol::NodeProjectionHealthCode::Stale),
+            ..live
+        };
+        let (requests, digest) = remote_notification_candidates(
+            &registration,
+            &sync,
+            &reconnect,
+            &remote_notification_test_settings(),
+        );
+        assert!(requests.is_empty());
+        let digest = digest.unwrap();
+        assert_eq!(digest.claim.prior_cursor, 10);
+        assert_eq!(digest.claim.through_cursor, 13);
+        assert_eq!(digest.request.digest.as_ref().unwrap().blocked, 1);
+        assert_eq!(digest.request.digest.as_ref().unwrap().completed, 1);
+        assert_eq!(
+            digest
+                .request
+                .digest
+                .as_ref()
+                .unwrap()
+                .scheduled_dispatch_failed,
+            1
+        );
+    }
+
+    #[test]
+    fn baseline_and_stale_reduced_revisions_do_not_notify() {
+        let node_id = Uuid::from_u128(2).to_string();
+        let stream_id = Uuid::from_u128(3).to_string();
+        let registration = crate::protocol::NodeRegistrationSnapshot {
+            alias: "work".into(),
+            target: "work.example".into(),
+            node_id: node_id.clone(),
+            revision: 1,
+            tombstone_epoch: 0,
+        };
+        let mut sync = NodeProjectionSync {
+            mode: NodeProjectionSyncMode::Baseline,
+            cursor: EventCursor {
+                stream_id: stream_id.clone(),
+                event_id: 8,
+            },
+            projection: remote_notification_projection(&node_id),
+            transitions: Vec::new(),
+        };
+        let commit = ProjectionCommit {
+            generation: 2,
+            previous_health: Some(crate::protocol::NodeProjectionHealthCode::Stale),
+            previous_cursor: Some(EventCursor {
+                stream_id,
+                event_id: 7,
+            }),
+        };
+        let result = remote_notification_candidates(
+            &registration,
+            &sync,
+            &commit,
+            &remote_notification_test_settings(),
+        );
+        assert!(result.0.is_empty() && result.1.is_none());
+
+        sync.mode = NodeProjectionSyncMode::Resumed;
+        sync.transitions.push(NodeProjectionTransition {
+            event_id: 8,
+            at_ms: 8,
+            kind: NodeProjectionTransitionKind::Agent {
+                workspace_id: "workspace-1".into(),
+                agent_id: "agent-blocked".into(),
+                revision: 1,
+            },
+        });
+        let result = remote_notification_candidates(
+            &registration,
+            &sync,
+            &commit,
+            &remote_notification_test_settings(),
+        );
+        assert!(result.0.is_empty() && result.1.is_none());
     }
 
     #[test]

--- a/src/desktop_notifications.rs
+++ b/src/desktop_notifications.rs
@@ -26,6 +26,22 @@ pub(crate) struct NotificationRequest {
     pub(crate) agent: String,
     pub(crate) workspace: String,
     pub(crate) shell: String,
+    pub(crate) node: Option<NotificationNodeContext>,
+    pub(crate) digest: Option<NotificationDigest>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct NotificationNodeContext {
+    pub(crate) alias: String,
+    pub(crate) node_id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct NotificationDigest {
+    pub(crate) blocked: u16,
+    pub(crate) completed: u16,
+    pub(crate) scheduled_dispatch_failed: u16,
+    pub(crate) scheduled_interrupted: u16,
 }
 
 pub(crate) trait NotificationSink: Send + Sync {
@@ -162,6 +178,8 @@ pub(crate) fn test_delivery(
         agent: "Test Agent".into(),
         workspace: "test-workspace".into(),
         shell: "test-shell".into(),
+        node: None,
+        digest: None,
     };
     let stopping = AtomicBool::new(false);
     let mut first_error = None;
@@ -211,46 +229,74 @@ fn sound_argv(settings: &NotificationDeliverySettings, reason: NotificationReaso
 }
 
 fn notify_send_argv(request: &NotificationRequest) -> Vec<String> {
-    let (title, body) = match request.reason {
-        NotificationReason::Blocked => (
-            "Boomux Agent blocked".into(),
+    let (title, mut body) = if let Some(digest) = &request.digest {
+        let node = request
+            .node
+            .as_ref()
+            .expect("remote notification digest requires Node context");
+        (
+            "Boomux remote activity".into(),
             format!(
-                "{} in workspace {}, shell {}. Open Boomux or run `boomux attention list`.",
-                sanitize(&request.agent),
-                sanitize(&request.workspace),
-                sanitize(&request.shell)
+                "Node {} ({}) reconnected: {} blocked, {} completed, {} dispatch failed, {} interrupted. Open Boomux to inspect.",
+                sanitize(&node.alias),
+                sanitize(&node.node_id),
+                digest.blocked,
+                digest.completed,
+                digest.scheduled_dispatch_failed,
+                digest.scheduled_interrupted,
             ),
-        ),
-        NotificationReason::Completed => (
-            "Boomux Agent completed".into(),
-            format!(
-                "{} in workspace {}, shell {}. Open Boomux or run `boomux attention list`.",
-                sanitize(&request.agent),
-                sanitize(&request.workspace),
-                sanitize(&request.shell)
+        )
+    } else {
+        match request.reason {
+            NotificationReason::Blocked => (
+                "Boomux Agent blocked".into(),
+                format!(
+                    "{} in workspace {}, shell {}. Open Boomux or run `boomux attention list`.",
+                    sanitize(&request.agent),
+                    sanitize(&request.workspace),
+                    sanitize(&request.shell)
+                ),
             ),
-        ),
-        NotificationReason::ScheduledDispatchFailed => (
-            "Boomux scheduled dispatch failed".into(),
-            format!(
-                "Schedule {} in workspace {} failed for execution {}. Run `boomux execution inspect {}`.",
-                sanitize(&request.agent),
-                sanitize(&request.workspace),
-                sanitize(&request.shell),
-                sanitize(&request.shell)
+            NotificationReason::Completed => (
+                "Boomux Agent completed".into(),
+                format!(
+                    "{} in workspace {}, shell {}. Open Boomux or run `boomux attention list`.",
+                    sanitize(&request.agent),
+                    sanitize(&request.workspace),
+                    sanitize(&request.shell)
+                ),
             ),
-        ),
-        NotificationReason::ScheduledInterrupted => (
-            "Boomux scheduled execution interrupted".into(),
-            format!(
-                "Schedule {} in workspace {} was interrupted for execution {}. Run `boomux execution inspect {}`.",
-                sanitize(&request.agent),
-                sanitize(&request.workspace),
-                sanitize(&request.shell),
-                sanitize(&request.shell)
+            NotificationReason::ScheduledDispatchFailed => (
+                "Boomux scheduled dispatch failed".into(),
+                format!(
+                    "Schedule {} in workspace {} failed for execution {}. Run `boomux execution inspect {}`.",
+                    sanitize(&request.agent),
+                    sanitize(&request.workspace),
+                    sanitize(&request.shell),
+                    sanitize(&request.shell)
+                ),
             ),
-        ),
+            NotificationReason::ScheduledInterrupted => (
+                "Boomux scheduled execution interrupted".into(),
+                format!(
+                    "Schedule {} in workspace {} was interrupted for execution {}. Run `boomux execution inspect {}`.",
+                    sanitize(&request.agent),
+                    sanitize(&request.workspace),
+                    sanitize(&request.shell),
+                    sanitize(&request.shell)
+                ),
+            ),
+        }
     };
+    if request.digest.is_none()
+        && let Some(node) = &request.node
+    {
+        body.push_str(&format!(
+            " Node {} ({}).",
+            sanitize(&node.alias),
+            sanitize(&node.node_id)
+        ));
+    }
     vec![
         "notify-send".into(),
         "--app-name".into(),
@@ -304,6 +350,8 @@ mod tests {
             agent: "OpenCode".into(),
             workspace: "boomux".into(),
             shell: "tests".into(),
+            node: None,
+            digest: None,
         }
     }
 
@@ -346,6 +394,35 @@ mod tests {
         ] {
             assert!(!arguments[4].contains(private));
         }
+    }
+
+    #[test]
+    fn remote_context_and_digest_are_bounded_and_prompt_free() {
+        let mut individual = request();
+        individual.node = Some(NotificationNodeContext {
+            alias: "work\nnode".into(),
+            node_id: "00000000-0000-0000-0000-000000000002".into(),
+        });
+        let arguments = notify_send_argv(&individual);
+        assert!(arguments[4].contains("Node work node (00000000-0000-0000-0000-000000000002)"));
+
+        let digest = NotificationRequest {
+            reason: NotificationReason::Blocked,
+            agent: String::new(),
+            workspace: String::new(),
+            shell: String::new(),
+            node: individual.node,
+            digest: Some(NotificationDigest {
+                blocked: 2,
+                completed: 3,
+                scheduled_dispatch_failed: 4,
+                scheduled_interrupted: 5,
+            }),
+        };
+        let arguments = notify_send_argv(&digest);
+        assert_eq!(arguments[3], "Boomux remote activity");
+        assert!(arguments[4].contains("2 blocked, 3 completed, 4 dispatch failed, 5 interrupted"));
+        assert!(!arguments[4].contains("prompt"));
     }
 
     #[test]

--- a/src/node_projection.rs
+++ b/src/node_projection.rs
@@ -20,7 +20,7 @@ pub(crate) struct NodeProjectionView {
 }
 use crate::state_store::{effective_uid, secure_state_dir, state_directory_from_environment};
 
-const NODE_CACHE_VERSION: u32 = 1;
+const NODE_CACHE_VERSION: u32 = 2;
 const MAX_CACHE_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_NODES: usize = 128;
 const MAX_WORKSPACES_PER_NODE: usize = 1_024;
@@ -31,10 +31,48 @@ const MAX_SCHEDULES_PER_NODE: usize = 1_024;
 const MAX_CAPABILITIES: usize = 96;
 const MAX_CAPABILITY_BYTES: usize = 128;
 const MAX_NAME_BYTES: usize = 256;
+const MAX_NOTIFICATION_CLAIMS_PER_NODE: usize = 512;
+const MAX_DIGEST_CLAIMS_PER_NODE: usize = 128;
+const MAX_NOTIFICATION_REASON_BYTES: usize = 64;
 
 pub(crate) struct NodeProjectionCache {
     path: PathBuf,
     state: Mutex<CacheState>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProjectionCommit {
+    pub(crate) generation: u64,
+    pub(crate) previous_health: Option<NodeProjectionHealthCode>,
+    pub(crate) previous_cursor: Option<EventCursor>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RemoteNotificationCategory {
+    AgentBlocked,
+    AgentCompleted,
+    ScheduledDispatchFailed,
+    ScheduledInterrupted,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RemoteNotificationClaim {
+    pub(crate) stream_id: String,
+    pub(crate) entity_id: String,
+    pub(crate) revision: u64,
+    pub(crate) category: RemoteNotificationCategory,
+    pub(crate) reason: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RemoteDigestClaim {
+    pub(crate) stream_id: String,
+    pub(crate) prior_cursor: u64,
+    pub(crate) through_cursor: u64,
+    pub(crate) enabled_categories: Vec<RemoteNotificationCategory>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize)]
@@ -58,6 +96,31 @@ struct CachedNode {
     capabilities: Vec<String>,
     cursor: Option<EventCursor>,
     projection: Option<NodeProjectionSnapshot>,
+    notification_claims: Vec<RemoteNotificationClaim>,
+    digest_claims: Vec<RemoteDigestClaim>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionOneCacheState {
+    version: u32,
+    nodes: Vec<VersionOneCachedNode>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionOneCachedNode {
+    node_id: String,
+    registration_revision: u64,
+    tombstone_epoch: u64,
+    generation: u64,
+    health: NodeProjectionHealthCode,
+    last_attempt_at_ms: Option<u64>,
+    last_success_at_ms: Option<u64>,
+    retry_at_ms: Option<u64>,
+    capabilities: Vec<String>,
+    cursor: Option<EventCursor>,
+    projection: Option<NodeProjectionSnapshot>,
 }
 
 impl NodeProjectionCache {
@@ -69,18 +132,18 @@ impl NodeProjectionCache {
     }
 
     fn load_at(path: PathBuf) -> Self {
-        let mut state = match load(&path) {
+        let (mut state, migrated) = match load(&path) {
             Ok(state) => state,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => empty_state(),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => (empty_state(), false),
             Err(error) => {
                 if !path.as_os_str().is_empty() {
                     quarantine(&path);
                 }
                 eprintln!("boomux: discarded invalid disposable Node cache: {error}");
-                empty_state()
+                (empty_state(), false)
             }
         };
-        let mut changed = false;
+        let mut changed = migrated;
         for node in &mut state.nodes {
             if node.health == NodeProjectionHealthCode::Online {
                 node.health = NodeProjectionHealthCode::Stale;
@@ -154,7 +217,7 @@ impl NodeProjectionCache {
         projection: NodeProjectionSnapshot,
         capabilities: Vec<String>,
         now_ms: u64,
-    ) -> io::Result<Option<u64>> {
+    ) -> io::Result<Option<ProjectionCommit>> {
         validate_projection(&projection)?;
         validate_capabilities(&capabilities)?;
         if projection.node_id != registration.node_id {
@@ -177,6 +240,17 @@ impl NodeProjectionCache {
         let generation = expected_generation
             .checked_add(1)
             .ok_or_else(|| io::Error::other("Node cache generation exhausted"))?;
+        let (previous_health, previous_cursor, notification_claims, digest_claims) = current
+            .filter(|index| state.nodes[*index].tombstone_epoch == registration.tombstone_epoch)
+            .map_or((None, None, Vec::new(), Vec::new()), |index| {
+                let node = &state.nodes[index];
+                (
+                    Some(node.health),
+                    node.cursor.clone(),
+                    node.notification_claims.clone(),
+                    node.digest_claims.clone(),
+                )
+            });
         let replacement = CachedNode {
             node_id: registration.node_id.clone(),
             registration_revision: registration.revision,
@@ -189,6 +263,8 @@ impl NodeProjectionCache {
             capabilities,
             cursor: Some(cursor),
             projection: Some(projection),
+            notification_claims,
+            digest_claims,
         };
         let mut next = state.clone();
         match current {
@@ -204,7 +280,11 @@ impl NodeProjectionCache {
         sort_nodes(&mut next);
         save(&self.path, &next)?;
         *state = next;
-        Ok(Some(generation))
+        Ok(Some(ProjectionCommit {
+            generation,
+            previous_health,
+            previous_cursor,
+        }))
     }
 
     pub(crate) fn mark_health(
@@ -242,6 +322,8 @@ impl NodeProjectionCache {
                 capabilities: Vec::new(),
                 cursor: None,
                 projection: None,
+                notification_claims: Vec::new(),
+                digest_claims: Vec::new(),
             },
             |index| state.nodes[index].clone(),
         );
@@ -266,6 +348,63 @@ impl NodeProjectionCache {
         save(&self.path, &next)?;
         *state = next;
         Ok(Some(generation))
+    }
+
+    pub(crate) fn claim_notifications(
+        &self,
+        registration: &NodeRegistrationSnapshot,
+        expected_generation: u64,
+        claims: &[RemoteNotificationClaim],
+        digest: Option<&RemoteDigestClaim>,
+    ) -> io::Result<Option<(Vec<bool>, bool)>> {
+        for claim in claims {
+            validate_notification_claim(claim)?;
+        }
+        if let Some(digest) = digest {
+            validate_digest_claim(digest)?;
+        }
+        let mut state = self.lock()?;
+        let Some(index) = state.nodes.iter().position(|node| {
+            node.node_id == registration.node_id
+                && node.tombstone_epoch == registration.tombstone_epoch
+                && node.generation == expected_generation
+        }) else {
+            return Ok(None);
+        };
+        let mut replacement = state.nodes[index].clone();
+        let mut accepted = Vec::with_capacity(claims.len());
+        for claim in claims {
+            if replacement.notification_claims.contains(claim) {
+                accepted.push(false);
+                continue;
+            }
+            replacement.notification_claims.push(claim.clone());
+            accepted.push(true);
+        }
+        if replacement.notification_claims.len() > MAX_NOTIFICATION_CLAIMS_PER_NODE {
+            let remove = replacement.notification_claims.len() - MAX_NOTIFICATION_CLAIMS_PER_NODE;
+            replacement.notification_claims.drain(..remove);
+        }
+        let digest_accepted = digest.is_some_and(|digest| {
+            if replacement.digest_claims.contains(digest) {
+                false
+            } else {
+                replacement.digest_claims.push(digest.clone());
+                true
+            }
+        });
+        if replacement.digest_claims.len() > MAX_DIGEST_CLAIMS_PER_NODE {
+            let remove = replacement.digest_claims.len() - MAX_DIGEST_CLAIMS_PER_NODE;
+            replacement.digest_claims.drain(..remove);
+        }
+        if !accepted.iter().any(|accepted| *accepted) && !digest_accepted {
+            return Ok(Some((accepted, false)));
+        }
+        let mut next = state.clone();
+        next.nodes[index] = replacement;
+        save(&self.path, &next)?;
+        *state = next;
+        Ok(Some((accepted, digest_accepted)))
     }
 
     pub(crate) fn remove(&self, node_id: &str) -> io::Result<bool> {
@@ -382,7 +521,7 @@ fn validate_capabilities(capabilities: &[String]) -> io::Result<()> {
     Ok(())
 }
 
-fn load(path: &Path) -> io::Result<CacheState> {
+fn load(path: &Path) -> io::Result<(CacheState, bool)> {
     let mut file = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW)
@@ -399,8 +538,50 @@ fn load(path: &Path) -> io::Result<CacheState> {
     }
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
     file.read_to_end(&mut bytes)?;
-    let state: CacheState =
-        serde_json::from_slice(&bytes).map_err(|error| invalid(error.to_string()))?;
+    let version = serde_json::from_slice::<serde_json::Value>(&bytes)
+        .map_err(|error| invalid(error.to_string()))?
+        .get("version")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| invalid("Node cache version is missing"))?;
+    let (state, migrated) = match version {
+        1 => {
+            let old: VersionOneCacheState =
+                serde_json::from_slice(&bytes).map_err(|error| invalid(error.to_string()))?;
+            if old.version != 1 {
+                return Err(invalid("invalid Node cache version"));
+            }
+            (
+                CacheState {
+                    version: NODE_CACHE_VERSION,
+                    nodes: old
+                        .nodes
+                        .into_iter()
+                        .map(|node| CachedNode {
+                            node_id: node.node_id,
+                            registration_revision: node.registration_revision,
+                            tombstone_epoch: node.tombstone_epoch,
+                            generation: node.generation,
+                            health: node.health,
+                            last_attempt_at_ms: node.last_attempt_at_ms,
+                            last_success_at_ms: node.last_success_at_ms,
+                            retry_at_ms: node.retry_at_ms,
+                            capabilities: node.capabilities,
+                            cursor: node.cursor,
+                            projection: node.projection,
+                            notification_claims: Vec::new(),
+                            digest_claims: Vec::new(),
+                        })
+                        .collect(),
+                },
+                true,
+            )
+        }
+        2 => (
+            serde_json::from_slice(&bytes).map_err(|error| invalid(error.to_string()))?,
+            false,
+        ),
+        _ => return Err(invalid("unsupported Node cache version")),
+    };
     if state.version != NODE_CACHE_VERSION || state.nodes.len() > MAX_NODES {
         return Err(invalid("unsupported or oversized Node cache"));
     }
@@ -412,6 +593,17 @@ fn load(path: &Path) -> io::Result<CacheState> {
             ));
         }
         validate_capabilities(&node.capabilities)?;
+        if node.notification_claims.len() > MAX_NOTIFICATION_CLAIMS_PER_NODE
+            || node.digest_claims.len() > MAX_DIGEST_CLAIMS_PER_NODE
+        {
+            return Err(invalid("Node notification claims exceed their bounds"));
+        }
+        for claim in &node.notification_claims {
+            validate_notification_claim(claim)?;
+        }
+        for claim in &node.digest_claims {
+            validate_digest_claim(claim)?;
+        }
         if let Some(projection) = &node.projection {
             if projection.node_id != node.node_id {
                 return Err(invalid("Node cache projection identity mismatch"));
@@ -419,7 +611,35 @@ fn load(path: &Path) -> io::Result<CacheState> {
             validate_projection(projection)?;
         }
     }
-    Ok(state)
+    Ok((state, migrated))
+}
+
+fn validate_notification_claim(claim: &RemoteNotificationClaim) -> io::Result<()> {
+    if Uuid::parse_str(&claim.stream_id).is_err()
+        || claim.entity_id.is_empty()
+        || claim.entity_id.len() > MAX_NAME_BYTES
+        || claim.revision == 0
+        || claim.reason.is_empty()
+        || claim.reason.len() > MAX_NOTIFICATION_REASON_BYTES
+        || claim.reason.chars().any(char::is_control)
+    {
+        return Err(invalid("Node notification claim is invalid"));
+    }
+    Ok(())
+}
+
+fn validate_digest_claim(claim: &RemoteDigestClaim) -> io::Result<()> {
+    let mut categories = claim.enabled_categories.clone();
+    categories.sort_unstable();
+    categories.dedup();
+    if Uuid::parse_str(&claim.stream_id).is_err()
+        || claim.prior_cursor > claim.through_cursor
+        || categories.is_empty()
+        || categories != claim.enabled_categories
+    {
+        return Err(invalid("Node notification digest claim is invalid"));
+    }
+    Ok(())
 }
 
 fn save(path: &Path, state: &CacheState) -> io::Result<()> {
@@ -537,7 +757,8 @@ mod tests {
                     vec!["protocol_32".into()],
                     10,
                 )
-                .unwrap(),
+                .unwrap()
+                .map(|commit| commit.generation),
             Some(1)
         );
         assert_eq!(
@@ -604,6 +825,100 @@ mod tests {
             assert_eq!(view.health.stale, code != NodeProjectionHealthCode::Online);
             assert!(view.projection.is_none());
         }
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn schema_one_migrates_explicitly_and_notification_claims_are_at_most_once() {
+        let root = std::env::temp_dir().join(format!("boomux-node-claims-{}", Uuid::new_v4()));
+        let path = root.join("boomux/node-cache.json");
+        let node_id = Uuid::from_u128(2).to_string();
+        let stream_id = Uuid::from_u128(3).to_string();
+        let registration = NodeRegistrationSnapshot {
+            alias: "work".into(),
+            target: "work.example".into(),
+            node_id: node_id.clone(),
+            revision: 1,
+            tombstone_epoch: 0,
+        };
+        let cache = NodeProjectionCache::load_at(path.clone());
+        let generation = cache
+            .commit_projection(
+                &registration,
+                0,
+                EventCursor {
+                    stream_id: stream_id.clone(),
+                    event_id: 7,
+                },
+                projection(node_id),
+                vec!["protocol_32".into()],
+                10,
+            )
+            .unwrap()
+            .unwrap()
+            .generation;
+        drop(cache);
+
+        let mut version_one: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        version_one["version"] = serde_json::json!(1);
+        version_one["nodes"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("notification_claims");
+        version_one["nodes"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("digest_claims");
+        fs::write(&path, serde_json::to_vec_pretty(&version_one).unwrap()).unwrap();
+        let cache = NodeProjectionCache::load_at(path.clone());
+        let migrated: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(migrated["version"], 2);
+        assert_eq!(
+            migrated["nodes"][0]["notification_claims"],
+            serde_json::json!([])
+        );
+        assert_eq!(migrated["nodes"][0]["digest_claims"], serde_json::json!([]));
+
+        let claim = RemoteNotificationClaim {
+            stream_id: stream_id.clone(),
+            entity_id: "agent-1".into(),
+            revision: 2,
+            category: RemoteNotificationCategory::AgentBlocked,
+            reason: "blocked".into(),
+        };
+        let digest = RemoteDigestClaim {
+            stream_id,
+            prior_cursor: 7,
+            through_cursor: 9,
+            enabled_categories: vec![RemoteNotificationCategory::AgentBlocked],
+        };
+        assert_eq!(
+            cache
+                .claim_notifications(
+                    &registration,
+                    generation,
+                    std::slice::from_ref(&claim),
+                    Some(&digest),
+                )
+                .unwrap(),
+            Some((vec![true], true))
+        );
+        assert_eq!(
+            cache
+                .claim_notifications(&registration, generation, &[claim], Some(&digest))
+                .unwrap(),
+            Some((vec![false], false))
+        );
+        drop(cache);
+        let cache = NodeProjectionCache::load_at(path);
+        assert_eq!(
+            cache
+                .claim_notifications(&registration, generation, &[], Some(&digest))
+                .unwrap(),
+            Some((Vec::new(), false))
+        );
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/tests/native_backend/notifications.rs
+++ b/tests/native_backend/notifications.rs
@@ -10,6 +10,15 @@ use uuid::Uuid;
 
 use crate::support::{TestDaemon, process_exists, profile, wait_until};
 
+struct RemoteSubscriber {
+    daemon: TestDaemon,
+    capture: PathBuf,
+    sound_capture: PathBuf,
+    sound_player: PathBuf,
+    config: PathBuf,
+    path: std::ffi::OsString,
+}
+
 #[test]
 fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
     let (daemon, capture, notify_send, sound_capture) = start_with_notifications();
@@ -313,6 +322,255 @@ fn notification_test_command_plays_the_configured_sound() {
     fs::remove_dir_all(directory).unwrap();
 }
 
+#[test]
+fn full_notification_queue_is_fail_open_for_agent_lifecycle() {
+    let (daemon, _capture, _notify_send, _sound_capture) = start_with_notifications();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "queue-workspace",
+            vec![ShellSpec::login("queue-shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+    fs::write(daemon.runtime_dir.join("notification-hang"), b"").unwrap();
+
+    for index in 0..40 {
+        let agent = daemon
+            .client
+            .register_agent(
+                &shell_id,
+                &run_id,
+                AgentRegistrationSpec {
+                    name: format!("queued-agent-{index}"),
+                    integration: "native-test".into(),
+                    external_session_id: Some(format!("queued-session-{index}")),
+                    report: AgentReport {
+                        state: AgentState::Blocked,
+                        authority: AgentAuthority::LifecycleIntegration,
+                        evidence: "queue saturation must fail open".into(),
+                        confidence: 90,
+                    },
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            daemon
+                .client
+                .get_agent(&agent.id)
+                .unwrap()
+                .observation
+                .state,
+            AgentState::Blocked
+        );
+    }
+    drop(attachment.stream);
+}
+
+#[test]
+fn remote_notifications_are_independent_digest_once_and_survive_restart() {
+    let owner = TestDaemon::start();
+    let owner_id = owner.client.node_identity().unwrap();
+    let workspace = owner
+        .client
+        .create_workspace(
+            "remote-notification-workspace",
+            vec![ShellSpec::login("remote-shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = owner.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = owner.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+    let mut first = start_remote_subscriber(&owner);
+    let second = start_remote_subscriber(&owner);
+    for subscriber in [&first, &second] {
+        subscriber
+            .daemon
+            .client
+            .add_node_registration("owner", "fake-owner", &owner_id)
+            .unwrap();
+        wait_until(
+            || {
+                subscriber
+                    .daemon
+                    .client
+                    .combined_node_snapshot(Some(owner_id.clone()))
+                    .is_ok_and(|snapshot| snapshot.nodes[0].current)
+            },
+            "remote notification subscriber did not establish its baseline",
+        );
+        assert_eq!(captured_notification_count(&subscriber.capture), 0);
+    }
+
+    let agent = owner
+        .client
+        .register_agent(
+            &shell_id,
+            &run_id,
+            AgentRegistrationSpec {
+                name: "remote-agent".into(),
+                integration: "native-test".into(),
+                external_session_id: Some("PRIVATE-REMOTE-SESSION".into()),
+                report: AgentReport {
+                    state: AgentState::Blocked,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "PRIVATE-REMOTE-EVIDENCE".into(),
+                    confidence: 90,
+                },
+            },
+        )
+        .unwrap();
+    for subscriber in [&first, &second] {
+        wait_until(
+            || captured_notification_count(&subscriber.capture) == 1,
+            "independent subscriber did not deliver live remote attention",
+        );
+        wait_until(
+            || captured_notification_count(&subscriber.sound_capture) == 1,
+            "independent subscriber did not deliver live remote sound",
+        );
+        let captured = fs::read(&subscriber.capture).unwrap();
+        assert!(!String::from_utf8_lossy(&captured).contains("PRIVATE-REMOTE"));
+        assert!(String::from_utf8_lossy(&captured).contains("owner"));
+        assert!(String::from_utf8_lossy(&captured).contains(&owner_id));
+    }
+
+    owner
+        .client
+        .report_agent(
+            &agent.id,
+            &run_id,
+            AgentReport {
+                state: AgentState::Working,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "resumed".into(),
+                confidence: 90,
+            },
+        )
+        .unwrap();
+    let failed_ssh = fs::read(first.daemon.runtime_dir.join("ssh")).unwrap();
+    fs::write(first.daemon.runtime_dir.join("ssh"), "#!/bin/sh\nexit 64\n").unwrap();
+    wait_until(
+        || {
+            first
+                .daemon
+                .client
+                .combined_node_snapshot(Some(owner_id.clone()))
+                .is_ok_and(|snapshot| !snapshot.nodes[0].current)
+        },
+        "subscriber did not become disconnected",
+    );
+    let offline_agent = owner
+        .client
+        .register_agent(
+            &shell_id,
+            &run_id,
+            AgentRegistrationSpec {
+                name: "offline-agent".into(),
+                integration: "native-test".into(),
+                external_session_id: Some("private-offline-session".into()),
+                report: AgentReport {
+                    state: AgentState::Blocked,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "private offline blocker".into(),
+                    confidence: 90,
+                },
+            },
+        )
+        .unwrap();
+    owner
+        .client
+        .report_agent(
+            &agent.id,
+            &run_id,
+            AgentReport {
+                state: AgentState::Done,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "private completion".into(),
+                confidence: 90,
+            },
+        )
+        .unwrap();
+    fs::write(first.daemon.runtime_dir.join("ssh"), failed_ssh).unwrap();
+    wait_until(
+        || captured_notification_count(&first.capture) == 2,
+        "valid-cursor reconnect did not deliver one digest",
+    );
+    thread::sleep(Duration::from_millis(1200));
+    assert_eq!(captured_notification_count(&first.capture), 2);
+    assert!(
+        String::from_utf8_lossy(&fs::read(&first.capture).unwrap()).contains("remote activity")
+    );
+    wait_until(
+        || captured_notification_count(&second.capture) == 3,
+        "online subscriber did not receive individual remote transitions",
+    );
+
+    let before_restart = captured_notification_count(&first.capture);
+    first.daemon.crash();
+    configure_remote_subscriber_restart(&mut first);
+    thread::sleep(Duration::from_millis(1200));
+    assert_eq!(captured_notification_count(&first.capture), before_restart);
+
+    let before_handoff = captured_notification_count(&second.capture);
+    let restart = second
+        .daemon
+        .command()
+        .env("BOOMUX_CONFIG", &second.config)
+        .env("BOOMUX_NOTIFICATION_CAPTURE", &second.capture)
+        .env("BOOMUX_SOUND_CAPTURE", &second.sound_capture)
+        .env("PATH", &second.path)
+        .args(["daemon", "restart"])
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "{}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    thread::sleep(Duration::from_millis(1200));
+    assert_eq!(captured_notification_count(&second.capture), before_handoff);
+
+    fs::remove_file(&first.sound_player).unwrap();
+    owner
+        .client
+        .report_agent(
+            &offline_agent.id,
+            &run_id,
+            AgentReport {
+                state: AgentState::Done,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "private done after sound failure".into(),
+                confidence: 90,
+            },
+        )
+        .unwrap();
+    wait_until(
+        || captured_notification_count(&first.capture) == before_restart + 1,
+        "desktop notification did not survive remote sound failure",
+    );
+    assert_eq!(
+        owner
+            .client
+            .get_agent(&offline_agent.id)
+            .unwrap()
+            .observation
+            .state,
+        AgentState::Done
+    );
+    let cache = fs::read(
+        first
+            .daemon
+            .runtime_dir
+            .join("state/boomux/node-cache.json"),
+    )
+    .unwrap();
+    assert!(!String::from_utf8_lossy(&cache).contains("private"));
+    drop(attachment.stream);
+}
+
 fn start_with_notifications() -> (TestDaemon, PathBuf, PathBuf, PathBuf) {
     let mut capture = None;
     let mut notify_send = None;
@@ -370,6 +628,93 @@ fn start_with_notifications() -> (TestDaemon, PathBuf, PathBuf, PathBuf) {
         notify_send.unwrap(),
         sound_capture.unwrap(),
     )
+}
+
+fn start_remote_subscriber(owner: &TestDaemon) -> RemoteSubscriber {
+    let mut capture = None;
+    let mut sound_capture = None;
+    let mut sound_player = None;
+    let mut config = None;
+    let mut path = None;
+    let daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let ssh = runtime_dir.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}\\0' ;;\n  *__federation-stdio*) exec env XDG_RUNTIME_DIR='{}' XDG_STATE_HOME='{}' '{}' __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
+                owner.executable.display(),
+                owner.executable.display(),
+                owner.runtime_dir.display(),
+                owner.runtime_dir.join("state").display(),
+                owner.executable.display(),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        let bin = runtime_dir.join("bin");
+        fs::create_dir(&bin).unwrap();
+        let notifier = bin.join("notify-send");
+        let player = bin.join("canberra-gtk-play");
+        let notifications = runtime_dir.join("remote-notifications");
+        let sounds = runtime_dir.join("remote-sounds");
+        fs::write(
+            &notifier,
+            "#!/bin/sh\nprintf '%s\\0' \"$@\" >> \"$BOOMUX_NOTIFICATION_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::write(
+            &player,
+            "#!/bin/sh\nprintf '%s\\0' \"$@\" >> \"$BOOMUX_SOUND_CAPTURE\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&notifier, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::set_permissions(&player, fs::Permissions::from_mode(0o700)).unwrap();
+        let configuration = runtime_dir.join("remote-notifications.toml");
+        fs::write(
+            &configuration,
+            "[notifications]\nenabled = true\nblocked = true\ncompleted = true\nscheduled_dispatch_failed = true\nscheduled_interrupted = true\n[notifications.sound]\nenabled = true\n",
+        )
+        .unwrap();
+        let paths = std::env::join_paths([
+            runtime_dir.to_path_buf(),
+            bin,
+            PathBuf::from("/usr/bin"),
+            PathBuf::from("/bin"),
+        ])
+        .unwrap();
+        command
+            .env("BOOMUX_CONFIG", &configuration)
+            .env("BOOMUX_NOTIFICATION_CAPTURE", &notifications)
+            .env("BOOMUX_SOUND_CAPTURE", &sounds)
+            .env("PATH", &paths);
+        capture = Some(notifications);
+        sound_capture = Some(sounds);
+        sound_player = Some(player);
+        config = Some(configuration);
+        path = Some(paths);
+    });
+    RemoteSubscriber {
+        daemon,
+        capture: capture.unwrap(),
+        sound_capture: sound_capture.unwrap(),
+        sound_player: sound_player.unwrap(),
+        config: config.unwrap(),
+        path: path.unwrap(),
+    }
+}
+
+fn configure_remote_subscriber_restart(subscriber: &mut RemoteSubscriber) {
+    let config = subscriber.config.clone();
+    let capture = subscriber.capture.clone();
+    let sound_capture = subscriber.sound_capture.clone();
+    let path = subscriber.path.clone();
+    subscriber.daemon.restart_with(|command| {
+        command
+            .env("BOOMUX_CONFIG", config)
+            .env("BOOMUX_NOTIFICATION_CAPTURE", capture)
+            .env("BOOMUX_SOUND_CAPTURE", sound_capture)
+            .env("PATH", path);
+    });
 }
 
 fn captured_notification_count(path: &Path) -> usize {


### PR DESCRIPTION
## Summary

- persist bounded remote notification claims in node-cache schema 2
- deliver proven live blocked/completed and enabled execution transitions once
- emit one bounded per-Node digest after valid-cursor reconnect
- suppress initial, expired-cursor, and replacement-stream baseline digests
- persist claims before fail-open enqueue and preserve them across restart/handoff
- include sanitized Node context without acknowledging owner attention
- keep remote events out of the local authoritative event vocabulary

## Stack

- GitHub stack #190
- depends on #204
- implements #183

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js`

Closes #183

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
