### PR TITLE
fix(node): streamline onboarding and dashboard chrome

### DIFF
--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -108,7 +108,9 @@ destructive changes, integration installation, Schedule enablement, and remote
 daemon management retain their existing explicit user authorization. Boomux
 never scans SSH configuration and automatically connects to every alias.
 
-The implemented registration CLI is `boomux node add ALIAS TARGET`, `node list`,
+The implemented registration CLI is `boomux node add ALIAS TARGET`, or guided
+interactive `boomux node add` from the dashboard command palette or Omarchy
+panel. Registration management continues with `node list`,
 `node inspect`, revision-conditional `node rename` and `node retarget`, and `node
 forget`. Add and retarget complete verified bootstrap before submitting a
 registration mutation to the local daemon. The selected helper path is

--- a/src/dashboard_projection.rs
+++ b/src/dashboard_projection.rs
@@ -27,8 +27,6 @@ fn local_node_placeholder() -> NodeView {
         health: boomux::protocol::NodeProjectionHealthCode::Online,
         current: true,
         stale: false,
-        observed_at_ms: 0,
-        observed_protocol_version: None,
         observed_capabilities: Vec::new(),
         scheduler: boomux::protocol::SchedulerHealth {
             state: boomux::protocol::SchedulerState::Offline,
@@ -340,8 +338,6 @@ pub(crate) fn project_remote_node(
         health: node.health,
         current: node.current,
         stale: node.stale,
-        observed_at_ms: node.observed_at_ms,
-        observed_protocol_version: node.observed_protocol_version,
         observed_capabilities: node.observed_capabilities.clone(),
         scheduler: node.scheduler.clone(),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -511,7 +511,10 @@ enum ProjectCommands {
 #[derive(Subcommand)]
 enum NodeCommands {
     /// Verify and persist a remote Boomux Node route
-    Add { alias: String, target: String },
+    Add {
+        alias: Option<String>,
+        target: Option<String>,
+    },
     /// List registered remote Nodes
     List,
     /// Inspect a registered remote Node by alias or exact Node ID
@@ -1798,6 +1801,7 @@ fn verified_remote_connection(
 fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>> {
     match command {
         NodeCommands::Add { alias, target } => {
+            let (alias, target) = resolve_node_add_inputs(alias, target, json)?;
             let mut remote = verified_remote_connection(&target, !json)?;
             remote.ping()?;
             let registration = client::connect_or_start()?.add_node_registration(
@@ -1966,6 +1970,59 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
         }
         NodeCommands::Rekey => rekey_node(),
     }
+}
+
+fn resolve_node_add_inputs(
+    alias: Option<String>,
+    target: Option<String>,
+    json: bool,
+) -> Result<(String, String), Box<dyn Error>> {
+    match (alias, target) {
+        (Some(alias), Some(target)) => return Ok((alias, target)),
+        (None, None) => {}
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "provide both ALIAS and TARGET, or omit both for guided setup",
+            )
+            .into());
+        }
+    }
+    if json || !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "guided Node setup requires an interactive terminal; use: boomux node add ALIAS TARGET",
+        )
+        .into());
+    }
+
+    println!("Add a remote Boomux Node");
+    println!("Boomux uses your normal OpenSSH configuration and keeps remote work on its owner.");
+    let target = prompt_node_value("SSH target (for example user@workbox): ", None)?;
+    let suggested_alias = target.rsplit('@').next().filter(|value| !value.is_empty());
+    let alias = prompt_node_value("Local alias", suggested_alias)?;
+    Ok((alias, target))
+}
+
+fn prompt_node_value(label: &str, default: Option<&str>) -> io::Result<String> {
+    match default {
+        Some(default) => print!("{label} [{default}]: "),
+        None => print!("{label}"),
+    }
+    std::io::Write::flush(&mut io::stdout())?;
+    let mut value = String::new();
+    io::stdin().read_line(&mut value)?;
+    let value = value.trim();
+    if value.is_empty() {
+        if let Some(default) = default {
+            return Ok(default.to_owned());
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Node setup value cannot be empty",
+        ));
+    }
+    Ok(value.to_owned())
 }
 
 fn node_snapshot_json(node: protocol::CombinedNode) -> Result<serde_json::Value, Box<dyn Error>> {
@@ -2206,6 +2263,11 @@ fn dashboard(
         true,
         |effect| match effect {
             tui::DashboardEffect::Quit => unreachable!("quit is handled by the dashboard runtime"),
+            tui::DashboardEffect::AddNode => tui::DashboardEvent::OperationCompleted(
+                terminal::open_node_add(terminal.as_deref())
+                    .map(|()| "Opened guided Node setup".into())
+                    .map_err(|error| error.to_string()),
+            ),
             tui::DashboardEffect::CheckForUpdates => {
                 let result = refresh.check(&client).map_err(|error| error.to_string());
                 match result {
@@ -2841,8 +2903,6 @@ fn dashboard_state(
                 health: node.health,
                 current: node.current,
                 stale: node.stale,
-                observed_at_ms: node.observed_at_ms,
-                observed_protocol_version: node.observed_protocol_version,
                 observed_capabilities: node.observed_capabilities.clone(),
                 scheduler: node.scheduler.clone(),
             };
@@ -9394,6 +9454,36 @@ mod tests {
     }
 
     #[test]
+    fn node_add_supports_explicit_and_guided_inputs() {
+        let explicit = Cli::try_parse_from(["boomux", "node", "add", "work", "user@host"]).unwrap();
+        assert!(matches!(
+            explicit.command,
+            Some(Commands::Node {
+                command: NodeCommands::Add {
+                    alias: Some(alias),
+                    target: Some(target),
+                }
+            }) if alias == "work" && target == "user@host"
+        ));
+        let guided = Cli::try_parse_from(["boomux", "node", "add"]).unwrap();
+        assert!(matches!(
+            guided.command,
+            Some(Commands::Node {
+                command: NodeCommands::Add {
+                    alias: None,
+                    target: None,
+                }
+            })
+        ));
+        assert_eq!(
+            resolve_node_add_inputs(Some("work".into()), Some("host".into()), false).unwrap(),
+            ("work".into(), "host".into())
+        );
+        assert!(resolve_node_add_inputs(Some("work".into()), None, false).is_err());
+        assert!(resolve_node_add_inputs(None, None, true).is_err());
+    }
+
+    #[test]
     fn node_snapshot_is_separate_json_command_with_structural_identities() {
         let cli = Cli::try_parse_from(["boomux", "--json", "node", "snapshot", "work"]).unwrap();
         assert!(matches!(
@@ -10223,8 +10313,6 @@ mod tests {
                 health: protocol::NodeProjectionHealthCode::Online,
                 current: true,
                 stale: false,
-                observed_at_ms: 0,
-                observed_protocol_version: None,
                 observed_capabilities: Vec::new(),
                 scheduler: protocol::SchedulerHealth {
                     state: protocol::SchedulerState::Active,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -163,6 +163,16 @@ fn open_with_expected_run(
     )
 }
 
+pub fn open_node_add(desktop_entry: Option<&str>) -> Result<(), Box<dyn Error>> {
+    launch(
+        desktop_entry,
+        "Add Boomux Node",
+        None,
+        attachment_executable()?.as_os_str(),
+        &["node".into(), "add".into()],
+    )
+}
+
 fn launch(
     desktop_entry: Option<&str>,
     title: &str,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -150,8 +150,6 @@ pub(crate) struct NodeView {
     pub(crate) health: NodeProjectionHealthCode,
     pub(crate) current: bool,
     pub(crate) stale: bool,
-    pub(crate) observed_at_ms: u64,
-    pub(crate) observed_protocol_version: Option<u32>,
     pub(crate) observed_capabilities: Vec<String>,
     pub(crate) scheduler: SchedulerHealth,
 }
@@ -771,6 +769,7 @@ impl AttentionReason {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum DashboardEffect {
     Quit,
+    AddNode,
     RestoreWorkspace(QualifiedIdentity),
     Open(OpenTarget),
     Close(CloseTarget),
@@ -1348,6 +1347,7 @@ impl PaletteActionGroup {
 enum PaletteKindGroup {
     BlockedAgents,
     Attention,
+    Nodes,
     Workspaces,
     Agents,
     Shells,
@@ -1363,6 +1363,7 @@ impl PaletteKindGroup {
         match self {
             Self::BlockedAgents => "BLOCKED AGENTS",
             Self::Attention => "ATTENTION",
+            Self::Nodes => "NODES",
             Self::Workspaces => "WORKSPACES",
             Self::Agents => "AGENTS",
             Self::Shells => "SHELLS",
@@ -1377,6 +1378,7 @@ impl PaletteKindGroup {
 
 #[derive(Clone)]
 enum PaletteCommand {
+    AddNode,
     CreateWorkspace,
     ShowHelp,
     Workspace {
@@ -1550,6 +1552,14 @@ impl CommandPalette {
         scheduling: &SchedulingView,
     ) -> Self {
         let mut entries = vec![
+            PaletteEntry {
+                action_group: PaletteActionGroup::Create,
+                kind_group: PaletteKindGroup::Nodes,
+                label: "Add remote Node".into(),
+                detail: "open guided SSH setup in a new terminal".into(),
+                keywords: "connect register ssh machine host".into(),
+                command: PaletteCommand::AddNode,
+            },
             PaletteEntry {
                 action_group: PaletteActionGroup::Create,
                 kind_group: PaletteKindGroup::Workspaces,
@@ -3442,6 +3452,7 @@ fn execute_effects(
 
 fn execute_palette_command(app: &mut App, command: PaletteCommand) -> Option<DashboardEffect> {
     match command {
+        PaletteCommand::AddNode => Some(DashboardEffect::AddNode),
         PaletteCommand::CreateWorkspace => {
             app.mode = Mode::PickProject(ProjectPicker::new(&app.project_context));
             None
@@ -4747,7 +4758,7 @@ fn workspace_display_name(workspace: &WorkspaceView) -> String {
     if workspace.node.local {
         return workspace.name.clone();
     }
-    let health = format!("{:?}", workspace.node.health).to_ascii_lowercase();
+    let health = node_health_label(workspace.node.health);
     let freshness = if workspace.node.stale || !workspace.node.current {
         " stale"
     } else {
@@ -4757,6 +4768,20 @@ fn workspace_display_name(workspace: &WorkspaceView) -> String {
         "[{} {health}{freshness}] {}",
         workspace.node.alias, workspace.name
     )
+}
+
+fn node_health_label(health: NodeProjectionHealthCode) -> &'static str {
+    match health {
+        NodeProjectionHealthCode::Unobserved => "unobserved",
+        NodeProjectionHealthCode::Online => "online",
+        NodeProjectionHealthCode::Reconnecting => "reconnecting",
+        NodeProjectionHealthCode::Stale => "stale",
+        NodeProjectionHealthCode::Unreachable => "unreachable",
+        NodeProjectionHealthCode::AuthenticationRequired => "auth required",
+        NodeProjectionHealthCode::IdentityChanged => "identity changed",
+        NodeProjectionHealthCode::IdentityConflict => "identity conflict",
+        NodeProjectionHealthCode::Unsupported => "unsupported",
+    }
 }
 
 fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
@@ -4776,17 +4801,8 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                 ]
             })
             .collect::<Vec<_>>();
-        let filter = app.node_filter.as_ref().map_or("all", |id| {
-            app.nodes
-                .iter()
-                .find(|node| &node.id == id)
-                .map_or("unknown", |node| node.alias.as_str())
-        });
         let mut spans = spans;
-        spans.push(Span::styled(
-            format!(" NODE:{filter}"),
-            Style::new().fg(YELLOW),
-        ));
+        append_node_filter(&mut spans, app);
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
         return;
     }
@@ -4804,7 +4820,7 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
             format!(" 1 WORKSPACES {} ", app.workspaces.len()),
             workspace_style,
         ),
-        Span::styled("      ALL: ", Style::new().fg(SUBTEXT)),
+        Span::raw("      "),
     ];
     spans.extend(
         PrimaryTab::ALL
@@ -4836,26 +4852,24 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                 ]
             }),
     );
-    spans.push(Span::styled(" NODES: ", Style::new().fg(SUBTEXT)));
-    for node in &app.nodes {
-        spans.push(Span::styled(
-            format!(
-                "{}({}) {}/{} sched:{}/{} p{} obs:{} caps:{}  ",
-                node.alias,
-                if node.local { "local" } else { "remote" },
-                format!("{:?}", node.health).to_ascii_lowercase(),
-                if node.stale { "stale" } else { "current" },
-                format!("{:?}", node.scheduler.state).to_ascii_lowercase(),
-                node.scheduler.active_executions,
-                node.observed_protocol_version
-                    .map_or_else(|| "?".into(), |version| version.to_string()),
-                node.observed_at_ms,
-                node.observed_capabilities.len(),
-            ),
-            Style::new().fg(if node.stale { YELLOW } else { GREEN }),
-        ));
-    }
+    append_node_filter(&mut spans, app);
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn append_node_filter<'a>(spans: &mut Vec<Span<'a>>, app: &'a App) {
+    if app.nodes.len() <= 1 && app.node_filter.is_none() {
+        return;
+    }
+    let filter = app.node_filter.as_ref().map_or("all", |id| {
+        app.nodes
+            .iter()
+            .find(|node| &node.id == id)
+            .map_or("unknown", |node| node.alias.as_str())
+    });
+    spans.push(Span::styled(
+        format!(" NODE:{filter}"),
+        Style::new().fg(YELLOW),
+    ));
 }
 
 fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
@@ -6713,8 +6727,6 @@ mod tests {
                 health: NodeProjectionHealthCode::Online,
                 current: true,
                 stale: false,
-                observed_at_ms: 0,
-                observed_protocol_version: None,
                 observed_capabilities: Vec::new(),
                 scheduler: SchedulerHealth {
                     state: crate::protocol::SchedulerState::Active,
@@ -6907,11 +6919,11 @@ mod tests {
             remote.node.stale = health != NodeProjectionHealthCode::Online;
             let mut wide = App::new(vec![remote.clone()], project_context());
             let mut compact = App::new(vec![remote], project_context());
-            let label = format!("{:?}", health).to_ascii_lowercase();
+            let label = node_health_label(health);
             let wide = rendered_text(&mut wide, 180, 24);
             let compact = rendered_text(&mut compact, 60, 20);
             assert!(
-                wide.contains(&format!("work(remote) {label}")),
+                wide.contains(&format!("[work {label}")),
                 "{health:?}: {wide}"
             );
             assert!(
@@ -7648,9 +7660,10 @@ mod tests {
         assert!(!text.contains("COMMANDS 1"));
         assert!(!text.contains("active agents"));
         let workspace_tab = text.find("WORKSPACES 1").expect("workspace tab");
-        let aggregate_label = text.find("ALL:").expect("aggregate label");
         let agent_tab = text.find("AGENTS 1").expect("agent tab");
-        assert!(workspace_tab < aggregate_label && aggregate_label < agent_tab);
+        assert!(workspace_tab < agent_tab);
+        assert!(!text.contains("NODES:"));
+        assert!(!text.contains("NODE:all"));
         assert!(lines.iter().any(|line| line.contains("> mixed")));
 
         app.select_tab(PrimaryTab::Agents);
@@ -7942,6 +7955,22 @@ mod tests {
             palette.selected_command(),
             Some(PaletteCommand::Attention { ref shell_id, .. }) if shell_id == "term_1"
         ));
+    }
+
+    #[test]
+    fn command_palette_opens_guided_node_setup() {
+        let mut palette = CommandPalette::new(&[]);
+        palette.query = "add remote node".into();
+        palette.update_matches();
+        assert!(matches!(
+            palette.selected_command(),
+            Some(PaletteCommand::AddNode)
+        ));
+        let mut app = App::new(Vec::new(), project_context());
+        assert_eq!(
+            execute_palette_command(&mut app, PaletteCommand::AddNode),
+            Some(DashboardEffect::AddNode)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove verbose federation diagnostics from the dashboard header
- show a compact Node filter only when multiple Nodes actually exist
- add guided interactive `boomux node add` while preserving explicit arguments
- open guided Node setup from the dashboard command palette in a fresh terminal
- keep remote health visible with concise resource-level labels

## Stack

- GitHub stack #190
- depends on #205
- incorporates dogfood feedback for #175 and #184

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
