### PR TITLE
feat(workspace): coordinate multi-node resources

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -500,8 +500,8 @@ Scheduled dispatch-failure and cold-interruption notification categories are
 configured independently as `[notifications] scheduled_dispatch_failed` and
 `scheduled_interrupted`; both default to false and never disclose schedule
 prompts or acknowledge Agent attention.
-Selecting a discovered project in the dashboard persists its canonical path as
-the workspace default cwd for later shells. Set
+Selecting a discovered project in the dashboard uses its name only and creates
+empty coordinator metadata. Set
 `[dashboard] follow_focused_terminal = false` to disable the default
 focus-following behavior.
 
@@ -511,25 +511,25 @@ Discover the same configured projects locally without starting the daemon:
 boomux project list --json
 ```
 
-Use the canonical `path` returned for workspace creation. An empty list with
-`roots_configured: false` means no roots are configured; inspect `warnings` when
-configured roots cannot be scanned.
+Use the canonical `path` returned when creating a Node-hosted item. An empty
+list with `roots_configured: false` means no roots are configured; inspect
+`warnings` when configured roots cannot be scanned.
 
 ## Manage Workspaces
 
 ```console
 boomux workspace list
 boomux workspace create "<name>"
-boomux workspace create "<name>" --cwd "/path/to/project"
 boomux workspace open "<name-or-id>"
 boomux workspace inspect "<name-or-id>"
 boomux workspace rename "<name-or-id>" "<new-name>"
 boomux workspace close "<name-or-id>"
 ```
 
-`workspace create` creates an empty workspace. `--cwd` stores an optional
-default used by dashboard shells and `shell create` when no explicit cwd is
-given. The default does not prevent individual shells from using other paths.
+On protocol 38 or newer, `workspace create` creates empty coordinator metadata.
+It does not select a Node or store a path; choose those when creating the first
+Shell, launcher, or schedule. Older daemons retain empty local Workspace
+creation.
 `workspace close` terminates every running shell process session and removes the
 workspace, all shell and launcher definitions, schedules and persisted prompts,
 retained terminal state, and all durable Agent and attention records associated

--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boomux
-description: Inspect and manage Boomux persistent terminal workspaces, launchers, shells, run-scoped agent instances, attention, projected sessions, recurring Agent schedules, notifications, process supervision, and integrations. Use when asked to discover shells, agents, sessions, or schedules, read terminal output, manage explicitly authorized recurring Agent prompts, supervise an explicitly identified external session, report agent lifecycle state, configure or test notifications, install or remove the OpenCode or Pi integration, create or open workspaces and shells, inspect status, rename or close targets, or manage the Boomux daemon.
-compatibility: Requires boomux on PATH. Some name operations require Boomux workspace context or an explicit --workspace; schedule names require BOOMUX_WORKSPACE_ID or explicit --workspace; agent mutation and supervision require exact shell-run context, and continuation schedules or supervision require caller-supplied exact canonical session identity.
+description: Inspect and manage Boomux Nodes, coordinated persistent terminal Workspaces, launchers, shells, run-scoped agent instances, attention, projected sessions, recurring Agent schedules, notifications, process supervision, and integrations. Use when asked to discover Nodes, shells, agents, sessions, or schedules, read terminal output, manage explicitly authorized recurring Agent prompts, supervise an explicitly identified external session, report agent lifecycle state, configure or test notifications, install or remove the OpenCode or Pi integration, create or open Workspaces and shells, inspect status, rename or close targets, or manage the local Boomux daemon.
+compatibility: Requires boomux on PATH. Federated resource identity is the pair of owning Node ID and Node-local inner ID. Some name operations require Workspace context or an explicit --workspace/--node; agent mutation and supervision require exact shell-run context, and continuation schedules or supervision require caller-supplied exact canonical session identity.
 metadata:
   author: boomux
-  version: "14"
+  version: "15"
 ---
 
 # Boomux
@@ -26,7 +26,7 @@ Inside a Boomux shell, discover siblings with:
 boomux shells
 ```
 
-Outside Boomux, discover every shell with:
+Outside Boomux, discover shells owned by the local Node with:
 
 ```console
 boomux list
@@ -38,7 +38,14 @@ Use these commands for structured inspection:
 boomux workspace list
 boomux workspace inspect "<workspace-name-or-id>"
 boomux shell inspect "<shell-name-or-id>" --workspace "<workspace-name-or-id>"
+boomux node snapshot --json
 ```
+
+`node snapshot` is the combined qualified view. Every projected Node-owned
+resource identity is `(node_id, inner_id)`; retain both fields together. Never
+route a remote inner ID without its owning Node ID. Cached remote rows can be
+stale and are suitable only for documented prompt-free summaries, not authority,
+private inspection, terminal reads, or mutation.
 
 For machine-readable inspection, add `--json`. Supported commands emit the
 stable `boomux.cli/v1` envelope. Discover the exact command, feature, and
@@ -49,10 +56,10 @@ boomux capabilities --json
 ```
 
 Parse `data` on success and `error.code` on a nonzero exit; do not parse human
-tables or `error.message`. JSON mutation support includes Agent register,
-ensure, and report; attention acknowledgment; schedule create, pause, resume,
-remove, and run; execution cancellation; and integration installation and
-uninstallation.
+tables or `error.message`. JSON mutation support includes Node registration
+management, Agent lifecycle reporting, attention acknowledgment, Schedule
+management, execution open/cancellation, and integration management. Treat this
+as illustrative; `capabilities.data.json_commands` is authoritative.
 
 Most daemon-backed inspection commands automatically start Boomux when it is
 not running. This includes `list`, `shells`, `read`, `events`, workspace, shell,
@@ -60,6 +67,42 @@ and launcher inspection, Agent, attention, session, and schedule inspection, and
 `doctor`. Use `boomux daemon status` first when starting the daemon would be an
 unwanted side effect. `capabilities`, `project list`, `integration list`, and
 `integration status` do not start it.
+
+## Manage Nodes And Federation
+
+Inspect or register persistent identity-pinned OpenSSH routes with:
+
+```console
+boomux node list --json
+boomux node inspect "<node-alias-or-id>" --json
+boomux node snapshot --json
+boomux node add "<alias>" "<user@host>"
+boomux node rename "<node>" "<new-alias>" --revision <revision> --json
+boomux node retarget "<node>" "<user@host>" --revision <revision> --json
+boomux node forget "<node>" --json
+boomux node rekey
+```
+
+`node add` verifies and pins the remote Node identity. Interactive setup may,
+after explicit confirmation, install or replace a remote helper and gracefully
+restart an incompatible remote daemon. JSON setup never approves installation;
+it returns typed `install_required` or `upgrade_required`. Retargeting must prove
+the pinned identity before replacing the route. Forget removes only the local
+registration and cached projection; it does not contact or delete the owner.
+`node rekey` changes this Node's durable identity and is local, interactive, and
+human-only; use it only after the command's exact confirmation requirements are
+explicitly authorized.
+
+For one unregistered ad hoc route, `boomux --remote "<user@host>" ...` uses a
+temporary verified connection and does not persist registration. Registered and
+ad hoc routes do not make hostnames or addresses resource identities.
+
+Node-qualified host operations include `project list`, launcher invocation,
+integration management, Session catalogs/resume, Schedule and execution
+management, and `open`. Preserve the same explicit `--node` on every follow-up
+operation. Remote paths, commands, catalogs, and integration assets are resolved
+only by their owning Node. Daemon status, restart, and stop remain local and are
+not routed through registration.
 
 Inspect bundled lifecycle integrations with:
 
@@ -227,6 +270,10 @@ Discover projected session metadata with:
 boomux session list --json
 boomux session list --workspace "<workspace-name-or-id>" --json
 boomux session inspect "<exact-session-id>" --json
+boomux session resume "<exact-session-id>"
+boomux session list --node "<node>" --json
+boomux session inspect "<exact-session-id>" --node "<same-node>" --json
+boomux session resume "<exact-session-id>" --node "<same-node>"
 ```
 
 Use the exact opaque session ID returned by `session list`. Never guess or
@@ -236,7 +283,9 @@ run of a running retained shell; otherwise it is last-known. Catalog-only
 OpenCode history has state `unknown`, no fabricated occurrence, and a sanitized
 host title. Registered-session descriptions remain durable Agent names.
 Protocol-13 sessions retain a `source_cwd` after shell removal so an exact
-canonical session can be resumed in its original context.
+canonical session can be resumed in its original context. Resume launches a
+native host process and requires authorization. A remote Session ID is exact
+only within its owning Node; keep the same `--node` used for discovery.
 
 ## Manage Agent Schedules
 
@@ -247,7 +296,7 @@ unattended Agent process and tool activity; never pass `--enabled` or run
 `schedule resume` without explicit authorization for that continuing effect.
 
 ```console
-boomux schedule create "<name>" --workspace "<workspace-name-or-id>" --cwd "/absolute/project/path" --integration opencode --prompt-file "/path/to/prompt.txt" --weekdays 09:00 --json
+boomux schedule create "<name>" --workspace "<workspace-name-or-id>" --node "<node>" --cwd "/absolute/owner/path" --integration opencode --prompt-file "/path/to/prompt.txt" --weekdays 09:00 --json
 boomux schedule list --json
 boomux schedule list --workspace "<workspace-name-or-id>" --json
 boomux schedule inspect "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
@@ -257,11 +306,12 @@ boomux schedule run "<exact-id-or-contextual-name>" --workspace "<workspace-name
 boomux execution list --workspace "<workspace-name-or-id>" --schedule "<schedule-name-or-id>" --limit 100 --json
 boomux execution inspect "<exact-execution-id>" --json
 boomux execution wait "<exact-execution-id>" --after-revision "<revision>" --wait-ms 30000 --json
+boomux execution open "<exact-execution-id>" --json
 boomux execution cancel "<exact-execution-id>" --json
 boomux schedule remove "<exact-id-or-contextual-name>" --workspace "<workspace-name-or-id>" --json
 ```
 
-Create requires explicit workspace, cwd, integration, exactly one prompt source,
+Create requires explicit Workspace, owner-local cwd, integration, exactly one prompt source,
 and exactly one trigger source. `--prompt` preserves the accepted bytes;
 `--prompt-file` snapshots exact UTF-8, including a final newline, and does not
 track later file changes. Use `--cron '<five fields>'`, `--every Nm|Nh`, `--daily
@@ -279,8 +329,10 @@ session, Agent ID, or shell ID.
 List, create, pause, resume, remove, run, and all execution responses are
 prompt-free. Inspect
 returns the private prompt under `data.schedule.prompt`; do not log or repeat it
-unless needed for the authorized request. Exact schedule IDs resolve globally.
-Names resolve only with explicit `--workspace` or `BOOMUX_WORKSPACE_ID`.
+unless needed for the authorized request. Exact Schedule and execution IDs are
+global only within one Node. Names resolve only with explicit `--workspace` or
+`BOOMUX_WORKSPACE_ID`; preserve `--node` for remote discovery and every exact
+follow-up operation.
 Removing a schedule removes its persisted prompt. Workspace close removes every
 owned schedule and persisted prompt and must be confirmed with that full scope.
 
@@ -291,6 +343,10 @@ before sending. Never retry with a new key when the intent is the same dispatch.
 Inspect the returned exact execution ID, and cancel only when process-tree
 termination is authorized. Execution exit or cancellation never means Agent
 `done`.
+
+`execution open` is also process-starting/presentation behavior. It opens only
+the exact active run or exact linked canonical Agent Session; it must not restart
+the reusable Schedule shell or substitute a later run or Session.
 
 Execution list responses are newest-first and contain `limit`, `truncated`, and
 prompt-free records. Limits are 1-1,000 and default to 100. Each execution has a
@@ -317,7 +373,7 @@ restricted day fields use OR. Boomux rejects schedules with no occurrence in a
 Gregorian 400-year cycle. Treat scheduler `offline` health as not evaluating
 timed work even when the daemon still answers other requests.
 
-Exact shell IDs resolve globally. Shell names resolve in the current workspace,
+Exact shell IDs are global only within one Node. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.
 `boomux read` and top-level `boomux close` require an exact shell ID outside a
 managed shell. If a name remains ambiguous, ask the user to select a target.
@@ -428,7 +484,11 @@ boomux "/path/to/project" -- command arg1 arg2
 Without `--name`, Boomux creates the next generated workspace and stores the
 selected path as its default cwd. With `--name`, it adds a shell to an existing
 exact-name workspace or creates that workspace with the selected path as its
-default. A command after `--` is an exact executable and argument vector; shell
+default. This shorthand is a local Node-owned workflow and can produce an
+external unlinked Workspace under protocol 38; it does not select or join a
+coordinated Workspace by equal name. Prefer `workspace create` followed by
+Node-qualified first-resource creation when coordination is intended. A command
+after `--` is an exact executable and argument vector; shell
 operators such as pipes or redirects work only when explicitly passed through a
 shell, for example `-- /bin/sh -lc 'command | command'`.
 
@@ -447,7 +507,7 @@ boomux doctor
 `boomux` and `boomux ui` must run from a fresh host terminal; they are rejected
 when `BOOMUX_SHELL_ID` is set. `boomux doctor` can run in either context.
 
-The dashboard has Workspaces, Agents, Shells, and Schedules views. `/` or
+The dashboard has Workspaces, Agents, Shells, Schedules, and Nodes views. `/` or
 `:` opens its action and search palette, `?` shows contextual help, `Enter`
 restores the selected workspace or opens the selected entry, and `x` followed
 by `y` confirms close or removal. Shell previews are bounded and read-only.
@@ -457,6 +517,12 @@ managed terminal selects its owning workspace and shell or Agent row once;
 manual navigation remains until another focus change. Press `Space` to pin the
 current dashboard selection and pause focus following; press it again to unpin
 and catch up to the currently focused terminal.
+
+The Nodes view inspects and refreshes registrations, starts guided setup,
+revision-safely renames or retargets routes, and forgets a registration after
+confirmation. It is not a resource filter. Coordinated Workspace rows aggregate
+persisted placements while every item retains its owner Node; external owner
+Workspaces remain distinct and offer explicit adopt/link actions.
 
 Each Agent Schedule appears once in its owning workspace with `KIND schedule`.
 That row is the durable definition, not a process; Enter navigates to its exact
@@ -509,9 +575,11 @@ Discover the same configured projects locally without starting the daemon:
 
 ```console
 boomux project list --json
+boomux project list --node "<node>" --json
 ```
 
-Use the canonical `path` returned when creating a Node-hosted item. An empty
+Use the canonical `path` only on the Node that returned it when creating a
+Node-hosted item. An empty
 list with `roots_configured: false` means no roots are configured; inspect
 `warnings` when configured roots cannot be scanned.
 
@@ -523,34 +591,52 @@ boomux workspace create "<name>"
 boomux workspace open "<name-or-id>"
 boomux workspace inspect "<name-or-id>"
 boomux workspace rename "<name-or-id>" "<new-name>"
+boomux workspace adopt "<external-workspace-name-or-id>" --node "<node>"
+boomux workspace link "<global-workspace-name-or-id>" "<owner-workspace-name-or-id>" --node "<node>"
 boomux workspace close "<name-or-id>"
+boomux workspace retry "<closing-global-workspace-name-or-id>"
 ```
 
 On protocol 38 or newer, `workspace create` creates empty coordinator metadata.
 It does not select a Node or store a path; choose those when creating the first
 Shell, launcher, or schedule. Older daemons retain empty local Workspace
-creation.
-`workspace close` terminates every running shell process session and removes the
-workspace, all shell and launcher definitions, schedules and persisted prompts,
-retained terminal state, and all durable Agent and attention records associated
-with it. Canonical OpenCode or Pi host data is not deleted. A workspace cannot
-close itself from one of its own shells. Confirm the exact target and full
-removal scope first.
+creation. Exactly one eligible Node may be selected implicitly; multiple eligible
+Nodes require explicit `--node`, while zero means creation is unavailable.
+Filesystem paths are interpreted only
+by that owner, and its first hosted resource establishes the placement. An
+explicit `--node` never falls back to local Shell or launcher creation.
 
-`workspace open` is an active, non-transactional restore operation. It invokes
-every launcher in creation order and attempts to open every shell even if an
-earlier item fails. Each shell opens with takeover, disconnecting its current
-writable controller, and an exited shell restarts as a new run. Obtain explicit
-authorization before running it, especially from inside that workspace. A
-launcher-only workspace is valid, but an empty workspace cannot be opened.
+Adopt creates a coordinated Workspace from one unlinked owner Workspace. Link's
+argument order is global Workspace first, owner Workspace second. Both require a
+current eligible owner and fresh identity-pinned revision. Equal names never
+establish membership.
+
+`workspace close` terminates every running Shell process and removes launchers,
+Schedules and persisted prompts, retained terminal state, and Agent/attention
+records after each owner confirms removal. A coordinated close can remain
+`closing`; unresolved membership is retained until `workspace retry` or repeated
+close succeeds. Canonical OpenCode or Pi host data is not deleted. A Workspace
+cannot close itself from one of its own Shells. Confirm the exact target and full
+multi-Node removal scope first.
+
+`workspace open` is an active, non-transactional restore operation. For a
+coordinated Workspace it attempts every currently available placement once and
+reports per-Node failures; unavailable membership remains visible, and ambiguous
+launcher outcomes are not replayed automatically. Each Shell opens with
+takeover, disconnecting its current writable controller, and an exited Shell
+restarts as a new run. `workspace open OWNER_ID --node NODE` instead addresses
+one owner-local Workspace and requires the exact owner Workspace ID remotely.
+Obtain explicit authorization before opening. A launcher-only Workspace is
+valid, but an empty Workspace cannot be opened.
 
 ## Manage Workspace Launchers
 
 ```console
 boomux launcher list --workspace "<workspace-name-or-id>"
-boomux launcher create "<name>" --workspace "<workspace-name-or-id>" --cwd "/path" -- command arg
+boomux launcher create "<name>" --workspace "<workspace-name-or-id>" --node "<node>" --cwd "/owner/path" -- command arg
 boomux launcher inspect "<name-or-id>" --workspace "<workspace-name-or-id>"
 boomux launcher invoke "<name-or-id>" --workspace "<workspace-name-or-id>"
+boomux launcher invoke "<exact-launcher-id>" --node "<node>"
 boomux launcher rename "<name-or-id>" "<new-name>" --workspace "<workspace-name-or-id>"
 boomux launcher remove "<name-or-id>" --workspace "<workspace-name-or-id>"
 ```
@@ -559,15 +645,17 @@ Launchers are durable ordered definitions, but each invocation is a detached,
 ephemeral process without a PTY or retained output. Commands are exact argument
 vectors; use an explicit shell for pipelines or expansion. `--cwd` defaults to
 the current directory. Removing a launcher does not terminate applications from
-earlier invocations. Exact launcher IDs resolve globally; names require current
-workspace context or `--workspace`.
+earlier invocations. Exact launcher IDs are global only within one Node; local
+names require current Workspace context or `--workspace`. Remote invocation
+requires the exact launcher ID and its owning `--node`.
 
 ## Manage Shells
 
 ```console
 boomux shell suggest-name "<workspace-name-or-id>" --json
-boomux shell create "<workspace-name-or-id>"
-boomux shell create "<workspace-name-or-id>" --name "<name>" --cwd "/path"
+boomux shell suggest-name "<exact-owner-workspace-id>" --node "<node>" --json
+boomux shell create "<workspace-name-or-id>" --node "<node>"
+boomux shell create "<workspace-name-or-id>" --node "<node>" --name "<name>" --cwd "/owner/path"
 boomux shell create "<workspace-name-or-id>" --name "<name>" -- command arg
 boomux shell inspect "<name-or-id>" --workspace "<workspace-name-or-id>"
 boomux shell rename "<name-or-id>" "<new-name>" --workspace "<workspace-name-or-id>"
@@ -587,6 +675,7 @@ exact `workspace_id` and nonempty `name`, without creating or reserving a shell.
 Use it only as a UI suggestion. Creation can still fail with typed
 `already_exists` if another operation claims the name first; request another
 suggestion rather than changing or inferring a name.
+Remote suggestion requires the exact owner Workspace ID plus `--node`.
 
 The contextual close shorthand is:
 
@@ -602,13 +691,15 @@ Open an exact shell ID in a new native terminal window:
 boomux open "<shell-id>"
 boomux open "<shell-id>" --title "<window-title>"
 boomux open "<shell-id>" --takeover
+boomux open "<exact-shell-id>" --node "<node>"
 boomux --terminal "kitty.desktop" open "<shell-id>"
 ```
 
 `--takeover` disconnects the current writable controller. Do not use it without
 the user's consent. Opening an exited shell explicitly restarts its stored
 command as a new run on the same durable shell identity; use `boomux read` when
-the goal is only to inspect retained output.
+the goal is only to inspect retained output. Remote open requires the exact
+Node-local Shell ID plus its owning `--node`; never infer either from a name.
 
 ## Manage The Daemon
 
@@ -618,14 +709,15 @@ boomux daemon restart
 boomux daemon stop
 ```
 
-`restart` performs a transactional graceful handoff that preserves pending,
+These commands affect only this Node. `restart` performs a transactional graceful handoff that preserves pending,
 running, and exited shells, including final exited terminal state, and reconnects
 active clients. It does not start a new process for an exited shell. `stop`
 terminates every managed process session and stops the daemon, but durable
 definitions remain. A later daemon-backed command can start Boomux again;
 recovered shells are pending and opening them starts new processes. Process
 memory, PTYs, and mutated environments do not survive. Confirm before either
-operation when the user did not request it explicitly.
+operation when the user did not request it explicitly. They do not restart or
+stop daemons on registered remote Nodes.
 
 ## Install Or Update This Skill
 
@@ -718,7 +810,9 @@ BOOMUX_RUN_ID
 Protocol 16 starts pending and exited shell runs with the attaching client's
 ephemeral Unix environment. Boomux does not persist or project that payload;
 terminal-profile and `BOOMUX_*` identity values are authoritative. Reattaching
-does not alter an already-running process environment.
+does not alter an already-running process environment. For protocol-35 remote
+attachment, the owner Node supplies its own process environment; the presenting
+Node's Unix environment is never forwarded.
 
 Detached launcher invocations inherit the invoking client's environment and
 receive `BOOMUX_WORKSPACE_ID`, `BOOMUX_WORKSPACE`, `BOOMUX_LAUNCHER_ID`, and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,18 +5,50 @@
 
 ## Boomux Node
 
-A durable authority for the Workspaces and runtime identities it owns. A Node is
+A durable authority for the runtime identities and host-local services it owns. A Node is
 identified independently from any hostname, SSH destination, network address,
 or other route used to reach it. A route changing does not change Node identity,
 and a route resolving to a different Node does not transfer ownership.
 
-Every Workspace belongs to exactly one Node. Resource identity across Nodes is
-the pair of owning Node identity and the resource's unchanged Node-local
-identity. The Node is an outer name-resolution scope: Workspace names are unique
-within a Node, while Shell, launcher, Agent Schedule, and other names retain
-their existing Workspace or identity-specific scopes. A projection of another
-Node can be stale or unavailable, but never becomes authoritative and cannot
-establish lifecycle completion or authorize mutation.
+Every Node-owned resource retains its owning Node identity. Resource identity
+across Nodes is the pair of owning Node identity and the resource's unchanged
+Node-local identity. A projection of another Node can be stale or unavailable,
+but never becomes authoritative and cannot establish lifecycle completion or
+authorize mutation.
+
+## Workspace
+
+A durable coordinator-owned place where a user organizes Shells, Agent
+Instances, launchers, and Agent Schedules that may execute on multiple Nodes.
+The Workspace coordinator owns its identity, name, and membership, but is not an
+execution placement and does not imply a default Node. Each Node-hosted resource
+in a Workspace retains its own Node authority and exact qualified identity.
+
+Creating Node-hosted work uses the sole eligible Node without an extra choice.
+When multiple Nodes are available, creation has no default and requires an
+explicit Node selection. A Workspace can remain useful while one member Node is
+stale or unavailable; that condition affects only work owned by that Node and
+does not transfer its authority to the coordinator or another Node.
+
+Filesystem context is placement-specific. A Workspace can retain a separate
+default working directory for each Node, and every path is interpreted and
+validated only by that Node. No path's existence or meaning is inferred from a
+different Node.
+
+A Node becomes a Workspace placement when the first Node-hosted resource is
+created there. Registering a Node does not add it to every Workspace, and an
+empty placement is not created as a side effect of discovery alone.
+
+A discovered Node-local Workspace can be presented before it belongs to a
+coordinator-owned Workspace. Adoption as a new Workspace or linking as a
+placement is explicit. Equal names never establish membership or merge
+authority by themselves.
+
+Opening a Workspace is one explicit request to open every currently available
+placement. Unavailable placements remain visible and produce per-Node results;
+an ambiguous start is never replayed automatically. Closing a Workspace retains
+its metadata and unresolved membership until every owning Node has confirmed
+the guarded removal of its resources.
 
 ## Workspace Launcher
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | Add a shell on one Node | `boomux shell create feature-x --node laptop --cwd /path/to/project` |
 | Register a remote Node | `boomux node add laptop user@host` |
 | Adopt an external Workspace | `boomux workspace adopt <workspace-id> --node laptop` |
-| Link an external Workspace | `boomux workspace link <workspace-id> feature-x --node laptop` |
+| Link an external Workspace | `boomux workspace link feature-x <owner-workspace-id> --node laptop` |
 | Retry an incomplete close | `boomux workspace retry <workspace-id>` |
 | Suggest an unused shell name | `boomux shell suggest-name feature-x` |
 | Add a randomly named shell | `boomux shell create feature-x` |

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | --- | --- |
 | Create a generated workspace | `boomux .` |
 | Create or add to a named workspace | `boomux . --name feature-x` |
-| Create an empty workspace with a default directory | `boomux workspace create feature-x --cwd .` |
+| Create an empty workspace | `boomux workspace create feature-x` |
 | Suggest an unused shell name | `boomux shell suggest-name feature-x` |
 | Add a randomly named shell | `boomux shell create feature-x` |
 | Open the new shell in another terminal | `boomux . --name feature-x --new` |

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 **Persistent workspaces for native terminal windows.**
 
 Boomux keeps shells and commands running after their terminal windows close. It
-groups related work into named workspaces that you can reopen from a dashboard,
-while continuing to use Ghostty, Alacritty, or another XDG terminal as ordinary
-native windows.
+groups related work into named Workspaces that can span independently
+authoritative Nodes and reopen from one dashboard, while continuing to use
+Ghostty, Alacritty, or another XDG terminal as ordinary native windows.
 
 Optional integrations show whether supported coding agents are working, blocked,
 idle, or untracked without trying to infer state from quiet terminal output.
@@ -106,7 +106,10 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 
 | Concept | Meaning |
 | --- | --- |
-| **Workspace** | A named group of managed shells, commands, and launchers. |
+| **Node** | The durable authority for the shells, launchers, schedules, paths, and other runtime identities it owns. A Node is not its SSH route. |
+| **Workspace** | A coordinator-owned organizing boundary whose resources may run on several Nodes. It does not imply a default Node. |
+| **Placement** | One Node's membership and filesystem context in a coordinated Workspace, established when the first resource is created or an existing Node-local Workspace is explicitly linked. |
+| **External Workspace** | A discovered Node-local Workspace that has not been adopted or linked. Equal names do not merge ownership. |
 | **Managed shell** | A persistent terminal session, usually running your login shell. |
 | **Command** | A managed terminal session that runs one command instead of a login shell. |
 | **Launcher** | A desktop command run when its workspace opens. Boomux does not retain its output or process. |
@@ -130,6 +133,11 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | Create a generated workspace | `boomux .` |
 | Create or add to a named workspace | `boomux . --name feature-x` |
 | Create an empty workspace | `boomux workspace create feature-x` |
+| Add a shell on one Node | `boomux shell create feature-x --node laptop --cwd /path/to/project` |
+| Register a remote Node | `boomux node add laptop user@host` |
+| Adopt an external Workspace | `boomux workspace adopt <workspace-id> --node laptop` |
+| Link an external Workspace | `boomux workspace link <workspace-id> feature-x --node laptop` |
+| Retry an incomplete close | `boomux workspace retry <workspace-id>` |
 | Suggest an unused shell name | `boomux shell suggest-name feature-x` |
 | Add a randomly named shell | `boomux shell create feature-x` |
 | Open the new shell in another terminal | `boomux . --name feature-x --new` |
@@ -141,7 +149,12 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 
 Without `--name`, Boomux creates the next `workspace-N` and stores the selected
 path as its default for later shells. With `--name`, it adds a shell to an
-existing exact-name workspace or creates a workspace with that default.
+existing exact-name Node-local workspace or creates one with that default. This
+path-opening shorthand is a local terminal workflow. In the coordinated CLI,
+`workspace create` instead creates empty coordinator metadata with no Node or
+path; the first `shell`, `launcher`, or `schedule` creation selects a Node and
+establishes that Node's placement-specific filesystem context. A sole eligible
+Node is selected automatically, while multiple eligible Nodes require `--node`.
 Shells created without an explicit shell name receive a memorable lowercase
 `adjective-noun` name such as `quiet-otter`; that concrete name is retained like
 any explicit name. `shell suggest-name` exposes the same collision-aware naming
@@ -169,9 +182,32 @@ terminate applications launched earlier. Exact launcher IDs can be invoked
 without `--workspace`; launcher names use the current managed workspace or an
 explicit `--workspace`.
 
+### Remote Nodes
+
+Register a remote Boomux authority through an ordinary OpenSSH destination:
+
+```console
+boomux node add laptop user@host
+boomux node list
+boomux node inspect laptop
+```
+
+Interactive setup verifies the remote Node identity. If its helper is missing or
+outdated, Boomux shows the exact destination and process impact before asking to
+install or replace it; an incompatible running daemon is changed through a
+graceful restart. Noninteractive and JSON requests never approve that mutation
+and instead return a typed `install_required` or `upgrade_required` error.
+Routes can later be revision-safely renamed or retargeted. Forgetting a route
+does not contact or delete the remote Node.
+
+Each Node remains authoritative for its own resources and paths. Cached remote
+state can remain visible while stale or unavailable, but it cannot authorize a
+mutation or silently transfer ownership. Use `boomux node --help` for the full
+management surface.
+
 ## Dashboard
 
-The dashboard has four primary views: Workspaces, Agents, Shells, and Schedules. The
+The dashboard has five primary views: Workspaces, Agents, Shells, Schedules, and Nodes. The
 Workspaces view combines the selected workspace's Agents, shells, commands,
 launchers, and schedule definitions in one item table. A `schedule` row represents
 the durable definition, opens its specialized history and controls, and never
@@ -179,7 +215,8 @@ represents an execution process. Its `ACTIVITY` column shows an Agent task, shel
 foreground process, stored command, launcher command, or schedule trigger; branch
 and worktree columns keep repository context visible without repeating full paths.
 
-The Agents view shows lifecycle status and recency, owning workspace and shell,
+Workspace, Agent, and Shell tables qualify Node-owned resources with a `NODE`
+column. The Agents view shows lifecycle status and recency, owning workspace and shell,
 root-session task, branch, and worktree. The Shells view distinguishes login
 shells from stored commands and shows run generation, process, branch, and
 worktree. Selecting an item opens a labeled detail panel with the full path,
@@ -195,12 +232,17 @@ from growing without limit. The schedule and history panes render side by side,
 then stack when the terminal is narrow. Schedule-owned execution shells do not
 appear as ordinary shell rows; only the owning schedule definition does.
 
+The Nodes view shows registered routes and health. It can inspect and refresh a
+Node, launch guided setup, revision-safely rename or retarget a route, and forget
+a registration after confirmation. Remote state remains secondary to the owning
+Node's authority.
+
 The workspace overview includes item and Agent-state counts plus its most urgent
 outstanding attention item.
 
 | Key | Action |
 | --- | --- |
-| `Tab`, `Shift-Tab`, `1`-`4` | Change view. |
+| `Tab`, `Shift-Tab`, `1`-`5` | Change view. |
 | `/` or `:` | Search actions, workspaces, and entries. |
 | `?` | Explain keys plus the selected kind and state. |
 | `h`, `l`, left, right | Move between workspace and entry tables. |
@@ -209,7 +251,7 @@ outstanding attention item.
 | `a` | Create a workspace or add a shell, depending on focus. |
 | `e` | Rename the selection. |
 | `x`, then `y` | Confirm closing or removing the selection. |
-| `q` or `Esc` | Quit from normal mode. |
+| `q` or `Esc` | Quit from normal mode after any in-flight mutation completes. |
 
 In Schedules, Left/Right changes between the schedule and history panes, `j`/`k`
 navigates the focused pane, and `[`/`]` also selects retained executions by exact
@@ -229,8 +271,13 @@ does not emulate one with pause/resume. Exact active Scheduled Execution attachm
 requires protocol 26; protocol-25 dashboards retain schedule controls and
 history while showing upgrade-and-restart guidance for Open.
 
-Closing a workspace terminates its managed shells and removes its schedules and
-persisted prompts. Closing a shell or command terminates its managed process.
+Opening a coordinated Workspace attempts every currently available placement
+and reports a result per Node. It does not automatically replay an ambiguous
+launcher start. Closing terminates managed shells and removes schedules and
+persisted prompts, but a partially completed close remains visibly `closing`
+with unresolved placement metadata until each owner confirms removal. Run
+`boomux workspace retry <workspace-id>` or repeat the close to resume it.
+Closing a shell or command terminates its managed process.
 Removing a launcher affects future workspace opens only. Press `?` in the
 dashboard for context-specific controls.
 
@@ -243,9 +290,10 @@ working, idle, blocked, and completed activity; opens workspaces or individual
 items; creates workspaces, shells, and coding-agent commands; acknowledges
 durable attention; and launches the full Boomux dashboard in a native terminal.
 
-The plugin requires Boomux `0.14.0` or newer and Omarchy's Quattro shell plugin
-system. Review its source before installation because Omarchy plugins run as
-unsandboxed code inside the long-running shell process.
+The plugin's federated Workspace support requires Boomux `0.19.0` or newer and
+Omarchy's Quattro shell plugin system. Review its source before installation
+because Omarchy plugins run as unsandboxed code inside the long-running shell
+process.
 
 ```console
 omarchy plugin add https://github.com/gardnmi/omarchy-boomux.git --enable
@@ -424,10 +472,12 @@ scheduled_dispatch_failed = "dialog-warning"
 scheduled_interrupted = "dialog-warning"
 ```
 
-Project roots provide workspace suggestions in the dashboard. Selecting one
-stores its path as the workspace default for shells added later. Free-text and
-legacy workspaces without a default continue to use the directory where the
-dashboard was opened. An explicit shell cwd always takes precedence.
+Project roots provide Workspace-name suggestions in the dashboard. Selecting one
+creates empty coordinator metadata using its name; it does not assign a Node or
+persist the discovered path. Choose the Node and working directory when adding
+the first shell, launcher, or schedule. Existing Node-local workspaces retain
+their own placement-specific defaults, and an explicit resource cwd takes
+precedence.
 
 List the same discovered projects without starting the daemon:
 
@@ -440,7 +490,8 @@ JSON output uses the stable `boomux.cli/v1` contract and includes canonical
 paths, root groups and ordering, warnings, and whether any roots are configured.
 
 The dashboard follows the most recently focused Boomux terminal by default,
-selecting its workspace and shell or Agent row. Manual dashboard navigation is
+including locally presented remote terminals, by selecting its exact Node,
+workspace, and shell or Agent row. Manual dashboard navigation is
 preserved until another managed terminal gains focus. Press `Space` to pin the
 current selection and pause following; press it again to unpin and catch up to
 the currently focused terminal. Set
@@ -496,6 +547,7 @@ Use built-in help for the complete, current CLI:
 ```console
 boomux --help
 boomux workspace --help
+boomux node --help
 boomux shell --help
 boomux launcher --help
 boomux agent --help

--- a/docs/adr/0003-keep-remote-nodes-authoritative.md
+++ b/docs/adr/0003-keep-remote-nodes-authoritative.md
@@ -1,6 +1,6 @@
 # Keep Remote Nodes Authoritative
 
-Status: Accepted; implementation pending
+Status: Accepted for runtime resources; Workspace ownership superseded by ADR 0004
 
 Remote Workspaces and their Shells, ShellRuns, Agent Instances, Schedules,
 Scheduled Executions, PTYs, and processes remain authoritative on one remote

--- a/docs/adr/0004-coordinate-multi-node-workspaces.md
+++ b/docs/adr/0004-coordinate-multi-node-workspaces.md
@@ -1,0 +1,30 @@
+# Coordinate Multi-Node Workspaces
+
+Status: Accepted; implementation pending
+
+A Workspace is the coordinator-owned place where a user organizes Shells,
+Agent Instances, launchers, and Agent Schedules across one or more Nodes. The
+coordinator owns Workspace identity, name, membership, and operation progress,
+but is not an execution placement and does not imply a default Node. Every
+runtime resource remains authoritative on exactly one explicitly selected Node.
+
+Each Workspace placement retains host-local settings, including its default
+working directory. Paths are never assumed to match across Nodes. The first
+resource created on a Node establishes that placement. When only one eligible
+Node exists, creation can use it directly; when several exist, no Node is
+preselected. Existing Node-local Workspaces remain visible but must be adopted
+or linked explicitly, and equal names never merge membership.
+
+Opening a Workspace fans out to every available placement and reports per-Node
+results without replaying ambiguous starts. Closing retains coordinator metadata
+and unresolved membership until guarded removal is confirmed by every owner.
+This costs coordinator persistence, placement-aware protocols, and partial
+operation tracking, but preserves a task-first user model without distributed
+process ownership or consensus between runtime authorities.
+
+The rejected alternatives are Node-owned Workspaces, replicated Workspace
+authority, and name-derived grouping. Node-owned Workspaces make machine
+placement the user's primary organizing boundary. Replicated authority requires
+conflict resolution during partitions. Name-derived grouping can silently join
+unrelated resources. Coordinator ownership with Node-owned placements keeps one
+metadata authority and one runtime authority for every operation.

--- a/docs/adr/0004-coordinate-multi-node-workspaces.md
+++ b/docs/adr/0004-coordinate-multi-node-workspaces.md
@@ -1,6 +1,6 @@
 # Coordinate Multi-Node Workspaces
 
-Status: Accepted; implementation pending
+Status: Accepted; implemented
 
 A Workspace is the coordinator-owned place where a user organizes Shells,
 Agent Instances, launchers, and Agent Schedules across one or more Nodes. The
@@ -18,6 +18,17 @@ or linked explicitly, and equal names never merge membership.
 Opening a Workspace fans out to every available placement and reports per-Node
 results without replaying ambiguous starts. Closing retains coordinator metadata
 and unresolved membership until guarded removal is confirmed by every owner.
+Resource creation durably prepares exact operation and request identity before
+owner mutation. Absence during reconciliation is inconclusive, while an observed
+exact resource completes placement. A bounded durable success ledger makes
+response-loss retry idempotent; concurrent identical handlers share that result,
+and concurrent first-placement requests preserve caller identity while using one
+canonical owner Workspace. Adoption and linking revalidate the live owner
+protocol, runtime capability, and revision rather than trusting cached projection
+eligibility. Preparation reserves durable completion capacity before owner
+mutation, and project eligibility preflight precedes empty metadata creation. A
+durable dispatch phase prevents later absence or route failure from being
+misread as proof that an ambiguous owner mutation never happened.
 This costs coordinator persistence, placement-aware protocols, and partial
 operation tracking, but preserves a task-first user model without distributed
 process ownership or consensus between runtime authorities.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@
 | `src/client.rs` | Daemon discovery/startup, protocol negotiation, typed management requests, and attachment setup |
 | `src/daemon.rs` | `DaemonService` coordination over durable registry, event-stream, shell-runtime, persistence, and handoff owners |
 | `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
+| `src/global_workspace_store.rs` | Independently versioned coordinator Workspace metadata, placement membership, initialization and schema migration, prepared resource recovery, and resumable close progress |
 | `src/node_identity.rs` | Stable Node identity persistence, federation admission leases, and bounded rekey drain |
 | `src/node_registration.rs` | Independently versioned remote Node registrations, identity pinning, admission drain, validation, and atomic storage |
 | `src/node_projection.rs` | Disposable owner-only remote projection cache, deterministic bounds, health, generation CAS, quarantine, and atomic storage |
@@ -113,8 +114,12 @@ Protocol 36 adds closed typed Node host services and owner-executed exact Agent
 Session resume.
 Protocol 37 adds Node-qualified remote Agent Schedule creation and bounded
 Scheduled Execution observation without adding local scheduler authority.
+Protocol 38 adds coordinator-owned Workspace identity and explicit Node-owned
+placements. Coordinator metadata is stored independently from Node-local runtime
+state; equal names never establish membership, and adoption and linking require
+exact owner identities and revisions.
 Remote notification presentation reuses protocol-32 atomic reduced transitions,
-so the core protocol remains 37. Node-cache schema 2 adds bounded local
+so it does not require a later protocol. Node-cache schema 2 adds bounded local
 at-most-once individual and reconnect-digest claims with an explicit schema-1
 migration.
 
@@ -191,6 +196,11 @@ workspace launcher in creation order using its own desktop environment, then
 opens native terminal windows for the workspace shells. Launcher processes are
 detached into their own sessions and reaped while the invoking client remains
 alive, but Boomux does not retain or manage their runtime lifecycle.
+For a protocol-38 global Workspace, the coordinator first returns explicit
+per-placement availability. The client then performs the same owner-side open on
+every available placement, using local attachment for the local owner and typed
+Node host services plus Node-qualified attachment for remote owners. Failures are
+reported per Node and do not replay an ambiguous launcher invocation.
 
 ### Daemon
 
@@ -626,7 +636,129 @@ Workspace through a fresh owner read, validates cwd and any continuation Session
 through protocol-36 owner host services, and sends the prompt only in the
 transient owner mutation request. Creation is not retried after channel loss;
 run-now remains the only Schedule write retried, using the unchanged dispatch
-key. The local scheduler never evaluates, dispatches, or retries remote work.
+key. Exact-ID Schedule creation canonicalizes cron whitespace and timezone before
+comparing an existing definition, so a normalizable wire replay is unchanged.
+The local scheduler never evaluates, dispatches, or retries remote work.
+Protocol 38 adds an independently versioned owner-only
+`global_workspaces.json` coordinator store. Schema 6 records global Workspace
+identity, name, revision, explicit `(node_id, workspace_id)` placements,
+owner-local Workspace names, durable close progress, and prompt-free prepared
+resource operations keyed by exact caller-generated operation UUID. It separates
+the caller-requested owner UUID from the canonical owner UUID selected for a
+shared first placement. Schema 6 also retains prompt-free SHA-256 request
+fingerprints and completed success snapshots for the newest 256 operations,
+subject to the file's 1 MiB total bound. Each pending operation physically
+reserves a conservative upper bound for its completed outcome; preparation
+evicts oldest completed outcomes as needed and rejects insufficient capacity
+before owner mutation. Preparing a distinct placement atomically expands every
+related pending reservation for the additional possible placement, preserving
+concurrent shared-revision creation without under-reserving either completion.
+Schema 6 adds a durable `owner_attempted` dispatch boundary. It is persisted
+within the completion reservation immediately before owner mutation. Schemas 1
+through 5 migrate explicitly to schema 6;
+unknown legacy owner names are learned from a fresh owner read,
+schema-2 pending resource UUIDs become their operation identities, and a
+schema-3 pending operation binds its previously unavailable fingerprint on its
+first structurally matching retry. A schema-4 pending operation acquires its
+completion reservation before its next owner dispatch. The Node-local `state.json` schema remains 13 and is the
+sole authority for Shells, launchers, Agent Instances, Agent Schedules, paths,
+and process lifecycle. On first coordinator-store creation, existing local
+Workspaces are initialized once as global Workspaces with one local placement. Later
+unlinked local or projected remote Workspaces remain external until an explicit
+revision-guarded adoption or link; names are display metadata and never infer
+membership.
+
+The combined Node snapshot adds global and external Workspace arrays only for
+protocol-38 peers. Placement availability is projected from current Node health;
+stale or unavailable projections never authorize owner mutations. Global close
+first persists `close_pending` for every placement, then performs fresh
+owner-revision-guarded closes. Confirmed and already-absent owners are removed
+from coordinator metadata individually. Unreachable or ambiguous outcomes remain
+persisted for explicit retry, and the global record is removed only after every
+owner is confirmed. A Workspace with no placements completes close immediately.
+Resource creation first persists a prompt-free prepared operation containing
+stable operation, requested and effective owner Workspace, and resource UUIDs,
+plus a hash of the complete request. Concurrent operations retain separate
+pending records; cancellation and completion target only the exact operation
+identity. Concurrent first resources on one Node may request distinct owner
+UUIDs but share the canonical prepared owner Workspace identity without sharing
+resource identity. Exact-operation handlers, including background reconciliation,
+serialize in coordinator memory, while durable completion and cancellation are
+idempotent against the terminal outcome.
+The owner atomically creates the Node-local placement and Shell, launcher, or
+Schedule, treats an exact replay as unchanged, and rejects conflicting ID reuse.
+This makes exact recovery retryable after transport ambiguity without
+name matching, shell interpolation, or duplicated runtime resources.
+The coordinator exposes one transaction for each Shell, launcher, and Schedule.
+It validates the selected Node against the current combined snapshot, persists
+the prepared operation, creates or exactly reads back the owner-local Workspace
+and resource, then atomically records the placement observation and converts the
+prepared operation to a completed outcome before acknowledging success. A failure between owner
+persistence and coordinator completion leaves the prepared UUIDs durable; the
+next request reads the exact owner resource and completes metadata without blind
+replay or a duplicate resource. An owner `not_found` observation is not proof of
+failure because it may race the in-flight owner mutation; reconciliation retains
+the pending record until an exact request retries or the exact resource is
+observed. A definitive synchronous owner rejection may cancel only its serialized
+operation. Schedule
+prompts remain only in the transient owner request, and launcher and Shell argv
+remain arrays throughout routing.
+Project creation prepares the new global Workspace metadata and first Shell in
+one coordinator-store replacement. An exact retry returns its stored success
+even after the original global revision becomes stale. A new project request by
+the same name resumes or replays only when Node, cwd, and Shell definition have
+the same semantic fingerprint; its newly requested UUIDs map to the canonical
+prepared or completed identities. Definitive owner rejection removes only that
+pending operation and removes still-empty global metadata only when no related
+operation remains.
+Before creating project metadata, the coordinator performs cached eligibility
+and fresh live capability preflight for the selected Node. Missing, ineligible,
+or runtime-capability-disabled owners therefore leave no empty global record. A
+definitive pre-owner failure on an existing exact preparation atomically cancels
+that operation and removes metadata only when it is still empty, unshared, and
+durably proven never dispatched. Every migrated pending operation is treated as
+attempted because an older schema cannot prove otherwise. Once attempted, later
+admission, capability, identity, synchronous owner error, or exact `not_found`
+cannot free the name or remove pending state; absence after a transport ambiguity
+does not prove the mutation was never attempted. Exact readback or an idempotent
+retry remains required. Network, timeout, persistence, and unknown outcomes also
+retain recovery state.
+
+Completed replay is guaranteed only while the operation remains in the bounded
+ledger: at most the newest 256 successful operations and potentially fewer when
+needed to keep the complete coordinator file within 1 MiB. Eviction is oldest
+first. After eviction there is no idempotency guarantee; the request is evaluated
+as new and ordinary identity and revision guards apply. Completed entries retain
+only response snapshots and request hashes, never Schedule prompts or attachment
+environments.
+
+Eligible placement owners are current, non-stale Nodes whose live daemon
+advertises protocol-38 global Workspace support. A daemon whose coordinator
+store did not load suppresses the capability and local eligibility. One eligible Node may be selected directly. Zero or
+multiple eligible Nodes require an explicit selector; no candidate is selected
+by default, and unavailable Nodes remain visible with their stable health and
+reason. Existing placement default cwd values are retained per owner. A new
+placement resolves its requested cwd on the selected owner and stores only that
+owner-local value.
+Adoption and linking use cached eligibility only as an initial presentation
+guard. Under one route admission reservation, they fetch a fresh protocol-38
+combined local snapshot, require its runtime `global_workspaces` capability and
+eligibility, read the exact owner revision from that same snapshot, and commit
+coordinator membership before releasing admission. A live downgrade or disabled
+coordinator store therefore fails even while protocol-38 eligibility remains in
+the projection cache.
+
+The dashboard groups resources only through persisted placement pairs. One
+global Workspace row aggregates qualified resources from all placements while
+each item retains its exact owner Node and owner Workspace ID. Unlinked owner
+Workspaces remain external singleton rows even when names match. External rows
+offer explicit revision-guarded adopt-as-new and link-to-existing actions. The
+Nodes tab is not a filter: it exposes inspection plus revision-pinned alias
+rename and verified retarget, confirmed route forget, and projection refresh.
+Refresh wakes that Node's existing projection worker; it never starts an
+overlapping observer.
+Resource tables place `NODE` after task identity columns rather than making Node
+the primary organizing column.
 
 Protocol-25 lists are daemon-bounded, newest-first pages with explicit limit and
 truncation. The request limit is optional on the wire; protocol 25 defaults it to

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@
 | `src/node_registration.rs` | Independently versioned remote Node registrations, identity pinning, admission drain, validation, and atomic storage |
 | `src/node_projection.rs` | Disposable owner-only remote projection cache, deterministic bounds, health, generation CAS, quarantine, and atomic storage |
 | `src/federation.rs` | Independently versioned federation handshake and verified stdio daemon bridging |
-| `src/ssh_bootstrap.rs` | Validated SSH targets, private invocation configuration, deadline-bound remote discovery, and helper compatibility selection |
+| `src/ssh_bootstrap.rs` | Validated SSH targets, private invocation configuration, bounded interactive authentication presentation, deadline-bound remote discovery, and helper compatibility selection |
 | `src/handoff.rs`, `src/fd_transfer.rs` | Graceful daemon replacement records and Unix descriptor transfer |
 | `src/attach.rs` | Terminal-side raw mode, control frames, live input/output, resize, focus, and reconnect handling |
 | `src/terminal.rs` | Selection and launch of native terminal windows through `xdg-terminal-exec` |
@@ -101,7 +101,15 @@ and deferred behavior are in [`remote-nodes.md`](remote-nodes.md).
 
 Public `boomux --remote TARGET` performs ad hoc bootstrap only. It
 discovers and verifies a compatible helper, or interactively installs one before
-opening and pinging a daemon-bound stdio channel. Explicit `boomux node add
+opening a daemon-bound stdio channel. The verified-connection boundary performs
+exactly one live ping: after connecting a Ready helper, or before transaction
+commit for an installed helper. Callers consume that verified result without a
+second channel write. One private owned OpenSSH
+master binds discovery, authorization, optional transactional replacement and
+owner/PID/start-identity claim recovery, process-neutral missing-install rollback,
+proof-bound daemon activation, daemon restart, final identity verification, protocol
+ping, and marker-only commit to the same
+authenticated endpoint. Explicit `boomux node add
 ALIAS TARGET` and revision-conditional registration management persist an
 identity-pinned route separately. A registration starts one noninteractive
 projection worker. Protocol 33 exposes cached projections through the separately

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,6 +126,10 @@ Protocol 38 adds coordinator-owned Workspace identity and explicit Node-owned
 placements. Coordinator metadata is stored independently from Node-local runtime
 state; equal names never establish membership, and adoption and linking require
 exact owner identities and revisions.
+Protocol 39 adds Node-qualified focused-terminal presentation to the combined
+Node snapshot and a prompt-free local invalidation event for responsive
+presentation. Focus remains ephemeral and controller-authorized, and is not
+persisted in the reduced remote projection cache.
 Remote notification presentation reuses protocol-32 atomic reduced transitions,
 so it does not require a later protocol. Node-cache schema 2 adds bounded local
 at-most-once individual and reconnect-digest claims with an explicit schema-1
@@ -330,7 +334,17 @@ Shell ID. The local daemon opens one identity-verified SSH helper channel and
 relays bounded `AttachFrame` values; the remote daemon retains PTY, controller,
 focus, takeover, resize, reconstruction, and exact-run authority. Remote
 transport loss closes only the local attachment and does not synthesize Shell,
-Agent, or Scheduled Execution completion.
+Agent, or Scheduled Execution completion. Protocol 39 also records a relayed
+focus gain as ephemeral presentation state on the local daemon after forwarding
+it to the owner. The presentation identity is the exact owner Node and Shell;
+it does not transfer focus authority or enter the remote projection cache.
+Presentation recording reflects the physical local focus report after the frame
+is written to the owner stream; it is not an acknowledgment that the owner
+accepted the frame and is never used as lifecycle evidence.
+The presenting daemon publishes a payload-free local invalidation after this
+recording so dashboards refresh the combined view on their next event poll. The
+owner's corresponding event remains owner-local and is excluded from reduced
+projection transitions.
 
 No emulator-specific adapter or compositor window ID is required.
 Spawned terminal windows start in independent process sessions with null
@@ -385,14 +399,22 @@ Agent presentation takes precedence when the current run has an active Agent or
 an exact `opencode` or `pi` foreground hint.
 
 The daemon retains the latest controller-authorized terminal focus gain as
-ephemeral workspace, shell, run, and monotonic revision metadata. With
+ephemeral workspace, shell, run, and monotonic revision metadata. Protocol 39
+also retains one monotonic presentation revision across local and relayed remote
+focus gains and exposes its exact `(node_id, shell_id)` through the combined
+Node snapshot. With
 `dashboard.follow_focused_terminal` enabled (the default), the dashboard uses a
 new revision as a one-shot selection trigger and resolves both shell and Agent
-rows by durable shell ID. Repeated snapshot refreshes do not enforce the
+rows by Node-qualified durable Shell identity. Repeated snapshot refreshes do not enforce the
 selection, so manual navigation remains usable until another terminal focus
 gain. Focus changes are deferred while an overlay or close confirmation is
 active. The setting is dashboard-local and disabling it does not stop focus
 reporting by attachments.
+Temporary projection absence does not reset the client's observed focus
+frontier. A replaced event stream or a handoff that changes the negotiated
+protocol resets it once. Same-version handoff retains the exact presentation
+frontier, while 39-to-38 and 38-to-39 transitions deliberately start the active
+protocol's revision domain without suppressing later physical focus gains.
 
 Selected-kind previews remain read-only. Workspace, launcher, and run metadata
 come from the polled snapshot. Shell output uses a bounded plain-text read only
@@ -711,6 +733,13 @@ observed. A definitive synchronous owner rejection may cancel only its serialize
 operation. Schedule
 prompts remain only in the transient owner request, and launcher and Shell argv
 remain arrays throughout routing.
+Protocol 39 adds an optional Node-qualified focused Shell and presentation
+revision to the combined Node snapshot. Protocol-38 responses omit the field.
+The value is live daemon memory, is returned only while the selected combined
+view still contains that exact Shell, and adds no durable projection field. A
+payload-free focus-presentation invalidation wakes protocol-39 clients without
+placing identity in the event stream; protocol-38 responses filter it while
+advancing their cursor.
 Project creation prepares the new global Workspace metadata and first Shell in
 one coordinator-store replacement. An exact retry returns its stored success
 even after the original global revision becomes stale. A new project request by

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -358,13 +358,17 @@ window has spawned, preserving retained output when terminal preparation fails.
 dashboard events and returns explicit external effects. The terminal runtime
 executes those effects through one backend interface and feeds typed completion
 events back into the model; model transitions do not call daemon or terminal
-callbacks directly. Rendering remains a function of typed model state. One
+callbacks directly. The backend runs effects serially off the terminal thread,
+so daemon, SSH, and preview latency cannot delay input or rendering; periodic
+refresh and preview reads are single-flight to keep stale work from accumulating.
+Rendering remains a function of typed model state. One
 daemon snapshot contains each workspace, its launchers, and its shells, avoiding
 races between separate list operations. Configured project roots provide
-workspace suggestions; selecting one persists its canonical path as the
-workspace's default cwd. Git information is still collected independently from
-shell directories and cached. A default cwd does not create workspace-level Git
-identity, and mixed-directory workspaces remain valid.
+Workspace-name suggestions; when global Workspaces are negotiated, selecting one
+creates empty coordinator metadata without retaining its path. Older peers
+retain empty local Workspace creation. Git information is still collected
+independently from item directories and cached. Paths do not create
+Workspace-level Git identity, and mixed-directory Workspaces remain valid.
 
 The dashboard establishes an atomic event-stream baseline and treats later
 events as invalidation signals for authoritative snapshot reprojection. It also
@@ -696,7 +700,8 @@ and process lifecycle. On first coordinator-store creation, existing local
 Workspaces are initialized once as global Workspaces with one local placement. Later
 unlinked local or projected remote Workspaces remain external until an explicit
 revision-guarded adoption or link; names are display metadata and never infer
-membership.
+membership. Creating a Workspace writes only empty coordinator metadata; Node
+and path selection begins when creating its first Node-hosted resource.
 
 The combined Node snapshot adds global and external Workspace arrays only for
 protocol-38 peers. Placement availability is projected from current Node health;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,13 +160,16 @@ output, resize, and detach events. Old-peer response transforms remain isolated
 in the daemon compatibility boundary and use the same feature registry when
 deciding which fields, values, and events to downgrade.
 
-The implemented protocol has seven durable identities beneath its implicit
-local Node. Federation will qualify each existing identity with a stable owning
-Node without rewriting the inner ID:
+The protocol qualifies every Node-owned durable identity with a stable owning
+Node without rewriting its inner ID. A coordinator-owned global Workspace is a
+separate organizing identity whose placements reference exact Node-local
+Workspace identities:
 
-- A workspace is a globally named shell container with a UUID and an optional
-  default working directory for newly created shells. The default is creation
-  behavior, not workspace identity; individual shells may use other paths.
+- A global Workspace owns its UUID, name, revision, placement membership, and
+  close state, but no process or filesystem context.
+- A Node-local workspace is a shell container with a UUID and optional default
+  working directory. Its default applies only on that owning Node; individual
+  resources may use other paths.
 - A shell is a durable process slot with a name, startup command, explicit
   working directory, and workspace ID.
 - A shell run identifies one process incarnation beneath that durable shell. It
@@ -521,8 +524,9 @@ explicit install or restart guidance.
 The optional vendor-neutral `boomux` Agent Skill documents the complete public
 CLI for compatible clients, including discovery, inspection, output reads,
 lifecycle operations, native-terminal opening, and daemon management.
-`BOOMUX_SHELL_ID` provides current-shell context while exact shell IDs remain
-globally addressable within the daemon. The installer safely removes an
+`BOOMUX_SHELL_ID` provides current-shell context. Federated resource identity is
+the pair of owning Node ID and unchanged Node-local ID; exact IDs are global only
+within one Node. The installer safely removes an
 untouched legacy `boomux-shells` skill and preserves customized copies.
 
 Read-only CLI integrations use the separate `boomux.cli/v1` JSON envelope rather
@@ -745,15 +749,16 @@ view still contains that exact Shell, and adds no durable projection field. A
 payload-free focus-presentation invalidation wakes protocol-39 clients without
 placing identity in the event stream; protocol-38 responses filter it while
 advancing their cursor.
-Project creation prepares the new global Workspace metadata and first Shell in
-one coordinator-store replacement. An exact retry returns its stored success
+The retained internal compound first-placement request prepares new global
+Workspace metadata and its first Shell in one coordinator-store replacement. It
+is a wire/recovery primitive, not a public CLI or dashboard creation flow. An exact retry returns its stored success
 even after the original global revision becomes stale. A new project request by
 the same name resumes or replays only when Node, cwd, and Shell definition have
 the same semantic fingerprint; its newly requested UUIDs map to the canonical
 prepared or completed identities. Definitive owner rejection removes only that
 pending operation and removes still-empty global metadata only when no related
 operation remains.
-Before creating project metadata, the coordinator performs cached eligibility
+Before creating compound first-placement metadata, the coordinator performs cached eligibility
 and fresh live capability preflight for the selected Node. Missing, ineligible,
 or runtime-capability-disabled owners therefore leave no empty global record. A
 definitive pre-owner failure on an existing exact preparation atomically cancels

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -108,6 +108,62 @@ the request. Identity change and unavailable-Node failures are also typed errors
 not message-parsed states.
 
 Node registration and SSH bootstrap are separately authorized operations.
+`node.add --json` never installs or replaces remote software. When discovery
+proves that Boomux is absent it returns `install_required`; when every discovered
+candidate is a known published build below the federation floor it returns
+`upgrade_required`. Both messages direct the operator to rerun the human command
+in an interactive terminal. Indeterminate executable, SSH, authentication,
+handshake, identity, and newer-version failures retain their own failure rather
+than being reported as either code, and no bootstrap mutation occurs.
+After authorization the pinned binary is uploaded to private transaction state,
+not the destination, and its current `daemon status --json` client proves the
+running daemon executable. Automatic upgrade requires that process executable,
+not merely the chosen old helper candidate, to exactly equal the install
+destination. Missing or unprovable process identity returns `upgrade_required`
+without activation. When no helper is discovered, a runtime probe must prove the
+socket path absent before upload and guarded activation repeats the check; an
+existing, racing, stale, or unprovable socket returns `install_required` without
+destination replacement or stop.
+On Linux, upgrade proof includes daemon PID, executable, negotiated protocol, and
+socket device/inode. The uploaded current binary revalidates that fingerprint on
+one open daemon connection immediately before activation; any race or unsupported
+proof boundary returns `upgrade_required` before destination mutation. Bootstrap
+platform preflight uses and verifies a fixed absolute command layout, so a
+poisoned `PATH` cannot select bootstrap tools; a missing layout is
+`bootstrap_unsupported_platform`.
+JSON and background bootstrap never mirror raw SSH master stderr. They retain
+only its bounded in-memory prefix for classification; overflow terminates the
+private master and returns a fixed transport failure.
+Bootstrap failures retain stable classes: `bootstrap_authentication_failed`,
+`bootstrap_transport_failed`, `bootstrap_malformed_helper`,
+`bootstrap_unsupported_platform`, `bootstrap_install_failed`, and
+`bootstrap_commit_outcome_unknown`. The last code is retryable and occurs only
+when the commit result is lost or malformed after successful installed-helper
+handshake and protocol ping; it does not promise rollback, and an exact retry
+rediscovers a compatible committed helper. Relative, oversized, or
+control-character-containing paths in framed discovery output are
+`bootstrap_malformed_helper`, not transport failures. A newer helper
+uses `unsupported_version`; changing or conflicting verified identities use
+`node_identity_changed` and `node_identity_conflict`. These classes contain only
+bounded diagnostics and are not collapsed into `invalid_argument` or `internal`.
+Install-stage failures identify a fixed non-secret stage such as stream, backup,
+activation, or watchdog readiness. They never include raw remote stderr, paths,
+shell startup output, or streamed bytes.
+The backup stage also covers rejection of an existing destination that is not an
+owner-owned bounded regular executable, metadata or byte-copy mismatch, and
+copy/fsync failure. These failures occur before atomic destination activation and
+leave the old executable pathname untouched.
+Bootstrap returns a connection only after exactly one live protocol ping. Ready
+helpers are pinged after connection; installed helpers use the pre-commit ping
+and are not pinged again by add, retarget, ad hoc, or dashboard callers. Failure
+of the required Ready ping remains a bootstrap failure before registration.
+`bootstrap_runtime_unavailable` identifies missing, malformed, unsupported, or
+unsafe remote daemon runtime discovery. Linux derives `/run/user/<numeric uid>`
+only when the remote environment omits `XDG_RUNTIME_DIR`; no local environment is
+forwarded. Post-install status, restart, helper verification, handshake, and ping
+failures identify that fixed stage without exposing remote stderr.
+An already-active remote bootstrap transaction returns the existing stable
+`busy` code before changing the destination.
 Per-Node observed capabilities must distinguish passive combined projection from
 process-starting, destructive, integration-management, Schedule, and
 exact-attachment support. The full compatibility and privacy rules are defined
@@ -300,8 +356,12 @@ Command payloads are:
 - `read`: shell/run identity, observed output revision, and rendered output.
 - `events`: stream identity, reconnect cursor, optional baseline snapshot, and a
   bounded event array.
-- `daemon.status`: `status`, `protocol_version`, `socket_path`, and nullable
-  `scheduler`. Scheduler data contains `state`, `max_concurrent`, and
+- `daemon.status`: `status`, `protocol_version`, `socket_path`, nullable `pid`,
+  `executable`, `socket_device`, and `socket_inode`, and nullable `scheduler`. On Linux, these identity fields
+  are populated only after same-user `SO_PEERCRED` and bounded absolute
+  `/proc/<pid>/exe` validation; the executable has a kernel ` (deleted)` suffix
+  removed. Other platforms or failed proof return null. Scheduler data contains
+  `state`, `max_concurrent`, and
   `active_executions`. State is `active` only for a running worker whose latest
   evaluation and next-occurrence projection succeeded; otherwise it is
   `offline`.

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -183,7 +183,6 @@ The following commands support `--json`:
 - `boomux project list`
 - `boomux workspace list`
 - `boomux workspace inspect`
-- `boomux workspace create-project`
 - `boomux node add`
 - `boomux node list`
 - `boomux node inspect`
@@ -226,8 +225,8 @@ The following commands support `--json`:
 - `boomux integration verify <opencode|pi>`
 - `boomux daemon status`
 
-JSON mutations are deliberately narrow. Atomic global Workspace project creation;
-Node registration add, rename, retarget, and forget; Agent register, ensure, and report;
+JSON mutations are deliberately narrow. Node registration add, rename, retarget,
+and forget; Agent register, ensure, and report;
 attention acknowledgment; schedule create, pause, resume, remove, and run;
 execution open and cancellation; and
 integration install and uninstall support the contract. Other mutation commands
@@ -258,12 +257,6 @@ Command payloads are:
 - `workspace.inspect`: on protocol 38, a global target returns coordinator
   `id`, `revision`, `name`, `closing`, and explicit placements. External or
   older local targets retain the owner Workspace inspection shape.
-- `workspace.create-project`: protocol-38-only atomic creation of one global
-  Workspace, its selected Node placement, and its first generated Shell. It
-  requires `--cwd`; `--node` is optional only when exactly one owner is eligible.
-  The response contains exact `node_id`, coordinator `workspace`, and owner
-  `shell` snapshots. The operation uses the same durable prepared request as the
-  dashboard and never exposes an intermediate empty Workspace.
 - `node.list`: an alias-then-Node-ID ordered array of registration objects.
 - `node.add`, `node.inspect`, `node.rename`, `node.retarget`, and `node.forget`:
   one registration object with `alias`, exact `target`, pinned `node_id`,
@@ -426,43 +419,30 @@ Protocol 38 adds `protocol_38`, `global_workspaces`,
 `resumable_workspace_close`.
 Protocol 39 adds `protocol_39` and `qualified_focused_terminal`.
 
-Protocol-38 `workspace create` without `--cwd` creates coordinator metadata
-without a default Node or cwd. The compatibility form with `--cwd` continues to
-create an unlinked local owner Workspace, visible as an external singleton until
-explicit adoption or linking. First global `shell create`, `launcher create`, or `schedule create`
-resolves `--node` against eligible owners. If exactly one owner is eligible it
-may be used without `--node`; zero or multiple eligible owners return a typed
-selection error listing disabled health reasons. The owner-local cwd is resolved
-on that Node. Exact argv arrays and private Schedule prompts are unchanged by
-coordination. `workspace open`, `close`, `rename`, `list`, and `inspect` resolve
-global IDs or names before considering external local records.
-`workspace create-project NAME --cwd PATH [--node NODE]` performs the dashboard's
-single prepared global Workspace plus first-Shell operation and returns their
-exact identities under `--json`; it is not equivalent to `workspace create`
-followed by `shell create`.
+Protocol-38 `workspace create` creates empty coordinator metadata without a
+default Node or cwd. First global `shell create`, `launcher create`, or
+`schedule create` resolves `--node` against eligible owners. If exactly one
+owner is eligible it may be used without `--node`; zero or multiple eligible
+owners return a typed selection error listing disabled health reasons. The
+owner-local cwd is resolved on that Node. Exact argv arrays and private Schedule
+prompts are unchanged by coordination. `workspace open`, `close`, `rename`,
+`list`, and `inspect` resolve global IDs or names before considering external
+local records.
 `workspace adopt TARGET --node NODE`, `workspace link GLOBAL OWNER --node NODE`,
 and `workspace retry GLOBAL` expose guarded adoption, linking, and unresolved
 close retry without requiring the TUI. Repeating `workspace close` for a closing
-global Workspace also uses the retry operation. Dashboard project selections
-use the same sole-owner or explicit no-default Node choice as first-resource
-creation, resolve the path on that owner, and create the global Workspace's first
-Shell and placement together. The path is never attached to empty coordinator
-metadata.
+global Workspace also uses the retry operation. Dashboard project suggestions
+contribute only the Workspace name; they create the same empty coordinator
+metadata as by-name creation. Node and path selection begins with first-resource
+creation.
 Prepared resource requests carry one caller-stable operation UUID. The client
 retries the exact request once after a lost connection, timeout, unknown outcome,
 or coordinator persistence failure. The coordinator returns the durable prior
 success before evaluating a now-stale revision guard. This replay guarantee lasts
 while the success remains among at most the newest 256 completed operations and
 within the 1 MiB coordinator-store bound; oldest-first eviction ends the
-guarantee. Project creation additionally resumes or replays a same-name request
-only when its Node, cwd, and Shell definition match. It verifies cached and live
-owner eligibility before persisting new metadata, so a missing or capability-
-disabled Node does not reserve the project name. Prepared requests reserve their
-completed-response footprint within the 1 MiB store and fail before owner
-mutation when capacity is unavailable. The coordinator durably marks owner
-dispatch before mutation; after that boundary, later capability, registration,
-identity, owner-error, or `not_found` results retain the pending project and name
-for exact recovery rather than allowing different semantics to reuse it.
+guarantee. Prepared requests reserve their completed-response footprint within
+the 1 MiB store and fail before owner mutation when capacity is unavailable.
 Adoption and linking fetch a fresh
 protocol-38 combined local snapshot over the admitted identity-pinned route and
 require its runtime `global_workspaces` capability before using the owner revision;

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -190,12 +190,13 @@ Command payloads are:
   filesystem without starting or contacting the daemon. With `--node`, the same
   bounded discovery runs on the verified owner and contacts the local routing
   daemon.
-- `workspace.list`: a `workspaces` array of `id`, `name`, `shell_count`,
-  `launcher_count`, `schedule_count`, `agent_count`, fixed `agent_state_counts`, and
-  `attention_count`.
-- `workspace.inspect`: one `workspace` object containing `id`, `name`, nullable
-  `default_cwd`, and prompt-free `shells`, `launchers`, `schedules`, and `agents`
-  arrays.
+- `workspace.list`: on protocol 38, `workspaces` contains coordinator Workspace
+  snapshots and `external_workspaces` contains unlinked qualified owner
+  singletons. On older protocols it retains the local summary array of `id`,
+  `name`, resource counts, fixed `agent_state_counts`, and `attention_count`.
+- `workspace.inspect`: on protocol 38, a global target returns coordinator
+  `id`, `revision`, `name`, `closing`, and explicit placements. External or
+  older local targets retain the owner Workspace inspection shape.
 - `node.list`: an alias-then-Node-ID ordered array of registration objects.
 - `node.add`, `node.inspect`, `node.rename`, `node.retarget`, and `node.forget`:
   one registration object with `alias`, exact `target`, pinned `node_id`,
@@ -206,11 +207,20 @@ Command payloads are:
   local alias; omission returns the all-Node overview. The local Node has alias
   `local`. A selector matching both that alias and a registration returns typed
   `ambiguous_target`; exact Node IDs disambiguate. Entries contain `node_id`,
-  `alias`, `local`, `health`, `current`, `stale`, `observed_at_ms`, nullable
+  `alias`, `local`, nullable `route`, nullable `registration_revision`, `health`,
+  `current`, `stale`, `observed_at_ms`, nullable
   `observed_protocol_version`, `observed_capabilities`, `scheduler`, and nullable
-  `local_snapshot` and `remote_projection` payloads. Every resource `id` and
+  `workspace_owner_eligible`, nullable `workspace_owner_unavailable_reason`,
+  `local_snapshot`, and `remote_projection` payloads. Every resource `id` and
   relationship ID in those payloads is `{ "node_id": "...", "inner_id":
   "..." }`; inner IDs are unchanged and must not be routed without their Node.
+  Protocol 38 also adds `workspaces` and `external_workspaces` arrays.
+  `workspaces` contains coordinator-owned `id`, `revision`, `name`, `closing`,
+  and explicit placements with Node ID, owner Workspace ID, observed owner
+  revision, nullable owner-local Workspace name, nullable owner-local `default_cwd`, and `active`, `close_pending`, or
+  `unavailable` state. `external_workspaces` contains unlinked qualified owner
+  identity, revision, name, nullable owner-local default cwd, and availability.
+  Protocol-37 and older responses omit both additive arrays.
 - `shell.suggest-name`: exact resolved `workspace_id` plus a nonempty generated
   `name` that does not match any shell name in that workspace at observation
   time.
@@ -337,6 +347,47 @@ Protocol 36 adds `protocol_36`, `typed_node_host_services`,
 `remote_exact_session_resume`.
 Protocol 37 adds `protocol_37`, `remote_agent_schedule_management`, and
 `remote_scheduled_execution_observation`.
+Protocol 38 adds `protocol_38`, `global_workspaces`,
+`multi_node_workspace_placements`, `guarded_workspace_adoption`, and
+`resumable_workspace_close`.
+
+Protocol-38 `workspace create` without `--cwd` creates coordinator metadata
+without a default Node or cwd. The compatibility form with `--cwd` continues to
+create an unlinked local owner Workspace, visible as an external singleton until
+explicit adoption or linking. First global `shell create`, `launcher create`, or `schedule create`
+resolves `--node` against eligible owners. If exactly one owner is eligible it
+may be used without `--node`; zero or multiple eligible owners return a typed
+selection error listing disabled health reasons. The owner-local cwd is resolved
+on that Node. Exact argv arrays and private Schedule prompts are unchanged by
+coordination. `workspace open`, `close`, `rename`, `list`, and `inspect` resolve
+global IDs or names before considering external local records.
+`workspace adopt TARGET --node NODE`, `workspace link GLOBAL OWNER --node NODE`,
+and `workspace retry GLOBAL` expose guarded adoption, linking, and unresolved
+close retry without requiring the TUI. Repeating `workspace close` for a closing
+global Workspace also uses the retry operation. Dashboard project selections
+use the same sole-owner or explicit no-default Node choice as first-resource
+creation, resolve the path on that owner, and create the global Workspace's first
+Shell and placement together. The path is never attached to empty coordinator
+metadata.
+Prepared resource requests carry one caller-stable operation UUID. The client
+retries the exact request once after a lost connection, timeout, unknown outcome,
+or coordinator persistence failure. The coordinator returns the durable prior
+success before evaluating a now-stale revision guard. This replay guarantee lasts
+while the success remains among at most the newest 256 completed operations and
+within the 1 MiB coordinator-store bound; oldest-first eviction ends the
+guarantee. Project creation additionally resumes or replays a same-name request
+only when its Node, cwd, and Shell definition match. It verifies cached and live
+owner eligibility before persisting new metadata, so a missing or capability-
+disabled Node does not reserve the project name. Prepared requests reserve their
+completed-response footprint within the 1 MiB store and fail before owner
+mutation when capacity is unavailable. The coordinator durably marks owner
+dispatch before mutation; after that boundary, later capability, registration,
+identity, owner-error, or `not_found` results retain the pending project and name
+for exact recovery rather than allowing different semantics to reuse it.
+Adoption and linking fetch a fresh
+protocol-38 combined local snapshot over the admitted identity-pinned route and
+require its runtime `global_workspaces` capability before using the owner revision;
+cached eligibility cannot authorize them.
 
 Node snapshot health is `unobserved`, `online`, `reconnecting`, `stale`,
 `unreachable`, `authentication_required`, `identity_changed`,

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -287,7 +287,9 @@ Command payloads are:
   revision, nullable owner-local Workspace name, nullable owner-local `default_cwd`, and `active`, `close_pending`, or
   `unavailable` state. `external_workspaces` contains unlinked qualified owner
   identity, revision, name, nullable owner-local default cwd, and availability.
-  Protocol-37 and older responses omit both additive arrays.
+  Protocol-37 and older responses omit both additive arrays. Protocol 39 adds
+  nullable `focused_terminal` with a monotonic presentation `revision` and exact
+  qualified `shell`; protocol-38 responses omit it.
 - `shell.suggest-name`: exact resolved `workspace_id` plus a nonempty generated
   `name` that does not match any shell name in that workspace at observation
   time. Protocol-38 responses also include exact `node_id` for local and routed
@@ -422,6 +424,7 @@ Protocol 37 adds `protocol_37`, `remote_agent_schedule_management`, and
 Protocol 38 adds `protocol_38`, `global_workspaces`,
 `multi_node_workspace_placements`, `guarded_workspace_adoption`, and
 `resumable_workspace_close`.
+Protocol 39 adds `protocol_39` and `qualified_focused_terminal`.
 
 Protocol-38 `workspace create` without `--cwd` creates coordinator metadata
 without a default Node or cwd. The compatibility form with `--cwd` continues to

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -94,6 +94,10 @@ New, separately named combined read-only surfaces can expose Node identity,
 health, observation time, and stale state, while every actionable resource is
 identified structurally by both its owning Node ID and unchanged resource ID.
 Names are resolved only within an explicit Node context when they are not local.
+`workspace open TARGET --node NODE` accepts the local Node only by exact Node ID,
+never by its display alias `local`, so an unlinked local owner Workspace cannot
+be confused with a same-ID global Workspace. Registered remote Nodes retain
+documented exact-ID or alias resolution.
 
 Cached remote projections can satisfy only documented prompt-free summary reads.
 Exact private inspection, terminal output, revision waits, and all mutations
@@ -123,6 +127,7 @@ The following commands support `--json`:
 - `boomux project list`
 - `boomux workspace list`
 - `boomux workspace inspect`
+- `boomux workspace create-project`
 - `boomux node add`
 - `boomux node list`
 - `boomux node inspect`
@@ -165,8 +170,8 @@ The following commands support `--json`:
 - `boomux integration verify <opencode|pi>`
 - `boomux daemon status`
 
-JSON mutations are deliberately narrow. Node registration add, rename, retarget,
-and forget; Agent register, ensure, and report;
+JSON mutations are deliberately narrow. Atomic global Workspace project creation;
+Node registration add, rename, retarget, and forget; Agent register, ensure, and report;
 attention acknowledgment; schedule create, pause, resume, remove, and run;
 execution open and cancellation; and
 integration install and uninstall support the contract. Other mutation commands
@@ -197,6 +202,12 @@ Command payloads are:
 - `workspace.inspect`: on protocol 38, a global target returns coordinator
   `id`, `revision`, `name`, `closing`, and explicit placements. External or
   older local targets retain the owner Workspace inspection shape.
+- `workspace.create-project`: protocol-38-only atomic creation of one global
+  Workspace, its selected Node placement, and its first generated Shell. It
+  requires `--cwd`; `--node` is optional only when exactly one owner is eligible.
+  The response contains exact `node_id`, coordinator `workspace`, and owner
+  `shell` snapshots. The operation uses the same durable prepared request as the
+  dashboard and never exposes an intermediate empty Workspace.
 - `node.list`: an alias-then-Node-ID ordered array of registration objects.
 - `node.add`, `node.inspect`, `node.rename`, `node.retarget`, and `node.forget`:
   one registration object with `alias`, exact `target`, pinned `node_id`,
@@ -223,7 +234,8 @@ Command payloads are:
   Protocol-37 and older responses omit both additive arrays.
 - `shell.suggest-name`: exact resolved `workspace_id` plus a nonempty generated
   `name` that does not match any shell name in that workspace at observation
-  time.
+  time. Protocol-38 responses also include exact `node_id` for local and routed
+  owners; older local responses omit it.
 - `shell.inspect`: one `shell` object.
 - `launcher.list`: workspace identity plus a `launchers` array.
 - `launcher.inspect`: one `launcher` object.
@@ -361,6 +373,10 @@ selection error listing disabled health reasons. The owner-local cwd is resolved
 on that Node. Exact argv arrays and private Schedule prompts are unchanged by
 coordination. `workspace open`, `close`, `rename`, `list`, and `inspect` resolve
 global IDs or names before considering external local records.
+`workspace create-project NAME --cwd PATH [--node NODE]` performs the dashboard's
+single prepared global Workspace plus first-Shell operation and returns their
+exact identities under `--json`; it is not equivalent to `workspace create`
+followed by `shell create`.
 `workspace adopt TARGET --node NODE`, `workspace link GLOBAL OWNER --node NODE`,
 and `workspace retry GLOBAL` expose guarded adoption, linking, and unresolved
 close retry without requiring the TUI. Repeating `workspace close` for a closing

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -49,16 +49,15 @@ from a CLI or daemon version string. Registration commands manage local routes
 only and do not imply projected reads or routed resource mutation.
 
 Protocol 33 advertises the separately named `node.snapshot` combined read. It
-contacts only the local daemon and never changes the local-only meaning of any
-existing snapshot or list operation.
+contacts only the local daemon and returns qualified local plus bounded cached
+remote projections. Legacy resource lists remain local-only.
 
 Protocol 34 advertises `typed_exact_node_routing` and
 `guarded_remote_management`. Dashboard effects carry structured Node-qualified
 identities, freshly inspect the owner before destructive confirmation, and use
 the resource revision, membership generation, run ID, Schedule/execution
 revision, observation revision, or dispatch key required by the operation.
-Stale Nodes and Nodes without the capability remain non-actionable. Existing
-unqualified CLI methods preserve local-only semantics.
+Stale Nodes and Nodes without the capability remain non-actionable.
 
 Protocol 35 advertises `remote_pty_attachment` and
 `owner_environment_attachment`. `boomux open SHELL --node SELECTOR` is a
@@ -81,19 +80,22 @@ Protocol 37 advertises `remote_agent_schedule_management` and
 prompt-free reduced projection and includes Node freshness, health, observation
 time, and scheduler health. Exact reads and all mutations are live owner-routed.
 
-That passive command advertises only what the installed local CLI can speak and
-never reports negotiated state for a registered Node. Implemented `node.list`
-and `node.inspect` return registration data only. Future combined projection data
-will carry each Node's observed protocol, capabilities, health, and observation
-time after contacting only the local daemon. Integrations must keep static CLI
-support, registration data, and per-Node runtime support distinct.
+`capabilities` advertises only what the installed local CLI can speak and never
+reports negotiated state for a registered Node. `node.list` and `node.inspect`
+return registration data only. `node.snapshot` carries each Node's observed
+protocol, capabilities, health, and observation time after contacting only the
+local daemon. Integrations must keep static CLI support, registration data, and
+per-Node runtime support distinct.
 
-Existing unqualified commands and JSON methods retain local-Node meaning and
-local-only result sets. Older clients continue to receive only local resources.
-New, separately named combined read-only surfaces can expose Node identity,
-health, observation time, and stale state, while every actionable resource is
-identified structurally by both its owning Node ID and unchanged resource ID.
-Names are resolved only within an explicit Node context when they are not local.
+Legacy resource commands and JSON methods retain local-Node meaning and
+local-only result sets. Protocol-38 unqualified Workspace list, inspect, open,
+rename, close, and resource creation resolve coordinated Workspaces first; older
+clients still receive only local resources. The separately named combined read
+exposes Node identity, health, observation time, and stale state, while every
+actionable resource is identified structurally by both its owning Node ID and
+unchanged resource ID. Routed commands that accept names resolve them only in an
+explicit Node context; `workspace open --node`, `shell suggest-name --node`, and
+`launcher invoke --node` require exact owner resource IDs.
 `workspace open TARGET --node NODE` accepts the local Node only by exact Node ID,
 never by its display alias `local`, so an unlinked local owner Workspace cannot
 be confused with a same-ID global Workspace. Registered remote Nodes retain
@@ -435,6 +437,11 @@ global Workspace also uses the retry operation. Dashboard project suggestions
 contribute only the Workspace name; they create the same empty coordinator
 metadata as by-name creation. Node and path selection begins with first-resource
 creation.
+An explicit `--node` on `shell create` or `launcher create` never falls back to
+local mutation. It fails with `unsupported_version` when global Workspaces are
+unavailable and with `invalid_argument` when the target is not coordinated.
+`workspace adopt`, `link`, and `retry` likewise fail with `unsupported_version`
+before target resolution on a pre-38 daemon.
 Prepared resource requests carry one caller-stable operation UUID. The client
 retries the exact request once after a lost connection, timeout, unknown outcome,
 or coordinator persistence failure. The coordinator returns the durable prior
@@ -705,11 +712,12 @@ selected workspace. The projection must have a canonical external session ID
 and its integration must equal `--integration`; descriptions, external IDs,
 latest-session selection, and names are never substitutes.
 
-Exact schedule IDs resolve globally for inspect, pause, resume, and remove.
-Schedule names resolve only with explicit `--workspace` or the exact current
-`BOOMUX_WORKSPACE_ID`. List is global unless `--workspace` is supplied. Removing
-a schedule removes its persisted prompt. Closing a workspace removes all owned
-schedules and persisted prompts along with the workspace.
+Exact Schedule IDs resolve globally only within the selected Node for inspect,
+pause, resume, and remove. Schedule names resolve only with explicit
+`--workspace` or the exact current `BOOMUX_WORKSPACE_ID`. List covers the
+selected Node unless `--workspace` narrows it. Removing a Schedule removes its
+persisted prompt. Closing a Workspace removes all owned Schedules and persisted
+prompts along with the Workspace.
 
 `read` returns `shell_id`, `run_id`, `output_revision`, `changed`, `status`, and
 `output`. Output is a JSON string containing the same bounded plain rendered text

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -41,6 +41,13 @@ Protocol 32 adds owner-side reduced Node projection cuts and the local
 Protocol 37 adds remote Schedule management and execution observation without a
 new event kind: owner events remain owner-local and the presenting Node receives
 only its existing projection invalidation.
+Protocol 39 adds live Node-qualified focused-terminal presentation to the
+combined Node snapshot and the prompt-free
+`focused_terminal_presentation_changed` invalidation event. The event wakes
+local presentation clients without carrying the focused identity; clients read
+the combined snapshot for the current value. It is not copied into another
+Node's projection transitions or persisted projection cache. A one-second
+ephemeral refresh remains the fallback for legacy or missed invalidations.
 Remote notification presentation adds no protocol or event kind. It consumes the
 protocol-32 reduced transition batch at the projection-cache boundary and never
 copies owner events into the presenting Node's domain journal.
@@ -126,6 +133,7 @@ The event vocabulary is:
   `agent_schedule_resumed`, `agent_schedule_removed`
 - `scheduled_execution_created`, `scheduled_execution_changed`
 - `node_projection_changed`
+- `focused_terminal_presentation_changed`
 - `handoff_completed`
 
 Output events carry run identity and the latest output revision, not raw PTY

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -77,6 +77,12 @@ owned by the remote daemon and never enter a local handoff manifest. Remote
 daemon replacement uses this existing descriptor-transfer protocol on the
 remote machine, and its attachment reconnect frames pass unchanged through the
 SSH bridge.
+Remote transactional upgrade copies the old executable into private rollback
+state before atomically replacing its installed pathname. It does not rename the
+live executable to the backup path: on Linux the old daemon therefore observes a
+deleted installed path and selects the replacement at that path for graceful
+handoff. Rollback performs the inverse atomic replacement before asking the
+provisional daemon to hand off to the restored executable.
 
 Local daemon replacement instead closes federation admission, drains admitted
 Node requests and projection commits to known outcome boundaries, stops

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -36,6 +36,8 @@ The private handoff channel carries a versioned manifest followed by Unix
   sanitized final VT state without process descriptors
 - The latest non-durable focused-terminal revision and workspace/shell/run
   identity, when it still refers to a transferred runtime
+- The latest non-durable Node-qualified presentation focus and its monotonic
+  revision, including an external Node Shell when that was focused most recently
 
 The PTY master is full duplex, so reader and writer duplicates do not need to be
 transferred separately. The replacement cannot inherit Unix parenthood; process
@@ -68,6 +70,13 @@ resuming readers, so output revisions remain ordered after the ownership
 boundary. The optional focused-terminal snapshot crosses the same graceful
 handoff so dashboard following does not forget the last focused managed window;
 ordinary cold recovery does not restore it.
+Protocol-39 qualified presentation focus crosses the same handoff independently
+from PTY ownership, so a later local or external focus gain always advances past
+the revision already observed by a surviving dashboard.
+An intermediate protocol-38 replacement may omit this additive field. A
+surviving dashboard detects the negotiated protocol transition from the
+`handoff_completed` boundary and resets its observed focus frontier once, so
+each protocol's revision domain remains usable.
 
 ## Accepted Remote Node Boundary
 

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -81,12 +81,13 @@ guaranteed after oldest-first eviction. Adoption and linking require a fresh
 identity-pinned protocol-38 combined local snapshot under the admitted route.
 That live snapshot must advertise runtime `global_workspaces` eligibility and
 contains the fresh exact owner revision used for commit. Cached projection
-eligibility alone cannot authorize either mutation. Project creation performs
-the same live capability preflight before persisting empty metadata; definitive
+eligibility alone cannot authorize either mutation. The retained internal
+compound first-placement request performs the same live capability preflight
+before persisting empty metadata; definitive
 pre-owner rejection cancels only an existing exact preparation durably marked as
 never attempted. Immediately before owner mutation the coordinator persists an
 attempted phase. Once set, later capability, registration, identity, owner-error,
-or exact-absence results retain the pending operation and project name because
+or exact-absence results retain the pending operation and Workspace name because
 they cannot disprove an earlier transport-ambiguous mutation. Ambiguous or
 network outcomes likewise retain any already-prepared recovery state.
 
@@ -112,8 +113,10 @@ The Node is an additional outer name-resolution scope, not a replacement for
 existing scopes. Workspace names are unique within one Node. Shell, launcher,
 and Agent Schedule names retain their Workspace scopes, and exact-only identities
 remain exact-only. A client resolving a name outside the local Node must supply
-explicit Node context. Existing unqualified operations retain local-Node meaning;
-federation never changes a legacy request into a remote mutation.
+explicit Node context. Legacy unqualified resource operations retain local-Node
+meaning; protocol-38 coordinated Workspace commands are the explicit exception
+and route only through persisted placement membership. Federation never changes
+a legacy request into an unqualified remote mutation.
 
 An SSH target is a route, not identity. Successful persistent registration pins
 the Node ID returned through an authenticated route. A later connection that

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -178,6 +178,189 @@ exact target, source, destination, and process impact. Noninteractive setup neve
 installs, replaces, or stops remote software. Routine background synchronization
 is noninteractive and never opens a hidden password, MFA, hardware-token, or
 host-key prompt.
+The interactive OpenSSH master's stderr is teed byte-for-byte to the invoking
+terminal while the same bounded prefix is retained in memory for failure
+classification. This is the only raw authentication-output presentation: it is
+not decoded, logged, persisted, included in diagnostics, or exposed to JSON and
+background operation. Password and confirmation prompts continue to use
+OpenSSH's `/dev/tty` handling. Batch setup captures the same bounded prefix
+silently. If master stderr exceeds 16 KiB, setup kills and reaps the private
+master process group and reports a fixed bounded transport failure instead of
+continuing with truncated authentication context. Guided terminal setup reports
+its outcome and waits for Enter before closing.
+
+One setup owns one explicit OpenSSH master from initial authentication through
+discovery, candidate checks, authorization, installation, daemon status and
+restart, final identity-pinned handshake, and live channel creation. Every
+command is a slave of that private owner-only control socket; an observation from
+one endpoint or account can never authorize mutation through another connection.
+The private configuration terminates any trailing `Match` scope inherited from
+the included user configuration before clearing `SendEnv`, so even an included
+file ending in a nonmatching block cannot retain environment forwarding.
+Every fixed command that contacts the remote daemon resolves its runtime
+environment on that authenticated host. It never forwards or persists the local
+environment. An existing remote `XDG_RUNTIME_DIR` must be a bounded safe absolute
+path. When it is absent on Linux, Boomux derives `/run/user/<numeric id -u>`;
+macOS retains the requirement for an explicit runtime directory. The selected
+directory must be a non-symlink directory owned by that numeric user with mode
+`0700`, and is exported only for that remote command. These rules cover helper
+probes, live federation and host-service channels, daemon status and restart,
+and rollback/watchdog daemon restoration. Missing, malformed, unsupported, or
+unsafe runtime discovery returns `bootstrap_runtime_unavailable` without
+including the path or raw remote stderr.
+Slave argv also installs a deliberately failing direct-connection fallback, so a
+missing control socket cannot make OpenSSH resolve or connect to the target
+again. Master disappearance at any stage is therefore a transport failure, not a
+route retry.
+Ordinary host-key checking remains enabled. Completion, refusal, timeout, and
+error terminate and reap the master and remove its private control directory.
+
+Discovery checks every bounded absolute executable candidate. A verified helper
+whose daemon identity and negotiated protocol are federation-compatible is used
+unchanged, even when another candidate is old. No candidates produces an install
+plan; candidates whose strict published version metadata all predates the
+federation protocol floor produce an upgrade plan. An inaccessible candidate,
+malformed handshake, unsupported newer protocol, conflicting Node identity, or
+indeterminate transport/authentication failure is not version evidence and fails
+without an install plan. Interactive install or upgrade presents one plan and
+asks once. JSON and other noninteractive invocation returns `install_required`
+or `upgrade_required` and performs no remote mutation.
+After authorization, Boomux acquires the remote transaction lock and uploads the
+pinned bytes only to the private transaction `new` path. It validates and marks
+that executable and starts the rollback watchdog without replacing the discovered
+destination. The uploaded current binary then runs `daemon status --json` as a
+client of the existing daemon; status does not start a missing daemon. This lets
+an old released installed helper participate even when its own CLI predates the
+additive process-identity fields. On Linux, the provisional client obtains the
+socket peer PID with `SO_PEERCRED`, validates same-user `/proc` ownership,
+resolves the bounded absolute `/proc/<pid>/exe` path after normalizing the
+kernel's ` (deleted)` suffix, and records the socket device and inode. Automatic
+upgrade requires that proven process executable to equal the install destination
+exactly. Immediately before rename, the provisional binary opens one negotiated
+daemon connection and binds activation to the exact PID, executable, protocol,
+and socket device/inode fingerprint while that connection remains open.
+Candidate equality or an earlier unbound status result is not evidence. Missing,
+changed, malformed, macOS, or otherwise unprovable identity returns
+`upgrade_required` without activating the upload.
+
+When discovery finds no helper, a separate fixed runtime probe must prove that
+the daemon socket path is absent before upload. Guarded activation repeats that
+check while holding the transaction claim. A socket that appears between checks,
+symlink, stale socket, malformed result, or failed probe returns
+`install_required` for manual daemon recovery without destination replacement or
+stop. Only a missing helper plus both absence checks may activate and be treated
+as having no pre-existing daemon.
+
+An install source is either the invoking binary for a matching OS/architecture
+or a checksum-verified asset from an explicit published release/protocol matrix.
+Matching OS/architecture is not ABI proof. Before showing a current-development
+binary plan, Boomux opens the source without following symlinks, rejects special,
+empty, changing, or oversized files, compares device, inode, length, mtime, and
+ctime metadata before and after the bounded read, and pins the retained bytes and
+their SHA-256.
+Authorization displays that digest, and installation uses those retained bytes
+rather than reopening a mutable executable path. A
+published asset must overlap both the federation floor and the invoking local
+wire range. If none does, setup fails before authorization or remote mutation
+and directs development users to build for the remote target and manually stream
+that current build.
+
+Authorized upload first acquires one atomic remote bootstrap lock. A locally
+generated unique validated transaction ID names its private upload, backup,
+captured pre-install daemon protocol or absence, activation marker,
+daemon-contact marker, renewable lease, and watchdog state;
+no backup name is shared between transactions. Concurrent
+setup fails `busy` before touching the destination. The replacement remains
+provisional under a bounded remote lease until explicit ID-matched commit.
+An existing destination is accepted only when it is a nonempty, bounded,
+owner-owned, non-symlink regular executable. Symlinks, special files,
+non-executable files, unsupported ownership, and ambiguous metadata fail at the
+fixed backup stage before the destination is changed. The installer copies the
+old bytes and preserved mode, owner, group, and timestamps into the private
+backup, then rechecks source metadata and compares the complete copy. A failed or
+out-of-space copy leaves the old destination inode untouched. On Linux the
+completed backup and later destination replacement are synced before progress is
+published.
+After proof, an idempotent activation command acquires the same claim, validates
+the transaction and destination, copies and verifies the backup, records
+activation intent, and atomically renames `new` over the destination. It never
+renames the running old executable into the transaction.
+Consequently Linux exposes the old daemon's executable as the deleted prior
+destination, and graceful restart's installed-path fallback selects the new
+destination rather than the protocol-old backup.
+Before returning the upload transaction ID, the uploader requires a readiness marker
+from the detached rollback watchdog and records its PID. A failure at any fixed
+filesystem, streaming, activation, or watchdog stage emits only a bounded
+non-secret stage marker and deterministic exit code. The client maps that marker
+to actionable `bootstrap_install_failed` detail; arbitrary remote stderr is never
+included in CLI diagnostics.
+Post-upload failures similarly name the fixed identity-proof, activation, graceful-restart,
+helper-verification, live-handshake, or protocol-ping stage without exposing raw
+remote output.
+Every bounded post-install stage first atomically replaces the lease value. The
+watchdog rolls back only after one complete 180-second interval without a new
+value. At expiry it acquires the claim and rereads the lease while renewal is
+excluded; a changed token releases the claim and begins a fresh interval. Commit,
+explicit rollback, renewal, and watchdog expiry coordinate through the
+transaction lock and claim directory. Each claim records a unique owner token,
+PID, process-start identity, and heartbeat. A contender may reclaim it only after
+a complete unrenewed 180-second lease and proof that the recorded PID/start owner
+is gone; an active owner remains protected. Before commit, master or local-process
+loss therefore lets the watchdog restore it automatically even when a healthy
+transaction spans several lease intervals. ABI/exec failure and every daemon-status, restart, helper,
+identity, live-handshake, or protocol-ping failure request rollback; a failed
+first installation removes only the destination activated by that transaction.
+Rollback never stops a daemon when the pre-install state was absent; an
+independently started runtime process survives and may require explicit operator
+recovery after filesystem restoration. If a provisional upgrade restarted the daemon,
+rollback atomically renames the complete backup over the provisional destination.
+When a daemon existed before activation and provisional helper work could have
+affected it, rollback gracefully restarts through the restored helper regardless
+of later status observations. The explicit
+rollback and detached watchdog share the same complete-backup and
+activation-intent markers, so a partial backup is never installed.
+An uploaded-only transaction has no activation intent, so explicit rollback or
+watchdog expiry removes only private transaction state and cannot touch the
+destination. Upload and activation acknowledgments are keyed by the caller's
+transaction ID; exact retry returns the existing uploaded or activated state.
+
+Commit is attempted only after a fresh helper handshake, final live identity
+verification, and an actual protocol ping all succeed. It atomically renames the
+complete transaction beneath the lock as a durable committed marker and returns
+a framed result. It is idempotent while that marker remains and does not delete
+the backup, transaction, or lock. The watchdog interprets the moved transaction
+as committed and eventually removes all of them; bounded stale-claim recovery
+also guarantees eventual lock cleanup after a commit process is killed. A lost
+or malformed commit acknowledgment is therefore
+`bootstrap_commit_outcome_unknown`, not a rollback promise: the marker may or may
+not have committed, and Boomux must not undo a replacement after its verified
+live channel was accepted. Retrying the exact bootstrap rediscovers the
+compatible installed helper and succeeds without another installation. While an
+uncommitted marker is absent, discovery suppresses only the provisional install
+destination so a retry cannot accept a helper that the watchdog will later roll
+back. Before the atomic marker the watchdog rolls back; after it the watchdog
+cleans up, so transport loss at no commit step can produce a partially finalized
+state.
+Every verified-bootstrap result has passed exactly one live protocol ping. A
+previously Ready helper is connected and pinged before the result is returned. An
+installed or upgraded helper is already pinged inside the transaction before
+commit, so registration, retarget, ad hoc connection, and dashboard consumers do
+not ping that returned handoff-era channel again. The remote may close the channel
+immediately after the successful verification ping without invalidating the
+verified handshake identity or a completed commit. A Ready helper that cannot
+answer its one required ping still fails before any registration mutation.
+An
+upgrade may use the existing graceful daemon restart command only when the new
+helper has verified provisionally and a separate runtime-aware status check shows
+that the running daemon protocol is outside the supported federation range. This
+status check runs for every upgrade, including when the provisional helper
+handshake itself looks compatible. The transaction is marked restarted before
+one graceful restart, the helper is inspected again afterward, and the final
+live channel must still pass its protocol ping. An absent daemon is not restarted
+and can start only through ordinary helper behavior. Pre-install presence and
+protocol are recorded durably before helper contact, so rollback and watchdog
+recovery do not depend on later socket, status, or daemon-generation races. An
+already-compatible daemon is never restarted for a release-version difference.
 
 The remote bridge command uses a fixed template. No prompt, resource ID,
 integration command, or user argument is interpolated into it. Its only variable
@@ -187,6 +370,10 @@ one documented shell-quoting function. SSH options belong to the user's SSH
 configuration, the target is passed as one validated argument, and a target
 beginning with `-` is invalid. The bridge opens no remote TCP listener and never
 exposes the local daemon socket to the remote machine.
+
+Framed executable candidates and install destinations that are relative,
+oversized, or contain control characters are malformed helper output and return
+`bootstrap_malformed_helper`; they are not transport evidence.
 
 Every registration carries a monotonic local registration revision.
 Synchronization and routed requests reserve admission and copy that revision

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -23,6 +23,8 @@
 > Protocol 38 implements coordinator-owned Workspace metadata, explicit
 > Node-owned placements, guarded adoption and linking, and resumable close
 > progress. Node-local runtime state remains authoritative on each owner.
+> Protocol 39 implements live Node-qualified focused-terminal presentation in
+> the combined Node snapshot without extending persisted remote projections.
 > Public `boomux --remote TARGET`
 > remains ad hoc.
 
@@ -665,6 +667,21 @@ and launches local presentation with a Node-qualified title. The dashboard opens
 current remote Shell rows and active exact Scheduled Execution runs only when
 the observed owner capabilities include remote attachment.
 
+Protocol 39 advertises `qualified_focused_terminal`. A focus frame relayed by a
+local attachment is still validated and recorded by the owning daemon. After a
+successful forward, the presenting daemon also advances one ephemeral
+presentation revision for the exact qualified Shell. The combined Node snapshot
+returns that value only while its selected Node view contains the Shell. It is
+not written to `node-cache.json`, copied into owner events, or used as lifecycle
+or mutation authority. This local physical-focus hint does not wait for a
+per-frame owner acknowledgment; the owner independently rejects stale controller
+frames under its existing attachment rules. Protocol-38 clients receive the
+combined snapshot without this additive field. The presenting daemon emits a
+payload-free `focused_terminal_presentation_changed` local invalidation so a
+dashboard reads the combined snapshot on its next event poll instead of waiting
+for the one-second fallback. The event does not become a reduced owner
+transition.
+
 Remote graceful handoff sends its existing reconnect boundary through the
 bridge. Local graceful handoff asks the local attachment to reconnect and opens
 a fresh SSH stream after finalization. No remote PTY descriptor, process handle,
@@ -774,7 +791,9 @@ stable schema. A client never infers federation support from a version string.
 Protocol-32 and older clients cannot request the combined snapshot and continue
 to receive only local resources from every legacy surface. Protocol 33 adds no
 new event kind; protocol-31 filtering of `node_projection_changed` remains the
-event compatibility boundary.
+event compatibility boundary. Protocol 39 adds the local-only
+`focused_terminal_presentation_changed` invalidation; older clients do not
+receive it, but their cursors advance across the filtered event.
 
 Federation has three independent compatibility boundaries:
 

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -20,6 +20,9 @@
 > 36 implements closed typed owner host services and exact Agent Session resume.
 > Protocol 37 implements Node-qualified remote Schedule creation, management,
 > execution observation, and presentation.
+> Protocol 38 implements coordinator-owned Workspace metadata, explicit
+> Node-owned placements, guarded adoption and linking, and resumable close
+> progress. Node-local runtime state remains authoritative on each owner.
 > Public `boomux --remote TARGET`
 > remains ad hoc.
 
@@ -33,6 +36,57 @@ Omarchy panel should nevertheless behave as native local presentation.
 
 Federation is not shared runtime ownership. Each Node remains a complete Boomux
 authority, and SSH is a replaceable transport between authorities and clients.
+
+The coordinating Node separately owns global Workspace identity, name,
+membership, and operation progress. A placement is always an explicit pair of
+stable Node ID and owner-local Workspace ID. It may retain an owner-local default
+working directory, but paths are never copied to or inferred for another Node.
+Equal Workspace names on different Nodes remain unrelated unless the user links
+the exact owner identity under revision guards.
+
+Placement eligibility requires a current identity-verified projection and the
+protocol-38 `global_workspaces` capability. Selection never defaults when more
+than one owner is eligible. Dashboard and CLI selectors show unavailable Nodes
+disabled with their health reason. Resource coordination durably prepares stable
+operation, requested and canonical owner Workspace, and resource UUIDs before
+owner mutation, validates the resulting owner metadata, and persists membership
+before success. After an ambiguous channel or coordinator write, the next exact
+request reads the prepared owner resource and completes coordinator metadata. A
+read that finds no resource retains the pending operation because it may have
+raced an in-flight owner mutation. Completed success is replayed from the
+coordinator's bounded durable outcome ledger even when the request's original
+revision is now stale; no prompt,
+attachment environment, or shell-interpolated command enters coordinator state.
+Preparation reserves enough physical store capacity for a conservative upper
+bound of the completed response, evicting oldest outcomes if necessary. A request
+that cannot reserve within 1 MiB fails before any owner mutation. Concurrent
+distinct placements atomically enlarge all related pending reservations for the
+additional future placement before either new owner dispatch proceeds.
+
+The dashboard has a dedicated Nodes tab rather than a Node filter. Inspection is
+read-only; alias rename and route retarget use registration revisions, retarget
+verifies the pinned identity before mutation, and forget requires confirmation
+and removes only the local route. Projection refresh wakes the selected Node's
+existing observer without starting an overlapping worker or changing remote
+authority.
+Prepared operations are isolated and serialized by operation UUID, so concurrent
+identical handlers return one durable result and cancellation cannot consume an
+in-flight or completed success. Distinct first-placement requests retain their
+requested owner UUIDs while sharing the canonical owner selected by the first
+prepared request. The completed ledger retains at most the newest 256 successes
+and may retain fewer to preserve the 1 MiB coordinator-store limit; replay is not
+guaranteed after oldest-first eviction. Adoption and linking require a fresh
+identity-pinned protocol-38 combined local snapshot under the admitted route.
+That live snapshot must advertise runtime `global_workspaces` eligibility and
+contains the fresh exact owner revision used for commit. Cached projection
+eligibility alone cannot authorize either mutation. Project creation performs
+the same live capability preflight before persisting empty metadata; definitive
+pre-owner rejection cancels only an existing exact preparation durably marked as
+never attempted. Immediately before owner mutation the coordinator persists an
+attempted phase. Once set, later capability, registration, identity, owner-error,
+or exact-absence results retain the pending operation and project name because
+they cannot disprove an earlier transport-ambiguous mutation. Ambiguous or
+network outcomes likewise retain any already-prepared recovery state.
 
 ## Identity And Ownership
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2345,7 +2345,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 38);
+            reject_protocol(&listener, 38, 37);
             reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
@@ -2518,7 +2519,8 @@ mod tests {
             )
             .unwrap();
 
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 38);
+            reject_protocol(&listener, 38, 37);
             reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
@@ -2585,7 +2587,8 @@ mod tests {
             )
             .unwrap();
 
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 38);
+            reject_protocol(&listener, 38, 37);
             reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
@@ -2634,7 +2637,8 @@ mod tests {
                 ),
             )
             .unwrap();
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 38);
+            reject_protocol(&listener, 38, 37);
             reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
@@ -2813,7 +2817,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 38);
+            reject_protocol(&listener, 38, 37);
             reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
@@ -2887,7 +2892,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 38);
+            reject_protocol(&listener, 38, 37);
             reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);

--- a/src/client.rs
+++ b/src/client.rs
@@ -450,6 +450,37 @@ impl Client {
         self.send(request).map(|(_, _, response)| response)
     }
 
+    fn workspace_resource_request(&self, request: Request) -> Result<Response> {
+        match self.request(request.clone()) {
+            Err(ClientError::Remote(error))
+                if matches!(
+                    error.code,
+                    Some(
+                        ErrorCode::PersistenceFailed
+                            | ErrorCode::OutcomeUnknown
+                            | ErrorCode::Timeout
+                    )
+                ) =>
+            {
+                self.request(request)
+            }
+            Err(ClientError::Transport(error))
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::ConnectionReset
+                        | io::ErrorKind::BrokenPipe
+                        | io::ErrorKind::ConnectionAborted
+                        | io::ErrorKind::NotConnected
+                        | io::ErrorKind::TimedOut
+                        | io::ErrorKind::UnexpectedEof
+                ) =>
+            {
+                self.request(request)
+            }
+            result => result,
+        }
+    }
+
     fn send(&self, request: Request) -> Result<(UnixStream, u32, Response)> {
         let mut version = self.protocol_version.load(Ordering::Acquire);
         if request
@@ -605,9 +636,245 @@ impl Client {
         }
     }
 
+    pub fn force_node_projection_refresh(
+        &self,
+        selector: impl Into<String>,
+    ) -> Result<NodeProjectionHealth> {
+        match self.request(Request::ForceNodeProjectionRefresh {
+            selector: selector.into(),
+        })? {
+            Response::NodeProjectionHealth { health } => Ok(health),
+            response => unexpected(response),
+        }
+    }
+
     pub fn combined_node_snapshot(&self, selector: Option<String>) -> Result<CombinedNodeSnapshot> {
         match self.request(Request::GetCombinedNodeSnapshot { selector })? {
             Response::CombinedNodeSnapshot { snapshot } => Ok(snapshot),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn create_global_workspace(
+        &self,
+        name: impl Into<String>,
+    ) -> Result<crate::protocol::GlobalWorkspaceSnapshot> {
+        match self.request(Request::CreateGlobalWorkspace { name: name.into() })? {
+            Response::GlobalWorkspace { workspace } => Ok(workspace),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn adopt_node_workspace(
+        &self,
+        identity: crate::protocol::QualifiedIdentity,
+        expected_revision: u64,
+    ) -> Result<crate::protocol::GlobalWorkspaceSnapshot> {
+        match self.request(Request::AdoptNodeWorkspace {
+            identity,
+            expected_revision,
+        })? {
+            Response::GlobalWorkspace { workspace } => Ok(workspace),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn link_node_workspace(
+        &self,
+        global_workspace_id: impl Into<String>,
+        expected_global_revision: u64,
+        identity: crate::protocol::QualifiedIdentity,
+        expected_owner_revision: u64,
+    ) -> Result<crate::protocol::GlobalWorkspaceSnapshot> {
+        match self.request(Request::LinkNodeWorkspace {
+            global_workspace_id: global_workspace_id.into(),
+            expected_global_revision,
+            identity,
+            expected_owner_revision,
+        })? {
+            Response::GlobalWorkspace { workspace } => Ok(workspace),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn rename_global_workspace(
+        &self,
+        workspace_id: impl Into<String>,
+        expected_revision: u64,
+        name: impl Into<String>,
+    ) -> Result<crate::protocol::GlobalWorkspaceSnapshot> {
+        match self.request(Request::RenameGlobalWorkspace {
+            workspace_id: workspace_id.into(),
+            expected_revision,
+            name: name.into(),
+        })? {
+            Response::GlobalWorkspace { workspace } => Ok(workspace),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn open_global_workspace(
+        &self,
+        workspace_id: impl Into<String>,
+        expected_revision: u64,
+    ) -> Result<crate::protocol::GlobalWorkspaceOperationResult> {
+        match self.request(Request::OpenGlobalWorkspace {
+            workspace_id: workspace_id.into(),
+            expected_revision,
+        })? {
+            Response::GlobalWorkspaceOperation { result } => Ok(result),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn close_global_workspace(
+        &self,
+        workspace_id: impl Into<String>,
+        expected_revision: u64,
+    ) -> Result<crate::protocol::GlobalWorkspaceOperationResult> {
+        match self.request(Request::CloseGlobalWorkspace {
+            workspace_id: workspace_id.into(),
+            expected_revision,
+        })? {
+            Response::GlobalWorkspaceOperation { result } => Ok(result),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn retry_global_workspace_close(
+        &self,
+        workspace_id: impl Into<String>,
+    ) -> Result<crate::protocol::GlobalWorkspaceOperationResult> {
+        match self.request(Request::RetryGlobalWorkspaceClose {
+            workspace_id: workspace_id.into(),
+        })? {
+            Response::GlobalWorkspaceOperation { result } => Ok(result),
+            response => unexpected(response),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_global_workspace_shell(
+        &self,
+        operation_id: impl Into<String>,
+        global_workspace_id: impl Into<String>,
+        expected_global_revision: u64,
+        node_id: impl Into<String>,
+        owner_workspace_id: impl Into<String>,
+        default_cwd: Option<PathBuf>,
+        shell_id: impl Into<String>,
+        shell: ShellSpec,
+    ) -> Result<(crate::protocol::GlobalWorkspaceSnapshot, ShellSnapshot)> {
+        match self.workspace_resource_request(Request::CreateGlobalWorkspaceShell {
+            operation_id: operation_id.into(),
+            global_workspace_id: global_workspace_id.into(),
+            expected_global_revision,
+            node_id: node_id.into(),
+            owner_workspace_id: owner_workspace_id.into(),
+            default_cwd,
+            shell_id: shell_id.into(),
+            shell,
+        })? {
+            Response::GlobalWorkspaceResource {
+                workspace,
+                resource: RoutedOperationResult::Shell { shell },
+            } => Ok((workspace, shell)),
+            response => unexpected(response),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_global_workspace_with_shell(
+        &self,
+        operation_id: impl Into<String>,
+        global_workspace_id: impl Into<String>,
+        name: impl Into<String>,
+        node_id: impl Into<String>,
+        owner_workspace_id: impl Into<String>,
+        default_cwd: PathBuf,
+        shell_id: impl Into<String>,
+        shell: ShellSpec,
+    ) -> Result<(crate::protocol::GlobalWorkspaceSnapshot, ShellSnapshot)> {
+        match self.workspace_resource_request(Request::CreateGlobalWorkspaceWithShell {
+            operation_id: operation_id.into(),
+            global_workspace_id: global_workspace_id.into(),
+            name: name.into(),
+            node_id: node_id.into(),
+            owner_workspace_id: owner_workspace_id.into(),
+            default_cwd,
+            shell_id: shell_id.into(),
+            shell,
+        })? {
+            Response::GlobalWorkspaceResource {
+                workspace,
+                resource: RoutedOperationResult::Shell { shell },
+            } => Ok((workspace, shell)),
+            response => unexpected(response),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_global_workspace_launcher(
+        &self,
+        operation_id: impl Into<String>,
+        global_workspace_id: impl Into<String>,
+        expected_global_revision: u64,
+        node_id: impl Into<String>,
+        owner_workspace_id: impl Into<String>,
+        default_cwd: Option<PathBuf>,
+        launcher_id: impl Into<String>,
+        spec: WorkspaceLauncherSpec,
+    ) -> Result<(
+        crate::protocol::GlobalWorkspaceSnapshot,
+        WorkspaceLauncherSnapshot,
+    )> {
+        match self.workspace_resource_request(Request::CreateGlobalWorkspaceLauncher {
+            operation_id: operation_id.into(),
+            global_workspace_id: global_workspace_id.into(),
+            expected_global_revision,
+            node_id: node_id.into(),
+            owner_workspace_id: owner_workspace_id.into(),
+            default_cwd,
+            launcher_id: launcher_id.into(),
+            spec,
+        })? {
+            Response::GlobalWorkspaceResource {
+                workspace,
+                resource: RoutedOperationResult::Launcher { launcher },
+            } => Ok((workspace, launcher)),
+            response => unexpected(response),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_global_workspace_agent_schedule(
+        &self,
+        operation_id: impl Into<String>,
+        global_workspace_id: impl Into<String>,
+        expected_global_revision: u64,
+        node_id: impl Into<String>,
+        owner_workspace_id: impl Into<String>,
+        default_cwd: Option<PathBuf>,
+        schedule_id: impl Into<String>,
+        spec: AgentScheduleSpec,
+    ) -> Result<(
+        crate::protocol::GlobalWorkspaceSnapshot,
+        AgentScheduleSnapshot,
+    )> {
+        match self.workspace_resource_request(Request::CreateGlobalWorkspaceAgentSchedule {
+            operation_id: operation_id.into(),
+            global_workspace_id: global_workspace_id.into(),
+            expected_global_revision,
+            node_id: node_id.into(),
+            owner_workspace_id: owner_workspace_id.into(),
+            default_cwd,
+            schedule_id: schedule_id.into(),
+            spec,
+        })? {
+            Response::GlobalWorkspaceResource {
+                workspace,
+                resource: RoutedOperationResult::AgentSchedule { schedule },
+            } => Ok((workspace, schedule)),
             response => unexpected(response),
         }
     }
@@ -1653,6 +1920,78 @@ mod tests {
         .unwrap();
     }
 
+    #[test]
+    fn workspace_resource_retries_the_identical_request_after_response_loss() {
+        let directory = env::temp_dir().join(format!("boomux-client-workspace-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let workspace_id = Uuid::from_u128(1).to_string();
+        let shell_id = Uuid::from_u128(2).to_string();
+        let server_workspace_id = workspace_id.clone();
+        let server_shell_id = shell_id.clone();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let first: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            drop(stream);
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let second: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(second, first);
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    protocol::PROTOCOL_VERSION,
+                    Response::GlobalWorkspaceResource {
+                        workspace: protocol::GlobalWorkspaceSnapshot {
+                            id: server_workspace_id.clone(),
+                            revision: 2,
+                            name: "retry".into(),
+                            closing: false,
+                            placements: Vec::new(),
+                        },
+                        resource: RoutedOperationResult::Shell {
+                            shell: ShellSnapshot {
+                                id: server_shell_id,
+                                revision: 1,
+                                workspace_id: server_workspace_id,
+                                name: "retry".into(),
+                                cwd: "/tmp".into(),
+                                command: Vec::new(),
+                                owner: protocol::ShellOwner::User,
+                                status: protocol::ShellStatus::Pending,
+                                run: None,
+                                foreground_process: None,
+                            },
+                        },
+                    },
+                ),
+            )
+            .unwrap();
+        });
+        let client = Client::from_socket_path(socket);
+        let (workspace, shell) = client
+            .create_global_workspace_shell(
+                Uuid::from_u128(3).to_string(),
+                &workspace_id,
+                1,
+                Uuid::from_u128(4).to_string(),
+                Uuid::from_u128(5).to_string(),
+                Some("/tmp".into()),
+                &shell_id,
+                ShellSpec {
+                    name: "retry".into(),
+                    cwd: "/tmp".into(),
+                    command: Vec::new(),
+                },
+            )
+            .unwrap();
+        assert_eq!(workspace.id, workspace_id);
+        assert_eq!(shell.id, shell_id);
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
     fn assert_two_stage_restart_from(old_version: u32) {
         let directory = env::temp_dir().join(format!("boomux-client-restart-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
@@ -1958,7 +2297,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
@@ -2130,7 +2470,8 @@ mod tests {
             )
             .unwrap();
 
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
@@ -2196,7 +2537,8 @@ mod tests {
             )
             .unwrap();
 
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
@@ -2244,7 +2586,8 @@ mod tests {
                 ),
             )
             .unwrap();
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
@@ -2422,7 +2765,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);
@@ -2495,7 +2839,8 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 36);
+            reject_protocol(&listener, protocol::PROTOCOL_VERSION, 37);
+            reject_protocol(&listener, 37, 36);
             reject_protocol(&listener, 36, 35);
             reject_protocol(&listener, 35, 34);
             reject_protocol(&listener, 34, 33);

--- a/src/client.rs
+++ b/src/client.rs
@@ -150,6 +150,13 @@ pub struct Client {
     protocol_version: Arc<AtomicU32>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DaemonPeerCredentials {
+    pub pid: u32,
+    pub uid: u32,
+    pub protocol_version: u32,
+}
+
 #[derive(Debug)]
 pub struct Attachment {
     pub stream: UnixStream,
@@ -565,6 +572,47 @@ impl Client {
 
     pub fn ping(&self) -> Result<()> {
         expect_ok(self.request(Request::Ping)?, Response::Pong)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn daemon_peer_credentials(&self) -> Result<DaemonPeerCredentials> {
+        let (stream, protocol_version, response) = self.send(Request::Ping)?;
+        expect_ok(response, Response::Pong)?;
+        let mut credentials = libc::ucred {
+            pid: 0,
+            uid: 0,
+            gid: 0,
+        };
+        let mut length = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+        let result = unsafe {
+            libc::getsockopt(
+                stream.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_PEERCRED,
+                std::ptr::from_mut(&mut credentials).cast(),
+                &mut length,
+            )
+        };
+        if result == -1 || length as usize != std::mem::size_of::<libc::ucred>() {
+            return Err(ClientError::Transport(io::Error::last_os_error()));
+        }
+        let pid = u32::try_from(credentials.pid).map_err(|_| {
+            ClientError::Transport(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "daemon socket peer returned an invalid PID",
+            ))
+        })?;
+        if pid == 0 {
+            return Err(ClientError::Transport(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "daemon socket peer returned an invalid PID",
+            )));
+        }
+        Ok(DaemonPeerCredentials {
+            pid,
+            uid: credentials.uid,
+            protocol_version,
+        })
     }
 
     pub fn node_identity(&self) -> Result<String> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1949,11 +1949,12 @@ fn send_registered_node_request_with_timeout(
     route_feature: Option<protocol::ProtocolFeature>,
 ) -> io::Result<Response> {
     let target = SshTarget::parse(registration.target.clone())?;
-    let helper = match ssh_bootstrap::plan_remote_bootstrap(
-        target.clone(),
+    let mut bootstrap = ssh_bootstrap::BootstrapSession::open(
+        target,
         SshAuthenticationMode::Batch,
         Duration::from_secs(2),
-    )? {
+    )?;
+    let helper = match bootstrap.plan(Duration::from_secs(2))? {
         RemoteBootstrapPlan::Ready(helper) => helper,
         RemoteBootstrapPlan::Install(_) => {
             return Err(io::Error::new(
@@ -1976,12 +1977,7 @@ fn send_registered_node_request_with_timeout(
             format!("remote Node does not support {}", feature.requirement()),
         ));
     }
-    let mut remote = ssh_bootstrap::connect_remote(
-        target,
-        helper,
-        SshAuthenticationMode::Batch,
-        Duration::from_secs(2),
-    )?;
+    let mut remote = bootstrap.connect(helper, Duration::from_secs(2))?;
     remote.request(request, response_timeout)
 }
 
@@ -7329,11 +7325,13 @@ fn fetch_node_projection(
     use crate::protocol::NodeProjectionHealthCode;
     let target = SshTarget::parse(registration.target.clone())
         .map_err(|error| (NodeProjectionHealthCode::Unreachable, error))?;
-    let helper = match ssh_bootstrap::plan_remote_bootstrap(
-        target.clone(),
+    let mut bootstrap = ssh_bootstrap::BootstrapSession::open(
+        target,
         SshAuthenticationMode::Batch,
         Duration::from_secs(2),
-    ) {
+    )
+    .map_err(|error| (classify_node_sync_error(&error), error))?;
+    let helper = match bootstrap.plan(Duration::from_secs(2)) {
         Ok(RemoteBootstrapPlan::Ready(helper)) => helper,
         Ok(RemoteBootstrapPlan::Install(_)) => {
             return Err((
@@ -7365,13 +7363,9 @@ fn fetch_node_projection(
             ),
         ));
     }
-    let mut remote = ssh_bootstrap::connect_remote(
-        target,
-        helper,
-        SshAuthenticationMode::Batch,
-        Duration::from_secs(2),
-    )
-    .map_err(|error| (classify_node_sync_error(&error), error))?;
+    let mut remote = bootstrap
+        .connect(helper, Duration::from_secs(2))
+        .map_err(|error| (classify_node_sync_error(&error), error))?;
     let sync = remote
         .node_projection_sync(after, Duration::from_secs(2))
         .map_err(|error| (classify_node_sync_error(&error), error))?;
@@ -7751,11 +7745,12 @@ impl DaemonService {
         profile: TerminalProfile,
     ) -> io::Result<()> {
         let target = SshTarget::parse(registration.target.clone())?;
-        let helper = match ssh_bootstrap::plan_remote_bootstrap(
-            target.clone(),
+        let mut bootstrap = ssh_bootstrap::BootstrapSession::open(
+            target,
             SshAuthenticationMode::Batch,
             HANDSHAKE_TIMEOUT,
-        )? {
+        )?;
+        let helper = match bootstrap.plan(HANDSHAKE_TIMEOUT)? {
             RemoteBootstrapPlan::Ready(helper) => helper,
             RemoteBootstrapPlan::Install(_) => {
                 return send_response(
@@ -7790,12 +7785,7 @@ impl DaemonService {
                 ),
             );
         }
-        let remote = ssh_bootstrap::connect_remote(
-            target,
-            helper,
-            SshAuthenticationMode::Batch,
-            HANDSHAKE_TIMEOUT,
-        )?;
+        let remote = bootstrap.connect(helper, HANDSHAKE_TIMEOUT)?;
         let (response, mut remote_reader, mut remote_writer) = remote.open_attachment(
             Request::ResumeAgentSession {
                 session_id: session_id.to_owned(),
@@ -7936,11 +7926,12 @@ impl DaemonService {
         profile: TerminalProfile,
     ) -> io::Result<()> {
         let target = SshTarget::parse(registration.target.clone())?;
-        let helper = match ssh_bootstrap::plan_remote_bootstrap(
-            target.clone(),
+        let mut bootstrap = ssh_bootstrap::BootstrapSession::open(
+            target,
             SshAuthenticationMode::Batch,
             HANDSHAKE_TIMEOUT,
-        )? {
+        )?;
+        let helper = match bootstrap.plan(HANDSHAKE_TIMEOUT)? {
             RemoteBootstrapPlan::Ready(helper) => helper,
             RemoteBootstrapPlan::Install(_) => {
                 return send_response(
@@ -8007,12 +7998,7 @@ impl DaemonService {
                 );
             }
         }
-        let remote = ssh_bootstrap::connect_remote(
-            target,
-            helper,
-            SshAuthenticationMode::Batch,
-            HANDSHAKE_TIMEOUT,
-        )?;
+        let remote = bootstrap.connect(helper, HANDSHAKE_TIMEOUT)?;
         let request = Request::Attach {
             shell_id: shell_id.to_owned(),
             takeover,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -50,13 +50,14 @@ use crate::protocol::{
     NodeProjectionAttention, NodeProjectionExecution, NodeProjectionLauncher,
     NodeProjectionSchedule, NodeProjectionShell, NodeProjectionSnapshot, NodeProjectionSync,
     NodeProjectionSyncMode, NodeProjectionTransition, NodeProjectionTransitionKind,
-    NodeProjectionWorkspace, NotificationDeliveryConfig, Request, Response, RoutedOperation,
-    RoutedOperationResult, ScheduledExecutionDispatchKind, ScheduledExecutionOutcome,
-    ScheduledExecutionReason, ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot,
-    ScheduledExecutionState, ScheduledOccurrence, ScheduledRunnerResult, SchedulerHealth,
-    SchedulerState, ShellOwner, ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec,
-    ShellStatus, Snapshot, TerminalPreview, TerminalProfile, UnixEnvironment,
-    UnixEnvironmentVariable, WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
+    NodeProjectionWorkspace, NotificationDeliveryConfig, QualifiedFocusedTerminalSnapshot,
+    QualifiedIdentity, Request, Response, RoutedOperation, RoutedOperationResult,
+    ScheduledExecutionDispatchKind, ScheduledExecutionOutcome, ScheduledExecutionReason,
+    ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot, ScheduledExecutionState,
+    ScheduledOccurrence, ScheduledRunnerResult, SchedulerHealth, SchedulerState, ShellOwner,
+    ShellRunExitReason, ShellRunSnapshot, ShellSnapshot, ShellSpec, ShellStatus, Snapshot,
+    TerminalPreview, TerminalProfile, UnixEnvironment, UnixEnvironmentVariable,
+    WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::ssh_bootstrap::{self, RemoteBootstrapPlan, SshAuthenticationMode, SshTarget};
 use crate::state_store::{
@@ -263,6 +264,7 @@ pub fn receive_handoff_with_notification_delivery(
             event_stream,
             notifications,
             focused_terminal,
+            presented_focused_terminal,
         } => {
             let store = StateStore::from_transferred_lock(state_lock)?;
             let socket_path = client::socket_path()?;
@@ -276,6 +278,7 @@ pub fn receive_handoff_with_notification_delivery(
                     exited,
                     events: Some(*event_stream),
                     focused_terminal: focused_terminal.map(|focused| *focused),
+                    presented_focused_terminal: presented_focused_terminal.map(|focused| *focused),
                 },
                 Some(&mut channel),
                 notifications
@@ -332,6 +335,7 @@ struct TransferredState {
     exited: Vec<handoff::TransferredExited>,
     events: Option<handoff::EventStreamManifest>,
     focused_terminal: Option<FocusedTerminalSnapshot>,
+    presented_focused_terminal: Option<QualifiedFocusedTerminalSnapshot>,
 }
 
 fn run_daemon(
@@ -392,6 +396,7 @@ fn run_daemon(
         registry.persist()?;
     }
     registry.import_focused_terminal(transferred.focused_terminal)?;
+    registry.import_presented_focused_terminal(transferred.presented_focused_terminal)?;
     if let Some(channel) = committed {
         {
             registry.events.transaction()?.reserve(1)?;
@@ -761,6 +766,7 @@ fn launch_replacement(
         }
         let state_lock = registry.state_lock_descriptor()?;
         let focused_terminal = registry.focused_terminal_for_handoff()?;
+        let presented_focused_terminal = registry.runtimes.presented_focused_terminal()?;
         launch_replacement_process(
             listener.as_fd(),
             daemon_lock.as_fd(),
@@ -770,6 +776,7 @@ fn launch_replacement(
             &event_stream,
             ReplacementOptions {
                 focused_terminal,
+                presented_focused_terminal,
                 notification_settings,
                 startup_environment,
             },
@@ -787,6 +794,7 @@ fn launch_replacement(
 
 struct ReplacementOptions {
     focused_terminal: Option<FocusedTerminalSnapshot>,
+    presented_focused_terminal: Option<QualifiedFocusedTerminalSnapshot>,
     notification_settings: Option<NotificationDeliverySettings>,
     startup_environment: Option<UnixEnvironment>,
 }
@@ -802,6 +810,7 @@ fn launch_replacement_process(
 ) -> io::Result<()> {
     let ReplacementOptions {
         focused_terminal,
+        presented_focused_terminal,
         notification_settings,
         startup_environment,
     } = options;
@@ -856,6 +865,7 @@ fn launch_replacement_process(
                 event_stream: event_stream.clone(),
                 notifications: notification_settings.map(Into::into),
                 focused_terminal,
+                presented_focused_terminal,
             },
         )?;
         send_descriptor(&channel, listener, handoff::LISTENER_MARKER)?;
@@ -1366,6 +1376,18 @@ fn response_for_version_with_schedule_shells(
     schedule_shell_ids: &HashSet<String>,
 ) -> Response {
     let mut response = response;
+    if !protocol::ProtocolFeature::QualifiedFocusedTerminal.is_supported_by(version) {
+        match &mut response {
+            Response::CombinedNodeSnapshot { snapshot } => snapshot.focused_terminal = None,
+            Response::Events { events, .. } => events.retain(|event| {
+                !matches!(
+                    event.kind,
+                    DaemonEventKind::FocusedTerminalPresentationChanged
+                )
+            }),
+            _ => {}
+        }
+    }
     if !protocol::ProtocolFeature::GlobalWorkspaces.is_supported_by(version) {
         match &mut response {
             Response::CombinedNodeSnapshot { snapshot } => {
@@ -2403,6 +2425,8 @@ struct ShellRuntimeManager {
 struct FocusState {
     revision: u64,
     focused_terminal: Option<FocusedTerminalSnapshot>,
+    presented_revision: u64,
+    presented_terminal: Option<QualifiedFocusedTerminalSnapshot>,
 }
 
 enum DurableMutation<T> {
@@ -3317,7 +3341,8 @@ fn reduce_projection_transition(event: &DaemonEvent) -> Option<NodeProjectionTra
             revision: execution.revision,
         },
         DaemonEventKind::HandoffCompleted => NodeProjectionTransitionKind::HandoffCompleted,
-        DaemonEventKind::NodeProjectionChanged { .. } => return None,
+        DaemonEventKind::NodeProjectionChanged { .. }
+        | DaemonEventKind::FocusedTerminalPresentationChanged => return None,
     };
     Some(NodeProjectionTransition {
         event_id: event.id,
@@ -5420,6 +5445,41 @@ impl ShellRuntimeManager {
 
     fn focused_terminal(&self) -> io::Result<Option<FocusedTerminalSnapshot>> {
         Ok(lock(&self.focus)?.focused_terminal.clone())
+    }
+
+    fn presented_focused_terminal(&self) -> io::Result<Option<QualifiedFocusedTerminalSnapshot>> {
+        Ok(lock(&self.focus)?.presented_terminal.clone())
+    }
+
+    fn record_presented_focus(&self, node_id: String, shell_id: String) -> io::Result<()> {
+        let mut focus = lock(&self.focus)?;
+        let revision = focus
+            .presented_revision
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("presented terminal focus revision exhausted"))?;
+        focus.presented_revision = revision;
+        focus.presented_terminal = Some(QualifiedFocusedTerminalSnapshot {
+            revision,
+            shell: QualifiedIdentity::new(node_id, shell_id),
+        });
+        Ok(())
+    }
+
+    fn import_presented_focus(
+        &self,
+        node_id: String,
+        shell_id: String,
+        revision: u64,
+    ) -> io::Result<()> {
+        let mut focus = lock(&self.focus)?;
+        if revision >= focus.presented_revision {
+            focus.presented_revision = revision;
+            focus.presented_terminal = Some(QualifiedFocusedTerminalSnapshot {
+                revision,
+                shell: QualifiedIdentity::new(node_id, shell_id),
+            });
+        }
+        Ok(())
     }
 
     fn record_focus_gained(
@@ -8057,6 +8117,13 @@ impl DaemonService {
             }
             let closes = matches!(frame, AttachFrame::Detached | AttachFrame::ReconnectAck);
             remote_writer.write_frame(&frame, RESPONSE_WRITE_TIMEOUT)?;
+            if matches!(frame, AttachFrame::FocusGained) {
+                self.runtimes
+                    .record_presented_focus(registration.node_id.clone(), shell_id.to_owned())?;
+                let _ = self.events.publish_runtime_batch(vec![
+                    DaemonEventKind::FocusedTerminalPresentationChanged,
+                ]);
+            }
             if closes {
                 if matches!(frame, AttachFrame::ReconnectAck) {
                     let _ = reconnect_finished.try_send(());
@@ -9277,10 +9344,32 @@ impl DaemonService {
                 .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
                 .then_with(|| left.identity.inner_id.cmp(&right.identity.inner_id))
         });
+        let focused_terminal = self
+            .runtimes
+            .presented_focused_terminal()?
+            .filter(|focused| {
+                nodes.iter().any(|node| {
+                    node.node_id == focused.shell.node_id
+                        && (node.local_snapshot.as_ref().is_some_and(|snapshot| {
+                            snapshot.workspaces.iter().any(|workspace| {
+                                workspace
+                                    .shells
+                                    .iter()
+                                    .any(|shell| shell.id == focused.shell.inner_id)
+                            })
+                        }) || node.remote_projection.as_ref().is_some_and(|projection| {
+                            projection
+                                .shells
+                                .iter()
+                                .any(|shell| shell.id == focused.shell.inner_id)
+                        }))
+                })
+            });
         Ok(CombinedNodeSnapshot {
             nodes,
             workspaces,
             external_workspaces,
+            focused_terminal,
         })
     }
 
@@ -13153,6 +13242,15 @@ impl DaemonService {
         }
         self.runtimes
             .record_focus_gained(shell.workspace_id.clone(), shell.id.clone(), run_id)?;
+        if let Some(identity) = &self.node_identity
+            && let Ok(node_id) = identity.id()
+        {
+            self.runtimes
+                .record_presented_focus(node_id, shell.id.clone())?;
+            let _ = self
+                .events
+                .publish_runtime_batch(vec![DaemonEventKind::FocusedTerminalPresentationChanged]);
+        }
         Ok(true)
     }
 
@@ -13168,7 +13266,32 @@ impl DaemonService {
         }
         let current = self.focus_target_is_current(&focused_terminal)?;
         self.runtimes
-            .import_focused_terminal(focused_terminal, current)
+            .import_focused_terminal(focused_terminal.clone(), current)?;
+        if current
+            && let Some(identity) = &self.node_identity
+            && let Ok(node_id) = identity.id()
+        {
+            self.runtimes.import_presented_focus(
+                node_id,
+                focused_terminal.shell_id,
+                focused_terminal.revision,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn import_presented_focused_terminal(
+        &self,
+        focused_terminal: Option<QualifiedFocusedTerminalSnapshot>,
+    ) -> io::Result<()> {
+        let Some(focused_terminal) = focused_terminal else {
+            return Ok(());
+        };
+        self.runtimes.import_presented_focus(
+            focused_terminal.shell.node_id,
+            focused_terminal.shell.inner_id,
+            focused_terminal.revision,
+        )
     }
 
     fn lifecycle_transaction(
@@ -17004,6 +17127,30 @@ mod tests {
     }
 
     #[test]
+    fn presented_focus_revisions_order_local_and_remote_nodes() {
+        let runtimes = ShellRuntimeManager::default();
+
+        runtimes
+            .record_presented_focus("local-node".into(), "local-shell".into())
+            .unwrap();
+        let local_revision = runtimes
+            .presented_focused_terminal()
+            .unwrap()
+            .unwrap()
+            .revision;
+        runtimes
+            .record_presented_focus("remote-node".into(), "remote-shell".into())
+            .unwrap();
+
+        let remote = runtimes.presented_focused_terminal().unwrap().unwrap();
+        assert!(remote.revision > local_revision);
+        assert_eq!(
+            remote.shell,
+            QualifiedIdentity::new("remote-node", "remote-shell")
+        );
+    }
+
+    #[test]
     fn focus_reports_from_a_replaced_controller_are_ignored() {
         let registry = DaemonService::default();
         let (_workspace, shell, runtime) = running_shell(&registry);
@@ -19348,6 +19495,52 @@ mod tests {
         } = response
         else {
             panic!("expected events");
+        };
+        assert_eq!(filtered_cursor, cursor);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn protocol_thirty_eight_filters_focus_invalidation_without_rewinding_cursor() {
+        let cursor = EventCursor {
+            stream_id: Uuid::new_v4().to_string(),
+            event_id: 5,
+        };
+        let response = Response::Events {
+            stream_id: cursor.stream_id.clone(),
+            cursor: cursor.clone(),
+            snapshot: None,
+            events: vec![DaemonEvent {
+                id: 5,
+                at_ms: 10,
+                kind: DaemonEventKind::FocusedTerminalPresentationChanged,
+            }],
+        };
+
+        let Response::Events {
+            cursor: current_cursor,
+            events: current_events,
+            ..
+        } = response_for_version(response.clone(), 39)
+        else {
+            panic!("expected current events");
+        };
+        assert_eq!(current_cursor, cursor);
+        assert!(matches!(
+            current_events.as_slice(),
+            [DaemonEvent {
+                kind: DaemonEventKind::FocusedTerminalPresentationChanged,
+                ..
+            }]
+        ));
+
+        let Response::Events {
+            cursor: filtered_cursor,
+            events,
+            ..
+        } = response_for_version(response, 38)
+        else {
+            panic!("expected filtered events");
         };
         assert_eq!(filtered_cursor, cursor);
         assert!(events.is_empty());
@@ -21919,13 +22112,27 @@ mod tests {
                     default_cwd: Some("/owner/work".into()),
                     available: true,
                 }],
+                focused_terminal: Some(protocol::QualifiedFocusedTerminalSnapshot {
+                    revision: 9,
+                    shell: protocol::QualifiedIdentity::new(node_id.clone(), "shell"),
+                }),
             },
         };
+        let Response::CombinedNodeSnapshot {
+            snapshot: protocol_thirty_eight,
+        } = response_for_version(response.clone(), 38)
+        else {
+            panic!("expected combined Node snapshot");
+        };
+        assert_eq!(protocol_thirty_eight.workspaces.len(), 1);
+        assert_eq!(protocol_thirty_eight.external_workspaces.len(), 1);
+        assert!(protocol_thirty_eight.focused_terminal.is_none());
         let Response::CombinedNodeSnapshot { snapshot } = response_for_version(response, 37) else {
             panic!("expected combined Node snapshot");
         };
         assert!(snapshot.workspaces.is_empty());
         assert!(snapshot.external_workspaces.is_empty());
+        assert!(snapshot.focused_terminal.is_none());
         let encoded_node = serde_json::to_value(&snapshot.nodes[0]).unwrap();
         assert!(encoded_node.get("route").is_none());
         assert!(encoded_node.get("registration_revision").is_none());
@@ -21958,6 +22165,7 @@ mod tests {
                         nodes: vec![current_node.clone()],
                         workspaces: Vec::new(),
                         external_workspaces: Vec::new(),
+                        focused_terminal: None,
                     },
                 },
                 version,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -18,6 +18,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
@@ -27,6 +28,10 @@ use crate::desktop_notifications::{
     NotificationReason, NotificationRequest, NotificationSink, category_enabled, test_delivery,
 };
 use crate::fd_transfer::send_descriptor;
+use crate::global_workspace_store::{
+    GlobalWorkspaceStore, PendingResourceKind, PendingWorkspaceResource, PreparedWorkspaceResource,
+    PreparedWorkspaceShell,
+};
 use crate::handoff;
 use crate::host_services::{self, PreparedIntegrationMutation};
 use crate::node_identity::{NodeIdentityLease, NodeIdentityManager};
@@ -354,6 +359,19 @@ fn run_daemon(
     }
     registry.node_registrations = Some(registrations);
     registry.node_projection_cache = Some(NodeProjectionCache::load_from_environment());
+    registry.global_workspaces = match GlobalWorkspaceStore::load_from_environment() {
+        Ok(store) => {
+            if let Some(identity) = registry.node_identity.as_ref() {
+                let node_id = identity.id()?;
+                store.initialize_local_once(&node_id, &registry.snapshot()?)?;
+            }
+            Some(store)
+        }
+        Err(error) => {
+            eprintln!("boomux: global Workspace coordination disabled: {error}");
+            None
+        }
+    };
     registry.startup_environment = capture_current_environment();
     registry.configure_scheduler_clock()?;
     registry.notification_settings = notification_settings.clone();
@@ -1248,6 +1266,8 @@ fn handle_connection_inner(
     let schedule_semantics_changed = matches!(
         &request.message,
         Request::CreateAgentSchedule { .. }
+            | Request::CreateWorkspaceAgentSchedule { .. }
+            | Request::CreateGlobalWorkspaceAgentSchedule { .. }
             | Request::PauseAgentSchedule { .. }
             | Request::ResumeAgentSchedule { .. }
             | Request::RemoveAgentSchedule { .. }
@@ -1326,6 +1346,15 @@ fn node_registration_error(error: io::Error) -> DaemonError {
     DaemonError::from(error)
 }
 
+fn global_workspace_error(error: io::Error) -> DaemonError {
+    if error.kind() == io::ErrorKind::InvalidInput && error.to_string().contains("revision changed")
+    {
+        DaemonError::lifecycle(ErrorCode::RevisionChanged, error.to_string())
+    } else {
+        DaemonError::from(error)
+    }
+}
+
 #[cfg(test)]
 fn response_for_version(response: Response, version: u32) -> Response {
     response_for_version_with_schedule_shells(response, version, &HashSet::new())
@@ -1337,6 +1366,22 @@ fn response_for_version_with_schedule_shells(
     schedule_shell_ids: &HashSet<String>,
 ) -> Response {
     let mut response = response;
+    if !protocol::ProtocolFeature::GlobalWorkspaces.is_supported_by(version) {
+        match &mut response {
+            Response::CombinedNodeSnapshot { snapshot } => {
+                snapshot.workspaces.clear();
+                snapshot.external_workspaces.clear();
+                for node in &mut snapshot.nodes {
+                    node.route = None;
+                    node.registration_revision = None;
+                    node.workspace_owner_eligible = false;
+                    node.workspace_owner_unavailable_reason = None;
+                }
+            }
+            Response::NodeProjectionSync { sync } => sync.capabilities.clear(),
+            _ => {}
+        }
+    }
     if !protocol::ProtocolFeature::NodeProjectionSync.is_supported_by(version)
         && let Response::Events { events, .. } = &mut response
     {
@@ -1950,6 +1995,14 @@ fn routed_response_timeout(operation: &RoutedOperation) -> Duration {
 }
 
 fn routed_owner_feature(operation: &RoutedOperation) -> Option<protocol::ProtocolFeature> {
+    if matches!(
+        operation,
+        RoutedOperation::CreateWorkspaceShell { .. }
+            | RoutedOperation::CreateWorkspaceLauncher { .. }
+            | RoutedOperation::CreateWorkspaceAgentSchedule { .. }
+    ) {
+        return Some(protocol::ProtocolFeature::GlobalWorkspaces);
+    }
     matches!(
         operation,
         RoutedOperation::CreateAgentSchedule { .. }
@@ -1968,6 +2021,68 @@ fn require_guard(actual: u64, expected: u64, resource: &str) -> DaemonResult<()>
             format!("{resource} revision is {actual}; guarded operation supplied {expected}"),
         ))
     }
+}
+
+fn request_fingerprint(value: &impl Serialize) -> DaemonResult<String> {
+    let bytes = serde_json::to_vec(value).map_err(|error| {
+        DaemonError::Internal(io::Error::other(format!(
+            "could not fingerprint Workspace operation: {error}"
+        )))
+    })?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
+}
+
+struct WorkspaceRequestFingerprint {
+    digest: String,
+    bytes: usize,
+}
+
+fn workspace_operation_fingerprints(
+    request: &Request,
+) -> DaemonResult<(Option<WorkspaceRequestFingerprint>, Option<String>)> {
+    let exact = matches!(
+        request,
+        Request::CreateGlobalWorkspaceShell { .. }
+            | Request::CreateGlobalWorkspaceWithShell { .. }
+            | Request::CreateGlobalWorkspaceLauncher { .. }
+            | Request::CreateGlobalWorkspaceAgentSchedule { .. }
+    )
+    .then(|| {
+        let bytes = serde_json::to_vec(request).map_err(|error| {
+            DaemonError::Internal(io::Error::other(format!(
+                "could not fingerprint Workspace operation: {error}"
+            )))
+        })?;
+        Ok::<_, DaemonError>(WorkspaceRequestFingerprint {
+            digest: format!("{:x}", Sha256::digest(&bytes)),
+            bytes: bytes.len(),
+        })
+    })
+    .transpose()?;
+    let semantic = match request {
+        Request::CreateGlobalWorkspaceWithShell {
+            name,
+            node_id,
+            default_cwd,
+            shell,
+            ..
+        } => Some(request_fingerprint(&(
+            "project_with_shell",
+            name,
+            node_id,
+            default_cwd,
+            shell,
+        ))?),
+        _ => None,
+    };
+    Ok((exact, semantic))
+}
+
+fn workspace_pre_owner_failure_is_ambiguous(error: &DaemonError) -> bool {
+    matches!(
+        error.wire_code(),
+        ErrorCode::OutcomeUnknown | ErrorCode::PersistenceFailed | ErrorCode::Timeout
+    )
 }
 
 fn bump_revision(revision: &Mutex<u64>, resource: &str) -> io::Result<()> {
@@ -2006,11 +2121,13 @@ struct DaemonService {
     node_identity: Option<Arc<NodeIdentityManager>>,
     node_registrations: Option<NodeRegistrationManager>,
     node_projection_cache: Option<NodeProjectionCache>,
+    global_workspaces: Option<GlobalWorkspaceStore>,
     durable: DurableRegistry,
     events: EventStream,
     runtimes: ShellRuntimeManager,
     remote_attachments: RemoteAttachmentManager,
     host_service_previews: Mutex<HashMap<String, HostServicePreview>>,
+    workspace_operation_locks: Mutex<HashMap<String, Weak<Mutex<()>>>>,
     mutation_lock: Mutex<()>,
     schedule_dispatch_lock: Mutex<()>,
     notification_settings: NotificationDeliverySettings,
@@ -2268,6 +2385,7 @@ struct SchedulerWorkerState {
 struct NodeProjectionWorkers {
     stop: Arc<AtomicBool>,
     handles: Mutex<HashMap<String, thread::JoinHandle<()>>>,
+    wake: Mutex<HashSet<String>>,
 }
 
 struct DurableRegistry {
@@ -3791,6 +3909,70 @@ impl DurableRegistry {
         ))
     }
 
+    fn create_workspace_exact(
+        &self,
+        workspace_id: &str,
+        name: String,
+        default_cwd: Option<PathBuf>,
+    ) -> io::Result<(WorkspaceSnapshot, Option<DurableUndo>)> {
+        validate_uuid(workspace_id, "workspace ID")?;
+        validate_name(&name)?;
+        if let Some(default_cwd) = &default_cwd {
+            validate_cwd(default_cwd)?;
+        }
+        if let Ok(existing) = self.workspace(workspace_id) {
+            let snapshot = existing.snapshot(self)?;
+            if snapshot.name == name && snapshot.default_cwd == default_cwd {
+                return Ok((snapshot, None));
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "workspace idempotency identity exists with a different definition",
+            ));
+        }
+        let workspace = Arc::new(Workspace {
+            id: workspace_id.to_owned(),
+            revision: Mutex::new(1),
+            name: Mutex::new(name.clone()),
+            default_cwd: default_cwd.clone(),
+            shell_ids: Mutex::new(Vec::new()),
+            launcher_ids: Mutex::new(Vec::new()),
+            agent_ids: Mutex::new(Vec::new()),
+            schedule_ids: Mutex::new(Vec::new()),
+        });
+        let snapshot = WorkspaceSnapshot {
+            id: workspace_id.to_owned(),
+            revision: 1,
+            name: name.clone(),
+            default_cwd,
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: Vec::new(),
+            schedules: Vec::new(),
+        };
+        let mut state = lock(&self.state)?;
+        if state
+            .workspaces
+            .values()
+            .any(|current| current.name.lock().is_ok_and(|current| *current == name))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("workspace name already exists: {name}"),
+            ));
+        }
+        state
+            .workspaces
+            .insert(workspace_id.to_owned(), Arc::clone(&workspace));
+        Ok((
+            snapshot,
+            Some(DurableUndo::CreatedWorkspace {
+                workspace,
+                shells: Vec::new(),
+            }),
+        ))
+    }
+
     fn create_shell(
         &self,
         workspace_id: &str,
@@ -3825,6 +4007,55 @@ impl DurableRegistry {
         drop(shell_ids);
         drop(state);
         Ok((snapshot, DurableUndo::CreatedShell { workspace, shell }))
+    }
+
+    fn create_shell_exact(
+        &self,
+        workspace_id: &str,
+        shell_id: &str,
+        spec: ShellSpec,
+    ) -> io::Result<(ShellSnapshot, Option<DurableUndo>)> {
+        validate_uuid(shell_id, "Shell idempotency key")?;
+        if let Some(existing) = lock(&self.state)?.shells.get(shell_id).cloned() {
+            let snapshot = existing.snapshot()?;
+            if snapshot.workspace_id == workspace_id
+                && snapshot.name == spec.name
+                && snapshot.cwd == spec.cwd
+                && snapshot.command == spec.command
+            {
+                return Ok((snapshot, None));
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "Shell idempotency key exists with a different definition",
+            ));
+        }
+        let workspace = self.workspace(workspace_id)?;
+        let shell = create_pending_shell_with_id(workspace_id, shell_id.to_owned(), spec)?;
+        let snapshot = shell.snapshot()?;
+        let mut state = lock(&self.state)?;
+        let mut shell_ids = lock(&workspace.shell_ids)?;
+        if shell_ids.iter().any(|id| {
+            state
+                .shells
+                .get(id)
+                .and_then(|existing| existing.name.lock().ok())
+                .is_some_and(|name| *name == snapshot.name)
+        }) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("shell name already exists: {}", snapshot.name),
+            ));
+        }
+        state.shells.insert(shell.id.clone(), Arc::clone(&shell));
+        shell_ids.push(shell.id.clone());
+        bump_revision(&workspace.revision, "workspace")?;
+        drop(shell_ids);
+        drop(state);
+        Ok((
+            snapshot,
+            Some(DurableUndo::CreatedShell { workspace, shell }),
+        ))
     }
 
     fn create_schedule_shell(
@@ -3976,6 +4207,70 @@ impl DurableRegistry {
         ))
     }
 
+    fn create_launcher_exact(
+        &self,
+        workspace_id: &str,
+        launcher_id: &str,
+        spec: WorkspaceLauncherSpec,
+    ) -> io::Result<(WorkspaceLauncherSnapshot, Option<DurableUndo>)> {
+        validate_uuid(launcher_id, "launcher idempotency key")?;
+        if let Some(existing) = lock(&self.state)?.launchers.get(launcher_id).cloned() {
+            let snapshot = existing.snapshot()?;
+            if snapshot.workspace_id == workspace_id
+                && snapshot.name == spec.name
+                && snapshot.cwd == spec.cwd
+                && snapshot.command == spec.command
+            {
+                return Ok((snapshot, None));
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "launcher idempotency key exists with a different definition",
+            ));
+        }
+        validate_name(&spec.name)?;
+        validate_cwd(&spec.cwd)?;
+        validate_launcher_command(&spec.command)?;
+        let workspace = self.workspace(workspace_id)?;
+        let launcher = Arc::new(WorkspaceLauncher {
+            id: launcher_id.to_owned(),
+            revision: Mutex::new(1),
+            workspace_id: workspace_id.into(),
+            name: Mutex::new(spec.name),
+            cwd: spec.cwd,
+            command: spec.command,
+        });
+        let snapshot = launcher.snapshot()?;
+        let mut state = lock(&self.state)?;
+        let mut launcher_ids = lock(&workspace.launcher_ids)?;
+        if launcher_ids.iter().any(|id| {
+            state
+                .launchers
+                .get(id)
+                .and_then(|existing| existing.name.lock().ok())
+                .is_some_and(|name| *name == snapshot.name)
+        }) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("workspace launcher name already exists: {}", snapshot.name),
+            ));
+        }
+        state
+            .launchers
+            .insert(launcher.id.clone(), Arc::clone(&launcher));
+        launcher_ids.push(launcher.id.clone());
+        bump_revision(&workspace.revision, "workspace")?;
+        drop(launcher_ids);
+        drop(state);
+        Ok((
+            snapshot,
+            Some(DurableUndo::CreatedLauncher {
+                workspace,
+                launcher,
+            }),
+        ))
+    }
+
     #[cfg(test)]
     fn create_schedule(
         &self,
@@ -3988,23 +4283,57 @@ impl DurableRegistry {
     fn create_schedule_at(
         &self,
         workspace_id: &str,
-        mut spec: AgentScheduleSpec,
+        spec: AgentScheduleSpec,
         now: u64,
     ) -> io::Result<(AgentScheduleSnapshot, DurableUndo)> {
-        validate_name(&spec.name)?;
-        validate_cwd(&spec.cwd)?;
-        validate_schedule_spec(&spec)?;
+        let (snapshot, undo) =
+            self.create_schedule_at_with_id(workspace_id, Uuid::new_v4().to_string(), spec, now)?;
+        Ok((
+            snapshot,
+            undo.expect("new random Schedule ID cannot be idempotent"),
+        ))
+    }
+
+    fn create_schedule_at_with_id(
+        &self,
+        workspace_id: &str,
+        schedule_id: String,
+        mut spec: AgentScheduleSpec,
+        now: u64,
+    ) -> io::Result<(AgentScheduleSnapshot, Option<DurableUndo>)> {
+        validate_uuid(&schedule_id, "Schedule idempotency key")?;
         spec.trigger.cron = crate::scheduling::canonicalize_cron(&spec.trigger.cron)
             .map_err(schedule_validation_error)?;
         spec.trigger.timezone = crate::scheduling::canonicalize_timezone(&spec.trigger.timezone)
             .map_err(schedule_validation_error)?;
+        if let Some(existing) = lock(&self.state)?.schedules.get(&schedule_id).cloned() {
+            let inspection = existing.inspection()?;
+            if inspection.schedule.workspace_id == workspace_id
+                && inspection.schedule.name == spec.name
+                && inspection.schedule.cwd == spec.cwd
+                && inspection.schedule.integration == spec.integration
+                && inspection.schedule.session == spec.session
+                && inspection.schedule.trigger == spec.trigger
+                && inspection.schedule.state == spec.state
+                && inspection.prompt == spec.prompt
+            {
+                return Ok((inspection.schedule, None));
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "Schedule idempotency key exists with a different definition",
+            ));
+        }
+        validate_name(&spec.name)?;
+        validate_cwd(&spec.cwd)?;
+        validate_schedule_spec(&spec)?;
         crate::scheduling::CronSchedule::compile(&spec.trigger.cron, &spec.trigger.timezone)
             .and_then(|cron| cron.ensure_possible())
             .map_err(schedule_validation_error)?;
         validate_schedule_capability(&spec.integration, &spec.session)?;
         let workspace = self.workspace(workspace_id)?;
         let schedule = Arc::new(AgentSchedule {
-            id: Uuid::new_v4().to_string(),
+            id: schedule_id,
             workspace_id: workspace_id.into(),
             cwd: spec.cwd,
             integration: spec.integration,
@@ -4066,10 +4395,10 @@ impl DurableRegistry {
         drop(state);
         Ok((
             snapshot,
-            DurableUndo::CreatedSchedule {
+            Some(DurableUndo::CreatedSchedule {
                 workspace,
                 schedule,
-            },
+            }),
         ))
     }
 
@@ -5768,6 +6097,7 @@ impl Default for DaemonService {
             node_identity: None,
             node_registrations: None,
             node_projection_cache: None,
+            global_workspaces: None,
             durable: DurableRegistry {
                 state: Mutex::new(DurableState::default()),
                 store: None,
@@ -5783,6 +6113,7 @@ impl Default for DaemonService {
             },
             remote_attachments: RemoteAttachmentManager::default(),
             host_service_previews: Mutex::new(HashMap::new()),
+            workspace_operation_locks: Mutex::new(HashMap::new()),
             mutation_lock: Mutex::new(()),
             schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
@@ -6603,7 +6934,7 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
             })
             .unwrap_or(false);
         if !admitted {
-            if interruptible_node_sleep(&service, Duration::from_millis(100)) {
+            if interruptible_node_sleep(&service, &node_id, Duration::from_millis(100)) {
                 return;
             }
             continue;
@@ -6754,7 +7085,7 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
                     .unwrap_or(crate::protocol::NodeProjectionHealthCode::Unreachable),
             )
         };
-        if interruptible_node_sleep(&service, delay) {
+        if interruptible_node_sleep(&service, &node_id, delay) {
             return;
         }
     }
@@ -7053,14 +7384,18 @@ fn fetch_node_projection(
             ),
         ));
     }
-    let capabilities = protocol::ProtocolFeature::ALL
-        .iter()
-        .copied()
-        .filter(|feature| feature.is_supported_by(version))
-        .flat_map(protocol::ProtocolFeature::capability_names)
-        .copied()
-        .map(str::to_owned)
-        .collect();
+    let capabilities = if protocol::ProtocolFeature::GlobalWorkspaces.is_supported_by(version) {
+        sync.capabilities.clone()
+    } else {
+        protocol::ProtocolFeature::ALL
+            .iter()
+            .copied()
+            .filter(|feature| feature.is_supported_by(version))
+            .flat_map(protocol::ProtocolFeature::capability_names)
+            .copied()
+            .map(str::to_owned)
+            .collect()
+    };
     Ok((sync, capabilities))
 }
 
@@ -7106,11 +7441,17 @@ fn node_projection_retry_delay(
     Duration::from_millis(base.saturating_mul(1_000).saturating_add(jitter))
 }
 
-fn interruptible_node_sleep(service: &DaemonService, duration: Duration) -> bool {
+fn interruptible_node_sleep(service: &DaemonService, node_id: &str, duration: Duration) -> bool {
     let deadline = Instant::now() + duration;
     while Instant::now() < deadline {
         if service.node_projection_workers.stop.load(Ordering::Acquire) {
             return true;
+        }
+        if lock(&service.node_projection_workers.wake)
+            .map(|mut wake| wake.remove(node_id))
+            .unwrap_or(false)
+        {
+            return false;
         }
         thread::sleep(
             deadline
@@ -7179,6 +7520,15 @@ impl DaemonService {
             DaemonError::lifecycle(
                 ErrorCode::NodeRegistrationUnavailable,
                 "Boomux Node projection cache is unavailable",
+            )
+        })
+    }
+
+    fn global_workspaces(&self) -> DaemonResult<&GlobalWorkspaceStore> {
+        self.global_workspaces.as_ref().ok_or_else(|| {
+            DaemonError::lifecycle(
+                ErrorCode::PersistenceFailed,
+                "global Workspace coordination is unavailable",
             )
         })
     }
@@ -8060,6 +8410,686 @@ impl DaemonService {
         }
     }
 
+    fn owner_workspace(
+        &self,
+        identity: &protocol::QualifiedIdentity,
+    ) -> DaemonResult<WorkspaceSnapshot> {
+        let local_node_id = self.node_identity()?.id()?;
+        if identity.node_id == local_node_id {
+            return Ok(self
+                .workspace(&identity.inner_id)?
+                .snapshot(&self.durable)?);
+        }
+        match self.route_node_operation(
+            &identity.node_id,
+            RoutedOperation::GetWorkspace {
+                workspace_id: identity.inner_id.clone(),
+            },
+        ) {
+            Response::RoutedNodeOperation {
+                result: RoutedOperationResult::Workspace { workspace },
+            } => Ok(workspace),
+            Response::Error { message, code } => Err(DaemonError::lifecycle(
+                code.unwrap_or(ErrorCode::Internal),
+                message,
+            )),
+            _ => Err(DaemonError::lifecycle(
+                ErrorCode::Internal,
+                "owner returned an unexpected Workspace response",
+            )),
+        }
+    }
+
+    fn with_live_workspace_node<T>(
+        &self,
+        node_id: &str,
+        operation: impl FnOnce(protocol::CombinedNode) -> DaemonResult<T>,
+    ) -> DaemonResult<T> {
+        let local_node_id = self.node_identity()?.id()?;
+        if node_id == local_node_id {
+            let snapshot = self.combined_node_snapshot(Some(&local_node_id))?;
+            let node = snapshot
+                .nodes
+                .into_iter()
+                .find(|node| node.local && node.node_id == local_node_id)
+                .ok_or_else(|| {
+                    DaemonError::lifecycle(ErrorCode::NotFound, "local owner Node not found")
+                })?;
+            Self::require_live_workspace_capability(&node)?;
+            return operation(node);
+        }
+        let registrations = self.node_registrations()?;
+        let registration = registrations
+            .inspect(node_id)
+            .map_err(node_registration_error)?;
+        if registration.node_id != node_id || !registrations.admit(&registration)? {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::RevisionChanged,
+                "owner Node registration changed before live verification",
+            ));
+        }
+        let result = (|| {
+            let response = send_registered_node_request_with_timeout(
+                &registration,
+                Request::GetCombinedNodeSnapshot {
+                    selector: Some(registration.node_id.clone()),
+                },
+                Duration::from_secs(2),
+                Some(protocol::ProtocolFeature::GlobalWorkspaces),
+            )
+            .map_err(|error| {
+                DaemonError::lifecycle(
+                    match error.kind() {
+                        io::ErrorKind::PermissionDenied => ErrorCode::NodeIdentityChanged,
+                        io::ErrorKind::Unsupported => ErrorCode::UnsupportedVersion,
+                        _ => ErrorCode::Timeout,
+                    },
+                    format!("live owner verification failed: {error}"),
+                )
+            })?;
+            let current = registrations
+                .with_current(&registration, || Ok(()))
+                .map_err(node_registration_error)?
+                .is_some();
+            if !current {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::RevisionChanged,
+                    "owner Node registration changed during live verification",
+                ));
+            }
+            let snapshot = match response {
+                Response::CombinedNodeSnapshot { snapshot } => snapshot,
+                Response::Error { message, code } => Err(DaemonError::lifecycle(
+                    code.unwrap_or(ErrorCode::Internal),
+                    message,
+                ))?,
+                _ => {
+                    return Err(DaemonError::lifecycle(
+                        ErrorCode::Internal,
+                        "owner returned an unexpected live capability response",
+                    ));
+                }
+            };
+            let node = snapshot
+                .nodes
+                .into_iter()
+                .find(|node| node.local && node.node_id == registration.node_id)
+                .ok_or_else(|| {
+                    DaemonError::lifecycle(
+                        ErrorCode::NodeIdentityChanged,
+                        "live capability response did not describe the pinned local Node",
+                    )
+                })?;
+            Self::require_live_workspace_capability(&node)?;
+            operation(node)
+        })();
+        registrations.release(&registration);
+        result
+    }
+
+    fn require_live_workspace_capability(node: &protocol::CombinedNode) -> DaemonResult<()> {
+        if node.workspace_owner_eligible
+            && node
+                .observed_capabilities
+                .iter()
+                .any(|capability| capability == "global_workspaces")
+        {
+            Ok(())
+        } else {
+            Err(DaemonError::lifecycle(
+                ErrorCode::UnsupportedVersion,
+                node.workspace_owner_unavailable_reason
+                    .clone()
+                    .unwrap_or_else(|| {
+                        "live owner does not advertise coordinated Workspace support".into()
+                    }),
+            ))
+        }
+    }
+
+    fn preflight_workspace_owner(&self, node_id: &str) -> DaemonResult<()> {
+        self.require_cached_workspace_owner_eligible(node_id)?;
+        self.with_live_workspace_node(node_id, |_| Ok(()))
+    }
+
+    fn require_cached_workspace_owner_eligible(&self, node_id: &str) -> DaemonResult<()> {
+        let snapshot = self.combined_node_snapshot(Some(node_id))?;
+        let node = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.node_id == node_id)
+            .ok_or_else(|| DaemonError::lifecycle(ErrorCode::NotFound, "owner Node not found"))?;
+        if node.workspace_owner_eligible {
+            Ok(())
+        } else {
+            Err(DaemonError::lifecycle(
+                ErrorCode::Busy,
+                node.workspace_owner_unavailable_reason
+                    .clone()
+                    .unwrap_or_else(|| "owner Node is not eligible for Workspace placement".into()),
+            ))
+        }
+    }
+
+    fn with_workspace_operation_lock<T>(
+        &self,
+        operation_id: &str,
+        operation: impl FnOnce() -> DaemonResult<T>,
+    ) -> DaemonResult<T> {
+        let operation_lock = {
+            let mut locks = lock(&self.workspace_operation_locks)?;
+            locks.retain(|_, operation_lock| operation_lock.strong_count() > 0);
+            locks
+                .entry(operation_id.to_owned())
+                .or_insert_with(Weak::new)
+                .upgrade()
+                .unwrap_or_else(|| {
+                    let operation_lock = Arc::new(Mutex::new(()));
+                    locks.insert(operation_id.to_owned(), Arc::downgrade(&operation_lock));
+                    operation_lock
+                })
+        };
+        let operation_guard = lock(&operation_lock)?;
+        let result = operation();
+        drop(operation_guard);
+        let mut locks = lock(&self.workspace_operation_locks)?;
+        if Arc::strong_count(&operation_lock) == 1 {
+            locks.remove(operation_id);
+        }
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create_global_workspace_resource(
+        &self,
+        operation_id: &str,
+        request_fingerprint: &str,
+        request_bytes: usize,
+        global_workspace_id: &str,
+        expected_global_revision: u64,
+        node_id: &str,
+        owner_workspace_id: &str,
+        default_cwd: Option<PathBuf>,
+        resource_id: &str,
+        kind: PendingResourceKind,
+        build: impl FnOnce(&PendingWorkspaceResource) -> RoutedOperation,
+    ) -> DaemonResult<(protocol::GlobalWorkspaceSnapshot, RoutedOperationResult)> {
+        self.with_workspace_operation_lock(operation_id, || {
+            self.create_global_workspace_resource_inner(
+                operation_id,
+                request_fingerprint,
+                request_bytes,
+                false,
+                global_workspace_id,
+                expected_global_revision,
+                node_id,
+                owner_workspace_id,
+                default_cwd,
+                resource_id,
+                kind,
+                build,
+            )
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create_global_workspace_resource_inner(
+        &self,
+        operation_id: &str,
+        request_fingerprint: &str,
+        request_bytes: usize,
+        owner_preflight_complete: bool,
+        global_workspace_id: &str,
+        expected_global_revision: u64,
+        node_id: &str,
+        owner_workspace_id: &str,
+        default_cwd: Option<PathBuf>,
+        resource_id: &str,
+        kind: PendingResourceKind,
+        build: impl FnOnce(&PendingWorkspaceResource) -> RoutedOperation,
+    ) -> DaemonResult<(protocol::GlobalWorkspaceSnapshot, RoutedOperationResult)> {
+        if let Some(completed) = self
+            .global_workspaces()?
+            .completed_operation(operation_id, request_fingerprint)
+            .map_err(global_workspace_error)?
+        {
+            return Ok((completed.workspace, completed.resource));
+        }
+        let global = self
+            .global_workspaces()?
+            .get(global_workspace_id)
+            .map_err(global_workspace_error)?;
+        require_guard(
+            global.revision,
+            expected_global_revision,
+            "global Workspace",
+        )?;
+        if global.closing {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::Busy,
+                "global Workspace close is in progress",
+            ));
+        }
+        if !owner_preflight_complete {
+            let selected = self.combined_node_snapshot(Some(node_id))?;
+            let node = selected
+                .nodes
+                .iter()
+                .find(|node| node.node_id == node_id)
+                .ok_or_else(|| {
+                    DaemonError::lifecycle(ErrorCode::NotFound, "selected Node not found")
+                })?;
+            if !node.workspace_owner_eligible {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::Busy,
+                    node.workspace_owner_unavailable_reason
+                        .clone()
+                        .unwrap_or_else(|| "selected Node is unavailable".into()),
+                ));
+            }
+        }
+        let existing = global
+            .placements
+            .iter()
+            .find(|placement| placement.node_id == node_id);
+        let owner = existing
+            .map(|placement| {
+                self.owner_workspace(&protocol::QualifiedIdentity::new(
+                    node_id,
+                    &placement.workspace_id,
+                ))
+            })
+            .transpose()?;
+        let owner_name = owner
+            .as_ref()
+            .map(|owner| owner.name.as_str())
+            .unwrap_or(&global.name);
+        let owner_cwd = owner
+            .as_ref()
+            .map(|owner| owner.default_cwd.clone())
+            .unwrap_or(default_cwd);
+        let prepared = self
+            .global_workspaces()?
+            .prepare_resource(
+                global_workspace_id,
+                operation_id,
+                request_fingerprint,
+                request_bytes,
+                expected_global_revision,
+                node_id,
+                owner_workspace_id,
+                owner_name,
+                owner_cwd,
+                resource_id,
+                kind,
+            )
+            .map_err(global_workspace_error)?;
+        let (mut pending, newly_prepared) = match prepared {
+            PreparedWorkspaceResource::Completed(completed) => {
+                let completed = *completed;
+                return Ok((completed.workspace, completed.resource));
+            }
+            PreparedWorkspaceResource::Pending {
+                pending,
+                newly_prepared,
+            } => (*pending, newly_prepared),
+        };
+        if !newly_prepared && let Some(resource) = self.pending_owner_resource(&pending)? {
+            Self::validate_pending_owner_resource(&pending, &resource)?;
+            let owner = self.owner_workspace(&protocol::QualifiedIdentity::new(
+                &pending.node_id,
+                &pending.owner_workspace_id,
+            ))?;
+            let completed = self
+                .global_workspaces()?
+                .complete_resource(&pending, &owner, &resource)
+                .map_err(global_workspace_error)?;
+            return Ok((completed.workspace, completed.resource));
+        }
+        let local_node_id = self.node_identity()?.id()?;
+        pending = self
+            .global_workspaces()?
+            .mark_owner_attempted(&pending)
+            .map_err(global_workspace_error)?;
+        let operation = build(&pending);
+        let response = if pending.node_id == local_node_id {
+            self.dispatch(operation.owner_request())
+                .unwrap_or_else(DaemonError::into_response)
+        } else {
+            self.route_node_operation(&pending.node_id, operation)
+        };
+        let resource = match response {
+            Response::RoutedNodeOperation { result } => result,
+            Response::Error { message, code } => {
+                if (!pending.creates_workspace || !pending.owner_attempted)
+                    && !matches!(
+                        code,
+                        Some(
+                            ErrorCode::OutcomeUnknown
+                                | ErrorCode::PersistenceFailed
+                                | ErrorCode::Timeout
+                        )
+                    )
+                {
+                    self.global_workspaces()?
+                        .cancel_resource(&pending)
+                        .map_err(global_workspace_error)?;
+                }
+                return Err(DaemonError::lifecycle(
+                    code.unwrap_or(ErrorCode::Internal),
+                    message,
+                ));
+            }
+            response => routed_result(response).map_err(|_| {
+                DaemonError::lifecycle(
+                    ErrorCode::Internal,
+                    "owner returned an unexpected resource response",
+                )
+            })?,
+        };
+        Self::validate_pending_owner_resource(&pending, &resource)?;
+        let resource_workspace_id = match &resource {
+            RoutedOperationResult::Shell { shell } => &shell.workspace_id,
+            RoutedOperationResult::Launcher { launcher } => &launcher.workspace_id,
+            RoutedOperationResult::AgentSchedule { schedule } => &schedule.workspace_id,
+            _ => {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::Internal,
+                    "owner returned an unexpected resource type",
+                ));
+            }
+        };
+        if resource_workspace_id != &pending.owner_workspace_id {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::Internal,
+                "owner resource belongs to a different Workspace",
+            ));
+        }
+        let owner = self.owner_workspace(&protocol::QualifiedIdentity::new(
+            &pending.node_id,
+            &pending.owner_workspace_id,
+        ))?;
+        if owner.name != pending.owner_workspace_name || owner.default_cwd != pending.default_cwd {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::OutcomeUnknown,
+                "owner Workspace metadata does not match the coordinator request",
+            ));
+        }
+        let completed = self
+            .global_workspaces()?
+            .complete_resource(&pending, &owner, &resource)
+            .map_err(global_workspace_error)?;
+        Ok((completed.workspace, completed.resource))
+    }
+
+    fn pending_owner_resource(
+        &self,
+        pending: &PendingWorkspaceResource,
+    ) -> DaemonResult<Option<RoutedOperationResult>> {
+        let operation = match pending.kind {
+            PendingResourceKind::Shell => RoutedOperation::GetShell {
+                shell_id: pending.resource_id.clone(),
+            },
+            PendingResourceKind::Launcher => RoutedOperation::GetLauncher {
+                launcher_id: pending.resource_id.clone(),
+            },
+            PendingResourceKind::AgentSchedule => RoutedOperation::GetAgentSchedule {
+                schedule_id: pending.resource_id.clone(),
+            },
+        };
+        let local_node_id = self.node_identity()?.id()?;
+        let response = if pending.node_id == local_node_id {
+            self.dispatch(operation.owner_request())
+                .unwrap_or_else(DaemonError::into_response)
+        } else {
+            self.route_node_operation(&pending.node_id, operation)
+        };
+        match response {
+            Response::Error {
+                code: Some(ErrorCode::NotFound),
+                ..
+            } => Ok(None),
+            Response::Error { message, code } => Err(DaemonError::lifecycle(
+                code.unwrap_or(ErrorCode::Internal),
+                message,
+            )),
+            Response::RoutedNodeOperation { result } => Ok(Some(result)),
+            response => routed_result(response).map(Some).map_err(|_| {
+                DaemonError::lifecycle(
+                    ErrorCode::Internal,
+                    "owner returned an unexpected pending-resource response",
+                )
+            }),
+        }
+    }
+
+    fn reconcile_pending_workspace_resources(&self) {
+        let pending = match self
+            .global_workspaces()
+            .and_then(|store| store.pending_resources().map_err(global_workspace_error))
+        {
+            Ok(pending) => pending,
+            Err(_) => return,
+        };
+        for pending in pending {
+            let recovered = self.with_workspace_operation_lock(&pending.operation_id, || {
+                let Some(resource) = self.pending_owner_resource(&pending)? else {
+                    self.global_workspaces()?
+                        .reconcile_resource(&pending, None)
+                        .map_err(global_workspace_error)?;
+                    return Ok(());
+                };
+                Self::validate_pending_owner_resource(&pending, &resource)?;
+                let owner = self.owner_workspace(&protocol::QualifiedIdentity::new(
+                    &pending.node_id,
+                    &pending.owner_workspace_id,
+                ))?;
+                self.global_workspaces()?
+                    .reconcile_resource(&pending, Some((&owner, &resource)))
+                    .map_err(global_workspace_error)?;
+                Ok::<(), DaemonError>(())
+            });
+            if let Err(error) = recovered {
+                eprintln!(
+                    "boomux: prepared Workspace resource {} remains unresolved: {error}",
+                    pending.operation_id
+                );
+            }
+        }
+    }
+
+    fn validate_pending_owner_resource(
+        pending: &PendingWorkspaceResource,
+        resource: &RoutedOperationResult,
+    ) -> DaemonResult<()> {
+        let (kind, resource_id, workspace_id) = match resource {
+            RoutedOperationResult::Shell { shell } => {
+                (PendingResourceKind::Shell, &shell.id, &shell.workspace_id)
+            }
+            RoutedOperationResult::Launcher { launcher } => (
+                PendingResourceKind::Launcher,
+                &launcher.id,
+                &launcher.workspace_id,
+            ),
+            RoutedOperationResult::AgentSchedule { schedule } => (
+                PendingResourceKind::AgentSchedule,
+                &schedule.id,
+                &schedule.workspace_id,
+            ),
+            _ => {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::Internal,
+                    "owner returned an unexpected prepared resource type",
+                ));
+            }
+        };
+        if kind != pending.kind
+            || resource_id != &pending.resource_id
+            || workspace_id != &pending.owner_workspace_id
+        {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::OutcomeUnknown,
+                "owner resource does not match the prepared identity",
+            ));
+        }
+        Ok(())
+    }
+
+    fn open_global_workspace(
+        &self,
+        workspace_id: &str,
+        expected_revision: u64,
+    ) -> DaemonResult<protocol::GlobalWorkspaceOperationResult> {
+        let workspace = self
+            .global_workspaces()?
+            .get(workspace_id)
+            .map_err(global_workspace_error)?;
+        require_guard(workspace.revision, expected_revision, "global Workspace")?;
+        if workspace.closing {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::Busy,
+                "global Workspace close is in progress",
+            ));
+        }
+        let placements = workspace
+            .placements
+            .iter()
+            .map(|placement| {
+                let identity = protocol::QualifiedIdentity::new(
+                    placement.node_id.clone(),
+                    placement.workspace_id.clone(),
+                );
+                match self.owner_workspace(&identity) {
+                    Ok(owner) if owner.revision >= placement.owner_revision => {
+                        protocol::WorkspacePlacementResult {
+                            node_id: placement.node_id.clone(),
+                            workspace_id: placement.workspace_id.clone(),
+                            status: "available".into(),
+                            message: None,
+                        }
+                    }
+                    Ok(_) => protocol::WorkspacePlacementResult {
+                        node_id: placement.node_id.clone(),
+                        workspace_id: placement.workspace_id.clone(),
+                        status: "stale".into(),
+                        message: Some("owner Workspace revision moved backwards".into()),
+                    },
+                    Err(error) => protocol::WorkspacePlacementResult {
+                        node_id: placement.node_id.clone(),
+                        workspace_id: placement.workspace_id.clone(),
+                        status: "unavailable".into(),
+                        message: Some(error.to_string()),
+                    },
+                }
+            })
+            .collect();
+        Ok(protocol::GlobalWorkspaceOperationResult {
+            workspace,
+            placements,
+        })
+    }
+
+    fn close_global_workspace(
+        &self,
+        workspace_id: &str,
+        expected_revision: Option<u64>,
+    ) -> DaemonResult<protocol::GlobalWorkspaceOperationResult> {
+        let mut workspace = self
+            .global_workspaces()?
+            .get(workspace_id)
+            .map_err(global_workspace_error)?;
+        if let Some(expected_revision) = expected_revision {
+            workspace = self
+                .global_workspaces()?
+                .begin_close(workspace_id, expected_revision)
+                .map_err(global_workspace_error)?;
+        } else if !workspace.closing {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::InvalidArgument,
+                "global Workspace is not awaiting close retry",
+            ));
+        }
+        if workspace.placements.is_empty() {
+            self.global_workspaces()?
+                .confirm_empty_closed(workspace_id)
+                .map_err(global_workspace_error)?;
+            return Ok(protocol::GlobalWorkspaceOperationResult {
+                workspace,
+                placements: Vec::new(),
+            });
+        }
+        let local_node_id = self.node_identity()?.id()?;
+        let mut results = Vec::new();
+        for placement in workspace.placements.clone() {
+            let identity = protocol::QualifiedIdentity::new(
+                placement.node_id.clone(),
+                placement.workspace_id.clone(),
+            );
+            let response = match self.owner_workspace(&identity) {
+                Ok(owner) if placement.node_id == local_node_id => self
+                    .dispatch(Request::GuardedCloseWorkspace {
+                        workspace_id: placement.workspace_id.clone(),
+                        expected_revision: owner.revision,
+                    })
+                    .unwrap_or_else(DaemonError::into_response),
+                Ok(owner) => self.route_node_operation(
+                    &placement.node_id,
+                    RoutedOperation::CloseWorkspace {
+                        workspace_id: placement.workspace_id.clone(),
+                        expected_revision: owner.revision,
+                    },
+                ),
+                Err(error) => error.into_response(),
+            };
+            let confirmed = matches!(response, Response::Ok)
+                || matches!(
+                    response,
+                    Response::RoutedNodeOperation {
+                        result: RoutedOperationResult::Ok
+                    }
+                )
+                || matches!(
+                    response,
+                    Response::Error {
+                        code: Some(ErrorCode::NotFound),
+                        ..
+                    }
+                );
+            if confirmed {
+                let remaining = self
+                    .global_workspaces()?
+                    .confirm_closed(workspace_id, &placement.node_id, &placement.workspace_id)
+                    .map_err(global_workspace_error)?;
+                if let Some(remaining) = remaining {
+                    workspace = remaining;
+                } else {
+                    workspace.placements.clear();
+                }
+                results.push(protocol::WorkspacePlacementResult {
+                    node_id: placement.node_id,
+                    workspace_id: placement.workspace_id,
+                    status: "closed".into(),
+                    message: None,
+                });
+            } else {
+                let message = match response {
+                    Response::Error { message, .. } => message,
+                    _ => "owner returned an unexpected close response".into(),
+                };
+                results.push(protocol::WorkspacePlacementResult {
+                    node_id: placement.node_id,
+                    workspace_id: placement.workspace_id,
+                    status: "unresolved".into(),
+                    message: Some(message),
+                });
+            }
+        }
+        Ok(protocol::GlobalWorkspaceOperationResult {
+            workspace,
+            placements: results,
+        })
+    }
+
     fn combined_node_snapshot(
         &self,
         selector: Option<&str>,
@@ -8110,14 +9140,19 @@ impl DaemonService {
                 node_id: local_node_id,
                 alias: "local".into(),
                 local: true,
+                route: None,
+                registration_revision: None,
                 health: NodeProjectionHealthCode::Online,
                 current: true,
                 stale: false,
                 observed_at_ms: unix_time_ms(),
                 observed_protocol_version: Some(protocol::PROTOCOL_VERSION),
-                observed_capabilities: protocol::protocol_capabilities()
-                    .map(str::to_owned)
-                    .collect(),
+                observed_capabilities: self.runtime_protocol_capabilities(),
+                workspace_owner_eligible: self.global_workspaces.is_some(),
+                workspace_owner_unavailable_reason: self
+                    .global_workspaces
+                    .is_none()
+                    .then(|| "coordinated Workspace storage is unavailable".into()),
                 scheduler,
                 local_snapshot: Some(snapshot),
                 remote_projection: None,
@@ -8140,16 +9175,34 @@ impl DaemonService {
                 .iter()
                 .filter_map(|capability| capability.strip_prefix("protocol_")?.parse().ok())
                 .max();
+            let workspace_owner_eligible = !view.health.stale
+                && view.health.code == NodeProjectionHealthCode::Online
+                && view
+                    .health
+                    .capabilities
+                    .iter()
+                    .any(|capability| capability == "global_workspaces");
+            let workspace_owner_unavailable_reason = (!workspace_owner_eligible).then(|| {
+                if view.health.stale || view.health.code != NodeProjectionHealthCode::Online {
+                    format!("Node health is {:?}", view.health.code).to_ascii_lowercase()
+                } else {
+                    "Node does not support coordinated Workspaces".into()
+                }
+            });
             nodes.push(CombinedNode {
                 node_id: registration.node_id.clone(),
                 alias: registration.alias.clone(),
                 local: false,
+                route: Some(registration.target.clone()),
+                registration_revision: Some(registration.revision),
                 health: view.health.code,
                 current: !view.health.stale,
                 stale: view.health.stale,
                 observed_at_ms: view.health.last_success_at_ms.unwrap_or(0),
                 observed_protocol_version,
                 observed_capabilities: view.health.capabilities,
+                workspace_owner_eligible,
+                workspace_owner_unavailable_reason,
                 scheduler,
                 local_snapshot: None,
                 remote_projection: view.projection,
@@ -8162,7 +9215,87 @@ impl DaemonService {
                 .then_with(|| left.alias.cmp(&right.alias))
                 .then_with(|| left.node_id.cmp(&right.node_id))
         });
-        Ok(CombinedNodeSnapshot { nodes })
+        let mut workspaces = self
+            .global_workspaces
+            .as_ref()
+            .map(GlobalWorkspaceStore::list)
+            .transpose()?
+            .unwrap_or_default();
+        let node_current = nodes
+            .iter()
+            .map(|node| (node.node_id.as_str(), node.current && !node.stale))
+            .collect::<HashMap<_, _>>();
+        for workspace in &mut workspaces {
+            for placement in &mut workspace.placements {
+                if !workspace.closing
+                    && !node_current
+                        .get(placement.node_id.as_str())
+                        .copied()
+                        .unwrap_or(false)
+                {
+                    placement.state = protocol::WorkspacePlacementState::Unavailable;
+                }
+            }
+        }
+        let linked = workspaces
+            .iter()
+            .flat_map(|workspace| &workspace.placements)
+            .map(|placement| (placement.node_id.clone(), placement.workspace_id.clone()))
+            .collect::<HashSet<_>>();
+        let mut external_workspaces = Vec::new();
+        for node in &nodes {
+            if let Some(snapshot) = &node.local_snapshot {
+                external_workspaces.extend(
+                    snapshot
+                        .workspaces
+                        .iter()
+                        .filter(|workspace| {
+                            !linked.contains(&(node.node_id.clone(), workspace.id.clone()))
+                        })
+                        .map(|workspace| protocol::ExternalWorkspaceSnapshot {
+                            identity: protocol::QualifiedIdentity::new(
+                                &node.node_id,
+                                &workspace.id,
+                            ),
+                            revision: workspace.revision,
+                            name: workspace.name.clone(),
+                            default_cwd: workspace.default_cwd.clone(),
+                            available: node.current && !node.stale,
+                        }),
+                );
+            }
+            if let Some(projection) = &node.remote_projection {
+                external_workspaces.extend(
+                    projection
+                        .workspaces
+                        .iter()
+                        .filter(|workspace| {
+                            !linked.contains(&(node.node_id.clone(), workspace.id.clone()))
+                        })
+                        .map(|workspace| protocol::ExternalWorkspaceSnapshot {
+                            identity: protocol::QualifiedIdentity::new(
+                                &node.node_id,
+                                &workspace.id,
+                            ),
+                            revision: 0,
+                            name: workspace.name.clone(),
+                            default_cwd: None,
+                            available: node.current && !node.stale,
+                        }),
+                );
+            }
+        }
+        external_workspaces.sort_by(|left, right| {
+            left.name
+                .cmp(&right.name)
+                .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
+                .then_with(|| left.identity.inner_id.cmp(&right.identity.inner_id))
+        });
+        Ok(CombinedNodeSnapshot {
+            nodes,
+            workspaces,
+            external_workspaces,
+        })
     }
 
     fn clock_now_ms(&self) -> u64 {
@@ -8270,6 +9403,20 @@ impl DaemonService {
             .spawn(move || node_projection_worker(service, worker_node_id))?;
         handles.insert(node_id, handle);
         Ok(())
+    }
+
+    fn force_node_projection_refresh(
+        &self,
+        selector: &str,
+    ) -> DaemonResult<protocol::NodeProjectionHealth> {
+        let registration = self
+            .node_registrations()?
+            .inspect(selector)
+            .map_err(node_registration_error)?;
+        lock(&self.node_projection_workers.wake)?.insert(registration.node_id.clone());
+        self.node_projection_cache()?
+            .health(&registration)
+            .map_err(DaemonError::from)
     }
 
     fn stop_node_projection_workers(&self) -> io::Result<()> {
@@ -9464,6 +10611,8 @@ impl DaemonService {
     }
 
     fn dispatch(&self, request: Request) -> DaemonResult<Response> {
+        let (workspace_request_fingerprint, workspace_semantic_fingerprint) =
+            workspace_operation_fingerprints(&request)?;
         let _dispatch_eligibility = matches!(
             &request,
             Request::RegisterAgent { .. }
@@ -9563,9 +10712,325 @@ impl DaemonService {
                     health: self.node_projection_cache()?.health(&registration)?,
                 })
             }
-            Request::GetCombinedNodeSnapshot { selector } => Ok(Response::CombinedNodeSnapshot {
-                snapshot: self.combined_node_snapshot(selector.as_deref())?,
+            Request::ForceNodeProjectionRefresh { selector } => {
+                Ok(Response::NodeProjectionHealth {
+                    health: self.force_node_projection_refresh(&selector)?,
+                })
+            }
+            Request::GetCombinedNodeSnapshot { selector } => {
+                self.reconcile_pending_workspace_resources();
+                Ok(Response::CombinedNodeSnapshot {
+                    snapshot: self.combined_node_snapshot(selector.as_deref())?,
+                })
+            }
+            Request::CreateGlobalWorkspace { name } => Ok(Response::GlobalWorkspace {
+                workspace: self
+                    .global_workspaces()?
+                    .create(name)
+                    .map_err(global_workspace_error)?,
             }),
+            Request::AdoptNodeWorkspace {
+                identity,
+                expected_revision,
+            } => {
+                self.require_cached_workspace_owner_eligible(&identity.node_id)?;
+                let node_id = identity.node_id.clone();
+                self.with_live_workspace_node(&identity.node_id, |node| {
+                    let owner = node
+                        .local_snapshot
+                        .and_then(|snapshot| {
+                            snapshot
+                                .workspaces
+                                .into_iter()
+                                .find(|workspace| workspace.id == identity.inner_id)
+                        })
+                        .ok_or_else(|| {
+                            DaemonError::lifecycle(
+                                ErrorCode::NotFound,
+                                "owner Workspace not found in live capability snapshot",
+                            )
+                        })?;
+                    Ok(Response::GlobalWorkspace {
+                        workspace: self
+                            .global_workspaces()?
+                            .adopt(&node_id, &owner, expected_revision)
+                            .map_err(global_workspace_error)?,
+                    })
+                })
+            }
+            Request::LinkNodeWorkspace {
+                global_workspace_id,
+                expected_global_revision,
+                identity,
+                expected_owner_revision,
+            } => {
+                self.require_cached_workspace_owner_eligible(&identity.node_id)?;
+                let node_id = identity.node_id.clone();
+                self.with_live_workspace_node(&identity.node_id, |node| {
+                    let owner = node
+                        .local_snapshot
+                        .and_then(|snapshot| {
+                            snapshot
+                                .workspaces
+                                .into_iter()
+                                .find(|workspace| workspace.id == identity.inner_id)
+                        })
+                        .ok_or_else(|| {
+                            DaemonError::lifecycle(
+                                ErrorCode::NotFound,
+                                "owner Workspace not found in live capability snapshot",
+                            )
+                        })?;
+                    Ok(Response::GlobalWorkspace {
+                        workspace: self
+                            .global_workspaces()?
+                            .link(
+                                &global_workspace_id,
+                                expected_global_revision,
+                                &node_id,
+                                &owner,
+                                expected_owner_revision,
+                            )
+                            .map_err(global_workspace_error)?,
+                    })
+                })
+            }
+            Request::RenameGlobalWorkspace {
+                workspace_id,
+                expected_revision,
+                name,
+            } => Ok(Response::GlobalWorkspace {
+                workspace: self
+                    .global_workspaces()?
+                    .rename(&workspace_id, expected_revision, name)
+                    .map_err(global_workspace_error)?,
+            }),
+            Request::OpenGlobalWorkspace {
+                workspace_id,
+                expected_revision,
+            } => Ok(Response::GlobalWorkspaceOperation {
+                result: self.open_global_workspace(&workspace_id, expected_revision)?,
+            }),
+            Request::CloseGlobalWorkspace {
+                workspace_id,
+                expected_revision,
+            } => Ok(Response::GlobalWorkspaceOperation {
+                result: self.close_global_workspace(&workspace_id, Some(expected_revision))?,
+            }),
+            Request::RetryGlobalWorkspaceClose { workspace_id } => {
+                Ok(Response::GlobalWorkspaceOperation {
+                    result: self.close_global_workspace(&workspace_id, None)?,
+                })
+            }
+            Request::CreateGlobalWorkspaceShell {
+                operation_id,
+                global_workspace_id,
+                expected_global_revision,
+                node_id,
+                owner_workspace_id,
+                default_cwd,
+                shell_id,
+                shell,
+            } => {
+                let request = workspace_request_fingerprint
+                    .as_ref()
+                    .expect("Workspace resource request has a fingerprint");
+                let (workspace, resource) = self.create_global_workspace_resource(
+                    &operation_id,
+                    &request.digest,
+                    request.bytes,
+                    &global_workspace_id,
+                    expected_global_revision,
+                    &node_id,
+                    &owner_workspace_id,
+                    default_cwd,
+                    &shell_id,
+                    PendingResourceKind::Shell,
+                    move |pending| RoutedOperation::CreateWorkspaceShell {
+                        workspace_id: pending.owner_workspace_id.clone(),
+                        workspace_name: pending.owner_workspace_name.clone(),
+                        default_cwd: pending.default_cwd.clone(),
+                        shell_id: pending.resource_id.clone(),
+                        shell,
+                    },
+                )?;
+                Ok(Response::GlobalWorkspaceResource {
+                    workspace,
+                    resource,
+                })
+            }
+            Request::CreateGlobalWorkspaceWithShell {
+                operation_id,
+                global_workspace_id,
+                name,
+                node_id,
+                owner_workspace_id,
+                default_cwd,
+                shell_id,
+                shell,
+            } => {
+                let request = workspace_request_fingerprint
+                    .as_ref()
+                    .expect("Workspace resource request has a fingerprint");
+                let request_fingerprint = request.digest.as_str();
+                let semantic_fingerprint = workspace_semantic_fingerprint
+                    .as_deref()
+                    .expect("project Workspace request has a semantic fingerprint");
+                let (workspace, resource) =
+                    self.with_workspace_operation_lock(&operation_id, || {
+                        if let Some(completed) = self
+                            .global_workspaces()?
+                            .completed_operation(&operation_id, request_fingerprint)
+                            .map_err(global_workspace_error)?
+                        {
+                            return Ok((completed.workspace, completed.resource));
+                        }
+                        if let Err(error) = self.preflight_workspace_owner(&node_id) {
+                            if !workspace_pre_owner_failure_is_ambiguous(&error) {
+                                self.global_workspaces()?
+                                    .cancel_pending_operation_if_never_attempted(
+                                        &operation_id,
+                                        request_fingerprint,
+                                    )
+                                    .map_err(global_workspace_error)?;
+                            }
+                            return Err(error);
+                        }
+                        let prepared = self
+                            .global_workspaces()?
+                            .prepare_workspace_shell(
+                                &operation_id,
+                                request_fingerprint,
+                                request.bytes,
+                                semantic_fingerprint,
+                                &global_workspace_id,
+                                &name,
+                                &node_id,
+                                &owner_workspace_id,
+                                default_cwd,
+                                &shell_id,
+                            )
+                            .map_err(global_workspace_error)?;
+                        let (prepared_workspace, pending) = match prepared {
+                            PreparedWorkspaceShell::Completed(completed) => {
+                                let completed = *completed;
+                                return Ok((completed.workspace, completed.resource));
+                            }
+                            PreparedWorkspaceShell::Pending { workspace, pending } => {
+                                (workspace, *pending)
+                            }
+                        };
+                        let result = self.create_global_workspace_resource_inner(
+                            &pending.operation_id,
+                            request_fingerprint,
+                            request.bytes,
+                            true,
+                            &prepared_workspace.id,
+                            prepared_workspace.revision,
+                            &pending.node_id,
+                            &pending.requested_owner_workspace_id,
+                            pending.default_cwd.clone(),
+                            &pending.resource_id,
+                            PendingResourceKind::Shell,
+                            move |pending| RoutedOperation::CreateWorkspaceShell {
+                                workspace_id: pending.owner_workspace_id.clone(),
+                                workspace_name: pending.owner_workspace_name.clone(),
+                                default_cwd: pending.default_cwd.clone(),
+                                shell_id: pending.resource_id.clone(),
+                                shell,
+                            },
+                        );
+                        if let Err(error) = &result
+                            && !workspace_pre_owner_failure_is_ambiguous(error)
+                        {
+                            self.global_workspaces()?
+                                .cancel_pending_operation_if_never_attempted(
+                                    &operation_id,
+                                    request_fingerprint,
+                                )
+                                .map_err(global_workspace_error)?;
+                        }
+                        result
+                    })?;
+                Ok(Response::GlobalWorkspaceResource {
+                    workspace,
+                    resource,
+                })
+            }
+            Request::CreateGlobalWorkspaceLauncher {
+                operation_id,
+                global_workspace_id,
+                expected_global_revision,
+                node_id,
+                owner_workspace_id,
+                default_cwd,
+                launcher_id,
+                spec,
+            } => {
+                let request = workspace_request_fingerprint
+                    .as_ref()
+                    .expect("Workspace resource request has a fingerprint");
+                let (workspace, resource) = self.create_global_workspace_resource(
+                    &operation_id,
+                    &request.digest,
+                    request.bytes,
+                    &global_workspace_id,
+                    expected_global_revision,
+                    &node_id,
+                    &owner_workspace_id,
+                    default_cwd,
+                    &launcher_id,
+                    PendingResourceKind::Launcher,
+                    move |pending| RoutedOperation::CreateWorkspaceLauncher {
+                        workspace_id: pending.owner_workspace_id.clone(),
+                        workspace_name: pending.owner_workspace_name.clone(),
+                        default_cwd: pending.default_cwd.clone(),
+                        launcher_id: pending.resource_id.clone(),
+                        spec,
+                    },
+                )?;
+                Ok(Response::GlobalWorkspaceResource {
+                    workspace,
+                    resource,
+                })
+            }
+            Request::CreateGlobalWorkspaceAgentSchedule {
+                operation_id,
+                global_workspace_id,
+                expected_global_revision,
+                node_id,
+                owner_workspace_id,
+                default_cwd,
+                schedule_id,
+                spec,
+            } => {
+                let request = workspace_request_fingerprint
+                    .as_ref()
+                    .expect("Workspace resource request has a fingerprint");
+                let (workspace, resource) = self.create_global_workspace_resource(
+                    &operation_id,
+                    &request.digest,
+                    request.bytes,
+                    &global_workspace_id,
+                    expected_global_revision,
+                    &node_id,
+                    &owner_workspace_id,
+                    default_cwd,
+                    &schedule_id,
+                    PendingResourceKind::AgentSchedule,
+                    move |pending| RoutedOperation::CreateWorkspaceAgentSchedule {
+                        workspace_id: pending.owner_workspace_id.clone(),
+                        workspace_name: pending.owner_workspace_name.clone(),
+                        default_cwd: pending.default_cwd.clone(),
+                        schedule_id: pending.resource_id.clone(),
+                        spec,
+                    },
+                )?;
+                Ok(Response::GlobalWorkspaceResource {
+                    workspace,
+                    resource,
+                })
+            }
             Request::RouteNodeOperation { node_id, operation } => {
                 Ok(self.route_node_operation(&node_id, operation))
             }
@@ -9675,6 +11140,142 @@ impl DaemonService {
                 let workspace = self.create_workspace_mutation(undo, name, default_cwd, shells)?;
                 let events = workspace_created_events(&workspace);
                 Ok((Response::Workspace { workspace }, events))
+            }),
+            Request::CreateWorkspaceShell {
+                workspace_id,
+                workspace_name,
+                default_cwd,
+                shell_id,
+                shell,
+            } => self.durable_mutation_outcome(|undo| {
+                let (workspace, workspace_undo) = self.durable.create_workspace_exact(
+                    &workspace_id,
+                    workspace_name,
+                    default_cwd,
+                )?;
+                let workspace_created = workspace_undo.is_some();
+                if let Some(record) = workspace_undo {
+                    undo.record(record);
+                }
+                let (shell, shell_undo) =
+                    self.durable
+                        .create_shell_exact(&workspace_id, &shell_id, shell)?;
+                let shell_created = shell_undo.is_some();
+                if let Some(record) = shell_undo {
+                    undo.record(record);
+                }
+                if !workspace_created && !shell_created {
+                    return Ok(DurableMutation::Unchanged(Response::Shell { shell }));
+                }
+                let mut events = Vec::new();
+                if workspace_created {
+                    events.push(DaemonEventKind::WorkspaceCreated {
+                        workspace_id: workspace.id,
+                        name: workspace.name,
+                    });
+                }
+                if shell_created {
+                    events.push(DaemonEventKind::ShellCreated {
+                        workspace_id,
+                        shell_id: shell.id.clone(),
+                        name: shell.name.clone(),
+                    });
+                }
+                Ok(DurableMutation::Changed(Response::Shell { shell }, events))
+            }),
+            Request::CreateWorkspaceLauncher {
+                workspace_id,
+                workspace_name,
+                default_cwd,
+                launcher_id,
+                spec,
+            } => self.durable_mutation_outcome(|undo| {
+                let (workspace, workspace_undo) = self.durable.create_workspace_exact(
+                    &workspace_id,
+                    workspace_name,
+                    default_cwd,
+                )?;
+                let workspace_created = workspace_undo.is_some();
+                if let Some(record) = workspace_undo {
+                    undo.record(record);
+                }
+                let (launcher, launcher_undo) =
+                    self.durable
+                        .create_launcher_exact(&workspace_id, &launcher_id, spec)?;
+                let launcher_created = launcher_undo.is_some();
+                if let Some(record) = launcher_undo {
+                    undo.record(record);
+                }
+                if !workspace_created && !launcher_created {
+                    return Ok(DurableMutation::Unchanged(Response::Launcher { launcher }));
+                }
+                let mut events = Vec::new();
+                if workspace_created {
+                    events.push(DaemonEventKind::WorkspaceCreated {
+                        workspace_id: workspace.id,
+                        name: workspace.name,
+                    });
+                }
+                if launcher_created {
+                    events.push(DaemonEventKind::LauncherCreated {
+                        workspace_id,
+                        launcher_id: launcher.id.clone(),
+                        name: launcher.name.clone(),
+                    });
+                }
+                Ok(DurableMutation::Changed(
+                    Response::Launcher { launcher },
+                    events,
+                ))
+            }),
+            Request::CreateWorkspaceAgentSchedule {
+                workspace_id,
+                workspace_name,
+                default_cwd,
+                schedule_id,
+                spec,
+            } => self.durable_mutation_outcome(|undo| {
+                let (workspace, workspace_undo) = self.durable.create_workspace_exact(
+                    &workspace_id,
+                    workspace_name,
+                    default_cwd,
+                )?;
+                let workspace_created = workspace_undo.is_some();
+                if let Some(record) = workspace_undo {
+                    undo.record(record);
+                }
+                let (schedule, schedule_undo) = self.durable.create_schedule_at_with_id(
+                    &workspace_id,
+                    schedule_id,
+                    spec,
+                    self.clock_now_ms(),
+                )?;
+                let schedule_created = schedule_undo.is_some();
+                if let Some(record) = schedule_undo {
+                    undo.record(record);
+                }
+                if !workspace_created && !schedule_created {
+                    return Ok(DurableMutation::Unchanged(Response::AgentSchedule {
+                        schedule,
+                    }));
+                }
+                let mut events = Vec::new();
+                if workspace_created {
+                    events.push(DaemonEventKind::WorkspaceCreated {
+                        workspace_id: workspace.id,
+                        name: workspace.name,
+                    });
+                }
+                if schedule_created {
+                    events.push(DaemonEventKind::AgentScheduleCreated {
+                        workspace_id,
+                        schedule: schedule.clone(),
+                    });
+                }
+                Ok(DurableMutation::Changed(
+                    Response::AgentSchedule { schedule },
+                    events,
+                ))
             }),
             Request::CreateShell {
                 workspace_id,
@@ -10497,6 +12098,7 @@ impl DaemonService {
             node_identity: None,
             node_registrations: None,
             node_projection_cache: None,
+            global_workspaces: None,
             durable: DurableRegistry {
                 state: Mutex::new(state),
                 store: Some(store),
@@ -10512,6 +12114,7 @@ impl DaemonService {
             },
             remote_attachments: RemoteAttachmentManager::default(),
             host_service_previews: Mutex::new(HashMap::new()),
+            workspace_operation_locks: Mutex::new(HashMap::new()),
             mutation_lock: Mutex::new(()),
             schedule_dispatch_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
@@ -11436,7 +13039,22 @@ impl DaemonService {
             cursor,
             projection,
             transitions,
+            capabilities: self.runtime_protocol_capabilities(),
         })
+    }
+
+    fn runtime_protocol_capabilities(&self) -> Vec<String> {
+        protocol::ProtocolFeature::ALL
+            .iter()
+            .copied()
+            .filter(|feature| {
+                *feature != protocol::ProtocolFeature::GlobalWorkspaces
+                    || self.global_workspaces.is_some()
+            })
+            .flat_map(protocol::ProtocolFeature::capability_names)
+            .copied()
+            .map(str::to_owned)
+            .collect()
     }
 
     fn scheduler_health(&self) -> io::Result<SchedulerHealth> {
@@ -12962,10 +14580,18 @@ impl Shell {
 }
 
 fn create_pending_shell(workspace_id: &str, spec: ShellSpec) -> io::Result<Arc<Shell>> {
+    create_pending_shell_with_id(workspace_id, Uuid::new_v4().to_string(), spec)
+}
+
+fn create_pending_shell_with_id(
+    workspace_id: &str,
+    shell_id: String,
+    spec: ShellSpec,
+) -> io::Result<Arc<Shell>> {
     validate_name(&spec.name)?;
     validate_cwd(&spec.cwd)?;
     Ok(Arc::new(Shell {
-        id: Uuid::new_v4().to_string(),
+        id: shell_id,
         revision: Mutex::new(1),
         workspace_id: workspace_id.to_owned(),
         name: Mutex::new(spec.name),
@@ -14121,6 +15747,18 @@ fn validate_name(name: &str) -> io::Result<()> {
     }
 }
 
+fn validate_uuid(value: &str, label: &str) -> io::Result<()> {
+    let parsed = Uuid::parse_str(value)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, format!("invalid {label}")))?;
+    if parsed.to_string() != value {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{label} must use canonical UUID syntax"),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_persisted_name(name: &str) -> io::Result<()> {
     if name.trim().is_empty() {
         Err(io::Error::new(
@@ -15237,6 +16875,52 @@ mod tests {
                 .workspaces
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn exact_workspace_shell_creation_is_atomic_idempotent_and_collision_safe() {
+        let registry = DaemonService::default();
+        let workspace_id = Uuid::from_u128(1).to_string();
+        let shell_id = Uuid::from_u128(2).to_string();
+        let cwd = env::temp_dir();
+        let request = Request::CreateWorkspaceShell {
+            workspace_id: workspace_id.clone(),
+            workspace_name: "coordinated".into(),
+            default_cwd: Some(cwd.clone()),
+            shell_id: shell_id.clone(),
+            shell: ShellSpec {
+                name: "shell".into(),
+                command: vec!["bash".into(), "-lc".into(), "printf %s safe".into()],
+                cwd: cwd.clone(),
+            },
+        };
+        assert!(matches!(
+            registry.dispatch(request.clone()).unwrap(),
+            Response::Shell { .. }
+        ));
+        assert!(matches!(
+            registry.dispatch(request).unwrap(),
+            Response::Shell { .. }
+        ));
+        let snapshot = registry.snapshot().unwrap();
+        assert_eq!(snapshot.workspaces.len(), 1);
+        assert_eq!(snapshot.workspaces[0].id, workspace_id);
+        assert_eq!(snapshot.workspaces[0].shells.len(), 1);
+        assert_eq!(snapshot.workspaces[0].shells[0].id, shell_id);
+
+        let conflict = registry.dispatch(Request::CreateWorkspaceShell {
+            workspace_id: snapshot.workspaces[0].id.clone(),
+            workspace_name: "coordinated".into(),
+            default_cwd: Some(cwd.clone()),
+            shell_id: snapshot.workspaces[0].shells[0].id.clone(),
+            shell: ShellSpec {
+                name: "different".into(),
+                command: vec!["bash".into()],
+                cwd,
+            },
+        });
+        assert!(conflict.is_err());
+        assert_eq!(registry.snapshot().unwrap().workspaces[0].shells.len(), 1);
     }
 
     #[test]
@@ -17880,6 +19564,7 @@ mod tests {
                     },
                 },
             ],
+            capabilities: Vec::new(),
         };
         let live = ProjectionCommit {
             generation: 2,
@@ -17951,6 +19636,7 @@ mod tests {
             },
             projection: remote_notification_projection(&node_id),
             transitions: Vec::new(),
+            capabilities: Vec::new(),
         };
         let commit = ProjectionCommit {
             generation: 2,
@@ -20205,6 +21891,111 @@ mod tests {
     }
 
     #[test]
+    fn protocol_thirty_seven_combined_snapshots_hide_coordinator_workspaces() {
+        let workspace_id = Uuid::from_u128(1).to_string();
+        let node_id = Uuid::from_u128(2).to_string();
+        let current_node = protocol::CombinedNode {
+            node_id: node_id.clone(),
+            alias: "remote".into(),
+            local: false,
+            route: Some("remote.example".into()),
+            registration_revision: Some(7),
+            health: protocol::NodeProjectionHealthCode::Online,
+            current: true,
+            stale: false,
+            observed_at_ms: 10,
+            observed_protocol_version: Some(37),
+            observed_capabilities: vec!["protocol_37".into()],
+            workspace_owner_eligible: true,
+            workspace_owner_unavailable_reason: Some("new field".into()),
+            scheduler: SchedulerHealth {
+                state: SchedulerState::Active,
+                max_concurrent: 1,
+                active_executions: 0,
+            },
+            local_snapshot: None,
+            remote_projection: None,
+        };
+        let response = Response::CombinedNodeSnapshot {
+            snapshot: protocol::CombinedNodeSnapshot {
+                nodes: vec![current_node.clone()],
+                workspaces: vec![protocol::GlobalWorkspaceSnapshot {
+                    id: workspace_id.clone(),
+                    revision: 1,
+                    name: "work".into(),
+                    closing: false,
+                    placements: Vec::new(),
+                }],
+                external_workspaces: vec![protocol::ExternalWorkspaceSnapshot {
+                    identity: protocol::QualifiedIdentity::new(node_id.clone(), workspace_id),
+                    revision: 1,
+                    name: "external".into(),
+                    default_cwd: Some("/owner/work".into()),
+                    available: true,
+                }],
+            },
+        };
+        let Response::CombinedNodeSnapshot { snapshot } = response_for_version(response, 37) else {
+            panic!("expected combined Node snapshot");
+        };
+        assert!(snapshot.workspaces.is_empty());
+        assert!(snapshot.external_workspaces.is_empty());
+        let encoded_node = serde_json::to_value(&snapshot.nodes[0]).unwrap();
+        assert!(encoded_node.get("route").is_none());
+        assert!(encoded_node.get("registration_revision").is_none());
+        assert!(encoded_node.get("workspace_owner_eligible").is_none());
+        assert!(
+            encoded_node
+                .get("workspace_owner_unavailable_reason")
+                .is_none()
+        );
+        #[derive(serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct ProtocolThirtySevenCombinedNode {
+            node_id: String,
+            alias: String,
+            local: bool,
+            health: protocol::NodeProjectionHealthCode,
+            current: bool,
+            stale: bool,
+            observed_at_ms: u64,
+            observed_protocol_version: Option<u32>,
+            observed_capabilities: Vec<String>,
+            scheduler: SchedulerHealth,
+            local_snapshot: Option<Snapshot>,
+            remote_projection: Option<NodeProjectionSnapshot>,
+        }
+        for version in 33..=37 {
+            let Response::CombinedNodeSnapshot { snapshot } = response_for_version(
+                Response::CombinedNodeSnapshot {
+                    snapshot: protocol::CombinedNodeSnapshot {
+                        nodes: vec![current_node.clone()],
+                        workspaces: Vec::new(),
+                        external_workspaces: Vec::new(),
+                    },
+                },
+                version,
+            ) else {
+                unreachable!();
+            };
+            let old: ProtocolThirtySevenCombinedNode =
+                serde_json::from_value(serde_json::to_value(&snapshot.nodes[0]).unwrap()).unwrap();
+            assert_eq!(old.node_id, node_id);
+            assert_eq!(old.alias, "remote");
+            assert!(!old.local);
+            assert_eq!(old.health, protocol::NodeProjectionHealthCode::Online);
+            assert!(old.current);
+            assert!(!old.stale);
+            assert_eq!(old.observed_at_ms, 10);
+            assert_eq!(old.observed_protocol_version, Some(37));
+            assert_eq!(old.observed_capabilities, ["protocol_37"]);
+            assert_eq!(old.scheduler.state, SchedulerState::Active);
+            assert!(old.local_snapshot.is_none());
+            assert!(old.remote_projection.is_none());
+        }
+    }
+
+    #[test]
     fn protocol_seventeen_responses_hide_focused_terminal() {
         let response = Response::Snapshot {
             snapshot: Snapshot {
@@ -20654,6 +22445,38 @@ mod tests {
         assert!(workspace.shells.is_empty());
         assert!(workspace.default_cwd.is_none());
         assert!(value.get("default_cwd").is_none());
+    }
+
+    #[test]
+    fn unavailable_global_store_suppresses_runtime_coordination_capabilities() {
+        let registry = DaemonService::default();
+        let capabilities = registry.runtime_protocol_capabilities();
+        assert!(!capabilities.iter().any(|capability| {
+            protocol::ProtocolFeature::GlobalWorkspaces
+                .capability_names()
+                .contains(&capability.as_str())
+        }));
+    }
+
+    #[test]
+    fn forced_node_projection_refresh_interrupts_only_the_existing_worker_sleep() {
+        let registry = DaemonService::default();
+        let node_id = Uuid::from_u128(42).to_string();
+        lock(&registry.node_projection_workers.wake)
+            .unwrap()
+            .insert(node_id.clone());
+        let started = Instant::now();
+        assert!(!interruptible_node_sleep(
+            &registry,
+            &node_id,
+            Duration::from_secs(1)
+        ));
+        assert!(started.elapsed() < Duration::from_millis(200));
+        assert!(
+            lock(&registry.node_projection_workers.wake)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src/dashboard_projection.rs
+++ b/src/dashboard_projection.rs
@@ -16,7 +16,8 @@ use crate::tui::{
     AgentShellView, AgentView, AttentionReason, ExecutionDisplayState, ExecutionOutcomeDisplay,
     ExecutionReasonDisplay, ExecutionView, LauncherView, NodeView, ScheduleDisplayState,
     ScheduleItemView, ScheduleView, TerminalKind, TerminalRunView, TerminalView,
-    WorkspaceAttentionView, WorkspaceItemView, WorkspaceView,
+    WorkspaceAttentionView, WorkspaceCoordinationView, WorkspaceItemOwnerView, WorkspaceItemView,
+    WorkspaceView,
 };
 
 fn local_node_placeholder() -> NodeView {
@@ -24,10 +25,16 @@ fn local_node_placeholder() -> NodeView {
         id: String::new(),
         alias: "local".into(),
         local: true,
+        route: None,
+        registration_revision: None,
         health: boomux::protocol::NodeProjectionHealthCode::Online,
         current: true,
         stale: false,
+        observed_at_ms: 0,
+        observed_protocol_version: None,
         observed_capabilities: Vec::new(),
+        workspace_owner_eligible: true,
+        workspace_owner_unavailable_reason: None,
         scheduler: boomux::protocol::SchedulerHealth {
             state: boomux::protocol::SchedulerState::Offline,
             max_concurrent: 0,
@@ -335,10 +342,16 @@ pub(crate) fn project_remote_node(
         id: node.node_id.clone(),
         alias: node.alias.clone(),
         local: false,
+        route: node.route.clone(),
+        registration_revision: node.registration_revision,
         health: node.health,
         current: node.current,
         stale: node.stale,
+        observed_at_ms: node.observed_at_ms,
+        observed_protocol_version: node.observed_protocol_version,
         observed_capabilities: node.observed_capabilities.clone(),
+        workspace_owner_eligible: node.workspace_owner_eligible,
+        workspace_owner_unavailable_reason: node.workspace_owner_unavailable_reason.clone(),
         scheduler: node.scheduler.clone(),
     };
     let mut workspaces = projection
@@ -466,6 +479,7 @@ pub(crate) fn project_remote_node(
                         })
                     }),
             );
+            let item_count = items.len();
             WorkspaceView {
                 node: node_view.clone(),
                 id: workspace.id.clone(),
@@ -476,6 +490,17 @@ pub(crate) fn project_remote_node(
                 agent_state_counts,
                 attention_count: workspace.attention_count as usize,
                 attention: Vec::new(),
+                item_owners: vec![
+                    WorkspaceItemOwnerView {
+                        node: node_view.clone(),
+                        workspace_id: workspace.id.clone(),
+                    };
+                    item_count
+                ],
+                coordination: WorkspaceCoordinationView::External {
+                    owner_revision: 0,
+                    available: node.current && !node.stale,
+                },
             }
         })
         .collect::<Vec<_>>();
@@ -629,6 +654,8 @@ fn project_workspace(
     let attention = agent_attention_projection::project_attention(std::slice::from_ref(workspace))
         .into_iter()
         .map(|item| WorkspaceAttentionView {
+            node_id: String::new(),
+            workspace_id: workspace.id.clone(),
             agent_id: item.agent.id,
             shell_id: item.agent.shell_id,
             agent_name: item.agent.name,
@@ -795,23 +822,36 @@ fn project_workspace(
             friendly_trigger: friendly_trigger(&schedule.trigger.cron),
         })
     });
+    let items = shells
+        .into_iter()
+        .chain(launchers)
+        .chain(schedules)
+        .collect::<Vec<_>>();
+    let node = local_node_placeholder();
     WorkspaceView {
-        node: local_node_placeholder(),
+        node: node.clone(),
         id: workspace.id.clone(),
         name: workspace.name.clone(),
         default_cwd: workspace
             .default_cwd
             .as_ref()
             .map(|cwd| cwd.display().to_string()),
-        items: shells
-            .into_iter()
-            .chain(launchers)
-            .chain(schedules)
-            .collect(),
+        item_owners: vec![
+            WorkspaceItemOwnerView {
+                node: node.clone(),
+                workspace_id: workspace.id.clone(),
+            };
+            items.len()
+        ],
+        items,
         sessions: session_views,
         agent_state_counts: agent_summary.states,
         attention_count: agent_summary.attention_count,
         attention,
+        coordination: WorkspaceCoordinationView::External {
+            owner_revision: workspace.revision,
+            available: true,
+        },
     }
 }
 

--- a/src/global_workspace_store.rs
+++ b/src/global_workspace_store.rs
@@ -1,0 +1,2944 @@
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::protocol::{
+    GlobalWorkspaceSnapshot, RoutedOperationResult, Snapshot, WorkspacePlacementSnapshot,
+    WorkspacePlacementState, WorkspaceSnapshot,
+};
+use crate::state_store::{effective_uid, secure_state_dir, state_directory_from_environment};
+
+const COORDINATOR_WORKSPACE_VERSION: u32 = 6;
+const MAX_STORE_BYTES: u64 = 1024 * 1024;
+const MAX_WORKSPACES: usize = 1_024;
+const MAX_PLACEMENTS: usize = 128;
+const MAX_PENDING_RESOURCES: usize = 1_024;
+const MAX_COMPLETED_OPERATIONS: usize = 256;
+const MAX_COMPLETION_RESERVATION_BYTES: usize = 768 * 1024;
+const COMPLETION_RESERVATION_OVERHEAD: usize = 64 * 1024;
+
+pub(crate) struct GlobalWorkspaceStore {
+    path: PathBuf,
+    state: Mutex<PersistedGlobalWorkspaces>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedGlobalWorkspaces {
+    version: u32,
+    local_migration_complete: bool,
+    workspaces: Vec<GlobalWorkspaceSnapshot>,
+    #[serde(default)]
+    pending_resources: Vec<PendingWorkspaceResource>,
+    #[serde(default)]
+    completed_operations: Vec<CompletedWorkspaceOperation>,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PendingResourceKind {
+    Shell,
+    Launcher,
+    AgentSchedule,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingWorkspaceResource {
+    #[serde(default)]
+    pub(crate) operation_id: String,
+    #[serde(default)]
+    pub(crate) creates_workspace: bool,
+    #[serde(default)]
+    pub(crate) request_fingerprint: Option<String>,
+    #[serde(default)]
+    pub(crate) semantic_fingerprint: Option<String>,
+    #[serde(default)]
+    completion_reservation: String,
+    #[serde(default)]
+    pub(crate) owner_attempted: bool,
+    pub(crate) global_workspace_id: String,
+    pub(crate) expected_global_revision: u64,
+    pub(crate) node_id: String,
+    #[serde(default)]
+    pub(crate) requested_owner_workspace_id: String,
+    pub(crate) owner_workspace_id: String,
+    pub(crate) owner_workspace_name: String,
+    pub(crate) default_cwd: Option<PathBuf>,
+    pub(crate) resource_id: String,
+    pub(crate) kind: PendingResourceKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CompletedWorkspaceOperation {
+    pub(crate) operation_id: String,
+    pub(crate) request_fingerprint: String,
+    #[serde(default)]
+    pub(crate) semantic_fingerprint: Option<String>,
+    #[serde(default)]
+    pub(crate) creates_workspace: bool,
+    pub(crate) workspace: GlobalWorkspaceSnapshot,
+    pub(crate) resource: RoutedOperationResult,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PreparedWorkspaceResource {
+    Pending {
+        pending: Box<PendingWorkspaceResource>,
+        newly_prepared: bool,
+    },
+    Completed(Box<CompletedWorkspaceOperation>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PreparedWorkspaceShell {
+    Pending {
+        workspace: GlobalWorkspaceSnapshot,
+        pending: Box<PendingWorkspaceResource>,
+    },
+    Completed(Box<CompletedWorkspaceOperation>),
+}
+
+impl GlobalWorkspaceStore {
+    pub(crate) fn load_from_environment() -> io::Result<Self> {
+        let path = state_directory_from_environment()?.join("global_workspaces.json");
+        Self::load_at(path)
+    }
+
+    fn load_at(path: PathBuf) -> io::Result<Self> {
+        let (state, migrated) = match load(&path) {
+            Ok(mut state) if (1..COORDINATOR_WORKSPACE_VERSION).contains(&state.version) => {
+                for pending in &mut state.pending_resources {
+                    if pending.operation_id.is_empty() {
+                        pending.operation_id.clone_from(&pending.resource_id);
+                    }
+                    if pending.requested_owner_workspace_id.is_empty() {
+                        pending
+                            .requested_owner_workspace_id
+                            .clone_from(&pending.owner_workspace_id);
+                    }
+                    // Older schemas cannot prove whether the owner request crossed
+                    // the transport boundary, so migration must retain recovery.
+                    pending.owner_attempted = true;
+                }
+                state.version = COORDINATOR_WORKSPACE_VERSION;
+                (state, true)
+            }
+            Ok(state) => (state, false),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => (
+                PersistedGlobalWorkspaces {
+                    version: COORDINATOR_WORKSPACE_VERSION,
+                    local_migration_complete: false,
+                    workspaces: Vec::new(),
+                    pending_resources: Vec::new(),
+                    completed_operations: Vec::new(),
+                },
+                false,
+            ),
+            Err(error) => return Err(error),
+        };
+        validate(&state)?;
+        if migrated {
+            save(&path, &state)?;
+        }
+        Ok(Self {
+            path,
+            state: Mutex::new(state),
+        })
+    }
+
+    pub(crate) fn initialize_local_once(
+        &self,
+        node_id: &str,
+        snapshot: &Snapshot,
+    ) -> io::Result<bool> {
+        let mut state = self.lock()?;
+        if state.local_migration_complete {
+            return Ok(false);
+        }
+        let mut replacement = state.clone();
+        for workspace in &snapshot.workspaces {
+            if replacement.workspaces.len() >= MAX_WORKSPACES {
+                return Err(invalid(
+                    "coordinator Workspace limit reached during migration",
+                ));
+            }
+            replacement.workspaces.push(GlobalWorkspaceSnapshot {
+                id: workspace.id.clone(),
+                revision: 1,
+                name: workspace.name.clone(),
+                closing: false,
+                placements: vec![placement(
+                    node_id,
+                    workspace,
+                    WorkspacePlacementState::Active,
+                )],
+            });
+        }
+        replacement.local_migration_complete = true;
+        validate(&replacement)?;
+        save(&self.path, &replacement)?;
+        *state = replacement;
+        Ok(true)
+    }
+
+    pub(crate) fn list(&self) -> io::Result<Vec<GlobalWorkspaceSnapshot>> {
+        let mut workspaces = self.lock()?.workspaces.clone();
+        workspaces.sort_by(|left, right| {
+            left.name
+                .cmp(&right.name)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        Ok(workspaces)
+    }
+
+    pub(crate) fn pending_resources(&self) -> io::Result<Vec<PendingWorkspaceResource>> {
+        Ok(self.lock()?.pending_resources.clone())
+    }
+
+    pub(crate) fn completed_operation(
+        &self,
+        operation_id: &str,
+        request_fingerprint: &str,
+    ) -> io::Result<Option<CompletedWorkspaceOperation>> {
+        let state = self.lock()?;
+        match state
+            .completed_operations
+            .iter()
+            .find(|completed| completed.operation_id == operation_id)
+        {
+            Some(completed) if completed.request_fingerprint == request_fingerprint => {
+                Ok(Some(completed.clone()))
+            }
+            Some(_) => Err(operation_conflict()),
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) fn get(&self, id: &str) -> io::Result<GlobalWorkspaceSnapshot> {
+        self.lock()?
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == id)
+            .cloned()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "global Workspace not found"))
+    }
+
+    pub(crate) fn create(&self, name: String) -> io::Result<GlobalWorkspaceSnapshot> {
+        validate_name(&name)?;
+        self.mutate(|state| {
+            if state
+                .workspaces
+                .iter()
+                .any(|workspace| workspace.name == name)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "global Workspace name already exists",
+                ));
+            }
+            if state.workspaces.len() >= MAX_WORKSPACES {
+                return Err(invalid("coordinator Workspace limit reached"));
+            }
+            let workspace = GlobalWorkspaceSnapshot {
+                id: Uuid::new_v4().to_string(),
+                revision: 1,
+                name,
+                closing: false,
+                placements: Vec::new(),
+            };
+            state.workspaces.push(workspace.clone());
+            Ok(workspace)
+        })
+    }
+
+    pub(crate) fn adopt(
+        &self,
+        node_id: &str,
+        owner: &WorkspaceSnapshot,
+        expected_revision: u64,
+    ) -> io::Result<GlobalWorkspaceSnapshot> {
+        require_revision(owner.revision, expected_revision, "owner Workspace")?;
+        self.mutate(|state| {
+            ensure_owner_unlinked(state, node_id, &owner.id)?;
+            if state
+                .workspaces
+                .iter()
+                .any(|workspace| workspace.name == owner.name)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "global Workspace name already exists; equal names are never merged",
+                ));
+            }
+            let workspace = GlobalWorkspaceSnapshot {
+                id: Uuid::new_v4().to_string(),
+                revision: 1,
+                name: owner.name.clone(),
+                closing: false,
+                placements: vec![placement(node_id, owner, WorkspacePlacementState::Active)],
+            };
+            state.workspaces.push(workspace.clone());
+            Ok(workspace)
+        })
+    }
+
+    pub(crate) fn link(
+        &self,
+        global_id: &str,
+        expected_global_revision: u64,
+        node_id: &str,
+        owner: &WorkspaceSnapshot,
+        expected_owner_revision: u64,
+    ) -> io::Result<GlobalWorkspaceSnapshot> {
+        require_revision(owner.revision, expected_owner_revision, "owner Workspace")?;
+        self.mutate(|state| {
+            ensure_owner_unlinked(state, node_id, &owner.id)?;
+            ensure_no_pending_resource(state, global_id)?;
+            let workspace = state
+                .workspaces
+                .iter_mut()
+                .find(|workspace| workspace.id == global_id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "global Workspace not found")
+                })?;
+            require_revision(
+                workspace.revision,
+                expected_global_revision,
+                "global Workspace",
+            )?;
+            if workspace.closing {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "global Workspace close is in progress",
+                ));
+            }
+            if workspace
+                .placements
+                .iter()
+                .any(|placement| placement.node_id == node_id)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "Workspace already has a placement on this Node",
+                ));
+            }
+            workspace.revision = next(workspace.revision)?;
+            workspace
+                .placements
+                .push(placement(node_id, owner, WorkspacePlacementState::Active));
+            workspace
+                .placements
+                .sort_by(|left, right| left.node_id.cmp(&right.node_id));
+            Ok(workspace.clone())
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn establish_placement(
+        &self,
+        global_id: &str,
+        expected_global_revision: u64,
+        node_id: &str,
+        owner: &WorkspaceSnapshot,
+    ) -> io::Result<GlobalWorkspaceSnapshot> {
+        self.mutate(|state| {
+            ensure_owner_unlinked_except(state, global_id, node_id, &owner.id)?;
+            let workspace = state
+                .workspaces
+                .iter_mut()
+                .find(|workspace| workspace.id == global_id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "global Workspace not found")
+                })?;
+            if let Some(existing) = workspace
+                .placements
+                .iter_mut()
+                .find(|placement| placement.node_id == node_id)
+            {
+                if existing.workspace_id != owner.id {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "Workspace already has a different placement on this Node",
+                    ));
+                }
+                existing.owner_workspace_name = Some(owner.name.clone());
+                existing.owner_revision = owner.revision;
+                existing.default_cwd.clone_from(&owner.default_cwd);
+                existing.state = WorkspacePlacementState::Active;
+                return Ok(workspace.clone());
+            }
+            require_revision(
+                workspace.revision,
+                expected_global_revision,
+                "global Workspace",
+            )?;
+            if workspace.closing {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "global Workspace close is in progress",
+                ));
+            }
+            workspace.revision = next(workspace.revision)?;
+            workspace
+                .placements
+                .push(placement(node_id, owner, WorkspacePlacementState::Active));
+            workspace
+                .placements
+                .sort_by(|left, right| left.node_id.cmp(&right.node_id));
+            Ok(workspace.clone())
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn prepare_resource(
+        &self,
+        global_id: &str,
+        operation_id: &str,
+        request_fingerprint: &str,
+        request_bytes: usize,
+        expected_global_revision: u64,
+        node_id: &str,
+        requested_owner_workspace_id: &str,
+        owner_workspace_name: &str,
+        default_cwd: Option<PathBuf>,
+        resource_id: &str,
+        kind: PendingResourceKind,
+    ) -> io::Result<PreparedWorkspaceResource> {
+        validate_name(owner_workspace_name)?;
+        self.mutate(|state| {
+            if let Some(completed) = state
+                .completed_operations
+                .iter()
+                .find(|completed| completed.operation_id == operation_id)
+            {
+                if completed.request_fingerprint != request_fingerprint {
+                    return Err(operation_conflict());
+                }
+                return Ok(PreparedWorkspaceResource::Completed(Box::new(
+                    completed.clone(),
+                )));
+            }
+            if let Some(index) = state
+                .pending_resources
+                .iter()
+                .position(|pending| pending.operation_id == operation_id)
+            {
+                let pending = &state.pending_resources[index];
+                if pending.global_workspace_id != global_id
+                    || pending.expected_global_revision != expected_global_revision
+                    || pending.node_id != node_id
+                    || pending.requested_owner_workspace_id != requested_owner_workspace_id
+                    || pending.owner_workspace_name != owner_workspace_name
+                    || pending.default_cwd != default_cwd
+                    || pending.resource_id != resource_id
+                    || pending.kind != kind
+                    || pending
+                        .request_fingerprint
+                        .as_deref()
+                        .is_some_and(|fingerprint| fingerprint != request_fingerprint)
+                {
+                    return Err(operation_conflict());
+                }
+                if state.pending_resources[index].request_fingerprint.is_none() {
+                    state.pending_resources[index].request_fingerprint =
+                        Some(request_fingerprint.to_owned());
+                }
+                if state.pending_resources[index]
+                    .completion_reservation
+                    .is_empty()
+                {
+                    let workspace = state
+                        .workspaces
+                        .iter()
+                        .find(|workspace| workspace.id == global_id)
+                        .ok_or_else(|| invalid("prepared Workspace is missing"))?;
+                    let projected = projected_workspace_with_pending(state, workspace, None)?;
+                    let reservation = completion_reservation_bytes(&projected, request_bytes)?;
+                    state.pending_resources[index].completion_reservation = " ".repeat(reservation);
+                    compact_prepared_state(state)?;
+                }
+                return Ok(PreparedWorkspaceResource::Pending {
+                    pending: Box::new(state.pending_resources[index].clone()),
+                    newly_prepared: false,
+                });
+            }
+            if state
+                .pending_resources
+                .iter()
+                .any(|pending| pending.node_id == node_id && pending.resource_id == resource_id)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "resource UUID is already reserved by another prepared operation",
+                ));
+            }
+            if state.pending_resources.len() >= MAX_PENDING_RESOURCES {
+                return Err(invalid("coordinator pending resource limit reached"));
+            }
+            let workspace = state
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.id == global_id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "global Workspace not found")
+                })?;
+            require_revision(
+                workspace.revision,
+                expected_global_revision,
+                "global Workspace",
+            )?;
+            if workspace.closing {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "global Workspace close is in progress",
+                ));
+            }
+            if let Some(placement) = workspace
+                .placements
+                .iter()
+                .find(|placement| placement.node_id == node_id)
+            {
+                ensure_owner_unlinked_except(state, global_id, node_id, &placement.workspace_id)?;
+            }
+            let prepared_owner = state.pending_resources.iter().find(|pending| {
+                pending.global_workspace_id == global_id && pending.node_id == node_id
+            });
+            let effective_owner_workspace_id = workspace
+                .placements
+                .iter()
+                .find(|placement| placement.node_id == node_id)
+                .map(|placement| placement.workspace_id.clone())
+                .or_else(|| prepared_owner.map(|pending| pending.owner_workspace_id.clone()))
+                .unwrap_or_else(|| requested_owner_workspace_id.to_owned());
+            ensure_owner_unlinked_except(state, global_id, node_id, &effective_owner_workspace_id)?;
+            let effective_owner_name = prepared_owner.map_or_else(
+                || owner_workspace_name.to_owned(),
+                |pending| pending.owner_workspace_name.clone(),
+            );
+            let effective_cwd =
+                prepared_owner.map_or(default_cwd, |pending| pending.default_cwd.clone());
+            let mut pending = PendingWorkspaceResource {
+                operation_id: operation_id.to_owned(),
+                creates_workspace: false,
+                request_fingerprint: Some(request_fingerprint.to_owned()),
+                semantic_fingerprint: None,
+                completion_reservation: String::new(),
+                owner_attempted: false,
+                global_workspace_id: global_id.to_owned(),
+                expected_global_revision,
+                node_id: node_id.to_owned(),
+                requested_owner_workspace_id: requested_owner_workspace_id.to_owned(),
+                owner_workspace_id: effective_owner_workspace_id,
+                owner_workspace_name: effective_owner_name,
+                default_cwd: effective_cwd,
+                resource_id: resource_id.to_owned(),
+                kind,
+            };
+            let workspace = workspace.clone();
+            reserve_new_pending_completion(state, &workspace, &mut pending, request_bytes)?;
+            state.pending_resources.push(pending.clone());
+            compact_prepared_state(state)?;
+            Ok(PreparedWorkspaceResource::Pending {
+                pending: Box::new(pending),
+                newly_prepared: true,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn prepare_workspace_shell(
+        &self,
+        operation_id: &str,
+        request_fingerprint: &str,
+        request_bytes: usize,
+        semantic_fingerprint: &str,
+        global_workspace_id: &str,
+        name: &str,
+        node_id: &str,
+        requested_owner_workspace_id: &str,
+        default_cwd: PathBuf,
+        shell_id: &str,
+    ) -> io::Result<PreparedWorkspaceShell> {
+        validate_name(name)?;
+        self.mutate(|state| {
+            if let Some(completed) = state
+                .completed_operations
+                .iter()
+                .find(|completed| completed.operation_id == operation_id)
+            {
+                if completed.request_fingerprint != request_fingerprint {
+                    return Err(operation_conflict());
+                }
+                return Ok(PreparedWorkspaceShell::Completed(Box::new(
+                    completed.clone(),
+                )));
+            }
+            if let Some(index) = state
+                .pending_resources
+                .iter()
+                .position(|pending| pending.operation_id == operation_id)
+            {
+                let pending = &state.pending_resources[index];
+                if !pending.creates_workspace
+                    || pending.global_workspace_id != global_workspace_id
+                    || pending.node_id != node_id
+                    || pending.requested_owner_workspace_id != requested_owner_workspace_id
+                    || pending.owner_workspace_name != name
+                    || pending.default_cwd.as_ref() != Some(&default_cwd)
+                    || pending.resource_id != shell_id
+                    || pending.kind != PendingResourceKind::Shell
+                    || pending
+                        .request_fingerprint
+                        .as_deref()
+                        .is_some_and(|fingerprint| fingerprint != request_fingerprint)
+                {
+                    return Err(operation_conflict());
+                }
+                if state.pending_resources[index].request_fingerprint.is_none() {
+                    state.pending_resources[index].request_fingerprint =
+                        Some(request_fingerprint.to_owned());
+                    state.pending_resources[index].semantic_fingerprint =
+                        Some(semantic_fingerprint.to_owned());
+                }
+                if state.pending_resources[index]
+                    .completion_reservation
+                    .is_empty()
+                {
+                    let workspace = state
+                        .workspaces
+                        .iter()
+                        .find(|workspace| workspace.id == global_workspace_id)
+                        .ok_or_else(|| invalid("prepared project Workspace is missing"))?;
+                    let projected = projected_workspace_with_pending(state, workspace, None)?;
+                    let reservation = completion_reservation_bytes(&projected, request_bytes)?;
+                    state.pending_resources[index].completion_reservation = " ".repeat(reservation);
+                    compact_prepared_state(state)?;
+                }
+                let pending = state.pending_resources[index].clone();
+                let workspace = state
+                    .workspaces
+                    .iter()
+                    .find(|workspace| workspace.id == pending.global_workspace_id)
+                    .cloned()
+                    .ok_or_else(|| invalid("prepared project Workspace is missing"))?;
+                return Ok(PreparedWorkspaceShell::Pending {
+                    workspace,
+                    pending: Box::new(pending),
+                });
+            }
+            if let Some(workspace) = state
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.name == name)
+                .cloned()
+            {
+                if let Some(completed) = state.completed_operations.iter().rev().find(|completed| {
+                    completed.creates_workspace
+                        && completed.workspace.id == workspace.id
+                        && completed.semantic_fingerprint.as_deref() == Some(semantic_fingerprint)
+                }) {
+                    let mut replay = completed.clone();
+                    replay.operation_id = operation_id.to_owned();
+                    replay.request_fingerprint = request_fingerprint.to_owned();
+                    push_completed(state, replay.clone())?;
+                    return Ok(PreparedWorkspaceShell::Completed(Box::new(replay)));
+                }
+                if let Some(existing_index) = state.pending_resources.iter().position(|pending| {
+                    pending.creates_workspace
+                        && pending.global_workspace_id == workspace.id
+                        && (pending.semantic_fingerprint.as_deref() == Some(semantic_fingerprint)
+                            || (pending.semantic_fingerprint.is_none()
+                                && pending.node_id == node_id
+                                && pending.owner_workspace_name == name
+                                && pending.default_cwd.as_ref() == Some(&default_cwd)))
+                        && pending.kind == PendingResourceKind::Shell
+                }) {
+                    if state.pending_resources.len() >= MAX_PENDING_RESOURCES {
+                        return Err(invalid("coordinator pending resource limit reached"));
+                    }
+                    if state.pending_resources[existing_index]
+                        .semantic_fingerprint
+                        .is_none()
+                    {
+                        state.pending_resources[existing_index].semantic_fingerprint =
+                            Some(semantic_fingerprint.to_owned());
+                    }
+                    let existing = state.pending_resources[existing_index].clone();
+                    let mut pending = PendingWorkspaceResource {
+                        operation_id: operation_id.to_owned(),
+                        creates_workspace: true,
+                        request_fingerprint: Some(request_fingerprint.to_owned()),
+                        semantic_fingerprint: Some(semantic_fingerprint.to_owned()),
+                        completion_reservation: String::new(),
+                        owner_attempted: false,
+                        global_workspace_id: existing.global_workspace_id,
+                        expected_global_revision: existing.expected_global_revision,
+                        node_id: existing.node_id,
+                        requested_owner_workspace_id: requested_owner_workspace_id.to_owned(),
+                        owner_workspace_id: existing.owner_workspace_id,
+                        owner_workspace_name: existing.owner_workspace_name,
+                        default_cwd: existing.default_cwd,
+                        resource_id: existing.resource_id,
+                        kind: PendingResourceKind::Shell,
+                    };
+                    reserve_new_pending_completion(state, &workspace, &mut pending, request_bytes)?;
+                    state.pending_resources.push(pending.clone());
+                    compact_prepared_state(state)?;
+                    return Ok(PreparedWorkspaceShell::Pending {
+                        workspace,
+                        pending: Box::new(pending),
+                    });
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "global Workspace name already exists",
+                ));
+            }
+            if state.workspaces.len() >= MAX_WORKSPACES
+                || state.pending_resources.len() >= MAX_PENDING_RESOURCES
+            {
+                return Err(invalid("coordinator Workspace preparation limit reached"));
+            }
+            if state
+                .workspaces
+                .iter()
+                .any(|workspace| workspace.id == global_workspace_id)
+                || state
+                    .pending_resources
+                    .iter()
+                    .any(|pending| pending.operation_id == operation_id)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "prepared project identity already exists",
+                ));
+            }
+            let workspace = GlobalWorkspaceSnapshot {
+                id: global_workspace_id.to_owned(),
+                revision: 1,
+                name: name.to_owned(),
+                closing: false,
+                placements: Vec::new(),
+            };
+            let mut pending = PendingWorkspaceResource {
+                operation_id: operation_id.to_owned(),
+                creates_workspace: true,
+                request_fingerprint: Some(request_fingerprint.to_owned()),
+                semantic_fingerprint: Some(semantic_fingerprint.to_owned()),
+                completion_reservation: String::new(),
+                owner_attempted: false,
+                global_workspace_id: global_workspace_id.to_owned(),
+                expected_global_revision: workspace.revision,
+                node_id: node_id.to_owned(),
+                requested_owner_workspace_id: requested_owner_workspace_id.to_owned(),
+                owner_workspace_id: requested_owner_workspace_id.to_owned(),
+                owner_workspace_name: name.to_owned(),
+                default_cwd: Some(default_cwd),
+                resource_id: shell_id.to_owned(),
+                kind: PendingResourceKind::Shell,
+            };
+            reserve_new_pending_completion(state, &workspace, &mut pending, request_bytes)?;
+            state.workspaces.push(workspace.clone());
+            state.pending_resources.push(pending.clone());
+            compact_prepared_state(state)?;
+            Ok(PreparedWorkspaceShell::Pending {
+                workspace,
+                pending: Box::new(pending),
+            })
+        })
+    }
+
+    pub(crate) fn cancel_resource(&self, pending: &PendingWorkspaceResource) -> io::Result<()> {
+        self.mutate(|state| {
+            let Some(index) = state
+                .pending_resources
+                .iter()
+                .position(|candidate| candidate.operation_id == pending.operation_id)
+            else {
+                if state.completed_operations.iter().any(|completed| {
+                    completed.operation_id == pending.operation_id
+                        && Some(completed.request_fingerprint.as_str())
+                            == pending.request_fingerprint.as_deref()
+                }) {
+                    return Ok(());
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "pending Workspace resource not found",
+                ));
+            };
+            if state.pending_resources[index].request_fingerprint != pending.request_fingerprint {
+                return Err(operation_conflict());
+            }
+            if state.pending_resources[index].creates_workspace
+                && state.pending_resources[index].owner_attempted
+            {
+                return Ok(());
+            }
+            remove_pending_at(state, index);
+            Ok(())
+        })
+    }
+
+    pub(crate) fn cancel_pending_operation_if_never_attempted(
+        &self,
+        operation_id: &str,
+        request_fingerprint: &str,
+    ) -> io::Result<bool> {
+        self.mutate(|state| {
+            let Some(index) = state
+                .pending_resources
+                .iter()
+                .position(|pending| pending.operation_id == operation_id)
+            else {
+                return Ok(false);
+            };
+            if state.pending_resources[index]
+                .request_fingerprint
+                .as_deref()
+                .is_some_and(|fingerprint| fingerprint != request_fingerprint)
+            {
+                return Err(operation_conflict());
+            }
+            if state.pending_resources[index].owner_attempted {
+                return Ok(false);
+            }
+            remove_pending_at(state, index);
+            Ok(true)
+        })
+    }
+
+    pub(crate) fn mark_owner_attempted(
+        &self,
+        pending: &PendingWorkspaceResource,
+    ) -> io::Result<PendingWorkspaceResource> {
+        self.mutate(|state| {
+            let index = state
+                .pending_resources
+                .iter()
+                .position(|candidate| candidate.operation_id == pending.operation_id)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "pending Workspace resource not found",
+                    )
+                })?;
+            if state.pending_resources[index].request_fingerprint != pending.request_fingerprint {
+                return Err(operation_conflict());
+            }
+            state.pending_resources[index].owner_attempted = true;
+            Ok(state.pending_resources[index].clone())
+        })
+    }
+
+    pub(crate) fn complete_resource(
+        &self,
+        pending: &PendingWorkspaceResource,
+        owner: &WorkspaceSnapshot,
+        resource: &RoutedOperationResult,
+    ) -> io::Result<CompletedWorkspaceOperation> {
+        self.mutate(|state| {
+            let Some(pending_index) = state
+                .pending_resources
+                .iter()
+                .position(|candidate| candidate.operation_id == pending.operation_id)
+            else {
+                let completed = state
+                    .completed_operations
+                    .iter()
+                    .find(|completed| {
+                        completed.operation_id == pending.operation_id
+                            && Some(completed.request_fingerprint.as_str())
+                                == pending.request_fingerprint.as_deref()
+                    })
+                    .cloned()
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::NotFound,
+                            "pending Workspace resource not found",
+                        )
+                    })?;
+                return Ok(completed);
+            };
+            if state.pending_resources[pending_index].request_fingerprint
+                != pending.request_fingerprint
+            {
+                return Err(operation_conflict());
+            }
+            let pending = state.pending_resources[pending_index].clone();
+            if owner.id != pending.owner_workspace_id
+                || owner.name != pending.owner_workspace_name
+                || owner.default_cwd != pending.default_cwd
+            {
+                return Err(invalid(
+                    "owner Workspace metadata does not match the prepared operation",
+                ));
+            }
+            ensure_owner_unlinked_except(
+                state,
+                &pending.global_workspace_id,
+                &pending.node_id,
+                &owner.id,
+            )?;
+            let workspace = state
+                .workspaces
+                .iter_mut()
+                .find(|workspace| workspace.id == pending.global_workspace_id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "global Workspace not found")
+                })?;
+            if let Some(existing) = workspace
+                .placements
+                .iter_mut()
+                .find(|placement| placement.node_id == pending.node_id)
+            {
+                if existing.workspace_id != owner.id {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "Workspace already has a different placement on this Node",
+                    ));
+                }
+                existing.owner_workspace_name = Some(owner.name.clone());
+                existing.owner_revision = owner.revision;
+                existing.default_cwd.clone_from(&owner.default_cwd);
+                existing.state = WorkspacePlacementState::Active;
+            } else {
+                workspace.revision = next(workspace.revision)?;
+                workspace.placements.push(placement(
+                    &pending.node_id,
+                    owner,
+                    WorkspacePlacementState::Active,
+                ));
+                workspace
+                    .placements
+                    .sort_by(|left, right| left.node_id.cmp(&right.node_id));
+            }
+            let result = workspace.clone();
+            let completed = CompletedWorkspaceOperation {
+                operation_id: pending.operation_id.clone(),
+                request_fingerprint: pending.request_fingerprint.clone().ok_or_else(|| {
+                    invalid("legacy prepared operation has no request fingerprint")
+                })?,
+                semantic_fingerprint: pending.semantic_fingerprint.clone(),
+                creates_workspace: pending.creates_workspace,
+                workspace: result,
+                resource: resource.clone(),
+            };
+            let completed_bytes = serde_json::to_vec(&completed)
+                .map_err(io::Error::other)?
+                .len();
+            if !pending.completion_reservation.is_empty()
+                && completed_bytes > pending.completion_reservation.len()
+            {
+                return Err(invalid(
+                    "completed Workspace operation exceeded its prepared capacity reservation",
+                ));
+            }
+            state.pending_resources.remove(pending_index);
+            push_completed(state, completed.clone())?;
+            Ok(completed)
+        })
+    }
+
+    pub(crate) fn reconcile_resource(
+        &self,
+        pending: &PendingWorkspaceResource,
+        observed: Option<(&WorkspaceSnapshot, &RoutedOperationResult)>,
+    ) -> io::Result<Option<CompletedWorkspaceOperation>> {
+        match observed {
+            Some((owner, resource)) => self.complete_resource(pending, owner, resource).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) fn rename(
+        &self,
+        id: &str,
+        expected_revision: u64,
+        name: String,
+    ) -> io::Result<GlobalWorkspaceSnapshot> {
+        validate_name(&name)?;
+        self.mutate(|state| {
+            ensure_no_pending_resource(state, id)?;
+            if state
+                .workspaces
+                .iter()
+                .any(|workspace| workspace.id != id && workspace.name == name)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "global Workspace name already exists",
+                ));
+            }
+            let workspace = state
+                .workspaces
+                .iter_mut()
+                .find(|workspace| workspace.id == id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "global Workspace not found")
+                })?;
+            require_revision(workspace.revision, expected_revision, "global Workspace")?;
+            if workspace.closing {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "global Workspace close is in progress",
+                ));
+            }
+            if workspace.name != name {
+                workspace.name = name;
+                workspace.revision = next(workspace.revision)?;
+            }
+            Ok(workspace.clone())
+        })
+    }
+
+    pub(crate) fn begin_close(
+        &self,
+        id: &str,
+        expected_revision: u64,
+    ) -> io::Result<GlobalWorkspaceSnapshot> {
+        self.mutate(|state| {
+            ensure_no_pending_resource(state, id)?;
+            let workspace = state
+                .workspaces
+                .iter_mut()
+                .find(|workspace| workspace.id == id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "global Workspace not found")
+                })?;
+            require_revision(workspace.revision, expected_revision, "global Workspace")?;
+            if !workspace.closing {
+                workspace.revision = next(workspace.revision)?;
+                workspace.closing = true;
+                for placement in &mut workspace.placements {
+                    placement.state = WorkspacePlacementState::ClosePending;
+                }
+            }
+            Ok(workspace.clone())
+        })
+    }
+
+    pub(crate) fn confirm_closed(
+        &self,
+        id: &str,
+        node_id: &str,
+        owner_id: &str,
+    ) -> io::Result<Option<GlobalWorkspaceSnapshot>> {
+        self.mutate(|state| {
+            let index = state
+                .workspaces
+                .iter()
+                .position(|workspace| workspace.id == id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "global Workspace not found")
+                })?;
+            let workspace = &mut state.workspaces[index];
+            if !workspace.closing {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "global Workspace is not closing",
+                ));
+            }
+            workspace.placements.retain(|placement| {
+                !(placement.node_id == node_id && placement.workspace_id == owner_id)
+            });
+            if workspace.placements.is_empty() {
+                state.workspaces.remove(index);
+                return Ok(None);
+            }
+            workspace.revision = next(workspace.revision)?;
+            Ok(Some(workspace.clone()))
+        })
+    }
+
+    pub(crate) fn confirm_empty_closed(&self, id: &str) -> io::Result<()> {
+        self.mutate(|state| {
+            let index = state
+                .workspaces
+                .iter()
+                .position(|workspace| workspace.id == id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "global Workspace not found")
+                })?;
+            let workspace = &state.workspaces[index];
+            if !workspace.closing || !workspace.placements.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "global Workspace still has unresolved placements",
+                ));
+            }
+            state.workspaces.remove(index);
+            Ok(())
+        })
+    }
+
+    fn mutate<T>(
+        &self,
+        operation: impl FnOnce(&mut PersistedGlobalWorkspaces) -> io::Result<T>,
+    ) -> io::Result<T> {
+        let mut state = self.lock()?;
+        let mut replacement = state.clone();
+        let result = operation(&mut replacement)?;
+        validate(&replacement)?;
+        save(&self.path, &replacement)?;
+        *state = replacement;
+        Ok(result)
+    }
+
+    fn lock(&self) -> io::Result<std::sync::MutexGuard<'_, PersistedGlobalWorkspaces>> {
+        self.state
+            .lock()
+            .map_err(|_| io::Error::other("global Workspace store lock is poisoned"))
+    }
+}
+
+fn placement(
+    node_id: &str,
+    workspace: &WorkspaceSnapshot,
+    state: WorkspacePlacementState,
+) -> WorkspacePlacementSnapshot {
+    WorkspacePlacementSnapshot {
+        node_id: node_id.to_owned(),
+        workspace_id: workspace.id.clone(),
+        owner_workspace_name: Some(workspace.name.clone()),
+        owner_revision: workspace.revision,
+        default_cwd: workspace.default_cwd.clone(),
+        state,
+    }
+}
+
+fn ensure_owner_unlinked(
+    state: &PersistedGlobalWorkspaces,
+    node_id: &str,
+    owner_id: &str,
+) -> io::Result<()> {
+    if state
+        .workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.placements)
+        .any(|placement| placement.node_id == node_id && placement.workspace_id == owner_id)
+    {
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "Node-local Workspace is already linked",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn ensure_owner_unlinked_except(
+    state: &PersistedGlobalWorkspaces,
+    global_id: &str,
+    node_id: &str,
+    owner_id: &str,
+) -> io::Result<()> {
+    if state
+        .workspaces
+        .iter()
+        .filter(|workspace| workspace.id != global_id)
+        .flat_map(|workspace| &workspace.placements)
+        .any(|placement| placement.node_id == node_id && placement.workspace_id == owner_id)
+    {
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "Node-local Workspace is already linked",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn ensure_no_pending_resource(
+    state: &PersistedGlobalWorkspaces,
+    global_id: &str,
+) -> io::Result<()> {
+    if state
+        .pending_resources
+        .iter()
+        .any(|pending| pending.global_workspace_id == global_id)
+    {
+        Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "global Workspace resource recovery is pending",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn remove_pending_at(state: &mut PersistedGlobalWorkspaces, index: usize) {
+    let pending = state.pending_resources.remove(index);
+    if pending.creates_workspace
+        && let Some(workspace_index) = state.workspaces.iter().position(|workspace| {
+            workspace.id == pending.global_workspace_id && workspace.placements.is_empty()
+        })
+        && !state
+            .pending_resources
+            .iter()
+            .any(|candidate| candidate.global_workspace_id == pending.global_workspace_id)
+    {
+        state.workspaces.remove(workspace_index);
+    }
+}
+
+fn push_completed(
+    state: &mut PersistedGlobalWorkspaces,
+    completed: CompletedWorkspaceOperation,
+) -> io::Result<()> {
+    if let Some(existing) = state
+        .completed_operations
+        .iter()
+        .find(|existing| existing.operation_id == completed.operation_id)
+    {
+        return if existing == &completed {
+            Ok(())
+        } else {
+            Err(operation_conflict())
+        };
+    }
+    state.completed_operations.push(completed);
+    while state.completed_operations.len() > MAX_COMPLETED_OPERATIONS
+        || serde_json::to_vec_pretty(state).is_ok_and(|bytes| bytes.len() as u64 > MAX_STORE_BYTES)
+    {
+        if state.completed_operations.len() == 1 {
+            return Err(invalid(
+                "completed Workspace operation exceeds the coordinator store limit",
+            ));
+        }
+        state.completed_operations.remove(0);
+    }
+    Ok(())
+}
+
+fn completion_reservation_bytes(
+    workspace: &GlobalWorkspaceSnapshot,
+    request_bytes: usize,
+) -> io::Result<usize> {
+    let workspace_bytes = serde_json::to_vec(workspace)
+        .map_err(io::Error::other)?
+        .len();
+    let reservation = request_bytes
+        .checked_mul(2)
+        .and_then(|bytes| bytes.checked_add(workspace_bytes.saturating_mul(2)))
+        .and_then(|bytes| bytes.checked_add(COMPLETION_RESERVATION_OVERHEAD))
+        .ok_or_else(|| invalid("completed Workspace operation capacity overflow"))?;
+    if reservation > MAX_COMPLETION_RESERVATION_BYTES {
+        return Err(invalid(
+            "Workspace resource request is too large for durable completion replay",
+        ));
+    }
+    Ok(reservation)
+}
+
+fn projected_completed_workspace(
+    workspace: &GlobalWorkspaceSnapshot,
+    pending: &PendingWorkspaceResource,
+) -> io::Result<GlobalWorkspaceSnapshot> {
+    let mut projected = workspace.clone();
+    if let Some(placement) = projected
+        .placements
+        .iter_mut()
+        .find(|placement| placement.node_id == pending.node_id)
+    {
+        placement
+            .workspace_id
+            .clone_from(&pending.owner_workspace_id);
+        placement.owner_workspace_name = Some(pending.owner_workspace_name.clone());
+        placement.owner_revision = u64::MAX;
+        placement.default_cwd.clone_from(&pending.default_cwd);
+        placement.state = WorkspacePlacementState::Active;
+    } else {
+        projected.revision = next(projected.revision)?;
+        projected.placements.push(WorkspacePlacementSnapshot {
+            node_id: pending.node_id.clone(),
+            workspace_id: pending.owner_workspace_id.clone(),
+            owner_workspace_name: Some(pending.owner_workspace_name.clone()),
+            owner_revision: u64::MAX,
+            default_cwd: pending.default_cwd.clone(),
+            state: WorkspacePlacementState::Active,
+        });
+        projected
+            .placements
+            .sort_by(|left, right| left.node_id.cmp(&right.node_id));
+    }
+    Ok(projected)
+}
+
+fn projected_workspace_with_pending(
+    state: &PersistedGlobalWorkspaces,
+    workspace: &GlobalWorkspaceSnapshot,
+    additional: Option<&PendingWorkspaceResource>,
+) -> io::Result<GlobalWorkspaceSnapshot> {
+    let mut projected = workspace.clone();
+    for pending in state
+        .pending_resources
+        .iter()
+        .filter(|pending| pending.global_workspace_id == workspace.id)
+        .chain(additional)
+    {
+        projected = projected_completed_workspace(&projected, pending)?;
+    }
+    Ok(projected)
+}
+
+fn reserve_new_pending_completion(
+    state: &mut PersistedGlobalWorkspaces,
+    workspace: &GlobalWorkspaceSnapshot,
+    pending: &mut PendingWorkspaceResource,
+    request_bytes: usize,
+) -> io::Result<()> {
+    let before = projected_workspace_with_pending(state, workspace, None)?;
+    let after = projected_completed_workspace(&before, pending)?;
+    let before_bytes = serde_json::to_vec(&before).map_err(io::Error::other)?.len();
+    let after_bytes = serde_json::to_vec(&after).map_err(io::Error::other)?.len();
+    let growth = after_bytes.saturating_sub(before_bytes).saturating_mul(2);
+    if growth > 0 {
+        for existing in state
+            .pending_resources
+            .iter_mut()
+            .filter(|existing| existing.global_workspace_id == workspace.id)
+        {
+            if existing.completion_reservation.is_empty() {
+                return Err(invalid(
+                    "legacy pending Workspace operation must reserve completion capacity before another placement is prepared",
+                ));
+            }
+            let expanded = existing
+                .completion_reservation
+                .len()
+                .checked_add(growth)
+                .ok_or_else(|| invalid("completed Workspace operation capacity overflow"))?;
+            if expanded > MAX_COMPLETION_RESERVATION_BYTES {
+                return Err(invalid(
+                    "Workspace placement growth exceeds durable completion replay capacity",
+                ));
+            }
+            existing
+                .completion_reservation
+                .push_str(&" ".repeat(growth));
+        }
+    }
+    pending.completion_reservation =
+        " ".repeat(completion_reservation_bytes(&after, request_bytes)?);
+    Ok(())
+}
+
+fn compact_prepared_state(state: &mut PersistedGlobalWorkspaces) -> io::Result<()> {
+    while serde_json::to_vec_pretty(state)
+        .map_err(io::Error::other)?
+        .len() as u64
+        > MAX_STORE_BYTES
+    {
+        if state.completed_operations.is_empty() {
+            return Err(invalid(
+                "coordinator store has insufficient capacity to reserve the completed Workspace operation",
+            ));
+        }
+        state.completed_operations.remove(0);
+    }
+    Ok(())
+}
+
+fn operation_conflict() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "prepared operation identity exists with a different request fingerprint",
+    )
+}
+
+fn require_revision(actual: u64, expected: u64, label: &str) -> io::Result<()> {
+    if actual == expected && expected > 0 {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{label} revision changed: expected {expected}, current {actual}"),
+        ))
+    }
+}
+
+fn next(revision: u64) -> io::Result<u64> {
+    revision
+        .checked_add(1)
+        .ok_or_else(|| io::Error::other("global Workspace revision exhausted"))
+}
+
+fn validate_name(name: &str) -> io::Result<()> {
+    if name.is_empty() || name.len() > 256 || name.chars().any(char::is_control) {
+        Err(invalid("global Workspace name is invalid"))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate(state: &PersistedGlobalWorkspaces) -> io::Result<()> {
+    if state.version != COORDINATOR_WORKSPACE_VERSION
+        || state.workspaces.len() > MAX_WORKSPACES
+        || state.pending_resources.len() > MAX_PENDING_RESOURCES
+        || state.completed_operations.len() > MAX_COMPLETED_OPERATIONS
+    {
+        return Err(invalid("unsupported or oversized global Workspace store"));
+    }
+    let mut ids = HashSet::new();
+    let mut names = HashSet::new();
+    let mut owners = HashSet::new();
+    for workspace in &state.workspaces {
+        validate_name(&workspace.name)?;
+        if Uuid::parse_str(&workspace.id).is_err()
+            || workspace.revision == 0
+            || workspace.placements.len() > MAX_PLACEMENTS
+            || !ids.insert(&workspace.id)
+            || !names.insert(&workspace.name)
+        {
+            return Err(invalid(
+                "global Workspace store contains invalid or duplicate metadata",
+            ));
+        }
+        for placement in &workspace.placements {
+            if Uuid::parse_str(&placement.node_id).is_err()
+                || placement.workspace_id.is_empty()
+                || !owners.insert((&placement.node_id, &placement.workspace_id))
+            {
+                return Err(invalid(
+                    "global Workspace store contains an invalid or duplicate placement",
+                ));
+            }
+            if workspace.closing != (placement.state == WorkspacePlacementState::ClosePending) {
+                return Err(invalid("global Workspace close progress is inconsistent"));
+            }
+        }
+    }
+    let mut pending = HashSet::new();
+    for operation in &state.pending_resources {
+        if Uuid::parse_str(&operation.global_workspace_id).is_err()
+            || Uuid::parse_str(&operation.operation_id).is_err()
+            || Uuid::parse_str(&operation.node_id).is_err()
+            || Uuid::parse_str(&operation.requested_owner_workspace_id).is_err()
+            || Uuid::parse_str(&operation.owner_workspace_id).is_err()
+            || Uuid::parse_str(&operation.resource_id).is_err()
+            || operation.expected_global_revision == 0
+            || !ids.contains(&operation.global_workspace_id)
+            || !pending.insert(&operation.operation_id)
+            || operation
+                .request_fingerprint
+                .as_deref()
+                .is_some_and(|fingerprint| !valid_fingerprint(fingerprint))
+            || operation
+                .semantic_fingerprint
+                .as_deref()
+                .is_some_and(|fingerprint| !valid_fingerprint(fingerprint))
+            || operation.completion_reservation.len() > MAX_COMPLETION_RESERVATION_BYTES
+            || operation
+                .completion_reservation
+                .bytes()
+                .any(|byte| byte != b' ')
+            || (!operation.completion_reservation.is_empty()
+                && operation.request_fingerprint.is_none())
+        {
+            return Err(invalid("global Workspace pending resource is invalid"));
+        }
+        validate_name(&operation.owner_workspace_name)?;
+    }
+    let mut completed = HashSet::new();
+    for operation in &state.completed_operations {
+        let resource_workspace_id = match &operation.resource {
+            RoutedOperationResult::Shell { shell } => &shell.workspace_id,
+            RoutedOperationResult::Launcher { launcher } => &launcher.workspace_id,
+            RoutedOperationResult::AgentSchedule { schedule } => &schedule.workspace_id,
+            _ => {
+                return Err(invalid(
+                    "completed Workspace operation has an invalid result",
+                ));
+            }
+        };
+        if Uuid::parse_str(&operation.operation_id).is_err()
+            || !valid_fingerprint(&operation.request_fingerprint)
+            || operation
+                .semantic_fingerprint
+                .as_deref()
+                .is_some_and(|fingerprint| !valid_fingerprint(fingerprint))
+            || Uuid::parse_str(&operation.workspace.id).is_err()
+            || operation.workspace.revision == 0
+            || operation.workspace.placements.len() > MAX_PLACEMENTS
+            || !operation
+                .workspace
+                .placements
+                .iter()
+                .any(|placement| placement.workspace_id == *resource_workspace_id)
+            || !completed.insert(&operation.operation_id)
+            || pending.contains(&operation.operation_id)
+        {
+            return Err(invalid("completed Workspace operation is invalid"));
+        }
+    }
+    Ok(())
+}
+
+fn valid_fingerprint(fingerprint: &str) -> bool {
+    fingerprint.len() == 64
+        && fingerprint
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn load(path: &Path) -> io::Result<PersistedGlobalWorkspaces> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.uid() != effective_uid() || metadata.mode() & 0o077 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "global Workspace store is not an owner-only regular file",
+        ));
+    }
+    if metadata.len() > MAX_STORE_BYTES {
+        return Err(invalid("global Workspace store exceeds the size limit"));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.read_to_end(&mut bytes)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|error| invalid(format!("could not parse global Workspace store: {error}")))
+}
+
+fn save(path: &Path, state: &PersistedGlobalWorkspaces) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("global Workspace path has no parent"))?;
+    secure_state_dir(parent)?;
+    let bytes = serde_json::to_vec_pretty(state).map_err(io::Error::other)?;
+    if bytes.len() as u64 > MAX_STORE_BYTES {
+        return Err(invalid("global Workspace store exceeds the size limit"));
+    }
+    let temporary = parent.join(format!(".global-workspaces-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)?;
+        let _ = File::open(parent).and_then(|directory| directory.sync_all());
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn invalid(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{
+        SchedulerHealth, SchedulerState, ShellOwner, ShellSnapshot, ShellStatus,
+    };
+    use std::os::unix::fs::PermissionsExt;
+
+    fn snapshot(id: &str, name: &str, revision: u64) -> WorkspaceSnapshot {
+        WorkspaceSnapshot {
+            id: id.into(),
+            revision,
+            name: name.into(),
+            default_cwd: Some("/owner/project".into()),
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: Vec::new(),
+            schedules: Vec::new(),
+        }
+    }
+
+    fn daemon_snapshot(workspaces: Vec<WorkspaceSnapshot>) -> Snapshot {
+        Snapshot {
+            workspaces,
+            focused_terminal: None,
+            scheduler: Some(SchedulerHealth {
+                state: SchedulerState::Active,
+                max_concurrent: 4,
+                active_executions: 0,
+            }),
+        }
+    }
+
+    fn fingerprint(value: u128) -> String {
+        format!("{value:064x}")
+    }
+
+    fn shell_result(id: &str, workspace_id: &str) -> RoutedOperationResult {
+        RoutedOperationResult::Shell {
+            shell: ShellSnapshot {
+                id: id.into(),
+                revision: 1,
+                workspace_id: workspace_id.into(),
+                name: "shell".into(),
+                cwd: "/owner/project".into(),
+                command: Vec::new(),
+                owner: ShellOwner::User,
+                status: ShellStatus::Pending,
+                run: None,
+                foreground_process: None,
+            },
+        }
+    }
+
+    #[test]
+    fn legacy_local_workspaces_initialize_once_with_local_placements() {
+        let root =
+            std::env::temp_dir().join(format!("boomux-global-workspaces-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        let node = Uuid::from_u128(1).to_string();
+        let owner = Uuid::from_u128(2).to_string();
+        assert!(
+            store
+                .initialize_local_once(&node, &daemon_snapshot(vec![snapshot(&owner, "local", 7)]))
+                .unwrap()
+        );
+        assert!(
+            !store
+                .initialize_local_once(&node, &daemon_snapshot(vec![snapshot("later", "later", 1)]))
+                .unwrap()
+        );
+        let workspace = &store.list().unwrap()[0];
+        assert_eq!(workspace.id, owner);
+        assert_eq!(workspace.placements[0].node_id, node);
+        drop(store);
+        assert_eq!(
+            GlobalWorkspaceStore::load_at(path)
+                .unwrap()
+                .list()
+                .unwrap()
+                .len(),
+            1
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn equal_names_never_merge_and_link_guards_both_authorities() {
+        let root = std::env::temp_dir().join(format!("boomux-global-link-{}", Uuid::new_v4()));
+        let store =
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap();
+        let local = Uuid::from_u128(1).to_string();
+        let remote = Uuid::from_u128(2).to_string();
+        let local_owner = snapshot(&Uuid::from_u128(3).to_string(), "same", 3);
+        store
+            .initialize_local_once(&local, &daemon_snapshot(vec![local_owner]))
+            .unwrap();
+        let remote_owner = snapshot(&Uuid::from_u128(4).to_string(), "same", 5);
+        assert_eq!(
+            store.adopt(&remote, &remote_owner, 5).unwrap_err().kind(),
+            io::ErrorKind::AlreadyExists
+        );
+        let global = store.list().unwrap().remove(0);
+        assert_eq!(
+            store
+                .link(&global.id, global.revision + 1, &remote, &remote_owner, 5)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        let linked = store
+            .link(&global.id, global.revision, &remote, &remote_owner, 5)
+            .unwrap();
+        assert_eq!(linked.placements.len(), 2);
+        assert!(
+            store
+                .link(&global.id, linked.revision, &remote, &remote_owner, 5)
+                .is_err()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn close_progress_survives_restart_until_every_owner_confirms() {
+        let root = std::env::temp_dir().join(format!("boomux-global-close-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let local = Uuid::from_u128(1).to_string();
+        let remote = Uuid::from_u128(2).to_string();
+        let first = snapshot(&Uuid::from_u128(3).to_string(), "work", 1);
+        let second = snapshot(&Uuid::from_u128(4).to_string(), "external", 1);
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        store
+            .initialize_local_once(&local, &daemon_snapshot(vec![first.clone()]))
+            .unwrap();
+        let global = store.list().unwrap().remove(0);
+        let linked = store
+            .link(&global.id, global.revision, &remote, &second, 1)
+            .unwrap();
+        let _closing = store.begin_close(&global.id, linked.revision).unwrap();
+        store.confirm_closed(&global.id, &local, &first.id).unwrap();
+        drop(store);
+        let restored = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        let unresolved = restored.get(&global.id).unwrap();
+        assert!(unresolved.closing);
+        assert_eq!(unresolved.placements.len(), 1);
+        assert!(
+            restored
+                .confirm_closed(&global.id, &remote, &second.id)
+                .unwrap()
+                .is_none()
+        );
+        assert!(restored.list().unwrap().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn empty_close_is_removed_only_after_close_begins() {
+        let root =
+            std::env::temp_dir().join(format!("boomux-global-empty-close-{}", Uuid::new_v4()));
+        let store =
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap();
+        let global = store.create("empty".into()).unwrap();
+        assert!(store.confirm_empty_closed(&global.id).is_err());
+        let closing = store.begin_close(&global.id, global.revision).unwrap();
+        assert!(closing.closing);
+        store.confirm_empty_closed(&global.id).unwrap();
+        assert!(store.list().unwrap().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn first_placement_is_revision_guarded_and_exact_replay_is_idempotent() {
+        let root = std::env::temp_dir().join(format!("boomux-global-establish-{}", Uuid::new_v4()));
+        let store =
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let global = store.create("work".into()).unwrap();
+        let node = Uuid::from_u128(2).to_string();
+        let owner = snapshot(&Uuid::from_u128(3).to_string(), "work", 2);
+        assert!(
+            store
+                .establish_placement(&global.id, global.revision + 1, &node, &owner)
+                .is_err()
+        );
+        let established = store
+            .establish_placement(&global.id, global.revision, &node, &owner)
+            .unwrap();
+        assert_eq!(established.placements.len(), 1);
+        let mut replay = owner.clone();
+        replay.revision = 3;
+        let replayed = store
+            .establish_placement(&global.id, global.revision, &node, &replay)
+            .unwrap();
+        assert_eq!(replayed.revision, established.revision);
+        assert_eq!(replayed.placements[0].owner_revision, 3);
+        let collision = snapshot(&Uuid::from_u128(4).to_string(), "work", 1);
+        assert_eq!(
+            store
+                .establish_placement(&global.id, replayed.revision, &node, &collision)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::AlreadyExists
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn schema_one_is_migrated_explicitly_and_owner_name_is_learned_later() {
+        let root = std::env::temp_dir().join(format!("boomux-global-v1-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        secure_state_dir(path.parent().unwrap()).unwrap();
+        let global_id = Uuid::from_u128(1).to_string();
+        let node_id = Uuid::from_u128(2).to_string();
+        let owner_id = Uuid::from_u128(3).to_string();
+        fs::write(
+            &path,
+            serde_json::to_vec(&serde_json::json!({
+                "version": 1,
+                "local_migration_complete": true,
+                "workspaces": [{
+                    "id": global_id,
+                    "revision": 1,
+                    "name": "global",
+                    "closing": false,
+                    "placements": [{
+                        "node_id": node_id,
+                        "workspace_id": owner_id,
+                        "owner_revision": 4,
+                        "default_cwd": "/owner/project",
+                        "state": "active"
+                    }]
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        let workspace = store.get(&global_id).unwrap();
+        assert_eq!(workspace.placements[0].owner_workspace_name, None);
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(persisted["version"], 6);
+        assert_eq!(persisted["pending_resources"], serde_json::json!([]));
+        assert_eq!(persisted["completed_operations"], serde_json::json!([]));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn schema_two_pending_resource_migrates_to_exact_operation_identity() {
+        let root = std::env::temp_dir().join(format!("boomux-global-v2-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        secure_state_dir(path.parent().unwrap()).unwrap();
+        let global_id = Uuid::from_u128(1).to_string();
+        let node_id = Uuid::from_u128(2).to_string();
+        let owner_id = Uuid::from_u128(3).to_string();
+        let resource_id = Uuid::from_u128(4).to_string();
+        fs::write(
+            &path,
+            serde_json::to_vec(&serde_json::json!({
+                "version": 2,
+                "local_migration_complete": true,
+                "workspaces": [{
+                    "id": global_id,
+                    "revision": 1,
+                    "name": "pending",
+                    "closing": false,
+                    "placements": []
+                }],
+                "pending_resources": [{
+                    "global_workspace_id": global_id,
+                    "expected_global_revision": 1,
+                    "node_id": node_id,
+                    "owner_workspace_id": owner_id,
+                    "owner_workspace_name": "pending",
+                    "default_cwd": "/owner/project",
+                    "resource_id": resource_id,
+                    "kind": "shell"
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        let pending = store.pending_resources().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].operation_id, resource_id);
+        assert!(!pending[0].creates_workspace);
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(persisted["version"], 6);
+        assert_eq!(
+            persisted["pending_resources"][0]["operation_id"],
+            resource_id
+        );
+        assert_eq!(pending[0].requested_owner_workspace_id, owner_id);
+        assert!(pending[0].owner_attempted);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn schema_three_pending_resource_migrates_requested_owner_and_empty_ledger() {
+        let root = std::env::temp_dir().join(format!("boomux-global-v3-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        secure_state_dir(path.parent().unwrap()).unwrap();
+        let global_id = Uuid::from_u128(1).to_string();
+        let node_id = Uuid::from_u128(2).to_string();
+        let owner_id = Uuid::from_u128(3).to_string();
+        let resource_id = Uuid::from_u128(4).to_string();
+        let operation_id = Uuid::from_u128(5).to_string();
+        fs::write(
+            &path,
+            serde_json::to_vec(&serde_json::json!({
+                "version": 3,
+                "local_migration_complete": true,
+                "workspaces": [{
+                    "id": global_id,
+                    "revision": 1,
+                    "name": "pending",
+                    "closing": false,
+                    "placements": []
+                }],
+                "pending_resources": [{
+                    "operation_id": operation_id,
+                    "creates_workspace": false,
+                    "global_workspace_id": global_id,
+                    "expected_global_revision": 1,
+                    "node_id": node_id,
+                    "owner_workspace_id": owner_id,
+                    "owner_workspace_name": "pending",
+                    "default_cwd": "/owner/project",
+                    "resource_id": resource_id,
+                    "kind": "shell"
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        let pending = store.pending_resources().unwrap().remove(0);
+        assert_eq!(pending.requested_owner_workspace_id, owner_id);
+        assert_eq!(pending.request_fingerprint, None);
+        assert!(pending.owner_attempted);
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(persisted["version"], 6);
+        assert_eq!(persisted["completed_operations"], serde_json::json!([]));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn prepared_resource_survives_restart_and_global_rename_keeps_owner_name() {
+        let root = std::env::temp_dir().join(format!("boomux-global-pending-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let node = Uuid::from_u128(1).to_string();
+        let owner = snapshot(&Uuid::from_u128(2).to_string(), "owner-local", 3);
+        let resource = Uuid::from_u128(3).to_string();
+        let operation = Uuid::from_u128(4).to_string();
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        store
+            .initialize_local_once(&node, &daemon_snapshot(vec![owner.clone()]))
+            .unwrap();
+        let global = store.list().unwrap().remove(0);
+        let renamed = store
+            .rename(&global.id, global.revision, "coordinator-name".into())
+            .unwrap();
+        let prepared = store
+            .prepare_resource(
+                &renamed.id,
+                &operation,
+                &fingerprint(1),
+                1024,
+                renamed.revision,
+                &node,
+                &owner.id,
+                &owner.name,
+                owner.default_cwd.clone(),
+                &resource,
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending {
+            pending,
+            newly_prepared,
+        } = prepared
+        else {
+            panic!("expected pending operation");
+        };
+        assert!(newly_prepared);
+        assert_eq!(
+            store
+                .rename(&renamed.id, renamed.revision, "blocked".into())
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::WouldBlock
+        );
+        assert_eq!(
+            store
+                .begin_close(&renamed.id, renamed.revision)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::WouldBlock
+        );
+        drop(store);
+        let restored = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        let replay = restored
+            .prepare_resource(
+                &renamed.id,
+                &operation,
+                &fingerprint(1),
+                1024,
+                renamed.revision,
+                &node,
+                &owner.id,
+                &owner.name,
+                owner.default_cwd.clone(),
+                &resource,
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending {
+            pending: replay,
+            newly_prepared,
+        } = replay
+        else {
+            panic!("expected pending replay");
+        };
+        assert!(!newly_prepared);
+        assert_eq!(replay, pending);
+        let backup = path.with_extension("backup");
+        fs::rename(&path, &backup).unwrap();
+        fs::create_dir(&path).unwrap();
+        assert!(
+            restored
+                .complete_resource(&replay, &owner, &shell_result(&resource, &owner.id))
+                .is_err()
+        );
+        fs::remove_dir(&path).unwrap();
+        fs::rename(&backup, &path).unwrap();
+        drop(restored);
+        let recovered = GlobalWorkspaceStore::load_at(path).unwrap();
+        let replay = recovered
+            .prepare_resource(
+                &renamed.id,
+                &operation,
+                &fingerprint(1),
+                1024,
+                renamed.revision,
+                &node,
+                &owner.id,
+                &owner.name,
+                owner.default_cwd.clone(),
+                &resource,
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending {
+            pending: replay,
+            newly_prepared,
+        } = replay
+        else {
+            panic!("expected pending replay");
+        };
+        assert!(!newly_prepared);
+        assert_eq!(replay, pending);
+        let completed = recovered
+            .complete_resource(&replay, &owner, &shell_result(&resource, &owner.id))
+            .unwrap();
+        assert_eq!(completed.workspace.name, "coordinator-name");
+        assert_eq!(
+            completed.workspace.placements[0]
+                .owner_workspace_name
+                .as_deref(),
+            Some("owner-local")
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn malformed_future_and_insecure_stores_fail_closed_without_replacement() {
+        for (label, bytes, mode) in [
+            ("malformed", b"not-json".to_vec(), 0o600),
+            (
+                "future",
+                br#"{"version":99,"local_migration_complete":true,"workspaces":[],"pending_resources":[]}"#.to_vec(),
+                0o600,
+            ),
+            (
+                "insecure",
+                br#"{"version":2,"local_migration_complete":true,"workspaces":[],"pending_resources":[]}"#.to_vec(),
+                0o644,
+            ),
+        ] {
+            let root = std::env::temp_dir().join(format!("boomux-global-{label}-{}", Uuid::new_v4()));
+            let path = root.join("boomux/global_workspaces.json");
+            secure_state_dir(path.parent().unwrap()).unwrap();
+            fs::write(&path, &bytes).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(mode)).unwrap();
+            assert!(GlobalWorkspaceStore::load_at(path.clone()).is_err());
+            assert_eq!(fs::read(&path).unwrap(), bytes);
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+
+    #[test]
+    fn concurrent_same_kind_operations_keep_exact_records_and_cancel_in_isolation() {
+        use std::sync::{Arc, Barrier};
+
+        let root =
+            std::env::temp_dir().join(format!("boomux-global-concurrent-{}", Uuid::new_v4()));
+        let store = Arc::new(
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap(),
+        );
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let global = store.create("concurrent".into()).unwrap();
+        let node = Uuid::from_u128(2).to_string();
+        let barrier = Arc::new(Barrier::new(3));
+        let mut handles = Vec::new();
+        for offset in 0..2_u128 {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            let global = global.clone();
+            let node = node.clone();
+            handles.push(std::thread::spawn(move || {
+                let operation = Uuid::from_u128(10 + offset).to_string();
+                let resource = Uuid::from_u128(20 + offset).to_string();
+                let requested_owner = Uuid::from_u128(30 + offset).to_string();
+                barrier.wait();
+                let prepared = store
+                    .prepare_resource(
+                        &global.id,
+                        &operation,
+                        &fingerprint(10 + offset),
+                        1024,
+                        global.revision,
+                        &node,
+                        &requested_owner,
+                        "concurrent",
+                        Some("/owner/project".into()),
+                        &resource,
+                        PendingResourceKind::Shell,
+                    )
+                    .unwrap();
+                let PreparedWorkspaceResource::Pending { pending, .. } = prepared else {
+                    panic!("expected pending operation");
+                };
+                pending
+            }));
+        }
+        barrier.wait();
+        let first = handles.remove(0).join().unwrap();
+        let second = handles.remove(0).join().unwrap();
+        assert_ne!(first.operation_id, second.operation_id);
+        assert_ne!(first.resource_id, second.resource_id);
+        assert_ne!(
+            first.requested_owner_workspace_id,
+            second.requested_owner_workspace_id
+        );
+        assert_eq!(first.owner_workspace_id, second.owner_workspace_id);
+        store.cancel_resource(&first).unwrap();
+        assert_eq!(store.pending_resources().unwrap(), vec![(*second).clone()]);
+        assert!(
+            store
+                .prepare_resource(
+                    &global.id,
+                    &second.operation_id,
+                    second.request_fingerprint.as_deref().unwrap(),
+                    1024,
+                    global.revision,
+                    &node,
+                    &second.requested_owner_workspace_id,
+                    "concurrent",
+                    Some("/owner/project".into()),
+                    &Uuid::new_v4().to_string(),
+                    PendingResourceKind::Shell,
+                )
+                .is_err()
+        );
+        let completed_owner = snapshot(&second.owner_workspace_id, "concurrent", 2);
+        store
+            .complete_resource(
+                &second,
+                &completed_owner,
+                &shell_result(&second.resource_id, &completed_owner.id),
+            )
+            .unwrap();
+        assert!(store.pending_resources().unwrap().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn reconcile_absence_retains_then_exact_observation_completes_and_replays() {
+        let root = std::env::temp_dir().join(format!("boomux-global-reconcile-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let global = store.create("reconcile".into()).unwrap();
+        let operation_id = Uuid::from_u128(2).to_string();
+        let node_id = Uuid::from_u128(3).to_string();
+        let owner_id = Uuid::from_u128(4).to_string();
+        let resource_id = Uuid::from_u128(5).to_string();
+        let request_fingerprint = fingerprint(6);
+        let prepared = store
+            .prepare_resource(
+                &global.id,
+                &operation_id,
+                &request_fingerprint,
+                1024,
+                global.revision,
+                &node_id,
+                &owner_id,
+                "reconcile",
+                Some("/owner/project".into()),
+                &resource_id,
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending { pending, .. } = prepared else {
+            panic!("expected pending operation");
+        };
+
+        assert_eq!(store.reconcile_resource(&pending, None).unwrap(), None);
+        assert_eq!(store.pending_resources().unwrap(), vec![(*pending).clone()]);
+
+        let owner = snapshot(&pending.owner_workspace_id, "reconcile", 2);
+        let resource = shell_result(&pending.resource_id, &pending.owner_workspace_id);
+        let completed = store
+            .reconcile_resource(&pending, Some((&owner, &resource)))
+            .unwrap()
+            .unwrap();
+        assert!(store.pending_resources().unwrap().is_empty());
+        assert_eq!(completed.workspace.revision, global.revision + 1);
+
+        drop(store);
+        let restored = GlobalWorkspaceStore::load_at(path).unwrap();
+        let replay = restored
+            .prepare_resource(
+                &global.id,
+                &operation_id,
+                &request_fingerprint,
+                1024,
+                global.revision,
+                &node_id,
+                &owner_id,
+                "reconcile",
+                Some("/owner/project".into()),
+                &resource_id,
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        assert_eq!(
+            replay,
+            PreparedWorkspaceResource::Completed(Box::new(completed))
+        );
+        assert!(
+            restored
+                .completed_operation(&operation_id, &fingerprint(7))
+                .is_err()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn concurrent_exact_completion_and_late_cancel_share_one_terminal_success() {
+        use std::sync::{Arc, Barrier};
+
+        let root = std::env::temp_dir().join(format!("boomux-global-cas-{}", Uuid::new_v4()));
+        let store = Arc::new(
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap(),
+        );
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let global = store.create("cas".into()).unwrap();
+        let prepared = store
+            .prepare_resource(
+                &global.id,
+                &Uuid::from_u128(2).to_string(),
+                &fingerprint(3),
+                1024,
+                global.revision,
+                &Uuid::from_u128(4).to_string(),
+                &Uuid::from_u128(5).to_string(),
+                "cas",
+                Some("/owner/project".into()),
+                &Uuid::from_u128(6).to_string(),
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending { pending, .. } = prepared else {
+            panic!("expected pending operation");
+        };
+        let owner = snapshot(&pending.owner_workspace_id, "cas", 2);
+        let resource = shell_result(&pending.resource_id, &pending.owner_workspace_id);
+        let barrier = Arc::new(Barrier::new(3));
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let store = Arc::clone(&store);
+            let pending = pending.clone();
+            let owner = owner.clone();
+            let resource = resource.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                store
+                    .complete_resource(&pending, &owner, &resource)
+                    .unwrap()
+            }));
+        }
+        barrier.wait();
+        let first = handles.remove(0).join().unwrap();
+        let second = handles.remove(0).join().unwrap();
+        assert_eq!(first, second);
+        store.cancel_resource(&pending).unwrap();
+        assert_eq!(
+            store
+                .completed_operation(
+                    &pending.operation_id,
+                    pending.request_fingerprint.as_deref().unwrap()
+                )
+                .unwrap(),
+            Some(first)
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn project_workspace_preparation_resumes_by_name_and_cancels_without_empty_metadata() {
+        let root = std::env::temp_dir().join(format!("boomux-global-project-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let node = Uuid::from_u128(2).to_string();
+        let prepared = store
+            .prepare_workspace_shell(
+                &Uuid::from_u128(3).to_string(),
+                &fingerprint(1),
+                1024,
+                &fingerprint(2),
+                &Uuid::from_u128(4).to_string(),
+                "project",
+                &node,
+                &Uuid::from_u128(5).to_string(),
+                "/owner/project".into(),
+                &Uuid::from_u128(6).to_string(),
+            )
+            .unwrap();
+        let PreparedWorkspaceShell::Pending { workspace, pending } = prepared else {
+            panic!("expected prepared project");
+        };
+        drop(store);
+        let restored = GlobalWorkspaceStore::load_at(path).unwrap();
+        let resumed = restored
+            .prepare_workspace_shell(
+                &Uuid::new_v4().to_string(),
+                &fingerprint(3),
+                1024,
+                &fingerprint(2),
+                &Uuid::new_v4().to_string(),
+                "project",
+                &node,
+                &Uuid::new_v4().to_string(),
+                "/owner/project".into(),
+                &Uuid::new_v4().to_string(),
+            )
+            .unwrap();
+        let PreparedWorkspaceShell::Pending {
+            workspace: resumed_workspace,
+            pending: resumed,
+        } = resumed
+        else {
+            panic!("expected resumed project");
+        };
+        assert_eq!(resumed_workspace.id, workspace.id);
+        assert_ne!(resumed.operation_id, pending.operation_id);
+        assert_eq!(resumed.owner_workspace_id, pending.owner_workspace_id);
+        assert_eq!(resumed.resource_id, pending.resource_id);
+        restored.cancel_resource(&resumed).unwrap();
+        restored.cancel_resource(&pending).unwrap();
+        assert!(restored.list().unwrap().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn completed_project_replays_by_exact_operation_and_matching_name_semantics() {
+        let root =
+            std::env::temp_dir().join(format!("boomux-global-project-replay-{}", Uuid::new_v4()));
+        let store =
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let operation_id = Uuid::from_u128(2).to_string();
+        let global_id = Uuid::from_u128(3).to_string();
+        let node_id = Uuid::from_u128(4).to_string();
+        let owner_id = Uuid::from_u128(5).to_string();
+        let shell_id = Uuid::from_u128(6).to_string();
+        let exact = fingerprint(7);
+        let semantic = fingerprint(8);
+        let prepared = store
+            .prepare_workspace_shell(
+                &operation_id,
+                &exact,
+                1024,
+                &semantic,
+                &global_id,
+                "project",
+                &node_id,
+                &owner_id,
+                "/owner/project".into(),
+                &shell_id,
+            )
+            .unwrap();
+        let PreparedWorkspaceShell::Pending { pending, .. } = prepared else {
+            panic!("expected pending project");
+        };
+        let owner = snapshot(&pending.owner_workspace_id, "project", 2);
+        let completed = store
+            .complete_resource(
+                &pending,
+                &owner,
+                &shell_result(&pending.resource_id, &pending.owner_workspace_id),
+            )
+            .unwrap();
+        assert_eq!(
+            store
+                .prepare_workspace_shell(
+                    &operation_id,
+                    &exact,
+                    1024,
+                    &semantic,
+                    &global_id,
+                    "project",
+                    &node_id,
+                    &owner_id,
+                    "/owner/project".into(),
+                    &shell_id,
+                )
+                .unwrap(),
+            PreparedWorkspaceShell::Completed(Box::new(completed.clone()))
+        );
+        let alias_operation = Uuid::from_u128(9).to_string();
+        let alias = store
+            .prepare_workspace_shell(
+                &alias_operation,
+                &fingerprint(10),
+                1024,
+                &semantic,
+                &Uuid::from_u128(11).to_string(),
+                "project",
+                &node_id,
+                &Uuid::from_u128(12).to_string(),
+                "/owner/project".into(),
+                &Uuid::from_u128(13).to_string(),
+            )
+            .unwrap();
+        let PreparedWorkspaceShell::Completed(alias) = alias else {
+            panic!("expected completed project alias");
+        };
+        assert_eq!(alias.operation_id, alias_operation);
+        assert_eq!(alias.workspace, completed.workspace);
+        assert_eq!(alias.resource, completed.resource);
+        assert!(
+            store
+                .prepare_workspace_shell(
+                    &Uuid::from_u128(14).to_string(),
+                    &fingerprint(15),
+                    1024,
+                    &fingerprint(16),
+                    &Uuid::from_u128(17).to_string(),
+                    "project",
+                    &node_id,
+                    &Uuid::from_u128(18).to_string(),
+                    "/owner/project".into(),
+                    &Uuid::from_u128(19).to_string(),
+                )
+                .is_err()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn definitive_project_preflight_cancels_exact_empty_metadata_for_new_semantics() {
+        let root = std::env::temp_dir().join(format!("boomux-global-preflight-{}", Uuid::new_v4()));
+        let store =
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let operation_id = Uuid::from_u128(2).to_string();
+        let exact = fingerprint(3);
+        store
+            .prepare_workspace_shell(
+                &operation_id,
+                &exact,
+                1024,
+                &fingerprint(4),
+                &Uuid::from_u128(5).to_string(),
+                "preflight-project",
+                &Uuid::from_u128(6).to_string(),
+                &Uuid::from_u128(7).to_string(),
+                "/owner/project".into(),
+                &Uuid::from_u128(8).to_string(),
+            )
+            .unwrap();
+        assert!(
+            store
+                .cancel_pending_operation_if_never_attempted(&operation_id, &exact)
+                .unwrap()
+        );
+        assert!(store.list().unwrap().is_empty());
+        let replacement = store
+            .prepare_workspace_shell(
+                &Uuid::from_u128(9).to_string(),
+                &fingerprint(10),
+                1024,
+                &fingerprint(11),
+                &Uuid::from_u128(12).to_string(),
+                "preflight-project",
+                &Uuid::from_u128(6).to_string(),
+                &Uuid::from_u128(13).to_string(),
+                "/owner/project".into(),
+                &Uuid::from_u128(14).to_string(),
+            )
+            .unwrap();
+        assert!(matches!(
+            replacement,
+            PreparedWorkspaceShell::Pending { .. }
+        ));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn attempted_project_retains_pending_name_across_later_definitive_failures() {
+        let root = std::env::temp_dir().join(format!("boomux-global-attempted-{}", Uuid::new_v4()));
+        let store =
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let operation_id = Uuid::from_u128(2).to_string();
+        let exact = fingerprint(3);
+        let prepared = store
+            .prepare_workspace_shell(
+                &operation_id,
+                &exact,
+                1024,
+                &fingerprint(4),
+                &Uuid::from_u128(5).to_string(),
+                "attempted-project",
+                &Uuid::from_u128(6).to_string(),
+                &Uuid::from_u128(7).to_string(),
+                "/owner/project".into(),
+                &Uuid::from_u128(8).to_string(),
+            )
+            .unwrap();
+        let PreparedWorkspaceShell::Pending { pending, .. } = prepared else {
+            panic!("expected pending project");
+        };
+        let attempted = store.mark_owner_attempted(&pending).unwrap();
+        assert!(attempted.owner_attempted);
+
+        // A later capability, admission, identity, or not-found failure cannot
+        // prove what happened after this durable dispatch boundary.
+        store.cancel_resource(&attempted).unwrap();
+        assert!(
+            !store
+                .cancel_pending_operation_if_never_attempted(&operation_id, &exact)
+                .unwrap()
+        );
+        assert_eq!(store.pending_resources().unwrap(), vec![attempted]);
+        assert_eq!(store.list().unwrap()[0].name, "attempted-project");
+        assert!(
+            store
+                .prepare_workspace_shell(
+                    &Uuid::from_u128(9).to_string(),
+                    &fingerprint(10),
+                    1024,
+                    &fingerprint(11),
+                    &Uuid::from_u128(12).to_string(),
+                    "attempted-project",
+                    &Uuid::from_u128(13).to_string(),
+                    &Uuid::from_u128(14).to_string(),
+                    "/different/project".into(),
+                    &Uuid::from_u128(15).to_string(),
+                )
+                .is_err()
+        );
+        assert_eq!(store.list().unwrap()[0].name, "attempted-project");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn schema_four_pending_operation_reserves_completion_capacity_on_retry() {
+        let root = std::env::temp_dir().join(format!("boomux-global-v4-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let global = store.create("v4-pending".into()).unwrap();
+        let operation_id = Uuid::from_u128(2).to_string();
+        let request_fingerprint = fingerprint(3);
+        store
+            .prepare_resource(
+                &global.id,
+                &operation_id,
+                &request_fingerprint,
+                1024,
+                global.revision,
+                &Uuid::from_u128(4).to_string(),
+                &Uuid::from_u128(5).to_string(),
+                "v4-pending",
+                Some("/owner/project".into()),
+                &Uuid::from_u128(6).to_string(),
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        drop(store);
+        let mut legacy: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        legacy["version"] = 4.into();
+        legacy["pending_resources"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("completion_reservation");
+        fs::write(&path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+
+        let migrated = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        assert!(
+            migrated.pending_resources().unwrap()[0]
+                .completion_reservation
+                .is_empty()
+        );
+        assert!(migrated.pending_resources().unwrap()[0].owner_attempted);
+        migrated
+            .prepare_resource(
+                &global.id,
+                &operation_id,
+                &request_fingerprint,
+                1024,
+                global.revision,
+                &Uuid::from_u128(4).to_string(),
+                &Uuid::from_u128(5).to_string(),
+                "v4-pending",
+                Some("/owner/project".into()),
+                &Uuid::from_u128(6).to_string(),
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(persisted["version"], 6);
+        assert!(
+            persisted["pending_resources"][0]["completion_reservation"]
+                .as_str()
+                .is_some_and(|reservation| !reservation.is_empty())
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn schema_five_pending_operation_migrates_as_conservatively_attempted() {
+        let root = std::env::temp_dir().join(format!("boomux-global-v5-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let global = store.create("v5-pending".into()).unwrap();
+        store
+            .prepare_resource(
+                &global.id,
+                &Uuid::from_u128(2).to_string(),
+                &fingerprint(3),
+                1024,
+                global.revision,
+                &Uuid::from_u128(4).to_string(),
+                &Uuid::from_u128(5).to_string(),
+                "v5-pending",
+                Some("/owner/project".into()),
+                &Uuid::from_u128(6).to_string(),
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        drop(store);
+        let mut legacy: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        legacy["version"] = 5.into();
+        legacy["pending_resources"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("owner_attempted");
+        fs::write(&path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+
+        let migrated = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        assert!(migrated.pending_resources().unwrap()[0].owner_attempted);
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(persisted["version"], 6);
+        assert_eq!(persisted["pending_resources"][0]["owner_attempted"], true);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn near_limit_store_reserves_completion_before_owner_mutation() {
+        let root = std::env::temp_dir().join(format!("boomux-global-capacity-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let global = store.create("capacity".into()).unwrap();
+        let owner = snapshot(&Uuid::from_u128(2).to_string(), "historical", 1);
+        let historical = GlobalWorkspaceSnapshot {
+            id: Uuid::from_u128(3).to_string(),
+            revision: 2,
+            name: "historical".into(),
+            closing: false,
+            placements: vec![placement(
+                &Uuid::from_u128(4).to_string(),
+                &owner,
+                WorkspacePlacementState::Active,
+            )],
+        };
+        store
+            .mutate(|state| {
+                for offset in 0..100_u128 {
+                    let mut resource =
+                        shell_result(&Uuid::from_u128(1_000 + offset).to_string(), &owner.id);
+                    let RoutedOperationResult::Shell { shell } = &mut resource else {
+                        unreachable!();
+                    };
+                    shell.command = vec!["x".repeat(20_000)];
+                    push_completed(
+                        state,
+                        CompletedWorkspaceOperation {
+                            operation_id: Uuid::from_u128(100 + offset).to_string(),
+                            request_fingerprint: fingerprint(100 + offset),
+                            semantic_fingerprint: None,
+                            creates_workspace: false,
+                            workspace: historical.clone(),
+                            resource,
+                        },
+                    )?;
+                }
+                Ok(())
+            })
+            .unwrap();
+        let before_bytes = fs::metadata(&path).unwrap().len();
+        let before_outcomes = store.lock().unwrap().completed_operations.len();
+        assert!(before_bytes > 850 * 1024);
+
+        let operation_id = Uuid::from_u128(10).to_string();
+        let node_id = Uuid::from_u128(11).to_string();
+        let owner_id = Uuid::from_u128(12).to_string();
+        let resource_id = Uuid::from_u128(13).to_string();
+        let prepared = store
+            .prepare_resource(
+                &global.id,
+                &operation_id,
+                &fingerprint(14),
+                50_000,
+                global.revision,
+                &node_id,
+                &owner_id,
+                "capacity",
+                Some("/owner/project".into()),
+                &resource_id,
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending { pending, .. } = prepared else {
+            panic!("expected capacity-reserved pending operation");
+        };
+        assert!(!pending.completion_reservation.is_empty());
+        assert!(store.lock().unwrap().completed_operations.len() < before_outcomes);
+        let completed_owner = snapshot(&pending.owner_workspace_id, "capacity", 2);
+        let mut resource = shell_result(&pending.resource_id, &pending.owner_workspace_id);
+        let RoutedOperationResult::Shell { shell } = &mut resource else {
+            unreachable!();
+        };
+        shell.command = vec!["y".repeat(50_000)];
+        store
+            .complete_resource(&pending, &completed_owner, &resource)
+            .unwrap();
+        assert!(fs::metadata(&path).unwrap().len() <= MAX_STORE_BYTES);
+
+        let error = store
+            .prepare_resource(
+                &global.id,
+                &Uuid::from_u128(20).to_string(),
+                &fingerprint(21),
+                MAX_COMPLETION_RESERVATION_BYTES,
+                global.revision + 1,
+                &node_id,
+                &Uuid::from_u128(22).to_string(),
+                "capacity",
+                Some("/owner/project".into()),
+                &Uuid::from_u128(23).to_string(),
+                PendingResourceKind::Shell,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("too large"));
+        assert!(store.pending_resources().unwrap().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn distinct_pending_placements_expand_each_others_completion_reservations() {
+        let root = std::env::temp_dir().join(format!("boomux-global-growth-{}", Uuid::new_v4()));
+        let store =
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let global = store.create("growth".into()).unwrap();
+        let first = store
+            .prepare_resource(
+                &global.id,
+                &Uuid::from_u128(2).to_string(),
+                &fingerprint(3),
+                1024,
+                global.revision,
+                &Uuid::from_u128(4).to_string(),
+                &Uuid::from_u128(5).to_string(),
+                "growth",
+                Some("/owner/one".into()),
+                &Uuid::from_u128(6).to_string(),
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending { pending: first, .. } = first else {
+            panic!("expected first pending placement");
+        };
+        let first_reservation = first.completion_reservation.len();
+        let second = store
+            .prepare_resource(
+                &global.id,
+                &Uuid::from_u128(7).to_string(),
+                &fingerprint(8),
+                1024,
+                global.revision,
+                &Uuid::from_u128(9).to_string(),
+                &Uuid::from_u128(10).to_string(),
+                "growth",
+                Some("/owner/two".into()),
+                &Uuid::from_u128(11).to_string(),
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending {
+            pending: second, ..
+        } = second
+        else {
+            panic!("expected second pending placement");
+        };
+        let pending = store.pending_resources().unwrap();
+        let expanded_first = pending
+            .iter()
+            .find(|pending| pending.operation_id == first.operation_id)
+            .unwrap();
+        assert!(expanded_first.completion_reservation.len() > first_reservation);
+
+        let second_owner = WorkspaceSnapshot {
+            id: second.owner_workspace_id.clone(),
+            revision: 1,
+            name: "growth".into(),
+            default_cwd: Some("/owner/two".into()),
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: Vec::new(),
+            schedules: Vec::new(),
+        };
+        store
+            .complete_resource(
+                &second,
+                &second_owner,
+                &shell_result(&second.resource_id, &second.owner_workspace_id),
+            )
+            .unwrap();
+        let first = store
+            .pending_resources()
+            .unwrap()
+            .into_iter()
+            .find(|pending| pending.operation_id == first.operation_id)
+            .unwrap();
+        let first_owner = WorkspaceSnapshot {
+            id: first.owner_workspace_id.clone(),
+            revision: 1,
+            name: "growth".into(),
+            default_cwd: Some("/owner/one".into()),
+            shells: Vec::new(),
+            launchers: Vec::new(),
+            agents: Vec::new(),
+            schedules: Vec::new(),
+        };
+        let completed = store
+            .complete_resource(
+                &first,
+                &first_owner,
+                &shell_result(&first.resource_id, &first.owner_workspace_id),
+            )
+            .unwrap();
+        assert_eq!(completed.workspace.placements.len(), 2);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn completed_operation_ledger_keeps_only_the_newest_bounded_outcomes() {
+        let node_id = Uuid::from_u128(1).to_string();
+        let owner = snapshot(&Uuid::from_u128(2).to_string(), "bounded", 1);
+        let workspace = GlobalWorkspaceSnapshot {
+            id: Uuid::from_u128(3).to_string(),
+            revision: 2,
+            name: "bounded".into(),
+            closing: false,
+            placements: vec![placement(&node_id, &owner, WorkspacePlacementState::Active)],
+        };
+        let mut state = PersistedGlobalWorkspaces {
+            version: COORDINATOR_WORKSPACE_VERSION,
+            local_migration_complete: true,
+            workspaces: vec![workspace.clone()],
+            pending_resources: Vec::new(),
+            completed_operations: Vec::new(),
+        };
+        for offset in 0..=MAX_COMPLETED_OPERATIONS {
+            push_completed(
+                &mut state,
+                CompletedWorkspaceOperation {
+                    operation_id: Uuid::from_u128(100 + offset as u128).to_string(),
+                    request_fingerprint: fingerprint(100 + offset as u128),
+                    semantic_fingerprint: None,
+                    creates_workspace: false,
+                    workspace: workspace.clone(),
+                    resource: shell_result(
+                        &Uuid::from_u128(1_000 + offset as u128).to_string(),
+                        &owner.id,
+                    ),
+                },
+            )
+            .unwrap();
+        }
+        assert_eq!(state.completed_operations.len(), MAX_COMPLETED_OPERATIONS);
+        assert_eq!(
+            state.completed_operations[0].operation_id,
+            Uuid::from_u128(101).to_string()
+        );
+        assert!(serde_json::to_vec(&state).unwrap().len() as u64 <= MAX_STORE_BYTES);
+        validate(&state).unwrap();
+    }
+}

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 use crate::client;
 use crate::fd_transfer::receive_descriptor;
 use crate::protocol::{
-    self, DaemonEvent, FocusedTerminalSnapshot, NotificationDeliveryConfig, TerminalProfile,
+    self, DaemonEvent, FocusedTerminalSnapshot, NotificationDeliveryConfig,
+    QualifiedFocusedTerminalSnapshot, TerminalProfile,
 };
 use crate::state_store;
 
@@ -39,6 +40,8 @@ pub(crate) struct Manifest {
     pub(crate) notifications: Option<NotificationDeliveryConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) focused_terminal: Option<FocusedTerminalSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) presented_focused_terminal: Option<QualifiedFocusedTerminalSnapshot>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -94,6 +97,7 @@ pub(crate) enum Bootstrap {
         event_stream: Box<EventStreamManifest>,
         notifications: Option<NotificationDeliveryConfig>,
         focused_terminal: Option<Box<FocusedTerminalSnapshot>>,
+        presented_focused_terminal: Option<Box<QualifiedFocusedTerminalSnapshot>>,
     },
 }
 
@@ -114,6 +118,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
     let event_stream = manifest.event_stream.clone();
     let notifications = manifest.notifications.clone();
     let focused_terminal = manifest.focused_terminal.clone().map(Box::new);
+    let presented_focused_terminal = manifest.presented_focused_terminal.clone().map(Box::new);
     let listener = receive_descriptor(&channel, LISTENER_MARKER)?;
     let runtime_lock = receive_descriptor(&channel, RUNTIME_LOCK_MARKER)?;
     let state_lock = receive_descriptor(&channel, STATE_LOCK_MARKER)?;
@@ -183,6 +188,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             event_stream: Box::new(event_stream),
             notifications,
             focused_terminal,
+            presented_focused_terminal,
         }),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -233,6 +239,20 @@ fn validate_pidfd(descriptor: &OwnedFd, expected_pid: u32) -> io::Result<()> {
 }
 
 fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
+    if manifest
+        .presented_focused_terminal
+        .as_ref()
+        .is_some_and(|focused| {
+            focused.revision == 0
+                || uuid::Uuid::parse_str(&focused.shell.node_id).is_err()
+                || uuid::Uuid::parse_str(&focused.shell.inner_id).is_err()
+        })
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "handoff manifest contains invalid presented terminal focus",
+        ));
+    }
     if manifest.notifications.as_ref().is_some_and(|settings| {
         !(1..=crate::daemon::MAX_SCHEDULED_EXECUTION_CONCURRENCY)
             .contains(&settings.max_scheduled_execution_concurrency)
@@ -426,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn old_manifest_defaults_focused_terminal() {
+    fn old_manifest_defaults_focus_state() {
         let manifest: Manifest = serde_json::from_value(serde_json::json!({
             "runtimes": [],
             "exited": [],
@@ -436,6 +456,7 @@ mod tests {
         .unwrap();
 
         assert!(manifest.focused_terminal.is_none());
+        assert!(manifest.presented_focused_terminal.is_none());
     }
 
     #[test]
@@ -452,12 +473,20 @@ mod tests {
             event_stream: event_stream(),
             notifications: None,
             focused_terminal: Some(focused_terminal.clone()),
+            presented_focused_terminal: Some(QualifiedFocusedTerminalSnapshot {
+                revision: 5,
+                shell: protocol::QualifiedIdentity::new(
+                    uuid::Uuid::from_u128(1).to_string(),
+                    uuid::Uuid::from_u128(2).to_string(),
+                ),
+            }),
         };
 
         let decoded: Manifest =
             serde_json::from_value(serde_json::to_value(manifest).unwrap()).unwrap();
 
         assert_eq!(decoded.focused_terminal, Some(focused_terminal));
+        assert_eq!(decoded.presented_focused_terminal.unwrap().revision, 5);
     }
 
     #[test]
@@ -480,6 +509,7 @@ mod tests {
                     ..Default::default()
                 }),
                 focused_terminal: None,
+                presented_focused_terminal: None,
             };
             assert_eq!(
                 validate_manifest(&manifest).unwrap_err().kind(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod fd_transfer;
 pub mod federation;
 #[allow(dead_code)]
 mod generated_names;
+pub(crate) mod global_workspace_store;
 mod handoff;
 pub mod host_services;
 #[allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,15 @@ impl DashboardRefresh {
         }
         match self.watch.poll(client) {
             Ok(poll) => {
+                let handoff_completed = poll.events.iter().any(|event| {
+                    matches!(&event.kind, protocol::DaemonEventKind::HandoffCompleted)
+                });
+                let protocol_changed = if handoff_completed {
+                    let negotiated = client.protocol_version()?;
+                    update_negotiated_protocol(&mut self.negotiated_protocol, negotiated)
+                } else {
+                    false
+                };
                 if poll.changed {
                     if poll.stream_changed || poll.baseline_replaced {
                         self.needs_reseed = true;
@@ -112,7 +121,10 @@ impl DashboardRefresh {
                         self.apply_events(&poll.events);
                     }
                     self.last_snapshot_at = Instant::now();
-                    return Ok(Some((self.watch.snapshot().clone(), poll.stream_changed)));
+                    return Ok(Some((
+                        self.watch.snapshot().clone(),
+                        poll.stream_changed || protocol_changed,
+                    )));
                 }
                 if self.last_snapshot_at.elapsed() < DASHBOARD_FALLBACK_REFRESH_INTERVAL {
                     return Ok(None);
@@ -249,6 +261,12 @@ impl DashboardRefresh {
             self.executions.remove(&id);
         }
     }
+}
+
+fn update_negotiated_protocol(current: &mut u32, negotiated: u32) -> bool {
+    let changed = *current != negotiated;
+    *current = negotiated;
+    changed
 }
 
 const BOOMUX_SKILL: &str = include_str!("../.agents/skills/boomux/SKILL.md");
@@ -1977,6 +1995,7 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
             if json {
                 let workspaces = snapshot.workspaces.clone();
                 let external_workspaces = snapshot.external_workspaces.clone();
+                let focused_terminal = snapshot.focused_terminal.clone();
                 let nodes = snapshot
                     .nodes
                     .into_iter()
@@ -1988,6 +2007,7 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
                         "nodes": nodes,
                         "workspaces": workspaces,
                         "external_workspaces": external_workspaces,
+                        "focused_terminal": focused_terminal,
                     }),
                 )
             } else {
@@ -3533,6 +3553,9 @@ fn dashboard_state(
     title_cache: &mut host_session_titles::Cache,
     reset_focus_revision: bool,
 ) -> tui::DashboardState {
+    let qualified_focused_terminal = combined
+        .as_ref()
+        .and_then(|snapshot| snapshot.focused_terminal.clone());
     let schedules_supported = protocol::ProtocolFeature::ScheduledExecutionObservation
         .is_supported_by(refresh.negotiated_protocol);
     let mut workspaces = dashboard_views_with_catalog(&snapshot.workspaces, git_cache, title_cache);
@@ -3652,7 +3675,11 @@ fn dashboard_state(
             .is_supported_by(refresh.negotiated_protocol),
         schedule_editing: protocol::ProtocolFeature::AgentScheduleEditing
             .is_supported_by(refresh.negotiated_protocol),
-        focused_terminal: snapshot.focused_terminal.map(focused_terminal_view),
+        focused_terminal: dashboard_focused_terminal_view(
+            refresh.negotiated_protocol,
+            qualified_focused_terminal,
+            snapshot.focused_terminal,
+        ),
         reset_focus_revision,
     }
 }
@@ -3849,8 +3876,32 @@ fn unavailable_placement_node(node_id: &str) -> tui::NodeView {
 fn focused_terminal_view(focused: protocol::FocusedTerminalSnapshot) -> tui::FocusedTerminalView {
     tui::FocusedTerminalView {
         revision: focused.revision,
+        node_id: None,
         workspace_id: focused.workspace_id,
         shell_id: focused.shell_id,
+    }
+}
+
+fn qualified_focused_terminal_view(
+    focused: protocol::QualifiedFocusedTerminalSnapshot,
+) -> tui::FocusedTerminalView {
+    tui::FocusedTerminalView {
+        revision: focused.revision,
+        node_id: Some(focused.shell.node_id),
+        workspace_id: String::new(),
+        shell_id: focused.shell.inner_id,
+    }
+}
+
+fn dashboard_focused_terminal_view(
+    negotiated_protocol: u32,
+    qualified: Option<protocol::QualifiedFocusedTerminalSnapshot>,
+    local: Option<protocol::FocusedTerminalSnapshot>,
+) -> Option<tui::FocusedTerminalView> {
+    if protocol::ProtocolFeature::QualifiedFocusedTerminal.is_supported_by(negotiated_protocol) {
+        qualified.map(qualified_focused_terminal_view)
+    } else {
+        local.map(focused_terminal_view)
     }
 }
 
@@ -14038,7 +14089,37 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 38);
+        assert_eq!(protocol::PROTOCOL_VERSION, 39);
+    }
+
+    #[test]
+    fn protocol_thirty_nine_focus_absence_does_not_restore_legacy_local_focus() {
+        let local = protocol::FocusedTerminalSnapshot {
+            revision: 8,
+            workspace_id: "local-workspace".into(),
+            shell_id: "local-shell".into(),
+            run_id: "local-run".into(),
+        };
+        assert!(
+            dashboard_focused_terminal_view(39, None, Some(local.clone())).is_none(),
+            "qualified focus absence is authoritative for protocol 39"
+        );
+        assert_eq!(
+            dashboard_focused_terminal_view(38, None, Some(local))
+                .unwrap()
+                .shell_id,
+            "local-shell"
+        );
+    }
+
+    #[test]
+    fn focus_frontier_resets_once_per_protocol_handoff_transition() {
+        let mut negotiated = 38;
+
+        assert!(update_negotiated_protocol(&mut negotiated, 39));
+        assert!(!update_negotiated_protocol(&mut negotiated, 39));
+        assert!(update_negotiated_protocol(&mut negotiated, 38));
+        assert!(!update_negotiated_protocol(&mut negotiated, 38));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -577,20 +577,7 @@ enum WorkspaceCommands {
     /// List workspaces
     List,
     /// Create an empty workspace
-    Create {
-        name: String,
-        #[arg(long)]
-        cwd: Option<PathBuf>,
-    },
-    /// Create a global Workspace and its first Shell atomically
-    CreateProject {
-        name: String,
-        #[arg(long)]
-        cwd: PathBuf,
-        /// Exact eligible Node alias or Node ID
-        #[arg(long)]
-        node: Option<String>,
-    },
+    Create { name: String },
     /// Open terminal windows and invoke launchers
     Open {
         target: String,
@@ -1260,7 +1247,6 @@ command_keys! {
     ProjectList => ("project.list", Json),
     WorkspaceList => ("workspace.list", Json),
     WorkspaceInspect => ("workspace.inspect", Json),
-    WorkspaceCreateProject => ("workspace.create-project", Json),
     Workspace => ("workspace", HumanOnly),
     NodeAdd => ("node.add", Json),
     NodeList => ("node.list", Json),
@@ -1339,9 +1325,6 @@ impl Cli {
             Some(Commands::Workspace {
                 command: WorkspaceCommands::Inspect { .. },
             }) => CommandKey::WorkspaceInspect,
-            Some(Commands::Workspace {
-                command: WorkspaceCommands::CreateProject { .. },
-            }) => CommandKey::WorkspaceCreateProject,
             Some(Commands::Node {
                 command: NodeCommands::Add { .. },
             }) => CommandKey::NodeAdd,
@@ -2676,6 +2659,7 @@ fn effective_terminal(override_entry: Option<&str>) -> Result<Option<String>, Bo
 
 fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
+    validate_dashboard_terminal(io::stdin().is_terminal(), io::stdout().is_terminal())?;
     let launch_cwd = resolve_directory(Path::new("."))?;
     let client = client::connect_or_start()?;
     let local_node_id = client.node_identity()?;
@@ -2719,7 +2703,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
         config.dashboard.follow_focused_terminal,
         project_context,
         true,
-        |effect| match effect {
+        move |effect| match effect {
             tui::DashboardEffect::Quit => unreachable!("quit is handled by the dashboard runtime"),
             tui::DashboardEffect::AddNode => tui::DashboardEvent::OperationCompleted(
                 terminal::open_node_add(terminal.as_deref())
@@ -2959,57 +2943,13 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 })();
                 tui::DashboardEvent::OperationCompleted(result)
             }
-            tui::DashboardEffect::CreateWorkspace { name, default_cwd } => {
+            tui::DashboardEffect::CreateWorkspace { name } => {
                 tui::DashboardEvent::OperationCompleted(
-                    create_dashboard_workspace(&client, &name, default_cwd.as_ref())
-                        .map_err(|error| error.to_string()),
+                    create_dashboard_workspace(&client, &name).map_err(|error| error.to_string()),
                 )
             }
-            tui::DashboardEffect::CreatePlacedWorkspace {
-                name,
-                default_cwd,
-                node_id,
-            } => {
-                let result = (|| {
-                    let combined = client
-                        .combined_node_snapshot(Some(node_id.clone()))
-                        .map_err(|error| error.to_string())?;
-                    let node = combined
-                        .nodes
-                        .iter()
-                        .find(|node| node.node_id == node_id)
-                        .ok_or_else(|| "selected Node is no longer available".to_owned())?;
-                    if !node.workspace_owner_eligible {
-                        return Err(node
-                            .workspace_owner_unavailable_reason
-                            .clone()
-                            .unwrap_or_else(|| "selected Node is unavailable".into()));
-                    }
-                    let cwd = resolve_owner_directory(&client, node, default_cwd)
-                        .map_err(|error| error.to_string())?;
-                    let shell_name = generated_shell_name(std::iter::empty())
-                        .map_err(|error| error.to_string())?;
-                    let (workspace, shell) = client
-                        .create_global_workspace_with_shell(
-                            Uuid::new_v4().to_string(),
-                            Uuid::new_v4().to_string(),
-                            name,
-                            &node_id,
-                            Uuid::new_v4().to_string(),
-                            cwd.clone(),
-                            Uuid::new_v4().to_string(),
-                            shell_spec(shell_name, &cwd, &[]),
-                        )
-                        .map_err(|error| error.to_string())?;
-                    Ok(format!(
-                        "Created {} with {} on Node {}",
-                        workspace.name, shell.name, node.alias
-                    ))
-                })();
-                tui::DashboardEvent::OperationCompleted(result)
-            }
             tui::DashboardEffect::CreateShell(workspace_id) => {
-                tui::DashboardEvent::OperationCompleted(
+                tui::DashboardEvent::ShellCreationCompleted(
                     local_dashboard_inner(&workspace_id, &local_node_id).and_then(|workspace_id| {
                         create_dashboard_shell(&client, workspace_id, &launch_cwd)
                             .map_err(|error| error.to_string())
@@ -3054,7 +2994,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                         .map_err(|error| error.to_string())?;
                     Ok(format!("Created {} on Node {}", shell.name, node.alias))
                 })();
-                tui::DashboardEvent::OperationCompleted(result)
+                tui::DashboardEvent::ShellCreationCompleted(result)
             }
             tui::DashboardEffect::AdoptExternalWorkspace {
                 identity,
@@ -4562,6 +4502,20 @@ fn ensure_host_terminal() -> Result<(), Box<dyn Error>> {
     }
 }
 
+fn validate_dashboard_terminal(
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+) -> io::Result<()> {
+    if stdin_is_terminal && stdout_is_terminal {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "dashboard requires an interactive terminal",
+        ))
+    }
+}
+
 fn resolve_directory(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
     let absolute = if path.is_absolute() {
         path.to_owned()
@@ -4735,18 +4689,6 @@ fn select_eligible_workspace_owner(
     Ok((*node).clone())
 }
 
-fn workspace_create_project_json(
-    workspace: &protocol::GlobalWorkspaceSnapshot,
-    node_id: &str,
-    shell: &protocol::ShellSnapshot,
-) -> serde_json::Value {
-    serde_json::json!({
-        "workspace": workspace,
-        "node_id": node_id,
-        "shell": cli_output::shell(shell, Some(&workspace.name)),
-    })
-}
-
 fn shell_suggestion_json(
     workspace_id: &str,
     name: &str,
@@ -4821,27 +4763,20 @@ fn resolve_owner_directory(
 fn create_dashboard_workspace(
     client: &client::Client,
     name: &str,
-    default_cwd: Option<&PathBuf>,
 ) -> Result<String, Box<dyn Error>> {
     let name = name.trim();
     if name.is_empty() {
         return Err("workspace name cannot be empty".into());
     }
-    if default_cwd.is_none() && client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+    if client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
         let workspace = client.create_global_workspace(name)?;
         return Ok(format!(
             "Created empty workspace {} ({})",
             workspace.name, workspace.id
         ));
     }
-    client.create_workspace_with_default_cwd(name, default_cwd.cloned(), Vec::new())?;
-    Ok(if default_cwd.is_some() {
-        format!(
-            "Created unlinked local workspace {name} with its project path; adopt or link it explicitly"
-        )
-    } else {
-        format!("Created empty workspace {name}")
-    })
+    client.create_workspace_with_default_cwd(name, None, Vec::new())?;
+    Ok(format!("Created empty workspace {name}"))
 }
 
 fn create_dashboard_shell(
@@ -6186,50 +6121,15 @@ fn workspace_command(
                 );
             }
         }
-        WorkspaceCommands::Create { name, cwd } => {
+        WorkspaceCommands::Create { name } => {
             let name = cli_name(name, "workspace")?;
-            if cwd.is_none() && client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+            if client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
                 let workspace = client.create_global_workspace(name)?;
                 println!("Created workspace {} ({})", workspace.name, workspace.id);
                 return Ok(());
             }
-            let default_cwd = cwd.as_deref().map(resolve_directory).transpose()?;
-            let workspace =
-                client.create_workspace_with_default_cwd(name, default_cwd, Vec::new())?;
+            let workspace = client.create_workspace_with_default_cwd(name, None, Vec::new())?;
             println!("Created workspace {} ({})", workspace.name, workspace.id);
-        }
-        WorkspaceCommands::CreateProject { name, cwd, node } => {
-            if !client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
-                return Err(cli_output::failure(
-                    "unsupported_version",
-                    "global Workspace project creation requires daemon protocol 38 or newer",
-                ));
-            }
-            let name = cli_name(name, "workspace")?;
-            let combined = client.combined_node_snapshot(None)?;
-            let node = select_eligible_workspace_owner(&combined.nodes, node.as_deref())?;
-            let cwd = resolve_owner_directory(&client, &node, cwd)?;
-            let shell_name = generated_shell_name(std::iter::empty())?;
-            let (workspace, shell) = client.create_global_workspace_with_shell(
-                Uuid::new_v4().to_string(),
-                Uuid::new_v4().to_string(),
-                &name,
-                &node.node_id,
-                Uuid::new_v4().to_string(),
-                cwd.clone(),
-                Uuid::new_v4().to_string(),
-                shell_spec(shell_name, &cwd, &[]),
-            )?;
-            if json {
-                return print_json(
-                    CommandKey::WorkspaceCreateProject,
-                    workspace_create_project_json(&workspace, &node.node_id, &shell),
-                );
-            }
-            println!(
-                "Created workspace {} ({}) with shell {} ({}) on Node {}",
-                workspace.name, workspace.id, shell.name, shell.id, node.alias
-            );
         }
         WorkspaceCommands::Open { target, node } => {
             if let Some(node_selector) = node {
@@ -11425,6 +11325,19 @@ mod tests {
     }
 
     #[test]
+    fn dashboard_requires_terminal_input_and_output() {
+        validate_dashboard_terminal(true, true).unwrap();
+        assert_eq!(
+            validate_dashboard_terminal(false, true).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert_eq!(
+            validate_dashboard_terminal(true, false).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
     fn parses_node_rekey_and_requires_exact_confirmation() {
         let cli = Cli::try_parse_from(["boomux", "node", "rekey"]).unwrap();
         assert!(matches!(
@@ -11828,32 +11741,6 @@ mod tests {
     }
 
     #[test]
-    fn parses_json_workspace_project_creation_without_splitting_arguments() {
-        let cli = Cli::try_parse_from([
-            "boomux",
-            "workspace",
-            "create-project",
-            "release; touch /tmp/nope",
-            "--cwd",
-            "/tmp/project $(false)",
-            "--node",
-            "node-id",
-            "--json",
-        ])
-        .unwrap();
-        assert_eq!(cli.command_descriptor().key, "workspace.create-project");
-        assert_eq!(cli.command_descriptor().output, OutputMode::Json);
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Workspace {
-                command: WorkspaceCommands::CreateProject { name, cwd, node }
-            }) if name == "release; touch /tmp/nope"
-                && cwd == Path::new("/tmp/project $(false)")
-                && node.as_deref() == Some("node-id")
-        ));
-    }
-
-    #[test]
     fn workspace_project_owner_selection_delegates_sole_and_requires_ambiguous_choice() {
         let local = combined_node("local-id", "local", true);
         let remote = combined_node("remote-id", "work", true);
@@ -11885,30 +11772,6 @@ mod tests {
             resolve_workspace_open_node(&nodes, "work").unwrap().node_id,
             "remote-id"
         );
-    }
-
-    #[test]
-    fn workspace_project_json_returns_exact_global_owner_and_shell_ids() {
-        let global = protocol::GlobalWorkspaceSnapshot {
-            id: "global-id".into(),
-            revision: 1,
-            name: "release".into(),
-            closing: false,
-            placements: vec![protocol::WorkspacePlacementSnapshot {
-                node_id: "node-id".into(),
-                workspace_id: "owner-id".into(),
-                owner_workspace_name: Some("release".into()),
-                owner_revision: 1,
-                default_cwd: Some("/tmp/project".into()),
-                state: protocol::WorkspacePlacementState::Active,
-            }],
-        };
-        let shell = shell("shell-id", "owner-id", "first");
-        let value = workspace_create_project_json(&global, "node-id", &shell);
-        assert_eq!(value["workspace"]["id"], "global-id");
-        assert_eq!(value["node_id"], "node-id");
-        assert_eq!(value["shell"]["id"], "shell-id");
-        assert_eq!(value["shell"]["workspace_id"], "owner-id");
     }
 
     #[test]
@@ -12007,27 +11870,13 @@ mod tests {
                 .unwrap()
                 .command,
             Some(Commands::Workspace {
-                command: WorkspaceCommands::Create { name, cwd: None }
+                command: WorkspaceCommands::Create { name }
             }) if name == "project"
         ));
-        assert!(matches!(
-            Cli::try_parse_from([
-                "boomux",
-                "workspace",
-                "create",
-                "project",
-                "--cwd",
-                "/tmp"
-            ])
-            .unwrap()
-            .command,
-            Some(Commands::Workspace {
-                command: WorkspaceCommands::Create {
-                    name,
-                    cwd: Some(cwd)
-                }
-            }) if name == "project" && cwd == Path::new("/tmp")
-        ));
+        assert!(
+            Cli::try_parse_from(["boomux", "workspace", "create", "project", "--cwd", "/tmp"])
+                .is_err()
+        );
         let cli = Cli::try_parse_from([
             "boomux",
             "launcher",
@@ -14144,7 +13993,6 @@ mod tests {
                 "project.list",
                 "workspace.list",
                 "workspace.inspect",
-                "workspace.create-project",
                 "node.add",
                 "node.list",
                 "node.inspect",

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,8 +562,23 @@ enum WorkspaceCommands {
     Inspect { target: String },
     /// Rename a workspace
     Rename { target: String, name: String },
+    /// Adopt an unlinked Node-local Workspace as a new coordinated Workspace
+    Adopt {
+        target: String,
+        #[arg(long)]
+        node: String,
+    },
+    /// Link an unlinked Node-local Workspace to a coordinated Workspace
+    Link {
+        target: String,
+        owner: String,
+        #[arg(long)]
+        node: String,
+    },
     /// Close a workspace and all of its shells
     Close { target: String },
+    /// Retry unresolved placement removals for a closing Workspace
+    Retry { target: String },
 }
 
 #[derive(Subcommand)]
@@ -578,6 +593,9 @@ enum LauncherCommands {
         name: String,
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: String,
+        /// Exact eligible Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
         #[arg(long, default_value = ".")]
         cwd: PathBuf,
         #[arg(last = true, num_args = 1.., required = true, value_name = "COMMAND")]
@@ -625,6 +643,9 @@ enum ShellCommands {
     /// Create a pending shell in a workspace
     Create {
         workspace: String,
+        /// Exact eligible Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
         #[arg(long)]
         name: Option<String>,
         #[arg(long)]
@@ -1414,7 +1435,10 @@ impl Cli {
                     WorkspaceCommands::Create { .. }
                     | WorkspaceCommands::Open { .. }
                     | WorkspaceCommands::Rename { .. }
-                    | WorkspaceCommands::Close { .. },
+                    | WorkspaceCommands::Adopt { .. }
+                    | WorkspaceCommands::Link { .. }
+                    | WorkspaceCommands::Close { .. }
+                    | WorkspaceCommands::Retry { .. },
             }) => CommandKey::Workspace,
             Some(Commands::Shell {
                 command:
@@ -1630,7 +1654,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
     }
 
     let result = match cli.command {
-        Some(Commands::Ui) => dashboard(cli.terminal.as_deref(), None),
+        Some(Commands::Ui) => dashboard(cli.terminal.as_deref()),
         Some(Commands::Doctor) => doctor(cli.terminal.as_deref()),
         Some(Commands::Capabilities) => capabilities(cli.json),
         Some(Commands::List) => list_shells(cli.json),
@@ -1708,7 +1732,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::ResumeSession { .. }) => unreachable!(),
         Some(Commands::ScheduledRunner { .. }) => unreachable!(),
         Some(Commands::FederationStdio) => unreachable!(),
-        None => dashboard(cli.terminal.as_deref(), None),
+        None => dashboard(cli.terminal.as_deref()),
     };
     result?;
     Ok(CliExit::Success)
@@ -1736,7 +1760,7 @@ fn remote_connect(target: &str, terminal: Option<&str>) -> Result<(), Box<dyn Er
             .supports(protocol::ProtocolFeature::CombinedNodeSnapshot)
             .unwrap_or(false)
     {
-        dashboard(terminal, Some(node_id))?;
+        dashboard(terminal)?;
     }
     Ok(())
 }
@@ -1891,6 +1915,8 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
         NodeCommands::Snapshot { selector } => {
             let snapshot = client::connect_or_start()?.combined_node_snapshot(selector)?;
             if json {
+                let workspaces = snapshot.workspaces.clone();
+                let external_workspaces = snapshot.external_workspaces.clone();
                 let nodes = snapshot
                     .nodes
                     .into_iter()
@@ -1898,7 +1924,11 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
                     .collect::<Result<Vec<_>, _>>()?;
                 print_json(
                     CommandKey::NodeSnapshot,
-                    serde_json::json!({ "nodes": nodes }),
+                    serde_json::json!({
+                        "nodes": nodes,
+                        "workspaces": workspaces,
+                        "external_workspaces": external_workspaces,
+                    }),
                 )
             } else {
                 println!("ALIAS\tOWNERSHIP\tHEALTH\tCURRENT\tOBSERVED\tWORKSPACES\tSCHEDULER");
@@ -1924,6 +1954,51 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
                         format!("{:?}", node.scheduler.state).to_ascii_lowercase(),
                         node.scheduler.active_executions,
                         node.scheduler.max_concurrent,
+                    );
+                }
+                println!("\nGLOBAL WORKSPACES");
+                println!("NAME\tID\tREVISION\tSTATE\tPLACEMENTS");
+                for workspace in snapshot.workspaces {
+                    println!(
+                        "{}\t{}\t{}\t{}\t{}",
+                        workspace.name,
+                        workspace.id,
+                        workspace.revision,
+                        if workspace.closing {
+                            "closing"
+                        } else {
+                            "active"
+                        },
+                        workspace.placements.len(),
+                    );
+                    for placement in workspace.placements {
+                        println!(
+                            "  ->\t{}:{}\t{}\t{:?}\t{}",
+                            placement.node_id,
+                            placement.workspace_id,
+                            placement.owner_revision,
+                            placement.state,
+                            placement
+                                .default_cwd
+                                .as_deref()
+                                .map_or_else(|| "-".into(), |path| path.display().to_string()),
+                        );
+                    }
+                }
+                println!("\nEXTERNAL WORKSPACES");
+                println!("NAME\tOWNER\tREVISION\tAVAILABLE\tDEFAULT CWD");
+                for workspace in snapshot.external_workspaces {
+                    println!(
+                        "{}\t{}:{}\t{}\t{}\t{}",
+                        workspace.name,
+                        workspace.identity.node_id,
+                        workspace.identity.inner_id,
+                        workspace.revision,
+                        workspace.available,
+                        workspace
+                            .default_cwd
+                            .as_deref()
+                            .map_or_else(|| "-".into(), |path| path.display().to_string()),
                     );
                 }
                 Ok(())
@@ -2030,27 +2105,36 @@ fn node_snapshot_json(node: protocol::CombinedNode) -> Result<serde_json::Value,
         node_id,
         alias,
         local,
+        route,
+        registration_revision,
         health,
         current,
         stale,
         observed_at_ms,
         observed_protocol_version,
         observed_capabilities,
+        workspace_owner_eligible,
+        workspace_owner_unavailable_reason,
         scheduler,
         local_snapshot,
         remote_projection,
+        ..
     } = node;
     let qualify = |value| qualify_resource_identities(value, &node_id);
     Ok(serde_json::json!({
         "node_id": node_id,
         "alias": alias,
         "local": local,
+        "route": route,
+        "registration_revision": registration_revision,
         "health": health,
         "current": current,
         "stale": stale,
         "observed_at_ms": observed_at_ms,
         "observed_protocol_version": observed_protocol_version,
         "observed_capabilities": observed_capabilities,
+        "workspace_owner_eligible": workspace_owner_eligible,
+        "workspace_owner_unavailable_reason": workspace_owner_unavailable_reason,
         "scheduler": scheduler,
         "local_snapshot": local_snapshot.map(serde_json::to_value).transpose()?.map(qualify),
         "remote_projection": remote_projection.map(serde_json::to_value).transpose()?.map(qualify),
@@ -2212,10 +2296,7 @@ fn effective_terminal(override_entry: Option<&str>) -> Result<Option<String>, Bo
     Ok(config::load()?.terminal)
 }
 
-fn dashboard(
-    terminal_override: Option<&str>,
-    initial_node_filter: Option<String>,
-) -> Result<(), Box<dyn Error>> {
+fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     ensure_host_terminal()?;
     let launch_cwd = resolve_directory(Path::new("."))?;
     let client = client::connect_or_start()?;
@@ -2247,7 +2328,7 @@ fn dashboard(
         roots_configured,
     };
 
-    let mut initial_state = dashboard_state(
+    let initial_state = dashboard_state(
         snapshot,
         combined,
         &refresh,
@@ -2255,7 +2336,6 @@ fn dashboard(
         &mut title_cache,
         false,
     );
-    initial_state.initial_node_filter = initial_node_filter;
     tui::run(
         initial_state,
         config.dashboard.follow_focused_terminal,
@@ -2292,6 +2372,12 @@ fn dashboard(
                     Err(error) => tui::DashboardEvent::RefreshCompleted(Err(error)),
                 }
             }
+            tui::DashboardEffect::RefreshNode(node_id) => tui::DashboardEvent::OperationCompleted(
+                client
+                    .force_node_projection_refresh(node_id)
+                    .map(|_| "Requested a fresh Node observation".into())
+                    .map_err(|error| error.to_string()),
+            ),
             tui::DashboardEffect::RestoreWorkspace(workspace_id) => {
                 let result = (|| {
                     let workspace_id = local_dashboard_inner(&workspace_id, &local_node_id)?;
@@ -2307,6 +2393,51 @@ fn dashboard(
                         workspace.name
                     ))
                 })();
+                tui::DashboardEvent::OperationCompleted(result)
+            }
+            tui::DashboardEffect::OpenGlobalWorkspace {
+                workspace_id,
+                expected_revision,
+            } => {
+                let result = (|| {
+                    let combined = client
+                        .combined_node_snapshot(None)
+                        .map_err(|error| error.to_string())?;
+                    let workspace = combined
+                        .workspaces
+                        .iter()
+                        .find(|workspace| workspace.id == workspace_id)
+                        .ok_or_else(|| "global Workspace is no longer retained".to_owned())?;
+                    if workspace.revision != expected_revision {
+                        return Err("global Workspace revision changed; refresh and retry".into());
+                    }
+                    open_coordinated_workspace(&client, &combined, workspace, terminal.as_deref())
+                        .map_err(|error| error.to_string())?;
+                    Ok(format!(
+                        "Opened {} across available placements",
+                        workspace.name
+                    ))
+                })();
+                tui::DashboardEvent::OperationCompleted(result)
+            }
+            tui::DashboardEffect::RetryGlobalWorkspaceClose { workspace_id } => {
+                let result = client
+                    .retry_global_workspace_close(workspace_id)
+                    .map(|result| {
+                        let unresolved = result
+                            .placements
+                            .iter()
+                            .filter(|placement| placement.status == "unresolved")
+                            .count();
+                        if unresolved == 0 {
+                            "Completed Workspace close".into()
+                        } else {
+                            format!(
+                                "Workspace close still has {unresolved} unresolved placement(s)"
+                            )
+                        }
+                    })
+                    .map_err(|error| error.to_string());
                 tui::DashboardEvent::OperationCompleted(result)
             }
             tui::DashboardEffect::Open(target) => {
@@ -2357,6 +2488,25 @@ fn dashboard(
             }
             tui::DashboardEffect::Close(target) => {
                 let result = (|| match &target {
+                    tui::CloseTarget::GlobalWorkspace {
+                        workspace_id,
+                        expected_revision,
+                    } => {
+                        let result = client
+                            .close_global_workspace(workspace_id, *expected_revision)
+                            .map_err(|error| error.to_string())?;
+                        let unresolved = result
+                            .placements
+                            .iter()
+                            .filter(|placement| placement.status != "closed")
+                            .count();
+                        if unresolved > 0 {
+                            return Err(format!(
+                                "Workspace close remains unresolved on {unresolved} Node(s); refresh and retry"
+                            ));
+                        }
+                        Ok("Closed global Workspace across every placement".into())
+                    }
                     tui::CloseTarget::Workspace(workspace_id) => {
                         let workspace =
                             routed_dashboard_workspace(&client, workspace_id, &local_node_id)?;
@@ -2437,6 +2587,49 @@ fn dashboard(
                         .map_err(|error| error.to_string()),
                 )
             }
+            tui::DashboardEffect::CreatePlacedWorkspace {
+                name,
+                default_cwd,
+                node_id,
+            } => {
+                let result = (|| {
+                    let combined = client
+                        .combined_node_snapshot(Some(node_id.clone()))
+                        .map_err(|error| error.to_string())?;
+                    let node = combined
+                        .nodes
+                        .iter()
+                        .find(|node| node.node_id == node_id)
+                        .ok_or_else(|| "selected Node is no longer available".to_owned())?;
+                    if !node.workspace_owner_eligible {
+                        return Err(node
+                            .workspace_owner_unavailable_reason
+                            .clone()
+                            .unwrap_or_else(|| "selected Node is unavailable".into()));
+                    }
+                    let cwd = resolve_owner_directory(&client, node, default_cwd)
+                        .map_err(|error| error.to_string())?;
+                    let shell_name = generated_shell_name(std::iter::empty())
+                        .map_err(|error| error.to_string())?;
+                    let (workspace, shell) = client
+                        .create_global_workspace_with_shell(
+                            Uuid::new_v4().to_string(),
+                            Uuid::new_v4().to_string(),
+                            name,
+                            &node_id,
+                            Uuid::new_v4().to_string(),
+                            cwd.clone(),
+                            Uuid::new_v4().to_string(),
+                            shell_spec(shell_name, &cwd, &[]),
+                        )
+                        .map_err(|error| error.to_string())?;
+                    Ok(format!(
+                        "Created {} with {} on Node {}",
+                        workspace.name, shell.name, node.alias
+                    ))
+                })();
+                tui::DashboardEvent::OperationCompleted(result)
+            }
             tui::DashboardEffect::CreateShell(workspace_id) => {
                 tui::DashboardEvent::OperationCompleted(
                     local_dashboard_inner(&workspace_id, &local_node_id).and_then(|workspace_id| {
@@ -2445,8 +2638,143 @@ fn dashboard(
                     }),
                 )
             }
+            tui::DashboardEffect::CreateGlobalShell {
+                workspace_id,
+                expected_revision,
+                node_id,
+                owner_workspace_id,
+                default_cwd,
+            } => {
+                let result = (|| {
+                    let combined = client
+                        .combined_node_snapshot(Some(node_id.clone()))
+                        .map_err(|error| error.to_string())?;
+                    let node = combined
+                        .nodes
+                        .iter()
+                        .find(|node| node.node_id == node_id)
+                        .ok_or_else(|| "selected Node is no longer available".to_owned())?;
+                    let cwd = resolve_owner_directory(
+                        &client,
+                        node,
+                        default_cwd.clone().unwrap_or_else(|| PathBuf::from(".")),
+                    )
+                    .map_err(|error| error.to_string())?;
+                    let name = generated_shell_name(std::iter::empty())
+                        .map_err(|error| error.to_string())?;
+                    let (_, shell) = client
+                        .create_global_workspace_shell(
+                            Uuid::new_v4().to_string(),
+                            workspace_id,
+                            expected_revision,
+                            node_id,
+                            owner_workspace_id,
+                            default_cwd.or_else(|| Some(cwd.clone())),
+                            Uuid::new_v4().to_string(),
+                            shell_spec(name, &cwd, &[]),
+                        )
+                        .map_err(|error| error.to_string())?;
+                    Ok(format!("Created {} on Node {}", shell.name, node.alias))
+                })();
+                tui::DashboardEvent::OperationCompleted(result)
+            }
+            tui::DashboardEffect::AdoptExternalWorkspace {
+                identity,
+                expected_revision,
+            } => {
+                let result = (|| {
+                    let owner = routed_dashboard_workspace(&client, &identity, &local_node_id)?;
+                    if expected_revision > 0 && owner.revision != expected_revision {
+                        return Err(format!(
+                            "owner Workspace revision changed: expected {expected_revision}, current {}",
+                            owner.revision
+                        ));
+                    }
+                    let global = client
+                        .adopt_node_workspace(identity, owner.revision)
+                        .map_err(|error| error.to_string())?;
+                    Ok(format!("Adopted {} as a new Workspace", global.name))
+                })();
+                tui::DashboardEvent::OperationCompleted(result)
+            }
+            tui::DashboardEffect::LinkExternalWorkspace {
+                workspace_id,
+                expected_revision,
+                identity,
+                expected_owner_revision,
+            } => {
+                let result = (|| {
+                    let owner = routed_dashboard_workspace(&client, &identity, &local_node_id)?;
+                    if expected_owner_revision > 0 && owner.revision != expected_owner_revision {
+                        return Err(format!(
+                            "owner Workspace revision changed: expected {expected_owner_revision}, current {}",
+                            owner.revision
+                        ));
+                    }
+                    let global = client
+                        .link_node_workspace(
+                            workspace_id,
+                            expected_revision,
+                            identity,
+                            owner.revision,
+                        )
+                        .map_err(|error| error.to_string())?;
+                    Ok(format!("Linked owner Workspace to {}", global.name))
+                })();
+                tui::DashboardEvent::OperationCompleted(result)
+            }
+            tui::DashboardEffect::RetargetNode {
+                node_id,
+                expected_revision,
+                route,
+            } => {
+                let result = (|| {
+                    let mut remote = verified_remote_connection(&route, true)
+                        .map_err(|error| error.to_string())?;
+                    remote.ping().map_err(|error| error.to_string())?;
+                    if remote.handshake.node_id != node_id {
+                        return Err("retargeted route reached a different Node identity".into());
+                    }
+                    let registration = client
+                        .retarget_node_registration(
+                            &node_id,
+                            route,
+                            node_id.clone(),
+                            expected_revision,
+                        )
+                        .map_err(|error| error.to_string())?;
+                    Ok(format!("Retargeted Node {}", registration.alias))
+                })();
+                tui::DashboardEvent::OperationCompleted(result)
+            }
+            tui::DashboardEffect::ForgetNode { node_id } => {
+                tui::DashboardEvent::OperationCompleted(
+                    client
+                        .forget_node_registration(node_id)
+                        .map(|registration| format!("Forgot Node {}", registration.alias))
+                        .map_err(|error| error.to_string()),
+                )
+            }
             tui::DashboardEffect::Rename { target, name } => {
                 let result = (|| match &target {
+                    tui::RenameTarget::Node {
+                        node_id,
+                        expected_revision,
+                    } => {
+                        client
+                            .rename_node_registration(node_id, &name, *expected_revision)
+                            .map_err(|error| error.to_string())?;
+                        Ok(format!("Renamed Node alias to {name}"))
+                    }
+                    tui::RenameTarget::GlobalWorkspace {
+                        workspace_id,
+                        expected_revision,
+                    } => {
+                        client
+                            .rename_global_workspace(workspace_id, *expected_revision, &name)
+                            .map_err(|error| error.to_string())?;
+                        Ok(format!("Renamed workspace to {name}"))
+                    }
                     tui::RenameTarget::Workspace(workspace_id) => {
                         let workspace =
                             routed_dashboard_workspace(&client, workspace_id, &local_node_id)?;
@@ -2895,21 +3223,27 @@ fn dashboard_state(
     };
     let mut nodes = Vec::new();
     if let Some(combined) = combined {
+        let global_workspaces = combined.workspaces;
+        let external_workspaces = combined.external_workspaces;
         for node in combined.nodes {
             let node_view = tui::NodeView {
                 id: node.node_id.clone(),
                 alias: node.alias.clone(),
                 local: node.local,
+                route: node.route.clone(),
+                registration_revision: node.registration_revision,
                 health: node.health,
                 current: node.current,
                 stale: node.stale,
+                observed_at_ms: node.observed_at_ms,
+                observed_protocol_version: node.observed_protocol_version,
                 observed_capabilities: node.observed_capabilities.clone(),
+                workspace_owner_eligible: node.workspace_owner_eligible,
+                workspace_owner_unavailable_reason: node.workspace_owner_unavailable_reason.clone(),
                 scheduler: node.scheduler.clone(),
             };
             if node.local {
-                for workspace in &mut workspaces {
-                    workspace.node = node_view.clone();
-                }
+                assign_local_workspace_node(&mut workspaces, &node_view);
                 for schedule in &mut schedules {
                     schedule.node_id = node.node_id.clone();
                     schedule.node_alias = node.alias.clone();
@@ -2923,6 +3257,18 @@ fn dashboard_state(
             }
             nodes.push(node_view);
         }
+        for schedule in &mut schedules {
+            if let Some(global) = global_workspaces.iter().find(|workspace| {
+                workspace.placements.iter().any(|placement| {
+                    placement.node_id == schedule.node_id
+                        && placement.workspace_id == schedule.workspace_id
+                })
+            }) {
+                schedule.workspace = global.name.clone();
+            }
+        }
+        workspaces =
+            group_dashboard_workspaces(workspaces, &nodes, global_workspaces, external_workspaces);
     }
     if nodes.is_empty() {
         nodes.extend(
@@ -2932,13 +3278,7 @@ fn dashboard_state(
                 .take(1),
         );
     }
-    workspaces.sort_by(|left, right| {
-        left.node
-            .alias
-            .cmp(&right.node.alias)
-            .then_with(|| left.name.cmp(&right.name))
-            .then_with(|| left.id.cmp(&right.id))
-    });
+    sort_dashboard_workspaces(&mut workspaces);
     schedules.sort_by(|left, right| {
         left.node_alias
             .cmp(&right.node_alias)
@@ -2957,8 +3297,24 @@ fn dashboard_state(
             .is_supported_by(refresh.negotiated_protocol),
         focused_terminal: snapshot.focused_terminal.map(focused_terminal_view),
         reset_focus_revision,
-        initial_node_filter: None,
     }
+}
+
+fn assign_local_workspace_node(workspaces: &mut [tui::WorkspaceView], node: &tui::NodeView) {
+    for workspace in workspaces {
+        workspace.node = node.clone();
+        for owner in &mut workspace.item_owners {
+            owner.node = node.clone();
+        }
+    }
+}
+
+fn sort_dashboard_workspaces(workspaces: &mut [tui::WorkspaceView]) {
+    workspaces.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.id.cmp(&right.id))
+    });
 }
 
 fn combined_node_snapshot_for_dashboard(
@@ -2968,6 +3324,168 @@ fn combined_node_snapshot_for_dashboard(
         client.combined_node_snapshot(None).map(Some)
     } else {
         Ok(None)
+    }
+}
+
+fn group_dashboard_workspaces(
+    mut owner_workspaces: Vec<tui::WorkspaceView>,
+    nodes: &[tui::NodeView],
+    global_workspaces: Vec<protocol::GlobalWorkspaceSnapshot>,
+    external_workspaces: Vec<protocol::ExternalWorkspaceSnapshot>,
+) -> Vec<tui::WorkspaceView> {
+    let fallback_node = nodes
+        .iter()
+        .find(|node| node.local)
+        .or_else(|| nodes.first())
+        .cloned();
+    let mut grouped = Vec::new();
+    for global in global_workspaces {
+        let mut items = Vec::new();
+        let mut item_owners = Vec::new();
+        let mut sessions = Vec::new();
+        let mut attention = Vec::new();
+        let mut counts = agent_attention_projection::AgentStateCounts::default();
+        let mut attention_count = 0;
+        let placements = global
+            .placements
+            .iter()
+            .map(|placement| {
+                let node = nodes
+                    .iter()
+                    .find(|node| node.id == placement.node_id)
+                    .cloned()
+                    .unwrap_or_else(|| unavailable_placement_node(&placement.node_id));
+                if let Some(index) = owner_workspaces.iter().position(|workspace| {
+                    workspace.node.id == placement.node_id && workspace.id == placement.workspace_id
+                }) {
+                    let owner = owner_workspaces.remove(index);
+                    let owner_item_count = owner.items.len();
+                    if owner.item_owners.len() == owner_item_count {
+                        item_owners.extend(owner.item_owners);
+                    } else {
+                        item_owners.extend((0..owner_item_count).map(|_| {
+                            tui::WorkspaceItemOwnerView {
+                                node: owner.node.clone(),
+                                workspace_id: owner.id.clone(),
+                            }
+                        }));
+                    }
+                    items.extend(owner.items);
+                    sessions.extend(owner.sessions);
+                    attention.extend(owner.attention.into_iter().map(|mut attention| {
+                        attention.node_id = owner.node.id.clone();
+                        attention.workspace_id = owner.id.clone();
+                        attention
+                    }));
+                    counts.unknown += owner.agent_state_counts.unknown;
+                    counts.working += owner.agent_state_counts.working;
+                    counts.blocked += owner.agent_state_counts.blocked;
+                    counts.idle += owner.agent_state_counts.idle;
+                    counts.inactive += owner.agent_state_counts.inactive;
+                    counts.done += owner.agent_state_counts.done;
+                    attention_count += owner.attention_count;
+                }
+                tui::WorkspacePlacementView {
+                    node,
+                    workspace_id: placement.workspace_id.clone(),
+                    owner_revision: placement.owner_revision,
+                    default_cwd: placement
+                        .default_cwd
+                        .as_ref()
+                        .map(|cwd| cwd.display().to_string()),
+                    state: placement.state,
+                }
+            })
+            .collect::<Vec<_>>();
+        let Some(node) = fallback_node
+            .clone()
+            .or_else(|| placements.first().map(|placement| placement.node.clone()))
+        else {
+            continue;
+        };
+        grouped.push(tui::WorkspaceView {
+            node,
+            id: global.id,
+            name: global.name,
+            default_cwd: None,
+            items,
+            sessions,
+            agent_state_counts: counts,
+            attention_count,
+            attention,
+            item_owners,
+            coordination: tui::WorkspaceCoordinationView::Global {
+                revision: global.revision,
+                closing: global.closing,
+                placements,
+            },
+        });
+    }
+    for external in external_workspaces {
+        if let Some(workspace) = owner_workspaces.iter_mut().find(|workspace| {
+            workspace.node.id == external.identity.node_id
+                && workspace.id == external.identity.inner_id
+        }) {
+            workspace.coordination = tui::WorkspaceCoordinationView::External {
+                owner_revision: external.revision,
+                available: external.available,
+            };
+            continue;
+        }
+        let Some(node) = nodes
+            .iter()
+            .find(|node| node.id == external.identity.node_id)
+            .cloned()
+        else {
+            continue;
+        };
+        grouped.push(tui::WorkspaceView {
+            node,
+            id: external.identity.inner_id,
+            name: external.name,
+            default_cwd: external
+                .default_cwd
+                .as_ref()
+                .map(|cwd| cwd.display().to_string()),
+            items: Vec::new(),
+            sessions: Vec::new(),
+            agent_state_counts: agent_attention_projection::AgentStateCounts::default(),
+            attention_count: 0,
+            attention: Vec::new(),
+            item_owners: Vec::new(),
+            coordination: tui::WorkspaceCoordinationView::External {
+                owner_revision: external.revision,
+                available: external.available,
+            },
+        });
+    }
+    grouped.extend(owner_workspaces);
+    grouped
+}
+
+fn unavailable_placement_node(node_id: &str) -> tui::NodeView {
+    tui::NodeView {
+        id: node_id.to_owned(),
+        alias: format!(
+            "unregistered:{}",
+            node_id.chars().take(8).collect::<String>()
+        ),
+        local: false,
+        route: None,
+        registration_revision: None,
+        health: protocol::NodeProjectionHealthCode::Unobserved,
+        current: false,
+        stale: true,
+        observed_at_ms: 0,
+        observed_protocol_version: None,
+        observed_capabilities: Vec::new(),
+        workspace_owner_eligible: false,
+        workspace_owner_unavailable_reason: Some("Node is not registered".into()),
+        scheduler: protocol::SchedulerHealth {
+            state: protocol::SchedulerState::Offline,
+            max_concurrent: 0,
+            active_executions: 0,
+        },
     }
 }
 
@@ -3686,6 +4204,174 @@ fn resolve_workspace_target<'a>(
         .ok_or_else(|| cli_output::failure("not_found", format!("workspace not found: {target}")))
 }
 
+fn resolve_global_workspace_target<'a>(
+    workspaces: &'a [protocol::GlobalWorkspaceSnapshot],
+    target: &str,
+) -> Option<&'a protocol::GlobalWorkspaceSnapshot> {
+    workspaces
+        .iter()
+        .find(|workspace| workspace.id == target)
+        .or_else(|| workspaces.iter().find(|workspace| workspace.name == target))
+}
+
+fn resolve_combined_node<'a>(
+    nodes: &'a [protocol::CombinedNode],
+    selector: &str,
+) -> Result<&'a protocol::CombinedNode, Box<dyn Error>> {
+    let matches = nodes
+        .iter()
+        .filter(|node| node.node_id == selector || node.alias == selector)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [node] => Ok(*node),
+        [] => Err(cli_output::failure(
+            "not_found",
+            format!("Node not found: {selector}"),
+        )),
+        _ => Err(cli_output::failure(
+            "ambiguous_target",
+            format!("Node selector is ambiguous: {selector}"),
+        )),
+    }
+}
+
+fn resolve_external_workspace<'a>(
+    workspaces: &'a [protocol::ExternalWorkspaceSnapshot],
+    node_id: &str,
+    target: &str,
+) -> Result<&'a protocol::ExternalWorkspaceSnapshot, Box<dyn Error>> {
+    workspaces
+        .iter()
+        .find(|workspace| {
+            workspace.identity.node_id == node_id
+                && (workspace.identity.inner_id == target || workspace.name == target)
+        })
+        .ok_or_else(|| {
+            cli_output::failure(
+                "not_found",
+                format!("unlinked owner Workspace not found: {target}"),
+            )
+        })
+}
+
+struct CoordinatedOwnerSelection {
+    workspace: protocol::GlobalWorkspaceSnapshot,
+    node: protocol::CombinedNode,
+    owner_workspace_id: String,
+    default_cwd: Option<PathBuf>,
+}
+
+fn select_coordinated_owner(
+    client: &client::Client,
+    workspace_target: &str,
+    node_selector: Option<&str>,
+) -> Result<Option<CoordinatedOwnerSelection>, Box<dyn Error>> {
+    if !client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+        return Ok(None);
+    }
+    let combined = client.combined_node_snapshot(None)?;
+    let Some(workspace) =
+        resolve_global_workspace_target(&combined.workspaces, workspace_target).cloned()
+    else {
+        return Ok(None);
+    };
+    let node = if let Some(selector) = node_selector {
+        let matches = combined
+            .nodes
+            .iter()
+            .filter(|node| node.node_id == selector || node.alias == selector)
+            .collect::<Vec<_>>();
+        let [node] = matches.as_slice() else {
+            return Err(cli_output::failure(
+                if matches.is_empty() {
+                    "not_found"
+                } else {
+                    "ambiguous_target"
+                },
+                format!("Node selector did not resolve uniquely: {selector}"),
+            ));
+        };
+        if !node.workspace_owner_eligible {
+            return Err(cli_output::failure(
+                "busy",
+                format!(
+                    "Node {} is unavailable for Workspace placement: {}",
+                    node.alias,
+                    node.workspace_owner_unavailable_reason
+                        .as_deref()
+                        .unwrap_or("unavailable")
+                ),
+            ));
+        }
+        (*node).clone()
+    } else {
+        let eligible = combined
+            .nodes
+            .iter()
+            .filter(|node| node.workspace_owner_eligible)
+            .collect::<Vec<_>>();
+        let [node] = eligible.as_slice() else {
+            let status = combined
+                .nodes
+                .iter()
+                .map(|node| {
+                    format!(
+                        "{} ({})",
+                        node.alias,
+                        if node.workspace_owner_eligible {
+                            "eligible"
+                        } else {
+                            node.workspace_owner_unavailable_reason
+                                .as_deref()
+                                .unwrap_or("unavailable")
+                        }
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(cli_output::failure(
+                "ambiguous_target",
+                format!(
+                    "Workspace resource placement requires --node when zero or multiple eligible Nodes exist; Nodes: {status}"
+                ),
+            ));
+        };
+        (*node).clone()
+    };
+    let placement = workspace
+        .placements
+        .iter()
+        .find(|placement| placement.node_id == node.node_id);
+    let owner_workspace_id = placement.map_or_else(
+        || Uuid::new_v4().to_string(),
+        |placement| placement.workspace_id.clone(),
+    );
+    let default_cwd = placement.and_then(|placement| placement.default_cwd.clone());
+    Ok(Some(CoordinatedOwnerSelection {
+        workspace,
+        node,
+        owner_workspace_id,
+        default_cwd,
+    }))
+}
+
+fn resolve_owner_directory(
+    client: &client::Client,
+    node: &protocol::CombinedNode,
+    path: PathBuf,
+) -> Result<PathBuf, Box<dyn Error>> {
+    if node.local {
+        return resolve_directory(&path);
+    }
+    match client.route_node_host_service(
+        &node.node_id,
+        protocol::HostServiceOperation::ResolveDirectory { path },
+    )? {
+        protocol::HostServiceResult::Directory { path } => Ok(path),
+        _ => Err("owner Node returned an unexpected directory response".into()),
+    }
+}
+
 fn create_dashboard_workspace(
     client: &client::Client,
     name: &str,
@@ -3695,8 +4381,21 @@ fn create_dashboard_workspace(
     if name.is_empty() {
         return Err("workspace name cannot be empty".into());
     }
+    if default_cwd.is_none() && client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+        let workspace = client.create_global_workspace(name)?;
+        return Ok(format!(
+            "Created empty workspace {} ({})",
+            workspace.name, workspace.id
+        ));
+    }
     client.create_workspace_with_default_cwd(name, default_cwd.cloned(), Vec::new())?;
-    Ok(format!("Created empty workspace {name}"))
+    Ok(if default_cwd.is_some() {
+        format!(
+            "Created unlinked local workspace {name} with its project path; adopt or link it explicitly"
+        )
+    } else {
+        format!("Created empty workspace {name}")
+    })
 }
 
 fn create_dashboard_shell(
@@ -4836,6 +5535,109 @@ fn list_shells(json: bool) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn open_coordinated_workspace(
+    client: &client::Client,
+    combined: &protocol::CombinedNodeSnapshot,
+    workspace: &protocol::GlobalWorkspaceSnapshot,
+    terminal_override: Option<&str>,
+) -> Result<(usize, usize), Box<dyn Error>> {
+    let operation = client.open_global_workspace(&workspace.id, workspace.revision)?;
+    let terminal = effective_terminal(terminal_override)?;
+    let mut opened_launchers = 0;
+    let mut opened_shells = 0;
+    let mut failures = Vec::new();
+    for placement in operation.placements {
+        let node = combined
+            .nodes
+            .iter()
+            .find(|node| node.node_id == placement.node_id);
+        let alias = node.map_or(placement.node_id.as_str(), |node| node.alias.as_str());
+        if placement.status != "available" {
+            failures.push(format!(
+                "Node {alias}: {}",
+                placement.message.unwrap_or(placement.status)
+            ));
+            continue;
+        }
+        let owner = if node.is_some_and(|node| node.local) {
+            client.get_workspace(&placement.workspace_id)
+        } else {
+            client
+                .route_node_operation(
+                    &placement.node_id,
+                    protocol::RoutedOperation::GetWorkspace {
+                        workspace_id: placement.workspace_id.clone(),
+                    },
+                )
+                .and_then(|result| match result {
+                    protocol::RoutedOperationResult::Workspace { workspace } => Ok(workspace),
+                    _ => Err(client::ClientError::Protocol(
+                        client::ProtocolError::UnexpectedResponse(Box::new(
+                            protocol::Response::RoutedNodeOperation { result },
+                        )),
+                    )),
+                })
+        };
+        let owner = match owner {
+            Ok(owner) => owner,
+            Err(error) => {
+                failures.push(format!("Node {alias}: {error}"));
+                continue;
+            }
+        };
+        if node.is_some_and(|node| node.local) {
+            match open_workspace(&owner, terminal.as_deref()) {
+                Ok(()) => {
+                    opened_launchers += owner.launchers.len();
+                    opened_shells += workspace_user_shell_count(&owner);
+                }
+                Err(error) => failures.push(format!("Node {alias}: {error}")),
+            }
+            continue;
+        }
+        for launcher in &owner.launchers {
+            match client.route_node_host_service(
+                &placement.node_id,
+                protocol::HostServiceOperation::InvokeLauncher {
+                    workspace_id: owner.id.clone(),
+                    launcher_id: launcher.id.clone(),
+                },
+            ) {
+                Ok(_) => opened_launchers += 1,
+                Err(error) => {
+                    failures.push(format!("Node {alias} launcher {}: {error}", launcher.name))
+                }
+            }
+        }
+        for shell in owner
+            .shells
+            .iter()
+            .filter(|shell| matches!(shell.owner, protocol::ShellOwner::User))
+        {
+            match terminal::open_remote(
+                terminal.as_deref(),
+                &placement.node_id,
+                &shell.id,
+                &format!("[{alias}] {} - {}", workspace.name, shell.name),
+                true,
+            ) {
+                Ok(()) => opened_shells += 1,
+                Err(error) => failures.push(format!("Node {alias} shell {}: {error}", shell.name)),
+            }
+        }
+    }
+    if failures.is_empty() {
+        Ok((opened_launchers, opened_shells))
+    } else {
+        Err(io::Error::other(format!(
+            "Workspace {} opened with per-Node failures: {}",
+            workspace.name,
+            failures.join("; ")
+        ))
+        .into())
+    }
+}
+
 fn workspace_command(
     command: WorkspaceCommands,
     json: bool,
@@ -4844,6 +5646,48 @@ fn workspace_command(
     let client = client::connect_or_start()?;
     match command {
         WorkspaceCommands::List => {
+            if client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+                let combined = client.combined_node_snapshot(None)?;
+                if json {
+                    return print_json(
+                        CommandKey::WorkspaceList,
+                        serde_json::json!({
+                            "workspaces": combined.workspaces,
+                            "external_workspaces": combined.external_workspaces,
+                        }),
+                    );
+                }
+                println!("NAME\tWORKSPACE ID\tREVISION\tSTATE\tPLACEMENTS");
+                for workspace in combined.workspaces {
+                    println!(
+                        "{}\t{}\t{}\t{}\t{}",
+                        workspace.name,
+                        workspace.id,
+                        workspace.revision,
+                        if workspace.closing {
+                            "closing"
+                        } else {
+                            "active"
+                        },
+                        workspace.placements.len(),
+                    );
+                }
+                if !combined.external_workspaces.is_empty() {
+                    println!("\nUNLINKED OWNER WORKSPACES");
+                    println!("NAME\tNODE ID\tOWNER WORKSPACE ID\tREVISION\tAVAILABLE");
+                    for workspace in combined.external_workspaces {
+                        println!(
+                            "{}\t{}\t{}\t{}\t{}",
+                            workspace.name,
+                            workspace.identity.node_id,
+                            workspace.identity.inner_id,
+                            workspace.revision,
+                            workspace.available,
+                        );
+                    }
+                }
+                return Ok(());
+            }
             let workspaces = client.snapshot()?.workspaces;
             if json {
                 let workspaces = workspaces
@@ -4888,6 +5732,11 @@ fn workspace_command(
         }
         WorkspaceCommands::Create { name, cwd } => {
             let name = cli_name(name, "workspace")?;
+            if cwd.is_none() && client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+                let workspace = client.create_global_workspace(name)?;
+                println!("Created workspace {} ({})", workspace.name, workspace.id);
+                return Ok(());
+            }
             let default_cwd = cwd.as_deref().map(resolve_directory).transpose()?;
             let workspace =
                 client.create_workspace_with_default_cwd(name, default_cwd, Vec::new())?;
@@ -4952,6 +5801,24 @@ fn workspace_command(
                 );
                 return Ok(());
             }
+            if client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+                let combined = client.combined_node_snapshot(None)?;
+                if let Some(workspace) =
+                    resolve_global_workspace_target(&combined.workspaces, &target).cloned()
+                {
+                    let (launchers, shells) = open_coordinated_workspace(
+                        &client,
+                        &combined,
+                        &workspace,
+                        terminal_override,
+                    )?;
+                    println!(
+                        "Opened {launchers} launcher(s) and {shells} shell(s) for {}",
+                        workspace.name
+                    );
+                    return Ok(());
+                }
+            }
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
             let terminal = effective_terminal(terminal_override)?;
@@ -4964,6 +5831,50 @@ fn workspace_command(
             );
         }
         WorkspaceCommands::Inspect { target } => {
+            if client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+                let combined = client.combined_node_snapshot(None)?;
+                if let Some(workspace) =
+                    resolve_global_workspace_target(&combined.workspaces, &target)
+                {
+                    if json {
+                        return print_json(
+                            CommandKey::WorkspaceInspect,
+                            serde_json::json!({ "workspace": workspace }),
+                        );
+                    }
+                    println!("ID\t{}", workspace.id);
+                    println!("NAME\t{}", workspace.name);
+                    println!("REVISION\t{}", workspace.revision);
+                    println!(
+                        "STATE\t{}",
+                        if workspace.closing {
+                            "closing"
+                        } else {
+                            "active"
+                        }
+                    );
+                    println!("PLACEMENTS\t{}", workspace.placements.len());
+                    if !workspace.placements.is_empty() {
+                        println!(
+                            "\nNODE ID\tOWNER WORKSPACE ID\tOWNER REVISION\tSTATE\tDEFAULT CWD"
+                        );
+                        for placement in &workspace.placements {
+                            println!(
+                                "{}\t{}\t{}\t{:?}\t{}",
+                                placement.node_id,
+                                placement.workspace_id,
+                                placement.owner_revision,
+                                placement.state,
+                                placement
+                                    .default_cwd
+                                    .as_deref()
+                                    .map_or_else(|| "-".into(), |path| path.display().to_string()),
+                            );
+                        }
+                    }
+                    return Ok(());
+                }
+            }
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
             let agent_summary = agent_attention_projection::summarize_workspace(workspace);
@@ -5068,12 +5979,153 @@ fn workspace_command(
         }
         WorkspaceCommands::Rename { target, name } => {
             let name = cli_name(name, "workspace")?;
+            if client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+                let combined = client.combined_node_snapshot(None)?;
+                if let Some(workspace) =
+                    resolve_global_workspace_target(&combined.workspaces, &target)
+                {
+                    let renamed =
+                        client.rename_global_workspace(&workspace.id, workspace.revision, &name)?;
+                    println!("Renamed workspace {} to {}", workspace.name, renamed.name);
+                    return Ok(());
+                }
+            }
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
             client.rename_workspace(&workspace.id, &name)?;
             println!("Renamed workspace {} to {name}", workspace.name);
         }
+        WorkspaceCommands::Adopt { target, node } => {
+            let combined = client.combined_node_snapshot(None)?;
+            let node = resolve_combined_node(&combined.nodes, &node)?;
+            if !node.workspace_owner_eligible {
+                return Err(cli_output::failure(
+                    "busy",
+                    node.workspace_owner_unavailable_reason
+                        .clone()
+                        .unwrap_or_else(|| "owner Node is not eligible for placement".into()),
+                ));
+            }
+            let external =
+                resolve_external_workspace(&combined.external_workspaces, &node.node_id, &target)?;
+            if !external.available {
+                return Err(cli_output::failure(
+                    "busy",
+                    "unavailable owner Workspace cannot be adopted",
+                ));
+            }
+            let local_node_id = combined
+                .nodes
+                .iter()
+                .find(|candidate| candidate.local)
+                .map(|candidate| candidate.node_id.as_str())
+                .unwrap_or_default();
+            let owner = routed_dashboard_workspace(&client, &external.identity, local_node_id)
+                .map_err(io::Error::other)?;
+            let workspace =
+                client.adopt_node_workspace(external.identity.clone(), owner.revision)?;
+            println!("Adopted workspace {} ({})", workspace.name, workspace.id);
+        }
+        WorkspaceCommands::Link {
+            target,
+            owner,
+            node,
+        } => {
+            let combined = client.combined_node_snapshot(None)?;
+            let workspace = resolve_global_workspace_target(&combined.workspaces, &target)
+                .ok_or_else(|| {
+                    cli_output::failure("not_found", format!("workspace not found: {target}"))
+                })?;
+            let node = resolve_combined_node(&combined.nodes, &node)?;
+            if !node.workspace_owner_eligible {
+                return Err(cli_output::failure(
+                    "busy",
+                    node.workspace_owner_unavailable_reason
+                        .clone()
+                        .unwrap_or_else(|| "owner Node is not eligible for placement".into()),
+                ));
+            }
+            let external =
+                resolve_external_workspace(&combined.external_workspaces, &node.node_id, &owner)?;
+            if !external.available {
+                return Err(cli_output::failure(
+                    "busy",
+                    "unavailable owner Workspace cannot be linked",
+                ));
+            }
+            let local_node_id = combined
+                .nodes
+                .iter()
+                .find(|candidate| candidate.local)
+                .map(|candidate| candidate.node_id.as_str())
+                .unwrap_or_default();
+            let owner = routed_dashboard_workspace(&client, &external.identity, local_node_id)
+                .map_err(io::Error::other)?;
+            let workspace = client.link_node_workspace(
+                &workspace.id,
+                workspace.revision,
+                external.identity.clone(),
+                owner.revision,
+            )?;
+            println!("Linked owner Workspace to {}", workspace.name);
+        }
         WorkspaceCommands::Close { target } => {
+            if client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+                let combined = client.combined_node_snapshot(None)?;
+                if let Some(workspace) =
+                    resolve_global_workspace_target(&combined.workspaces, &target)
+                {
+                    if let Ok(shell_id) = env::var("BOOMUX_SHELL_ID") {
+                        let local_node_id = combined
+                            .nodes
+                            .iter()
+                            .find(|node| node.local)
+                            .map(|node| node.node_id.as_str());
+                        let current_owner = workspace
+                            .placements
+                            .iter()
+                            .find(|placement| Some(placement.node_id.as_str()) == local_node_id);
+                        if let Some(current_owner) = current_owner {
+                            match client.get_workspace(&current_owner.workspace_id) {
+                                Ok(owner)
+                                    if owner.shells.iter().any(|shell| shell.id == shell_id) =>
+                                {
+                                    return Err(
+                                        "cannot close the current workspace from inside it; use the dashboard or another shell"
+                                            .into(),
+                                    );
+                                }
+                                Ok(_) => {}
+                                Err(client::ClientError::Remote(error))
+                                    if error.code == Some(protocol::ErrorCode::NotFound) => {}
+                                Err(error) => return Err(error.into()),
+                            }
+                        }
+                    }
+                    let result = if workspace.closing {
+                        client.retry_global_workspace_close(&workspace.id)?
+                    } else {
+                        client.close_global_workspace(&workspace.id, workspace.revision)?
+                    };
+                    let unresolved = result
+                        .placements
+                        .iter()
+                        .filter(|placement| placement.status != "closed")
+                        .count();
+                    if unresolved > 0 {
+                        return Err(io::Error::other(format!(
+                            "Workspace {} close remains unresolved on {unresolved} Node(s); retry with the same Workspace ID",
+                            workspace.name
+                        ))
+                        .into());
+                    }
+                    println!(
+                        "Closed workspace {} across all confirmed placements",
+                        workspace.name
+                    );
+                    return Ok(());
+                }
+            }
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
             if env::var("BOOMUX_SHELL_ID")
@@ -5090,6 +6142,26 @@ fn workspace_command(
                 "Closed workspace {}; its schedules and persisted prompts were removed",
                 workspace.name
             );
+        }
+        WorkspaceCommands::Retry { target } => {
+            let combined = client.combined_node_snapshot(None)?;
+            let workspace = resolve_global_workspace_target(&combined.workspaces, &target)
+                .ok_or_else(|| {
+                    cli_output::failure("not_found", format!("workspace not found: {target}"))
+                })?;
+            if !workspace.closing {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    "Workspace is not awaiting close retry",
+                ));
+            }
+            let result = client.retry_global_workspace_close(&workspace.id)?;
+            let unresolved = result
+                .placements
+                .iter()
+                .filter(|placement| placement.status == "unresolved")
+                .count();
+            println!("Retried Workspace close; {unresolved} placement(s) unresolved");
         }
     }
     Ok(())
@@ -5152,10 +6224,38 @@ fn shell_command(command: ShellCommands, json: bool) -> Result<(), Box<dyn Error
         }
         ShellCommands::Create {
             workspace,
+            node,
             name,
             cwd,
             command,
         } => {
+            if let Some(selection) = select_coordinated_owner(&client, &workspace, node.as_deref())?
+            {
+                let requested_cwd = cwd
+                    .or_else(|| selection.default_cwd.clone())
+                    .unwrap_or_else(|| PathBuf::from("."));
+                let cwd = resolve_owner_directory(&client, &selection.node, requested_cwd)?;
+                let name = match name {
+                    Some(name) => cli_name(name, "shell")?,
+                    None => generated_shell_name(std::iter::empty())?,
+                };
+                let owner_default_cwd = selection.default_cwd.clone().or_else(|| Some(cwd.clone()));
+                let (_, shell) = client.create_global_workspace_shell(
+                    Uuid::new_v4().to_string(),
+                    &selection.workspace.id,
+                    selection.workspace.revision,
+                    &selection.node.node_id,
+                    selection.owner_workspace_id,
+                    owner_default_cwd,
+                    Uuid::new_v4().to_string(),
+                    shell_spec(name, &cwd, &command),
+                )?;
+                println!(
+                    "Created pending shell {} ({}) in {} on Node {}",
+                    shell.name, shell.id, selection.workspace.name, selection.node.alias
+                );
+                return Ok(());
+            }
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &workspace)?;
             let cwd = resolve_shell_cwd(
@@ -5268,10 +6368,31 @@ fn launcher_command(command: LauncherCommands, json: bool) -> Result<(), Box<dyn
         LauncherCommands::Create {
             name,
             workspace,
+            node,
             cwd,
             command,
         } => {
             let name = cli_name(name, "workspace launcher")?;
+            if let Some(selection) = select_coordinated_owner(&client, &workspace, node.as_deref())?
+            {
+                let cwd = resolve_owner_directory(&client, &selection.node, cwd)?;
+                let owner_default_cwd = selection.default_cwd.clone().or_else(|| Some(cwd.clone()));
+                let (_, launcher) = client.create_global_workspace_launcher(
+                    Uuid::new_v4().to_string(),
+                    &selection.workspace.id,
+                    selection.workspace.revision,
+                    &selection.node.node_id,
+                    selection.owner_workspace_id,
+                    owner_default_cwd,
+                    Uuid::new_v4().to_string(),
+                    WorkspaceLauncherSpec { name, cwd, command },
+                )?;
+                println!(
+                    "Created launcher {} ({}) in {} on Node {}",
+                    launcher.name, launcher.id, selection.workspace.name, selection.node.alias
+                );
+                return Ok(());
+            }
             let snapshot = client.snapshot()?;
             let workspace = resolve_workspace_target(&snapshot.workspaces, &workspace)?;
             let launcher = client.create_launcher(
@@ -5845,6 +6966,15 @@ fn remote_session_command(
 
 fn schedule_command(command: ScheduleCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
+    if let ScheduleCommands::Create(arguments) = &command
+        && let Some(selection) =
+            select_coordinated_owner(&client, &arguments.workspace, arguments.node.as_deref())?
+    {
+        let ScheduleCommands::Create(arguments) = command else {
+            unreachable!()
+        };
+        return create_coordinated_schedule(&client, *arguments, selection, json);
+    }
     if let Some(node) = command.node().map(str::to_owned) {
         return remote_schedule_command(&client, command, &node, json);
     }
@@ -7068,6 +8198,161 @@ fn validate_schedule_protocol(negotiated: u32) -> Result<(), Box<dyn Error>> {
                 ),
             )
         })
+}
+
+fn create_coordinated_schedule(
+    client: &client::Client,
+    arguments: ScheduleCreateArgs,
+    selection: CoordinatedOwnerSelection,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let name = cli_name(arguments.name, "schedule")?;
+    let cwd = resolve_owner_directory(client, &selection.node, arguments.cwd)?;
+    let prompt = schedule_prompt(arguments.prompt, arguments.prompt_file.as_deref())?;
+    let cron = schedule_cron(
+        arguments.cron.as_deref(),
+        arguments.every.as_deref(),
+        arguments.daily.as_deref(),
+        arguments.weekdays.as_deref(),
+        arguments.weekly.as_deref(),
+    )?;
+    let timezone = arguments
+        .timezone
+        .as_deref()
+        .map(boomux::scheduling::canonicalize_timezone)
+        .transpose()?
+        .map_or_else(boomux::scheduling::resolve_system_timezone, Ok)?;
+    let integration = schedule_integration(&arguments.integration)?;
+    let session = if let Some(session_id) = arguments.continue_session.as_deref() {
+        if selection.workspace.placements.iter().all(|placement| {
+            placement.node_id != selection.node.node_id
+                || placement.workspace_id != selection.owner_workspace_id
+        }) {
+            return Err(cli_output::failure(
+                "invalid_argument",
+                "a continuation Schedule requires an existing placement on the selected Node",
+            ));
+        }
+        let external_session_id = if selection.node.local {
+            let owner = client.get_workspace(&selection.owner_workspace_id)?;
+            let catalog = discover_host_catalog(std::slice::from_ref(&owner));
+            let sessions = session_projection::project_workspaces_with_catalog(
+                std::slice::from_ref(&owner),
+                Some(&catalog),
+            );
+            let session =
+                session_projection::resolve_exact(&sessions, session_id).map_err(|_| {
+                    cli_output::failure(
+                        "not_found",
+                        format!("projected session not found on selected Node: {session_id}"),
+                    )
+                })?;
+            if session.integration != integration.key {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    "continued session integration does not match --integration",
+                ));
+            }
+            session.external_session_id.clone().ok_or_else(|| {
+                cli_output::failure(
+                    "invalid_argument",
+                    "continued projected session has no canonical external session ID",
+                )
+            })?
+        } else {
+            let result = client.route_node_host_service(
+                &selection.node.node_id,
+                protocol::HostServiceOperation::InspectAgentSession {
+                    session_id: session_id.to_owned(),
+                },
+            )?;
+            let protocol::HostServiceResult::AgentSession { session } = result else {
+                return Err("owner Node returned an unexpected Agent Session response".into());
+            };
+            if session.summary.workspace_id != selection.owner_workspace_id
+                || session.summary.integration != integration.key
+            {
+                return Err(cli_output::failure(
+                    "invalid_argument",
+                    "continued session must belong to the selected placement and integration",
+                ));
+            }
+            session.summary.external_session_id.ok_or_else(|| {
+                cli_output::failure(
+                    "invalid_argument",
+                    "continued projected session has no canonical external session ID",
+                )
+            })?
+        };
+        boomux::scheduling::validate_external_session_id(&external_session_id)?;
+        if !integration
+            .schedule_dispatch
+            .is_some_and(|dispatch| dispatch.continuation)
+        {
+            return Err(cli_output::failure(
+                "unsupported_integration",
+                "integration does not support continuation schedule dispatch",
+            ));
+        }
+        AgentScheduleSession::Continue {
+            external_session_id,
+        }
+    } else {
+        if !integration
+            .schedule_dispatch
+            .is_some_and(|dispatch| dispatch.fresh)
+        {
+            return Err(cli_output::failure(
+                "unsupported_integration",
+                "integration does not support fresh schedule dispatch",
+            ));
+        }
+        AgentScheduleSession::Fresh
+    };
+    let spec = AgentScheduleSpec {
+        name,
+        cwd: cwd.clone(),
+        integration: integration.key.to_owned(),
+        prompt,
+        session,
+        trigger: AgentScheduleTrigger { cron, timezone },
+        state: if arguments.enabled {
+            AgentScheduleState::Enabled
+        } else {
+            AgentScheduleState::Paused
+        },
+        overlap_policy: AgentScheduleOverlapPolicy::Skip,
+    };
+    let owner_default_cwd = selection.default_cwd.clone().or(Some(cwd));
+    let (_, schedule) = client.create_global_workspace_agent_schedule(
+        Uuid::new_v4().to_string(),
+        &selection.workspace.id,
+        selection.workspace.revision,
+        &selection.node.node_id,
+        selection.owner_workspace_id,
+        owner_default_cwd,
+        Uuid::new_v4().to_string(),
+        spec,
+    )?;
+    if json {
+        return print_json(
+            CommandKey::ScheduleCreate,
+            serde_json::json!({
+                "node_id": selection.node.node_id,
+                "workspace_id": selection.workspace.id,
+                "schedule": cli_output::schedule(&schedule, Some(&selection.workspace.name)),
+            }),
+        );
+    }
+    println!(
+        "Created {} schedule {} ({}) in {} on Node {}",
+        cli_output::schedule_state(schedule.state),
+        sanitize_table_cell(&schedule.name),
+        sanitize_table_cell(&schedule.id),
+        selection.workspace.name,
+        selection.node.alias,
+    );
+    Ok(())
 }
 
 fn create_schedule(
@@ -8836,6 +10121,156 @@ mod tests {
         }
     }
 
+    #[test]
+    fn global_workspace_grouping_uses_exact_placements_and_keeps_equal_name_external() {
+        let first = workspace("owner-1", "same", vec![shell("shell-1", "owner-1", "one")]);
+        let second = workspace(
+            "owner-2",
+            "different",
+            vec![shell("shell-2", "owner-2", "two")],
+        );
+        let external = workspace("owner-3", "same", Vec::new());
+        let mut cache = git::Cache::default();
+        let mut views = dashboard_projection::project(&[first, second, external], &mut cache);
+        let mut local = views[0].node.clone();
+        local.id = Uuid::from_u128(1).to_string();
+        let mut remote = local.clone();
+        remote.id = Uuid::from_u128(2).to_string();
+        remote.alias = "work".into();
+        remote.local = false;
+        let mut other = remote.clone();
+        other.id = Uuid::from_u128(3).to_string();
+        other.alias = "other".into();
+        views[0].node = local.clone();
+        views[1].node = remote.clone();
+        views[2].node = other.clone();
+        for (view, node) in views.iter_mut().zip([&local, &remote, &other]) {
+            view.item_owners = vec![
+                tui::WorkspaceItemOwnerView {
+                    node: node.clone(),
+                    workspace_id: view.id.clone(),
+                };
+                view.items.len()
+            ];
+        }
+        let global_id = Uuid::from_u128(10).to_string();
+        let grouped = group_dashboard_workspaces(
+            views,
+            &[local.clone(), remote.clone(), other.clone()],
+            vec![protocol::GlobalWorkspaceSnapshot {
+                id: global_id.clone(),
+                revision: 2,
+                name: "same".into(),
+                closing: false,
+                placements: vec![
+                    protocol::WorkspacePlacementSnapshot {
+                        node_id: local.id.clone(),
+                        workspace_id: "owner-1".into(),
+                        owner_workspace_name: Some("local-owner".into()),
+                        owner_revision: 1,
+                        default_cwd: None,
+                        state: protocol::WorkspacePlacementState::Active,
+                    },
+                    protocol::WorkspacePlacementSnapshot {
+                        node_id: remote.id.clone(),
+                        workspace_id: "owner-2".into(),
+                        owner_workspace_name: Some("remote-owner".into()),
+                        owner_revision: 1,
+                        default_cwd: None,
+                        state: protocol::WorkspacePlacementState::Active,
+                    },
+                    protocol::WorkspacePlacementSnapshot {
+                        node_id: Uuid::from_u128(99).to_string(),
+                        workspace_id: "missing-owner".into(),
+                        owner_workspace_name: Some("missing".into()),
+                        owner_revision: 1,
+                        default_cwd: None,
+                        state: protocol::WorkspacePlacementState::Unavailable,
+                    },
+                ],
+            }],
+            vec![protocol::ExternalWorkspaceSnapshot {
+                identity: protocol::QualifiedIdentity::new(&other.id, "owner-3"),
+                revision: 1,
+                name: "same".into(),
+                default_cwd: None,
+                available: true,
+            }],
+        );
+        assert_eq!(grouped.len(), 2);
+        let global = grouped
+            .iter()
+            .find(|workspace| workspace.id == global_id)
+            .unwrap();
+        assert_eq!(global.items.len(), 2);
+        let tui::WorkspaceCoordinationView::Global { placements, .. } = &global.coordination else {
+            panic!("expected global Workspace");
+        };
+        assert_eq!(placements.len(), 3);
+        assert!(placements.iter().any(|placement| {
+            placement.workspace_id == "missing-owner"
+                && placement.node.alias.starts_with("unregistered:")
+                && !placement.node.current
+        }));
+        assert_eq!(global.item_owners[0].node.id, local.id);
+        assert_eq!(global.item_owners[1].node.id, remote.id);
+        let singleton = grouped
+            .iter()
+            .find(|workspace| workspace.id == "owner-3")
+            .unwrap();
+        assert!(matches!(
+            singleton.coordination,
+            tui::WorkspaceCoordinationView::External { .. }
+        ));
+    }
+
+    #[test]
+    fn dashboard_workspaces_sort_by_task_name_before_node_alias() {
+        let mut cache = git::Cache::default();
+        let mut views = dashboard_projection::project(
+            &[
+                workspace("owner-z", "alpha", Vec::new()),
+                workspace("owner-a", "zulu", Vec::new()),
+            ],
+            &mut cache,
+        );
+        views[0].node.alias = "z-node".into();
+        views[1].node.alias = "a-node".into();
+        sort_dashboard_workspaces(&mut views);
+        assert_eq!(
+            views
+                .iter()
+                .map(|workspace| workspace.name.as_str())
+                .collect::<Vec<_>>(),
+            ["alpha", "zulu"]
+        );
+    }
+
+    #[test]
+    fn local_schedule_item_owner_is_rewritten_before_action_qualification() {
+        let snapshot = workspace(
+            "owner-local",
+            "local",
+            vec![shell("shell-local", "owner-local", "placeholder")],
+        );
+        let mut cache = git::Cache::default();
+        let mut views = dashboard_projection::project(&[snapshot], &mut cache);
+        views[0].items[0] = tui::WorkspaceItemView::Schedule(tui::ScheduleItemView {
+            id: "schedule-local".into(),
+            name: "schedule".into(),
+            integration: "opencode".into(),
+            state: tui::ScheduleDisplayState::Paused,
+            friendly_trigger: "daily".into(),
+        });
+        let mut local = views[0].node.clone();
+        local.id = Uuid::from_u128(88).to_string();
+        assign_local_workspace_node(&mut views, &local);
+        let owner = &views[0].item_owners[0];
+        let action_id = protocol::QualifiedIdentity::new(&owner.node.id, "schedule-local");
+        assert_eq!(action_id.node_id, local.id);
+        assert_eq!(action_id.inner_id, "schedule-local");
+    }
+
     fn schedule(id: &str, workspace_id: &str, name: &str) -> AgentScheduleSnapshot {
         AgentScheduleSnapshot {
             id: id.into(),
@@ -9532,6 +10967,36 @@ mod tests {
     }
 
     #[test]
+    fn parses_public_workspace_adopt_link_and_retry_commands() {
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "workspace", "adopt", "owner", "--node", "work"])
+                .unwrap()
+                .command,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::Adopt { target, node }
+            }) if target == "owner" && node == "work"
+        ));
+        assert!(matches!(
+            Cli::try_parse_from([
+                "boomux", "workspace", "link", "global", "owner", "--node", "work"
+            ])
+            .unwrap()
+            .command,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::Link { target, owner, node }
+            }) if target == "global" && owner == "owner" && node == "work"
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "workspace", "retry", "global"])
+                .unwrap()
+                .command,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::Retry { target }
+            }) if target == "global"
+        ));
+    }
+
+    #[test]
     fn parses_global_json_for_supported_integration_commands() {
         for arguments in [
             vec!["boomux", "--json", "capabilities"],
@@ -9661,6 +11126,7 @@ mod tests {
                     workspace,
                     cwd,
                     command,
+                    ..
                 }
             }) if name == "editor"
                 && workspace == "project"
@@ -9708,6 +11174,7 @@ mod tests {
                     name: Some(name),
                     cwd,
                     command,
+                    ..
                 }
             }) if workspace == "project"
                 && name == "tests"
@@ -10310,10 +11777,16 @@ mod tests {
                 id: String::new(),
                 alias: "local".into(),
                 local: true,
+                route: None,
+                registration_revision: None,
                 health: protocol::NodeProjectionHealthCode::Online,
                 current: true,
                 stale: false,
+                observed_at_ms: 0,
+                observed_protocol_version: Some(protocol::PROTOCOL_VERSION),
                 observed_capabilities: Vec::new(),
+                workspace_owner_eligible: true,
+                workspace_owner_unavailable_reason: None,
                 scheduler: protocol::SchedulerHealth {
                     state: protocol::SchedulerState::Active,
                     max_concurrent: 4,
@@ -10327,6 +11800,11 @@ mod tests {
             agent_state_counts: agent_attention_projection::AgentStateCounts::default(),
             attention_count: 0,
             attention: Vec::new(),
+            item_owners: Vec::new(),
+            coordination: tui::WorkspaceCoordinationView::External {
+                owner_revision: 1,
+                available: true,
+            },
             sessions: vec![tui::AgentSessionView {
                 id: "session".into(),
                 label: "opencode".into(),
@@ -11687,7 +13165,7 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 37);
+        assert_eq!(protocol::PROTOCOL_VERSION, 38);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -551,6 +551,15 @@ enum WorkspaceCommands {
         #[arg(long)]
         cwd: Option<PathBuf>,
     },
+    /// Create a global Workspace and its first Shell atomically
+    CreateProject {
+        name: String,
+        #[arg(long)]
+        cwd: PathBuf,
+        /// Exact eligible Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
     /// Open terminal windows and invoke launchers
     Open {
         target: String,
@@ -1220,6 +1229,7 @@ command_keys! {
     ProjectList => ("project.list", Json),
     WorkspaceList => ("workspace.list", Json),
     WorkspaceInspect => ("workspace.inspect", Json),
+    WorkspaceCreateProject => ("workspace.create-project", Json),
     Workspace => ("workspace", HumanOnly),
     NodeAdd => ("node.add", Json),
     NodeList => ("node.list", Json),
@@ -1298,6 +1308,9 @@ impl Cli {
             Some(Commands::Workspace {
                 command: WorkspaceCommands::Inspect { .. },
             }) => CommandKey::WorkspaceInspect,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::CreateProject { .. },
+            }) => CommandKey::WorkspaceCreateProject,
             Some(Commands::Node {
                 command: NodeCommands::Add { .. },
             }) => CommandKey::NodeAdd,
@@ -4235,6 +4248,27 @@ fn resolve_combined_node<'a>(
     }
 }
 
+fn resolve_workspace_open_node<'a>(
+    nodes: &'a [protocol::CombinedNode],
+    selector: &str,
+) -> Result<&'a protocol::CombinedNode, Box<dyn Error>> {
+    let matches = nodes
+        .iter()
+        .filter(|node| node.node_id == selector || (!node.local && node.alias == selector))
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [node] => Ok(*node),
+        [] => Err(cli_output::failure(
+            "not_found",
+            format!("Node not found: {selector}"),
+        )),
+        _ => Err(cli_output::failure(
+            "ambiguous_target",
+            format!("Node selector is ambiguous: {selector}"),
+        )),
+    }
+}
+
 fn resolve_external_workspace<'a>(
     workspaces: &'a [protocol::ExternalWorkspaceSnapshot],
     node_id: &str,
@@ -4252,6 +4286,85 @@ fn resolve_external_workspace<'a>(
                 format!("unlinked owner Workspace not found: {target}"),
             )
         })
+}
+
+fn select_eligible_workspace_owner(
+    nodes: &[protocol::CombinedNode],
+    node_selector: Option<&str>,
+) -> Result<protocol::CombinedNode, Box<dyn Error>> {
+    if let Some(selector) = node_selector {
+        let node = resolve_combined_node(nodes, selector)?;
+        if !node.workspace_owner_eligible {
+            return Err(cli_output::failure(
+                "busy",
+                format!(
+                    "Node {} is unavailable for Workspace placement: {}",
+                    node.alias,
+                    node.workspace_owner_unavailable_reason
+                        .as_deref()
+                        .unwrap_or("unavailable")
+                ),
+            ));
+        }
+        return Ok(node.clone());
+    }
+    let eligible = nodes
+        .iter()
+        .filter(|node| node.workspace_owner_eligible)
+        .collect::<Vec<_>>();
+    let [node] = eligible.as_slice() else {
+        let status = nodes
+            .iter()
+            .map(|node| {
+                format!(
+                    "{} ({})",
+                    node.alias,
+                    if node.workspace_owner_eligible {
+                        "eligible"
+                    } else {
+                        node.workspace_owner_unavailable_reason
+                            .as_deref()
+                            .unwrap_or("unavailable")
+                    }
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(cli_output::failure(
+            "ambiguous_target",
+            format!(
+                "Workspace resource placement requires --node when zero or multiple eligible Nodes exist; Nodes: {status}"
+            ),
+        ));
+    };
+    Ok((*node).clone())
+}
+
+fn workspace_create_project_json(
+    workspace: &protocol::GlobalWorkspaceSnapshot,
+    node_id: &str,
+    shell: &protocol::ShellSnapshot,
+) -> serde_json::Value {
+    serde_json::json!({
+        "workspace": workspace,
+        "node_id": node_id,
+        "shell": cli_output::shell(shell, Some(&workspace.name)),
+    })
+}
+
+fn shell_suggestion_json(
+    workspace_id: &str,
+    name: &str,
+    node_id: Option<&str>,
+) -> serde_json::Value {
+    let mut data = serde_json::json!({
+        "workspace_id": workspace_id,
+        "name": name,
+    });
+    if let Some(node_id) = node_id {
+        data["node_id"] = serde_json::Value::String(node_id.to_owned());
+    }
+    data
 }
 
 struct CoordinatedOwnerSelection {
@@ -4275,69 +4388,7 @@ fn select_coordinated_owner(
     else {
         return Ok(None);
     };
-    let node = if let Some(selector) = node_selector {
-        let matches = combined
-            .nodes
-            .iter()
-            .filter(|node| node.node_id == selector || node.alias == selector)
-            .collect::<Vec<_>>();
-        let [node] = matches.as_slice() else {
-            return Err(cli_output::failure(
-                if matches.is_empty() {
-                    "not_found"
-                } else {
-                    "ambiguous_target"
-                },
-                format!("Node selector did not resolve uniquely: {selector}"),
-            ));
-        };
-        if !node.workspace_owner_eligible {
-            return Err(cli_output::failure(
-                "busy",
-                format!(
-                    "Node {} is unavailable for Workspace placement: {}",
-                    node.alias,
-                    node.workspace_owner_unavailable_reason
-                        .as_deref()
-                        .unwrap_or("unavailable")
-                ),
-            ));
-        }
-        (*node).clone()
-    } else {
-        let eligible = combined
-            .nodes
-            .iter()
-            .filter(|node| node.workspace_owner_eligible)
-            .collect::<Vec<_>>();
-        let [node] = eligible.as_slice() else {
-            let status = combined
-                .nodes
-                .iter()
-                .map(|node| {
-                    format!(
-                        "{} ({})",
-                        node.alias,
-                        if node.workspace_owner_eligible {
-                            "eligible"
-                        } else {
-                            node.workspace_owner_unavailable_reason
-                                .as_deref()
-                                .unwrap_or("unavailable")
-                        }
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            return Err(cli_output::failure(
-                "ambiguous_target",
-                format!(
-                    "Workspace resource placement requires --node when zero or multiple eligible Nodes exist; Nodes: {status}"
-                ),
-            ));
-        };
-        (*node).clone()
-    };
+    let node = select_eligible_workspace_owner(&combined.nodes, node_selector)?;
     let placement = workspace
         .placements
         .iter()
@@ -5742,9 +5793,58 @@ fn workspace_command(
                 client.create_workspace_with_default_cwd(name, default_cwd, Vec::new())?;
             println!("Created workspace {} ({})", workspace.name, workspace.id);
         }
+        WorkspaceCommands::CreateProject { name, cwd, node } => {
+            if !client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+                return Err(cli_output::failure(
+                    "unsupported_version",
+                    "global Workspace project creation requires daemon protocol 38 or newer",
+                ));
+            }
+            let name = cli_name(name, "workspace")?;
+            let combined = client.combined_node_snapshot(None)?;
+            let node = select_eligible_workspace_owner(&combined.nodes, node.as_deref())?;
+            let cwd = resolve_owner_directory(&client, &node, cwd)?;
+            let shell_name = generated_shell_name(std::iter::empty())?;
+            let (workspace, shell) = client.create_global_workspace_with_shell(
+                Uuid::new_v4().to_string(),
+                Uuid::new_v4().to_string(),
+                &name,
+                &node.node_id,
+                Uuid::new_v4().to_string(),
+                cwd.clone(),
+                Uuid::new_v4().to_string(),
+                shell_spec(shell_name, &cwd, &[]),
+            )?;
+            if json {
+                return print_json(
+                    CommandKey::WorkspaceCreateProject,
+                    workspace_create_project_json(&workspace, &node.node_id, &shell),
+                );
+            }
+            println!(
+                "Created workspace {} ({}) with shell {} ({}) on Node {}",
+                workspace.name, workspace.id, shell.name, shell.id, node.alias
+            );
+        }
         WorkspaceCommands::Open { target, node } => {
-            if let Some(node) = node {
-                let registration = client.node_registration(node)?;
+            if let Some(node_selector) = node {
+                let combined = client.combined_node_snapshot(None)?;
+                let selected_node = resolve_workspace_open_node(&combined.nodes, &node_selector)?;
+                if selected_node.local {
+                    let snapshot = client.snapshot()?;
+                    let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
+                    let terminal = effective_terminal(terminal_override)?;
+                    open_workspace(workspace, terminal.as_deref())?;
+                    println!(
+                        "Opened {} launcher(s) and {} shell(s) for {} on Node {}",
+                        workspace.launchers.len(),
+                        workspace_user_shell_count(workspace),
+                        workspace.name,
+                        selected_node.alias,
+                    );
+                    return Ok(());
+                }
+                let registration = client.node_registration(&selected_node.node_id)?;
                 let workspace = match client.route_node_operation(
                     &registration.node_id,
                     protocol::RoutedOperation::GetWorkspace {
@@ -6206,12 +6306,27 @@ fn shell_command(command: ShellCommands, json: bool) -> Result<(), Box<dyn Error
             let name =
                 generated_shell_name(workspace.shells.iter().map(|shell| shell.name.as_str()))?;
             if json {
+                let node_id = if client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+                    Some(
+                        client
+                            .combined_node_snapshot(None)?
+                            .nodes
+                            .into_iter()
+                            .find(|node| node.local)
+                            .map(|node| node.node_id)
+                            .ok_or_else(|| {
+                                cli_output::failure(
+                                    "internal",
+                                    "local Node identity is unavailable",
+                                )
+                            })?,
+                    )
+                } else {
+                    None
+                };
                 return print_json(
                     CommandKey::ShellSuggestName,
-                    serde_json::json!({
-                        "workspace_id": workspace.id,
-                        "name": name,
-                    }),
+                    shell_suggestion_json(&workspace.id, &name, node_id.as_deref()),
                 );
             }
             println!(
@@ -10121,6 +10236,31 @@ mod tests {
         }
     }
 
+    fn combined_node(id: &str, alias: &str, eligible: bool) -> protocol::CombinedNode {
+        protocol::CombinedNode {
+            node_id: id.into(),
+            alias: alias.into(),
+            local: alias == "local",
+            route: None,
+            registration_revision: None,
+            health: protocol::NodeProjectionHealthCode::Online,
+            current: true,
+            stale: false,
+            observed_at_ms: 1,
+            observed_protocol_version: Some(protocol::PROTOCOL_VERSION),
+            observed_capabilities: vec!["global_workspaces".into()],
+            workspace_owner_eligible: eligible,
+            workspace_owner_unavailable_reason: (!eligible).then(|| "unavailable".into()),
+            scheduler: protocol::SchedulerHealth {
+                state: protocol::SchedulerState::Active,
+                active_executions: 0,
+                max_concurrent: 4,
+            },
+            local_snapshot: None,
+            remote_projection: None,
+        }
+    }
+
     #[test]
     fn global_workspace_grouping_uses_exact_placements_and_keeps_equal_name_external() {
         let first = workspace("owner-1", "same", vec![shell("shell-1", "owner-1", "one")]);
@@ -10994,6 +11134,99 @@ mod tests {
                 command: WorkspaceCommands::Retry { target }
             }) if target == "global"
         ));
+    }
+
+    #[test]
+    fn parses_json_workspace_project_creation_without_splitting_arguments() {
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "workspace",
+            "create-project",
+            "release; touch /tmp/nope",
+            "--cwd",
+            "/tmp/project $(false)",
+            "--node",
+            "node-id",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(cli.command_descriptor().key, "workspace.create-project");
+        assert_eq!(cli.command_descriptor().output, OutputMode::Json);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::CreateProject { name, cwd, node }
+            }) if name == "release; touch /tmp/nope"
+                && cwd == Path::new("/tmp/project $(false)")
+                && node.as_deref() == Some("node-id")
+        ));
+    }
+
+    #[test]
+    fn workspace_project_owner_selection_delegates_sole_and_requires_ambiguous_choice() {
+        let local = combined_node("local-id", "local", true);
+        let remote = combined_node("remote-id", "work", true);
+        assert_eq!(
+            select_eligible_workspace_owner(std::slice::from_ref(&local), None)
+                .unwrap()
+                .node_id,
+            "local-id"
+        );
+        assert!(select_eligible_workspace_owner(&[local.clone(), remote.clone()], None).is_err());
+        assert_eq!(
+            select_eligible_workspace_owner(&[local, remote], Some("remote-id"))
+                .unwrap()
+                .node_id,
+            "remote-id"
+        );
+    }
+
+    #[test]
+    fn workspace_open_node_resolution_requires_exact_local_identity() {
+        let local = combined_node("local-id", "local", true);
+        let remote = combined_node("remote-id", "work", true);
+        let nodes = [local, remote];
+        assert!(resolve_workspace_open_node(&nodes, "local").is_err());
+        let selected = resolve_workspace_open_node(&nodes, "local-id").unwrap();
+        assert!(selected.local);
+        assert_eq!(selected.node_id, "local-id");
+        assert_eq!(
+            resolve_workspace_open_node(&nodes, "work").unwrap().node_id,
+            "remote-id"
+        );
+    }
+
+    #[test]
+    fn workspace_project_json_returns_exact_global_owner_and_shell_ids() {
+        let global = protocol::GlobalWorkspaceSnapshot {
+            id: "global-id".into(),
+            revision: 1,
+            name: "release".into(),
+            closing: false,
+            placements: vec![protocol::WorkspacePlacementSnapshot {
+                node_id: "node-id".into(),
+                workspace_id: "owner-id".into(),
+                owner_workspace_name: Some("release".into()),
+                owner_revision: 1,
+                default_cwd: Some("/tmp/project".into()),
+                state: protocol::WorkspacePlacementState::Active,
+            }],
+        };
+        let shell = shell("shell-id", "owner-id", "first");
+        let value = workspace_create_project_json(&global, "node-id", &shell);
+        assert_eq!(value["workspace"]["id"], "global-id");
+        assert_eq!(value["node_id"], "node-id");
+        assert_eq!(value["shell"]["id"], "shell-id");
+        assert_eq!(value["shell"]["workspace_id"], "owner-id");
+    }
+
+    #[test]
+    fn protocol_thirty_eight_shell_suggestion_identifies_its_exact_local_node() {
+        let current = shell_suggestion_json("owner-id", "first", Some("local-node-id"));
+        assert_eq!(current["node_id"], "local-node-id");
+        assert_eq!(current["workspace_id"], "owner-id");
+        let legacy = shell_suggestion_json("owner-id", "first", None);
+        assert!(legacy.get("node_id").is_none());
     }
 
     #[test]
@@ -13190,6 +13423,7 @@ mod tests {
                 "project.list",
                 "workspace.list",
                 "workspace.inspect",
+                "workspace.create-project",
                 "node.add",
                 "node.list",
                 "node.inspect",

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,10 @@ use std::error::Error;
 use std::ffi::OsString;
 use std::fmt::Write as _;
 use std::fs;
-use std::io::{self, IsTerminal, Read};
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::io::{self, BufRead, IsTerminal, Read};
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::process::{CommandExt, ExitStatusExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
@@ -496,6 +498,17 @@ enum Commands {
     },
     #[command(name = "__federation-stdio", hide = true)]
     FederationStdio,
+    #[command(name = "__guided-node-add", hide = true)]
+    GuidedNodeAdd,
+    #[command(name = "__bootstrap-activate", hide = true)]
+    BootstrapActivate {
+        transaction: String,
+        expected_pid: u32,
+        expected_protocol: u32,
+        expected_executable: String,
+        expected_socket_device: u64,
+        expected_socket_inode: u64,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1491,6 +1504,8 @@ impl Cli {
             Some(Commands::ResumeSession { .. }) => CommandKey::ResumeSessionInternal,
             Some(Commands::ScheduledRunner { .. }) => CommandKey::Attach,
             Some(Commands::FederationStdio) => CommandKey::Attach,
+            Some(Commands::GuidedNodeAdd) => CommandKey::NodeAdd,
+            Some(Commands::BootstrapActivate { .. }) => CommandKey::Daemon,
         }
     }
 }
@@ -1527,6 +1542,12 @@ impl CliExit {
 }
 
 fn main() -> ExitCode {
+    if env::var_os("BOOMUX_INTERNAL_GUIDED_STOP").as_deref() == Some(std::ffi::OsStr::new("1")) {
+        unsafe {
+            env::remove_var("BOOMUX_INTERNAL_GUIDED_STOP");
+            libc::raise(libc::SIGSTOP);
+        }
+    }
     let json_requested = requests_json(env::args_os().skip(1));
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
@@ -1644,6 +1665,27 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             federation::run_stdio_helper()?;
             return Ok(CliExit::Success);
         }
+        Some(Commands::GuidedNodeAdd) => {
+            return guided_node_add().map(CliExit::Child);
+        }
+        Some(Commands::BootstrapActivate {
+            transaction,
+            expected_pid,
+            expected_protocol,
+            expected_executable,
+            expected_socket_device,
+            expected_socket_inode,
+        }) => {
+            bootstrap_activate(
+                transaction,
+                *expected_pid,
+                *expected_protocol,
+                expected_executable,
+                *expected_socket_device,
+                *expected_socket_inode,
+            )?;
+            return Ok(CliExit::Success);
+        }
         _ => {}
     }
 
@@ -1745,6 +1787,8 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::ResumeSession { .. }) => unreachable!(),
         Some(Commands::ScheduledRunner { .. }) => unreachable!(),
         Some(Commands::FederationStdio) => unreachable!(),
+        Some(Commands::GuidedNodeAdd) => unreachable!(),
+        Some(Commands::BootstrapActivate { .. }) => unreachable!(),
         None => dashboard(cli.terminal.as_deref()),
     };
     result?;
@@ -1752,8 +1796,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
 }
 
 fn remote_connect(target: &str, terminal: Option<&str>) -> Result<(), Box<dyn Error>> {
-    let mut connection = verified_remote_connection(target, true)?;
-    connection.ping()?;
+    let connection = verified_remote_connection(target, true)?;
     println!(
         "Connected to Boomux Node {} (protocol {}, helper {}, {})",
         connection.handshake.node_id,
@@ -1792,18 +1835,23 @@ fn verified_remote_connection(
     } else {
         ssh_bootstrap::SshAuthenticationMode::Batch
     };
-    let helper = match ssh_bootstrap::plan_remote_bootstrap(
-        target.clone(),
-        authentication,
-        TIMEOUT,
-    )? {
-        ssh_bootstrap::RemoteBootstrapPlan::Ready(helper) => helper,
-        ssh_bootstrap::RemoteBootstrapPlan::Install(_plan) if !interactive => {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "remote Boomux installation is required, but noninteractive --remote never modifies remote software",
-            )
-            .into());
+    let mut session = ssh_bootstrap::BootstrapSession::open(target, authentication, TIMEOUT)
+        .map_err(bootstrap_cli_failure)?;
+    // Both branches return a channel verified by exactly one protocol ping. An
+    // installed channel is pinged before commit inside install_and_connect.
+    match session.plan(TIMEOUT).map_err(bootstrap_cli_failure)? {
+        ssh_bootstrap::RemoteBootstrapPlan::Ready(helper) => {
+            let mut connection = session
+                .connect(helper, TIMEOUT)
+                .map_err(bootstrap_cli_failure)?;
+            connection.ping().map_err(bootstrap_cli_failure)?;
+            Ok(connection)
+        }
+        ssh_bootstrap::RemoteBootstrapPlan::Install(plan) if !interactive => {
+            Err(cli_output::failure(
+                plan.reason.error_code(),
+                plan.reason.noninteractive_message(),
+            ))
         }
         ssh_bootstrap::RemoteBootstrapPlan::Install(plan) => {
             println!("Remote target: {}", plan.target.as_str());
@@ -1811,10 +1859,10 @@ fn verified_remote_connection(
             println!("Install destination: {}", plan.destination.as_str());
             println!(
                 "Process impact: {}",
-                if plan.may_restart_daemon {
-                    "the daemon may be gracefully restarted only if the installed helper cannot connect to the running daemon"
+                if plan.reason == ssh_bootstrap::RemoteInstallReason::Upgrade {
+                    "the pinned binary is uploaded privately first; activation occurs only if that provisional client proves the running daemon executable is this destination, then the previous executable is retained for rollback and an incompatible daemon is gracefully restarted"
                 } else {
-                    "a detached daemon may be started; no running daemon will be restarted for a release-version difference"
+                    "the pinned binary is uploaded privately first; the runtime socket must remain absent through guarded activation, and rollback removes only a destination activated by this transaction"
                 }
             );
             if !confirm_setup("Install Boomux on this remote target?")? {
@@ -1824,23 +1872,22 @@ fn verified_remote_connection(
                 )
                 .into());
             }
-            ssh_bootstrap::install_remote(&plan, authentication, TIMEOUT)?
+            session
+                .install_and_connect(&plan, TIMEOUT)
+                .map_err(bootstrap_cli_failure)
         }
-    };
-    Ok(ssh_bootstrap::connect_remote(
-        target,
-        helper,
-        authentication,
-        TIMEOUT,
-    )?)
+    }
+}
+
+fn bootstrap_cli_failure(error: io::Error) -> Box<dyn Error> {
+    cli_output::failure(ssh_bootstrap::error_code(&error), error.to_string())
 }
 
 fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>> {
     match command {
         NodeCommands::Add { alias, target } => {
             let (alias, target) = resolve_node_add_inputs(alias, target, json)?;
-            let mut remote = verified_remote_connection(&target, !json)?;
-            remote.ping()?;
+            let remote = verified_remote_connection(&target, !json)?;
             let registration = client::connect_or_start()?.add_node_registration(
                 alias,
                 target,
@@ -2042,8 +2089,7 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
                     ),
                 ));
             }
-            let mut remote = verified_remote_connection(&target, !json)?;
-            remote.ping()?;
+            let remote = verified_remote_connection(&target, !json)?;
             let registration = local.retarget_node_registration(
                 selector,
                 target,
@@ -2058,6 +2104,157 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
         }
         NodeCommands::Rekey => rekey_node(),
     }
+}
+
+fn guided_node_add() -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
+    let executable = env::current_exe()?;
+    let stdin = io::stdin();
+    let interactive = stdin.is_terminal() && io::stdout().is_terminal();
+    let mut input = stdin.lock();
+    let mut output = io::stdout().lock();
+    guided_node_add_with(
+        &executable,
+        &mut input,
+        &mut output,
+        interactive,
+        interactive.then(|| stdin.as_raw_fd()),
+    )
+}
+
+fn restore_terminal_foreground(fd: i32, foreground: i32) {
+    unsafe {
+        let previous = libc::signal(libc::SIGTTOU, libc::SIG_IGN);
+        let _ = libc::tcsetpgrp(fd, foreground);
+        libc::signal(libc::SIGTTOU, previous);
+    }
+}
+
+fn guided_node_add_with(
+    executable: &Path,
+    input: &mut impl BufRead,
+    output: &mut impl io::Write,
+    wait_for_newline: bool,
+    terminal_fd: Option<i32>,
+) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
+    let mut command = Command::new(executable);
+    command.args(["node", "add"]);
+    if terminal_fd.is_some() {
+        command.env("BOOMUX_INTERNAL_GUIDED_STOP", "1");
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setpgid(0, 0) == -1 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
+            });
+        }
+    }
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            writeln!(output, "\nNode setup failed to start: {error}")?;
+            hold_guided_result(input, output, wait_for_newline)?;
+            return Ok(process_adapter::ProcessExit::Code(1));
+        }
+    };
+
+    let original_foreground = if let Some(fd) = terminal_fd {
+        let foreground = unsafe { libc::tcgetpgrp(fd) };
+        let child_group = i32::try_from(child.id()).unwrap_or(i32::MAX);
+        let mut stopped_status = 0;
+        let stopped = unsafe { libc::waitpid(child_group, &mut stopped_status, libc::WUNTRACED) };
+        if foreground == -1
+            || stopped != child_group
+            || !libc::WIFSTOPPED(stopped_status)
+            || unsafe { libc::tcsetpgrp(fd, child_group) } == -1
+        {
+            let error = io::Error::last_os_error();
+            unsafe {
+                libc::kill(-child_group, libc::SIGKILL);
+            }
+            let _ = child.wait();
+            writeln!(
+                output,
+                "\nNode setup failed to acquire the terminal: {error}"
+            )?;
+            hold_guided_result(input, output, wait_for_newline)?;
+            return Ok(process_adapter::ProcessExit::Code(1));
+        }
+        let continued = if cfg!(test) && env::var_os("BOOMUX_TEST_GUIDED_SIGCONT_FAILURE").is_some()
+        {
+            Err(io::Error::other("injected SIGCONT failure"))
+        } else if unsafe { libc::kill(-child_group, libc::SIGCONT) } == -1 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        };
+        if let Err(error) = continued {
+            unsafe {
+                libc::kill(-child_group, libc::SIGKILL);
+            }
+            restore_terminal_foreground(fd, foreground);
+            let _ = child.wait();
+            writeln!(output, "\nNode setup failed to continue: {error}")?;
+            hold_guided_result(input, output, wait_for_newline)?;
+            return Ok(process_adapter::ProcessExit::Code(1));
+        }
+        Some((fd, foreground))
+    } else {
+        None
+    };
+    let status = child.wait();
+    if let Some((fd, foreground)) = original_foreground {
+        restore_terminal_foreground(fd, foreground);
+    }
+    let status = match status {
+        Ok(status) => status,
+        Err(error) => {
+            writeln!(output, "\nNode setup status could not be read: {error}")?;
+            hold_guided_result(input, output, wait_for_newline)?;
+            return Ok(process_adapter::ProcessExit::Code(1));
+        }
+    };
+    writeln!(
+        output,
+        "\nNode setup {} ({}).",
+        if status.success() {
+            "finished"
+        } else {
+            "failed"
+        },
+        match status.code() {
+            Some(code) => format!("exit {code}"),
+            None => format!("signal {}", status.signal().unwrap_or(0)),
+        }
+    )?;
+    hold_guided_result(input, output, wait_for_newline)?;
+    Ok(match status.code() {
+        Some(code) => process_adapter::ProcessExit::Code(code),
+        None => process_adapter::ProcessExit::Signal(status.signal().unwrap_or(0)),
+    })
+}
+
+fn hold_guided_result(
+    input: &mut impl BufRead,
+    output: &mut impl io::Write,
+    wait_for_newline: bool,
+) -> io::Result<()> {
+    if !wait_for_newline {
+        writeln!(
+            output,
+            "No interactive terminal is available; closing without waiting."
+        )?;
+        return Ok(());
+    }
+    write!(output, "Press Enter to close. ")?;
+    output.flush()?;
+    let mut bytes = Vec::new();
+    let count = input.read_until(b'\n', &mut bytes)?;
+    if count == 0 || bytes.last() != Some(&b'\n') {
+        writeln!(output, "\nInput closed before a newline; closing now.")?;
+    }
+    Ok(())
 }
 
 fn resolve_node_add_inputs(
@@ -2246,14 +2443,22 @@ fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Err
     let client = client::connect()?;
     match command {
         DaemonCommands::Status if json => {
-            let protocol_version = client.protocol_version()?;
             let scheduler = client.snapshot()?.scheduler;
+            let identity = daemon_process_identity(&client);
+            let protocol_version = identity.as_ref().map_or_else(
+                || client.protocol_version(),
+                |identity| Ok(identity.protocol_version),
+            )?;
             print_json(
                 CommandKey::DaemonStatus,
                 serde_json::json!({
                     "status": "running",
                     "protocol_version": protocol_version,
                     "socket_path": client.socket_path().display().to_string(),
+                    "pid": identity.as_ref().map(|identity| identity.pid),
+                    "executable": identity.as_ref().and_then(|identity| identity.executable.as_deref()),
+                    "socket_device": identity.as_ref().map(|identity| identity.socket_device),
+                    "socket_inode": identity.as_ref().map(|identity| identity.socket_inode),
                     "scheduler": scheduler.map(|health| serde_json::json!({
                         "state": match health.state {
                             protocol::SchedulerState::Active => "active",
@@ -2296,6 +2501,146 @@ fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Err
         DaemonCommands::Run | DaemonCommands::ReceiveHandoff { .. } => unreachable!(),
     }
     Ok(())
+}
+
+struct DaemonProcessIdentity {
+    pid: u32,
+    protocol_version: u32,
+    executable: Option<String>,
+    socket_device: u64,
+    socket_inode: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_process_identity(client: &client::Client) -> Option<DaemonProcessIdentity> {
+    let socket_before = fs::metadata(client.socket_path()).ok()?;
+    let credentials = match client.daemon_peer_credentials() {
+        Ok(credentials) if credentials.uid == unsafe { libc::geteuid() } => credentials,
+        _ => return None,
+    };
+    let socket_after = fs::metadata(client.socket_path()).ok()?;
+    if socket_before.dev() != socket_after.dev() || socket_before.ino() != socket_after.ino() {
+        return None;
+    }
+    let process_directory = PathBuf::from(format!("/proc/{}", credentials.pid));
+    if fs::metadata(&process_directory).map_or(true, |metadata| {
+        metadata.uid() != credentials.uid || !metadata.is_dir()
+    }) {
+        return None;
+    }
+    let executable = fs::read_link(process_directory.join("exe"))
+        .ok()
+        .and_then(|executable| normalize_daemon_executable(executable.as_os_str().as_bytes()));
+    Some(DaemonProcessIdentity {
+        pid: credentials.pid,
+        protocol_version: credentials.protocol_version,
+        executable,
+        socket_device: socket_after.dev(),
+        socket_inode: socket_after.ino(),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn normalize_daemon_executable(path: &[u8]) -> Option<String> {
+    const MAX_EXECUTABLE_PATH: usize = 4096;
+    let mut bytes = path;
+    if let Some(path) = bytes.strip_suffix(b" (deleted)") {
+        bytes = path;
+    }
+    if bytes.is_empty()
+        || bytes.len() > MAX_EXECUTABLE_PATH
+        || bytes.iter().any(u8::is_ascii_control)
+    {
+        return None;
+    }
+    let executable = match String::from_utf8(bytes.to_vec()) {
+        Ok(executable) => executable,
+        Err(_) => return None,
+    };
+    let executable_path = Path::new(&executable);
+    if !executable_path.is_absolute() {
+        return None;
+    }
+    Some(executable)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn daemon_process_identity(_client: &client::Client) -> Option<DaemonProcessIdentity> {
+    None
+}
+
+fn bootstrap_activate(
+    transaction: &str,
+    expected_pid: u32,
+    expected_protocol: u32,
+    expected_executable: &str,
+    expected_socket_device: u64,
+    expected_socket_inode: u64,
+) -> io::Result<()> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (
+            transaction,
+            expected_pid,
+            expected_protocol,
+            expected_executable,
+            expected_socket_device,
+            expected_socket_inode,
+        );
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "proof-bound bootstrap activation is unsupported on this platform",
+        ));
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let suffix = transaction
+            .strip_prefix(".boomux.bootstrap.")
+            .filter(|suffix| {
+                suffix.len() == 8 && suffix.bytes().all(|byte| byte.is_ascii_alphanumeric())
+            })
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "invalid bootstrap transaction")
+            })?;
+        let _ = suffix;
+        let home = env::var_os("HOME")
+            .map(PathBuf::from)
+            .filter(|home| home.is_absolute())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "HOME must be absolute"))?;
+        let directory = home.join(".local/bin");
+        let destination = directory.join("boomux");
+        if destination.as_os_str().as_bytes() != expected_executable.as_bytes() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "bootstrap destination does not match the daemon proof",
+            ));
+        }
+        let provisional = directory.join(transaction).join("new");
+        let socket = client::socket_path()?;
+        let daemon_client = client::Client::from_socket_path(socket);
+        let identity = daemon_process_identity(&daemon_client).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "the daemon identity could not be bound to activation",
+            )
+        })?;
+        if identity.pid != expected_pid
+            || identity.protocol_version != expected_protocol
+            || identity.executable.as_deref() != Some(expected_executable)
+            || identity.socket_device != expected_socket_device
+            || identity.socket_inode != expected_socket_inode
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "the daemon identity changed before activation",
+            ));
+        }
+        fs::rename(&provisional, &destination)?;
+        fs::File::open(&destination)?.sync_all()?;
+        fs::File::create(directory.join(transaction).join("activated"))?.sync_all()?;
+        fs::File::open(&directory)?.sync_all()?;
+        Ok(())
+    }
 }
 
 fn should_open_new_window(new_window: bool, terminal: Option<&str>) -> bool {
@@ -2742,9 +3087,8 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 route,
             } => {
                 let result = (|| {
-                    let mut remote = verified_remote_connection(&route, true)
+                    let remote = verified_remote_connection(&route, true)
                         .map_err(|error| error.to_string())?;
-                    remote.ping().map_err(|error| error.to_string())?;
                     if remote.handshake.node_id != node_id {
                         return Err("retargeted route reached a different Node identity".into());
                     }
@@ -5398,7 +5742,7 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         .copied()
         .chain(protocol::protocol_capabilities())
         .collect::<Vec<_>>();
-    let error_codes = [
+    let error_codes: &[&str] = &[
         "invalid_argument",
         "not_found",
         "already_exists",
@@ -5409,6 +5753,16 @@ fn capabilities(json: bool) -> Result<(), Box<dyn Error>> {
         "persistence_failed",
         "timeout",
         "unsupported_version",
+        "install_required",
+        "upgrade_required",
+        "bootstrap_authentication_failed",
+        "bootstrap_transport_failed",
+        "bootstrap_malformed_helper",
+        "bootstrap_unsupported_platform",
+        "bootstrap_install_failed",
+        "bootstrap_commit_outcome_unknown",
+        "bootstrap_runtime_unavailable",
+        "node_identity_conflict",
         "cursor_expired",
         "run_changed",
         "revision_ahead",
@@ -10200,6 +10554,18 @@ mod tests {
     use crate::integration_management::{opencode_config_root, pi_config_root};
     use std::os::unix::net::UnixListener;
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn daemon_executable_normalization_is_exact_and_bounded() {
+        assert_eq!(
+            normalize_daemon_executable(b"/custom/path with spaces/boomux (deleted)"),
+            Some("/custom/path with spaces/boomux".into())
+        );
+        assert_eq!(normalize_daemon_executable(b"relative/boomux"), None);
+        assert_eq!(normalize_daemon_executable(b"/bad\npath"), None);
+        assert_eq!(normalize_daemon_executable(&vec![b'x'; 4097]), None);
+    }
+
     fn shell(id: &str, workspace_id: &str, name: &str) -> ShellSnapshot {
         ShellSnapshot {
             owner: boomux::protocol::ShellOwner::User,
@@ -11056,6 +11422,280 @@ mod tests {
         );
         assert!(resolve_node_add_inputs(Some("work".into()), None, false).is_err());
         assert!(resolve_node_add_inputs(None, None, true).is_err());
+
+        let held = Cli::try_parse_from(["boomux", "__guided-node-add"]).unwrap();
+        assert!(matches!(held.command, Some(Commands::GuidedNodeAdd)));
+        assert_eq!(held.command_descriptor().key, "node.add");
+    }
+
+    #[test]
+    fn guided_node_add_preserves_failure_status_and_distinguishes_newline_from_eof() {
+        let directory = env::temp_dir().join(format!("boomux-guided-{}", Uuid::new_v4()));
+        fs::create_dir(&directory).unwrap();
+        let child = directory.join("child");
+        let child_output = directory.join("child-output");
+        fs::write(
+            &child,
+            format!(
+                "#!/bin/sh\nprintf 'child failed\\n'\nprintf 'child failed\\n' > '{}'\nexit 7\n",
+                child_output.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&child, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut newline = io::Cursor::new(b"\n");
+        let mut output = Vec::new();
+        assert_eq!(
+            guided_node_add_with(&child, &mut newline, &mut output, true, None).unwrap(),
+            process_adapter::ProcessExit::Code(7)
+        );
+        let output = String::from_utf8(output).unwrap();
+        assert_eq!(fs::read_to_string(&child_output).unwrap(), "child failed\n");
+        assert!(output.contains("Node setup failed (exit 7)."));
+        assert!(output.contains("Press Enter to close."));
+        assert!(!output.contains("Input closed before a newline"));
+
+        let mut eof = io::Cursor::new(b"partial");
+        let mut output = Vec::new();
+        assert_eq!(
+            guided_node_add_with(&child, &mut eof, &mut output, true, None).unwrap(),
+            process_adapter::ProcessExit::Code(7)
+        );
+        assert!(
+            String::from_utf8(output)
+                .unwrap()
+                .contains("Input closed before a newline")
+        );
+
+        let mut eof = io::Cursor::new(Vec::<u8>::new());
+        let mut output = Vec::new();
+        assert_eq!(
+            guided_node_add_with(
+                &directory.join("missing"),
+                &mut eof,
+                &mut output,
+                true,
+                None,
+            )
+            .unwrap(),
+            process_adapter::ProcessExit::Code(1)
+        );
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("failed to start"));
+        assert!(output.contains("Press Enter to close."));
+        assert!(output.contains("Input closed before a newline"));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn guided_pty_helper_process() {
+        let Some(executable) = env::var_os("BOOMUX_TEST_GUIDED_EXECUTABLE") else {
+            return;
+        };
+        let stdin = io::stdin();
+        let mut input = stdin.lock();
+        let mut output = io::stdout().lock();
+        let outcome = guided_node_add_with(
+            Path::new(&executable),
+            &mut input,
+            &mut output,
+            true,
+            Some(stdin.as_raw_fd()),
+        )
+        .unwrap();
+        std::process::exit(match outcome {
+            process_adapter::ProcessExit::Code(code) => code,
+            process_adapter::ProcessExit::Signal(signal) => 128 + signal,
+        });
+    }
+
+    #[test]
+    fn guided_node_add_pty_interrupts_child_and_holds_for_newline() {
+        use std::os::fd::{FromRawFd, OwnedFd};
+
+        let directory = env::temp_dir().join(format!("boomux-guided-pty-{}", Uuid::new_v4()));
+        fs::create_dir(&directory).unwrap();
+        let child = directory.join("child");
+        fs::write(
+            &child,
+            "#!/bin/sh\nkill -STOP $$\nprintf 'child-ready\\n'\nread line\nexit 7\n",
+        )
+        .unwrap();
+        fs::set_permissions(&child, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut master = 0;
+        let mut slave = 0;
+        assert_eq!(
+            unsafe {
+                libc::openpty(
+                    &mut master,
+                    &mut slave,
+                    std::ptr::null_mut(),
+                    std::ptr::null(),
+                    std::ptr::null(),
+                )
+            },
+            0
+        );
+        let master = unsafe { OwnedFd::from_raw_fd(master) };
+        let slave = unsafe { OwnedFd::from_raw_fd(slave) };
+        let stdin = Stdio::from(slave.try_clone().unwrap());
+        let stdout = Stdio::from(slave.try_clone().unwrap());
+        let stderr = Stdio::from(slave);
+        let mut command = Command::new(env::current_exe().unwrap());
+        command
+            .args(["--exact", "tests::guided_pty_helper_process", "--nocapture"])
+            .env("BOOMUX_TEST_GUIDED_EXECUTABLE", &child)
+            .stdin(stdin)
+            .stdout(stdout)
+            .stderr(stderr);
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 || libc::ioctl(0, libc::TIOCSCTTY, 0) == -1 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
+            });
+        }
+        let mut wrapper = command.spawn().unwrap();
+        let mut master = std::fs::File::from(master);
+        let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+        assert_ne!(flags, -1);
+        assert_ne!(
+            unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK,) },
+            -1
+        );
+        let mut output = Vec::new();
+        read_pty_until(
+            &mut master,
+            &mut output,
+            b"child-ready",
+            Duration::from_secs(3),
+        );
+        io::Write::write_all(&mut master, &[3]).unwrap();
+        read_pty_until(
+            &mut master,
+            &mut output,
+            b"Press Enter to close.",
+            Duration::from_secs(3),
+        );
+        assert!(wrapper.try_wait().unwrap().is_none());
+        io::Write::write_all(&mut master, b"\n").unwrap();
+        let status = wrapper.wait().unwrap();
+        assert_eq!(status.code(), Some(130));
+        let output = String::from_utf8_lossy(&output);
+        assert!(output.contains("Node setup failed (signal 2)."));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn guided_node_add_pty_restores_foreground_and_kills_group_after_sigcont_failure() {
+        use std::os::fd::{FromRawFd, OwnedFd};
+
+        let directory = env::temp_dir().join(format!("boomux-guided-cont-{}", Uuid::new_v4()));
+        fs::create_dir(&directory).unwrap();
+        let child = directory.join("child");
+        let resumed = directory.join("resumed");
+        fs::write(
+            &child,
+            format!(
+                "#!/bin/sh\nkill -STOP $$\nprintf resumed > '{}'\nsleep 30\n",
+                resumed.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&child, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut master = 0;
+        let mut slave = 0;
+        assert_eq!(
+            unsafe {
+                libc::openpty(
+                    &mut master,
+                    &mut slave,
+                    std::ptr::null_mut(),
+                    std::ptr::null(),
+                    std::ptr::null(),
+                )
+            },
+            0
+        );
+        let master = unsafe { OwnedFd::from_raw_fd(master) };
+        let slave = unsafe { OwnedFd::from_raw_fd(slave) };
+        let mut command = Command::new(env::current_exe().unwrap());
+        command
+            .args(["--exact", "tests::guided_pty_helper_process", "--nocapture"])
+            .env("BOOMUX_TEST_GUIDED_EXECUTABLE", &child)
+            .env("BOOMUX_TEST_GUIDED_SIGCONT_FAILURE", "1")
+            .stdin(Stdio::from(slave.try_clone().unwrap()))
+            .stdout(Stdio::from(slave.try_clone().unwrap()))
+            .stderr(Stdio::from(slave));
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 || libc::ioctl(0, libc::TIOCSCTTY, 0) == -1 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
+            });
+        }
+        let mut wrapper = command.spawn().unwrap();
+        let mut master = std::fs::File::from(master);
+        let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+        assert_ne!(flags, -1);
+        assert_ne!(
+            unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) },
+            -1
+        );
+        let mut output = Vec::new();
+        read_pty_until(
+            &mut master,
+            &mut output,
+            b"Node setup failed to continue",
+            Duration::from_secs(3),
+        );
+        read_pty_until(
+            &mut master,
+            &mut output,
+            b"Press Enter to close.",
+            Duration::from_secs(3),
+        );
+        assert!(wrapper.try_wait().unwrap().is_none());
+        assert!(!resumed.exists());
+        io::Write::write_all(&mut master, b"\n").unwrap();
+        assert_eq!(wrapper.wait().unwrap().code(), Some(1));
+        assert!(!resumed.exists());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    fn read_pty_until(
+        master: &mut fs::File,
+        output: &mut Vec<u8>,
+        expected: &[u8],
+        timeout: Duration,
+    ) {
+        let deadline = Instant::now() + timeout;
+        let mut bytes = [0_u8; 1024];
+        while !output
+            .windows(expected.len())
+            .any(|window| window == expected)
+        {
+            match master.read(&mut bytes) {
+                Ok(0) => panic!("PTY closed before {:?}", String::from_utf8_lossy(expected)),
+                Ok(count) => output.extend_from_slice(&bytes[..count]),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "PTY output: {}",
+                        String::from_utf8_lossy(output)
+                    );
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("PTY read failed: {error}"),
+            }
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,7 +333,7 @@ const READ_BYTES: usize = 1024 * 1024;
     subcommand_value_name = "SUBCOMMAND"
 )]
 struct Cli {
-    /// Emit the stable boomux.cli/v1 JSON envelope
+    /// Emit the stable boomux.cli/v1 envelope for commands advertised by capabilities
     #[arg(long, global = true)]
     json: bool,
 
@@ -580,6 +580,8 @@ enum WorkspaceCommands {
     Create { name: String },
     /// Open terminal windows and invoke launchers
     Open {
+        /// Coordinated Workspace name/ID, or exact owner Workspace ID with --node
+        #[arg(value_name = "WORKSPACE")]
         target: String,
         /// Exact registered Node alias or Node ID
         #[arg(long)]
@@ -591,21 +593,29 @@ enum WorkspaceCommands {
     Rename { target: String, name: String },
     /// Adopt an unlinked Node-local Workspace as a new coordinated Workspace
     Adopt {
+        #[arg(value_name = "EXTERNAL_WORKSPACE")]
         target: String,
+        /// Exact eligible Node alias or Node ID
         #[arg(long)]
         node: String,
     },
     /// Link an unlinked Node-local Workspace to a coordinated Workspace
     Link {
+        #[arg(value_name = "GLOBAL_WORKSPACE")]
         target: String,
+        #[arg(value_name = "OWNER_WORKSPACE")]
         owner: String,
+        /// Exact eligible Node alias or Node ID
         #[arg(long)]
         node: String,
     },
     /// Close a workspace and all of its shells
     Close { target: String },
     /// Retry unresolved placement removals for a closing Workspace
-    Retry { target: String },
+    Retry {
+        #[arg(value_name = "CLOSING_GLOBAL_WORKSPACE")]
+        target: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -618,7 +628,8 @@ enum LauncherCommands {
     /// Create a launcher in a workspace
     Create {
         name: String,
-        #[arg(long, value_name = "NAME_OR_ID")]
+        /// Coordinated Workspace name or ID when --node is used
+        #[arg(long, value_name = "WORKSPACE")]
         workspace: String,
         /// Exact eligible Node alias or Node ID
         #[arg(long)]
@@ -636,6 +647,8 @@ enum LauncherCommands {
     },
     /// Invoke a launcher as a detached process
     Invoke {
+        /// Launcher name/ID locally, or exact launcher ID with --node
+        #[arg(value_name = "LAUNCHER")]
         target: String,
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
@@ -662,6 +675,8 @@ enum LauncherCommands {
 enum ShellCommands {
     /// Suggest an unused generated name without reserving it
     SuggestName {
+        /// Workspace name/ID locally, or exact owner Workspace ID with --node
+        #[arg(value_name = "WORKSPACE")]
         workspace: String,
         /// Exact registered Node alias or Node ID
         #[arg(long)]
@@ -669,6 +684,8 @@ enum ShellCommands {
     },
     /// Create a pending shell in a workspace
     Create {
+        /// Coordinated Workspace name or ID when --node is used
+        #[arg(value_name = "WORKSPACE")]
         workspace: String,
         /// Exact eligible Node alias or Node ID
         #[arg(long)]
@@ -4711,6 +4728,46 @@ struct CoordinatedOwnerSelection {
     default_cwd: Option<PathBuf>,
 }
 
+fn require_protocol_feature(
+    client: &client::Client,
+    feature: protocol::ProtocolFeature,
+) -> Result<(), Box<dyn Error>> {
+    if client.supports(feature)? {
+        return Ok(());
+    }
+    Err(cli_output::failure(
+        "unsupported_version",
+        format!(
+            "{} requires daemon protocol {} or newer",
+            feature.requirement(),
+            feature.minimum_version()
+        ),
+    ))
+}
+
+fn require_explicit_coordinated_owner<T>(
+    selection: Option<T>,
+    node_selector: Option<&str>,
+    global_workspaces_supported: bool,
+) -> Result<Option<T>, Box<dyn Error>> {
+    if selection.is_some() || node_selector.is_none() {
+        return Ok(selection);
+    }
+    if !global_workspaces_supported {
+        return Err(cli_output::failure(
+            "unsupported_version",
+            format!(
+                "explicit Workspace placement requires daemon protocol {} or newer",
+                protocol::ProtocolFeature::GlobalWorkspaces.minimum_version()
+            ),
+        ));
+    }
+    Err(cli_output::failure(
+        "invalid_argument",
+        "--node can create a Shell or launcher only in a coordinated Workspace; adopt or link an external Workspace first",
+    ))
+}
+
 fn select_coordinated_owner(
     client: &client::Client,
     workspace_target: &str,
@@ -6401,6 +6458,7 @@ fn workspace_command(
             println!("Renamed workspace {} to {name}", workspace.name);
         }
         WorkspaceCommands::Adopt { target, node } => {
+            require_protocol_feature(&client, protocol::ProtocolFeature::GlobalWorkspaces)?;
             let combined = client.combined_node_snapshot(None)?;
             let node = resolve_combined_node(&combined.nodes, &node)?;
             if !node.workspace_owner_eligible {
@@ -6436,6 +6494,7 @@ fn workspace_command(
             owner,
             node,
         } => {
+            require_protocol_feature(&client, protocol::ProtocolFeature::GlobalWorkspaces)?;
             let combined = client.combined_node_snapshot(None)?;
             let workspace = resolve_global_workspace_target(&combined.workspaces, &target)
                 .ok_or_else(|| {
@@ -6549,6 +6608,7 @@ fn workspace_command(
             );
         }
         WorkspaceCommands::Retry { target } => {
+            require_protocol_feature(&client, protocol::ProtocolFeature::GlobalWorkspaces)?;
             let combined = client.combined_node_snapshot(None)?;
             let workspace = resolve_global_workspace_target(&combined.workspaces, &target)
                 .ok_or_else(|| {
@@ -6649,8 +6709,14 @@ fn shell_command(command: ShellCommands, json: bool) -> Result<(), Box<dyn Error
             cwd,
             command,
         } => {
-            if let Some(selection) = select_coordinated_owner(&client, &workspace, node.as_deref())?
-            {
+            let global_workspaces_supported =
+                client.supports(protocol::ProtocolFeature::GlobalWorkspaces)?;
+            let selection = select_coordinated_owner(&client, &workspace, node.as_deref())?;
+            if let Some(selection) = require_explicit_coordinated_owner(
+                selection,
+                node.as_deref(),
+                global_workspaces_supported,
+            )? {
                 let requested_cwd = cwd
                     .or_else(|| selection.default_cwd.clone())
                     .unwrap_or_else(|| PathBuf::from("."));
@@ -6793,8 +6859,14 @@ fn launcher_command(command: LauncherCommands, json: bool) -> Result<(), Box<dyn
             command,
         } => {
             let name = cli_name(name, "workspace launcher")?;
-            if let Some(selection) = select_coordinated_owner(&client, &workspace, node.as_deref())?
-            {
+            let global_workspaces_supported =
+                client.supports(protocol::ProtocolFeature::GlobalWorkspaces)?;
+            let selection = select_coordinated_owner(&client, &workspace, node.as_deref())?;
+            if let Some(selection) = require_explicit_coordinated_owner(
+                selection,
+                node.as_deref(),
+                global_workspaces_supported,
+            )? {
                 let cwd = resolve_owner_directory(&client, &selection.node, cwd)?;
                 let owner_default_cwd = selection.default_cwd.clone().or_else(|| Some(cwd.clone()));
                 let (_, launcher) = client.create_global_workspace_launcher(
@@ -11741,7 +11813,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_project_owner_selection_delegates_sole_and_requires_ambiguous_choice() {
+    fn workspace_resource_owner_selection_delegates_sole_and_requires_ambiguous_choice() {
         let local = combined_node("local-id", "local", true);
         let remote = combined_node("remote-id", "work", true);
         assert_eq!(
@@ -11756,6 +11828,27 @@ mod tests {
                 .unwrap()
                 .node_id,
             "remote-id"
+        );
+    }
+
+    #[test]
+    fn explicit_node_placement_never_falls_back_to_local_creation() {
+        assert_eq!(
+            require_explicit_coordinated_owner(Some(7), Some("work"), true).unwrap(),
+            Some(7)
+        );
+        let external = require_explicit_coordinated_owner::<()>(None, Some("work"), true)
+            .unwrap_err()
+            .to_string();
+        assert!(external.contains("coordinated Workspace"));
+        let legacy = require_explicit_coordinated_owner::<()>(None, Some("work"), false)
+            .unwrap_err()
+            .to_string();
+        assert!(legacy.contains("protocol 38"));
+        assert!(
+            require_explicit_coordinated_owner::<()>(None, None, false)
+                .unwrap()
+                .is_none()
         );
     }
 
@@ -14197,12 +14290,24 @@ mod tests {
             "boomux close",
             "boomux open",
             "boomux project list",
+            "boomux node add",
+            "boomux node list",
+            "boomux node inspect",
+            "boomux node snapshot",
+            "boomux node rename",
+            "boomux node retarget",
+            "boomux node forget",
+            "boomux node rekey",
             "boomux workspace list",
             "boomux workspace create",
             "boomux workspace open",
             "boomux workspace inspect",
             "boomux workspace rename",
+            "boomux workspace adopt",
+            "boomux workspace link",
             "boomux workspace close",
+            "boomux workspace retry",
+            "boomux shell suggest-name",
             "boomux shell create",
             "boomux shell inspect",
             "boomux shell rename",
@@ -14225,6 +14330,19 @@ mod tests {
             "boomux notification test",
             "boomux session list",
             "boomux session inspect",
+            "boomux session resume",
+            "boomux schedule create",
+            "boomux schedule list",
+            "boomux schedule inspect",
+            "boomux schedule pause",
+            "boomux schedule resume",
+            "boomux schedule remove",
+            "boomux schedule run",
+            "boomux execution list",
+            "boomux execution inspect",
+            "boomux execution wait",
+            "boomux execution open",
+            "boomux execution cancel",
             "boomux integration list",
             "boomux integration status",
             "boomux integration install",
@@ -14250,7 +14368,11 @@ mod tests {
         }
         assert!(BOOMUX_SKILL.contains("BOOMUX_SHELL_ID"));
         assert!(BOOMUX_SKILL.contains("--workspace"));
+        assert!(BOOMUX_SKILL.contains("--node"));
+        assert!(BOOMUX_SKILL.contains("--revision"));
         assert!(BOOMUX_SKILL.contains("--terminal"));
+        assert!(!BOOMUX_SKILL.contains("boomux session read"));
+        assert!(!BOOMUX_SKILL.contains("workspace create \"<name>\" --cwd"));
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 38;
+pub const PROTOCOL_VERSION: u32 = 39;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -167,6 +167,10 @@ define_protocol_features! {
         "multi_node_workspace_placements",
         "guarded_workspace_adoption",
         "resumable_workspace_close",
+    ]),
+    QualifiedFocusedTerminal => (39, "Node-qualified focused terminal presentation", [
+        "protocol_39",
+        "qualified_focused_terminal",
     ]),
 }
 
@@ -474,6 +478,13 @@ pub struct FocusedTerminalSnapshot {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QualifiedFocusedTerminalSnapshot {
+    pub revision: u64,
+    pub shell: QualifiedIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NodeRegistrationSnapshot {
     pub alias: String,
     pub target: String,
@@ -741,6 +752,8 @@ pub struct CombinedNodeSnapshot {
     pub workspaces: Vec<GlobalWorkspaceSnapshot>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub external_workspaces: Vec<ExternalWorkspaceSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub focused_terminal: Option<QualifiedFocusedTerminalSnapshot>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1856,6 +1869,7 @@ pub enum DaemonEventKind {
         node_id: String,
         cache_generation: u64,
     },
+    FocusedTerminalPresentationChanged,
     HandoffCompleted,
 }
 
@@ -3215,8 +3229,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_thirty_eight_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 38);
+    fn protocol_version_is_thirty_nine_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 39);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -3388,6 +3402,10 @@ mod tests {
                 nodes: Vec::new(),
                 workspaces: Vec::new(),
                 external_workspaces: Vec::new(),
+                focused_terminal: Some(QualifiedFocusedTerminalSnapshot {
+                    revision: 4,
+                    shell: QualifiedIdentity::new("node", "shell"),
+                }),
             },
         };
         assert_eq!(
@@ -4495,6 +4513,7 @@ mod tests {
                     "resumable_workspace_close",
                 ][..],
             ),
+            (39, &["protocol_39", "qualified_focused_terminal"][..]),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 37;
+pub const PROTOCOL_VERSION: u32 = 38;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -160,6 +160,13 @@ define_protocol_features! {
         "protocol_37",
         "remote_agent_schedule_management",
         "remote_scheduled_execution_observation",
+    ]),
+    GlobalWorkspaces => (38, "coordinated multi-Node Workspaces", [
+        "protocol_38",
+        "global_workspaces",
+        "multi_node_workspace_placements",
+        "guarded_workspace_adoption",
+        "resumable_workspace_close",
     ]),
 }
 
@@ -722,12 +729,77 @@ pub struct NodeProjectionSync {
     pub cursor: EventCursor,
     pub projection: NodeProjectionSnapshot,
     pub transitions: Vec<NodeProjectionTransition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CombinedNodeSnapshot {
     pub nodes: Vec<CombinedNode>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workspaces: Vec<GlobalWorkspaceSnapshot>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external_workspaces: Vec<ExternalWorkspaceSnapshot>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspacePlacementState {
+    Active,
+    ClosePending,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspacePlacementSnapshot {
+    pub node_id: String,
+    pub workspace_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_workspace_name: Option<String>,
+    pub owner_revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_cwd: Option<PathBuf>,
+    pub state: WorkspacePlacementState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GlobalWorkspaceSnapshot {
+    pub id: String,
+    pub revision: u64,
+    pub name: String,
+    pub closing: bool,
+    pub placements: Vec<WorkspacePlacementSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalWorkspaceSnapshot {
+    pub identity: QualifiedIdentity,
+    pub revision: u64,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_cwd: Option<PathBuf>,
+    pub available: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspacePlacementResult {
+    pub node_id: String,
+    pub workspace_id: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GlobalWorkspaceOperationResult {
+    pub workspace: GlobalWorkspaceSnapshot,
+    pub placements: Vec<WorkspacePlacementResult>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -736,6 +808,10 @@ pub struct CombinedNode {
     pub node_id: String,
     pub alias: String,
     pub local: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registration_revision: Option<u64>,
     pub health: NodeProjectionHealthCode,
     pub current: bool,
     pub stale: bool,
@@ -744,6 +820,10 @@ pub struct CombinedNode {
     pub observed_protocol_version: Option<u32>,
     #[serde(default)]
     pub observed_capabilities: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub workspace_owner_eligible: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_unavailable_reason: Option<String>,
     pub scheduler: SchedulerHealth,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub local_snapshot: Option<Snapshot>,
@@ -1219,6 +1299,30 @@ pub enum ErrorCode {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
 pub enum RoutedOperation {
+    CreateWorkspaceShell {
+        workspace_id: String,
+        workspace_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
+        shell_id: String,
+        shell: ShellSpec,
+    },
+    CreateWorkspaceLauncher {
+        workspace_id: String,
+        workspace_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
+        launcher_id: String,
+        spec: WorkspaceLauncherSpec,
+    },
+    CreateWorkspaceAgentSchedule {
+        workspace_id: String,
+        workspace_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
+        schedule_id: String,
+        spec: AgentScheduleSpec,
+    },
     CreateAgentSchedule {
         workspace_id: String,
         spec: AgentScheduleSpec,
@@ -1349,6 +1453,12 @@ impl RoutedOperation {
             ResourceRevision, ResourceRevisionAndRun, ScheduleRevision,
         };
         match self {
+            Self::CreateWorkspaceShell { .. }
+            | Self::CreateWorkspaceLauncher { .. }
+            | Self::CreateWorkspaceAgentSchedule { .. } => RoutedOperationClass {
+                guard: ExactId,
+                ambiguity: RetrySameRequest,
+            },
             Self::CreateAgentSchedule { .. } => RoutedOperationClass {
                 guard: None,
                 ambiguity: ReadAndProve,
@@ -1408,6 +1518,9 @@ impl RoutedOperation {
 
     pub fn ambiguity_probe(&self) -> Option<Request> {
         match self {
+            Self::CreateWorkspaceShell { .. }
+            | Self::CreateWorkspaceLauncher { .. }
+            | Self::CreateWorkspaceAgentSchedule { .. } => None,
             Self::RenameWorkspace { workspace_id, .. }
             | Self::CloseWorkspace { workspace_id, .. } => Some(Request::GetWorkspace {
                 workspace_id: workspace_id.clone(),
@@ -1439,6 +1552,45 @@ impl RoutedOperation {
 
     pub fn owner_request(&self) -> Request {
         match self.clone() {
+            Self::CreateWorkspaceShell {
+                workspace_id,
+                workspace_name,
+                default_cwd,
+                shell_id,
+                shell,
+            } => Request::CreateWorkspaceShell {
+                workspace_id,
+                workspace_name,
+                default_cwd,
+                shell_id,
+                shell,
+            },
+            Self::CreateWorkspaceLauncher {
+                workspace_id,
+                workspace_name,
+                default_cwd,
+                launcher_id,
+                spec,
+            } => Request::CreateWorkspaceLauncher {
+                workspace_id,
+                workspace_name,
+                default_cwd,
+                launcher_id,
+                spec,
+            },
+            Self::CreateWorkspaceAgentSchedule {
+                workspace_id,
+                workspace_name,
+                default_cwd,
+                schedule_id,
+                spec,
+            } => Request::CreateWorkspaceAgentSchedule {
+                workspace_id,
+                workspace_name,
+                default_cwd,
+                schedule_id,
+                spec,
+            },
             Self::CreateAgentSchedule { workspace_id, spec } => {
                 Request::CreateAgentSchedule { workspace_id, spec }
             }
@@ -1867,9 +2019,84 @@ pub enum Request {
     GetNodeProjectionHealth {
         selector: String,
     },
+    ForceNodeProjectionRefresh {
+        selector: String,
+    },
     GetCombinedNodeSnapshot {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         selector: Option<String>,
+    },
+    CreateGlobalWorkspace {
+        name: String,
+    },
+    AdoptNodeWorkspace {
+        identity: QualifiedIdentity,
+        expected_revision: u64,
+    },
+    LinkNodeWorkspace {
+        global_workspace_id: String,
+        expected_global_revision: u64,
+        identity: QualifiedIdentity,
+        expected_owner_revision: u64,
+    },
+    RenameGlobalWorkspace {
+        workspace_id: String,
+        expected_revision: u64,
+        name: String,
+    },
+    OpenGlobalWorkspace {
+        workspace_id: String,
+        expected_revision: u64,
+    },
+    CloseGlobalWorkspace {
+        workspace_id: String,
+        expected_revision: u64,
+    },
+    RetryGlobalWorkspaceClose {
+        workspace_id: String,
+    },
+    CreateGlobalWorkspaceShell {
+        operation_id: String,
+        global_workspace_id: String,
+        expected_global_revision: u64,
+        node_id: String,
+        owner_workspace_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
+        shell_id: String,
+        shell: ShellSpec,
+    },
+    CreateGlobalWorkspaceWithShell {
+        operation_id: String,
+        global_workspace_id: String,
+        name: String,
+        node_id: String,
+        owner_workspace_id: String,
+        default_cwd: PathBuf,
+        shell_id: String,
+        shell: ShellSpec,
+    },
+    CreateGlobalWorkspaceLauncher {
+        operation_id: String,
+        global_workspace_id: String,
+        expected_global_revision: u64,
+        node_id: String,
+        owner_workspace_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
+        launcher_id: String,
+        spec: WorkspaceLauncherSpec,
+    },
+    CreateGlobalWorkspaceAgentSchedule {
+        operation_id: String,
+        global_workspace_id: String,
+        expected_global_revision: u64,
+        node_id: String,
+        owner_workspace_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
+        schedule_id: String,
+        spec: AgentScheduleSpec,
     },
     RouteNodeOperation {
         node_id: String,
@@ -1934,6 +2161,30 @@ pub enum Request {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         default_cwd: Option<PathBuf>,
         shells: Vec<ShellSpec>,
+    },
+    CreateWorkspaceShell {
+        workspace_id: String,
+        workspace_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
+        shell_id: String,
+        shell: ShellSpec,
+    },
+    CreateWorkspaceLauncher {
+        workspace_id: String,
+        workspace_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
+        launcher_id: String,
+        spec: WorkspaceLauncherSpec,
+    },
+    CreateWorkspaceAgentSchedule {
+        workspace_id: String,
+        workspace_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_cwd: Option<PathBuf>,
+        schedule_id: String,
+        spec: AgentScheduleSpec,
     },
     CreateShell {
         #[serde(default)]
@@ -2149,6 +2400,30 @@ impl Request {
                 Some(ProtocolFeature::NodeProjectionSync)
             }
             Self::GetCombinedNodeSnapshot { .. } => Some(ProtocolFeature::CombinedNodeSnapshot),
+            Self::ForceNodeProjectionRefresh { .. } => Some(ProtocolFeature::GlobalWorkspaces),
+            Self::CreateGlobalWorkspace { .. }
+            | Self::AdoptNodeWorkspace { .. }
+            | Self::LinkNodeWorkspace { .. }
+            | Self::RenameGlobalWorkspace { .. }
+            | Self::OpenGlobalWorkspace { .. }
+            | Self::CloseGlobalWorkspace { .. }
+            | Self::RetryGlobalWorkspaceClose { .. }
+            | Self::CreateGlobalWorkspaceShell { .. }
+            | Self::CreateGlobalWorkspaceWithShell { .. }
+            | Self::CreateGlobalWorkspaceLauncher { .. }
+            | Self::CreateGlobalWorkspaceAgentSchedule { .. } => {
+                Some(ProtocolFeature::GlobalWorkspaces)
+            }
+            Self::CreateWorkspaceShell { .. }
+            | Self::CreateWorkspaceLauncher { .. }
+            | Self::CreateWorkspaceAgentSchedule { .. }
+            | Self::RouteNodeOperation {
+                operation:
+                    RoutedOperation::CreateWorkspaceShell { .. }
+                    | RoutedOperation::CreateWorkspaceLauncher { .. }
+                    | RoutedOperation::CreateWorkspaceAgentSchedule { .. },
+                ..
+            } => Some(ProtocolFeature::GlobalWorkspaces),
             Self::RouteNodeOperation {
                 operation:
                     RoutedOperation::CreateAgentSchedule { .. }
@@ -2297,6 +2572,16 @@ pub enum Response {
     },
     CombinedNodeSnapshot {
         snapshot: CombinedNodeSnapshot,
+    },
+    GlobalWorkspace {
+        workspace: GlobalWorkspaceSnapshot,
+    },
+    GlobalWorkspaceOperation {
+        result: GlobalWorkspaceOperationResult,
+    },
+    GlobalWorkspaceResource {
+        workspace: GlobalWorkspaceSnapshot,
+        resource: RoutedOperationResult,
     },
     RoutedNodeOperation {
         result: RoutedOperationResult,
@@ -2930,8 +3215,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_thirty_seven_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 37);
+    fn protocol_version_is_thirty_eight_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 38);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -3099,7 +3384,11 @@ mod tests {
             request
         );
         let response = Response::CombinedNodeSnapshot {
-            snapshot: CombinedNodeSnapshot { nodes: Vec::new() },
+            snapshot: CombinedNodeSnapshot {
+                nodes: Vec::new(),
+                workspaces: Vec::new(),
+                external_workspaces: Vec::new(),
+            },
         };
         assert_eq!(
             serde_json::from_value::<Response>(serde_json::to_value(&response).unwrap()).unwrap(),
@@ -3202,6 +3491,130 @@ mod tests {
                 expected_revision: 4,
             }
             .is_retryable()
+        );
+    }
+
+    #[test]
+    fn protocol_thirty_eight_coordinates_workspaces_and_exact_owner_creation() {
+        let node_id = uuid::Uuid::from_u128(1).to_string();
+        let workspace_id = uuid::Uuid::from_u128(2).to_string();
+        let requests = vec![
+            Request::CreateGlobalWorkspace {
+                name: "work".into(),
+            },
+            Request::AdoptNodeWorkspace {
+                identity: QualifiedIdentity::new(&node_id, &workspace_id),
+                expected_revision: 3,
+            },
+            Request::LinkNodeWorkspace {
+                global_workspace_id: uuid::Uuid::from_u128(3).to_string(),
+                expected_global_revision: 4,
+                identity: QualifiedIdentity::new(&node_id, &workspace_id),
+                expected_owner_revision: 3,
+            },
+            Request::OpenGlobalWorkspace {
+                workspace_id: workspace_id.clone(),
+                expected_revision: 4,
+            },
+            Request::CloseGlobalWorkspace {
+                workspace_id: workspace_id.clone(),
+                expected_revision: 4,
+            },
+            Request::RetryGlobalWorkspaceClose {
+                workspace_id: workspace_id.clone(),
+            },
+            Request::CreateGlobalWorkspaceWithShell {
+                operation_id: uuid::Uuid::from_u128(11).to_string(),
+                global_workspace_id: uuid::Uuid::from_u128(12).to_string(),
+                name: "project".into(),
+                node_id: node_id.clone(),
+                owner_workspace_id: uuid::Uuid::from_u128(13).to_string(),
+                default_cwd: "/owner/project".into(),
+                shell_id: uuid::Uuid::from_u128(14).to_string(),
+                shell: ShellSpec {
+                    name: "project".into(),
+                    cwd: "/owner/project".into(),
+                    command: Vec::new(),
+                },
+            },
+        ];
+        for request in requests {
+            assert_eq!(
+                request.required_feature(),
+                Some(ProtocolFeature::GlobalWorkspaces)
+            );
+            assert_eq!(
+                serde_json::from_value::<Request>(serde_json::to_value(&request).unwrap()).unwrap(),
+                request
+            );
+        }
+
+        let operation = RoutedOperation::CreateWorkspaceShell {
+            workspace_id: workspace_id.clone(),
+            workspace_name: "work".into(),
+            default_cwd: Some("/owner/work".into()),
+            shell_id: uuid::Uuid::from_u128(4).to_string(),
+            shell: ShellSpec {
+                name: "shell".into(),
+                cwd: "/owner/work".into(),
+                command: vec!["bash".into(), "-lc".into(), "printf %s safe".into()],
+            },
+        };
+        assert!(operation.is_retryable());
+        assert_eq!(operation.classification().guard, RoutedGuard::ExactId);
+        assert!(matches!(
+            operation.owner_request(),
+            Request::CreateWorkspaceShell { .. }
+        ));
+        let request = Request::RouteNodeOperation { node_id, operation };
+        assert_eq!(
+            request.required_feature(),
+            Some(ProtocolFeature::GlobalWorkspaces)
+        );
+
+        let schedule = RoutedOperation::CreateWorkspaceAgentSchedule {
+            workspace_id,
+            workspace_name: "work".into(),
+            default_cwd: Some("/owner/work".into()),
+            schedule_id: uuid::Uuid::from_u128(5).to_string(),
+            spec: AgentScheduleSpec {
+                name: "review".into(),
+                cwd: "/owner/work".into(),
+                integration: "opencode".into(),
+                prompt: "PRIVATE WORKSPACE PROMPT".into(),
+                session: AgentScheduleSession::Fresh,
+                trigger: AgentScheduleTrigger {
+                    cron: "0 2 * * *".into(),
+                    timezone: "UTC".into(),
+                },
+                state: AgentScheduleState::Paused,
+                overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            },
+        };
+        assert!(!format!("{schedule:?}").contains("PRIVATE WORKSPACE PROMPT"));
+        assert!(format!("{schedule:?}").contains("<redacted>"));
+
+        let request = Request::CreateGlobalWorkspaceAgentSchedule {
+            operation_id: uuid::Uuid::from_u128(10).to_string(),
+            global_workspace_id: uuid::Uuid::from_u128(6).to_string(),
+            expected_global_revision: 1,
+            node_id: uuid::Uuid::from_u128(7).to_string(),
+            owner_workspace_id: uuid::Uuid::from_u128(8).to_string(),
+            default_cwd: Some("/owner/work".into()),
+            schedule_id: uuid::Uuid::from_u128(9).to_string(),
+            spec: match schedule {
+                RoutedOperation::CreateWorkspaceAgentSchedule { spec, .. } => spec,
+                _ => unreachable!(),
+            },
+        };
+        assert_eq!(
+            request.required_feature(),
+            Some(ProtocolFeature::GlobalWorkspaces)
+        );
+        assert!(!format!("{request:?}").contains("PRIVATE WORKSPACE PROMPT"));
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(&request).unwrap()).unwrap(),
+            request
         );
     }
 
@@ -4070,6 +4483,16 @@ mod tests {
                     "protocol_37",
                     "remote_agent_schedule_management",
                     "remote_scheduled_execution_observation",
+                ][..],
+            ),
+            (
+                38,
+                &[
+                    "protocol_38",
+                    "global_workspaces",
+                    "multi_node_workspace_placements",
+                    "guarded_workspace_adoption",
+                    "resumable_workspace_close",
                 ][..],
             ),
         ];

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4343,6 +4343,49 @@ mod tests {
                     },
                 }],
             ),
+            (
+                38,
+                vec![
+                    Request::CreateGlobalWorkspace {
+                        name: "work".into(),
+                    },
+                    Request::AdoptNodeWorkspace {
+                        identity: QualifiedIdentity::new("node-1", "owner-1"),
+                        expected_revision: 1,
+                    },
+                    Request::LinkNodeWorkspace {
+                        global_workspace_id: "global-1".into(),
+                        expected_global_revision: 1,
+                        identity: QualifiedIdentity::new("node-1", "owner-1"),
+                        expected_owner_revision: 1,
+                    },
+                    Request::OpenGlobalWorkspace {
+                        workspace_id: "global-1".into(),
+                        expected_revision: 1,
+                    },
+                    Request::CloseGlobalWorkspace {
+                        workspace_id: "global-1".into(),
+                        expected_revision: 1,
+                    },
+                    Request::RetryGlobalWorkspaceClose {
+                        workspace_id: "global-1".into(),
+                    },
+                    Request::CreateGlobalWorkspaceShell {
+                        operation_id: "operation-1".into(),
+                        global_workspace_id: "global-1".into(),
+                        expected_global_revision: 1,
+                        node_id: "node-1".into(),
+                        owner_workspace_id: "owner-1".into(),
+                        default_cwd: Some("/owner/work".into()),
+                        shell_id: "shell-1".into(),
+                        shell: ShellSpec {
+                            name: "shell".into(),
+                            cwd: "/owner/work".into(),
+                            command: Vec::new(),
+                        },
+                    },
+                ],
+            ),
         ];
 
         for (expected, requests) in groups {

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -340,6 +340,7 @@ pub fn canonicalize_timezone(timezone: &str) -> Result<String, SchedulingError> 
         return Err(SchedulingError::EmptyValue { field: "timezone" });
     }
     timezone
+        .trim()
         .parse::<chrono_tz::Tz>()
         .map(|timezone| timezone.to_string())
         .map_err(|_| SchedulingError::InvalidTimezone)
@@ -586,6 +587,7 @@ mod tests {
             "America/New_York"
         );
         assert_eq!(canonicalize_timezone("UTC").unwrap(), "UTC");
+        assert_eq!(canonicalize_timezone(" \tUTC\n").unwrap(), "UTC");
         assert!(canonicalize_timezone("Not/A_Private_Zone").is_err());
         assert!(canonicalize_timezone("").is_err());
 

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -1387,7 +1387,7 @@ fn run_bounded_command(mut command: Command, timeout: Duration) -> io::Result<Ss
     }
     if !status.expect("checked above").success() {
         return Err(io::Error::other(
-            "SSH probe failed; verify target resolution, the SSH service, authentication, and remote shell support",
+            "SSH probe failed; verify target resolution, the SSH service, credentials, and remote shell support",
         ));
     }
     Ok(SshProbeOutput { stdout, stderr })
@@ -1829,7 +1829,7 @@ mod tests {
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(
             error.to_string(),
-            "SSH probe failed; verify target resolution, the SSH service, authentication, and remote shell support"
+            "SSH probe failed; verify target resolution, the SSH service, credentials, and remote shell support"
         );
     }
 

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -3839,7 +3839,7 @@ mod tests {
         let output = run_streaming_command_capture(
             command,
             transaction.upload_input(bytes),
-            Duration::from_secs(1),
+            Duration::from_secs(5),
         )
         .unwrap();
         assert_eq!(

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -1386,7 +1386,9 @@ fn run_bounded_command(mut command: Command, timeout: Duration) -> io::Result<Ss
         return Err(invalid_probe("SSH probe output exceeds the size limit"));
     }
     if !status.expect("checked above").success() {
-        return Err(io::Error::other("SSH probe exited unsuccessfully"));
+        return Err(io::Error::other(
+            "SSH probe failed; verify target resolution, the SSH service, authentication, and remote shell support",
+        ));
     }
     Ok(SshProbeOutput { stdout, stderr })
 }
@@ -1823,11 +1825,11 @@ mod tests {
 
         let mut command = Command::new("sh");
         command.args(["-c", "exit 7"]);
+        let error = run_bounded_command(command, Duration::from_secs(1)).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(
-            run_bounded_command(command, Duration::from_secs(1))
-                .unwrap_err()
-                .kind(),
-            io::ErrorKind::Other
+            error.to_string(),
+            "SSH probe failed; verify target resolution, the SSH service, authentication, and remote shell support"
         );
     }
 

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -3626,8 +3626,170 @@ mod tests {
         fs::write(script, contents).unwrap();
     }
 
-    fn runtime_directory() -> PathBuf {
-        env::temp_dir().join(format!("boomux-ssh-{}", Uuid::new_v4()))
+    struct TestDirectory {
+        path: PathBuf,
+        watchdogs: PathBuf,
+    }
+
+    impl std::ops::Deref for TestDirectory {
+        type Target = Path;
+
+        fn deref(&self) -> &Self::Target {
+            &self.path
+        }
+    }
+
+    impl AsRef<Path> for TestDirectory {
+        fn as_ref(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl AsRef<OsStr> for TestDirectory {
+        fn as_ref(&self) -> &OsStr {
+            self.path.as_os_str()
+        }
+    }
+
+    impl TestDirectory {
+        fn reap_watchdogs(&self) {
+            let mut pids = fs::read_to_string(&self.watchdogs)
+                .unwrap_or_default()
+                .lines()
+                .filter_map(|line| {
+                    let (pid, start) = line.split_once('\t')?;
+                    Some((pid.parse::<i32>().ok()?, start.to_owned()))
+                })
+                .collect::<HashSet<_>>();
+            let bin = self.path.join(".local/bin");
+            if let Ok(entries) = fs::read_dir(&bin) {
+                for entry in entries.filter_map(Result::ok) {
+                    let pid_file = entry.path().join("watchdog_pid");
+                    if let Ok(pid) = fs::read_to_string(pid_file)
+                        && let Ok(pid) = pid.trim().parse()
+                        && let Some(start) = test_process_start(pid)
+                    {
+                        pids.insert((pid, start));
+                    }
+                }
+            }
+            for (pid, start) in &pids {
+                if test_process_start(*pid).as_ref() != Some(start) {
+                    continue;
+                }
+                unsafe {
+                    libc::kill(*pid, libc::SIGTERM);
+                }
+            }
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while pids
+                .iter()
+                .any(|(pid, start)| test_process_start(*pid).as_ref() == Some(start))
+                && Instant::now() < deadline
+            {
+                thread::sleep(Duration::from_millis(10));
+            }
+            for (pid, start) in pids {
+                if test_process_start(pid).as_ref() == Some(&start) {
+                    unsafe {
+                        libc::kill(pid, libc::SIGKILL);
+                    }
+                }
+            }
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            self.reap_watchdogs();
+            let _ = fs::remove_dir_all(&self.path);
+            let _ = fs::remove_file(&self.watchdogs);
+        }
+    }
+
+    fn runtime_directory() -> TestDirectory {
+        let id = Uuid::new_v4();
+        TestDirectory {
+            path: env::temp_dir().join(format!("boomux-ssh-{id}")),
+            watchdogs: env::temp_dir().join(format!("boomux-ssh-watchdogs-{id}")),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn test_process_start(pid: i32) -> Option<String> {
+        let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        let mut fields = stat.rsplit_once(") ")?.1.split_whitespace();
+        if fields.next()? == "Z" {
+            return None;
+        }
+        fields.nth(18).map(str::to_owned)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn test_process_start(pid: i32) -> Option<String> {
+        let output = Command::new("/bin/ps")
+            .args(["-p", &pid.to_string(), "-o", "lstart="])
+            .output()
+            .ok()?;
+        output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+            .filter(|start| !start.is_empty())
+    }
+
+    fn local_shell_command(shell: &str, home: &Path) -> Command {
+        let runtime = home.join("runtime");
+        fs::create_dir_all(&runtime).unwrap();
+        fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+        let shell = match shell {
+            "sh" => "/bin/sh",
+            "bash" => "/bin/bash",
+            _ => panic!("unsupported test shell: {shell}"),
+        };
+        let mut command = Command::new(shell);
+        command
+            .env_clear()
+            .env("HOME", home)
+            .env("PATH", "/usr/bin:/bin")
+            .env("XDG_RUNTIME_DIR", runtime)
+            .env("XDG_STATE_HOME", home.join("state"))
+            .current_dir(home);
+        command
+    }
+
+    fn record_watchdog(home: &Path, transaction: &InstallTransactionId) {
+        let pid = fs::read_to_string(
+            home.join(".local/bin")
+                .join(&transaction.0)
+                .join("watchdog_pid"),
+        )
+        .unwrap();
+        let pid = pid.trim().parse::<i32>().unwrap();
+        let start = test_process_start(pid).unwrap();
+        let id = home.file_name().unwrap().to_string_lossy();
+        let registry = env::temp_dir().join(format!(
+            "boomux-ssh-watchdogs-{}",
+            id.trim_start_matches("boomux-ssh-")
+        ));
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(registry)
+            .unwrap();
+        writeln!(file, "{pid}\t{start}").unwrap();
+    }
+
+    fn gate_watchdog(command: &str) -> String {
+        let command = command.replacen(
+            "while [ -d \"$lock\" ]; do /bin/sleep 1;",
+            "while [ -d \"$lock\" ]; do test_watchdog_tick;",
+            1,
+        );
+        assert_ne!(command, REMOTE_INSTALL_COMMAND);
+        format!(
+            "test_watchdog_tick() {{ while [ ! -e \"$HOME/watchdog-tick\" ]; do /bin/sleep 0.01; done; /bin/sleep 0.01; }}; {command}"
+        )
     }
 
     fn shell_printf(bytes: &[u8]) -> String {
@@ -3672,8 +3834,8 @@ mod tests {
         command_text: &str,
     ) -> InstallTransactionId {
         let transaction = InstallTransactionId::generate();
-        let mut command = Command::new(shell);
-        command.args(["-c", command_text]).env("HOME", home);
+        let mut command = local_shell_command(shell, home);
+        command.args(["-c", command_text]);
         let output = run_streaming_command_capture(
             command,
             transaction.upload_input(bytes),
@@ -3684,6 +3846,7 @@ mod tests {
             InstallTransactionId::parse_probe(&output.stdout).unwrap(),
             transaction
         );
+        record_watchdog(home, &transaction);
         transaction
     }
 
@@ -3693,14 +3856,8 @@ mod tests {
         transaction: &InstallTransactionId,
         reason: RemoteInstallReason,
     ) {
-        let runtime = home.join("runtime");
-        fs::create_dir_all(&runtime).unwrap();
-        fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
-        let mut activate = Command::new(shell);
-        activate
-            .args(["-c", REMOTE_INSTALL_ACTIVATE_COMMAND])
-            .env("HOME", home)
-            .env("XDG_RUNTIME_DIR", runtime);
+        let mut activate = local_shell_command(shell, home);
+        activate.args(["-c", REMOTE_INSTALL_ACTIVATE_COMMAND]);
         let output = run_streaming_command_capture(
             activate,
             transaction.activation_input(
@@ -3847,14 +4004,24 @@ mod tests {
         input: &[u8],
     ) -> std::process::Output {
         let transaction = InstallTransactionId::generate();
-        let mut child = Command::new(shell)
-            .args(["-c", command_text])
+        let shell = match shell {
+            "sh" => "/bin/sh",
+            "bash" => "/bin/bash",
+            _ => panic!("unsupported test shell: {shell}"),
+        };
+        let mut command = Command::new(shell);
+        command
+            .env_clear()
             .env("HOME", home)
+            .env("PATH", "/usr/bin:/bin")
+            .args(["-c", command_text])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+            .stderr(Stdio::piped());
+        if home.is_absolute() && home.is_dir() {
+            command.current_dir(home);
+        }
+        let mut child = command.spawn().unwrap();
         let _ = child
             .stdin
             .take()
@@ -3869,14 +4036,8 @@ mod tests {
         home: &Path,
         transaction: &InstallTransactionId,
     ) -> io::Result<()> {
-        let runtime = home.join("runtime");
-        fs::create_dir_all(&runtime)?;
-        fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700))?;
-        let mut child = Command::new(shell);
-        child
-            .args(["-c", command_text])
-            .env("HOME", home)
-            .env("XDG_RUNTIME_DIR", runtime);
+        let mut child = local_shell_command(shell, home);
+        child.args(["-c", command_text]);
         run_streaming_command(
             child,
             transaction.activation_input(
@@ -3987,8 +4148,8 @@ mod tests {
     }
 
     fn run_local_transaction(home: &Path, command: &str, transaction: &InstallTransactionId) {
-        let mut child = Command::new("sh");
-        child.args(["-c", command]).env("HOME", home);
+        let mut child = local_shell_command("sh", home);
+        child.args(["-c", command]);
         run_streaming_command(child, transaction.input(), Duration::from_secs(1)).unwrap();
     }
 
@@ -4617,9 +4778,7 @@ mod tests {
         let output = shell_printf(&oversized);
         let ssh = write_master_stderr_ssh(
             &runtime,
-            &format!(
-                "{output} >&2; : > \"$control.ready\"; trap 'rm -f \"$control.ready\"' EXIT HUP INT TERM; while :; do sleep 60; done"
-            ),
+            &format!("{output} >&2; while :; do /bin/sleep 60; done"),
         );
         let mirror_path = runtime.join("interactive-mirror");
         let mirror = fs::File::create(&mirror_path).unwrap();
@@ -5840,21 +5999,22 @@ mod tests {
         let destination = directory.join(".local/bin/boomux");
         fs::write(&destination, b"previous").unwrap();
         fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
-        let install = REMOTE_INSTALL_COMMAND.replace("lease_limit=180", "lease_limit=1");
+        let install =
+            gate_watchdog(&REMOTE_INSTALL_COMMAND.replace("lease_limit=180", "lease_limit=1"));
         let transaction = run_local_upload_with_command(&directory, b"replacement", "sh", &install);
         assert_eq!(fs::read(&destination).unwrap(), b"previous");
         run_local_activation(&directory, "sh", &transaction, RemoteInstallReason::Missing);
         assert_eq!(fs::read(&destination).unwrap(), b"replacement");
         assert_eq!(fs::metadata(&destination).unwrap().mode() & 0o777, 0o755);
         let commit = REMOTE_INSTALL_COMMIT_COMMAND.replace("sleep 180", "sleep 3");
-        let mut child = Command::new("sh");
-        child.args(["-c", &commit]).env("HOME", &directory);
+        let mut child = local_shell_command("sh", &directory);
+        child.args(["-c", &commit]);
         let output =
             run_streaming_command_capture(child, transaction.input(), Duration::from_secs(1))
                 .unwrap();
         parse_install_commit(&output.stdout).unwrap();
-        let mut retry = Command::new("sh");
-        retry.args(["-c", &commit]).env("HOME", &directory);
+        let mut retry = local_shell_command("sh", &directory);
+        retry.args(["-c", &commit]);
         let retry =
             run_streaming_command_capture(retry, transaction.input(), Duration::from_secs(1))
                 .unwrap();
@@ -5864,12 +6024,7 @@ mod tests {
                 .join(".local/bin/.boomux.bootstrap.lock/committed/backup")
                 .exists()
         );
-        let lock = directory.join(".local/bin/.boomux.bootstrap.lock");
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while lock.exists() && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(20));
-        }
-        assert!(!lock.exists());
+        directory.reap_watchdogs();
         fs::remove_dir_all(directory).unwrap();
     }
 
@@ -5896,6 +6051,7 @@ mod tests {
             let install = REMOTE_INSTALL_COMMAND
                 .replace("lease_limit=180", "lease_limit=1")
                 .replace("[ \"$claim_age\" -ge 180 ]", "[ \"$claim_age\" -ge 1 ]");
+            let install = gate_watchdog(&install);
             let transaction =
                 run_local_upload_with_command(&directory, b"replacement", "sh", &install);
             run_local_activation(&directory, "sh", &transaction, RemoteInstallReason::Missing);
@@ -5904,13 +6060,14 @@ mod tests {
             let injected = format!("{}; kill -KILL $$;", needle.trim_end_matches(';'));
             let commit_command = commit_base.replacen(needle, &injected, 1);
             assert_ne!(commit_command, commit_base);
-            let mut child = Command::new("sh");
-            child.args(["-c", &commit_command]).env("HOME", &directory);
+            let mut child = local_shell_command("sh", &directory);
+            child.args(["-c", &commit_command]);
             assert!(
                 run_streaming_command_capture(child, transaction.input(), Duration::from_secs(1),)
                     .is_err(),
                 "commit unexpectedly acknowledged after cut at {needle}"
             );
+            fs::write(directory.join("watchdog-tick"), b"").unwrap();
 
             let lock = directory.join(".local/bin/.boomux.bootstrap.lock");
             let deadline = Instant::now() + Duration::from_secs(4);

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -5419,7 +5419,7 @@ mod tests {
     fn unreleased_local_protocol_has_no_compatible_published_release() {
         let error = select_published_release("x86_64-unknown-linux-gnu").unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::Unsupported);
-        assert!(error.to_string().contains("local protocol 38"));
+        assert!(error.to_string().contains("local protocol 39"));
         assert!(error.to_string().contains("manually stream"));
     }
 

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -76,9 +76,9 @@ pub const REMOTE_INSTALL_COMMAND: &str = concat!(
     "stage=lock_id; stage_code=79; printf '%s\\n' \"$txn\" > \"$lock/id\"; printf '0\\n' > \"$transaction/lease\"; temporary=$transaction/new.next; ",
     "stage=stream; stage_code=80; /bin/cat > \"$temporary\"; ",
     "stage=mode; stage_code=81; /bin/chmod 755 \"$temporary\"; upload_uid=$(/usr/bin/id -u); upload_size=$(/usr/bin/stat -Lc '%s' -- \"$temporary\" 2>/dev/null || /usr/bin/stat -f '%z' \"$temporary\"); case \"$upload_uid:$upload_size\" in *[!0-9:]*) false ;; esac; if [ \"$upload_size\" -le 0 ] || [ \"$upload_size\" -gt 268435456 ] || [ -L \"$temporary\" ] || [ ! -f \"$temporary\" ] || [ ! -x \"$temporary\" ]; then false; fi; /bin/mv \"$temporary\" \"$transaction/new\"; : > \"$transaction/new_ready\"; sync_install_path \"$transaction/new\"; ",
-    "stage=watchdog_spawn; stage_code=84; ( exec 3>&-; trap '' HUP; lease_limit=180; lease_value=$(/bin/cat \"$transaction/lease\"); unchanged=0; : > \"$transaction/watchdog_ready\"; ",
+    "stage=watchdog_spawn; stage_code=84; ( exec 3>&-; trap '' HUP; lease_limit=180; lease_value=$(/bin/cat \"$transaction/lease\"); unchanged=0; committed=false; : > \"$transaction/watchdog_ready\"; ",
     remote_claim_functions!(),
-    "while [ ! -e \"$transaction/watchdog_pid\" ]; do /bin/sleep 1; done; claim_pid_override=$(/bin/cat \"$transaction/watchdog_pid\"); while [ -d \"$lock\" ]; do /bin/sleep 1; current=$(/bin/cat \"$transaction/lease\" 2>/dev/null || true); if [ \"$current\" != \"$lease_value\" ]; then lease_value=$current; unchanged=0; continue; fi; unchanged=$((unchanged + 1)); [ \"$unchanged\" -lt \"$lease_limit\" ] && continue; if claim_acquire; then current=$(/bin/cat \"$lock/id\" 2>/dev/null || true); claimed_lease=$(/bin/cat \"$transaction/lease\" 2>/dev/null || true); if [ \"$current\" != \"$txn\" ]; then claim_release; exit; fi; if [ \"$claimed_lease\" != \"$lease_value\" ]; then claim_release; lease_value=$claimed_lease; unchanged=0; continue; fi; restore_install; /bin/rm -rf \"$transaction\" \"$lock\"; exit; fi; unchanged=0; done ) </dev/null >/dev/null 2>&1 & watchdog=$!; ",
+    "while :; do if claim_pid_override=$(/bin/cat \"$transaction/watchdog_pid\" 2>/dev/null); then break; fi; if claim_pid_override=$(/bin/cat \"$lock/committed/watchdog_pid\" 2>/dev/null); then transaction=$lock/committed; committed=true; break; fi; [ -d \"$lock\" ] || exit; /bin/sleep 1; done; while [ -d \"$lock\" ]; do /bin/sleep 1; current=$(/bin/cat \"$transaction/lease\" 2>/dev/null || true); if [ \"$current\" != \"$lease_value\" ]; then lease_value=$current; unchanged=0; continue; fi; unchanged=$((unchanged + 1)); [ \"$unchanged\" -lt \"$lease_limit\" ] && continue; if claim_acquire; then current=$(/bin/cat \"$lock/id\" 2>/dev/null || true); claimed_lease=$(/bin/cat \"$transaction/lease\" 2>/dev/null || true); if [ \"$current\" != \"$txn\" ]; then claim_release; exit; fi; if [ \"$claimed_lease\" != \"$lease_value\" ]; then claim_release; lease_value=$claimed_lease; unchanged=0; continue; fi; if ! $committed; then restore_install; fi; /bin/rm -rf \"$transaction\" \"$lock\"; exit; fi; unchanged=0; done ) </dev/null >/dev/null 2>&1 & watchdog=$!; ",
     "stage=watchdog_ready; stage_code=85; attempts=0; while [ ! -e \"$transaction/watchdog_ready\" ]; do kill -0 \"$watchdog\"; attempts=$((attempts + 1)); [ \"$attempts\" -lt 10000 ]; done; ",
     "stage=watchdog_pid; stage_code=86; printf '%s\\n' \"$watchdog\" > \"$transaction/watchdog_pid\"; rm -f \"$transaction/watchdog_ready\"; ",
     "stage=result; stage_code=87; printf 'boomux-install-transaction-v1\\0%s\\0' \"$txn\"; ",
@@ -3781,14 +3781,14 @@ mod tests {
     }
 
     fn gate_watchdog(command: &str) -> String {
-        let command = command.replacen(
+        let gated = command.replacen(
             "while [ -d \"$lock\" ]; do /bin/sleep 1;",
             "while [ -d \"$lock\" ]; do test_watchdog_tick;",
             1,
         );
-        assert_ne!(command, REMOTE_INSTALL_COMMAND);
+        assert_ne!(gated, command);
         format!(
-            "test_watchdog_tick() {{ while [ ! -e \"$HOME/watchdog-tick\" ]; do /bin/sleep 0.01; done; /bin/sleep 0.01; }}; {command}"
+            "test_watchdog_tick() {{ while [ ! -e \"$HOME/watchdog-tick\" ]; do /bin/sleep 0.01; done; /bin/sleep 0.01; }}; {gated}"
         )
     }
 
@@ -6052,8 +6052,14 @@ mod tests {
                 .replace("lease_limit=180", "lease_limit=1")
                 .replace("[ \"$claim_age\" -ge 180 ]", "[ \"$claim_age\" -ge 1 ]");
             let install = gate_watchdog(&install);
+            let delayed_install = install.replacen(
+                "while :; do if claim_pid_override=",
+                "while [ ! -e \"$HOME/watchdog-pid-release\" ]; do /bin/sleep 0.01; done; while :; do if claim_pid_override=",
+                1,
+            );
+            assert_ne!(delayed_install, install);
             let transaction =
-                run_local_upload_with_command(&directory, b"replacement", "sh", &install);
+                run_local_upload_with_command(&directory, b"replacement", "sh", &delayed_install);
             run_local_activation(&directory, "sh", &transaction, RemoteInstallReason::Missing);
 
             let commit_base = REMOTE_INSTALL_COMMIT_COMMAND.replace("sleep 180", "sleep 1");
@@ -6067,10 +6073,11 @@ mod tests {
                     .is_err(),
                 "commit unexpectedly acknowledged after cut at {needle}"
             );
+            fs::write(directory.join("watchdog-pid-release"), b"").unwrap();
             fs::write(directory.join("watchdog-tick"), b"").unwrap();
 
             let lock = directory.join(".local/bin/.boomux.bootstrap.lock");
-            let deadline = Instant::now() + Duration::from_secs(4);
+            let deadline = Instant::now() + Duration::from_secs(15);
             while lock.exists() && Instant::now() < deadline {
                 thread::sleep(Duration::from_millis(20));
             }

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -30,14 +30,175 @@ const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const PLATFORM_PROBE_PREFIX: &[u8] = b"boomux-platform-v1";
 const EXECUTABLE_PROBE_PREFIX: &[u8] = b"boomux-executables-v1";
 const INSTALL_DESTINATION_PROBE_PREFIX: &[u8] = b"boomux-install-destination-v1";
-const MAX_RELEASE_BYTES: u64 = 128 * 1024 * 1024;
-const REMOTE_INSTALL_COMMAND: &str = "set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; umask 077; directory=$HOME/.local/bin; destination=$directory/boomux; mkdir -p \"$directory\"; temporary=$(mktemp \"$directory/.boomux.XXXXXXXX\"); trap 'rm -f \"$temporary\"' EXIT HUP INT TERM; cat > \"$temporary\"; chmod 755 \"$temporary\"; mv -f \"$temporary\" \"$destination\"; trap - EXIT HUP INT TERM";
-const REMOTE_RESTART_COMMAND: &str =
-    "case \"$HOME\" in /*) exec \"$HOME/.local/bin/boomux\" daemon restart ;; *) exit 1 ;; esac";
+const INSTALL_TRANSACTION_PREFIX: &[u8] = b"boomux-install-transaction-v1";
+const INSTALL_ACTIVATION_PREFIX: &[u8] = b"boomux-install-activation-v1";
+const INSTALL_COMMIT_PREFIX: &[u8] = b"boomux-install-commit-v1";
+const INSTALL_STAGE_PREFIX: &str = "boomux-install-stage-v1";
+const RUNTIME_STAGE_PREFIX: &str = "boomux-runtime-v1";
+const DAEMON_STATUS_PREFIX: &[u8] = b"boomux-daemon-status-v1";
+const DAEMON_PRESENCE_PREFIX: &[u8] = b"boomux-daemon-presence-v1";
+const MAX_RELEASE_BYTES: u64 = 256 * 1024 * 1024;
 
-pub const PLATFORM_PROBE_COMMAND: &str = "os=$(uname -s) || exit; arch=$(uname -m) || exit; printf 'boomux-platform-v1\\0%s\\0%s\\0' \"$os\" \"$arch\"";
-pub const EXECUTABLE_PROBE_COMMAND: &str = "printf 'boomux-executables-v1\\0'; path=$(command -v boomux 2>/dev/null || true); for candidate in \"$path\" /usr/local/bin/boomux /usr/bin/boomux /opt/homebrew/bin/boomux /home/linuxbrew/.linuxbrew/bin/boomux \"$HOME/.local/bin/boomux\" \"$HOME/.local/share/mise/shims/boomux\" \"$HOME/.nix-profile/bin/boomux\" /run/current-system/sw/bin/boomux; do case \"$candidate\" in /*) [ -f \"$candidate\" ] && [ -x \"$candidate\" ] && printf '%s\\0' \"$candidate\" ;; esac; done";
+macro_rules! remote_runtime_prefix {
+    () => {
+        "PATH=/usr/bin:/bin; export PATH; boomux_runtime_fail() { printf 'boomux-runtime-v1:%s:%s\\n' \"$1\" \"$2\" >&2; exit \"$2\"; }; boomux_os=$(/usr/bin/uname -s 2>/dev/null) || boomux_runtime_fail unsupported 91; boomux_uid=$(/usr/bin/id -u 2>/dev/null) || boomux_runtime_fail invalid 89; case \"$boomux_uid\" in ''|*[!0-9]*) boomux_runtime_fail invalid 89 ;; esac; if [ -n \"${XDG_RUNTIME_DIR-}\" ]; then boomux_runtime=$XDG_RUNTIME_DIR; elif [ \"$boomux_os\" = Linux ]; then boomux_runtime=/run/user/$boomux_uid; else boomux_runtime_fail missing 88; fi; case \"$boomux_runtime\" in /*) ;; *) boomux_runtime_fail invalid 89 ;; esac; [ \"${#boomux_runtime}\" -le 4096 ] || boomux_runtime_fail invalid 89; case \"$boomux_runtime\" in *[!A-Za-z0-9_./-]*) boomux_runtime_fail invalid 89 ;; esac; [ -d \"$boomux_runtime\" ] && [ ! -L \"$boomux_runtime\" ] || boomux_runtime_fail unsafe 90; case \"$boomux_os\" in Linux) boomux_runtime_stat=$(/usr/bin/stat -Lc '%u:%a' -- \"$boomux_runtime\" 2>/dev/null) || boomux_runtime_fail unsafe 90 ;; Darwin) boomux_runtime_owner=$(/usr/bin/stat -f '%u' \"$boomux_runtime\" 2>/dev/null) || boomux_runtime_fail unsafe 90; boomux_runtime_mode=$(/usr/bin/stat -f '%Lp' \"$boomux_runtime\" 2>/dev/null) || boomux_runtime_fail unsafe 90; boomux_runtime_stat=$boomux_runtime_owner:$boomux_runtime_mode ;; *) boomux_runtime_fail unsupported 91 ;; esac; [ \"$boomux_runtime_stat\" = \"$boomux_uid:700\" ] || boomux_runtime_fail unsafe 90; XDG_RUNTIME_DIR=$boomux_runtime; export XDG_RUNTIME_DIR; "
+    };
+}
+
+macro_rules! remote_install_restore {
+    () => {
+        "sync_install_path() { boomux_sync_os=$(/usr/bin/uname -s 2>/dev/null || true); if [ \"$boomux_sync_os\" = Linux ]; then /bin/sync -f \"$1\"; fi; }; restore_install() { prior_daemon=$(/bin/cat \"$transaction/prior_daemon\" 2>/dev/null || true); contacted=false; [ ! -e \"$transaction/daemon_contacted\" ] || contacted=true; if [ -e \"$transaction/missing\" ]; then if [ -e \"$transaction/restore_required\" ]; then /bin/rm -f \"$destination\"; sync_install_path \"$directory\"; fi; elif [ -e \"$transaction/backup_ready\" ] && [ -e \"$transaction/restore_required\" ]; then /bin/mv -f \"$transaction/backup\" \"$destination\"; sync_install_path \"$destination\"; sync_install_path \"$directory\"; fi; case \"$prior_daemon:$contacted\" in [0-9]*:true) boomux_runtime_daemon daemon restart >/dev/null 2>&1 || true ;; esac; }; "
+    };
+}
+
+macro_rules! remote_claim_functions {
+    () => {
+        "claim_process_start() { claim_pid=$1; case \"$boomux_os\" in Linux) claim_stat=$(/bin/cat \"/proc/$claim_pid/stat\" 2>/dev/null) || return 1; claim_tail=${claim_stat##*) }; set -- $claim_tail; [ \"$#\" -ge 20 ] || return 1; shift 19; printf '%s' \"$1\" ;; Darwin) /bin/ps -p \"$claim_pid\" -o lstart= 2>/dev/null ;; *) return 1 ;; esac; }; claim_release() { /bin/rm -rf \"$lock/claim\"; }; claim_acquire() { boomux_os=$(/usr/bin/uname -s 2>/dev/null) || return 1; claim_now=$(/bin/date +%s 2>/dev/null) || return 1; claim_pid=${claim_pid_override-$$}; claim_start=$(claim_process_start \"$claim_pid\") || return 1; claim_owner=$txn:$claim_pid:$claim_start; if ! /bin/mkdir \"$lock/claim\" 2>/dev/null; then old_pid=$(/bin/cat \"$lock/claim/pid\" 2>/dev/null || true); old_start=$(/bin/cat \"$lock/claim/start\" 2>/dev/null || true); old_heartbeat=$(/bin/cat \"$lock/claim/heartbeat\" 2>/dev/null || true); case \"$old_pid:$old_heartbeat\" in *[!0-9:]*) return 1 ;; esac; claim_age=$((claim_now - old_heartbeat)); [ \"$claim_age\" -ge 180 ] || return 1; old_current=$(claim_process_start \"$old_pid\" 2>/dev/null || true); if /bin/kill -0 \"$old_pid\" 2>/dev/null && [ \"$old_current\" = \"$old_start\" ]; then return 1; fi; /bin/rm -rf \"$lock/claim\"; /bin/mkdir \"$lock/claim\" 2>/dev/null || return 1; fi; printf '%s\\n' \"$claim_owner\" > \"$lock/claim/owner\"; printf '%s\\n' \"$claim_pid\" > \"$lock/claim/pid\"; printf '%s\\n' \"$claim_start\" > \"$lock/claim/start\"; printf '%s\\n' \"$claim_now\" > \"$lock/claim/heartbeat\"; }; "
+    };
+}
+
+const REMOTE_RUNTIME_PREFIX: &str = remote_runtime_prefix!();
+#[doc(hidden)]
+pub const REMOTE_INSTALL_COMMAND: &str = concat!(
+    "boomux_runtime_daemon() ( ",
+    remote_runtime_prefix!(),
+    "exec \"$destination\" \"$@\"; ); ",
+    "set -u; exec 3>&2; exec 2>/dev/null; umask 077; IFS= read -r txn; ",
+    "stage=home; stage_code=74; transaction=; watchdog=; lock_owned=false; ",
+    remote_install_restore!(),
+    "rollback_install() { set +e; if [ -n \"$watchdog\" ]; then kill \"$watchdog\" 2>/dev/null || true; fi; if [ -n \"$transaction\" ]; then restore_install; /bin/rm -rf \"$transaction\"; fi; if [ \"$lock_owned\" = true ]; then /bin/rm -rf \"$lock\"; fi; }; ",
+    "fail_install() { trap - EXIT HUP INT TERM; set +e; printf 'boomux-install-stage-v1:%s:%s\\n' \"$stage\" \"$stage_code\" >&3; rollback_install; exit \"$stage_code\"; }; ",
+    "trap fail_install EXIT; trap 'exit 129' HUP; trap 'exit 130' INT; trap 'exit 143' TERM; set -e; ",
+    "case \"$HOME\" in /*) ;; *) exit 1 ;; esac; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; destination=$directory/boomux; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; ",
+    "stage=directory; stage_code=75; /bin/mkdir -p \"$directory\"; ",
+    "stage=lock; stage_code=76; if ! /bin/mkdir \"$lock\" 2>/dev/null; then current=$(/bin/cat \"$lock/id\" 2>/dev/null || true); if [ \"$current\" = \"$txn\" ] && [ -e \"$transaction/new_ready\" ]; then /bin/cat >/dev/null; printf 'boomux-install-transaction-v1\\0%s\\0' \"$txn\"; trap - EXIT HUP INT TERM; exit; fi; trap - EXIT HUP INT TERM; exit 73; fi; lock_owned=true; ",
+    "stage=transaction; stage_code=77; /bin/mkdir \"$transaction\"; ",
+    "stage=lock_id; stage_code=79; printf '%s\\n' \"$txn\" > \"$lock/id\"; printf '0\\n' > \"$transaction/lease\"; temporary=$transaction/new.next; ",
+    "stage=stream; stage_code=80; /bin/cat > \"$temporary\"; ",
+    "stage=mode; stage_code=81; /bin/chmod 755 \"$temporary\"; upload_uid=$(/usr/bin/id -u); upload_size=$(/usr/bin/stat -Lc '%s' -- \"$temporary\" 2>/dev/null || /usr/bin/stat -f '%z' \"$temporary\"); case \"$upload_uid:$upload_size\" in *[!0-9:]*) false ;; esac; if [ \"$upload_size\" -le 0 ] || [ \"$upload_size\" -gt 268435456 ] || [ -L \"$temporary\" ] || [ ! -f \"$temporary\" ] || [ ! -x \"$temporary\" ]; then false; fi; /bin/mv \"$temporary\" \"$transaction/new\"; : > \"$transaction/new_ready\"; sync_install_path \"$transaction/new\"; ",
+    "stage=watchdog_spawn; stage_code=84; ( exec 3>&-; trap '' HUP; lease_limit=180; lease_value=$(/bin/cat \"$transaction/lease\"); unchanged=0; : > \"$transaction/watchdog_ready\"; ",
+    remote_claim_functions!(),
+    "while [ ! -e \"$transaction/watchdog_pid\" ]; do /bin/sleep 1; done; claim_pid_override=$(/bin/cat \"$transaction/watchdog_pid\"); while [ -d \"$lock\" ]; do /bin/sleep 1; current=$(/bin/cat \"$transaction/lease\" 2>/dev/null || true); if [ \"$current\" != \"$lease_value\" ]; then lease_value=$current; unchanged=0; continue; fi; unchanged=$((unchanged + 1)); [ \"$unchanged\" -lt \"$lease_limit\" ] && continue; if claim_acquire; then current=$(/bin/cat \"$lock/id\" 2>/dev/null || true); claimed_lease=$(/bin/cat \"$transaction/lease\" 2>/dev/null || true); if [ \"$current\" != \"$txn\" ]; then claim_release; exit; fi; if [ \"$claimed_lease\" != \"$lease_value\" ]; then claim_release; lease_value=$claimed_lease; unchanged=0; continue; fi; restore_install; /bin/rm -rf \"$transaction\" \"$lock\"; exit; fi; unchanged=0; done ) </dev/null >/dev/null 2>&1 & watchdog=$!; ",
+    "stage=watchdog_ready; stage_code=85; attempts=0; while [ ! -e \"$transaction/watchdog_ready\" ]; do kill -0 \"$watchdog\"; attempts=$((attempts + 1)); [ \"$attempts\" -lt 10000 ]; done; ",
+    "stage=watchdog_pid; stage_code=86; printf '%s\\n' \"$watchdog\" > \"$transaction/watchdog_pid\"; rm -f \"$transaction/watchdog_ready\"; ",
+    "stage=result; stage_code=87; printf 'boomux-install-transaction-v1\\0%s\\0' \"$txn\"; ",
+    "trap - EXIT HUP INT TERM; exec 3>&-"
+);
+#[allow(dead_code)]
+const REMOTE_INSTALL_ACTIVATE_COMMAND_LEGACY: &str = concat!(
+    "boomux_runtime_daemon() ( ",
+    remote_runtime_prefix!(),
+    "exec \"$destination\" \"$@\"; ); ",
+    "set -eu; exec 3>&2; exec 2>/dev/null; umask 077; IFS= read -r txn; IFS= read -r reason; IFS= read -r prior; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; case \"$reason:$prior\" in missing:absent|upgrade:[0-9]*) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; destination=$directory/boomux; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; backup=$transaction/backup; ",
+    "[ \"$(/bin/cat \"$lock/id\")\" = \"$txn\" ]; if ! /bin/mkdir \"$lock/claim\" 2>/dev/null; then exit 73; fi; trap '/bin/rmdir \"$lock/claim\" 2>/dev/null || true' EXIT HUP INT TERM; if [ -e \"$transaction/activated\" ]; then trap - EXIT HUP INT TERM; /bin/rmdir \"$lock/claim\"; printf 'boomux-install-activation-v1\\0activated\\0'; exit; fi; if [ ! -e \"$transaction/new_ready\" ] || [ ! -f \"$transaction/new\" ] || [ ! -x \"$transaction/new\" ] || [ -L \"$transaction/new\" ]; then false; fi; ",
+    "if [ \"$reason\" = missing ]; then ",
+    remote_runtime_prefix!(),
+    "socket=$XDG_RUNTIME_DIR/boomux/daemon.sock; if [ -S \"$socket\" ] || [ -e \"$socket\" ] || [ -L \"$socket\" ]; then trap - EXIT HUP INT TERM; /bin/rmdir \"$lock/claim\"; printf 'boomux-install-activation-v1\\0daemon_present\\0'; exit; fi; fi; ",
+    "sync_install_path() { boomux_sync_os=$(/usr/bin/uname -s 2>/dev/null || true); if [ \"$boomux_sync_os\" = Linux ]; then /bin/sync -f \"$1\"; fi; }; restore_activation() { if [ -e \"$transaction/restore_required\" ]; then if [ -e \"$transaction/missing\" ]; then /bin/rm -f \"$destination\"; elif [ -e \"$transaction/backup_ready\" ]; then /bin/mv -f \"$backup\" \"$destination\"; fi; sync_install_path \"$directory\"; fi; }; fail_activation() { code=$?; trap - EXIT HUP INT TERM; set +e; restore_activation; /bin/rmdir \"$lock/claim\" 2>/dev/null || true; exit \"$code\"; }; trap fail_activation EXIT HUP INT TERM; install_os=$(/usr/bin/uname -s); install_uid=$(/usr/bin/id -u); case \"$install_uid\" in ''|*[!0-9]*) false ;; esac; case \"$install_os\" in Linux) install_metadata() { /usr/bin/stat -Lc '%u:%g:%a:%s:%Y' -- \"$1\"; }; install_size() { /usr/bin/stat -Lc '%s' -- \"$1\"; } ;; Darwin) install_metadata() { /usr/bin/stat -f '%u:%g:%Lp:%z:%m' \"$1\"; }; install_size() { /usr/bin/stat -f '%z' \"$1\"; } ;; *) false ;; esac; if [ -e \"$destination\" ] || [ -L \"$destination\" ]; then if [ -L \"$destination\" ] || [ ! -f \"$destination\" ] || [ ! -x \"$destination\" ]; then false; fi; destination_metadata=$(install_metadata \"$destination\"); destination_owner=${destination_metadata%%:*}; [ \"$destination_owner\" = \"$install_uid\" ]; destination_size=$(install_size \"$destination\"); case \"$destination_size\" in ''|*[!0-9]*) false ;; esac; if [ \"$destination_size\" -le 0 ] || [ \"$destination_size\" -gt 268435456 ]; then false; fi; /bin/cp -p \"$destination\" \"$backup\"; if [ -L \"$backup\" ] || [ ! -f \"$backup\" ] || [ ! -x \"$backup\" ]; then false; fi; [ \"$(install_metadata \"$destination\")\" = \"$destination_metadata\" ]; [ \"$(install_metadata \"$backup\")\" = \"$destination_metadata\" ]; /usr/bin/cmp -s \"$destination\" \"$backup\"; sync_install_path \"$backup\"; : > \"$transaction/backup_ready\"; else : > \"$transaction/missing\"; fi; printf '%s\\n' \"$prior\" > \"$transaction/prior_daemon\"; : > \"$transaction/restore_required\"; /bin/mv -f \"$transaction/new\" \"$destination\"; sync_install_path \"$destination\"; sync_install_path \"$directory\"; : > \"$transaction/activated\"; trap - EXIT HUP INT TERM; /bin/rmdir \"$lock/claim\"; printf 'boomux-install-activation-v1\\0activated\\0'"
+);
+#[doc(hidden)]
+pub const REMOTE_INSTALL_ACTIVATE_COMMAND: &str = concat!(
+    "set -eu; exec 3>&2; exec 2>/dev/null; umask 077; ",
+    "IFS= read -r txn; IFS= read -r reason; IFS= read -r prior; IFS= read -r proof_pid; IFS= read -r proof_executable; IFS= read -r proof_device; IFS= read -r proof_inode; ",
+    "case \"$HOME\" in /*) ;; *) exit 1 ;; esac; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; case \"$reason:$prior\" in missing:absent|upgrade:[0-9]*) ;; *) exit 2 ;; esac; ",
+    "directory=$HOME/.local/bin; destination=$directory/boomux; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; backup=$transaction/backup; [ \"$(/bin/cat \"$lock/id\")\" = \"$txn\" ]; ",
+    remote_claim_functions!(),
+    "claim_acquire || exit 73; trap claim_release EXIT HUP INT TERM; ",
+    "if [ -e \"$transaction/activated\" ]; then trap - EXIT HUP INT TERM; claim_release; printf 'boomux-install-activation-v1\\0activated\\0'; exit; fi; [ -e \"$transaction/new_ready\" ] && [ -f \"$transaction/new\" ] && [ -x \"$transaction/new\" ] && [ ! -L \"$transaction/new\" ]; ",
+    "restore_activation() { if [ -e \"$transaction/restore_required\" ]; then if [ -e \"$transaction/missing\" ]; then /bin/rm -f \"$destination\"; elif [ -e \"$transaction/backup_ready\" ]; then /bin/mv -f \"$backup\" \"$destination\"; fi; fi; }; fail_activation() { code=$?; trap - EXIT HUP INT TERM; set +e; restore_activation; claim_release; exit \"$code\"; }; trap fail_activation EXIT HUP INT TERM; ",
+    "if [ -e \"$destination\" ] || [ -L \"$destination\" ]; then if [ -L \"$destination\" ] || [ ! -f \"$destination\" ] || [ ! -x \"$destination\" ]; then false; fi; /bin/cp -p \"$destination\" \"$backup\"; if [ -L \"$backup\" ] || [ ! -f \"$backup\" ] || [ ! -x \"$backup\" ]; then false; fi; /usr/bin/cmp -s \"$destination\" \"$backup\"; : > \"$transaction/backup_ready\"; else : > \"$transaction/missing\"; fi; printf '%s\\n' \"$prior\" > \"$transaction/prior_daemon\"; : > \"$transaction/restore_required\"; ",
+    "if [ \"$reason\" = missing ]; then ",
+    remote_runtime_prefix!(),
+    "socket=$XDG_RUNTIME_DIR/boomux/daemon.sock; if [ -S \"$socket\" ] || [ -e \"$socket\" ] || [ -L \"$socket\" ]; then restore_activation; /bin/rm -f \"$transaction/restore_required\"; trap - EXIT HUP INT TERM; claim_release; printf 'boomux-install-activation-v1\\0daemon_present\\0'; exit; fi; /bin/mv -f \"$transaction/new\" \"$destination\"; : > \"$transaction/activated\"; else case \"$proof_pid:$proof_device:$proof_inode\" in *[!0-9:]*) false ;; esac; [ \"$proof_executable\" = \"$destination\" ]; \"$transaction/new\" __bootstrap-activate \"$txn\" \"$proof_pid\" \"$prior\" \"$proof_executable\" \"$proof_device\" \"$proof_inode\"; fi; ",
+    "trap - EXIT HUP INT TERM; claim_release; printf 'boomux-install-activation-v1\\0activated\\0'"
+);
+#[doc(hidden)]
+#[allow(dead_code)]
+const REMOTE_INSTALL_ROLLBACK_COMMAND_LEGACY: &str = concat!(
+    "boomux_runtime_daemon() ( ",
+    remote_runtime_prefix!(),
+    "exec \"$destination\" \"$@\"; ); ",
+    "set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; destination=$directory/boomux; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; [ \"$(/bin/cat \"$lock/id\")\" = \"$txn\" ]; /bin/mkdir \"$lock/claim\"; trap '/bin/rmdir \"$lock/claim\" 2>/dev/null || true' EXIT HUP INT TERM; watchdog=$(/bin/cat \"$transaction/watchdog_pid\" 2>/dev/null || true); ",
+    remote_install_restore!(),
+    "case \"$watchdog\" in *[!0-9]*|'') ;; *) kill \"$watchdog\" 2>/dev/null || true ;; esac; restore_install; trap - EXIT HUP INT TERM; /bin/rm -rf \"$transaction\" \"$lock\""
+);
+#[doc(hidden)]
+pub const REMOTE_INSTALL_ROLLBACK_COMMAND: &str = concat!(
+    "PATH=/usr/bin:/bin; export PATH; boomux_runtime_daemon() ( ",
+    remote_runtime_prefix!(),
+    "exec \"$destination\" \"$@\"; ); set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; destination=$directory/boomux; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; [ \"$(/bin/cat \"$lock/id\")\" = \"$txn\" ]; ",
+    remote_claim_functions!(),
+    "claim_acquire || exit 73; trap claim_release EXIT HUP INT TERM; watchdog=$(/bin/cat \"$transaction/watchdog_pid\" 2>/dev/null || true); ",
+    remote_install_restore!(),
+    "case \"$watchdog\" in *[!0-9]*|'') ;; *) /bin/kill \"$watchdog\" 2>/dev/null || true ;; esac; restore_install; trap - EXIT HUP INT TERM; /bin/rm -rf \"$transaction\" \"$lock\""
+);
+#[allow(dead_code)]
+const REMOTE_INSTALL_COMMIT_COMMAND_LEGACY: &str = "set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; committed=$lock/committed; [ \"$(cat \"$lock/id\")\" = \"$txn\" ]; ( trap '' HUP; sleep 180; if [ \"$(cat \"$lock/id\" 2>/dev/null || true)\" = \"$txn\" ]; then rm -rf \"$lock/claim\"; fi ) </dev/null >/dev/null 2>&1 & if [ -d \"$committed\" ]; then printf 'boomux-install-commit-v1\\0committed\\0'; exit; fi; mkdir \"$lock/claim\"; trap 'rmdir \"$lock/claim\" 2>/dev/null || true' EXIT HUP INT TERM; if [ -d \"$committed\" ]; then :; elif [ -d \"$transaction\" ]; then mv \"$transaction\" \"$committed\"; else exit 1; fi; trap - EXIT HUP INT TERM; rmdir \"$lock/claim\"; printf 'boomux-install-commit-v1\\0committed\\0'";
+const REMOTE_INSTALL_COMMIT_COMMAND: &str = concat!(
+    "PATH=/usr/bin:/bin; export PATH; set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; committed=$lock/committed; [ \"$(/bin/cat \"$lock/id\")\" = \"$txn\" ]; ",
+    remote_claim_functions!(),
+    "if [ -d \"$committed\" ]; then printf 'boomux-install-commit-v1\\0committed\\0'; exit; fi; claim_acquire || exit 73; trap claim_release EXIT HUP INT TERM; if [ -d \"$committed\" ]; then :; elif [ -d \"$transaction\" ]; then /bin/mv \"$transaction\" \"$committed\"; else exit 1; fi; trap - EXIT HUP INT TERM; claim_release; printf 'boomux-install-commit-v1\\0committed\\0'"
+);
+#[doc(hidden)]
+pub const REMOTE_INSTALL_MARK_RESTARTED_COMMAND: &str = "set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; [ \"$(cat \"$lock/id\")\" = \"$txn\" ]; : > \"$transaction/restarted\"";
+const REMOTE_INSTALL_MARK_DAEMON_CONTACTED_COMMAND: &str = "set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; [ \"$(cat \"$lock/id\")\" = \"$txn\" ]; : > \"$transaction/daemon_contacted\"";
+#[allow(dead_code)]
+const REMOTE_INSTALL_RENEW_COMMAND_LEGACY: &str = "set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; IFS= read -r renewal; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; case \"$renewal\" in ''|*[!0-9]*) exit 2 ;; esac; directory=$HOME/.local/bin; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; temporary=$transaction/lease.next.$$; printf '%s\\n' \"$renewal\" > \"$temporary\"; if ! /bin/mkdir \"$lock/claim\" 2>/dev/null; then /bin/rm -f \"$temporary\"; exit 3; fi; trap '/bin/rm -f \"$temporary\"; /bin/rmdir \"$lock/claim\" 2>/dev/null || true' EXIT HUP INT TERM; [ \"$(/bin/cat \"$lock/id\")\" = \"$txn\" ]; /bin/mv -f \"$temporary\" \"$transaction/lease\"; trap - EXIT HUP INT TERM; /bin/rmdir \"$lock/claim\"";
+const REMOTE_INSTALL_RENEW_COMMAND: &str = concat!(
+    "PATH=/usr/bin:/bin; export PATH; set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; IFS= read -r renewal; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; case \"$renewal\" in ''|*[!0-9]*) exit 2 ;; esac; directory=$HOME/.local/bin; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; temporary=$transaction/lease.next.$$; printf '%s\\n' \"$renewal\" > \"$temporary\"; ",
+    remote_claim_functions!(),
+    "if [ -d \"$lock/claim\" ] || ! claim_acquire; then /bin/rm -f \"$temporary\"; exit 3; fi; trap '/bin/rm -f \"$temporary\"; claim_release' EXIT HUP INT TERM; [ \"$(/bin/cat \"$lock/id\")\" = \"$txn\" ]; /bin/mv -f \"$temporary\" \"$transaction/lease\"; trap - EXIT HUP INT TERM; claim_release"
+);
+
+pub const PLATFORM_PROBE_COMMAND: &str = "os=$(/usr/bin/uname -s) || exit 92; arch=$(/usr/bin/uname -m) || exit 92; case \"$os\" in Linux|Darwin) ;; *) exit 92 ;; esac; for command in /usr/bin/uname /usr/bin/id /usr/bin/stat /usr/bin/cmp /bin/cat /bin/chmod /bin/cp /bin/date /bin/kill /bin/mkdir /bin/mv /bin/ps /bin/rm /bin/rmdir /bin/sleep /bin/sync; do [ -x \"$command\" ] || exit 92; done; printf 'boomux-platform-v1\\0%s\\0%s\\0' \"$os\" \"$arch\"";
+pub const EXECUTABLE_PROBE_COMMAND: &str = "printf 'boomux-executables-v1\\0'; path=$(command -v boomux 2>/dev/null || true); for candidate in \"$path\" /usr/local/bin/boomux /usr/bin/boomux /opt/homebrew/bin/boomux /home/linuxbrew/.linuxbrew/bin/boomux \"$HOME/.local/bin/boomux\" \"$HOME/.local/share/mise/shims/boomux\" \"$HOME/.nix-profile/bin/boomux\" /run/current-system/sw/bin/boomux; do case \"$candidate\" in /*) if [ \"$candidate\" = \"$HOME/.local/bin/boomux\" ] && [ -d \"$HOME/.local/bin/.boomux.bootstrap.lock\" ] && [ ! -d \"$HOME/.local/bin/.boomux.bootstrap.lock/committed\" ]; then continue; fi; [ -f \"$candidate\" ] && [ -x \"$candidate\" ] && printf '%s\\0' \"$candidate\" ;; esac; done; true";
 pub const INSTALL_DESTINATION_PROBE_COMMAND: &str = "case \"$HOME\" in /*) printf 'boomux-install-destination-v1\\0%s\\0' \"$HOME/.local/bin/boomux\" ;; *) exit 1 ;; esac";
+
+fn remote_daemon_command(executable: &RemoteExecutable, arguments: &str) -> String {
+    format!(
+        "{REMOTE_RUNTIME_PREFIX}exec {} {arguments}",
+        quote_posix_shell(executable.as_str())
+    )
+}
+
+fn remote_installed_daemon_command(arguments: &str) -> String {
+    format!(
+        "case \"$HOME\" in /*) ;; *) exit 89 ;; esac; {REMOTE_RUNTIME_PREFIX}exec \"$HOME/.local/bin/boomux\" {arguments}"
+    )
+}
+
+fn remote_daemon_status_command() -> String {
+    format!(
+        "case \"$HOME\" in /*) ;; *) exit 89 ;; esac; {REMOTE_RUNTIME_PREFIX}if [ ! -S \"$XDG_RUNTIME_DIR/boomux/daemon.sock\" ]; then printf 'boomux-daemon-status-v1\\0absent\\0'; exit; fi; exec \"$HOME/.local/bin/boomux\" daemon status --json"
+    )
+}
+
+fn remote_daemon_status_command_for(executable: &RemoteExecutable) -> String {
+    if executable.as_str().ends_with("/.local/bin/boomux") {
+        return remote_daemon_status_command();
+    }
+    format!(
+        "{REMOTE_RUNTIME_PREFIX}if [ ! -S \"$XDG_RUNTIME_DIR/boomux/daemon.sock\" ]; then printf 'boomux-daemon-status-v1\\0absent\\0'; exit; fi; exec {} daemon status --json",
+        quote_posix_shell(executable.as_str())
+    )
+}
+
+fn remote_transaction_daemon_status_command(transaction: &InstallTransactionId) -> String {
+    format!(
+        "case \"$HOME\" in /*) ;; *) exit 89 ;; esac; {REMOTE_RUNTIME_PREFIX}exec \"$HOME/.local/bin/{}/new\" daemon status --json",
+        transaction.0
+    )
+}
+
+fn remote_daemon_presence_command() -> String {
+    format!(
+        "{REMOTE_RUNTIME_PREFIX}socket=$XDG_RUNTIME_DIR/boomux/daemon.sock; if [ -S \"$socket\" ] || [ -e \"$socket\" ] || [ -L \"$socket\" ]; then printf 'boomux-daemon-presence-v1\\0present\\0'; else printf 'boomux-daemon-presence-v1\\0absent\\0'; fi"
+    )
+}
+
+fn remote_helper_command(executable: &RemoteExecutable) -> String {
+    remote_daemon_command(executable, "__federation-stdio")
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SshAuthenticationMode {
@@ -91,21 +252,49 @@ pub struct RemoteDiscovery {
 pub struct CompatibleRemoteHelper {
     pub executable: RemoteExecutable,
     pub handshake: FederationHandshake,
+    bootstrap_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteInstallSource {
-    CurrentBinary(PathBuf),
-    Release { target: &'static str, tag: String },
+    CurrentBinary {
+        path: PathBuf,
+        sha256: String,
+        bytes: Vec<u8>,
+    },
+    Release {
+        target: &'static str,
+        tag: String,
+        sha256: String,
+        bytes: Vec<u8>,
+    },
 }
 
 impl RemoteInstallSource {
     pub fn description(&self) -> String {
         match self {
-            Self::CurrentBinary(path) => format!("current binary {}", path.display()),
-            Self::Release { target, tag } => {
-                format!("checksum-verified GitHub release {tag} for {target}")
+            Self::CurrentBinary { path, sha256, .. } => {
+                format!(
+                    "ABI-unverified pinned current binary {} (sha256 {sha256})",
+                    path.display()
+                )
             }
+            Self::Release {
+                target,
+                tag,
+                sha256,
+                ..
+            } => {
+                format!(
+                    "pinned checksum-verified GitHub release {tag} for {target} (sha256 {sha256})"
+                )
+            }
+        }
+    }
+
+    fn bytes(&self) -> &[u8] {
+        match self {
+            Self::CurrentBinary { bytes, .. } | Self::Release { bytes, .. } => bytes,
         }
     }
 }
@@ -115,12 +304,292 @@ pub struct RemoteInstallPlan {
     pub target: SshTarget,
     pub destination: RemoteExecutable,
     pub source: RemoteInstallSource,
-    pub may_restart_daemon: bool,
+    pub reason: RemoteInstallReason,
+    bootstrap_id: Option<Uuid>,
+    upgrade_helper: Option<RemoteExecutable>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteInstallReason {
+    Missing,
+    Upgrade,
+}
+
+#[derive(Debug)]
+struct ClassifiedBootstrapError {
+    code: &'static str,
+    message: String,
+}
+
+impl std::fmt::Display for ClassifiedBootstrapError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ClassifiedBootstrapError {}
+
+fn classified_error(
+    kind: io::ErrorKind,
+    code: &'static str,
+    message: impl Into<String>,
+) -> io::Error {
+    io::Error::new(
+        kind,
+        ClassifiedBootstrapError {
+            code,
+            message: message.into(),
+        },
+    )
+}
+
+fn post_install_failure(stage: &'static str, error: io::Error) -> io::Error {
+    if error_code(&error) == "bootstrap_runtime_unavailable" {
+        return error;
+    }
+    let message = match stage {
+        "stream" => "remote provisional executable upload failed",
+        "activation" => "remote guarded executable activation failed",
+        "daemon_status" => "remote post-install daemon status verification failed",
+        "daemon_restart" => "remote post-install graceful daemon restart failed",
+        "helper_verification" => "remote post-install helper verification failed",
+        "live_handshake" => "remote post-install live helper handshake failed",
+        "protocol_ping" => "remote post-install protocol ping failed",
+        _ => "remote post-install verification failed",
+    };
+    let transport = matches!(
+        error.kind(),
+        io::ErrorKind::TimedOut
+            | io::ErrorKind::ConnectionRefused
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::NotConnected
+            | io::ErrorKind::BrokenPipe
+            | io::ErrorKind::UnexpectedEof
+    );
+    classified_error(
+        error.kind(),
+        if transport {
+            "bootstrap_transport_failed"
+        } else {
+            "bootstrap_install_failed"
+        },
+        message,
+    )
+}
+
+fn post_contact_failure(
+    stage: &'static str,
+    error: io::Error,
+    reason: RemoteInstallReason,
+) -> io::Error {
+    let error = post_install_failure(stage, error);
+    if reason != RemoteInstallReason::Missing {
+        return error;
+    }
+    classified_error(
+        error.kind(),
+        error_code(&error),
+        format!(
+            "{error}; filesystem rollback does not stop runtime processes, so a daemon started independently during bootstrap may remain and require manual recovery"
+        ),
+    )
+}
+
+pub fn error_code(error: &io::Error) -> &'static str {
+    if let Some(classified) = error
+        .get_ref()
+        .and_then(|error| error.downcast_ref::<ClassifiedBootstrapError>())
+    {
+        return classified.code;
+    }
+    let message = error.to_string();
+    match error.kind() {
+        io::ErrorKind::PermissionDenied if message.contains("different Node identities") => {
+            "node_identity_conflict"
+        }
+        io::ErrorKind::PermissionDenied if message.contains("identity changed") => {
+            "node_identity_changed"
+        }
+        io::ErrorKind::PermissionDenied => "bootstrap_authentication_failed",
+        io::ErrorKind::TimedOut
+        | io::ErrorKind::ConnectionRefused
+        | io::ErrorKind::ConnectionReset
+        | io::ErrorKind::ConnectionAborted
+        | io::ErrorKind::NotConnected
+        | io::ErrorKind::BrokenPipe
+        | io::ErrorKind::UnexpectedEof => "bootstrap_transport_failed",
+        io::ErrorKind::Unsupported if message.contains("platform") => {
+            "bootstrap_unsupported_platform"
+        }
+        io::ErrorKind::Unsupported => "unsupported_version",
+        io::ErrorKind::InvalidData
+            if message.contains("platform")
+                || message.contains("operating system")
+                || message.contains("architecture")
+                || message.contains("release asset") =>
+        {
+            "bootstrap_unsupported_platform"
+        }
+        io::ErrorKind::InvalidData if message.contains("newer incompatible") => {
+            "unsupported_version"
+        }
+        io::ErrorKind::InvalidData if message.contains("install source") => {
+            "bootstrap_install_failed"
+        }
+        io::ErrorKind::InvalidData => "bootstrap_malformed_helper",
+        io::ErrorKind::Other
+            if message.contains("install")
+                || message.contains("rollback")
+                || message.contains("release asset") =>
+        {
+            "bootstrap_install_failed"
+        }
+        io::ErrorKind::Other => "bootstrap_transport_failed",
+        _ => "bootstrap_transport_failed",
+    }
+}
+
+impl RemoteInstallReason {
+    pub const fn error_code(self) -> &'static str {
+        match self {
+            Self::Missing => "install_required",
+            Self::Upgrade => "upgrade_required",
+        }
+    }
+
+    pub const fn noninteractive_message(self) -> &'static str {
+        match self {
+            Self::Missing => {
+                "remote Boomux installation is required; rerun `boomux node add ALIAS TARGET` in an interactive terminal to review and authorize it"
+            }
+            Self::Upgrade => {
+                "remote Boomux is outdated and must be upgraded; rerun `boomux node add ALIAS TARGET` in an interactive terminal to review and authorize it"
+            }
+        }
+    }
 }
 
 pub enum RemoteBootstrapPlan {
     Ready(CompatibleRemoteHelper),
     Install(RemoteInstallPlan),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InstallTransactionId(String);
+
+impl InstallTransactionId {
+    fn generate() -> Self {
+        let simple = Uuid::new_v4().simple().to_string();
+        Self(format!(".boomux.bootstrap.{}", &simple[..8]))
+    }
+
+    fn parse_probe(output: &[u8]) -> io::Result<Self> {
+        let fields = parse_nul_fields(output, INSTALL_TRANSACTION_PREFIX)?;
+        if fields.len() != 1 {
+            return Err(invalid_probe(
+                "remote install returned an invalid transaction field count",
+            ));
+        }
+        let value = std::str::from_utf8(fields[0])
+            .map_err(|_| invalid_probe("remote install returned a non-UTF-8 transaction ID"))?;
+        let suffix = value
+            .strip_prefix(".boomux.bootstrap.")
+            .filter(|suffix| {
+                suffix.len() == 8 && suffix.bytes().all(|byte| byte.is_ascii_alphanumeric())
+            })
+            .ok_or_else(|| invalid_probe("remote install returned an invalid transaction ID"))?;
+        let _ = suffix;
+        Ok(Self(value.to_owned()))
+    }
+
+    fn input(&self) -> Vec<u8> {
+        let mut input = self.0.as_bytes().to_vec();
+        input.push(b'\n');
+        input
+    }
+
+    fn upload_input(&self, bytes: &[u8]) -> Vec<u8> {
+        let mut input = self.input();
+        input.extend_from_slice(bytes);
+        input
+    }
+
+    fn activation_input(&self, reason: RemoteInstallReason, prior: &RemoteDaemonStatus) -> Vec<u8> {
+        let mut input = self.input();
+        match reason {
+            RemoteInstallReason::Missing => input.extend_from_slice(b"missing\nabsent\n\n\n\n\n"),
+            RemoteInstallReason::Upgrade => {
+                input.extend_from_slice(b"upgrade\n");
+                match prior {
+                    RemoteDaemonStatus::Present {
+                        protocol_version,
+                        pid: Some(pid),
+                        executable: Some(executable),
+                        socket_device: Some(socket_device),
+                        socket_inode: Some(socket_inode),
+                    } => {
+                        input.extend_from_slice(protocol_version.to_string().as_bytes());
+                        input.push(b'\n');
+                        input.extend_from_slice(pid.to_string().as_bytes());
+                        input.push(b'\n');
+                        input.extend_from_slice(executable.as_str().as_bytes());
+                        input.push(b'\n');
+                        input.extend_from_slice(socket_device.to_string().as_bytes());
+                        input.push(b'\n');
+                        input.extend_from_slice(socket_inode.to_string().as_bytes());
+                        input.push(b'\n');
+                    }
+                    _ => input.extend_from_slice(b"absent\n\n\n\n\n"),
+                }
+            }
+        }
+        input
+    }
+
+    fn renewal_input(&self, renewal: u64) -> Vec<u8> {
+        let mut input = self.input();
+        input.extend_from_slice(renewal.to_string().as_bytes());
+        input.push(b'\n');
+        input
+    }
+}
+
+fn parse_install_activation(output: &[u8]) -> io::Result<bool> {
+    let fields = parse_nul_fields(output, INSTALL_ACTIVATION_PREFIX)?;
+    match fields.as_slice() {
+        [b"activated"] => Ok(true),
+        [b"daemon_present"] => Ok(false),
+        _ => Err(invalid_probe(
+            "remote install activation returned an invalid result",
+        )),
+    }
+}
+
+fn shadow_upgrade_required(helper: &RemoteExecutable) -> io::Error {
+    let path = helper.as_str();
+    classified_error(
+        io::ErrorKind::Unsupported,
+        "upgrade_required",
+        format!(
+            "could not prove that the running remote daemon executable is the install destination; update the verified helper {path} through its owner or package mechanism, or explicitly stop the daemon before retrying"
+        ),
+    )
+}
+
+fn install_presence_required(message: &str) -> io::Error {
+    classified_error(io::ErrorKind::Unsupported, "install_required", message)
+}
+
+fn parse_install_commit(output: &[u8]) -> io::Result<()> {
+    let fields = parse_nul_fields(output, INSTALL_COMMIT_PREFIX)?;
+    if fields.len() == 1 && fields[0] == b"committed" {
+        Ok(())
+    } else {
+        Err(invalid_probe(
+            "remote install commit returned an invalid result",
+        ))
+    }
 }
 
 pub struct RemoteConnection {
@@ -131,6 +600,7 @@ pub struct RemoteConnection {
     stderr_reader: Option<BoundedReader>,
     pub executable: RemoteExecutable,
     pub handshake: FederationHandshake,
+    _bootstrap_session: Option<BootstrapSession>,
 }
 
 pub(crate) struct RemoteAttachmentReader {
@@ -138,6 +608,7 @@ pub(crate) struct RemoteAttachmentReader {
     pid: i32,
     stdout: ChildStdout,
     stderr_reader: Option<BoundedReader>,
+    _bootstrap_session: Option<BootstrapSession>,
 }
 
 pub(crate) struct RemoteAttachmentWriter(Option<ChildStdin>);
@@ -159,6 +630,7 @@ impl RemoteConnection {
                     pid: this.pid,
                     stdout: std::ptr::read(&this.stdout),
                     stderr_reader: this.stderr_reader.take(),
+                    _bootstrap_session: this._bootstrap_session.take(),
                 },
                 RemoteAttachmentWriter(this.stdin.take()),
             )
@@ -195,6 +667,15 @@ impl RemoteConnection {
             Err(invalid_probe(
                 "remote helper returned an invalid ping response",
             ))
+        }
+    }
+
+    fn ping_with_timeout(&mut self, timeout: Duration) -> io::Result<()> {
+        match self.request(Request::Ping, timeout)? {
+            Response::Pong => Ok(()),
+            _ => Err(invalid_probe(
+                "remote helper returned an invalid post-install ping response",
+            )),
         }
     }
 
@@ -424,12 +905,24 @@ impl RemotePlatform {
         let operating_system = match fields[0] {
             b"Linux" => RemoteOperatingSystem::Linux,
             b"Darwin" => RemoteOperatingSystem::MacOs,
-            _ => return Err(invalid_probe("remote operating system is unsupported")),
+            _ => {
+                return Err(classified_error(
+                    io::ErrorKind::Unsupported,
+                    "bootstrap_unsupported_platform",
+                    "remote operating system is unsupported",
+                ));
+            }
         };
         let architecture = match fields[1] {
             b"x86_64" | b"amd64" => RemoteArchitecture::X86_64,
             b"aarch64" | b"arm64" => RemoteArchitecture::Aarch64,
-            _ => return Err(invalid_probe("remote architecture is unsupported")),
+            _ => {
+                return Err(classified_error(
+                    io::ErrorKind::Unsupported,
+                    "bootstrap_unsupported_platform",
+                    "remote architecture is unsupported",
+                ));
+            }
         };
         Ok(Self {
             operating_system,
@@ -491,7 +984,8 @@ pub fn parse_executable_probe(output: &[u8]) -> io::Result<Vec<RemoteExecutable>
     for field in fields {
         let value = std::str::from_utf8(field)
             .map_err(|_| invalid_probe("executable probe returned non-UTF-8 data"))?;
-        let executable = RemoteExecutable::parse(value.to_owned())?;
+        let executable = RemoteExecutable::parse(value.to_owned())
+            .map_err(|_| invalid_probe("executable probe returned an invalid executable path"))?;
         if seen.insert(executable.0.clone()) {
             executables.push(executable);
         }
@@ -509,6 +1003,7 @@ pub fn parse_install_destination_probe(output: &[u8]) -> io::Result<RemoteExecut
     let value = std::str::from_utf8(fields[0])
         .map_err(|_| invalid_probe("install destination probe returned non-UTF-8 data"))?;
     RemoteExecutable::parse(value.to_owned())
+        .map_err(|_| invalid_probe("install destination probe returned an invalid executable path"))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -570,6 +1065,18 @@ pub struct SshInvocation {
     authentication: SshAuthenticationMode,
 }
 
+pub struct BootstrapSession {
+    id: Uuid,
+    program: OsString,
+    directory: PathBuf,
+    config_path: PathBuf,
+    control_path: PathBuf,
+    target: SshTarget,
+    master: Child,
+    master_pid: i32,
+    stderr_reader: Option<MasterStderrReader>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SshProbeOutput {
     pub stdout: Vec<u8>,
@@ -577,6 +1084,585 @@ pub struct SshProbeOutput {
 }
 
 type BoundedReader = thread::JoinHandle<io::Result<(Vec<u8>, bool)>>;
+
+trait StderrMirror: Write + AsRawFd + Send {}
+
+impl<T: Write + AsRawFd + Send> StderrMirror for T {}
+
+#[derive(Debug, Clone, Copy)]
+enum MasterStderrEvent {
+    Truncated,
+    MirrorFailed,
+}
+
+struct MasterStderrReader {
+    reader: BoundedReader,
+    events: mpsc::Receiver<MasterStderrEvent>,
+}
+
+impl MasterStderrReader {
+    fn event(&self) -> Option<MasterStderrEvent> {
+        self.events.try_recv().ok()
+    }
+
+    fn finish(self) -> (io::Result<(Vec<u8>, bool)>, Option<MasterStderrEvent>) {
+        let result = join_bounded_reader(self.reader);
+        (result, self.events.try_recv().ok())
+    }
+}
+
+impl BootstrapSession {
+    pub fn open(
+        target: SshTarget,
+        authentication: SshAuthenticationMode,
+        timeout: Duration,
+    ) -> io::Result<Self> {
+        let socket_path = crate::client::socket_path()?;
+        let runtime_directory = socket_path
+            .parent()
+            .ok_or_else(|| io::Error::other("Boomux runtime socket has no parent"))?;
+        let user_config = env::var_os("HOME")
+            .filter(|home| !home.is_empty())
+            .map(PathBuf::from)
+            .map(|home| home.join(".ssh/config"));
+        let stderr_mirror = match authentication {
+            SshAuthenticationMode::Interactive => Some(Box::new(
+                OpenOptions::new()
+                    .write(true)
+                    .custom_flags(libc::O_CLOEXEC | libc::O_NONBLOCK)
+                    .open("/dev/tty")?,
+            ) as Box<dyn StderrMirror>),
+            SshAuthenticationMode::Batch => None,
+        };
+        Self::open_at_with_mirror(
+            runtime_directory,
+            user_config.as_deref(),
+            target,
+            authentication,
+            timeout,
+            OsStr::new("ssh"),
+            stderr_mirror,
+        )
+    }
+
+    #[cfg(test)]
+    fn open_at(
+        runtime_directory: &Path,
+        user_config: Option<&Path>,
+        target: SshTarget,
+        authentication: SshAuthenticationMode,
+        timeout: Duration,
+        program: &OsStr,
+    ) -> io::Result<Self> {
+        Self::open_at_with_mirror(
+            runtime_directory,
+            user_config,
+            target,
+            authentication,
+            timeout,
+            program,
+            None,
+        )
+    }
+
+    fn open_at_with_mirror(
+        runtime_directory: &Path,
+        user_config: Option<&Path>,
+        target: SshTarget,
+        authentication: SshAuthenticationMode,
+        timeout: Duration,
+        program: &OsStr,
+        stderr_mirror: Option<Box<dyn StderrMirror>>,
+    ) -> io::Result<Self> {
+        if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "SSH bootstrap timeout is outside the supported bound",
+            ));
+        }
+        let (directory, config_path, control_path) =
+            prepare_ssh_directory(runtime_directory, user_config)?;
+        let mut command = Command::new(program);
+        append_ssh_security_options(&mut command, &config_path, &control_path, authentication);
+        command
+            .args(["-o", "ControlMaster=yes"])
+            .args(["-o", "ControlPersist=no"])
+            .arg("-N")
+            .arg(target.as_str())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
+            });
+        }
+        let mut master = match command.spawn() {
+            Ok(master) => master,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&directory);
+                return Err(error);
+            }
+        };
+        let master_pid = i32::try_from(master.id()).map_err(|error| {
+            let _ = master.kill();
+            let _ = master.wait();
+            let _ = fs::remove_dir_all(&directory);
+            io::Error::other(format!("child PID overflow: {error}"))
+        })?;
+        let stderr = match master.stderr.take() {
+            Some(stderr) => stderr,
+            None => {
+                let _ = kill_process_group(master_pid, &mut master);
+                let _ = fs::remove_dir_all(&directory);
+                return Err(io::Error::other("SSH master stderr was not captured"));
+            }
+        };
+        let deadline = Instant::now() + timeout;
+        let stderr_reader = match spawn_master_stderr_reader(
+            stderr,
+            MAX_PROBE_STDERR_BYTES,
+            if authentication == SshAuthenticationMode::Interactive {
+                stderr_mirror
+            } else {
+                None
+            },
+            master_pid,
+            deadline,
+        ) {
+            Ok(reader) => reader,
+            Err(error) => {
+                let _ = kill_process_group(master_pid, &mut master);
+                let _ = fs::remove_dir_all(&directory);
+                return Err(error);
+            }
+        };
+        loop {
+            if let Some(event) = stderr_reader.event() {
+                let _ = kill_process_group(master_pid, &mut master);
+                let _ = stderr_reader.finish();
+                let _ = fs::remove_dir_all(&directory);
+                return Err(master_stderr_event_error(event));
+            }
+            let status = match master.try_wait() {
+                Ok(status) => status,
+                Err(error) => {
+                    let _ = kill_process_group(master_pid, &mut master);
+                    let _ = stderr_reader.finish();
+                    let _ = fs::remove_dir_all(&directory);
+                    return Err(error);
+                }
+            };
+            if let Some(status) = status {
+                let (result, event) = stderr_reader.finish();
+                let _ = fs::remove_dir_all(&directory);
+                if let Some(event) = event {
+                    return Err(master_stderr_event_error(event));
+                }
+                let (stderr, truncated) = result?;
+                if truncated {
+                    return Err(master_stderr_event_error(MasterStderrEvent::Truncated));
+                }
+                return Err(classify_ssh_start_failure(status.code(), &stderr));
+            }
+            let mut check = Command::new(program);
+            check
+                .arg("-F")
+                .arg(&config_path)
+                .arg("-S")
+                .arg(&control_path)
+                .args(["-O", "check"])
+                .arg(target.as_str())
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            if check.status().is_ok_and(|status| status.success()) {
+                if let Some(event) = stderr_reader.event() {
+                    let _ = kill_process_group(master_pid, &mut master);
+                    let _ = stderr_reader.finish();
+                    let _ = fs::remove_dir_all(&directory);
+                    return Err(master_stderr_event_error(event));
+                }
+                break;
+            }
+            if Instant::now() >= deadline {
+                let _ = kill_process_group(master_pid, &mut master);
+                let _ = stderr_reader.finish();
+                let _ = fs::remove_dir_all(&directory);
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "SSH bootstrap authentication timed out",
+                ));
+            }
+            thread::sleep(CHILD_POLL_INTERVAL);
+        }
+        Ok(Self {
+            id: Uuid::new_v4(),
+            program: program.to_owned(),
+            directory,
+            config_path,
+            control_path,
+            target,
+            master,
+            master_pid,
+            stderr_reader: Some(stderr_reader),
+        })
+    }
+
+    fn command(&self, remote_command: &str) -> Command {
+        slave_command(
+            &self.program,
+            &self.config_path,
+            &self.control_path,
+            &self.target,
+            remote_command,
+        )
+    }
+
+    pub fn plan(&mut self, timeout: Duration) -> io::Result<RemoteBootstrapPlan> {
+        let discovery = discover_remote_in_session(self, timeout)?;
+        let selection = inspect_remote_helpers_in_session(self, &discovery.executables, timeout)?;
+        if let Some(helper) = selection.compatible {
+            return Ok(RemoteBootstrapPlan::Ready(helper));
+        }
+        let reason = if discovery.executables.is_empty() {
+            RemoteInstallReason::Missing
+        } else if selection.incompatible == discovery.executables.len() {
+            RemoteInstallReason::Upgrade
+        } else {
+            return Err(io::Error::other(
+                "remote Boomux candidates could not be verified; refusing remote modification",
+            ));
+        };
+        let source = select_install_source(discovery.platform)?;
+        let upgrade_helper = (reason == RemoteInstallReason::Upgrade)
+            .then(|| selection.incompatible_executables.first().cloned())
+            .flatten();
+        Ok(RemoteBootstrapPlan::Install(RemoteInstallPlan {
+            target: self.target.clone(),
+            destination: discovery.install_destination,
+            source,
+            reason,
+            bootstrap_id: Some(self.id),
+            upgrade_helper,
+        }))
+    }
+
+    pub fn connect(
+        self,
+        helper: CompatibleRemoteHelper,
+        timeout: Duration,
+    ) -> io::Result<RemoteConnection> {
+        if helper.bootstrap_id != Some(self.id) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "remote helper observation belongs to a different bootstrap endpoint",
+            ));
+        }
+        connect_remote_in_session(self, helper, timeout)
+    }
+
+    pub fn install_and_connect(
+        self,
+        plan: &RemoteInstallPlan,
+        timeout: Duration,
+    ) -> io::Result<RemoteConnection> {
+        if plan.bootstrap_id != Some(self.id) || plan.target != self.target {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "remote install authorization belongs to a different bootstrap endpoint",
+            ));
+        }
+        let upgrade_helper = if plan.reason == RemoteInstallReason::Upgrade {
+            Some(plan.upgrade_helper.as_ref().ok_or_else(|| {
+                invalid_probe("remote upgrade omitted its verified outdated helper")
+            })?)
+        } else {
+            prove_remote_daemon_absent(&self, timeout)?;
+            None
+        };
+        let requested_transaction = InstallTransactionId::generate();
+        let upload = || {
+            run_streaming_command_capture(
+                self.command(REMOTE_INSTALL_COMMAND),
+                requested_transaction.upload_input(plan.source.bytes()),
+                timeout,
+            )
+            .and_then(|output| InstallTransactionId::parse_probe(&output.stdout))
+        };
+        let transaction = match upload() {
+            Ok(transaction) if transaction == requested_transaction => transaction,
+            Ok(_) => {
+                return Err(post_install_failure(
+                    "stream",
+                    invalid_probe("remote upload acknowledged a different transaction"),
+                ));
+            }
+            Err(first_error) => match upload() {
+                Ok(transaction) if transaction == requested_transaction => transaction,
+                Ok(_) => {
+                    return Err(post_install_failure(
+                        "stream",
+                        invalid_probe("upload retry acknowledged a different transaction"),
+                    ));
+                }
+                Err(retry_error) => {
+                    return Err(post_install_failure(
+                        "stream",
+                        io::Error::new(
+                            retry_error.kind(),
+                            format!("upload retry failed after ambiguous outcome: {first_error}"),
+                        ),
+                    ));
+                }
+            },
+        };
+        let mut renewal = 0_u64;
+        macro_rules! renew_lease {
+            ($stage:literal) => {{
+                renewal += 1;
+                if let Err(error) = run_streaming_command(
+                    self.command(REMOTE_INSTALL_RENEW_COMMAND),
+                    transaction.renewal_input(renewal),
+                    timeout,
+                ) {
+                    let _ = self.rollback_install(&transaction, timeout);
+                    return Err(post_install_failure($stage, error));
+                }
+            }};
+        }
+        renew_lease!("daemon_status");
+        let prior_daemon = if let Some(helper) = upgrade_helper {
+            let status = run_bounded_command(
+                self.command(&remote_transaction_daemon_status_command(&transaction)),
+                timeout,
+            )
+            .and_then(|output| parse_remote_daemon_status(&output.stdout));
+            match status {
+                Ok(status) if status.proves_executable(&plan.destination) => status,
+                _ => {
+                    return Err(shadow_upgrade_required(helper));
+                }
+            }
+        } else {
+            RemoteDaemonStatus::Absent
+        };
+        renew_lease!("activation");
+        let activate = || {
+            run_streaming_command_capture(
+                self.command(REMOTE_INSTALL_ACTIVATE_COMMAND),
+                transaction.activation_input(plan.reason, &prior_daemon),
+                timeout,
+            )
+            .and_then(|output| parse_install_activation(&output.stdout))
+        };
+        let activated = match activate() {
+            Ok(activated) => activated,
+            Err(first_error) => match activate() {
+                Ok(activated) => activated,
+                Err(retry_error) => {
+                    return Err(post_install_failure(
+                        "activation",
+                        io::Error::new(
+                            retry_error.kind(),
+                            format!(
+                                "activation retry failed after ambiguous outcome: {first_error}"
+                            ),
+                        ),
+                    ));
+                }
+            },
+        };
+        if !activated {
+            return Err(install_presence_required(
+                "a remote daemon socket appeared before activation; recover or stop that daemon before retrying installation",
+            ));
+        }
+        renew_lease!("helper_verification");
+        if let Err(error) = run_streaming_command(
+            self.command(REMOTE_INSTALL_MARK_DAEMON_CONTACTED_COMMAND),
+            transaction.input(),
+            timeout,
+        ) {
+            self.rollback_install(&transaction, timeout)?;
+            return Err(post_contact_failure(
+                "helper_verification",
+                error,
+                plan.reason,
+            ));
+        }
+        renew_lease!("helper_verification");
+        let initial_helper = (|| {
+            let candidates = [plan.destination.clone()];
+            let helper =
+                match inspect_remote_helpers_in_session(&self, &candidates, timeout)?.compatible {
+                    Some(helper) => helper,
+                    None => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Unsupported,
+                            "installed remote helper is not federation-compatible",
+                        ));
+                    }
+                };
+            Ok(helper)
+        })();
+        let daemon_status = if plan.reason == RemoteInstallReason::Upgrade {
+            renew_lease!("daemon_status");
+            match remote_daemon_status_in_session(&self, &plan.destination, timeout) {
+                Ok(status) => Some(status),
+                Err(error) => {
+                    self.rollback_install(&transaction, timeout)?;
+                    return Err(post_contact_failure("daemon_status", error, plan.reason));
+                }
+            }
+        } else {
+            None
+        };
+        let helper = if daemon_status
+            .as_ref()
+            .is_some_and(RemoteDaemonStatus::restart_required)
+        {
+            renew_lease!("daemon_restart");
+            if let Err(error) = run_streaming_command(
+                self.command(REMOTE_INSTALL_MARK_RESTARTED_COMMAND),
+                transaction.input(),
+                timeout,
+            ) {
+                self.rollback_install(&transaction, timeout)?;
+                return Err(post_contact_failure("daemon_restart", error, plan.reason));
+            }
+            renew_lease!("daemon_restart");
+            if let Err(error) = run_bounded_command(
+                self.command(&remote_installed_daemon_command("daemon restart")),
+                timeout,
+            ) {
+                self.rollback_install(&transaction, timeout)?;
+                return Err(post_contact_failure("daemon_restart", error, plan.reason));
+            }
+            renew_lease!("helper_verification");
+            match inspect_remote_helpers_in_session(
+                &self,
+                std::slice::from_ref(&plan.destination),
+                timeout,
+            )
+            .and_then(|inspection| {
+                inspection.compatible.ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "installed remote helper failed after daemon restart",
+                    )
+                })
+            }) {
+                Ok(helper) => helper,
+                Err(error) => {
+                    self.rollback_install(&transaction, timeout)?;
+                    return Err(post_contact_failure(
+                        "helper_verification",
+                        error,
+                        plan.reason,
+                    ));
+                }
+            }
+        } else {
+            match initial_helper {
+                Ok(helper) => helper,
+                Err(error) => {
+                    self.rollback_install(&transaction, timeout)?;
+                    return Err(post_contact_failure(
+                        "helper_verification",
+                        error,
+                        plan.reason,
+                    ));
+                }
+            }
+        };
+
+        renew_lease!("live_handshake");
+        let command = self.command(&remote_helper_command(&helper.executable));
+        let mut connection = match connect_remote_command(command, helper, timeout, None) {
+            Ok(connection) => connection,
+            Err(error) => {
+                self.rollback_install(&transaction, timeout)?;
+                return Err(post_contact_failure("live_handshake", error, plan.reason));
+            }
+        };
+        renew_lease!("protocol_ping");
+        if let Err(error) = connection.ping_with_timeout(timeout) {
+            drop(connection);
+            self.rollback_install(&transaction, timeout)?;
+            return Err(post_contact_failure("protocol_ping", error, plan.reason));
+        }
+        renew_lease!("commit");
+        let commit = run_streaming_command_capture(
+            self.command(REMOTE_INSTALL_COMMIT_COMMAND),
+            transaction.input(),
+            timeout,
+        )
+        .and_then(|output| parse_install_commit(&output.stdout));
+        if let Err(error) = commit {
+            drop(connection);
+            return Err(classified_error(
+                io::ErrorKind::Other,
+                "bootstrap_commit_outcome_unknown",
+                format!(
+                    "remote install commit outcome is unknown after successful helper verification and protocol ping; retry the exact bootstrap to discover the installed helper: {error}"
+                ),
+            ));
+        }
+        connection._bootstrap_session = Some(self);
+        Ok(connection)
+    }
+
+    fn rollback_install(
+        &self,
+        transaction: &InstallTransactionId,
+        timeout: Duration,
+    ) -> io::Result<()> {
+        run_streaming_command(
+            self.command(REMOTE_INSTALL_ROLLBACK_COMMAND),
+            transaction.input(),
+            timeout,
+        )
+    }
+}
+
+fn slave_command(
+    program: &OsStr,
+    config_path: &Path,
+    control_path: &Path,
+    target: &SshTarget,
+    remote_command: &str,
+) -> Command {
+    let mut command = Command::new(program);
+    append_ssh_security_options(
+        &mut command,
+        config_path,
+        control_path,
+        SshAuthenticationMode::Batch,
+    );
+    command
+        .args(["-o", "ControlMaster=no"])
+        .args(["-o", "HostName=boomux-mux-only.invalid"])
+        .args(["-o", "ProxyCommand=/bin/false"])
+        .args(["-o", "ConnectionAttempts=1"])
+        .arg(target.as_str())
+        .arg(remote_command);
+    command
+}
+
+impl Drop for BootstrapSession {
+    fn drop(&mut self) {
+        let _ = kill_process_group(self.master_pid, &mut self.master);
+        if let Some(reader) = self.stderr_reader.take() {
+            let _ = reader.finish();
+        }
+        let _ = fs::remove_dir_all(&self.directory);
+    }
+}
 
 impl SshInvocation {
     pub fn prepare(
@@ -685,10 +1771,7 @@ impl SshInvocation {
             runtime_directory,
             user_config,
             target,
-            format!(
-                "{} __federation-stdio",
-                quote_posix_shell(executable.as_str())
-            ),
+            remote_helper_command(&executable),
             authentication,
         )
     }
@@ -741,6 +1824,7 @@ impl SshInvocation {
                 .open(&config_path)?;
             if let Some(user_config) = user_config {
                 writeln!(config, "Include {}", quote_ssh_config_path(user_config)?)?;
+                writeln!(config, "Match all")?;
             }
             // SendEnv is list-valued, so clear user entries after their config.
             writeln!(config, "SendEnv -*")?;
@@ -766,6 +1850,119 @@ impl SshInvocation {
     }
 }
 
+fn append_ssh_security_options(
+    command: &mut Command,
+    config_path: &Path,
+    control_path: &Path,
+    authentication: SshAuthenticationMode,
+) {
+    command
+        .arg("-F")
+        .arg(config_path)
+        .arg("-T")
+        .args(["-o", "ClearAllForwardings=yes"])
+        .args(["-o", "ForwardAgent=no"])
+        .args(["-o", "ForwardX11=no"])
+        .args(["-o", "PermitLocalCommand=no"])
+        .args(["-o", "RemoteCommand=none"])
+        .args(["-o", "ForkAfterAuthentication=no"])
+        .args(["-o", "StdinNull=no"])
+        .arg("-o")
+        .arg(format!(
+            "ControlPath={}",
+            control_path.to_str().expect("validated SSH control path")
+        ))
+        .args([
+            "-o",
+            match authentication {
+                SshAuthenticationMode::Interactive => "BatchMode=no",
+                SshAuthenticationMode::Batch => "BatchMode=yes",
+            },
+        ]);
+}
+
+fn prepare_ssh_directory(
+    runtime_directory: &Path,
+    user_config: Option<&Path>,
+) -> io::Result<(PathBuf, PathBuf, PathBuf)> {
+    secure_runtime_directory(runtime_directory)?;
+    let nonce = Uuid::new_v4().simple().to_string();
+    let directory = runtime_directory.join(format!("ssh-{}", &nonce[..16]));
+    fs::create_dir(&directory)?;
+    fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
+    let config_path = directory.join("config");
+    let control_path = directory.join("c");
+    if control_path.as_os_str().as_bytes().len() > MAX_CONTROL_PATH_BYTES {
+        let _ = fs::remove_dir_all(&directory);
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SSH control socket path exceeds the safe Unix socket bound",
+        ));
+    }
+    validate_option_path(&control_path, "SSH control socket")?;
+    let result = (|| {
+        let mut config = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&config_path)?;
+        if let Some(user_config) = user_config {
+            writeln!(config, "Include {}", quote_ssh_config_path(user_config)?)?;
+            writeln!(config, "Match all")?;
+        }
+        writeln!(config, "SendEnv -*")?;
+        writeln!(config, "Host *")?;
+        writeln!(config, "    ServerAliveInterval 15")?;
+        writeln!(config, "    ServerAliveCountMax 3")?;
+        config.sync_all()
+    })();
+    if let Err(error) = result {
+        let _ = fs::remove_dir_all(&directory);
+        return Err(error);
+    }
+    Ok((directory, config_path, control_path))
+}
+
+fn classify_ssh_start_failure(status: Option<i32>, stderr: &[u8]) -> io::Error {
+    let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    if stderr.contains("permission denied")
+        || stderr.contains("authentication failed")
+        || stderr.contains("host key verification failed")
+    {
+        classified_error(
+            io::ErrorKind::PermissionDenied,
+            "bootstrap_authentication_failed",
+            "SSH authentication or host-key verification failed",
+        )
+    } else {
+        classified_error(
+            io::ErrorKind::ConnectionRefused,
+            "bootstrap_transport_failed",
+            format!(
+                "SSH bootstrap transport failed{}",
+                status.map_or_else(String::new, |status| format!(" with status {status}"))
+            ),
+        )
+    }
+}
+
+fn master_stderr_event_error(event: MasterStderrEvent) -> io::Error {
+    let message = match event {
+        MasterStderrEvent::Truncated => {
+            "SSH bootstrap authentication output exceeded the supported bound"
+        }
+        MasterStderrEvent::MirrorFailed => {
+            "SSH bootstrap authentication output could not be shown safely"
+        }
+    };
+    classified_error(
+        io::ErrorKind::ConnectionAborted,
+        "bootstrap_transport_failed",
+        message,
+    )
+}
+
+#[cfg(test)]
 pub fn discover_remote(
     target: SshTarget,
     authentication: SshAuthenticationMode,
@@ -789,55 +1986,219 @@ pub fn discover_remote(
     )
 }
 
+fn discover_remote_in_session(
+    session: &BootstrapSession,
+    timeout: Duration,
+) -> io::Result<RemoteDiscovery> {
+    let run = |probe: RemoteProbe| run_bounded_command(session.command(probe.command()), timeout);
+    let platform = RemotePlatform::parse_probe(&run(RemoteProbe::Platform)?.stdout)?;
+    let executables = parse_executable_probe(&run(RemoteProbe::Executables)?.stdout)?;
+    let install_destination =
+        parse_install_destination_probe(&run(RemoteProbe::InstallDestination)?.stdout)?;
+    Ok(RemoteDiscovery {
+        platform,
+        executables,
+        install_destination,
+    })
+}
+
+#[cfg(test)]
 pub fn plan_remote_bootstrap(
     target: SshTarget,
     authentication: SshAuthenticationMode,
     timeout: Duration,
 ) -> io::Result<RemoteBootstrapPlan> {
-    let discovery = discover_remote(target.clone(), authentication, timeout)?;
-    if let Ok(helper) = find_compatible_remote_helper(
+    let socket_path = crate::client::socket_path()?;
+    let runtime_directory = socket_path
+        .parent()
+        .ok_or_else(|| io::Error::other("Boomux runtime socket has no parent"))?;
+    let user_config = env::var_os("HOME")
+        .filter(|home| !home.is_empty())
+        .map(PathBuf::from)
+        .map(|home| home.join(".ssh/config"));
+    plan_remote_bootstrap_at(
+        runtime_directory,
+        user_config.as_deref(),
+        target,
+        authentication,
+        timeout,
+        OsStr::new("ssh"),
+    )
+}
+
+#[cfg(test)]
+fn plan_remote_bootstrap_at(
+    runtime_directory: &Path,
+    user_config: Option<&Path>,
+    target: SshTarget,
+    authentication: SshAuthenticationMode,
+    timeout: Duration,
+    program: &OsStr,
+) -> io::Result<RemoteBootstrapPlan> {
+    let discovery = discover_remote_at(
+        runtime_directory,
+        user_config,
+        target.clone(),
+        authentication,
+        timeout,
+        program,
+    )?;
+    let selection = inspect_remote_helpers_at(
+        runtime_directory,
+        user_config,
         target.clone(),
         &discovery.executables,
         authentication,
         timeout,
-    ) {
+        program,
+    )?;
+    if let Some(helper) = selection.compatible {
         return Ok(RemoteBootstrapPlan::Ready(helper));
     }
+    let reason = if discovery.executables.is_empty() {
+        RemoteInstallReason::Missing
+    } else if selection.incompatible == discovery.executables.len() {
+        RemoteInstallReason::Upgrade
+    } else {
+        return Err(io::Error::other(
+            "remote Boomux candidates could not be verified; check remote executable access and SSH transport before retrying",
+        ));
+    };
     let source = select_install_source(discovery.platform)?;
+    let upgrade_helper = (reason == RemoteInstallReason::Upgrade)
+        .then(|| selection.incompatible_executables.first().cloned())
+        .flatten();
     Ok(RemoteBootstrapPlan::Install(RemoteInstallPlan {
         target,
         destination: discovery.install_destination,
         source,
-        may_restart_daemon: !discovery.executables.is_empty(),
+        reason,
+        bootstrap_id: None,
+        upgrade_helper,
     }))
 }
 
-pub fn install_remote(
-    plan: &RemoteInstallPlan,
-    authentication: SshAuthenticationMode,
-    timeout: Duration,
-) -> io::Result<CompatibleRemoteHelper> {
-    let binary = load_install_source(&plan.source)?;
-    let invocation =
-        prepare_fixed_invocation(plan.target.clone(), REMOTE_INSTALL_COMMAND, authentication)?;
-    run_streaming_command(invocation.command(), binary, timeout)?;
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RemoteDaemonStatus {
+    Absent,
+    Present {
+        protocol_version: u32,
+        pid: Option<u32>,
+        executable: Option<RemoteExecutable>,
+        socket_device: Option<u64>,
+        socket_inode: Option<u64>,
+    },
+}
 
-    let candidates = [plan.destination.clone()];
-    match find_compatible_remote_helper(plan.target.clone(), &candidates, authentication, timeout) {
-        Ok(helper) => Ok(helper),
-        Err(first_error) if plan.may_restart_daemon => {
-            let restart = prepare_fixed_invocation(
-                plan.target.clone(),
-                REMOTE_RESTART_COMMAND,
-                authentication,
-            )?;
-            run_bounded_command(restart.command(), timeout).map_err(|_| first_error)?;
-            find_compatible_remote_helper(plan.target.clone(), &candidates, authentication, timeout)
-        }
-        Err(error) => Err(error),
+impl RemoteDaemonStatus {
+    fn restart_required(&self) -> bool {
+        matches!(
+            self,
+            Self::Present {
+                protocol_version, ..
+            }
+                if !(federation_protocol_floor()..=protocol::PROTOCOL_VERSION)
+                    .contains(protocol_version)
+        )
+    }
+
+    fn proves_executable(&self, destination: &RemoteExecutable) -> bool {
+        matches!(
+            self,
+            Self::Present {
+                pid: Some(_),
+                executable: Some(executable),
+                socket_device: Some(_),
+                socket_inode: Some(_),
+                ..
+            } if executable == destination
+        )
     }
 }
 
+fn remote_daemon_status_in_session(
+    session: &BootstrapSession,
+    executable: &RemoteExecutable,
+    timeout: Duration,
+) -> io::Result<RemoteDaemonStatus> {
+    let status = run_bounded_command(
+        session.command(&remote_daemon_status_command_for(executable)),
+        timeout,
+    )?;
+    parse_remote_daemon_status(&status.stdout)
+}
+
+fn prove_remote_daemon_absent(session: &BootstrapSession, timeout: Duration) -> io::Result<()> {
+    let output = run_bounded_command(session.command(&remote_daemon_presence_command()), timeout)
+        .map_err(|_| {
+            install_presence_required(
+                "remote daemon absence could not be proven; inspect or remove the runtime socket manually before installing Boomux",
+            )
+        })?;
+    let fields = parse_nul_fields(&output.stdout, DAEMON_PRESENCE_PREFIX).map_err(|_| {
+        install_presence_required(
+            "remote daemon absence could not be proven; inspect or remove the runtime socket manually before installing Boomux",
+        )
+    })?;
+    if fields == [b"absent"] {
+        Ok(())
+    } else {
+        Err(install_presence_required(
+            "a remote daemon socket already exists; stop or recover that daemon and remove only a confirmed stale socket before installing Boomux",
+        ))
+    }
+}
+
+fn parse_remote_daemon_status(stdout: &[u8]) -> io::Result<RemoteDaemonStatus> {
+    if stdout.starts_with(DAEMON_STATUS_PREFIX) {
+        let fields = parse_nul_fields(stdout, DAEMON_STATUS_PREFIX)?;
+        return if fields == [b"absent"] {
+            Ok(RemoteDaemonStatus::Absent)
+        } else {
+            Err(invalid_probe(
+                "remote daemon status returned an invalid result",
+            ))
+        };
+    }
+    let value: serde_json::Value = serde_json::from_slice(stdout)
+        .map_err(|_| invalid_probe("remote daemon status returned invalid JSON"))?;
+    if value.get("schema").and_then(serde_json::Value::as_str) != Some("boomux.cli/v1")
+        || value.get("command").and_then(serde_json::Value::as_str) != Some("daemon.status")
+    {
+        return Err(invalid_probe(
+            "remote daemon status returned an invalid envelope",
+        ));
+    }
+    let version = value
+        .pointer("/data/protocol_version")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|version| u32::try_from(version).ok())
+        .ok_or_else(|| invalid_probe("remote daemon status omitted its protocol version"))?;
+    let pid = value
+        .pointer("/data/pid")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|pid| u32::try_from(pid).ok())
+        .filter(|pid| *pid != 0);
+    let executable = value
+        .pointer("/data/executable")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|executable| RemoteExecutable::parse(executable).ok());
+    let socket_device = value
+        .pointer("/data/socket_device")
+        .and_then(serde_json::Value::as_u64);
+    let socket_inode = value
+        .pointer("/data/socket_inode")
+        .and_then(serde_json::Value::as_u64);
+    Ok(RemoteDaemonStatus::Present {
+        protocol_version: version,
+        pid,
+        executable,
+        socket_device,
+        socket_inode,
+    })
+}
+
+#[cfg(test)]
 pub fn connect_remote(
     target: SshTarget,
     helper: CompatibleRemoteHelper,
@@ -851,7 +2212,30 @@ pub fn connect_remote(
         ));
     }
     let invocation = SshInvocation::prepare(target, helper.executable.clone(), authentication)?;
-    let mut command = invocation.command();
+    connect_remote_command(invocation.command(), helper, timeout, None)
+}
+
+fn connect_remote_in_session(
+    session: BootstrapSession,
+    helper: CompatibleRemoteHelper,
+    timeout: Duration,
+) -> io::Result<RemoteConnection> {
+    let command = session.command(&remote_helper_command(&helper.executable));
+    connect_remote_command(command, helper, timeout, Some(session))
+}
+
+fn connect_remote_command(
+    mut command: Command,
+    helper: CompatibleRemoteHelper,
+    timeout: Duration,
+    bootstrap_session: Option<BootstrapSession>,
+) -> io::Result<RemoteConnection> {
+    if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SSH connection timeout is outside the supported bound",
+        ));
+    }
     command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -927,7 +2311,10 @@ pub fn connect_remote(
         Ok(handshake) => handshake,
         Err(error) => {
             let _ = kill_process_group(pid, &mut child);
-            let _ = join_bounded_reader(stderr_reader);
+            let (stderr, truncated) = join_bounded_reader(stderr_reader)?;
+            if !truncated && let Some(runtime_error) = runtime_stage_failure(None, &stderr) {
+                return Err(runtime_error);
+            }
             return Err(error);
         }
     };
@@ -944,6 +2331,7 @@ pub fn connect_remote(
         stderr_reader: Some(stderr_reader),
         executable: helper.executable,
         handshake,
+        _bootstrap_session: bootstrap_session,
     })
 }
 
@@ -951,7 +2339,7 @@ fn validate_live_handshake(
     expected: &FederationHandshake,
     actual: &FederationHandshake,
 ) -> io::Result<()> {
-    if !(protocol::MIN_PROTOCOL_VERSION..=protocol::PROTOCOL_VERSION)
+    if !(federation_protocol_floor()..=protocol::PROTOCOL_VERSION)
         .contains(&actual.core_protocol_version)
     {
         return Err(invalid_probe(
@@ -959,68 +2347,134 @@ fn validate_live_handshake(
         ));
     }
     if actual.node_id != expected.node_id {
-        return Err(io::Error::new(
+        return Err(classified_error(
             io::ErrorKind::PermissionDenied,
+            "node_identity_changed",
             "remote helper identity changed after bootstrap",
         ));
     }
     Ok(())
 }
 
-fn prepare_fixed_invocation(
-    target: SshTarget,
-    command: &'static str,
-    authentication: SshAuthenticationMode,
-) -> io::Result<SshInvocation> {
-    let socket_path = crate::client::socket_path()?;
-    let runtime_directory = socket_path
-        .parent()
-        .ok_or_else(|| io::Error::other("Boomux runtime socket has no parent"))?;
-    let user_config = env::var_os("HOME")
-        .filter(|home| !home.is_empty())
-        .map(PathBuf::from)
-        .map(|home| home.join(".ssh/config"));
-    SshInvocation::prepare_command_at(
-        runtime_directory,
-        user_config.as_deref(),
-        target,
-        command.to_owned(),
-        authentication,
-    )
-}
-
 fn select_install_source(platform: RemotePlatform) -> io::Result<RemoteInstallSource> {
     if platform.matches_local() {
-        return Ok(RemoteInstallSource::CurrentBinary(env::current_exe()?));
+        let path = env::current_exe()?;
+        let bytes = read_bounded_file(&path)?;
+        let sha256 = format!("{:x}", Sha256::digest(&bytes));
+        return Ok(RemoteInstallSource::CurrentBinary {
+            path,
+            sha256,
+            bytes,
+        });
     }
     let target = platform.release_target().ok_or_else(|| {
-        io::Error::new(
+        classified_error(
             io::ErrorKind::Unsupported,
+            "bootstrap_unsupported_platform",
             "no Boomux release asset supports the remote platform",
         )
     })?;
+    let release = select_published_release(target)?;
+    let bytes = download_release_binary(target, release.tag)?;
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
     Ok(RemoteInstallSource::Release {
         target,
-        tag: format!("v{}", env!("CARGO_PKG_VERSION")),
+        tag: release.tag.to_owned(),
+        sha256,
+        bytes,
     })
 }
 
-fn load_install_source(source: &RemoteInstallSource) -> io::Result<Vec<u8>> {
-    match source {
-        RemoteInstallSource::CurrentBinary(path) => read_bounded_file(path),
-        RemoteInstallSource::Release { target, tag } => download_release_binary(target, tag),
-    }
+fn select_published_release(target: &str) -> io::Result<&'static PublishedRelease> {
+    PUBLISHED_RELEASES
+        .iter()
+        .rev()
+        .find(|release| {
+            release.target == target
+                && release.protocol_version >= federation_protocol_floor()
+                && release.protocol_version <= protocol::PROTOCOL_VERSION
+        })
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "no published Boomux release for {target} is compatible with local protocol {}; build for the remote target and manually stream the current development binary",
+                    protocol::PROTOCOL_VERSION
+                ),
+            )
+        })
+}
+
+#[derive(Debug)]
+struct PublishedRelease {
+    tag: &'static str,
+    target: &'static str,
+    protocol_version: u32,
+}
+
+// Keep this matrix explicit: package versions on development branches do not
+// prove that an asset exists or that its wire protocol matches this source.
+const PUBLISHED_RELEASES: &[PublishedRelease] = &[PublishedRelease {
+    tag: "v0.18.1",
+    target: "x86_64-unknown-linux-gnu",
+    protocol_version: 27,
+}];
+
+const fn federation_protocol_floor() -> u32 {
+    protocol::ProtocolFeature::FederationChannel.minimum_version()
 }
 
 fn read_bounded_file(path: &Path) -> io::Result<Vec<u8>> {
-    let metadata = fs::metadata(path)?;
-    if !metadata.is_file() || metadata.len() == 0 || metadata.len() > MAX_RELEASE_BYTES {
-        return Err(io::Error::new(
+    read_bounded_file_with_hook(path, || {})
+}
+
+fn read_bounded_file_with_hook(path: &Path, after_metadata: impl FnOnce()) -> io::Result<Vec<u8>> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|_| {
+            classified_error(
+                io::ErrorKind::InvalidData,
+                "bootstrap_install_failed",
+                "Boomux install source could not be opened safely",
+            )
+        })?;
+    let before = file.metadata()?;
+    if !before.is_file() || before.len() == 0 || before.len() > MAX_RELEASE_BYTES {
+        return Err(classified_error(
             io::ErrorKind::InvalidData,
+            "bootstrap_install_failed",
             "Boomux install source is not a bounded regular file",
         ));
     }
-    fs::read(path)
+    after_metadata();
+    let mut bytes = Vec::with_capacity(usize::try_from(before.len()).unwrap_or(0));
+    Read::by_ref(&mut file)
+        .take(MAX_RELEASE_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    let after = file.metadata()?;
+    if bytes.len() as u64 != before.len()
+        || bytes.len() as u64 > MAX_RELEASE_BYTES
+        || file_metadata_changed(&before, &after)
+    {
+        return Err(classified_error(
+            io::ErrorKind::InvalidData,
+            "bootstrap_install_failed",
+            "Boomux install source changed while it was being pinned",
+        ));
+    }
+    Ok(bytes)
+}
+
+fn file_metadata_changed(before: &fs::Metadata, after: &fs::Metadata) -> bool {
+    before.dev() != after.dev()
+        || before.ino() != after.ino()
+        || before.len() != after.len()
+        || before.mtime() != after.mtime()
+        || before.mtime_nsec() != after.mtime_nsec()
+        || before.ctime() != after.ctime()
+        || before.ctime_nsec() != after.ctime_nsec()
 }
 
 fn download_release_binary(target: &str, tag: &str) -> io::Result<Vec<u8>> {
@@ -1116,12 +2570,144 @@ fn verify_release_checksum(archive: &Path, checksum: &Path, archive_name: &str) 
     Ok(())
 }
 
+#[cfg(test)]
 pub fn find_compatible_remote_helper(
     target: SshTarget,
     executables: &[RemoteExecutable],
     authentication: SshAuthenticationMode,
     timeout: Duration,
 ) -> io::Result<CompatibleRemoteHelper> {
+    inspect_remote_helpers(target, executables, authentication, timeout)?
+        .compatible
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "no discovered remote Boomux executable is federation-compatible",
+            )
+        })
+}
+
+struct RemoteHelperInspection {
+    compatible: Option<CompatibleRemoteHelper>,
+    incompatible: usize,
+    incompatible_executables: Vec<RemoteExecutable>,
+}
+
+fn inspect_remote_helpers_in_session(
+    session: &BootstrapSession,
+    executables: &[RemoteExecutable],
+    timeout: Duration,
+) -> io::Result<RemoteHelperInspection> {
+    if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SSH helper selection timeout is outside the supported bound",
+        ));
+    }
+    let deadline = Instant::now() + timeout;
+    let mut compatible: Option<CompatibleRemoteHelper> = None;
+    let mut incompatible = 0;
+    let mut incompatible_executables = Vec::new();
+    let mut indeterminate = 0;
+    let mut first_indeterminate_error = None;
+    for (index, executable) in executables.iter().enumerate() {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "SSH helper selection timed out",
+            ));
+        }
+        let candidates_left = u32::try_from(executables.len() - index).unwrap_or(u32::MAX);
+        let candidate_budget = remaining / candidates_left;
+        if candidate_budget.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "SSH helper selection timed out",
+            ));
+        }
+        let candidate_deadline = Instant::now() + candidate_budget;
+        let helper_command = remote_helper_command(executable);
+        match run_helper_probe_command(session.command(&helper_command), candidate_budget) {
+            Ok(handshake) => {
+                if let Some(selected) = &compatible {
+                    if selected.handshake.node_id != handshake.node_id {
+                        return Err(classified_error(
+                            io::ErrorKind::PermissionDenied,
+                            "node_identity_conflict",
+                            "discovered remote Boomux executables reported different Node identities",
+                        ));
+                    }
+                } else {
+                    compatible = Some(CompatibleRemoteHelper {
+                        executable: executable.clone(),
+                        handshake,
+                        bootstrap_id: Some(session.id),
+                    });
+                }
+            }
+            Err(helper_error) => {
+                let remaining = candidate_deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    indeterminate += 1;
+                    first_indeterminate_error.get_or_insert(helper_error);
+                    continue;
+                }
+                let version = run_bounded_command(
+                    session.command(&format!(
+                        "{} --version",
+                        quote_posix_shell(executable.as_str())
+                    )),
+                    remaining,
+                );
+                let published_version = version
+                    .as_ref()
+                    .ok()
+                    .and_then(|output| published_protocol_from_version_output(&output.stdout));
+                if matches!(
+                    helper_error.kind(),
+                    io::ErrorKind::UnexpectedEof | io::ErrorKind::Unsupported
+                ) && published_version
+                    .is_some_and(|version| version < federation_protocol_floor())
+                {
+                    incompatible += 1;
+                    incompatible_executables.push(executable.clone());
+                } else {
+                    indeterminate += 1;
+                    let error = if matches!(
+                        helper_error.kind(),
+                        io::ErrorKind::InvalidData | io::ErrorKind::PermissionDenied
+                    ) {
+                        helper_error
+                    } else {
+                        version.err().unwrap_or(helper_error)
+                    };
+                    first_indeterminate_error.get_or_insert(error);
+                }
+            }
+        }
+    }
+    if compatible.is_none() && indeterminate > 0 {
+        return Err(first_indeterminate_error.unwrap_or_else(|| {
+            io::Error::other(
+                "remote Boomux candidate failed compatibility verification; refusing remote modification",
+            )
+        }));
+    }
+    Ok(RemoteHelperInspection {
+        compatible,
+        incompatible,
+        incompatible_executables,
+    })
+}
+
+#[cfg(test)]
+fn inspect_remote_helpers(
+    target: SshTarget,
+    executables: &[RemoteExecutable],
+    authentication: SshAuthenticationMode,
+    timeout: Duration,
+) -> io::Result<RemoteHelperInspection> {
     let socket_path = crate::client::socket_path()?;
     let runtime_directory = socket_path
         .parent()
@@ -1130,7 +2716,7 @@ pub fn find_compatible_remote_helper(
         .filter(|home| !home.is_empty())
         .map(PathBuf::from)
         .map(|home| home.join(".ssh/config"));
-    find_compatible_remote_helper_at(
+    inspect_remote_helpers_at(
         runtime_directory,
         user_config.as_deref(),
         target,
@@ -1141,6 +2727,7 @@ pub fn find_compatible_remote_helper(
     )
 }
 
+#[cfg(test)]
 fn find_compatible_remote_helper_at(
     runtime_directory: &Path,
     user_config: Option<&Path>,
@@ -1150,6 +2737,34 @@ fn find_compatible_remote_helper_at(
     timeout: Duration,
     program: &OsStr,
 ) -> io::Result<CompatibleRemoteHelper> {
+    inspect_remote_helpers_at(
+        runtime_directory,
+        user_config,
+        target,
+        executables,
+        authentication,
+        timeout,
+        program,
+    )?
+    .compatible
+    .ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "no discovered remote Boomux executable is federation-compatible",
+        )
+    })
+}
+
+#[cfg(test)]
+fn inspect_remote_helpers_at(
+    runtime_directory: &Path,
+    user_config: Option<&Path>,
+    target: SshTarget,
+    executables: &[RemoteExecutable],
+    authentication: SshAuthenticationMode,
+    timeout: Duration,
+    program: &OsStr,
+) -> io::Result<RemoteHelperInspection> {
     if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -1162,7 +2777,12 @@ fn find_compatible_remote_helper_at(
             "SSH helper selection timeout overflow",
         )
     })?;
-    for executable in executables {
+    let mut compatible: Option<CompatibleRemoteHelper> = None;
+    let mut incompatible = 0;
+    let mut incompatible_executables = Vec::new();
+    let mut indeterminate = 0;
+    let mut first_indeterminate_error = None;
+    for (index, executable) in executables.iter().enumerate() {
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             return Err(io::Error::new(
@@ -1170,36 +2790,128 @@ fn find_compatible_remote_helper_at(
                 "SSH helper selection timed out",
             ));
         }
+        let candidates_left = u32::try_from(executables.len() - index).unwrap_or(u32::MAX);
+        let candidate_budget = remaining / candidates_left;
+        if candidate_budget.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "SSH helper selection timed out",
+            ));
+        }
+        let candidate_deadline = Instant::now() + candidate_budget;
         let invocation = SshInvocation::prepare_command_with_program_at(
             runtime_directory,
             user_config,
             target.clone(),
-            format!(
-                "{} __federation-stdio",
-                quote_posix_shell(executable.as_str())
-            ),
+            remote_helper_command(executable),
             authentication,
             program,
         )?;
-        if let Ok(handshake) = invocation.verify_helper(remaining) {
-            return Ok(CompatibleRemoteHelper {
-                executable: executable.clone(),
-                handshake,
-            });
+        match invocation.verify_helper(candidate_budget) {
+            Ok(handshake) => {
+                if let Some(selected) = &compatible {
+                    if selected.handshake.node_id != handshake.node_id {
+                        return Err(classified_error(
+                            io::ErrorKind::PermissionDenied,
+                            "node_identity_conflict",
+                            "discovered remote Boomux executables reported different Node identities",
+                        ));
+                    }
+                } else {
+                    compatible = Some(CompatibleRemoteHelper {
+                        executable: executable.clone(),
+                        handshake,
+                        bootstrap_id: None,
+                    });
+                }
+            }
+            Err(helper_error) => {
+                let remaining = candidate_deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    indeterminate += 1;
+                    first_indeterminate_error.get_or_insert(helper_error);
+                    continue;
+                }
+                let version = SshInvocation::prepare_command_with_program_at(
+                    runtime_directory,
+                    user_config,
+                    target.clone(),
+                    format!("{} --version", quote_posix_shell(executable.as_str())),
+                    authentication,
+                    program,
+                )?
+                .run_probe(remaining);
+                let published_version = version
+                    .as_ref()
+                    .ok()
+                    .and_then(|output| published_protocol_from_version_output(&output.stdout));
+                if matches!(
+                    helper_error.kind(),
+                    io::ErrorKind::UnexpectedEof | io::ErrorKind::Unsupported
+                ) && published_version
+                    .is_some_and(|version| version < federation_protocol_floor())
+                {
+                    incompatible += 1;
+                    incompatible_executables.push(executable.clone());
+                } else {
+                    indeterminate += 1;
+                    let error = if matches!(
+                        helper_error.kind(),
+                        io::ErrorKind::InvalidData | io::ErrorKind::PermissionDenied
+                    ) {
+                        helper_error
+                    } else {
+                        version.err().unwrap_or(helper_error)
+                    };
+                    first_indeterminate_error.get_or_insert(error);
+                }
+            }
         }
     }
-    if Instant::now() >= deadline {
-        return Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "SSH helper selection timed out",
-        ));
+    if compatible.is_none() && indeterminate > 0 {
+        return Err(first_indeterminate_error.unwrap_or_else(|| {
+            io::Error::other(
+                "remote Boomux candidate failed compatibility verification; refusing remote modification",
+            )
+        }));
     }
-    Err(io::Error::new(
-        io::ErrorKind::NotFound,
-        "no discovered remote Boomux executable is federation-compatible",
-    ))
+    Ok(RemoteHelperInspection {
+        compatible,
+        incompatible,
+        incompatible_executables,
+    })
 }
 
+fn published_protocol_from_version_output(output: &[u8]) -> Option<u32> {
+    if output.len() > 128 {
+        return None;
+    }
+    let version = std::str::from_utf8(output)
+        .ok()?
+        .strip_prefix("boomux ")?
+        .strip_suffix('\n')?;
+    if version.is_empty()
+        || version.len() > 32
+        || !version
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || byte == b'.')
+    {
+        return None;
+    }
+    match version {
+        "0.2.0" | "0.3.0" | "0.4.0" | "0.4.1" => Some(16),
+        "0.4.2" => Some(17),
+        "0.5.0" => Some(18),
+        "0.5.1" => Some(19),
+        "0.6.0" | "0.7.0" | "0.8.0" | "0.9.0" | "0.9.1" | "0.10.0" | "0.10.1" | "0.11.0"
+        | "0.12.0" | "0.13.0" => Some(20),
+        "0.14.0" | "0.14.1" | "0.14.2" | "0.15.0" => Some(21),
+        "0.16.0" | "0.17.0" | "0.18.0" | "0.18.1" => Some(27),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
 fn discover_remote_at(
     runtime_directory: &Path,
     user_config: Option<&Path>,
@@ -1315,7 +3027,11 @@ fn parse_nul_fields<'a>(output: &'a [u8], prefix: &[u8]) -> io::Result<Vec<&'a [
 }
 
 fn invalid_probe(message: &'static str) -> io::Error {
-    io::Error::new(io::ErrorKind::InvalidData, message)
+    classified_error(
+        io::ErrorKind::InvalidData,
+        "bootstrap_malformed_helper",
+        message,
+    )
 }
 
 fn run_bounded_command(mut command: Command, timeout: Duration) -> io::Result<SshProbeOutput> {
@@ -1385,19 +3101,129 @@ fn run_bounded_command(mut command: Command, timeout: Duration) -> io::Result<Ss
     if stdout_truncated || stderr_truncated {
         return Err(invalid_probe("SSH probe output exceeds the size limit"));
     }
-    if !status.expect("checked above").success() {
-        return Err(io::Error::other(
-            "SSH probe failed; verify target resolution, the SSH service, credentials, and remote shell support",
-        ));
+    let status = status.expect("checked above");
+    if !status.success() {
+        return Err(classify_ssh_command_failure(status.code(), &stderr));
     }
     Ok(SshProbeOutput { stdout, stderr })
 }
 
-fn run_streaming_command(
+fn classify_ssh_command_failure(status: Option<i32>, stderr: &[u8]) -> io::Error {
+    let lower = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    if lower.contains("permission denied")
+        || lower.contains("authentication failed")
+        || lower.contains("host key verification failed")
+    {
+        return classified_error(
+            io::ErrorKind::PermissionDenied,
+            "bootstrap_authentication_failed",
+            "SSH authentication or host-key verification failed",
+        );
+    }
+    if status == Some(73) {
+        return classified_error(
+            io::ErrorKind::ResourceBusy,
+            "busy",
+            "another remote Boomux bootstrap transaction is active",
+        );
+    }
+    if status == Some(92) {
+        return classified_error(
+            io::ErrorKind::Unsupported,
+            "bootstrap_unsupported_platform",
+            "remote platform does not provide the fixed command layout required for safe bootstrap",
+        );
+    }
+    if let Some(error) = runtime_stage_failure(status, stderr) {
+        return error;
+    }
+    if let Some(detail) = install_stage_failure(status, stderr) {
+        return classified_error(io::ErrorKind::Other, "bootstrap_install_failed", detail);
+    }
+    if status == Some(255) {
+        return classified_error(
+            io::ErrorKind::ConnectionAborted,
+            "bootstrap_transport_failed",
+            "SSH transport failed while using the authenticated bootstrap endpoint",
+        );
+    }
+    io::Error::other("SSH remote command failed; verify executable access and remote shell support")
+}
+
+fn runtime_stage_failure(status: Option<i32>, stderr: &[u8]) -> Option<io::Error> {
+    let (reason, code) = std::str::from_utf8(stderr).ok()?.lines().find_map(|line| {
+        let fields = line.strip_prefix(RUNTIME_STAGE_PREFIX)?.strip_prefix(':')?;
+        let (reason, code) = fields.split_once(':')?;
+        let code = code.parse::<i32>().ok()?;
+        (status.is_none() || status == Some(code)).then_some((reason, code))
+    })?;
+    let message = match (reason, code) {
+        ("missing", 88) => {
+            "remote runtime discovery failed: XDG_RUNTIME_DIR is unset on a non-Linux host"
+        }
+        ("invalid", 89) => {
+            "remote runtime discovery failed: user identity or XDG_RUNTIME_DIR is invalid"
+        }
+        ("unsafe", 90) => {
+            "remote runtime discovery failed: runtime directory must be an owner-controlled, non-symlink directory with mode 0700"
+        }
+        ("unsupported", 91) => {
+            "remote runtime discovery failed: remote operating system is unsupported"
+        }
+        _ => return None,
+    };
+    Some(classified_error(
+        io::ErrorKind::NotFound,
+        "bootstrap_runtime_unavailable",
+        message,
+    ))
+}
+
+fn install_stage_failure(status: Option<i32>, stderr: &[u8]) -> Option<&'static str> {
+    let status = status?;
+    let marker = std::str::from_utf8(stderr).ok()?.lines().find_map(|line| {
+        let fields = line.strip_prefix(INSTALL_STAGE_PREFIX)?.strip_prefix(':')?;
+        let (stage, code) = fields.split_once(':')?;
+        (code.parse::<i32>().ok()? == status).then_some(stage)
+    })?;
+    Some(match marker {
+        "home" => "remote Boomux install failed: remote HOME is not an absolute path",
+        "directory" => "remote Boomux install failed while creating the owner install directory",
+        "lock" => "remote Boomux install failed while acquiring its transaction lock",
+        "transaction" => {
+            "remote Boomux install failed while creating its private transaction directory"
+        }
+        "transaction_id" => {
+            "remote Boomux install failed because mktemp returned an invalid transaction name"
+        }
+        "lock_id" => "remote Boomux install failed while recording its transaction identity",
+        "stream" => {
+            "remote Boomux install failed while writing the streamed binary; check remote free space and quota"
+        }
+        "mode" => "remote Boomux install failed while making the streamed binary executable",
+        "backup" => "remote Boomux install failed while preserving the previous executable",
+        "activate" => "remote Boomux install failed while activating the replacement executable",
+        "watchdog_spawn" => "remote Boomux install failed while starting the rollback watchdog",
+        "watchdog_ready" => {
+            "remote Boomux install failed because the rollback watchdog did not become ready"
+        }
+        "watchdog_pid" => {
+            "remote Boomux install failed while recording rollback watchdog ownership"
+        }
+        "result" => "remote Boomux install failed while returning its transaction result",
+        _ => return None,
+    })
+}
+
+fn run_streaming_command(command: Command, input: Vec<u8>, timeout: Duration) -> io::Result<()> {
+    run_streaming_command_capture(command, input, timeout).map(|_| ())
+}
+
+fn run_streaming_command_capture(
     mut command: Command,
     input: Vec<u8>,
     timeout: Duration,
-) -> io::Result<()> {
+) -> io::Result<SshProbeOutput> {
     if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -1406,7 +3232,7 @@ fn run_streaming_command(
     }
     command
         .stdin(Stdio::piped())
-        .stdout(Stdio::null())
+        .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     unsafe {
         command.pre_exec(|| {
@@ -1427,6 +3253,11 @@ fn run_streaming_command(
         .stderr
         .take()
         .ok_or_else(|| io::Error::other("SSH install stderr was not captured"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("SSH install stdout was not captured"))?;
+    let stdout_reader = spawn_bounded_reader(stdout, MAX_PROBE_OUTPUT_BYTES, "install-stdout")?;
     let stderr_reader = spawn_bounded_reader(stderr, MAX_PROBE_STDERR_BYTES, "stderr")?;
     let writer = thread::Builder::new()
         .name("boomux-ssh-install-input".into())
@@ -1444,23 +3275,40 @@ fn run_streaming_command(
         }
         thread::sleep(CHILD_POLL_INTERVAL);
     };
-    writer
+    let write_result = writer
         .join()
-        .map_err(|_| io::Error::other("SSH install input worker panicked"))??;
-    let (_, stderr_truncated) = join_bounded_reader(stderr_reader)?;
+        .map_err(|_| io::Error::other("SSH install input worker panicked"))?;
+    let (stdout, stdout_truncated) = join_bounded_reader(stdout_reader)?;
+    let (stderr, stderr_truncated) = join_bounded_reader(stderr_reader)?;
     if status.is_none() {
         return Err(io::Error::new(
             io::ErrorKind::TimedOut,
             "SSH install timed out",
         ));
     }
-    if stderr_truncated {
-        return Err(invalid_probe("SSH install stderr exceeds the size limit"));
+    if stdout_truncated || stderr_truncated {
+        return Err(invalid_probe("SSH install output exceeds the size limit"));
     }
-    if !status.expect("checked above").success() {
-        return Err(io::Error::other("remote Boomux install failed"));
+    let status = status.expect("checked above");
+    if !status.success() {
+        let error = classify_ssh_command_failure(status.code(), &stderr);
+        return if error.kind() == io::ErrorKind::Other
+            && error
+                .get_ref()
+                .and_then(|error| error.downcast_ref::<ClassifiedBootstrapError>())
+                .is_none()
+        {
+            Err(classified_error(
+                io::ErrorKind::Other,
+                "bootstrap_install_failed",
+                "remote Boomux install failed",
+            ))
+        } else {
+            Err(error)
+        };
     }
-    Ok(())
+    write_result?;
+    Ok(SshProbeOutput { stdout, stderr })
 }
 
 fn run_helper_probe_command(
@@ -1509,11 +3357,17 @@ fn run_helper_probe_command(
         .spawn(move || {
             let result = (|| {
                 let handshake = crate::federation::read_handshake(&mut stdout)?;
-                if !(protocol::MIN_PROTOCOL_VERSION..=protocol::PROTOCOL_VERSION)
-                    .contains(&handshake.core_protocol_version)
-                {
-                    return Err(invalid_probe(
-                        "remote helper reported an incompatible core protocol",
+                if handshake.core_protocol_version < federation_protocol_floor() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "remote helper reported an older incompatible core protocol",
+                    ));
+                }
+                if handshake.core_protocol_version > protocol::PROTOCOL_VERSION {
+                    return Err(classified_error(
+                        io::ErrorKind::Unsupported,
+                        "unsupported_version",
+                        "remote helper reported a newer incompatible core protocol",
                     ));
                 }
                 protocol::write_message(
@@ -1566,9 +3420,12 @@ fn run_helper_probe_command(
     protocol_worker
         .join()
         .map_err(|_| io::Error::other("SSH helper probe worker panicked"))?;
-    let (_, stderr_truncated) = join_bounded_reader(stderr_reader)?;
+    let (stderr, stderr_truncated) = join_bounded_reader(stderr_reader)?;
     if stderr_truncated {
         return Err(invalid_probe("SSH helper stderr exceeds the size limit"));
+    }
+    if let Some(error) = runtime_stage_failure(status.and_then(|status| status.code()), &stderr) {
+        return Err(error);
     }
     if result.is_ok() && status.is_none() {
         return Err(io::Error::new(
@@ -1577,7 +3434,16 @@ fn run_helper_probe_command(
         ));
     }
     if status.is_some_and(|status| !status.success()) {
-        return Err(io::Error::other("SSH helper exited unsuccessfully"));
+        return Err(classify_ssh_command_failure(
+            status.and_then(|status| status.code()),
+            &stderr,
+        ));
+    }
+    if result.is_err()
+        && (String::from_utf8_lossy(&stderr).contains("Permission denied")
+            || String::from_utf8_lossy(&stderr).contains("Host key verification failed"))
+    {
+        return Err(classify_ssh_command_failure(Some(255), &stderr));
     }
     result
 }
@@ -1591,6 +3457,115 @@ fn kill_process_group(pid: i32, child: &mut std::process::Child) -> io::Result<(
     }
     let _ = child.wait();
     Ok(())
+}
+
+fn spawn_master_stderr_reader(
+    mut reader: impl Read + Send + 'static,
+    limit: usize,
+    mut mirror: Option<Box<dyn StderrMirror>>,
+    master_pid: i32,
+    deadline: Instant,
+) -> io::Result<MasterStderrReader> {
+    if let Some(mirror) = mirror.as_ref() {
+        let flags = unsafe { libc::fcntl(mirror.as_raw_fd(), libc::F_GETFL) };
+        if flags == -1
+            || unsafe { libc::fcntl(mirror.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) }
+                == -1
+        {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    let (event_sender, events) = mpsc::channel();
+    let reader = thread::Builder::new()
+        .name("boomux-ssh-master-stderr".into())
+        .spawn(move || {
+            let mut retained = Vec::with_capacity(limit);
+            let mut buffer = [0_u8; 4096];
+            loop {
+                let count = match reader.read(&mut buffer) {
+                    Ok(0) => return Ok((retained, false)),
+                    Ok(count) => count,
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(error) => return Err(error),
+                };
+                let mirrored = count.min(limit.saturating_sub(retained.len()));
+                if mirrored != 0 {
+                    if let Some(mirror) = mirror.as_mut()
+                        && write_mirror_with_deadline(
+                            mirror.as_mut(),
+                            &buffer[..mirrored],
+                            deadline,
+                        )
+                        .is_err()
+                    {
+                        let _ = event_sender.send(MasterStderrEvent::MirrorFailed);
+                        unsafe {
+                            libc::kill(-master_pid, libc::SIGKILL);
+                        }
+                        return Err(io::Error::other("SSH master stderr mirror failed"));
+                    }
+                    retained.extend_from_slice(&buffer[..mirrored]);
+                }
+                if mirrored < count {
+                    let _ = event_sender.send(MasterStderrEvent::Truncated);
+                    unsafe {
+                        libc::kill(-master_pid, libc::SIGKILL);
+                    }
+                    return Ok((retained, true));
+                }
+            }
+        })?;
+    Ok(MasterStderrReader { reader, events })
+}
+
+fn write_mirror_with_deadline(
+    mirror: &mut dyn StderrMirror,
+    mut bytes: &[u8],
+    deadline: Instant,
+) -> io::Result<()> {
+    while !bytes.is_empty() {
+        match mirror.write(bytes) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "terminal output closed",
+                ));
+            }
+            Ok(count) => bytes = &bytes[count..],
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "terminal output timed out",
+                    ));
+                }
+                let mut descriptor = libc::pollfd {
+                    fd: mirror.as_raw_fd(),
+                    events: libc::POLLOUT,
+                    revents: 0,
+                };
+                let milliseconds =
+                    i32::try_from(remaining.as_millis().min(i32::MAX as u128)).unwrap_or(i32::MAX);
+                let status = unsafe { libc::poll(&mut descriptor, 1, milliseconds) };
+                if status == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "terminal output timed out",
+                    ));
+                }
+                if status == -1 {
+                    let error = io::Error::last_os_error();
+                    if error.kind() != io::ErrorKind::Interrupted {
+                        return Err(error);
+                    }
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    mirror.flush()
 }
 
 fn spawn_bounded_reader(
@@ -1628,6 +3603,29 @@ mod tests {
     use super::*;
     use crate::federation::{FEDERATION_VERSION, FederationConnectionMode};
 
+    const CONTROL_MASTER_SCRIPT: &str = "control=; previous=; master=false; check=false; last=; for arg do last=$arg; case \"$previous\" in -S) control=$arg ;; -O) [ \"$arg\" = check ] && check=true ;; esac; case \"$arg\" in ControlPath=*) control=${arg#ControlPath=} ;; -N) master=true ;; esac; previous=$arg; done; if $master; then : > \"$control.ready\"; trap 'rm -f \"$control.ready\"' EXIT HUP INT TERM; while :; do sleep 60; done; fi; if $check; then [ -e \"$control.ready\" ]; exit; fi; case \"$last\" in *'boomux-install-activation-v1'*) cat >/dev/null; printf 'boomux-install-activation-v1\\0activated\\0'; exit ;; *'boomux-install-transaction-v1'*) IFS= read -r boomux_test_txn; printf() { case \"$1\" in boomux-install-transaction-v1*) command printf 'boomux-install-transaction-v1\\0%s\\0' \"$boomux_test_txn\" ;; *) command printf \"$@\" ;; esac; } ;; *'prior_daemon.next'*|*': > \"$transaction/daemon_contacted\"'*|*'lease.next'*) cat >/dev/null; exit ;; esac";
+    const CONTROL_MASTER_ONLY_SCRIPT: &str = "control=; previous=; master=false; check=false; for arg do case \"$previous\" in -S) control=$arg ;; -O) [ \"$arg\" = check ] && check=true ;; esac; case \"$arg\" in ControlPath=*) control=${arg#ControlPath=} ;; -N) master=true ;; esac; previous=$arg; done; if $master; then : > \"$control.ready\"; trap 'rm -f \"$control.ready\"' EXIT HUP INT TERM; while :; do sleep 60; done; fi; if $check; then [ -e \"$control.ready\" ]; exit; fi";
+
+    fn add_fake_daemon_identity(script: &Path, executable: &str) {
+        let contents = fs::read_to_string(script).unwrap();
+        let contents = contents
+            .replace(
+                "\"protocol_version\":21}",
+                &format!(
+                    "\"protocol_version\":21,\"pid\":123,\"executable\":{},\"socket_device\":1,\"socket_inode\":1}}",
+                    serde_json::to_string(executable).unwrap()
+                ),
+            )
+            .replace(
+                "\"protocol_version\":38}",
+                &format!(
+                    "\"protocol_version\":38,\"pid\":123,\"executable\":{},\"socket_device\":1,\"socket_inode\":1}}",
+                    serde_json::to_string(executable).unwrap()
+                ),
+            );
+        fs::write(script, contents).unwrap();
+    }
+
     fn runtime_directory() -> PathBuf {
         env::temp_dir().join(format!("boomux-ssh-{}", Uuid::new_v4()))
     }
@@ -1638,6 +3636,404 @@ mod tests {
             .map(|byte| format!("\\{byte:03o}"))
             .collect::<String>();
         format!("printf '{escaped}'")
+    }
+
+    fn write_master_stderr_ssh(runtime: &Path, master_body: &str) -> PathBuf {
+        let ssh = runtime.join("ssh-master-stderr");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\ncontrol=; previous=; master=false; check=false\nfor arg do\n  case \"$previous\" in -S) control=$arg ;; -O) [ \"$arg\" = check ] && check=true ;; esac\n  case \"$arg\" in ControlPath=*) control=${{arg#ControlPath=}} ;; -N) master=true ;; esac\n  previous=$arg\ndone\nif $master; then\n  {master_body}\nfi\nif $check; then [ -e \"$control.ready\" ]; exit; fi\nexit 64\n"
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        ssh
+    }
+
+    fn run_local_install(home: &Path, bytes: &[u8]) -> InstallTransactionId {
+        run_local_install_with_shell(home, bytes, "sh")
+    }
+
+    fn run_local_install_with_shell(
+        home: &Path,
+        bytes: &[u8],
+        shell: &str,
+    ) -> InstallTransactionId {
+        let transaction = run_local_upload_with_command(home, bytes, shell, REMOTE_INSTALL_COMMAND);
+        run_local_activation(home, shell, &transaction, RemoteInstallReason::Missing);
+        transaction
+    }
+
+    fn run_local_upload_with_command(
+        home: &Path,
+        bytes: &[u8],
+        shell: &str,
+        command_text: &str,
+    ) -> InstallTransactionId {
+        let transaction = InstallTransactionId::generate();
+        let mut command = Command::new(shell);
+        command.args(["-c", command_text]).env("HOME", home);
+        let output = run_streaming_command_capture(
+            command,
+            transaction.upload_input(bytes),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+        assert_eq!(
+            InstallTransactionId::parse_probe(&output.stdout).unwrap(),
+            transaction
+        );
+        transaction
+    }
+
+    fn run_local_activation(
+        home: &Path,
+        shell: &str,
+        transaction: &InstallTransactionId,
+        reason: RemoteInstallReason,
+    ) {
+        let runtime = home.join("runtime");
+        fs::create_dir_all(&runtime).unwrap();
+        fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+        let mut activate = Command::new(shell);
+        activate
+            .args(["-c", REMOTE_INSTALL_ACTIVATE_COMMAND])
+            .env("HOME", home)
+            .env("XDG_RUNTIME_DIR", runtime);
+        let output = run_streaming_command_capture(
+            activate,
+            transaction.activation_input(
+                reason,
+                &RemoteDaemonStatus::Present {
+                    protocol_version: protocol::PROTOCOL_VERSION,
+                    pid: Some(1),
+                    executable: Some(RemoteExecutable::parse("/tmp/test-destination").unwrap()),
+                    socket_device: Some(1),
+                    socket_inode: Some(1),
+                },
+            ),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+        assert!(parse_install_activation(&output.stdout).unwrap());
+    }
+
+    #[test]
+    fn exact_install_script_runs_under_posix_sh_and_bash() {
+        for shell in ["sh", "bash"] {
+            let directory = runtime_directory();
+            fs::create_dir_all(directory.join(".local/bin")).unwrap();
+            let destination = directory.join(".local/bin/boomux");
+            fs::write(&destination, b"previous").unwrap();
+            fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+            let previous_metadata = fs::metadata(&destination).unwrap();
+            let transaction = run_local_install_with_shell(&directory, b"replacement", shell);
+            assert_eq!(fs::read(&destination).unwrap(), b"replacement");
+            let backup = directory
+                .join(".local/bin")
+                .join(&transaction.0)
+                .join("backup");
+            let backup_metadata = fs::metadata(&backup).unwrap();
+            assert_eq!(fs::read(&backup).unwrap(), b"previous");
+            assert_eq!(backup_metadata.mode(), previous_metadata.mode());
+            assert_eq!(backup_metadata.uid(), previous_metadata.uid());
+            assert_eq!(backup_metadata.gid(), previous_metadata.gid());
+            assert_eq!(backup_metadata.mtime(), previous_metadata.mtime());
+            run_local_transaction(&directory, REMOTE_INSTALL_ROLLBACK_COMMAND, &transaction);
+            assert_eq!(fs::read(&destination).unwrap(), b"previous");
+            fs::remove_dir_all(directory).unwrap();
+        }
+    }
+
+    #[test]
+    fn install_rejects_symlink_special_and_non_executable_destinations_before_activation() {
+        use std::os::unix::fs::FileTypeExt;
+
+        for kind in ["symlink", "fifo", "non-executable"] {
+            let directory = runtime_directory();
+            let bin = directory.join(".local/bin");
+            fs::create_dir_all(&bin).unwrap();
+            let destination = bin.join("boomux");
+            let target = directory.join("target");
+            match kind {
+                "symlink" => {
+                    fs::write(&target, b"outside").unwrap();
+                    std::os::unix::fs::symlink(&target, &destination).unwrap();
+                }
+                "fifo" => {
+                    let path = std::ffi::CString::new(destination.as_os_str().as_bytes()).unwrap();
+                    assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o700) }, 0);
+                }
+                "non-executable" => {
+                    fs::write(&destination, b"old").unwrap();
+                    fs::set_permissions(&destination, fs::Permissions::from_mode(0o600)).unwrap();
+                }
+                _ => unreachable!(),
+            }
+
+            let transaction = run_local_upload_with_command(
+                &directory,
+                b"replacement",
+                "sh",
+                REMOTE_INSTALL_COMMAND,
+            );
+            let result = run_activation_script(
+                "sh",
+                REMOTE_INSTALL_ACTIVATE_COMMAND,
+                &directory,
+                &transaction,
+            );
+            assert!(result.is_err(), "{kind}");
+            match kind {
+                "symlink" => {
+                    assert_eq!(fs::read_link(&destination).unwrap(), target);
+                    assert_eq!(fs::read(&target).unwrap(), b"outside");
+                }
+                "fifo" => assert!(
+                    fs::symlink_metadata(&destination)
+                        .unwrap()
+                        .file_type()
+                        .is_fifo()
+                ),
+                "non-executable" => {
+                    assert_eq!(fs::read(&destination).unwrap(), b"old");
+                    assert_eq!(fs::metadata(&destination).unwrap().mode() & 0o777, 0o600);
+                }
+                _ => unreachable!(),
+            }
+            run_local_transaction(&directory, REMOTE_INSTALL_ROLLBACK_COMMAND, &transaction);
+            assert!(!bin.join(".boomux.bootstrap.lock").exists());
+            fs::remove_dir_all(directory).unwrap();
+        }
+    }
+
+    #[test]
+    fn disk_full_backup_copy_failure_leaves_the_old_destination_untouched() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let directory = runtime_directory();
+        let bin = directory.join(".local/bin");
+        fs::create_dir_all(&bin).unwrap();
+        let destination = bin.join("boomux");
+        fs::write(&destination, b"previous").unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let transaction =
+            run_local_upload_with_command(&directory, b"replacement", "sh", REMOTE_INSTALL_COMMAND);
+        let command = REMOTE_INSTALL_ACTIVATE_COMMAND.replacen(
+            "backup=$transaction/backup;",
+            "backup=/dev/full;",
+            1,
+        );
+        assert_ne!(command, REMOTE_INSTALL_ACTIVATE_COMMAND);
+        assert!(run_activation_script("sh", &command, &directory, &transaction).is_err());
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        assert_eq!(fs::metadata(&destination).unwrap().mode() & 0o777, 0o755);
+        assert!(
+            fs::metadata("/dev/full")
+                .unwrap()
+                .file_type()
+                .is_char_device()
+        );
+        run_local_transaction(&directory, REMOTE_INSTALL_ROLLBACK_COMMAND, &transaction);
+        assert!(!bin.join(".boomux.bootstrap.lock").exists());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    fn run_install_script_raw(
+        shell: &str,
+        command_text: &str,
+        home: &Path,
+        input: &[u8],
+    ) -> std::process::Output {
+        let transaction = InstallTransactionId::generate();
+        let mut child = Command::new(shell)
+            .args(["-c", command_text])
+            .env("HOME", home)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let _ = child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(&transaction.upload_input(input));
+        child.wait_with_output().unwrap()
+    }
+
+    fn run_activation_script(
+        shell: &str,
+        command_text: &str,
+        home: &Path,
+        transaction: &InstallTransactionId,
+    ) -> io::Result<()> {
+        let runtime = home.join("runtime");
+        fs::create_dir_all(&runtime)?;
+        fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700))?;
+        let mut child = Command::new(shell);
+        child
+            .args(["-c", command_text])
+            .env("HOME", home)
+            .env("XDG_RUNTIME_DIR", runtime);
+        run_streaming_command(
+            child,
+            transaction.activation_input(
+                RemoteInstallReason::Missing,
+                &RemoteDaemonStatus::Present {
+                    protocol_version: protocol::PROTOCOL_VERSION,
+                    pid: Some(1),
+                    executable: Some(RemoteExecutable::parse("/tmp/test").unwrap()),
+                    socket_device: Some(1),
+                    socket_inode: Some(1),
+                },
+            ),
+            Duration::from_secs(1),
+        )
+    }
+
+    #[test]
+    fn every_install_stage_reports_only_a_bounded_marker_and_rolls_back() {
+        let stages = [
+            ("directory", 75),
+            ("lock", 76),
+            ("transaction", 77),
+            ("lock_id", 79),
+            ("stream", 80),
+            ("mode", 81),
+            ("watchdog_spawn", 84),
+            ("watchdog_ready", 85),
+            ("watchdog_pid", 86),
+            ("result", 87),
+        ];
+        for shell in ["sh", "bash"] {
+            for (stage, code) in stages {
+                let directory = runtime_directory();
+                let bin = directory.join(".local/bin");
+                fs::create_dir_all(&bin).unwrap();
+                let destination = bin.join("boomux");
+                fs::write(&destination, b"previous").unwrap();
+                fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+                let assignment = format!("stage={stage}; stage_code={code};");
+                let injected = format!("{assignment} printf 'private remote detail' >&2; false;");
+                let command = REMOTE_INSTALL_COMMAND.replacen(&assignment, &injected, 1);
+                assert_ne!(command, REMOTE_INSTALL_COMMAND);
+
+                let output = run_install_script_raw(shell, &command, &directory, b"replacement");
+                assert_eq!(output.status.code(), Some(code), "{shell} stage {stage}");
+                assert_eq!(
+                    output.stderr,
+                    format!("{INSTALL_STAGE_PREFIX}:{stage}:{code}\n").as_bytes(),
+                    "{shell} stage {stage}"
+                );
+                let error = classify_ssh_command_failure(output.status.code(), &output.stderr);
+                assert_eq!(error_code(&error), "bootstrap_install_failed");
+                assert!(error.to_string().contains("remote Boomux install failed"));
+                assert!(!error.to_string().contains("private remote detail"));
+                assert_eq!(fs::read(&destination).unwrap(), b"previous");
+                assert!(
+                    fs::read_dir(&bin)
+                        .unwrap()
+                        .filter_map(Result::ok)
+                        .all(|entry| !entry.file_name().to_string_lossy().starts_with(".boomux.")),
+                    "{shell} stage {stage} left transaction state"
+                );
+                fs::remove_dir_all(directory).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_remote_home_has_a_fixed_non_secret_install_stage() {
+        let output = run_install_script_raw(
+            "bash",
+            REMOTE_INSTALL_COMMAND,
+            Path::new("relative-home"),
+            b"replacement",
+        );
+        assert_eq!(output.status.code(), Some(74));
+        assert_eq!(output.stderr, b"boomux-install-stage-v1:home:74\n");
+        let error = classify_ssh_command_failure(output.status.code(), &output.stderr);
+        assert_eq!(error_code(&error), "bootstrap_install_failed");
+        assert!(error.to_string().contains("HOME is not an absolute path"));
+    }
+
+    #[test]
+    fn failed_watchdog_readiness_is_typed_and_restores_the_previous_binary() {
+        let directory = runtime_directory();
+        let bin = directory.join(".local/bin");
+        fs::create_dir_all(&bin).unwrap();
+        let destination = bin.join("boomux");
+        fs::write(&destination, b"previous").unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let command = REMOTE_INSTALL_COMMAND.replacen(
+            ": > \"$transaction/watchdog_ready\"; claim_process_start",
+            "exit 1; claim_process_start",
+            1,
+        );
+        let output = run_install_script_raw("bash", &command, &directory, b"replacement");
+        assert_eq!(output.status.code(), Some(85));
+        assert_eq!(
+            output.stderr,
+            b"boomux-install-stage-v1:watchdog_ready:85\n"
+        );
+        let error = classify_ssh_command_failure(output.status.code(), &output.stderr);
+        assert_eq!(error_code(&error), "bootstrap_install_failed");
+        assert!(error.to_string().contains("watchdog did not become ready"));
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        assert!(!bin.join(".boomux.bootstrap.lock").exists());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    fn run_local_transaction(home: &Path, command: &str, transaction: &InstallTransactionId) {
+        let mut child = Command::new("sh");
+        child.args(["-c", command]).env("HOME", home);
+        run_streaming_command(child, transaction.input(), Duration::from_secs(1)).unwrap();
+    }
+
+    fn compatible_helper_script(node_id: &str) -> String {
+        let handshake = FederationHandshake {
+            version: FEDERATION_VERSION,
+            node_id: node_id.into(),
+            helper_version: env!("CARGO_PKG_VERSION").into(),
+            core_protocol_version: protocol::PROTOCOL_VERSION,
+            connection_mode: FederationConnectionMode::AdHoc,
+        };
+        let mut handshake_bytes = Vec::new();
+        crate::federation::write_handshake(&mut handshake_bytes, &handshake).unwrap();
+        let mut request_bytes = Vec::new();
+        protocol::write_message(
+            &mut request_bytes,
+            &Envelope::with_version(protocol::PROTOCOL_VERSION, Request::Ping),
+        )
+        .unwrap();
+        let mut response_bytes = Vec::new();
+        protocol::write_message(
+            &mut response_bytes,
+            &Envelope::with_version(protocol::PROTOCOL_VERSION, Response::Pong),
+        )
+        .unwrap();
+        format!(
+            "{}; dd bs=1 count={} of=/dev/null 2>/dev/null; {}",
+            shell_printf(&handshake_bytes),
+            request_bytes.len(),
+            shell_printf(&response_bytes),
+        )
+    }
+
+    fn write_bootstrap_ssh(runtime: &Path, executable_cases: &str, candidates: &str) -> PathBuf {
+        fs::create_dir_all(runtime).unwrap();
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in *'exec '*) last=${{last##*exec }} ;; esac\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{candidates}' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/person/.local/bin/boomux\\0' ;;\n{executable_cases}\n  *) exit 64 ;;\nesac\n"
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        ssh
     }
 
     #[test]
@@ -1697,11 +4093,24 @@ mod tests {
         assert_eq!(arguments[arguments.len() - 2], "workbox");
         assert_eq!(
             arguments.last().unwrap(),
-            "'/opt/boomux'\\''s bin/boomux' __federation-stdio"
+            &OsString::from(remote_helper_command(
+                &RemoteExecutable::parse("/opt/boomux's bin/boomux").unwrap()
+            ))
+        );
+        assert!(
+            arguments
+                .last()
+                .unwrap()
+                .to_string_lossy()
+                .contains("exec '/opt/boomux'\\''s bin/boomux' __federation-stdio")
         );
 
         let config = fs::read_to_string(invocation.config_path()).unwrap();
-        assert!(config.starts_with("Include \"/home/person/.ssh/config\"\nSendEnv -*\nHost *\n"));
+        assert!(
+            config.starts_with(
+                "Include \"/home/person/.ssh/config\"\nMatch all\nSendEnv -*\nHost *\n"
+            )
+        );
         assert!(config.contains("ServerAliveInterval 15"));
         assert_eq!(
             fs::symlink_metadata(invocation.config_path())
@@ -1714,6 +4123,394 @@ mod tests {
         drop(invocation);
         assert!(!directory.exists());
         fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn generated_config_ends_trailing_included_match_before_clearing_sendenv() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let user_config = runtime.join("user-config");
+        fs::write(
+            &user_config,
+            "Host *\n    SendEnv BOOMUX_SECRET\nMatch host never-matches\n",
+        )
+        .unwrap();
+        let invocation = SshInvocation::prepare_at(
+            &runtime,
+            Some(&user_config),
+            SshTarget::parse("workbox").unwrap(),
+            RemoteExecutable::parse("/usr/bin/boomux").unwrap(),
+            SshAuthenticationMode::Batch,
+        )
+        .unwrap();
+        let output = Command::new("ssh")
+            .args(["-G", "-F"])
+            .arg(invocation.config_path())
+            .arg("workbox")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "ssh -G failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let effective = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+        assert!(!effective.contains("boomux_secret"), "{effective}");
+        assert!(!effective.lines().any(|line| line.starts_with("sendenv ")));
+        drop(invocation);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    fn run_runtime_prefix(runtime: Option<&Path>, path: Option<&Path>) -> std::process::Output {
+        run_runtime_prefix_text(REMOTE_RUNTIME_PREFIX, runtime, path)
+    }
+
+    fn run_runtime_prefix_text(
+        prefix: &str,
+        runtime: Option<&Path>,
+        path: Option<&Path>,
+    ) -> std::process::Output {
+        let mut command = Command::new("/bin/sh");
+        command
+            .args(["-c", &format!("{prefix}printf '%s' \"$XDG_RUNTIME_DIR\"")])
+            .env_remove("XDG_RUNTIME_DIR");
+        if let Some(runtime) = runtime {
+            command.env("XDG_RUNTIME_DIR", runtime);
+        }
+        if let Some(path) = path {
+            command.env("PATH", path);
+        }
+        command.output().unwrap()
+    }
+
+    #[test]
+    fn linux_runtime_discovery_derives_or_validates_owner_runtime_without_local_forwarding() {
+        let uid = unsafe { libc::geteuid() };
+        let derived = PathBuf::from(format!("/run/user/{uid}"));
+        let output = run_runtime_prefix(None, None);
+        assert!(
+            output.status.success(),
+            "runtime discovery failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(output.stdout, derived.as_os_str().as_bytes());
+
+        let supplied = runtime_directory();
+        fs::create_dir(&supplied).unwrap();
+        fs::set_permissions(&supplied, fs::Permissions::from_mode(0o700)).unwrap();
+        let output = run_runtime_prefix(Some(&supplied), None);
+        assert!(output.status.success());
+        assert_eq!(output.stdout, supplied.as_os_str().as_bytes());
+        assert!(
+            !remote_helper_command(&RemoteExecutable::parse("/bin/boomux").unwrap())
+                .contains(supplied.to_str().unwrap())
+        );
+        fs::remove_dir_all(supplied).unwrap();
+    }
+
+    #[test]
+    fn runtime_discovery_rejects_malicious_identity_and_unsafe_environment() {
+        let relative = run_runtime_prefix(Some(Path::new("relative")), None);
+        assert_eq!(relative.status.code(), Some(89));
+        assert_eq!(relative.stderr, b"boomux-runtime-v1:invalid:89\n");
+        assert_eq!(
+            error_code(&classify_ssh_command_failure(
+                relative.status.code(),
+                &relative.stderr
+            )),
+            "bootstrap_runtime_unavailable"
+        );
+
+        let unsafe_runtime = runtime_directory();
+        fs::create_dir(&unsafe_runtime).unwrap();
+        fs::set_permissions(&unsafe_runtime, fs::Permissions::from_mode(0o755)).unwrap();
+        let unsafe_output = run_runtime_prefix(Some(&unsafe_runtime), None);
+        assert_eq!(unsafe_output.status.code(), Some(90));
+        assert_eq!(unsafe_output.stderr, b"boomux-runtime-v1:unsafe:90\n");
+        fs::remove_dir_all(unsafe_runtime).unwrap();
+
+        let malicious_prefix =
+            REMOTE_RUNTIME_PREFIX.replace("/usr/bin/id -u", "printf '1;touch-pwned\\n'");
+        let malicious = run_runtime_prefix_text(&malicious_prefix, None, None);
+        assert_eq!(malicious.status.code(), Some(89));
+        assert_eq!(malicious.stderr, b"boomux-runtime-v1:invalid:89\n");
+    }
+
+    #[test]
+    fn macos_runtime_discovery_preserves_explicit_runtime_and_rejects_absence() {
+        let root = runtime_directory();
+        let runtime = root.join("runtime");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir(&runtime).unwrap();
+        fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+        let uid = unsafe { libc::geteuid() };
+        let macos_prefix = REMOTE_RUNTIME_PREFIX
+            .replace("/usr/bin/uname -s", "printf 'Darwin\\n'")
+            .replace("/usr/bin/stat -f '%u'", &format!("printf '{uid}\\n'"))
+            .replace("/usr/bin/stat -f '%Lp'", "printf '700\\n'");
+        let supplied = run_runtime_prefix_text(&macos_prefix, Some(&runtime), None);
+        assert!(supplied.status.success());
+        assert_eq!(supplied.stdout, runtime.as_os_str().as_bytes());
+
+        let missing = run_runtime_prefix_text(&macos_prefix, None, None);
+        assert_eq!(missing.status.code(), Some(88));
+        assert_eq!(missing.stderr, b"boomux-runtime-v1:missing:88\n");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn post_install_failures_name_the_fixed_stage_without_remote_stderr() {
+        for (stage, expected) in [
+            ("daemon_status", "daemon status"),
+            ("daemon_restart", "daemon restart"),
+            ("helper_verification", "helper verification"),
+            ("live_handshake", "live helper handshake"),
+            ("protocol_ping", "protocol ping"),
+        ] {
+            let error =
+                post_install_failure(stage, io::Error::other("private remote stderr and path"));
+            assert_eq!(error_code(&error), "bootstrap_install_failed");
+            assert!(error.to_string().contains(expected));
+            assert!(!error.to_string().contains("private remote"));
+        }
+        let runtime = classify_ssh_command_failure(
+            Some(90),
+            b"boomux-runtime-v1:unsafe:90\nprivate remote stderr",
+        );
+        let preserved = post_install_failure("daemon_status", runtime);
+        assert_eq!(error_code(&preserved), "bootstrap_runtime_unavailable");
+        assert!(!preserved.to_string().contains("private remote"));
+    }
+
+    #[test]
+    fn daemon_status_distinguishes_absent_compatible_and_incompatible() {
+        assert_eq!(
+            parse_remote_daemon_status(b"boomux-daemon-status-v1\0absent\0").unwrap(),
+            RemoteDaemonStatus::Absent
+        );
+        for (version, expected) in [
+            (
+                21,
+                RemoteDaemonStatus::Present {
+                    protocol_version: 21,
+                    pid: None,
+                    executable: None,
+                    socket_device: None,
+                    socket_inode: None,
+                },
+            ),
+            (
+                protocol::PROTOCOL_VERSION,
+                RemoteDaemonStatus::Present {
+                    protocol_version: protocol::PROTOCOL_VERSION,
+                    pid: None,
+                    executable: None,
+                    socket_device: None,
+                    socket_inode: None,
+                },
+            ),
+            (
+                protocol::PROTOCOL_VERSION + 1,
+                RemoteDaemonStatus::Present {
+                    protocol_version: protocol::PROTOCOL_VERSION + 1,
+                    pid: None,
+                    executable: None,
+                    socket_device: None,
+                    socket_inode: None,
+                },
+            ),
+        ] {
+            let status = format!(
+                "{{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{{\"protocol_version\":{version}}}}}"
+            );
+            assert_eq!(
+                parse_remote_daemon_status(status.as_bytes()).unwrap(),
+                expected
+            );
+        }
+        let status = br#"{"schema":"boomux.cli/v1","command":"daemon.status","data":{"protocol_version":38,"pid":42,"executable":"/custom/path with spaces/boomux","socket_device":7,"socket_inode":8}}"#;
+        let parsed = parse_remote_daemon_status(status).unwrap();
+        assert!(parsed.proves_executable(
+            &RemoteExecutable::parse("/custom/path with spaces/boomux").unwrap()
+        ));
+        assert!(!parsed.proves_executable(&RemoteExecutable::parse("/other/boomux").unwrap()));
+
+        let runtime = runtime_directory();
+        fs::create_dir(&runtime).unwrap();
+        fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", &remote_daemon_status_command()])
+            .env("HOME", &runtime)
+            .env("XDG_RUNTIME_DIR", &runtime);
+        let output = run_bounded_command(command, Duration::from_secs(1)).unwrap();
+        assert_eq!(
+            parse_remote_daemon_status(&output.stdout).unwrap(),
+            RemoteDaemonStatus::Absent
+        );
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn running_non_destination_helper_rejects_shadow_upgrade_before_remote_mutation() {
+        for (helper_path, daemon_executable) in [
+            ("/usr/bin/boomux", "/usr/bin/boomux"),
+            ("/custom/bin/boomux", "/custom/bin/boomux"),
+            (
+                "/custom/path with spaces/boomux",
+                "/custom/path with spaces/boomux",
+            ),
+            (
+                "/home/person/.local/bin/boomux",
+                "/deleted/undiscovered/boomux",
+            ),
+        ] {
+            let runtime = runtime_directory();
+            fs::create_dir_all(&runtime).unwrap();
+            let mutated = runtime.join("mutated");
+            let log = runtime.join("ssh.log");
+            let ssh = runtime.join("ssh");
+            let status = serde_json::json!({
+                "schema": "boomux.cli/v1",
+                "command": "daemon.status",
+                "data": {
+                    "protocol_version": 21,
+                    "pid": 123,
+                    "executable": daemon_executable,
+                }
+            })
+            .to_string();
+            fs::write(
+                &ssh,
+                format!(
+                    "#!/bin/sh\n{CONTROL_MASTER_SCRIPT}\nlast=\nfor arg do last=$arg; done\nprintf '%s\\n' \"$last\" >> {}\ncase \"$last\" in\n  *'daemon status --json'*) printf '%s' {} ;;\n  *'boomux-install-transaction-v1'*) cat >/dev/null; printf 'boomux-install-transaction-v1\\0.boomux.bootstrap.ABC12345\\0' ;;\n  *'daemon restart'*|*'daemon stop'*) : > {}; exit 99 ;;\n  *) exit 64 ;;\nesac\n",
+                    quote_posix_shell(log.to_str().unwrap()),
+                    quote_posix_shell(&status),
+                    quote_posix_shell(mutated.to_str().unwrap()),
+                ),
+            )
+            .unwrap();
+            fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+            let session = BootstrapSession::open_at(
+                &runtime,
+                None,
+                SshTarget::parse("workbox").unwrap(),
+                SshAuthenticationMode::Batch,
+                Duration::from_secs(1),
+                ssh.as_os_str(),
+            )
+            .unwrap();
+            let plan = RemoteInstallPlan {
+                target: SshTarget::parse("workbox").unwrap(),
+                destination: RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+                source: RemoteInstallSource::CurrentBinary {
+                    path: runtime.join("pinned"),
+                    sha256: format!("{:x}", Sha256::digest(b"replacement")),
+                    bytes: b"replacement".to_vec(),
+                },
+                reason: RemoteInstallReason::Upgrade,
+                bootstrap_id: Some(session.id),
+                upgrade_helper: Some(RemoteExecutable::parse(helper_path).unwrap()),
+            };
+            let error = session
+                .install_and_connect(&plan, Duration::from_secs(1))
+                .err()
+                .expect("shadow upgrade must fail");
+            assert_eq!(error_code(&error), "upgrade_required");
+            assert!(error.to_string().contains(helper_path));
+            assert!(error.to_string().contains("owner or package mechanism"));
+            assert!(error.to_string().contains("explicitly stop the daemon"));
+            assert!(!mutated.exists());
+            let commands = fs::read_to_string(&log).unwrap();
+            assert!(commands.contains("/new\" daemon status --json"));
+            assert!(commands.contains("boomux-install-transaction-v1"));
+            fs::remove_dir_all(runtime).unwrap();
+        }
+    }
+
+    #[test]
+    fn missing_helper_requires_proven_socket_absence_before_remote_mutation() {
+        for (case, probe) in [
+            (
+                "undiscovered daemon",
+                "printf 'boomux-daemon-presence-v1\\0present\\0'",
+            ),
+            (
+                "stale socket",
+                "printf 'boomux-daemon-presence-v1\\0present\\0'",
+            ),
+            ("unknown presence", "exit 71"),
+        ] {
+            let runtime = runtime_directory();
+            fs::create_dir_all(&runtime).unwrap();
+            let mutated = runtime.join("mutated");
+            let ssh = runtime.join("ssh");
+            fs::write(
+                &ssh,
+                format!(
+                    "#!/bin/sh\n{CONTROL_MASTER_SCRIPT}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *'boomux-daemon-presence-v1'*) {probe} ;;\n  *'boomux-install-transaction-v1'*|*'daemon restart'*|*'daemon stop'*) : > {}; exit 99 ;;\n  *) exit 64 ;;\nesac\n",
+                    quote_posix_shell(mutated.to_str().unwrap()),
+                ),
+            )
+            .unwrap();
+            fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+            let session = BootstrapSession::open_at(
+                &runtime,
+                None,
+                SshTarget::parse("workbox").unwrap(),
+                SshAuthenticationMode::Batch,
+                Duration::from_secs(1),
+                ssh.as_os_str(),
+            )
+            .unwrap();
+            let plan = RemoteInstallPlan {
+                target: SshTarget::parse("workbox").unwrap(),
+                destination: RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+                source: RemoteInstallSource::CurrentBinary {
+                    path: runtime.join("pinned"),
+                    sha256: format!("{:x}", Sha256::digest(b"replacement")),
+                    bytes: b"replacement".to_vec(),
+                },
+                reason: RemoteInstallReason::Missing,
+                bootstrap_id: Some(session.id),
+                upgrade_helper: None,
+            };
+            let error = session
+                .install_and_connect(&plan, Duration::from_secs(1))
+                .err()
+                .unwrap_or_else(|| panic!("{case} must prevent installation"));
+            assert_eq!(error_code(&error), "install_required", "{case}");
+            assert!(!mutated.exists(), "{case}");
+            fs::remove_dir_all(runtime).unwrap();
+        }
+    }
+
+    #[test]
+    fn live_helper_handshake_preserves_runtime_discovery_failure() {
+        let unsafe_runtime = runtime_directory();
+        fs::create_dir(&unsafe_runtime).unwrap();
+        fs::set_permissions(&unsafe_runtime, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", &format!("{REMOTE_RUNTIME_PREFIX}exec false")])
+            .env("XDG_RUNTIME_DIR", &unsafe_runtime);
+        let helper = CompatibleRemoteHelper {
+            executable: RemoteExecutable::parse("/bin/false").unwrap(),
+            handshake: FederationHandshake {
+                version: FEDERATION_VERSION,
+                node_id: Uuid::new_v4().to_string(),
+                helper_version: "test".into(),
+                core_protocol_version: protocol::PROTOCOL_VERSION,
+                connection_mode: FederationConnectionMode::AdHoc,
+            },
+            bootstrap_id: None,
+        };
+        let error = connect_remote_command(command, helper, Duration::from_secs(1), None)
+            .err()
+            .expect("unsafe runtime must fail before the helper handshake");
+        assert_eq!(error_code(&error), "bootstrap_runtime_unavailable");
+        assert!(error.to_string().contains("owner-controlled"));
+        fs::remove_dir_all(unsafe_runtime).unwrap();
     }
 
     #[test]
@@ -1738,6 +4535,162 @@ mod tests {
     }
 
     #[test]
+    fn master_stderr_is_mirrored_live_only_for_interactive_authentication() {
+        let challenge = b"To authenticate, visit:\nhttps://login.tailscale.test/a?c=123\n\xff";
+        for authentication in [
+            SshAuthenticationMode::Interactive,
+            SshAuthenticationMode::Batch,
+        ] {
+            let runtime = runtime_directory();
+            fs::create_dir_all(&runtime).unwrap();
+            let first = shell_printf(&challenge[..17]);
+            let second = shell_printf(&challenge[17..43]);
+            let third = shell_printf(&challenge[43..]);
+            let ssh = write_master_stderr_ssh(
+                &runtime,
+                &format!(
+                    "{first} >&2; {second} >&2; {third} >&2; : > \"$control.ready\"; trap 'rm -f \"$control.ready\"' EXIT HUP INT TERM; while :; do sleep 60; done"
+                ),
+            );
+            let (mut mirrored, mirror) = std::os::unix::net::UnixStream::pair().unwrap();
+            mirrored
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .unwrap();
+            let session = BootstrapSession::open_at_with_mirror(
+                &runtime,
+                None,
+                SshTarget::parse("workbox").unwrap(),
+                authentication,
+                Duration::from_secs(2),
+                ssh.as_os_str(),
+                Some(Box::new(mirror)),
+            )
+            .unwrap();
+
+            if authentication == SshAuthenticationMode::Interactive {
+                let mut output = vec![0; challenge.len()];
+                mirrored.read_exact(&mut output).unwrap();
+                assert_eq!(output, challenge);
+            } else {
+                let mut byte = [0];
+                assert_eq!(mirrored.read(&mut byte).unwrap(), 0);
+            }
+            drop(session);
+            fs::remove_dir_all(runtime).unwrap();
+        }
+    }
+
+    #[test]
+    fn master_stderr_classification_uses_retained_bytes_without_batch_mirroring() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let private =
+            b"private challenge: https://login.test/token\nPermission denied (publickey).\n";
+        let first = shell_printf(&private[..31]);
+        let second = shell_printf(&private[31..]);
+        let ssh =
+            write_master_stderr_ssh(&runtime, &format!("{first} >&2; {second} >&2; exit 255"));
+        let mirror_path = runtime.join("batch-mirror");
+        let mirror = fs::File::create(&mirror_path).unwrap();
+        let error = BootstrapSession::open_at_with_mirror(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(2),
+            ssh.as_os_str(),
+            Some(Box::new(mirror)),
+        )
+        .err()
+        .expect("the fake master must fail authentication");
+        assert_eq!(error_code(&error), "bootstrap_authentication_failed");
+        assert!(!error.to_string().contains("login.test"));
+        assert!(fs::read(&mirror_path).unwrap().is_empty());
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn master_stderr_truncation_kills_the_waiting_master_and_reports_the_bound() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let oversized = vec![b'x'; MAX_PROBE_STDERR_BYTES + 1];
+        let output = shell_printf(&oversized);
+        let ssh = write_master_stderr_ssh(
+            &runtime,
+            &format!(
+                "{output} >&2; : > \"$control.ready\"; trap 'rm -f \"$control.ready\"' EXIT HUP INT TERM; while :; do sleep 60; done"
+            ),
+        );
+        let mirror_path = runtime.join("interactive-mirror");
+        let mirror = fs::File::create(&mirror_path).unwrap();
+        let started = Instant::now();
+        let error = BootstrapSession::open_at_with_mirror(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Interactive,
+            Duration::from_secs(10),
+            ssh.as_os_str(),
+            Some(Box::new(mirror)),
+        )
+        .err()
+        .expect("oversized master stderr must fail");
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert_eq!(error_code(&error), "bootstrap_transport_failed");
+        assert!(error.to_string().contains("exceeded the supported bound"));
+        assert_eq!(
+            fs::read(&mirror_path).unwrap(),
+            &oversized[..MAX_PROBE_STDERR_BYTES]
+        );
+        assert!(
+            fs::read_dir(&runtime)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| {
+                    !entry.file_type().unwrap().is_dir()
+                        || !entry.file_name().to_string_lossy().starts_with("ssh-")
+                })
+        );
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn real_ssh_missing_master_cannot_fall_back_to_a_network_connection() {
+        let runtime = runtime_directory();
+        let (directory, config, control) = prepare_ssh_directory(&runtime, None).unwrap();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let mut file = OpenOptions::new().append(true).open(&config).unwrap();
+        writeln!(
+            file,
+            "Host workbox\n    HostName 127.0.0.1\n    Port {port}\n    ConnectTimeout 1"
+        )
+        .unwrap();
+        let command = slave_command(
+            OsStr::new("ssh"),
+            &config,
+            &control,
+            &SshTarget::parse("workbox").unwrap(),
+            "true",
+        );
+        let arguments = command_arguments(&command);
+        assert!(
+            arguments
+                .windows(2)
+                .any(|pair| pair == ["-o", "ProxyCommand=/bin/false"])
+        );
+        assert!(run_bounded_command(command, Duration::from_secs(2)).is_err());
+        thread::sleep(Duration::from_millis(50));
+        assert!(matches!(
+            listener.accept(),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock
+        ));
+        fs::remove_dir_all(directory).unwrap();
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
     fn parses_supported_platforms_and_current_release_matrix() {
         let linux = RemotePlatform::parse_probe(b"boomux-platform-v1\0Linux\0x86_64\0").unwrap();
         assert_eq!(linux.operating_system, RemoteOperatingSystem::Linux);
@@ -1751,8 +4704,6 @@ mod tests {
 
         for invalid in [
             &b"wrong\0Linux\0x86_64\0"[..],
-            &b"boomux-platform-v1\0Plan9\0x86_64\0"[..],
-            &b"boomux-platform-v1\0Linux\0mips\0"[..],
             &b"boomux-platform-v1\0Linux\0x86_64"[..],
         ] {
             assert_eq!(
@@ -1760,6 +4711,26 @@ mod tests {
                 io::ErrorKind::InvalidData
             );
         }
+        for unsupported in [
+            &b"boomux-platform-v1\0Plan9\0x86_64\0"[..],
+            &b"boomux-platform-v1\0Linux\0mips\0"[..],
+        ] {
+            let error = RemotePlatform::parse_probe(unsupported).unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+            assert_eq!(error_code(&error), "bootstrap_unsupported_platform");
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn platform_preflight_ignores_a_poisoned_path() {
+        let mut command = Command::new("/bin/sh");
+        command
+            .args(["-c", PLATFORM_PROBE_COMMAND])
+            .env("PATH", "/definitely/not/a/bootstrap/tool/path");
+        let output = run_bounded_command(command, Duration::from_secs(1)).unwrap();
+        let platform = RemotePlatform::parse_probe(&output.stdout).unwrap();
+        assert_eq!(platform.operating_system, RemoteOperatingSystem::Linux);
     }
 
     #[test]
@@ -1775,12 +4746,20 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["/usr/bin/boomux", "/opt/boomux/bin/boomux"]
         );
-        assert_eq!(
-            parse_executable_probe(b"boomux-executables-v1\0relative/boomux\0")
-                .unwrap_err()
-                .kind(),
-            io::ErrorKind::InvalidInput
-        );
+        for invalid in [
+            b"boomux-executables-v1\0relative/boomux\0".to_vec(),
+            b"boomux-executables-v1\0/opt/boomux\nbin\0".to_vec(),
+            {
+                let mut probe = b"boomux-executables-v1\0/".to_vec();
+                probe.extend(std::iter::repeat_n(b'x', MAX_REMOTE_EXECUTABLE_BYTES));
+                probe.push(0);
+                probe
+            },
+        ] {
+            let error = parse_executable_probe(&invalid).unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+            assert_eq!(error_code(&error), "bootstrap_malformed_helper");
+        }
 
         assert_eq!(
             parse_install_destination_probe(
@@ -1790,12 +4769,11 @@ mod tests {
             .as_str(),
             "/home/person/.local/bin/boomux"
         );
-        assert_eq!(
+        let error =
             parse_install_destination_probe(b"boomux-install-destination-v1\0relative/boomux\0")
-                .unwrap_err()
-                .kind(),
-            io::ErrorKind::InvalidInput
-        );
+                .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(error_code(&error), "bootstrap_malformed_helper");
     }
 
     #[test]
@@ -1816,6 +4794,40 @@ mod tests {
     }
 
     #[test]
+    fn executable_probe_hides_only_an_uncommitted_provisional_destination() {
+        let home = runtime_directory();
+        let bin = home.join(".local/bin");
+        let destination = bin.join("boomux");
+        let lock = bin.join(".boomux.bootstrap.lock");
+        fs::create_dir_all(&lock).unwrap();
+        fs::write(&destination, "#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let run = || {
+            let mut command = Command::new("sh");
+            command
+                .args(["-c", EXECUTABLE_PROBE_COMMAND])
+                .env("HOME", &home)
+                .env("PATH", format!("{}:/usr/bin:/bin", bin.display()));
+            let output = run_bounded_command(command, Duration::from_secs(1)).unwrap();
+            parse_executable_probe(&output.stdout).unwrap()
+        };
+        assert!(
+            !run()
+                .iter()
+                .any(|path| path.as_str() == destination.to_str().unwrap())
+        );
+
+        fs::create_dir(lock.join("committed")).unwrap();
+        assert!(
+            run()
+                .iter()
+                .any(|path| path.as_str() == destination.to_str().unwrap())
+        );
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
     fn bounded_runner_captures_output_and_classifies_exit() {
         let mut command = Command::new("sh");
         command.args(["-c", "printf stdout; printf stderr >&2"]);
@@ -1829,7 +4841,7 @@ mod tests {
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(
             error.to_string(),
-            "SSH probe failed; verify target resolution, the SSH service, credentials, and remote shell support"
+            "SSH remote command failed; verify executable access and remote shell support"
         );
     }
 
@@ -1981,7 +4993,7 @@ mod tests {
         fs::write(
             &ssh,
             format!(
-                "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  \"'/bad/boomux' __federation-stdio\") printf 'NOTMAGIC' ;;\n  \"'/good/boomux' __federation-stdio\") {}; dd bs=1 count={} of=/dev/null 2>/dev/null; {} ;;\n  *) exit 64 ;;\nesac\n",
+                "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in *'exec '*) last=${{last##*exec }} ;; esac\ncase \"$last\" in\n  \"'/bad/boomux' __federation-stdio\") printf 'NOTMAGIC' ;;\n  \"'/good/boomux' __federation-stdio\") {}; dd bs=1 count={} of=/dev/null 2>/dev/null; {} ;;\n  *) exit 64 ;;\nesac\n",
                 shell_printf(&handshake_bytes),
                 request_bytes.len(),
                 shell_printf(&response_bytes),
@@ -2006,6 +5018,737 @@ mod tests {
         .unwrap();
         assert_eq!(compatible.executable, candidates[1]);
         assert_eq!(compatible.handshake, handshake);
+        assert_eq!(
+            fs::read_dir(&runtime)
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().starts_with("ssh-"))
+                .count(),
+            0
+        );
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn bootstrap_plans_install_when_no_remote_executable_exists() {
+        let runtime = runtime_directory();
+        let ssh = write_bootstrap_ssh(&runtime, "", "");
+        let plan = plan_remote_bootstrap_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let RemoteBootstrapPlan::Install(plan) = plan else {
+            panic!("expected install plan");
+        };
+        assert_eq!(plan.reason, RemoteInstallReason::Missing);
+        assert_eq!(plan.destination.as_str(), "/home/person/.local/bin/boomux");
+        assert!(matches!(
+            plan.source,
+            RemoteInstallSource::CurrentBinary { .. }
+        ));
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn bootstrap_plans_upgrade_for_a_known_old_protocol_helper() {
+        let runtime = runtime_directory();
+        let ssh = write_bootstrap_ssh(
+            &runtime,
+            "  \"'/old/boomux' __federation-stdio\") exit 2 ;;\n  \"'/old/boomux' --version\") printf 'boomux 0.14.2\\n' ;;",
+            "/old/boomux\\0",
+        );
+        let plan = plan_remote_bootstrap_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        assert!(matches!(
+            plan,
+            RemoteBootstrapPlan::Install(RemoteInstallPlan {
+                reason: RemoteInstallReason::Upgrade,
+                ..
+            })
+        ));
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn bootstrap_keeps_a_compatible_candidate_when_an_old_one_is_also_discovered() {
+        let runtime = runtime_directory();
+        let node_id = Uuid::new_v4().to_string();
+        let good = compatible_helper_script(&node_id);
+        let ssh = write_bootstrap_ssh(
+            &runtime,
+            &format!(
+                "  \"'/old/boomux' __federation-stdio\") exit 2 ;;\n  \"'/old/boomux' --version\") printf 'boomux 0.14.2\\n' ;;\n  \"'/good/boomux' __federation-stdio\") {good} ;;"
+            ),
+            "/old/boomux\\0/good/boomux\\0",
+        );
+        let plan = plan_remote_bootstrap_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let RemoteBootstrapPlan::Ready(helper) = plan else {
+            panic!("expected compatible helper");
+        };
+        assert_eq!(helper.executable.as_str(), "/good/boomux");
+        assert_eq!(helper.handshake.node_id, node_id);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn mixed_compatible_identities_fail_as_a_typed_conflict() {
+        let runtime = runtime_directory();
+        let first = compatible_helper_script(&Uuid::new_v4().to_string());
+        let second = compatible_helper_script(&Uuid::new_v4().to_string());
+        let ssh = write_bootstrap_ssh(
+            &runtime,
+            &format!(
+                "  \"'/first/boomux' __federation-stdio\") {first} ;;\n  \"'/second/boomux' __federation-stdio\") {second} ;;"
+            ),
+            "/first/boomux\\0/second/boomux\\0",
+        );
+        let error = plan_remote_bootstrap_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .err()
+        .expect("identity conflict must fail");
+        assert_eq!(error_code(&error), "node_identity_conflict");
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn newer_helper_is_unsupported_and_never_an_upgrade_candidate() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let handshake = FederationHandshake {
+            version: FEDERATION_VERSION,
+            node_id: Uuid::new_v4().to_string(),
+            helper_version: "future".into(),
+            core_protocol_version: protocol::PROTOCOL_VERSION + 1,
+            connection_mode: FederationConnectionMode::AdHoc,
+        };
+        let mut bytes = Vec::new();
+        crate::federation::write_handshake(&mut bytes, &handshake).unwrap();
+        let ssh = write_bootstrap_ssh(
+            &runtime,
+            &format!(
+                "  \"'/future/boomux' __federation-stdio\") {} ;;\n  \"'/future/boomux' --version\") printf 'boomux 99.0.0\\n' ;;",
+                shell_printf(&bytes)
+            ),
+            "/future/boomux\\0",
+        );
+        let error = plan_remote_bootstrap_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .err()
+        .expect("newer helper must fail");
+        assert_eq!(error_code(&error), "unsupported_version");
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn bootstrap_error_codes_preserve_failure_semantics() {
+        for (error, code) in [
+            (
+                io::Error::new(io::ErrorKind::PermissionDenied, "SSH authentication failed"),
+                "bootstrap_authentication_failed",
+            ),
+            (
+                io::Error::new(io::ErrorKind::ConnectionAborted, "route EOF"),
+                "bootstrap_transport_failed",
+            ),
+            (
+                invalid_probe("remote helper returned an invalid header"),
+                "bootstrap_malformed_helper",
+            ),
+            (
+                RemotePlatform::parse_probe(b"boomux-platform-v1\0Linux\0mips\0").unwrap_err(),
+                "bootstrap_unsupported_platform",
+            ),
+            (
+                io::Error::other("remote Boomux install failed"),
+                "bootstrap_install_failed",
+            ),
+        ] {
+            assert_eq!(error_code(&error), code);
+        }
+    }
+
+    #[test]
+    fn stalled_candidate_cannot_starve_a_later_compatible_helper() {
+        let runtime = runtime_directory();
+        let node_id = Uuid::new_v4().to_string();
+        let good = compatible_helper_script(&node_id);
+        let ssh = write_bootstrap_ssh(
+            &runtime,
+            &format!(
+                "  \"'/stalled/boomux' __federation-stdio\") sleep 2 ;;\n  \"'/good/boomux' __federation-stdio\") {good} ;;"
+            ),
+            "/stalled/boomux\\0/good/boomux\\0",
+        );
+        let plan = plan_remote_bootstrap_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_millis(400),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let RemoteBootstrapPlan::Ready(helper) = plan else {
+            panic!("expected compatible helper");
+        };
+        assert_eq!(helper.executable.as_str(), "/good/boomux");
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn inaccessible_and_malformed_candidates_do_not_authorize_replacement() {
+        for (executable_case, expected_code) in [
+            (
+                "  \"'/bad/boomux' __federation-stdio\" | \"'/bad/boomux' --version\") exit 126 ;;",
+                "bootstrap_transport_failed",
+            ),
+            (
+                "  \"'/bad/boomux' __federation-stdio\") printf 'NOTMAGIC' ;;\n  \"'/bad/boomux' --version\") printf 'boomux 0.14.2\\n' ;;",
+                "bootstrap_malformed_helper",
+            ),
+        ] {
+            let runtime = runtime_directory();
+            let ssh = write_bootstrap_ssh(&runtime, executable_case, "/bad/boomux\\0");
+            let error = plan_remote_bootstrap_at(
+                &runtime,
+                None,
+                SshTarget::parse("workbox").unwrap(),
+                SshAuthenticationMode::Batch,
+                Duration::from_secs(1),
+                ssh.as_os_str(),
+            )
+            .err()
+            .expect("candidate must fail closed");
+            assert_eq!(error_code(&error), expected_code);
+            fs::remove_dir_all(runtime).unwrap();
+        }
+    }
+
+    #[test]
+    fn unreleased_local_protocol_has_no_compatible_published_release() {
+        let error = select_published_release("x86_64-unknown-linux-gnu").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+        assert!(error.to_string().contains("local protocol 38"));
+        assert!(error.to_string().contains("manually stream"));
+    }
+
+    #[test]
+    fn session_rolls_back_prior_helper_after_installed_binary_cannot_execute() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let remote = runtime.join("remote");
+        fs::create_dir_all(&remote).unwrap();
+        let destination = remote.join("boomux");
+        let backup = remote.join("backup");
+        let restart = remote.join("restart");
+        fs::write(&destination, b"previous-helper").unwrap();
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\n{control}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *'boomux-install-transaction-v1'*) mv {destination} {backup}; cat > {destination}; printf 'boomux-install-transaction-v1\\0.boomux.bootstrap.ABC12345\\0' ;;\n  *'transaction/watchdog_pid'*'daemon stop'*) cat >/dev/null; rm -f {destination}; mv {backup} {destination} ;;\n  *'daemon status --json'*) exit 126 ;;\n  *'daemon restart'*) : > {restart} ;;\n  *\"'/home/person/.local/bin/boomux' __federation-stdio\" | \"'/home/person/.local/bin/boomux' --version\") exit 126 ;;\n  *) exit 64 ;;\nesac\n",
+                control = CONTROL_MASTER_SCRIPT,
+                destination = quote_posix_shell(destination.to_str().unwrap()),
+                backup = quote_posix_shell(backup.to_str().unwrap()),
+                restart = quote_posix_shell(restart.to_str().unwrap()),
+            ),
+        )
+        .unwrap();
+        let script = fs::read_to_string(&ssh).unwrap().replace(
+            &format!(
+                "mv {} {}; cat > {};",
+                quote_posix_shell(destination.to_str().unwrap()),
+                quote_posix_shell(backup.to_str().unwrap()),
+                quote_posix_shell(destination.to_str().unwrap())
+            ),
+            "cat >/dev/null;",
+        );
+        fs::write(&ssh, script).unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let plan = RemoteInstallPlan {
+            target: SshTarget::parse("workbox").unwrap(),
+            destination: RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            source: RemoteInstallSource::CurrentBinary {
+                path: runtime.join("pinned"),
+                sha256: format!("{:x}", Sha256::digest(b"wrong-abi")),
+                bytes: b"wrong-abi".to_vec(),
+            },
+            reason: RemoteInstallReason::Upgrade,
+            bootstrap_id: Some(session.id),
+            upgrade_helper: Some(
+                RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            ),
+        };
+
+        assert!(
+            session
+                .install_and_connect(&plan, Duration::from_secs(1))
+                .is_err()
+        );
+        assert_eq!(fs::read(&destination).unwrap(), b"previous-helper");
+        assert!(!backup.exists());
+        assert!(!restart.exists());
+        assert_eq!(
+            fs::read_dir(&runtime)
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().starts_with("ssh-"))
+                .count(),
+            0
+        );
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn post_install_protocol_ping_eof_rolls_back_before_commit() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let destination = runtime.join("destination");
+        let backup = runtime.join("backup");
+        let count = runtime.join("count");
+        let committed = runtime.join("committed");
+        fs::write(&destination, b"previous-helper").unwrap();
+        let handshake = FederationHandshake {
+            version: FEDERATION_VERSION,
+            node_id: Uuid::new_v4().to_string(),
+            helper_version: "test".into(),
+            core_protocol_version: protocol::PROTOCOL_VERSION,
+            connection_mode: FederationConnectionMode::AdHoc,
+        };
+        let mut handshake_bytes = Vec::new();
+        crate::federation::write_handshake(&mut handshake_bytes, &handshake).unwrap();
+        let mut request = Vec::new();
+        protocol::write_message(
+            &mut request,
+            &Envelope::with_version(protocol::PROTOCOL_VERSION, Request::Ping),
+        )
+        .unwrap();
+        let mut pong = Vec::new();
+        protocol::write_message(
+            &mut pong,
+            &Envelope::with_version(protocol::PROTOCOL_VERSION, Response::Pong),
+        )
+        .unwrap();
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\n{control}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *'boomux-install-transaction-v1'*) mv {destination} {backup}; cat > {destination}; printf 'boomux-install-transaction-v1\\0.boomux.bootstrap.ABC12345\\0' ;;\n  *'transaction/watchdog_pid'*'restore_install'*) cat >/dev/null; rm -f {destination}; mv {backup} {destination} ;;\n  *'daemon status --json'*) printf '%s' '{{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{{\"protocol_version\":38}}}}' ;;\n  *'daemon restart'*) exit 99 ;;\n  *'rm -f \"$transaction/backup\"'*) cat >/dev/null; : > {committed} ;;\n  *\"'/home/person/.local/bin/boomux' __federation-stdio\") n=0; [ ! -f {count} ] || n=$(cat {count}); n=$((n + 1)); printf '%s' \"$n\" > {count}; {handshake}; dd bs=1 count={request_len} of=/dev/null 2>/dev/null; [ \"$n\" -eq 1 ] && {pong} ;;\n  *) exit 64 ;;\nesac\n",
+                control = CONTROL_MASTER_SCRIPT,
+                destination = quote_posix_shell(destination.to_str().unwrap()),
+                backup = quote_posix_shell(backup.to_str().unwrap()),
+                committed = quote_posix_shell(committed.to_str().unwrap()),
+                count = quote_posix_shell(count.to_str().unwrap()),
+                handshake = shell_printf(&handshake_bytes),
+                request_len = request.len(),
+                pong = shell_printf(&pong),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        add_fake_daemon_identity(&ssh, "/home/person/.local/bin/boomux");
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let plan = RemoteInstallPlan {
+            target: SshTarget::parse("workbox").unwrap(),
+            destination: RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            source: RemoteInstallSource::CurrentBinary {
+                path: runtime.join("pinned"),
+                sha256: format!("{:x}", Sha256::digest(b"replacement")),
+                bytes: b"replacement".to_vec(),
+            },
+            reason: RemoteInstallReason::Upgrade,
+            bootstrap_id: Some(session.id),
+            upgrade_helper: Some(
+                RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            ),
+        };
+        let error = session
+            .install_and_connect(&plan, Duration::from_secs(1))
+            .err()
+            .expect("post-install ping EOF must fail");
+        assert_eq!(error_code(&error), "bootstrap_transport_failed");
+        assert_eq!(fs::read(&destination).unwrap(), b"previous-helper");
+        assert!(!backup.exists());
+        assert!(!committed.exists());
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn compatible_running_daemon_is_checked_without_restart_before_commit() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let destination = runtime.join("destination");
+        let backup = runtime.join("backup");
+        let count = runtime.join("count");
+        let committed = runtime.join("committed");
+        let status_checked = runtime.join("status-checked");
+        fs::write(&destination, b"previous-helper").unwrap();
+        let helper = compatible_helper_script(&Uuid::new_v4().to_string());
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\n{control}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *'boomux-install-transaction-v1'*) mv {destination} {backup}; cat > {destination}; printf 'boomux-install-transaction-v1\\0.boomux.bootstrap.ABC12345\\0' ;;\n  *'committed=$lock/committed'*) cat >/dev/null; [ \"$(cat {count})\" -eq 2 ]; : > {committed}; printf 'boomux-install-commit-v1\\0committed\\0' ;;\n  *'transaction/watchdog_pid'*'daemon stop'*) exit 70 ;;\n  *'daemon status --json'*) : > {status_checked}; printf '%s' '{{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{{\"protocol_version\":38}}}}' ;;\n  *'daemon restart'*) exit 99 ;;\n  *\"'/home/person/.local/bin/boomux' __federation-stdio\") n=0; [ ! -f {count} ] || n=$(cat {count}); n=$((n + 1)); printf '%s' \"$n\" > {count}; {helper} ;;\n  *) exit 64 ;;\nesac\n",
+                control = CONTROL_MASTER_SCRIPT,
+                destination = quote_posix_shell(destination.to_str().unwrap()),
+                backup = quote_posix_shell(backup.to_str().unwrap()),
+                count = quote_posix_shell(count.to_str().unwrap()),
+                committed = quote_posix_shell(committed.to_str().unwrap()),
+                status_checked = quote_posix_shell(status_checked.to_str().unwrap()),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        add_fake_daemon_identity(&ssh, "/home/person/.local/bin/boomux");
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let plan = RemoteInstallPlan {
+            target: SshTarget::parse("workbox").unwrap(),
+            destination: RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            source: RemoteInstallSource::CurrentBinary {
+                path: runtime.join("pinned"),
+                sha256: format!("{:x}", Sha256::digest(b"replacement")),
+                bytes: b"replacement".to_vec(),
+            },
+            reason: RemoteInstallReason::Upgrade,
+            bootstrap_id: Some(session.id),
+            upgrade_helper: Some(
+                RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            ),
+        };
+        let connection = session
+            .install_and_connect(&plan, Duration::from_secs(1))
+            .unwrap();
+        assert!(committed.exists());
+        assert!(status_checked.exists());
+        assert!(backup.exists());
+        assert_eq!(fs::read_to_string(&count).unwrap(), "2");
+        drop(connection);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn upgrade_with_absent_daemon_refuses_before_activation() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let destination = runtime.join("destination");
+        let backup = runtime.join("backup");
+        let count = runtime.join("count");
+        let started = runtime.join("started-by-helper");
+        let restarted = runtime.join("explicit-restart");
+        let committed = runtime.join("committed");
+        fs::write(&destination, b"previous-helper").unwrap();
+        let helper = compatible_helper_script(&Uuid::new_v4().to_string());
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\n{control}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *'boomux-install-transaction-v1'*) mv {destination} {backup}; cat > {destination}; printf 'boomux-install-transaction-v1\\0.boomux.bootstrap.ABC12345\\0' ;;\n  *': > \"$transaction/daemon_absent\"'*) cat >/dev/null ;;\n  *'committed=$lock/committed'*) cat >/dev/null; [ \"$(cat {count})\" -eq 2 ]; : > {committed}; printf 'boomux-install-commit-v1\\0committed\\0' ;;\n  *'daemon status --json'*) if [ -e {started} ]; then printf '%s' '{{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{{\"protocol_version\":38}}}}'; else printf 'boomux-daemon-status-v1\\0absent\\0'; fi ;;\n  *'daemon restart'*) : > {restarted} ;;\n  *\"'/home/person/.local/bin/boomux' __federation-stdio\") : > {started}; n=0; [ ! -f {count} ] || n=$(cat {count}); n=$((n + 1)); printf '%s' \"$n\" > {count}; {helper} ;;\n  *) exit 64 ;;\nesac\n",
+                control = CONTROL_MASTER_SCRIPT,
+                destination = quote_posix_shell(destination.to_str().unwrap()),
+                backup = quote_posix_shell(backup.to_str().unwrap()),
+                count = quote_posix_shell(count.to_str().unwrap()),
+                started = quote_posix_shell(started.to_str().unwrap()),
+                restarted = quote_posix_shell(restarted.to_str().unwrap()),
+                committed = quote_posix_shell(committed.to_str().unwrap()),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let plan = RemoteInstallPlan {
+            target: SshTarget::parse("workbox").unwrap(),
+            destination: RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            source: RemoteInstallSource::CurrentBinary {
+                path: runtime.join("pinned"),
+                sha256: format!("{:x}", Sha256::digest(b"replacement")),
+                bytes: b"replacement".to_vec(),
+            },
+            reason: RemoteInstallReason::Upgrade,
+            bootstrap_id: Some(session.id),
+            upgrade_helper: Some(
+                RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            ),
+        };
+        let error = session
+            .install_and_connect(&plan, Duration::from_secs(1))
+            .err()
+            .expect("upgrade requires a running daemon identity");
+        assert_eq!(error_code(&error), "upgrade_required");
+        assert!(!restarted.exists());
+        assert!(!committed.exists());
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn unset_runtime_old_daemon_upgrade_restarts_verifies_pings_and_commits() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let destination = runtime.join("destination");
+        let backup = runtime.join("backup");
+        let socket = runtime.join("remote-runtime/boomux/daemon.sock");
+        let restarted = runtime.join("restarted");
+        let committed = runtime.join("committed");
+        let count = runtime.join("helper-count");
+        let log = runtime.join("stages");
+        fs::create_dir_all(socket.parent().unwrap()).unwrap();
+        fs::write(&socket, b"existing-socket").unwrap();
+        fs::write(&destination, b"protocol-21-helper").unwrap();
+
+        let old_handshake = FederationHandshake {
+            version: FEDERATION_VERSION,
+            node_id: Uuid::new_v4().to_string(),
+            helper_version: "old".into(),
+            core_protocol_version: protocol::PROTOCOL_VERSION,
+            connection_mode: FederationConnectionMode::AdHoc,
+        };
+        let current_helper = compatible_helper_script(&old_handshake.node_id);
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\n{control}\nunset XDG_RUNTIME_DIR\nlast=\nfor arg do last=$arg; done\nrequire_runtime() {{ case \"$last\" in *boomux-runtime-v1*'/run/user/$boomux_uid'*'export XDG_RUNTIME_DIR'*) [ -e {socket} ] ;; *) return 1 ;; esac; }}\ncase \"$last\" in\n  *'boomux-install-transaction-v1'*) mv {destination} {backup}; cat > {destination}; printf 'boomux-install-transaction-v1\\0.boomux.bootstrap.ABC12345\\0'; printf 'install\\n' >> {log} ;;\n  *': > \"$transaction/restarted\"'*) cat >/dev/null; : > {restarted}; printf 'mark-restarted\\n' >> {log} ;;\n  *'committed=$lock/committed'*) cat >/dev/null; [ \"$(cat {count})\" -eq 3 ]; : > {committed}; printf 'commit\\n' >> {log}; printf 'boomux-install-commit-v1\\0committed\\0' ;;\n  *'daemon status --json'*) require_runtime || exit 97; [ -e {socket} ] || exit 98; printf 'status\\n' >> {log}; printf '%s' '{{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{{\"protocol_version\":21}}}}' ;;\n  *'daemon restart'*) require_runtime || exit 97; [ -e {socket} ] || exit 98; : > {restarted}; printf 'restart\\n' >> {log} ;;\n  *\"'/home/person/.local/bin/boomux' __federation-stdio\") require_runtime || exit 97; [ -e {socket} ] || exit 98; n=0; [ ! -e {count} ] || n=$(cat {count}); n=$((n + 1)); printf '%s' \"$n\" > {count}; if [ \"$n\" -eq 1 ]; then printf 'helper-old\\n' >> {log}; {old_handshake}; else printf 'helper-current\\n' >> {log}; {current_helper}; fi ;;\n  \"'/home/person/.local/bin/boomux' --version\") printf 'version\\n' >> {log}; printf 'boomux {version}\\n' ;;\n  *) exit 64 ;;\nesac\n",
+                control = CONTROL_MASTER_SCRIPT,
+                socket = quote_posix_shell(socket.to_str().unwrap()),
+                destination = quote_posix_shell(destination.to_str().unwrap()),
+                backup = quote_posix_shell(backup.to_str().unwrap()),
+                restarted = quote_posix_shell(restarted.to_str().unwrap()),
+                committed = quote_posix_shell(committed.to_str().unwrap()),
+                count = quote_posix_shell(count.to_str().unwrap()),
+                log = quote_posix_shell(log.to_str().unwrap()),
+                old_handshake = current_helper,
+                version = env!("CARGO_PKG_VERSION"),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        add_fake_daemon_identity(&ssh, "/home/person/.local/bin/boomux");
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let plan = RemoteInstallPlan {
+            target: SshTarget::parse("workbox").unwrap(),
+            destination: RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            source: RemoteInstallSource::CurrentBinary {
+                path: runtime.join("pinned"),
+                sha256: format!("{:x}", Sha256::digest(b"replacement")),
+                bytes: b"replacement".to_vec(),
+            },
+            reason: RemoteInstallReason::Upgrade,
+            bootstrap_id: Some(session.id),
+            upgrade_helper: Some(
+                RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            ),
+        };
+        let connection = session
+            .install_and_connect(&plan, Duration::from_secs(1))
+            .unwrap();
+        assert!(restarted.exists());
+        assert!(committed.exists());
+        assert_eq!(fs::read(&destination).unwrap(), b"replacement");
+        assert_eq!(
+            fs::read_to_string(&log).unwrap(),
+            "install\nstatus\nhelper-old\nstatus\nmark-restarted\nrestart\nhelper-current\nhelper-current\ncommit\n"
+        );
+        drop(connection);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn lost_commit_ack_is_unknown_and_exact_retry_discovers_installed_helper() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let destination = runtime.join("destination");
+        let backup = runtime.join("backup");
+        let installed = runtime.join("installed");
+        let committed = runtime.join("committed");
+        fs::write(&destination, b"previous-helper").unwrap();
+        let helper = compatible_helper_script(&Uuid::new_v4().to_string());
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\n{control}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0'; [ -e {installed} ] && printf '/home/person/.local/bin/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/person/.local/bin/boomux\\0' ;;\n  *'boomux-install-transaction-v1'*) mv {destination} {backup}; cat > {destination}; : > {installed}; printf 'boomux-install-transaction-v1\\0.boomux.bootstrap.ABC12345\\0' ;;\n  *'committed=$lock/committed'*) cat >/dev/null; : > {committed}; printf 'boomux-install-commit-v1\\0committed'; exit 255 ;;\n  *'daemon status --json'*) printf '%s' '{{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{{\"protocol_version\":38}}}}' ;;\n  *'daemon restart'*) exit 99 ;;\n  *\"'/home/person/.local/bin/boomux' __federation-stdio\") {helper} ;;\n  *) exit 64 ;;\nesac\n",
+                control = CONTROL_MASTER_SCRIPT,
+                destination = quote_posix_shell(destination.to_str().unwrap()),
+                backup = quote_posix_shell(backup.to_str().unwrap()),
+                installed = quote_posix_shell(installed.to_str().unwrap()),
+                committed = quote_posix_shell(committed.to_str().unwrap()),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        add_fake_daemon_identity(&ssh, "/home/person/.local/bin/boomux");
+
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let plan = RemoteInstallPlan {
+            target: SshTarget::parse("workbox").unwrap(),
+            destination: RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            source: RemoteInstallSource::CurrentBinary {
+                path: runtime.join("pinned"),
+                sha256: format!("{:x}", Sha256::digest(b"replacement")),
+                bytes: b"replacement".to_vec(),
+            },
+            reason: RemoteInstallReason::Upgrade,
+            bootstrap_id: Some(session.id),
+            upgrade_helper: Some(
+                RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            ),
+        };
+        let error = session
+            .install_and_connect(&plan, Duration::from_secs(1))
+            .err()
+            .expect("lost commit acknowledgment must be unknown");
+        assert_eq!(error_code(&error), "bootstrap_commit_outcome_unknown");
+        assert!(committed.exists());
+        assert_eq!(fs::read(&destination).unwrap(), b"replacement");
+        assert!(backup.exists());
+
+        let mut retry = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let RemoteBootstrapPlan::Ready(helper) = retry.plan(Duration::from_secs(1)).unwrap() else {
+            panic!("exact retry must discover the committed compatible helper");
+        };
+        let mut connection = retry.connect(helper, Duration::from_secs(1)).unwrap();
+        connection
+            .ping_with_timeout(Duration::from_secs(1))
+            .unwrap();
+        drop(connection);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn observation_from_one_master_cannot_authorize_another_route() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!("#!/bin/sh\n{CONTROL_MASTER_SCRIPT}\nexit 64\n"),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        let first = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let second = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let helper = CompatibleRemoteHelper {
+            executable: RemoteExecutable::parse("/remote/boomux").unwrap(),
+            handshake: FederationHandshake {
+                version: FEDERATION_VERSION,
+                node_id: Uuid::new_v4().to_string(),
+                helper_version: "test".into(),
+                core_protocol_version: protocol::PROTOCOL_VERSION,
+                connection_mode: FederationConnectionMode::AdHoc,
+            },
+            bootstrap_id: Some(first.id),
+        };
+        let error = second
+            .connect(helper, Duration::from_secs(1))
+            .err()
+            .expect("cross-master observation must fail");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(error.to_string().contains("different bootstrap endpoint"));
+        drop(first);
         assert_eq!(
             fs::read_dir(&runtime)
                 .unwrap()
@@ -2097,19 +5840,488 @@ mod tests {
         let destination = directory.join(".local/bin/boomux");
         fs::write(&destination, b"previous").unwrap();
         fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
-        let mut command = Command::new("sh");
-        command
-            .args(["-c", REMOTE_INSTALL_COMMAND])
-            .env("HOME", &directory);
-        run_streaming_command(command, b"replacement".to_vec(), Duration::from_secs(1)).unwrap();
+        let install = REMOTE_INSTALL_COMMAND.replace("lease_limit=180", "lease_limit=1");
+        let transaction = run_local_upload_with_command(&directory, b"replacement", "sh", &install);
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        run_local_activation(&directory, "sh", &transaction, RemoteInstallReason::Missing);
         assert_eq!(fs::read(&destination).unwrap(), b"replacement");
         assert_eq!(fs::metadata(&destination).unwrap().mode() & 0o777, 0o755);
+        let commit = REMOTE_INSTALL_COMMIT_COMMAND.replace("sleep 180", "sleep 3");
+        let mut child = Command::new("sh");
+        child.args(["-c", &commit]).env("HOME", &directory);
+        let output =
+            run_streaming_command_capture(child, transaction.input(), Duration::from_secs(1))
+                .unwrap();
+        parse_install_commit(&output.stdout).unwrap();
+        let mut retry = Command::new("sh");
+        retry.args(["-c", &commit]).env("HOME", &directory);
+        let retry =
+            run_streaming_command_capture(retry, transaction.input(), Duration::from_secs(1))
+                .unwrap();
+        parse_install_commit(&retry.stdout).unwrap();
         assert!(
-            fs::read_dir(directory.join(".local/bin"))
-                .unwrap()
-                .filter_map(Result::ok)
-                .all(|entry| !entry.file_name().to_string_lossy().starts_with(".boomux."))
+            directory
+                .join(".local/bin/.boomux.bootstrap.lock/committed/backup")
+                .exists()
         );
+        let lock = directory.join(".local/bin/.boomux.bootstrap.lock");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while lock.exists() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(!lock.exists());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn commit_transport_loss_at_every_step_preserves_atomic_outcome_and_cleans_lock() {
+        let cuts = [
+            ("directory=$HOME/.local/bin;", false),
+            ("[ \"$(/bin/cat \"$lock/id\")\" = \"$txn\" ];", false),
+            ("claim_acquire || exit 73;", false),
+            ("/bin/mv \"$transaction\" \"$committed\";", true),
+            ("trap - EXIT HUP INT TERM; claim_release;", true),
+            (
+                "claim_release; printf 'boomux-install-commit-v1\\0committed\\0'",
+                true,
+            ),
+        ];
+        for (needle, committed) in cuts {
+            let directory = runtime_directory();
+            fs::create_dir_all(directory.join(".local/bin")).unwrap();
+            let destination = directory.join(".local/bin/boomux");
+            fs::write(&destination, b"previous").unwrap();
+            fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+
+            let install = REMOTE_INSTALL_COMMAND
+                .replace("lease_limit=180", "lease_limit=1")
+                .replace("[ \"$claim_age\" -ge 180 ]", "[ \"$claim_age\" -ge 1 ]");
+            let transaction =
+                run_local_upload_with_command(&directory, b"replacement", "sh", &install);
+            run_local_activation(&directory, "sh", &transaction, RemoteInstallReason::Missing);
+
+            let commit_base = REMOTE_INSTALL_COMMIT_COMMAND.replace("sleep 180", "sleep 1");
+            let injected = format!("{}; kill -KILL $$;", needle.trim_end_matches(';'));
+            let commit_command = commit_base.replacen(needle, &injected, 1);
+            assert_ne!(commit_command, commit_base);
+            let mut child = Command::new("sh");
+            child.args(["-c", &commit_command]).env("HOME", &directory);
+            assert!(
+                run_streaming_command_capture(child, transaction.input(), Duration::from_secs(1),)
+                    .is_err(),
+                "commit unexpectedly acknowledged after cut at {needle}"
+            );
+
+            let lock = directory.join(".local/bin/.boomux.bootstrap.lock");
+            let deadline = Instant::now() + Duration::from_secs(4);
+            while lock.exists() && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(20));
+            }
+            assert!(!lock.exists(), "stale lock after cut at {needle}");
+            assert_eq!(
+                fs::read(&destination).unwrap(),
+                if committed {
+                    &b"replacement"[..]
+                } else {
+                    &b"previous"[..]
+                },
+                "wrong outcome after cut at {needle}"
+            );
+            fs::remove_dir_all(directory).unwrap();
+        }
+    }
+
+    #[test]
+    fn post_install_failure_atomically_restores_previous_or_missing_destination() {
+        for previous in [Some(&b"previous"[..]), None] {
+            let directory = runtime_directory();
+            fs::create_dir_all(directory.join(".local/bin")).unwrap();
+            let destination = directory.join(".local/bin/boomux");
+            if let Some(previous) = previous {
+                fs::write(&destination, previous).unwrap();
+                fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+            }
+            let transaction = run_local_install(&directory, b"incompatible-abi");
+            assert_eq!(fs::read(&destination).unwrap(), b"incompatible-abi");
+
+            run_local_transaction(&directory, REMOTE_INSTALL_ROLLBACK_COMMAND, &transaction);
+            match previous {
+                Some(previous) => assert_eq!(fs::read(&destination).unwrap(), previous),
+                None => assert!(!destination.exists()),
+            }
+            assert!(
+                fs::read_dir(directory.join(".local/bin"))
+                    .unwrap()
+                    .filter_map(Result::ok)
+                    .all(|entry| !entry.file_name().to_string_lossy().starts_with(".boomux."))
+            );
+            fs::remove_dir_all(directory).unwrap();
+        }
+    }
+
+    #[test]
+    fn concurrent_install_transaction_fails_busy_without_touching_the_first() {
+        let directory = runtime_directory();
+        fs::create_dir_all(directory.join(".local/bin")).unwrap();
+        let destination = directory.join(".local/bin/boomux");
+        fs::write(&destination, b"previous").unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let first = run_local_install(&directory, b"first-provisional");
+
+        let mut second = Command::new("sh");
+        second
+            .args(["-c", REMOTE_INSTALL_COMMAND])
+            .env("HOME", &directory);
+        let second_transaction = InstallTransactionId::generate();
+        let error = run_streaming_command_capture(
+            second,
+            second_transaction.upload_input(b"second-provisional"),
+            Duration::from_secs(1),
+        )
+        .unwrap_err();
+        assert_eq!(error_code(&error), "busy");
+        assert_eq!(fs::read(&destination).unwrap(), b"first-provisional");
+        assert!(directory.join(".local/bin/.boomux.bootstrap.lock").is_dir());
+
+        run_local_transaction(&directory, REMOTE_INSTALL_ROLLBACK_COMMAND, &first);
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn two_bootstrap_sessions_share_atomic_remote_install_exclusion() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let home = runtime.join("remote-home");
+        fs::create_dir_all(home.join(".local/bin")).unwrap();
+        let destination = home.join(".local/bin/boomux");
+        fs::write(&destination, b"previous").unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\n{CONTROL_MASTER_ONLY_SCRIPT}\nlast=\nfor arg do last=$arg; done\nexec env HOME={} /bin/sh -c \"$last\"\n",
+                quote_posix_shell(home.to_str().unwrap())
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        let first = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let second = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let transaction = InstallTransactionId::generate();
+        let output = run_streaming_command_capture(
+            first.command(REMOTE_INSTALL_COMMAND),
+            transaction.upload_input(b"first"),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+        assert_eq!(
+            InstallTransactionId::parse_probe(&output.stdout).unwrap(),
+            transaction
+        );
+        let second_transaction = InstallTransactionId::generate();
+        let error = run_streaming_command_capture(
+            second.command(REMOTE_INSTALL_COMMAND),
+            second_transaction.upload_input(b"second"),
+            Duration::from_secs(1),
+        )
+        .unwrap_err();
+        assert_eq!(error_code(&error), "busy");
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        run_streaming_command(
+            first.command(REMOTE_INSTALL_ROLLBACK_COMMAND),
+            transaction.input(),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        drop(first);
+        drop(second);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn rollback_watchdog_restores_after_local_status_is_lost() {
+        let directory = runtime_directory();
+        fs::create_dir_all(directory.join(".local/bin")).unwrap();
+        let destination = directory.join(".local/bin/boomux");
+        fs::write(&destination, b"previous").unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let command_text = REMOTE_INSTALL_COMMAND.replacen("lease_limit=180", "lease_limit=1", 1);
+        let transaction =
+            run_local_upload_with_command(&directory, b"provisional", "sh", &command_text);
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        assert!(
+            directory
+                .join(".local/bin")
+                .join(&transaction.0)
+                .join("new")
+                .exists()
+        );
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let lock = directory.join(".local/bin/.boomux.bootstrap.lock");
+        while lock.exists() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        assert!(!lock.exists());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn renewable_lease_survives_multiple_simulated_watchdog_windows() {
+        let directory = runtime_directory();
+        fs::create_dir_all(directory.join(".local/bin")).unwrap();
+        let destination = directory.join(".local/bin/boomux");
+        fs::write(&destination, b"previous").unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let install = REMOTE_INSTALL_COMMAND.replace("lease_limit=180", "lease_limit=2");
+        let transaction = run_local_upload_with_command(&directory, b"replacement", "sh", &install);
+        for renewal in 1..=4 {
+            thread::sleep(Duration::from_secs(1));
+            let mut renew = Command::new("sh");
+            renew
+                .args(["-c", REMOTE_INSTALL_RENEW_COMMAND])
+                .env("HOME", &directory);
+            run_streaming_command(
+                renew,
+                transaction.renewal_input(renewal),
+                Duration::from_secs(1),
+            )
+            .unwrap();
+            assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        }
+        run_local_activation(&directory, "sh", &transaction, RemoteInstallReason::Missing);
+        run_local_transaction(&directory, REMOTE_INSTALL_COMMIT_COMMAND, &transaction);
+        assert_eq!(fs::read(&destination).unwrap(), b"replacement");
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn watchdog_honors_renewal_at_the_claim_boundary() {
+        let directory = runtime_directory();
+        fs::create_dir_all(directory.join(".local/bin")).unwrap();
+        let destination = directory.join(".local/bin/boomux");
+        fs::write(&destination, b"previous").unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let install = REMOTE_INSTALL_COMMAND
+            .replace("lease_limit=180", "lease_limit=1")
+            .replacen(
+                "if claim_acquire; then current=",
+                ": > \"$HOME/watchdog-boundary\"; while [ ! -e \"$HOME/watchdog-release\" ]; do /bin/sleep 1; done; if claim_acquire; then current=",
+                1,
+            )
+            .replacen(
+                "lease_value=$claimed_lease; unchanged=0; continue",
+                "lease_value=$claimed_lease; unchanged=0; : > \"$HOME/watchdog-honored\"; continue",
+                1,
+            );
+        assert!(install.contains("watchdog-boundary"));
+        assert!(install.contains("watchdog-honored"));
+        let transaction = run_local_upload_with_command(&directory, b"replacement", "sh", &install);
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while !directory.join("watchdog-boundary").exists() {
+            assert!(Instant::now() < deadline, "watchdog did not reach boundary");
+            thread::sleep(Duration::from_millis(10));
+        }
+        let claim = directory.join(".local/bin/.boomux.bootstrap.lock/claim");
+        fs::create_dir(&claim).unwrap();
+        let mut blocked_renewal = Command::new("sh");
+        blocked_renewal
+            .args(["-c", REMOTE_INSTALL_RENEW_COMMAND])
+            .env("HOME", &directory);
+        assert!(
+            run_streaming_command(
+                blocked_renewal,
+                transaction.renewal_input(1),
+                Duration::from_secs(1),
+            )
+            .is_err()
+        );
+        assert_eq!(
+            fs::read_to_string(
+                directory
+                    .join(".local/bin")
+                    .join(&transaction.0)
+                    .join("lease")
+            )
+            .unwrap(),
+            "0\n"
+        );
+        fs::remove_dir(&claim).unwrap();
+        let mut renew = Command::new("sh");
+        renew
+            .args(["-c", REMOTE_INSTALL_RENEW_COMMAND])
+            .env("HOME", &directory);
+        run_streaming_command(renew, transaction.renewal_input(1), Duration::from_secs(1)).unwrap();
+        fs::write(directory.join("watchdog-release"), b"").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while !directory.join("watchdog-honored").exists() {
+            assert!(
+                Instant::now() < deadline,
+                "watchdog did not honor boundary renewal"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(fs::read(&destination).unwrap(), b"previous");
+        run_local_activation(&directory, "sh", &transaction, RemoteInstallReason::Missing);
+        run_local_transaction(&directory, REMOTE_INSTALL_COMMIT_COMMAND, &transaction);
+        assert_eq!(fs::read(&destination).unwrap(), b"replacement");
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn rollback_restores_daemon_consistency_for_restarted_and_first_installs() {
+        let directory = runtime_directory();
+        fs::create_dir_all(directory.join(".local/bin")).unwrap();
+        let destination = directory.join(".local/bin/boomux");
+        let log = directory.join("daemon-actions");
+        fs::write(
+            &destination,
+            format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n", log.display()),
+        )
+        .unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let transaction = run_local_install(&directory, b"provisional");
+        fs::write(
+            directory
+                .join(".local/bin")
+                .join(&transaction.0)
+                .join("prior_daemon"),
+            protocol::PROTOCOL_VERSION.to_string(),
+        )
+        .unwrap();
+        fs::write(
+            directory
+                .join(".local/bin")
+                .join(&transaction.0)
+                .join("daemon_contacted"),
+            b"",
+        )
+        .unwrap();
+        run_local_transaction(&directory, REMOTE_INSTALL_ROLLBACK_COMMAND, &transaction);
+        assert_eq!(fs::read_to_string(&log).unwrap(), "daemon restart\n");
+
+        fs::remove_file(&destination).unwrap();
+        let provisional = format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n", log.display());
+        let transaction = run_local_install(&directory, provisional.as_bytes());
+        fs::write(
+            directory
+                .join(".local/bin")
+                .join(&transaction.0)
+                .join("prior_daemon"),
+            b"absent",
+        )
+        .unwrap();
+        fs::write(
+            directory
+                .join(".local/bin")
+                .join(&transaction.0)
+                .join("daemon_contacted"),
+            b"",
+        )
+        .unwrap();
+        run_local_transaction(&directory, REMOTE_INSTALL_ROLLBACK_COMMAND, &transaction);
+        assert!(!destination.exists());
+        assert_eq!(fs::read_to_string(&log).unwrap(), "daemon restart\n");
+
+        fs::write(
+            &destination,
+            format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n", log.display()),
+        )
+        .unwrap();
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+        let transaction = run_local_install(&directory, provisional.as_bytes());
+        fs::write(
+            directory
+                .join(".local/bin")
+                .join(&transaction.0)
+                .join("prior_daemon"),
+            b"absent",
+        )
+        .unwrap();
+        fs::write(
+            directory
+                .join(".local/bin")
+                .join(&transaction.0)
+                .join("daemon_contacted"),
+            b"",
+        )
+        .unwrap();
+        run_local_transaction(&directory, REMOTE_INSTALL_ROLLBACK_COMMAND, &transaction);
+        assert!(destination.exists());
+        assert_eq!(fs::read_to_string(&log).unwrap(), "daemon restart\n");
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn pinned_source_bytes_survive_path_replacement() {
+        let directory = runtime_directory();
+        fs::create_dir_all(&directory).unwrap();
+        let source_path = directory.join("boomux-source");
+        fs::write(&source_path, b"authorized-bytes").unwrap();
+        let bytes = read_bounded_file(&source_path).unwrap();
+        let source = RemoteInstallSource::CurrentBinary {
+            path: source_path.clone(),
+            sha256: format!("{:x}", Sha256::digest(&bytes)),
+            bytes,
+        };
+        fs::write(&source_path, b"replaced-after-confirmation").unwrap();
+        assert_eq!(source.bytes(), b"authorized-bytes");
+        assert!(source.description().contains("sha256"));
+        let transaction = run_local_install(&directory, source.bytes());
+        assert_eq!(
+            fs::read(directory.join(".local/bin/boomux")).unwrap(),
+            b"authorized-bytes"
+        );
+        run_local_transaction(&directory, REMOTE_INSTALL_ROLLBACK_COMMAND, &transaction);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn install_source_pinning_rejects_symlinks_and_special_files() {
+        let directory = runtime_directory();
+        fs::create_dir_all(&directory).unwrap();
+        let regular = directory.join("regular");
+        let symlink = directory.join("symlink");
+        fs::write(&regular, b"boomux").unwrap();
+        std::os::unix::fs::symlink(&regular, &symlink).unwrap();
+        assert!(read_bounded_file(&symlink).is_err());
+        assert!(read_bounded_file(&directory).is_err());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn install_source_pinning_rejects_same_length_in_place_mutation() {
+        let directory = runtime_directory();
+        fs::create_dir_all(&directory).unwrap();
+        let source = directory.join("source");
+        fs::write(&source, b"before!!").unwrap();
+        let error = read_bounded_file_with_hook(&source, || {
+            let mut file = OpenOptions::new().write(true).open(&source).unwrap();
+            file.write_all(b"after!!!").unwrap();
+            file.sync_all().unwrap();
+        })
+        .unwrap_err();
+        assert_eq!(error_code(&error), "bootstrap_install_failed");
+        assert!(error.to_string().contains("changed while"));
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -164,13 +164,18 @@ fn open_with_expected_run(
 }
 
 pub fn open_node_add(desktop_entry: Option<&str>) -> Result<(), Box<dyn Error>> {
+    let arguments = node_add_arguments();
     launch(
         desktop_entry,
         "Add Boomux Node",
         None,
         attachment_executable()?.as_os_str(),
-        &["node".into(), "add".into()],
+        &arguments,
     )
+}
+
+fn node_add_arguments() -> [OsString; 1] {
+    ["__guided-node-add".into()]
 }
 
 fn launch(
@@ -411,6 +416,11 @@ mod tests {
             .map(OsStr::new)
             .map(OsStr::to_owned)
         );
+    }
+
+    #[test]
+    fn guided_node_add_uses_only_the_hidden_wrapper_argument() {
+        assert_eq!(node_add_arguments(), [OsString::from("__guided-node-add")]);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -396,6 +396,7 @@ pub(crate) enum ExecutionOutcomeDisplay {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct FocusedTerminalView {
     pub(crate) revision: u64,
+    pub(crate) node_id: Option<String>,
     pub(crate) workspace_id: String,
     pub(crate) shell_id: String,
 }
@@ -2256,7 +2257,6 @@ impl App {
             return;
         }
         let Some(focused) = focused_terminal else {
-            self.observed_focus_revision = None;
             return;
         };
         if self
@@ -2279,8 +2279,12 @@ impl App {
                         .enumerate()
                         .find(|(item_index, item)| {
                             let (node, owner_workspace_id) = workspace.item_owner(*item_index);
-                            node.local
-                                && owner_workspace_id == focused.workspace_id
+                            focused
+                                .node_id
+                                .as_ref()
+                                .map_or(node.local, |node_id| node.id == *node_id)
+                                && (focused.node_id.is_some()
+                                    || owner_workspace_id == focused.workspace_id)
                                 && !matches!(item, WorkspaceItemView::Launcher(_))
                                 && item.id() == focused.shell_id
                                 && (self.primary_tab != PrimaryTab::Workspaces
@@ -7960,6 +7964,33 @@ mod tests {
     }
 
     #[test]
+    fn focus_following_selects_the_exact_remote_node_when_shell_ids_collide() {
+        let mut local = workspace("same-workspace", "local");
+        local.node.id = "00000000-0000-0000-0000-000000000001".into();
+        let mut remote = local.clone();
+        remote.node.id = "00000000-0000-0000-0000-000000000002".into();
+        remote.node.alias = "work".into();
+        remote.node.local = false;
+        let mut app = App::new(vec![local, remote], project_context());
+
+        app.enable_focus_following(Some(&FocusedTerminalView {
+            revision: 1,
+            node_id: Some("00000000-0000-0000-0000-000000000002".into()),
+            workspace_id: String::new(),
+            shell_id: "term_1".into(),
+        }));
+
+        assert_eq!(
+            app.selected().map(|workspace| workspace.node.id.as_str()),
+            Some("00000000-0000-0000-0000-000000000002")
+        );
+        assert_eq!(
+            app.selected_item().map(WorkspaceItemView::id),
+            Some("term_1")
+        );
+    }
+
+    #[test]
     fn every_remote_health_code_is_unmistakable_wide_and_compact() {
         for health in [
             NodeProjectionHealthCode::Unobserved,
@@ -8321,6 +8352,7 @@ mod tests {
         let mut app = App::new(vec![one, two], project_context());
         let focused = FocusedTerminalView {
             revision: 1,
+            node_id: None,
             workspace_id: "w2".into(),
             shell_id: "s2".into(),
         };
@@ -8357,13 +8389,15 @@ mod tests {
         app.apply_focused_terminal(None);
         app.apply_focused_terminal(Some(&FocusedTerminalView {
             revision: 1,
+            node_id: None,
             workspace_id: "w1".into(),
             shell_id: "s1".into(),
         }));
         assert_eq!(
             app.selected().map(|workspace| workspace.id.as_str()),
-            Some("w1")
+            Some("w2")
         );
+        assert_eq!(app.observed_focus_revision, Some(2));
     }
 
     #[test]
@@ -8387,6 +8421,7 @@ mod tests {
         app.select_tab(PrimaryTab::Agents);
         app.apply_focused_terminal(Some(&FocusedTerminalView {
             revision: 1,
+            node_id: None,
             workspace_id: "w3".into(),
             shell_id: "agent-2".into(),
         }));
@@ -8398,6 +8433,7 @@ mod tests {
 
         app.apply_focused_terminal(Some(&FocusedTerminalView {
             revision: 2,
+            node_id: None,
             workspace_id: "w2".into(),
             shell_id: "shell-1".into(),
         }));
@@ -8411,6 +8447,7 @@ mod tests {
         app.select_tab(PrimaryTab::Shells);
         app.apply_focused_terminal(Some(&FocusedTerminalView {
             revision: 3,
+            node_id: None,
             workspace_id: "w4".into(),
             shell_id: "shell-2".into(),
         }));
@@ -8422,6 +8459,7 @@ mod tests {
 
         app.apply_focused_terminal(Some(&FocusedTerminalView {
             revision: 4,
+            node_id: None,
             workspace_id: "w1".into(),
             shell_id: "agent-1".into(),
         }));
@@ -8441,6 +8479,7 @@ mod tests {
         set_shell_id(&mut two, "s2");
         let focused = FocusedTerminalView {
             revision: 1,
+            node_id: None,
             workspace_id: "w2".into(),
             shell_id: "s2".into(),
         };
@@ -8476,6 +8515,7 @@ mod tests {
         let mut app = App::new(vec![one, two], project_context());
         app.enable_focus_following(Some(&FocusedTerminalView {
             revision: 1,
+            node_id: None,
             workspace_id: "w1".into(),
             shell_id: "s1".into(),
         }));
@@ -8483,6 +8523,7 @@ mod tests {
         app.toggle_selection_pin();
         app.apply_focused_terminal(Some(&FocusedTerminalView {
             revision: 2,
+            node_id: None,
             workspace_id: "w2".into(),
             shell_id: "s2".into(),
         }));
@@ -8496,6 +8537,7 @@ mod tests {
         assert_eq!(app.observed_focus_revision, None);
         app.apply_focused_terminal(Some(&FocusedTerminalView {
             revision: 2,
+            node_id: None,
             workspace_id: "w2".into(),
             shell_id: "s2".into(),
         }));
@@ -8520,6 +8562,7 @@ mod tests {
         set_shell_id(&mut one, "s1");
         let focused = FocusedTerminalView {
             revision: 1,
+            node_id: None,
             workspace_id: "w2".into(),
             shell_id: "s2".into(),
         };

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -51,26 +51,30 @@ const BOOMUX_SMOKE: [&str; 5] = [
 const TERMINAL_PREVIEW_ROWS: usize = 16;
 const TERMINAL_PREVIEW_SCROLL_STEP: usize = 12;
 const PREVIEW_RESERVED_ITEM_HEIGHT: u16 = 6;
-const AGENT_TABLE_HEADERS: [&str; 7] = [
+const AGENT_TABLE_HEADERS: [&str; 8] = [
     "STATUS",
     "UPDATED",
     "WORKSPACE",
+    "NODE",
     "SHELL",
     "TASK",
     "ROOT BRANCH",
     "ROOT WORKTREE",
 ];
-const SHELL_TABLE_HEADERS: [&str; 8] = [
+const SHELL_TABLE_HEADERS: [&str; 9] = [
     "STATUS",
     "RUN",
     "WORKSPACE",
+    "NODE",
     "SHELL",
     "KIND",
     "PROCESS",
     "BRANCH",
     "WORKTREE",
 ];
-const ITEM_TABLE_HEADERS: [&str; 6] = ["KIND", "STATUS", "NAME", "ACTIVITY", "BRANCH", "WORKTREE"];
+const ITEM_TABLE_HEADERS: [&str; 7] = [
+    "KIND", "STATUS", "NAME", "NODE", "ACTIVITY", "BRANCH", "WORKTREE",
+];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum BombAnimationFrame {
@@ -147,10 +151,16 @@ pub(crate) struct NodeView {
     pub(crate) id: String,
     pub(crate) alias: String,
     pub(crate) local: bool,
+    pub(crate) route: Option<String>,
+    pub(crate) registration_revision: Option<u64>,
     pub(crate) health: NodeProjectionHealthCode,
     pub(crate) current: bool,
     pub(crate) stale: bool,
+    pub(crate) observed_at_ms: u64,
+    pub(crate) observed_protocol_version: Option<u32>,
     pub(crate) observed_capabilities: Vec<String>,
+    pub(crate) workspace_owner_eligible: bool,
+    pub(crate) workspace_owner_unavailable_reason: Option<String>,
     pub(crate) scheduler: SchedulerHealth,
 }
 
@@ -165,6 +175,36 @@ pub(crate) struct WorkspaceView {
     pub(crate) agent_state_counts: AgentStateCounts,
     pub(crate) attention_count: usize,
     pub(crate) attention: Vec<WorkspaceAttentionView>,
+    pub(crate) item_owners: Vec<WorkspaceItemOwnerView>,
+    pub(crate) coordination: WorkspaceCoordinationView,
+}
+
+#[derive(Clone)]
+pub(crate) struct WorkspaceItemOwnerView {
+    pub(crate) node: NodeView,
+    pub(crate) workspace_id: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct WorkspacePlacementView {
+    pub(crate) node: NodeView,
+    pub(crate) workspace_id: String,
+    pub(crate) owner_revision: u64,
+    pub(crate) default_cwd: Option<String>,
+    pub(crate) state: crate::protocol::WorkspacePlacementState,
+}
+
+#[derive(Clone)]
+pub(crate) enum WorkspaceCoordinationView {
+    Global {
+        revision: u64,
+        closing: bool,
+        placements: Vec<WorkspacePlacementView>,
+    },
+    External {
+        owner_revision: u64,
+        available: bool,
+    },
 }
 
 pub(crate) struct DashboardState {
@@ -176,7 +216,6 @@ pub(crate) struct DashboardState {
     pub(crate) schedule_editing: bool,
     pub(crate) focused_terminal: Option<FocusedTerminalView>,
     pub(crate) reset_focus_revision: bool,
-    pub(crate) initial_node_filter: Option<String>,
 }
 
 pub(crate) struct ScheduleEditInspection {
@@ -363,6 +402,8 @@ pub(crate) struct FocusedTerminalView {
 
 #[derive(Clone)]
 pub(crate) struct WorkspaceAttentionView {
+    pub(crate) node_id: String,
+    pub(crate) workspace_id: String,
     pub(crate) agent_id: String,
     pub(crate) shell_id: String,
     pub(crate) agent_name: String,
@@ -542,28 +583,6 @@ impl WorkspaceView {
         self.node.local && self.node.current && !self.node.stale
     }
 
-    fn shell_attachable(&self) -> bool {
-        self.local_actionable()
-            || (self.node.current
-                && !self.node.stale
-                && self
-                    .node
-                    .observed_capabilities
-                    .iter()
-                    .any(|capability| capability == "remote_pty_attachment"))
-    }
-
-    fn launcher_invokable(&self) -> bool {
-        self.local_actionable()
-            || (self.node.current
-                && !self.node.stale
-                && self
-                    .node
-                    .observed_capabilities
-                    .iter()
-                    .any(|capability| capability == "typed_node_host_services"))
-    }
-
     fn shell_count(&self) -> usize {
         self.items
             .iter()
@@ -617,6 +636,56 @@ impl WorkspaceView {
             .iter()
             .filter(|item| item.ordinary_visible())
             .count()
+    }
+
+    fn item_owner(&self, index: usize) -> (&NodeView, &str) {
+        self.item_owners
+            .get(index)
+            .map_or((&self.node, self.id.as_str()), |owner| {
+                (&owner.node, owner.workspace_id.as_str())
+            })
+    }
+
+    fn qualify_item(&self, index: usize, inner_id: impl Into<String>) -> QualifiedIdentity {
+        QualifiedIdentity::new(self.item_owner(index).0.id.clone(), inner_id)
+    }
+
+    fn qualify_item_workspace(&self, index: usize) -> QualifiedIdentity {
+        let (node, workspace_id) = self.item_owner(index);
+        QualifiedIdentity::new(node.id.clone(), workspace_id)
+    }
+
+    fn item_actionable(&self, index: usize) -> bool {
+        let node = self.item_owner(index).0;
+        node.current
+            && !node.stale
+            && (node.local
+                || node
+                    .observed_capabilities
+                    .iter()
+                    .any(|capability| capability == "guarded_remote_management"))
+    }
+
+    fn item_shell_attachable(&self, index: usize) -> bool {
+        let node = self.item_owner(index).0;
+        (node.local && node.current && !node.stale)
+            || (node.current
+                && !node.stale
+                && node
+                    .observed_capabilities
+                    .iter()
+                    .any(|capability| capability == "remote_pty_attachment"))
+    }
+
+    fn item_launcher_invokable(&self, index: usize) -> bool {
+        let node = self.item_owner(index).0;
+        (node.local && node.current && !node.stale)
+            || (node.current
+                && !node.stale
+                && node
+                    .observed_capabilities
+                    .iter()
+                    .any(|capability| capability == "typed_node_host_services"))
     }
 }
 
@@ -777,12 +846,50 @@ pub(crate) enum DashboardEffect {
         name: String,
         default_cwd: Option<PathBuf>,
     },
+    CreatePlacedWorkspace {
+        name: String,
+        default_cwd: PathBuf,
+        node_id: String,
+    },
     CreateShell(QualifiedIdentity),
+    CreateGlobalShell {
+        workspace_id: String,
+        expected_revision: u64,
+        node_id: String,
+        owner_workspace_id: String,
+        default_cwd: Option<PathBuf>,
+    },
+    AdoptExternalWorkspace {
+        identity: QualifiedIdentity,
+        expected_revision: u64,
+    },
+    OpenGlobalWorkspace {
+        workspace_id: String,
+        expected_revision: u64,
+    },
+    RetryGlobalWorkspaceClose {
+        workspace_id: String,
+    },
+    LinkExternalWorkspace {
+        workspace_id: String,
+        expected_revision: u64,
+        identity: QualifiedIdentity,
+        expected_owner_revision: u64,
+    },
+    RetargetNode {
+        node_id: String,
+        expected_revision: u64,
+        route: String,
+    },
+    ForgetNode {
+        node_id: String,
+    },
     Rename {
         target: RenameTarget,
         name: String,
     },
     CheckForUpdates,
+    RefreshNode(String),
     Refresh,
     RunSchedule(QualifiedIdentity),
     PauseSchedule(QualifiedIdentity),
@@ -869,6 +976,7 @@ struct App {
     workspace_state: TableState,
     item_state: TableState,
     global_state: TableState,
+    node_state: TableState,
     primary_tab: PrimaryTab,
     focus: Focus,
     mode: Mode,
@@ -879,7 +987,6 @@ struct App {
     follow_focused_terminal: bool,
     selection_pinned: bool,
     observed_focus_revision: Option<u64>,
-    node_filter: Option<String>,
 }
 
 struct TerminalPreviewState {
@@ -902,14 +1009,16 @@ enum PrimaryTab {
     Agents,
     Shells,
     Schedules,
+    Nodes,
 }
 
 impl PrimaryTab {
-    const ALL: [Self; 4] = [
+    const ALL: [Self; 5] = [
         Self::Workspaces,
         Self::Agents,
         Self::Shells,
         Self::Schedules,
+        Self::Nodes,
     ];
 
     fn kind(self) -> Option<ItemKind> {
@@ -918,6 +1027,7 @@ impl PrimaryTab {
             Self::Agents => Some(ItemKind::Agent),
             Self::Shells => Some(ItemKind::Shell),
             Self::Schedules => None,
+            Self::Nodes => None,
         }
     }
 
@@ -927,6 +1037,7 @@ impl PrimaryTab {
             Self::Agents => "AGENTS",
             Self::Shells => "SHELLS",
             Self::Schedules => "SCHEDULES",
+            Self::Nodes => "NODES",
         }
     }
 }
@@ -962,6 +1073,14 @@ pub(crate) enum OpenTarget {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum RenameTarget {
+    GlobalWorkspace {
+        workspace_id: String,
+        expected_revision: u64,
+    },
+    Node {
+        node_id: String,
+        expected_revision: u64,
+    },
     Workspace(QualifiedIdentity),
     Shell(QualifiedIdentity),
     Launcher(QualifiedIdentity),
@@ -969,6 +1088,10 @@ pub(crate) enum RenameTarget {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum CloseTarget {
+    GlobalWorkspace {
+        workspace_id: String,
+        expected_revision: u64,
+    },
     Workspace(QualifiedIdentity),
     Shell(QualifiedIdentity),
     Launcher(QualifiedIdentity),
@@ -979,6 +1102,8 @@ pub(crate) enum CloseTarget {
 impl RenameTarget {
     fn label(&self) -> &'static str {
         match self {
+            Self::GlobalWorkspace { .. } => "workspace",
+            Self::Node { .. } => "Node alias",
             Self::Workspace(_) => "workspace",
             Self::Shell(_) => "shell",
             Self::Launcher(_) => "launcher",
@@ -991,8 +1116,120 @@ enum Mode {
     PickProject(ProjectPicker),
     Palette(CommandPalette),
     Help,
-    Rename { target: RenameTarget, input: String },
+    Rename {
+        target: RenameTarget,
+        input: String,
+    },
+    SelectWorkspaceNode(WorkspaceNodePicker),
+    LinkWorkspace(LinkWorkspacePicker),
+    InspectNode(NodeView),
+    RetargetNode {
+        node_id: String,
+        expected_revision: u64,
+        input: String,
+    },
+    ConfirmForgetNode(NodeView),
     EditSchedule(ScheduleEditor),
+}
+
+struct LinkWorkspacePicker {
+    identity: QualifiedIdentity,
+    expected_owner_revision: u64,
+    workspaces: Vec<(String, String, u64)>,
+    selected: Option<usize>,
+}
+
+struct WorkspaceNodePicker {
+    workspace_id: String,
+    workspace_name: String,
+    expected_revision: u64,
+    placements: Vec<WorkspacePlacementView>,
+    nodes: Vec<NodeView>,
+    selected: Option<usize>,
+    project: Option<(String, PathBuf)>,
+}
+
+impl WorkspaceNodePicker {
+    fn move_selection(&mut self, forwards: bool) {
+        let eligible = self
+            .nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(index, node)| node.workspace_owner_eligible.then_some(index))
+            .collect::<Vec<_>>();
+        if eligible.is_empty() {
+            self.selected = None;
+            return;
+        }
+        self.selected = Some(
+            match self
+                .selected
+                .and_then(|selected| eligible.iter().position(|index| *index == selected))
+            {
+                Some(position) if forwards => eligible[(position + 1) % eligible.len()],
+                Some(0) => *eligible.last().expect("eligible Node"),
+                Some(position) => eligible[position - 1],
+                None if forwards => eligible[0],
+                None => *eligible.last().expect("eligible Node"),
+            },
+        );
+    }
+
+    fn effect(&self) -> Option<DashboardEffect> {
+        let node = self.nodes.get(self.selected?)?;
+        if !node.workspace_owner_eligible {
+            return None;
+        }
+        if let Some((name, default_cwd)) = &self.project {
+            return Some(DashboardEffect::CreatePlacedWorkspace {
+                name: name.clone(),
+                default_cwd: default_cwd.clone(),
+                node_id: node.id.clone(),
+            });
+        }
+        let placement = self
+            .placements
+            .iter()
+            .find(|placement| placement.node.id == node.id);
+        Some(DashboardEffect::CreateGlobalShell {
+            workspace_id: self.workspace_id.clone(),
+            expected_revision: self.expected_revision,
+            node_id: node.id.clone(),
+            owner_workspace_id: placement.map_or_else(
+                || uuid::Uuid::new_v4().to_string(),
+                |placement| placement.workspace_id.clone(),
+            ),
+            default_cwd: placement
+                .and_then(|placement| placement.default_cwd.as_deref())
+                .map(PathBuf::from),
+        })
+    }
+}
+
+impl LinkWorkspacePicker {
+    fn move_selection(&mut self, forwards: bool) {
+        if self.workspaces.is_empty() {
+            self.selected = None;
+            return;
+        }
+        self.selected = Some(match self.selected {
+            Some(index) if forwards => (index + 1) % self.workspaces.len(),
+            Some(0) => self.workspaces.len() - 1,
+            Some(index) => index - 1,
+            None if forwards => 0,
+            None => self.workspaces.len() - 1,
+        });
+    }
+
+    fn effect(&self) -> Option<DashboardEffect> {
+        let (workspace_id, _, expected_revision) = self.workspaces.get(self.selected?)?;
+        Some(DashboardEffect::LinkExternalWorkspace {
+            workspace_id: workspace_id.clone(),
+            expected_revision: *expected_revision,
+            identity: self.identity.clone(),
+            expected_owner_revision: self.expected_owner_revision,
+        })
+    }
 }
 
 struct ScheduleEditor {
@@ -1615,7 +1852,7 @@ impl CommandPalette {
                 });
             }
 
-            for item in &workspace.items {
+            for (item_index, item) in workspace.items.iter().enumerate() {
                 if !item.ordinary_visible() {
                     continue;
                 }
@@ -1624,8 +1861,8 @@ impl CommandPalette {
                     continue;
                 }
                 let identity = ItemIdentity {
-                    workspace_id: workspace.qualify(&workspace.id),
-                    item_id: workspace.qualify(item.id()),
+                    workspace_id: workspace.qualify_item_workspace(item_index),
+                    item_id: workspace.qualify_item(item_index, item.id()),
                     kind: if kind == ItemKind::Launcher {
                         ItemIdentityKind::Launcher
                     } else {
@@ -1654,7 +1891,9 @@ impl CommandPalette {
                     (ItemPaletteAction::Rename, PaletteActionGroup::Rename),
                     (ItemPaletteAction::Close, PaletteActionGroup::Close),
                 ] {
-                    if !workspace.actionable() && !matches!(action, ItemPaletteAction::GoTo) {
+                    if !workspace.item_actionable(item_index)
+                        && !matches!(action, ItemPaletteAction::GoTo)
+                    {
                         continue;
                     }
                     entries.push(PaletteEntry {
@@ -1704,9 +1943,34 @@ impl CommandPalette {
                             attention.shell_id
                         ),
                         command: PaletteCommand::Attention {
-                            workspace_id: workspace.qualify(&workspace.id),
-                            shell_id: workspace.qualify(&attention.shell_id),
-                            agent_id: workspace.qualify(&attention.agent_id),
+                            workspace_id: QualifiedIdentity::new(
+                                if attention.node_id.is_empty() {
+                                    workspace.node.id.clone()
+                                } else {
+                                    attention.node_id.clone()
+                                },
+                                if attention.workspace_id.is_empty() {
+                                    workspace.id.clone()
+                                } else {
+                                    attention.workspace_id.clone()
+                                },
+                            ),
+                            shell_id: QualifiedIdentity::new(
+                                if attention.node_id.is_empty() {
+                                    workspace.node.id.clone()
+                                } else {
+                                    attention.node_id.clone()
+                                },
+                                &attention.shell_id,
+                            ),
+                            agent_id: QualifiedIdentity::new(
+                                if attention.node_id.is_empty() {
+                                    workspace.node.id.clone()
+                                } else {
+                                    attention.node_id.clone()
+                                },
+                                &attention.agent_id,
+                            ),
                         },
                     },
                 ));
@@ -1950,6 +2214,7 @@ impl App {
             }
             nodes
         });
+        let has_nodes = !nodes.is_empty();
         Self {
             nodes,
             all_workspaces: workspaces.clone(),
@@ -1967,6 +2232,7 @@ impl App {
             workspace_state,
             item_state,
             global_state: TableState::default(),
+            node_state: TableState::default().with_selected(has_nodes.then_some(0)),
             primary_tab: PrimaryTab::Workspaces,
             focus: Focus::Workspaces,
             mode: Mode::Normal,
@@ -1977,63 +2243,7 @@ impl App {
             follow_focused_terminal: false,
             selection_pinned: false,
             observed_focus_revision: None,
-            node_filter: None,
         }
-    }
-
-    fn cycle_node_filter(&mut self) {
-        if self.nodes.is_empty() {
-            return;
-        }
-        let filter = match self
-            .node_filter
-            .as_ref()
-            .and_then(|id| self.nodes.iter().position(|node| &node.id == id))
-        {
-            None => Some(self.nodes[0].id.clone()),
-            Some(index) if index + 1 < self.nodes.len() => Some(self.nodes[index + 1].id.clone()),
-            Some(_) => None,
-        };
-        self.set_node_filter(filter);
-    }
-
-    fn set_node_filter(&mut self, filter: Option<String>) {
-        self.node_filter = filter.filter(|id| self.nodes.iter().any(|node| &node.id == id));
-        let workspaces = self
-            .all_workspaces
-            .iter()
-            .filter(|workspace| {
-                self.node_filter
-                    .as_ref()
-                    .is_none_or(|node_id| workspace.node.id == *node_id)
-            })
-            .cloned()
-            .collect();
-        let schedules = self
-            .all_schedules
-            .iter()
-            .filter(|schedule| {
-                self.node_filter
-                    .as_ref()
-                    .is_none_or(|node_id| schedule.node_id == *node_id)
-            })
-            .cloned()
-            .collect();
-        self.replace_workspaces(workspaces);
-        self.replace_schedules(schedules);
-        self.message = Some(Message {
-            text: self.node_filter.as_ref().map_or_else(
-                || "Showing all Nodes".into(),
-                |id| {
-                    let node = self.nodes.iter().find(|node| &node.id == id);
-                    format!(
-                        "Showing Node {}",
-                        node.map_or(id.as_str(), |node| &node.alias)
-                    )
-                },
-            ),
-            error: false,
-        });
     }
 
     fn enable_focus_following(&mut self, focused_terminal: Option<&FocusedTerminalView>) {
@@ -2058,21 +2268,26 @@ impl App {
         if !matches!(self.mode, Mode::Normal) || self.pending_close.is_some() {
             return;
         }
-        let Some(workspace_index) = self
-            .workspaces
-            .iter()
-            .position(|workspace| workspace.node.local && workspace.id == focused.workspace_id)
-        else {
-            return;
-        };
-        let Some(item_index) = self.workspaces[workspace_index]
-            .items
-            .iter()
-            .position(|item| {
-                !matches!(item, WorkspaceItemView::Launcher(_))
-                    && item.id() == focused.shell_id
-                    && (self.primary_tab != PrimaryTab::Workspaces || item.ordinary_visible())
-            })
+        let Some((workspace_index, item_index)) =
+            self.workspaces
+                .iter()
+                .enumerate()
+                .find_map(|(workspace_index, workspace)| {
+                    workspace
+                        .items
+                        .iter()
+                        .enumerate()
+                        .find(|(item_index, item)| {
+                            let (node, owner_workspace_id) = workspace.item_owner(*item_index);
+                            node.local
+                                && owner_workspace_id == focused.workspace_id
+                                && !matches!(item, WorkspaceItemView::Launcher(_))
+                                && item.id() == focused.shell_id
+                                && (self.primary_tab != PrimaryTab::Workspaces
+                                    || item.ordinary_visible())
+                        })
+                        .map(|(item_index, _)| (workspace_index, item_index))
+                })
         else {
             return;
         };
@@ -2095,7 +2310,7 @@ impl App {
                     .checked_sub(1),
             );
         } else {
-            let identity = item_identity(&self.workspaces[workspace_index], item);
+            let identity = item_identity(&self.workspaces[workspace_index], item_index, item);
             self.global_state
                 .select(self.global_item_position(&identity));
         }
@@ -2250,6 +2465,9 @@ impl App {
     }
 
     fn global_item_count(&self) -> usize {
+        if self.primary_tab == PrimaryTab::Nodes {
+            return self.nodes.len();
+        }
         if self.primary_tab == PrimaryTab::Schedules {
             return self.schedules.len();
         }
@@ -2267,6 +2485,13 @@ impl App {
         self.primary_tab = tab;
         if tab == PrimaryTab::Workspaces {
             self.focus = Focus::Workspaces;
+            return;
+        }
+        if tab == PrimaryTab::Nodes {
+            self.focus = Focus::Workspaces;
+            self.node_state
+                .select((!self.nodes.is_empty()).then_some(0));
+            self.message = None;
             return;
         }
         self.focus = if tab == PrimaryTab::Schedules {
@@ -2301,6 +2526,16 @@ impl App {
             return;
         }
         if self.primary_tab != PrimaryTab::Workspaces {
+            if self.primary_tab == PrimaryTab::Nodes {
+                if !self.nodes.is_empty() {
+                    let next = self
+                        .node_state
+                        .selected()
+                        .map_or(0, |index| (index + 1) % self.nodes.len());
+                    self.node_state.select(Some(next));
+                }
+                return;
+            }
             let item_count = self.global_item_count();
             if item_count > 0 {
                 let next = self
@@ -2349,6 +2584,19 @@ impl App {
             return;
         }
         if self.primary_tab != PrimaryTab::Workspaces {
+            if self.primary_tab == PrimaryTab::Nodes {
+                if !self.nodes.is_empty() {
+                    let previous = self.node_state.selected().map_or(0, |index| {
+                        if index == 0 {
+                            self.nodes.len() - 1
+                        } else {
+                            index - 1
+                        }
+                    });
+                    self.node_state.select(Some(previous));
+                }
+                return;
+            }
             let item_count = self.global_item_count();
             if item_count > 0 {
                 let previous = self.global_state.selected().map_or(0, |index| {
@@ -2434,8 +2682,11 @@ impl App {
 
     fn select_item_identity(&mut self, identity: &ItemIdentity) -> bool {
         let Some(workspace_index) = self.workspaces.iter().position(|workspace| {
-            workspace.node.id == identity.workspace_id.node_id
-                && workspace.id == identity.workspace_id.inner_id
+            workspace.items.iter().enumerate().any(|(item_index, _)| {
+                let (node, workspace_id) = workspace.item_owner(item_index);
+                node.id == identity.workspace_id.node_id
+                    && workspace_id == identity.workspace_id.inner_id
+            })
         }) else {
             self.message = Some(Message {
                 text: "item workspace is no longer available".into(),
@@ -2446,10 +2697,18 @@ impl App {
         let Some(item_ordinal) = self.workspaces[workspace_index]
             .items
             .iter()
-            .filter(|item| item.ordinary_visible())
-            .position(|item| item_matches(item, identity))
+            .enumerate()
+            .filter(|(_, item)| item.ordinary_visible())
+            .position(|(item_index, item)| {
+                let owner = self.workspaces[workspace_index].item_owner(item_index);
+                owner.0.id == identity.workspace_id.node_id
+                    && owner.1 == identity.workspace_id.inner_id
+                    && item_matches(item, identity)
+            })
         else {
-            self.select_workspace(&identity.workspace_id, Focus::Workspaces);
+            self.select_tab(PrimaryTab::Workspaces);
+            self.workspace_state.select(Some(workspace_index));
+            self.select_first_details();
             self.message = Some(Message {
                 text: "item is no longer available; selected its workspace".into(),
                 error: true,
@@ -2522,14 +2781,34 @@ impl App {
     }
 
     fn request_rename(&mut self) -> Option<DashboardEffect> {
+        if self.primary_tab == PrimaryTab::Nodes {
+            if let Some(node) = self
+                .node_state
+                .selected()
+                .and_then(|index| self.nodes.get(index))
+                .filter(|node| !node.local)
+                && let Some(expected_revision) = node.registration_revision
+            {
+                self.mode = Mode::Rename {
+                    target: RenameTarget::Node {
+                        node_id: node.id.clone(),
+                        expected_revision,
+                    },
+                    input: String::new(),
+                };
+            }
+            return None;
+        }
         let schedule_id = if self.primary_tab == PrimaryTab::Schedules {
             self.selected_schedule()
                 .map(|schedule| schedule.qualify(&schedule.id))
         } else {
             match self.selected_item() {
-                Some(WorkspaceItemView::Schedule(schedule)) => self
-                    .selected_item_workspace()
-                    .map(|workspace| workspace.qualify(&schedule.id)),
+                Some(WorkspaceItemView::Schedule(schedule)) => {
+                    self.selected_item_location().map(|(workspace, item)| {
+                        self.workspaces[workspace].qualify_item(item, &schedule.id)
+                    })
+                }
                 _ => None,
             }
         };
@@ -2557,21 +2836,44 @@ impl App {
             return None;
         }
         let target = if self.primary_tab != PrimaryTab::Workspaces {
-            self.selected_item_workspace()
-                .filter(|workspace| workspace.actionable())
-                .zip(self.selected_item().filter(|item| item.ordinary_visible()))
-                .and_then(|(workspace, item)| item_rename_target(workspace, item))
+            self.selected_item_location().and_then(|(workspace, item)| {
+                let workspace = &self.workspaces[workspace];
+                workspace
+                    .item_actionable(item)
+                    .then(|| workspace.items.get(item))
+                    .flatten()
+                    .filter(|item| item.ordinary_visible())
+                    .and_then(|value| item_rename_target(workspace, item, value))
+            })
         } else {
             match self.focus {
                 Focus::Workspaces => self
                     .selected()
                     .filter(|workspace| workspace.actionable())
-                    .map(|workspace| RenameTarget::Workspace(workspace.qualify(&workspace.id))),
-                Focus::Items => self
-                    .selected()
-                    .filter(|workspace| workspace.actionable())
-                    .zip(self.selected_item().filter(|item| item.ordinary_visible()))
-                    .and_then(|(workspace, item)| item_rename_target(workspace, item)),
+                    .and_then(|workspace| match workspace.coordination {
+                        WorkspaceCoordinationView::Global {
+                            revision,
+                            closing: false,
+                            ..
+                        } => Some(RenameTarget::GlobalWorkspace {
+                            workspace_id: workspace.id.clone(),
+                            expected_revision: revision,
+                        }),
+                        WorkspaceCoordinationView::External {
+                            available: true, ..
+                        } => Some(RenameTarget::Workspace(workspace.qualify(&workspace.id))),
+                        WorkspaceCoordinationView::Global { .. }
+                        | WorkspaceCoordinationView::External { .. } => None,
+                    }),
+                Focus::Items => self.selected_item_location().and_then(|(workspace, item)| {
+                    let workspace = &self.workspaces[workspace];
+                    workspace
+                        .item_actionable(item)
+                        .then(|| workspace.items.get(item))
+                        .flatten()
+                        .filter(|item| item.ordinary_visible())
+                        .and_then(|value| item_rename_target(workspace, item, value))
+                }),
             }
         };
         if let Some(target) = target {
@@ -2585,6 +2887,9 @@ impl App {
     }
 
     fn request_add(&mut self) -> Option<DashboardEffect> {
+        if self.primary_tab == PrimaryTab::Nodes {
+            return Some(DashboardEffect::AddNode);
+        }
         if self.primary_tab == PrimaryTab::Schedules {
             self.message = Some(Message {
                 text: "Create schedules with `boomux schedule create --help` (new schedules are paused by default)".into(),
@@ -2602,21 +2907,139 @@ impl App {
                 None
             }
             Focus::Items => {
-                let workspace_id = self
-                    .selected()
-                    .filter(|workspace| workspace.local_actionable())
-                    .map(|workspace| workspace.qualify(&workspace.id))?;
-                Some(DashboardEffect::CreateShell(workspace_id))
+                let workspace = self.selected()?.clone();
+                if let WorkspaceCoordinationView::Global {
+                    revision,
+                    placements,
+                    ..
+                } = &workspace.coordination
+                {
+                    let eligible = self
+                        .nodes
+                        .iter()
+                        .filter(|node| node.workspace_owner_eligible)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    if let [node] = eligible.as_slice() {
+                        return Some(global_shell_effect(&workspace, *revision, placements, node));
+                    }
+                    self.mode = Mode::SelectWorkspaceNode(WorkspaceNodePicker {
+                        workspace_id: workspace.id.clone(),
+                        workspace_name: workspace.name.clone(),
+                        expected_revision: *revision,
+                        placements: placements.clone(),
+                        nodes: self.nodes.clone(),
+                        selected: None,
+                        project: None,
+                    });
+                    self.message = None;
+                    return None;
+                }
+                workspace
+                    .local_actionable()
+                    .then(|| DashboardEffect::CreateShell(workspace.qualify(&workspace.id)))
             }
         }
     }
 
-    fn create_workspace(&mut self, name: &str, default_cwd: Option<PathBuf>) -> DashboardEffect {
-        self.mode = Mode::Normal;
-        DashboardEffect::CreateWorkspace {
-            name: name.to_owned(),
-            default_cwd,
+    fn adopt_selected_external(&self) -> Option<DashboardEffect> {
+        let workspace = self.selected()?;
+        let WorkspaceCoordinationView::External {
+            owner_revision,
+            available,
+        } = workspace.coordination
+        else {
+            return None;
+        };
+        (available && workspace.node.workspace_owner_eligible).then(|| {
+            DashboardEffect::AdoptExternalWorkspace {
+                identity: workspace.qualify(&workspace.id),
+                expected_revision: owner_revision,
+            }
+        })
+    }
+
+    fn link_selected_external(&mut self) {
+        let Some(workspace) = self.selected().cloned() else {
+            return;
+        };
+        let WorkspaceCoordinationView::External {
+            owner_revision,
+            available,
+        } = workspace.coordination
+        else {
+            return;
+        };
+        if !available || !workspace.node.workspace_owner_eligible {
+            self.message = Some(Message {
+                text: workspace
+                    .node
+                    .workspace_owner_unavailable_reason
+                    .clone()
+                    .unwrap_or_else(|| "Unavailable external Workspaces cannot be linked".into()),
+                error: true,
+            });
+            return;
         }
+        let workspaces = self
+            .workspaces
+            .iter()
+            .filter_map(|candidate| match candidate.coordination {
+                WorkspaceCoordinationView::Global {
+                    revision,
+                    closing: false,
+                    ..
+                } => Some((candidate.id.clone(), candidate.name.clone(), revision)),
+                WorkspaceCoordinationView::Global { .. }
+                | WorkspaceCoordinationView::External { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        self.mode = Mode::LinkWorkspace(LinkWorkspacePicker {
+            identity: workspace.qualify(&workspace.id),
+            expected_owner_revision: owner_revision,
+            workspaces,
+            selected: None,
+        });
+        self.message = None;
+    }
+
+    fn create_workspace(
+        &mut self,
+        name: &str,
+        default_cwd: Option<PathBuf>,
+    ) -> Option<DashboardEffect> {
+        if let Some(default_cwd) = default_cwd {
+            let eligible = self
+                .nodes
+                .iter()
+                .filter(|node| node.workspace_owner_eligible)
+                .cloned()
+                .collect::<Vec<_>>();
+            if let [node] = eligible.as_slice() {
+                self.mode = Mode::Normal;
+                return Some(DashboardEffect::CreatePlacedWorkspace {
+                    name: name.to_owned(),
+                    default_cwd,
+                    node_id: node.id.clone(),
+                });
+            }
+            self.mode = Mode::SelectWorkspaceNode(WorkspaceNodePicker {
+                workspace_id: String::new(),
+                workspace_name: name.to_owned(),
+                expected_revision: 0,
+                placements: Vec::new(),
+                nodes: self.nodes.clone(),
+                selected: None,
+                project: Some((name.to_owned(), default_cwd)),
+            });
+            self.message = None;
+            return None;
+        }
+        self.mode = Mode::Normal;
+        Some(DashboardEffect::CreateWorkspace {
+            name: name.to_owned(),
+            default_cwd: None,
+        })
     }
 
     fn rename(&mut self, target: RenameTarget, name: String) -> DashboardEffect {
@@ -2628,9 +3051,28 @@ impl App {
         if self.primary_tab != PrimaryTab::Workspaces {
             return None;
         }
-        self.selected()
-            .filter(|workspace| workspace.local_actionable())
-            .map(|workspace| DashboardEffect::RestoreWorkspace(workspace.qualify(&workspace.id)))
+        let workspace = self.selected()?;
+        match workspace.coordination {
+            WorkspaceCoordinationView::Global {
+                revision,
+                closing: false,
+                ..
+            } => Some(DashboardEffect::OpenGlobalWorkspace {
+                workspace_id: workspace.id.clone(),
+                expected_revision: revision,
+            }),
+            WorkspaceCoordinationView::Global { closing: true, .. } => {
+                Some(DashboardEffect::RetryGlobalWorkspaceClose {
+                    workspace_id: workspace.id.clone(),
+                })
+            }
+            WorkspaceCoordinationView::External {
+                available: true, ..
+            } if workspace.local_actionable() => Some(DashboardEffect::RestoreWorkspace(
+                workspace.qualify(&workspace.id),
+            )),
+            WorkspaceCoordinationView::External { .. } => None,
+        }
     }
 
     fn open_selected_item(&self) -> Option<DashboardEffect> {
@@ -2638,33 +3080,39 @@ impl App {
         {
             return None;
         }
-        let workspace = self.selected_item_workspace()?;
-        let workspace_id = workspace.qualify(&workspace.id);
-        let target = self.selected_item().and_then(|item| match item {
-            WorkspaceItemView::Shell(shell) => workspace
-                .shell_attachable()
-                .then(|| OpenTarget::Shell(workspace.qualify(&shell.id))),
-            WorkspaceItemView::AgentShell(agent_shell) => workspace
-                .shell_attachable()
-                .then(|| OpenTarget::Shell(workspace.qualify(&agent_shell.shell.id))),
-            WorkspaceItemView::Launcher(launcher) => {
-                workspace
-                    .launcher_invokable()
+        let (workspace_index, item_index) = self.selected_item_location()?;
+        let workspace = &self.workspaces[workspace_index];
+        let workspace_id = workspace.qualify_item_workspace(item_index);
+        let target = workspace
+            .items
+            .get(item_index)
+            .and_then(|item| match item {
+                WorkspaceItemView::Shell(shell) => workspace
+                    .item_shell_attachable(item_index)
+                    .then(|| OpenTarget::Shell(workspace.qualify_item(item_index, &shell.id))),
+                WorkspaceItemView::AgentShell(agent_shell) => {
+                    workspace.item_shell_attachable(item_index).then(|| {
+                        OpenTarget::Shell(workspace.qualify_item(item_index, &agent_shell.shell.id))
+                    })
+                }
+                WorkspaceItemView::Launcher(launcher) => workspace
+                    .item_launcher_invokable(item_index)
                     .then(|| OpenTarget::Launcher {
                         workspace_id,
-                        launcher_id: workspace.qualify(&launcher.id),
-                    })
-            }
-            WorkspaceItemView::Schedule(_) => None,
-        })?;
+                        launcher_id: workspace.qualify_item(item_index, &launcher.id),
+                    }),
+                WorkspaceItemView::Schedule(_) => None,
+            })?;
         Some(DashboardEffect::Open(target))
     }
 
     fn activate_selected_item(&mut self) -> Option<DashboardEffect> {
         let schedule_id = match self.selected_item() {
-            Some(WorkspaceItemView::Schedule(schedule)) => self
-                .selected_item_workspace()
-                .map(|workspace| workspace.qualify(&schedule.id)),
+            Some(WorkspaceItemView::Schedule(schedule)) => {
+                self.selected_item_location().map(|(workspace, item)| {
+                    self.workspaces[workspace].qualify_item(item, &schedule.id)
+                })
+            }
             _ => None,
         };
         if let Some(schedule_id) = schedule_id {
@@ -2677,6 +3125,18 @@ impl App {
     }
 
     fn request_close(&mut self) {
+        if self.primary_tab == PrimaryTab::Nodes {
+            if let Some(node) = self
+                .node_state
+                .selected()
+                .and_then(|index| self.nodes.get(index))
+                .filter(|node| !node.local)
+                .cloned()
+            {
+                self.mode = Mode::ConfirmForgetNode(node);
+            }
+            return;
+        }
         if self.primary_tab == PrimaryTab::Schedules {
             self.pending_close = self
                 .selected_schedule()
@@ -2690,28 +3150,81 @@ impl App {
             return;
         }
         self.pending_close = if self.primary_tab != PrimaryTab::Workspaces {
-            self.selected_item_workspace()
-                .filter(|workspace| workspace.actionable())
-                .zip(self.selected_item().filter(|item| item.ordinary_visible()))
-                .map(|(workspace, item)| item_pending_close(workspace, item))
+            self.selected_item_location().and_then(|(workspace, item)| {
+                let workspace = &self.workspaces[workspace];
+                workspace
+                    .item_actionable(item)
+                    .then(|| workspace.items.get(item))
+                    .flatten()
+                    .filter(|item| item.ordinary_visible())
+                    .map(|value| item_pending_close(workspace, item, value))
+            })
         } else {
             match self.focus {
                 Focus::Workspaces => self
                     .selected()
                     .filter(|workspace| workspace.actionable())
-                    .map(|workspace| PendingClose {
-                        target: CloseTarget::Workspace(workspace.qualify(&workspace.id)),
-                        name: workspace.name.clone(),
-                        shell_count: workspace.process_count(),
-                        launcher_count: workspace.launcher_count(),
+                    .and_then(|workspace| {
+                        let target = match workspace.coordination {
+                            WorkspaceCoordinationView::Global {
+                                revision,
+                                closing: false,
+                                ..
+                            } => CloseTarget::GlobalWorkspace {
+                                workspace_id: workspace.id.clone(),
+                                expected_revision: revision,
+                            },
+                            WorkspaceCoordinationView::External {
+                                available: true, ..
+                            } => CloseTarget::Workspace(workspace.qualify(&workspace.id)),
+                            WorkspaceCoordinationView::Global { .. }
+                            | WorkspaceCoordinationView::External { .. } => return None,
+                        };
+                        Some(PendingClose {
+                            target,
+                            name: workspace.name.clone(),
+                            shell_count: workspace.process_count(),
+                            launcher_count: workspace.launcher_count(),
+                        })
                     }),
-                Focus::Items => self
-                    .selected()
-                    .filter(|workspace| workspace.actionable())
-                    .zip(self.selected_item().filter(|item| item.ordinary_visible()))
-                    .map(|(workspace, item)| item_pending_close(workspace, item)),
+                Focus::Items => self.selected_item_location().and_then(|(workspace, item)| {
+                    let workspace = &self.workspaces[workspace];
+                    workspace
+                        .item_actionable(item)
+                        .then(|| workspace.items.get(item))
+                        .flatten()
+                        .filter(|item| item.ordinary_visible())
+                        .map(|value| item_pending_close(workspace, item, value))
+                }),
             }
         };
+    }
+
+    fn inspect_selected_node(&mut self) {
+        if let Some(node) = self
+            .node_state
+            .selected()
+            .and_then(|index| self.nodes.get(index))
+            .cloned()
+        {
+            self.mode = Mode::InspectNode(node);
+        }
+    }
+
+    fn retarget_selected_node(&mut self) {
+        if let Some(node) = self
+            .node_state
+            .selected()
+            .and_then(|index| self.nodes.get(index))
+            .filter(|node| !node.local)
+            && let Some(expected_revision) = node.registration_revision
+        {
+            self.mode = Mode::RetargetNode {
+                node_id: node.id.clone(),
+                expected_revision,
+                input: node.route.clone().unwrap_or_default(),
+            };
+        }
     }
 
     fn cancel_close(&mut self) {
@@ -2891,6 +3404,10 @@ impl App {
             KeyCode::Home => self.scroll_terminal_preview_to_start(),
             KeyCode::End => self.scroll_terminal_preview_to_end(),
             KeyCode::Enter => {
+                if self.primary_tab == PrimaryTab::Nodes {
+                    self.inspect_selected_node();
+                    return None;
+                }
                 if self.primary_tab == PrimaryTab::Schedules {
                     return self.open_selected_schedule_link();
                 }
@@ -2903,8 +3420,16 @@ impl App {
                     }
                 };
             }
+            KeyCode::Char('r') if self.primary_tab == PrimaryTab::Nodes => {
+                return self
+                    .node_state
+                    .selected()
+                    .and_then(|index| self.nodes.get(index))
+                    .filter(|node| !node.local)
+                    .map(|node| DashboardEffect::RefreshNode(node.id.clone()))
+                    .or(Some(DashboardEffect::Refresh));
+            }
             KeyCode::Char('r') => return Some(DashboardEffect::Refresh),
-            KeyCode::Char('n') => self.cycle_node_filter(),
             KeyCode::Char('[') if self.primary_tab == PrimaryTab::Schedules => {
                 self.cycle_execution(false);
             }
@@ -2948,7 +3473,16 @@ impl App {
             }
             KeyCode::Char('x') => self.request_close(),
             KeyCode::Char('a') => return self.request_add(),
+            KeyCode::Char('d') if self.primary_tab == PrimaryTab::Workspaces => {
+                return self.adopt_selected_external();
+            }
+            KeyCode::Char('L') if self.primary_tab == PrimaryTab::Workspaces => {
+                self.link_selected_external();
+            }
             KeyCode::Char('e') => return self.request_rename(),
+            KeyCode::Char('t') if self.primary_tab == PrimaryTab::Nodes => {
+                self.retarget_selected_node();
+            }
             KeyCode::Char(' ') => self.toggle_selection_pin(),
             KeyCode::Char('/' | ':') => self.open_palette(),
             KeyCode::Char('?') => self.mode = Mode::Help,
@@ -2976,26 +3510,16 @@ impl App {
                 self.nodes = state.nodes;
                 self.all_workspaces = state.workspaces;
                 self.all_schedules = state.schedules;
-                let workspaces = self
-                    .all_workspaces
-                    .iter()
-                    .filter(|workspace| {
-                        self.node_filter
-                            .as_ref()
-                            .is_none_or(|node_id| workspace.node.id == *node_id)
-                    })
-                    .cloned()
-                    .collect();
-                let schedules = self
-                    .all_schedules
-                    .iter()
-                    .filter(|schedule| {
-                        self.node_filter
-                            .as_ref()
-                            .is_none_or(|node_id| schedule.node_id == *node_id)
-                    })
-                    .cloned()
-                    .collect();
+                let workspaces = self.all_workspaces.clone();
+                let schedules = self.all_schedules.clone();
+                self.node_state.select(
+                    (!self.nodes.is_empty()).then_some(
+                        self.node_state
+                            .selected()
+                            .unwrap_or(0)
+                            .min(self.nodes.len().saturating_sub(1)),
+                    ),
+                );
                 self.replace_workspaces(workspaces);
                 self.replace_schedules(schedules);
                 self.scheduling = state.scheduling;
@@ -3014,12 +3538,14 @@ impl App {
         let selected = if self.primary_tab == PrimaryTab::Workspaces && self.focus != Focus::Items {
             None
         } else {
-            let workspace = self
-                .selected_item_workspace()
-                .filter(|workspace| workspace.actionable())?;
-            self.selected_item().and_then(|item| match item {
+            let (workspace_index, item_index) = self.selected_item_location()?;
+            let workspace = &self.workspaces[workspace_index];
+            if !workspace.item_actionable(item_index) {
+                return None;
+            }
+            workspace.items.get(item_index).and_then(|item| match item {
                 WorkspaceItemView::Shell(shell) if shell.kind == TerminalKind::Shell => Some((
-                    workspace.qualify(&shell.id),
+                    workspace.qualify_item(item_index, &shell.id),
                     shell.run.as_ref().map(|run| run.id.clone()),
                     shell.run.as_ref().map_or(0, |run| run.output_revision),
                 )),
@@ -3219,11 +3745,9 @@ impl App {
 
     fn select_agent_id(&mut self, agent_id: &QualifiedIdentity) -> bool {
         let Some((workspace_index, item_index)) = self.workspaces.iter().enumerate().find_map(|(workspace_index, workspace)| {
-            if workspace.node.id != agent_id.node_id {
-                return None;
-            }
             workspace.items.iter().enumerate().find_map(|(item_index, item)| {
-                matches!(item, WorkspaceItemView::AgentShell(agent) if agent.agent.as_ref().is_some_and(|agent| agent.id == agent_id.inner_id))
+                (workspace.item_owner(item_index).0.id == agent_id.node_id
+                    && matches!(item, WorkspaceItemView::AgentShell(agent) if agent.agent.as_ref().is_some_and(|agent| agent.id == agent_id.inner_id)))
                     .then_some((workspace_index, item_index))
             })
         }) else {
@@ -3232,6 +3756,7 @@ impl App {
         self.select_tab(PrimaryTab::Agents);
         let identity = item_identity(
             &self.workspaces[workspace_index],
+            item_index,
             &self.workspaces[workspace_index].items[item_index],
         );
         self.global_state
@@ -3242,7 +3767,11 @@ impl App {
     fn workspace_item_identity(&self) -> Option<ItemIdentity> {
         let (workspace_index, item_index) = self.selected_item_location()?;
         let workspace = self.workspaces.get(workspace_index)?;
-        Some(item_identity(workspace, workspace.items.get(item_index)?))
+        Some(item_identity(
+            workspace,
+            item_index,
+            workspace.items.get(item_index)?,
+        ))
     }
 
     fn global_item_identity(&self) -> Option<ItemIdentity> {
@@ -3252,6 +3781,7 @@ impl App {
         let (workspace, item) = self.selected_item_location()?;
         Some(item_identity(
             &self.workspaces[workspace],
+            item,
             &self.workspaces[workspace].items[item],
         ))
     }
@@ -3261,15 +3791,20 @@ impl App {
             self.global_item_location(ordinal)
                 .is_some_and(|(workspace, item)| {
                     let workspace = &self.workspaces[workspace];
+                    let owner = workspace.item_owner(item);
                     item_matches(&workspace.items[item], identity)
-                        && workspace.node.id == identity.workspace_id.node_id
-                        && workspace.id == identity.workspace_id.inner_id
+                        && owner.0.id == identity.workspace_id.node_id
+                        && owner.1 == identity.workspace_id.inner_id
                 })
         })
     }
 }
 
-fn item_identity(workspace: &WorkspaceView, item: &WorkspaceItemView) -> ItemIdentity {
+fn item_identity(
+    workspace: &WorkspaceView,
+    item_index: usize,
+    item: &WorkspaceItemView,
+) -> ItemIdentity {
     let (item_id, kind) = match item {
         WorkspaceItemView::Shell(shell) => (shell.id.clone(), ItemIdentityKind::Shell),
         WorkspaceItemView::AgentShell(agent) => (agent.shell.id.clone(), ItemIdentityKind::Shell),
@@ -3277,9 +3812,32 @@ fn item_identity(workspace: &WorkspaceView, item: &WorkspaceItemView) -> ItemIde
         WorkspaceItemView::Schedule(schedule) => (schedule.id.clone(), ItemIdentityKind::Schedule),
     };
     ItemIdentity {
-        workspace_id: workspace.qualify(&workspace.id),
-        item_id: workspace.qualify(item_id),
+        workspace_id: workspace.qualify_item_workspace(item_index),
+        item_id: workspace.qualify_item(item_index, item_id),
         kind,
+    }
+}
+
+fn global_shell_effect(
+    workspace: &WorkspaceView,
+    expected_revision: u64,
+    placements: &[WorkspacePlacementView],
+    node: &NodeView,
+) -> DashboardEffect {
+    let placement = placements
+        .iter()
+        .find(|placement| placement.node.id == node.id);
+    DashboardEffect::CreateGlobalShell {
+        workspace_id: workspace.id.clone(),
+        expected_revision,
+        node_id: node.id.clone(),
+        owner_workspace_id: placement.map_or_else(
+            || uuid::Uuid::new_v4().to_string(),
+            |placement| placement.workspace_id.clone(),
+        ),
+        default_cwd: placement
+            .and_then(|placement| placement.default_cwd.as_deref())
+            .map(PathBuf::from),
     }
 }
 
@@ -3300,41 +3858,51 @@ fn item_matches(item: &WorkspaceItemView, identity: &ItemIdentity) -> bool {
     }
 }
 
-fn item_rename_target(workspace: &WorkspaceView, item: &WorkspaceItemView) -> Option<RenameTarget> {
+fn item_rename_target(
+    workspace: &WorkspaceView,
+    item_index: usize,
+    item: &WorkspaceItemView,
+) -> Option<RenameTarget> {
     match item {
-        WorkspaceItemView::Shell(shell) => Some(RenameTarget::Shell(workspace.qualify(&shell.id))),
-        WorkspaceItemView::AgentShell(agent) => {
-            Some(RenameTarget::Shell(workspace.qualify(&agent.shell.id)))
-        }
-        WorkspaceItemView::Launcher(launcher) => {
-            Some(RenameTarget::Launcher(workspace.qualify(&launcher.id)))
-        }
+        WorkspaceItemView::Shell(shell) => Some(RenameTarget::Shell(
+            workspace.qualify_item(item_index, &shell.id),
+        )),
+        WorkspaceItemView::AgentShell(agent) => Some(RenameTarget::Shell(
+            workspace.qualify_item(item_index, &agent.shell.id),
+        )),
+        WorkspaceItemView::Launcher(launcher) => Some(RenameTarget::Launcher(
+            workspace.qualify_item(item_index, &launcher.id),
+        )),
         WorkspaceItemView::Schedule(_) => None,
     }
 }
 
-fn item_pending_close(workspace: &WorkspaceView, item: &WorkspaceItemView) -> PendingClose {
+fn item_pending_close(
+    workspace: &WorkspaceView,
+    item_index: usize,
+    item: &WorkspaceItemView,
+) -> PendingClose {
     match item {
         WorkspaceItemView::Shell(shell) => PendingClose {
-            target: CloseTarget::Shell(workspace.qualify(&shell.id)),
+            target: CloseTarget::Shell(workspace.qualify_item(item_index, &shell.id)),
             name: shell.name.clone(),
             shell_count: 1,
             launcher_count: 0,
         },
         WorkspaceItemView::AgentShell(agent) => PendingClose {
-            target: CloseTarget::Shell(workspace.qualify(&agent.shell.id)),
+            target: CloseTarget::Shell(workspace.qualify_item(item_index, &agent.shell.id)),
             name: agent.shell.name.clone(),
             shell_count: 1,
             launcher_count: 0,
         },
         WorkspaceItemView::Launcher(launcher) => PendingClose {
-            target: CloseTarget::Launcher(workspace.qualify(&launcher.id)),
+            target: CloseTarget::Launcher(workspace.qualify_item(item_index, &launcher.id)),
             name: launcher.name.clone(),
             shell_count: 0,
             launcher_count: 1,
         },
         WorkspaceItemView::Schedule(schedule) => PendingClose {
-            target: CloseTarget::Schedule(workspace.qualify(&schedule.id)),
+            target: CloseTarget::Schedule(workspace.qualify_item(item_index, &schedule.id)),
             name: schedule.name.clone(),
             shell_count: 0,
             launcher_count: 0,
@@ -3356,11 +3924,9 @@ pub(crate) fn run<B: DashboardBackend>(
     }
     let mut app = App::new(state.workspaces, project_context);
     app.nodes = state.nodes;
+    app.node_state.select((!app.nodes.is_empty()).then_some(0));
     app.all_schedules = state.schedules.clone();
     app.schedules = state.schedules;
-    if state.initial_node_filter.is_some() {
-        app.set_node_filter(state.initial_node_filter);
-    }
     app.scheduling = state.scheduling;
     app.exact_run_attachment = state.exact_run_attachment;
     app.schedule_editing = state.schedule_editing;
@@ -3657,11 +4223,11 @@ fn handle_mode_key(
                     .custom_name()
                     .expect("nonempty workspace name")
                     .to_owned();
-                Some(app.create_workspace(&name, None))
+                app.create_workspace(&name, None)
             }
             KeyCode::Enter if picker.selected().is_some() => {
                 let project = picker.selected().expect("selected project").clone();
-                Some(app.create_workspace(&project.name, Some(project.path)))
+                app.create_workspace(&project.name, Some(project.path))
             }
             KeyCode::Enter => {
                 app.mode = Mode::PickProject(picker);
@@ -3697,6 +4263,107 @@ fn handle_mode_key(
             }
             _ => {
                 app.mode = Mode::PickProject(picker);
+                None
+            }
+        },
+        Mode::SelectWorkspaceNode(mut picker) => match key {
+            KeyCode::Enter => match picker.effect() {
+                Some(effect) => Some(effect),
+                None => {
+                    app.mode = Mode::SelectWorkspaceNode(picker);
+                    None
+                }
+            },
+            KeyCode::Down | KeyCode::Char('j') => {
+                picker.move_selection(true);
+                app.mode = Mode::SelectWorkspaceNode(picker);
+                None
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                picker.move_selection(false);
+                app.mode = Mode::SelectWorkspaceNode(picker);
+                None
+            }
+            KeyCode::Esc => None,
+            _ => {
+                app.mode = Mode::SelectWorkspaceNode(picker);
+                None
+            }
+        },
+        Mode::LinkWorkspace(mut picker) => match key {
+            KeyCode::Enter => match picker.effect() {
+                Some(effect) => Some(effect),
+                None => {
+                    app.mode = Mode::LinkWorkspace(picker);
+                    None
+                }
+            },
+            KeyCode::Down | KeyCode::Char('j') => {
+                picker.move_selection(true);
+                app.mode = Mode::LinkWorkspace(picker);
+                None
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                picker.move_selection(false);
+                app.mode = Mode::LinkWorkspace(picker);
+                None
+            }
+            KeyCode::Esc => None,
+            _ => {
+                app.mode = Mode::LinkWorkspace(picker);
+                None
+            }
+        },
+        Mode::InspectNode(node) => match key {
+            KeyCode::Esc | KeyCode::Enter => None,
+            _ => {
+                app.mode = Mode::InspectNode(node);
+                None
+            }
+        },
+        Mode::RetargetNode {
+            node_id,
+            expected_revision,
+            mut input,
+        } => match key {
+            KeyCode::Enter if !input.trim().is_empty() => Some(DashboardEffect::RetargetNode {
+                node_id,
+                expected_revision,
+                route: input.trim().to_owned(),
+            }),
+            KeyCode::Esc => None,
+            KeyCode::Backspace => {
+                input.pop();
+                app.mode = Mode::RetargetNode {
+                    node_id,
+                    expected_revision,
+                    input,
+                };
+                None
+            }
+            KeyCode::Char(character) => {
+                input.push(character);
+                app.mode = Mode::RetargetNode {
+                    node_id,
+                    expected_revision,
+                    input,
+                };
+                None
+            }
+            _ => {
+                app.mode = Mode::RetargetNode {
+                    node_id,
+                    expected_revision,
+                    input,
+                };
+                None
+            }
+        },
+        Mode::ConfirmForgetNode(node) => match key {
+            KeyCode::Char('y') => Some(DashboardEffect::ForgetNode { node_id: node.id }),
+            KeyCode::Char('n') | KeyCode::Esc => None,
+            _ => {
+                app.mode = Mode::ConfirmForgetNode(node);
                 None
             }
         },
@@ -3826,7 +4493,9 @@ fn render(frame: &mut Frame, app: &mut App) {
     .areas(area);
 
     render_tabs(frame, tabs_area, app);
-    if app.primary_tab == PrimaryTab::Schedules {
+    if app.primary_tab == PrimaryTab::Nodes {
+        render_nodes(frame, dashboard_area, app);
+    } else if app.primary_tab == PrimaryTab::Schedules {
         render_schedules(frame, dashboard_area, app);
     } else if app.primary_tab != PrimaryTab::Workspaces {
         render_global_items(frame, dashboard_area, app);
@@ -3847,9 +4516,211 @@ fn render(frame: &mut Frame, app: &mut App) {
         Mode::PickProject(picker) => render_project_picker(frame, area, picker),
         Mode::Palette(palette) => render_command_palette(frame, area, palette),
         Mode::Help => render_help_overlay(frame, area, app),
+        Mode::SelectWorkspaceNode(picker) => render_workspace_node_picker(frame, area, picker),
+        Mode::LinkWorkspace(picker) => render_link_workspace_picker(frame, area, picker),
+        Mode::InspectNode(node) => render_node_inspection(frame, area, node),
+        Mode::RetargetNode { input, .. } => render_node_retarget(frame, area, input),
+        Mode::ConfirmForgetNode(node) => render_node_forget_confirmation(frame, area, node),
         Mode::EditSchedule(editor) => render_schedule_editor(frame, area, editor),
         Mode::Normal | Mode::Rename { .. } => {}
     }
+}
+
+fn render_node_inspection(frame: &mut Frame, area: Rect, node: &NodeView) {
+    let popup = centered_rect(area, 70, 72);
+    frame.render_widget(Clear, popup);
+    let lines = vec![
+        Line::from(format!("ID           {}", node.id)),
+        Line::from(format!("Alias        {}", node.alias)),
+        Line::from(format!(
+            "Route        {}",
+            node.route.as_deref().unwrap_or("local")
+        )),
+        Line::from(format!(
+            "Revision     {}",
+            node.registration_revision
+                .map_or_else(|| "-".into(), |value| value.to_string())
+        )),
+        Line::from(format!("Health       {}", node_health_label(node.health))),
+        Line::from(format!("Current      {}", node.current)),
+        Line::from(format!("Stale        {}", node.stale)),
+        Line::from(format!(
+            "Protocol     {}",
+            node.observed_protocol_version
+                .map_or_else(|| "-".into(), |value| value.to_string())
+        )),
+        Line::from(format!(
+            "Last sync    {}",
+            if node.observed_at_ms == 0 {
+                "never".into()
+            } else {
+                compact_recency(node.observed_at_ms)
+            }
+        )),
+        Line::from(format!(
+            "Scheduler    {:?} {}/{}",
+            node.scheduler.state, node.scheduler.active_executions, node.scheduler.max_concurrent
+        )),
+        Line::from(format!(
+            "Placement    {}",
+            if node.workspace_owner_eligible {
+                "eligible"
+            } else {
+                node.workspace_owner_unavailable_reason
+                    .as_deref()
+                    .unwrap_or("unavailable")
+            }
+        )),
+        Line::from(format!(
+            "Capabilities {}",
+            node.observed_capabilities.join(", ")
+        )),
+        Line::from(""),
+        Line::styled("enter/esc close", Style::new().fg(SUBTEXT)),
+    ];
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::bordered()
+                    .title(" Node inspection ")
+                    .border_style(Style::new().fg(TEAL)),
+            )
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn render_node_retarget(frame: &mut Frame, area: Rect, input: &str) {
+    let popup = centered_rect(area, 68, 24);
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Paragraph::new(format!(
+            "New SSH route:\n\n{input}_\n\nenter verify and retarget  esc cancel"
+        ))
+        .block(
+            Block::bordered()
+                .title(" Retarget Node ")
+                .border_style(Style::new().fg(YELLOW)),
+        ),
+        popup,
+    );
+}
+
+fn render_node_forget_confirmation(frame: &mut Frame, area: Rect, node: &NodeView) {
+    let popup = centered_rect(area, 64, 24);
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Paragraph::new(format!(
+            "Forget Node {} ({})?\n\nThis removes only the local route and projection. Remote work continues.\n\ny confirm  n/esc cancel",
+            node.alias, node.id
+        ))
+        .block(Block::bordered().title(" Confirm forget ").border_style(Style::new().fg(RED)))
+        .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn render_workspace_node_picker(frame: &mut Frame, area: Rect, picker: &WorkspaceNodePicker) {
+    let popup = centered_rect(area, 76, 70);
+    frame.render_widget(Clear, popup);
+    let block = Block::bordered()
+        .title(format!(
+            " Place first resource for {} ",
+            picker.workspace_name
+        ))
+        .border_style(Style::new().fg(TEAL));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+    let [notice, table_area, help] = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Fill(1),
+        Constraint::Length(1),
+    ])
+    .areas(inner);
+    frame.render_widget(
+        Paragraph::new("No Node is preselected. Unavailable owners remain visible but disabled.")
+            .style(Style::new().fg(SUBTEXT)),
+        notice,
+    );
+    let rows = picker.nodes.iter().map(|node| {
+        let status = if node.workspace_owner_eligible {
+            "eligible".into()
+        } else {
+            node.workspace_owner_unavailable_reason
+                .clone()
+                .unwrap_or_else(|| "unavailable".into())
+        };
+        Row::new([
+            node.alias.clone(),
+            node_health_label(node.health).into(),
+            status,
+            node.route.clone().unwrap_or_else(|| "local".into()),
+        ])
+        .style(Style::new().fg(if node.workspace_owner_eligible {
+            TEXT
+        } else {
+            OVERLAY
+        }))
+    });
+    let mut state = TableState::default().with_selected(picker.selected);
+    frame.render_stateful_widget(
+        Table::new(
+            rows,
+            [
+                Constraint::Length(16),
+                Constraint::Length(18),
+                Constraint::Min(24),
+                Constraint::Length(24),
+            ],
+        )
+        .header(Row::new(["NODE", "HEALTH", "PLACEMENT", "ROUTE"]).style(Style::new().fg(BLUE)))
+        .row_highlight_style(Style::new().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("> "),
+        table_area,
+        &mut state,
+    );
+    frame.render_widget(
+        Paragraph::new("j/k select eligible Node  enter confirm  esc cancel")
+            .style(Style::new().fg(SUBTEXT)),
+        help,
+    );
+}
+
+fn render_link_workspace_picker(frame: &mut Frame, area: Rect, picker: &LinkWorkspacePicker) {
+    let popup = centered_rect(area, 60, 60);
+    frame.render_widget(Clear, popup);
+    let block = Block::bordered()
+        .title(" Link external Workspace to ")
+        .border_style(Style::new().fg(TEAL));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+    let [table_area, help] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(inner);
+    let rows = picker
+        .workspaces
+        .iter()
+        .map(|(id, name, revision)| Row::new([name.clone(), short_id(id), revision.to_string()]));
+    let mut state = TableState::default().with_selected(picker.selected);
+    frame.render_stateful_widget(
+        Table::new(
+            rows,
+            [
+                Constraint::Min(20),
+                Constraint::Length(10),
+                Constraint::Length(10),
+            ],
+        )
+        .header(Row::new(["WORKSPACE", "ID", "REVISION"]).style(Style::new().fg(BLUE)))
+        .row_highlight_style(Style::new().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("> "),
+        table_area,
+        &mut state,
+    );
+    frame.render_widget(
+        Paragraph::new("j/k select  enter guarded link  esc cancel")
+            .style(Style::new().fg(SUBTEXT)),
+        help,
+    );
 }
 
 fn render_schedule_editor(frame: &mut Frame, area: Rect, editor: &ScheduleEditor) {
@@ -4801,8 +5672,6 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                 ]
             })
             .collect::<Vec<_>>();
-        let mut spans = spans;
-        append_node_filter(&mut spans, app);
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
         return;
     }
@@ -4839,6 +5708,7 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                         app.workspaces.iter().map(WorkspaceView::shell_count).sum()
                     }
                     PrimaryTab::Schedules => app.schedules.len(),
+                    PrimaryTab::Nodes => app.nodes.len(),
                     PrimaryTab::Workspaces => unreachable!("workspace tab is rendered separately"),
                 };
                 let style = if *tab == app.primary_tab {
@@ -4852,24 +5722,65 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                 ]
             }),
     );
-    append_node_filter(&mut spans, app);
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
-fn append_node_filter<'a>(spans: &mut Vec<Span<'a>>, app: &'a App) {
-    if app.nodes.len() <= 1 && app.node_filter.is_none() {
-        return;
-    }
-    let filter = app.node_filter.as_ref().map_or("all", |id| {
-        app.nodes
-            .iter()
-            .find(|node| &node.id == id)
-            .map_or("unknown", |node| node.alias.as_str())
+fn render_nodes(frame: &mut Frame, area: Rect, app: &mut App) {
+    let rows = app.nodes.iter().map(|node| {
+        let protocol = node
+            .observed_protocol_version
+            .map_or_else(|| "-".into(), |version| version.to_string());
+        let last_sync = if node.observed_at_ms == 0 {
+            "never".into()
+        } else {
+            compact_recency(node.observed_at_ms)
+        };
+        let scheduler = match node.scheduler.state {
+            crate::protocol::SchedulerState::Active => "active",
+            crate::protocol::SchedulerState::Offline => "offline",
+        };
+        Row::new(vec![
+            node.alias.clone(),
+            node_health_label(node.health).into(),
+            node.route.clone().unwrap_or_else(|| "local".into()),
+            protocol,
+            last_sync,
+            scheduler.into(),
+            node.observed_capabilities.join(","),
+        ])
     });
-    spans.push(Span::styled(
-        format!(" NODE:{filter}"),
-        Style::new().fg(YELLOW),
-    ));
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(14),
+            Constraint::Length(18),
+            Constraint::Length(24),
+            Constraint::Length(9),
+            Constraint::Length(12),
+            Constraint::Length(11),
+            Constraint::Fill(1),
+        ],
+    )
+    .header(
+        Row::new([
+            "ALIAS",
+            "HEALTH",
+            "ROUTE",
+            "PROTOCOL",
+            "LAST SYNC",
+            "SCHEDULER",
+            "CAPABILITIES",
+        ])
+        .style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)),
+    )
+    .block(
+        Block::bordered()
+            .title(" Nodes ")
+            .border_style(Style::new().fg(OVERLAY)),
+    )
+    .row_highlight_style(Style::new().fg(TEXT).add_modifier(Modifier::REVERSED))
+    .highlight_symbol("> ");
+    frame.render_stateful_widget(table, area, &mut app.node_state);
 }
 
 fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
@@ -4884,6 +5795,7 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
             Layout::vertical([Constraint::Fill(1), Constraint::Length(preview_height)]).areas(area);
         (table_area, Some(preview_area))
     });
+    let show_node = app.nodes.len() > 1;
     let rows = if app.workspaces.is_empty() {
         vec![Row::new([Cell::from(Span::styled(
             "No workspaces. Press a to create one.",
@@ -4892,11 +5804,38 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
     } else {
         app.workspaces
             .iter()
-            .map(|workspace| Row::new([Cell::from(workspace_display_name(workspace))]))
+            .map(|workspace| {
+                let mut cells = vec![Cell::from(if show_node {
+                    workspace.name.clone()
+                } else {
+                    workspace_display_name(workspace)
+                })];
+                if show_node {
+                    cells.push(Cell::from(match &workspace.coordination {
+                        WorkspaceCoordinationView::Global { placements, .. } => placements
+                            .iter()
+                            .map(|placement| placement.node.alias.as_str())
+                            .collect::<Vec<_>>()
+                            .join(","),
+                        WorkspaceCoordinationView::External { .. } => workspace.node.alias.clone(),
+                    }));
+                }
+                Row::new(cells)
+            })
             .collect()
     };
-    let table = Table::new(rows, [Constraint::Min(8)])
-        .header(Row::new(["NAME"]).style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
+    let widths = if show_node {
+        vec![Constraint::Min(8), Constraint::Length(12)]
+    } else {
+        vec![Constraint::Min(8)]
+    };
+    let headers = if show_node {
+        vec!["NAME", "NODE"]
+    } else {
+        vec!["NAME"]
+    };
+    let table = Table::new(rows, widths)
+        .header(Row::new(headers).style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
         .block(
             Block::bordered()
                 .title(format!(" Workspaces ({}) ", app.workspaces.len()))
@@ -4936,9 +5875,13 @@ fn render_schedules(frame: &mut Frame, area: Rect, app: &mut App) {
         (area, None)
     };
     let show_trigger = table_area.width >= 60;
+    let show_node = app.nodes.len() > 1;
     let show_workspace = table_area.width >= 74;
     let show_integration = table_area.width >= 88;
     let mut headers = vec!["NAME"];
+    if show_node {
+        headers.push("NODE");
+    }
     if show_trigger {
         headers.push("TRIGGER");
     }
@@ -4999,21 +5942,20 @@ fn render_schedules(frame: &mut Frame, area: Rect, app: &mut App) {
                     },
                     occurrence_recency,
                 );
-                let mut values = vec![if schedule.node_alias == "local" {
+                let mut values = vec![if show_node || schedule.node_alias == "local" {
                     schedule.name.clone()
                 } else {
                     format!("[{}] {}", schedule.node_alias, schedule.name)
                 }];
+                if show_node {
+                    values.push(schedule.node_alias.clone());
+                }
                 if show_trigger {
                     values.push(schedule.friendly_trigger.clone());
                 }
                 values.extend([next, last, schedule.state.label().into()]);
                 if show_workspace {
-                    values.push(if schedule.node_alias == "local" {
-                        schedule.workspace.clone()
-                    } else {
-                        format!("[{}] {}", schedule.node_alias, schedule.workspace)
-                    });
+                    values.push(schedule.workspace.clone());
                 }
                 if show_integration {
                     values.push(schedule.integration.clone());
@@ -5221,44 +6163,58 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
         (items_area, Some(preview_area))
     });
     let (rows, widths, header) = if app.primary_tab == PrimaryTab::Agents {
-        let values: Vec<[String; 7]> = app
+        let values: Vec<[String; 8]> = app
             .workspaces
             .iter()
             .flat_map(|workspace| {
-                workspace.items.iter().filter_map(move |item| {
-                    let WorkspaceItemView::AgentShell(agent) = item else {
-                        return None;
-                    };
-                    let task = matched_agent_session(workspace, agent)
-                        .and_then(session_task_label)
-                        .unwrap_or("-");
-                    let (updated, branch, worktree) = agent.agent.as_ref().map_or_else(
-                        || ("-".into(), "-".into(), "-".into()),
-                        |view| {
-                            (
-                                compact_recency(view.updated_at_ms),
-                                view.root_branch.clone(),
-                                view.root_worktree.clone(),
-                            )
-                        },
-                    );
-                    Some([
-                        agent.state().label().to_owned(),
-                        updated,
-                        workspace_display_name(workspace),
-                        agent.shell.name.clone(),
-                        task.to_owned(),
-                        branch,
-                        worktree,
-                    ])
-                })
+                workspace
+                    .items
+                    .iter()
+                    .enumerate()
+                    .filter_map(move |(item_index, item)| {
+                        let WorkspaceItemView::AgentShell(agent) = item else {
+                            return None;
+                        };
+                        let task = matched_agent_session(workspace, agent)
+                            .and_then(session_task_label)
+                            .unwrap_or("-");
+                        let (updated, branch, worktree) = agent.agent.as_ref().map_or_else(
+                            || ("-".into(), "-".into(), "-".into()),
+                            |view| {
+                                (
+                                    compact_recency(view.updated_at_ms),
+                                    view.root_branch.clone(),
+                                    view.root_worktree.clone(),
+                                )
+                            },
+                        );
+                        Some([
+                            agent.state().label().to_owned(),
+                            updated,
+                            workspace_display_name(workspace),
+                            workspace.item_owner(item_index).0.alias.clone(),
+                            agent.shell.name.clone(),
+                            task.to_owned(),
+                            branch,
+                            worktree,
+                        ])
+                    })
             })
             .collect();
         let widths = agent_column_widths(items_inner.width, &values);
         let rows: Vec<_> = values
             .into_iter()
             .map(
-                |[status, updated, workspace, shell, task, branch, worktree]| {
+                |[
+                    status,
+                    updated,
+                    workspace,
+                    node,
+                    shell,
+                    task,
+                    branch,
+                    worktree,
+                ]| {
                     Row::new([
                         Cell::from(Span::styled(
                             status.clone(),
@@ -5266,6 +6222,7 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                         )),
                         Cell::from(updated),
                         Cell::from(workspace),
+                        Cell::from(node),
                         Cell::from(shell),
                         Cell::from(task),
                         Cell::from(branch),
@@ -5276,28 +6233,33 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
             .collect();
         (rows, widths, AGENT_TABLE_HEADERS.to_vec())
     } else if app.primary_tab == PrimaryTab::Shells {
-        let values: Vec<[String; 8]> = app
+        let values: Vec<[String; 9]> = app
             .workspaces
             .iter()
             .flat_map(|workspace| {
-                workspace.items.iter().filter_map(move |item| {
-                    let WorkspaceItemView::Shell(shell) = item else {
-                        return None;
-                    };
-                    Some([
-                        shell.table_status(),
-                        shell
-                            .run
-                            .as_ref()
-                            .map_or_else(|| "-".into(), |run| format!("#{}", run.generation)),
-                        workspace_display_name(workspace),
-                        shell.name.clone(),
-                        shell.kind.label().into(),
-                        shell.process().into(),
-                        shell.branch.clone(),
-                        shell.worktree.clone(),
-                    ])
-                })
+                workspace
+                    .items
+                    .iter()
+                    .enumerate()
+                    .filter_map(move |(item_index, item)| {
+                        let WorkspaceItemView::Shell(shell) = item else {
+                            return None;
+                        };
+                        Some([
+                            shell.table_status(),
+                            shell
+                                .run
+                                .as_ref()
+                                .map_or_else(|| "-".into(), |run| format!("#{}", run.generation)),
+                            workspace_display_name(workspace),
+                            workspace.item_owner(item_index).0.alias.clone(),
+                            shell.name.clone(),
+                            shell.kind.label().into(),
+                            shell.process().into(),
+                            shell.branch.clone(),
+                            shell.worktree.clone(),
+                        ])
+                    })
             })
             .collect();
         let widths = shell_column_widths(items_inner.width, &values);
@@ -5308,6 +6270,7 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                     status,
                     run,
                     workspace,
+                    node,
                     shell,
                     kind,
                     process,
@@ -5321,6 +6284,7 @@ fn render_global_items(frame: &mut Frame, area: Rect, app: &mut App) {
                         )),
                         Cell::from(run),
                         Cell::from(workspace),
+                        Cell::from(node),
                         Cell::from(shell),
                         Cell::from(kind),
                         Cell::from(process),
@@ -5449,74 +6413,83 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
             Layout::vertical([Constraint::Fill(1), Constraint::Length(panel_height)]).areas(inner);
         (items_area, Some(preview_area))
     });
-    let values: Vec<[String; 6]> = selected
+    let values: Vec<[String; 7]> = selected
         .into_iter()
         .flat_map(|workspace| {
             workspace
                 .items
                 .iter()
-                .filter(|item| item.ordinary_visible())
-                .map(|item| match item {
-                    WorkspaceItemView::Shell(terminal) => [
-                        terminal.kind.label().into(),
-                        terminal.table_status(),
-                        terminal.name.clone(),
-                        terminal.process().into(),
-                        terminal.branch.clone(),
-                        terminal.worktree.clone(),
-                    ],
-                    WorkspaceItemView::AgentShell(agent_shell) => {
-                        let (activity, branch, worktree) = agent_shell.agent.as_ref().map_or_else(
-                            || {
-                                (
-                                    agent_shell.shell.process().to_owned(),
-                                    agent_shell.shell.branch.clone(),
-                                    agent_shell.shell.worktree.clone(),
-                                )
-                            },
-                            |agent| {
-                                (
-                                    matched_agent_session(workspace, agent_shell)
-                                        .and_then(session_task_label)
-                                        .unwrap_or(&agent.integration)
-                                        .to_owned(),
-                                    agent.root_branch.clone(),
-                                    agent.root_worktree.clone(),
-                                )
-                            },
-                        );
-                        [
-                            "agent".into(),
-                            agent_shell.state().label().into(),
-                            agent_shell.shell.name.clone(),
-                            activity,
-                            branch,
-                            worktree,
-                        ]
+                .enumerate()
+                .filter(|(_, item)| item.ordinary_visible())
+                .map(|(item_index, item)| {
+                    let node = workspace.item_owner(item_index).0.alias.clone();
+                    match item {
+                        WorkspaceItemView::Shell(terminal) => [
+                            terminal.kind.label().into(),
+                            terminal.table_status(),
+                            terminal.name.clone(),
+                            node,
+                            terminal.process().into(),
+                            terminal.branch.clone(),
+                            terminal.worktree.clone(),
+                        ],
+                        WorkspaceItemView::AgentShell(agent_shell) => {
+                            let (activity, branch, worktree) =
+                                agent_shell.agent.as_ref().map_or_else(
+                                    || {
+                                        (
+                                            agent_shell.shell.process().to_owned(),
+                                            agent_shell.shell.branch.clone(),
+                                            agent_shell.shell.worktree.clone(),
+                                        )
+                                    },
+                                    |agent| {
+                                        (
+                                            matched_agent_session(workspace, agent_shell)
+                                                .and_then(session_task_label)
+                                                .unwrap_or(&agent.integration)
+                                                .to_owned(),
+                                            agent.root_branch.clone(),
+                                            agent.root_worktree.clone(),
+                                        )
+                                    },
+                                );
+                            [
+                                "agent".into(),
+                                agent_shell.state().label().into(),
+                                agent_shell.shell.name.clone(),
+                                node,
+                                activity,
+                                branch,
+                                worktree,
+                            ]
+                        }
+                        WorkspaceItemView::Launcher(launcher) => [
+                            "launcher".into(),
+                            "ready".into(),
+                            launcher.name.clone(),
+                            node,
+                            launcher.command.clone(),
+                            launcher.branch.clone(),
+                            launcher.worktree.clone(),
+                        ],
+                        WorkspaceItemView::Schedule(schedule) => [
+                            "schedule".into(),
+                            schedule.state.label().into(),
+                            schedule.name.clone(),
+                            node,
+                            format!("{} · {}", schedule.integration, schedule.friendly_trigger),
+                            "-".into(),
+                            "-".into(),
+                        ],
                     }
-                    WorkspaceItemView::Launcher(launcher) => [
-                        "launcher".into(),
-                        "ready".into(),
-                        launcher.name.clone(),
-                        launcher.command.clone(),
-                        launcher.branch.clone(),
-                        launcher.worktree.clone(),
-                    ],
-                    WorkspaceItemView::Schedule(schedule) => [
-                        "schedule".into(),
-                        schedule.state.label().into(),
-                        schedule.name.clone(),
-                        format!("{} · {}", schedule.integration, schedule.friendly_trigger),
-                        "-".into(),
-                        "-".into(),
-                    ],
                 })
         })
         .collect();
     let widths = item_column_widths(items_inner.width, &values);
     let rows = values
         .into_iter()
-        .map(|[kind, status, name, activity, branch, worktree]| {
+        .map(|[kind, status, name, node, activity, branch, worktree]| {
             let kind_color = match kind.as_str() {
                 "agent" => TEAL,
                 "command" | "launcher" | "schedule" => YELLOW,
@@ -5529,6 +6502,7 @@ fn render_items(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut App) {
                     Style::new().fg(status_color(&status)),
                 )),
                 Cell::from(name),
+                Cell::from(node),
                 Cell::from(activity),
                 Cell::from(branch),
                 Cell::from(worktree),
@@ -5579,6 +6553,38 @@ fn workspace_preview(workspace: &WorkspaceView) -> ContextualPreview {
             Span::styled("default  ", Style::new().fg(SUBTEXT)),
             Span::raw(default_cwd.clone()),
         ]));
+    }
+    match &workspace.coordination {
+        WorkspaceCoordinationView::Global {
+            revision,
+            closing,
+            placements,
+        } => {
+            lines.push(Line::from(format!(
+                "global revision {revision} · {}",
+                if *closing { "closing" } else { "active" }
+            )));
+            lines.extend(placements.iter().map(|placement| {
+                Line::from(format!(
+                    "{} · {:?} · owner r{} · {}",
+                    placement.node.alias,
+                    placement.state,
+                    placement.owner_revision,
+                    placement.default_cwd.as_deref().unwrap_or("no default cwd")
+                ))
+            }));
+        }
+        WorkspaceCoordinationView::External {
+            owner_revision,
+            available,
+        } => lines.push(Line::from(format!(
+            "external owner revision {owner_revision} · {}",
+            if *available {
+                "available"
+            } else {
+                "unavailable"
+            }
+        ))),
     }
     lines.extend([
         Line::from(format!(
@@ -6051,16 +7057,16 @@ fn integration_display_name(integration: &str) -> &str {
     boomux::integrations::display_name(integration)
 }
 
-fn item_column_widths(width: u16, rows: &[[String; 6]]) -> Vec<Constraint> {
+fn item_column_widths(width: u16, rows: &[[String; 7]]) -> Vec<Constraint> {
     let caps = if width >= 140 {
-        [10, 12, 24, 52, 32, 24]
+        [10, 12, 24, 14, 52, 32, 24]
     } else if width >= 100 {
-        [10, 11, 18, 36, 24, 20]
+        [10, 11, 18, 12, 36, 24, 20]
     } else {
-        [8, 10, 14, 24, 18, 16]
+        [8, 10, 14, 9, 24, 18, 16]
     };
     let minimums = ITEM_TABLE_HEADERS.map(|header| header.len() as u16);
-    let mut widths: [u16; 6] = std::array::from_fn(|index| {
+    let mut widths: [u16; 7] = std::array::from_fn(|index| {
         rows.iter()
             .map(|row| row[index].chars().count() as u16)
             .max()
@@ -6070,10 +7076,10 @@ fn item_column_widths(width: u16, rows: &[[String; 6]]) -> Vec<Constraint> {
             .min(caps[index])
     });
 
-    // Five column gaps and the highlight marker also consume table width.
-    let available = width.saturating_sub(7);
+    // Six column gaps and the highlight marker also consume table width.
+    let available = width.saturating_sub(8);
     let mut overflow = widths.iter().sum::<u16>().saturating_sub(available);
-    for index in [3, 5, 4, 2, 1, 0] {
+    for index in [4, 6, 5, 2, 3, 1, 0] {
         let reduction = widths[index].saturating_sub(minimums[index]).min(overflow);
         widths[index] -= reduction;
         overflow -= reduction;
@@ -6133,18 +7139,18 @@ fn schedule_column_widths(width: u16, headers: &[&str], rows: &[Vec<String>]) ->
     widths.into_iter().map(Constraint::Length).collect()
 }
 
-fn shell_column_widths(width: u16, rows: &[[String; 8]]) -> Vec<Constraint> {
+fn shell_column_widths(width: u16, rows: &[[String; 9]]) -> Vec<Constraint> {
     let caps = if width >= 160 {
-        [12, 6, 24, 20, 9, 40, 32, 24]
+        [12, 6, 24, 14, 20, 9, 40, 32, 24]
     } else if width >= 120 {
-        [12, 6, 18, 16, 9, 28, 24, 20]
+        [12, 6, 18, 12, 16, 9, 28, 24, 20]
     } else if width >= 90 {
-        [11, 5, 14, 13, 8, 20, 18, 16]
+        [11, 5, 14, 10, 13, 8, 20, 18, 16]
     } else {
-        [10, 4, 11, 10, 7, 14, 12, 13]
+        [10, 4, 11, 8, 10, 7, 14, 12, 13]
     };
     let minimums = SHELL_TABLE_HEADERS.map(|header| header.len() as u16);
-    let mut widths: [u16; 8] = std::array::from_fn(|index| {
+    let mut widths: [u16; 9] = std::array::from_fn(|index| {
         rows.iter()
             .map(|row| row[index].chars().count() as u16)
             .max()
@@ -6154,10 +7160,10 @@ fn shell_column_widths(width: u16, rows: &[[String; 8]]) -> Vec<Constraint> {
             .min(caps[index])
     });
 
-    // Seven column gaps and the highlight marker also consume table width.
-    let available = width.saturating_sub(9);
+    // Eight column gaps and the highlight marker also consume table width.
+    let available = width.saturating_sub(10);
     let mut overflow = widths.iter().sum::<u16>().saturating_sub(available);
-    for index in [5, 7, 2, 3, 6, 4, 0, 1] {
+    for index in [6, 8, 2, 4, 7, 3, 5, 0, 1] {
         let reduction = widths[index].saturating_sub(minimums[index]).min(overflow);
         widths[index] -= reduction;
         overflow -= reduction;
@@ -6186,18 +7192,18 @@ fn global_column_widths(width: u16) -> Vec<Constraint> {
     ]
 }
 
-fn agent_column_widths(width: u16, rows: &[[String; 7]]) -> Vec<Constraint> {
+fn agent_column_widths(width: u16, rows: &[[String; 8]]) -> Vec<Constraint> {
     let caps = if width >= 160 {
-        [10, 9, 24, 16, 52, 36, 24]
+        [10, 9, 24, 14, 16, 52, 36, 24]
     } else if width >= 140 {
-        [10, 9, 20, 16, 44, 28, 20]
+        [10, 9, 20, 12, 16, 44, 28, 20]
     } else if width >= 100 {
-        [9, 8, 14, 12, 32, 18, 16]
+        [9, 8, 14, 10, 12, 32, 18, 16]
     } else {
-        [8, 7, 11, 10, 24, 12, 13]
+        [8, 7, 11, 8, 10, 24, 12, 13]
     };
     let minimums = AGENT_TABLE_HEADERS.map(|header| header.len() as u16);
-    let mut widths: [u16; 7] = std::array::from_fn(|index| {
+    let mut widths: [u16; 8] = std::array::from_fn(|index| {
         rows.iter()
             .map(|row| row[index].chars().count() as u16)
             .max()
@@ -6207,10 +7213,10 @@ fn agent_column_widths(width: u16, rows: &[[String; 7]]) -> Vec<Constraint> {
             .min(caps[index])
     });
 
-    // Six column gaps and the highlight marker also consume table width.
-    let available = width.saturating_sub(8);
+    // Seven column gaps and the highlight marker also consume table width.
+    let available = width.saturating_sub(9);
     let mut overflow = widths.iter().sum::<u16>().saturating_sub(available);
-    for index in [4, 2, 5, 3, 6, 0, 1] {
+    for index in [5, 2, 6, 4, 7, 3, 0, 1] {
         let reduction = widths[index].saturating_sub(minimums[index]).min(overflow);
         widths[index] -= reduction;
         overflow -= reduction;
@@ -6266,6 +7272,10 @@ fn session_state_color(state: AgentDisplayState) -> Color {
 fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
     let line = if let Some(pending) = &app.pending_close {
         let prompt = match pending.target {
+            CloseTarget::GlobalWorkspace { .. } => format!(
+                " Close global workspace '{}', fan out guarded removal across {} shell(s) and {} launcher(s)?  ",
+                pending.name, pending.shell_count, pending.launcher_count
+            ),
             CloseTarget::Workspace(_) => format!(
                 " Close workspace '{}', terminate {} shell(s), and remove {} launcher(s)?  ",
                 pending.name, pending.shell_count, pending.launcher_count
@@ -6314,6 +7324,36 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
         ))
     } else {
         let launcher_selected = matches!(app.selected_item(), Some(WorkspaceItemView::Launcher(_)));
+        if app.primary_tab == PrimaryTab::Nodes {
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(" j/k", Style::new().fg(TEAL)),
+                    Span::styled(" navigate  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("a", Style::new().fg(GREEN)),
+                    Span::styled(" add Node  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("r", Style::new().fg(BLUE)),
+                    Span::styled(" retry/refresh  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("enter", Style::new().fg(GREEN)),
+                    Span::styled(" inspect  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("e", Style::new().fg(YELLOW)),
+                    Span::styled(" rename  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("t", Style::new().fg(YELLOW)),
+                    Span::styled(" retarget  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("x", Style::new().fg(RED)),
+                    Span::styled(" forget  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("tab/shift-tab", Style::new().fg(TEAL)),
+                    Span::styled(" views  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("1-5", Style::new().fg(TEAL)),
+                    Span::styled(" select view  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("/", Style::new().fg(TEAL)),
+                    Span::styled(" palette  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("q", Style::new().fg(RED)),
+                    Span::styled(" quit", Style::new().fg(SUBTEXT)),
+                ])),
+                area,
+            );
+            return;
+        }
         if app.primary_tab == PrimaryTab::Schedules {
             let paused = app
                 .selected_schedule()
@@ -6407,7 +7447,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 if app.primary_tab == PrimaryTab::Workspaces {
                     " navigate  tab/shift-tab views  h/l panes  "
                 } else {
-                    " navigate  tab/shift-tab views  1-4 select view  "
+                    " navigate  tab/shift-tab views  1-5 select view  "
                 },
                 Style::new().fg(SUBTEXT),
             ),
@@ -6454,6 +7494,24 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                     Style::new().fg(SUBTEXT),
                 ),
             ]);
+            if app.focus == Focus::Workspaces
+                && app.selected().is_some_and(|workspace| {
+                    matches!(
+                        workspace.coordination,
+                        WorkspaceCoordinationView::External {
+                            available: true,
+                            ..
+                        }
+                    )
+                })
+            {
+                spans.extend([
+                    Span::styled("d", Style::new().fg(GREEN)),
+                    Span::styled(" adopt as new  ", Style::new().fg(SUBTEXT)),
+                    Span::styled("L", Style::new().fg(GREEN)),
+                    Span::styled(" link existing  ", Style::new().fg(SUBTEXT)),
+                ]);
+            }
         }
         spans.extend([
             Span::styled("e", Style::new().fg(YELLOW)),
@@ -6724,10 +7782,16 @@ mod tests {
                 id: String::new(),
                 alias: "local".into(),
                 local: true,
+                route: None,
+                registration_revision: None,
                 health: NodeProjectionHealthCode::Online,
                 current: true,
                 stale: false,
+                observed_at_ms: current_time_ms(),
+                observed_protocol_version: Some(crate::protocol::PROTOCOL_VERSION),
                 observed_capabilities: Vec::new(),
+                workspace_owner_eligible: true,
+                workspace_owner_unavailable_reason: None,
                 scheduler: SchedulerHealth {
                     state: crate::protocol::SchedulerState::Active,
                     max_concurrent: 4,
@@ -6756,6 +7820,11 @@ mod tests {
             agent_state_counts: AgentStateCounts::default(),
             attention_count: 0,
             attention: Vec::new(),
+            item_owners: Vec::new(),
+            coordination: WorkspaceCoordinationView::External {
+                owner_revision: 1,
+                available: true,
+            },
         }
     }
 
@@ -6887,13 +7956,6 @@ mod tests {
         app.request_close();
         assert!(app.pending_close.is_none());
 
-        app.cycle_node_filter();
-        assert_eq!(app.workspaces.len(), 1);
-        assert_eq!(app.workspaces[0].node.alias, "local");
-        app.cycle_node_filter();
-        assert_eq!(app.workspaces.len(), 1);
-        assert_eq!(app.workspaces[0].node.alias, "work");
-        app.cycle_node_filter();
         assert_eq!(app.workspaces.len(), 2);
     }
 
@@ -6931,6 +7993,244 @@ mod tests {
                 "{health:?}: {compact}"
             );
         }
+    }
+
+    #[test]
+    fn nodes_tab_renders_route_protocol_health_and_scheduler() {
+        let mut remote = workspace("remote-workspace", "remote");
+        remote.node.id = "00000000-0000-0000-0000-000000000002".into();
+        remote.node.alias = "work".into();
+        remote.node.local = false;
+        remote.node.route = Some("user@workbox".into());
+        remote.node.health = NodeProjectionHealthCode::Reconnecting;
+        remote.node.observed_protocol_version = Some(38);
+        remote.node.observed_capabilities = vec!["global_workspaces".into()];
+        let mut app = App::new(vec![remote], project_context());
+        app.select_tab(PrimaryTab::Nodes);
+        assert_eq!(app.request_add(), Some(DashboardEffect::AddNode));
+
+        let rendered = rendered_text(&mut app, 180, 24);
+        for expected in [
+            "ALIAS",
+            "HEALTH",
+            "ROUTE",
+            "PROTOCOL",
+            "SCHEDULER",
+            "work",
+            "reconnecting",
+            "user@workbox",
+            "38",
+            "global_workspaces",
+            "add Node",
+            "retry/refresh",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "missing {expected}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn multi_node_workspace_table_uses_an_explicit_node_column() {
+        let local = workspace("local-workspace", "local work");
+        let mut remote = workspace("remote-workspace", "remote work");
+        remote.node.id = "00000000-0000-0000-0000-000000000002".into();
+        remote.node.alias = "work".into();
+        remote.node.local = false;
+        let mut app = App::new(vec![local, remote], project_context());
+
+        let rendered = rendered_text(&mut app, 180, 24);
+        assert!(rendered.contains("NAME"));
+        assert!(rendered.contains("NODE"));
+        assert!(rendered.contains("local work"));
+        assert!(rendered.contains("remote work"));
+        assert!(rendered.contains("work"));
+    }
+
+    #[test]
+    fn first_resource_node_picker_has_no_default_and_disables_unavailable_nodes() {
+        let mut global = workspace("global-1", "coordinated");
+        global.items.clear();
+        global.coordination = WorkspaceCoordinationView::Global {
+            revision: 4,
+            closing: false,
+            placements: Vec::new(),
+        };
+        let mut local = global.node.clone();
+        local.id = "00000000-0000-0000-0000-000000000001".into();
+        local.workspace_owner_eligible = true;
+        let mut remote = local.clone();
+        remote.id = "00000000-0000-0000-0000-000000000002".into();
+        remote.alias = "work".into();
+        remote.local = false;
+        remote.route = Some("user@work".into());
+        let mut unavailable = remote.clone();
+        unavailable.id = "00000000-0000-0000-0000-000000000003".into();
+        unavailable.alias = "offline".into();
+        unavailable.workspace_owner_eligible = false;
+        unavailable.workspace_owner_unavailable_reason = Some("Node health is unreachable".into());
+        let mut app = App::new(vec![global], project_context());
+        app.nodes = vec![local, remote, unavailable];
+        app.focus = Focus::Items;
+
+        assert_eq!(app.request_add(), None);
+        let Mode::SelectWorkspaceNode(picker) = &app.mode else {
+            panic!("expected Node placement picker");
+        };
+        assert_eq!(picker.selected, None);
+        let rendered = rendered_text(&mut app, 140, 36);
+        assert!(rendered.contains("No Node is preselected"));
+        assert!(rendered.contains("offline"));
+        assert!(rendered.contains("Node health is unreachable"));
+
+        assert_eq!(app.update_key(KeyCode::Down, KeyModifiers::NONE), None);
+        let effect = app.update_key(KeyCode::Enter, KeyModifiers::NONE);
+        assert!(
+            matches!(effect, Some(DashboardEffect::CreateGlobalShell { node_id, .. }) if node_id == "00000000-0000-0000-0000-000000000001")
+        );
+    }
+
+    #[test]
+    fn nodes_tab_management_actions_are_exact_and_forget_is_confirmed() {
+        let mut remote = workspace("remote-workspace", "remote");
+        remote.node.id = "00000000-0000-0000-0000-000000000002".into();
+        remote.node.alias = "work".into();
+        remote.node.local = false;
+        remote.node.route = Some("user@work".into());
+        remote.node.registration_revision = Some(7);
+        let mut app = App::new(vec![remote], project_context());
+        app.select_tab(PrimaryTab::Nodes);
+
+        assert!(matches!(
+            app.update_key(KeyCode::Char('r'), KeyModifiers::NONE),
+            Some(DashboardEffect::RefreshNode(node_id))
+                if node_id == "00000000-0000-0000-0000-000000000002"
+        ));
+
+        assert_eq!(app.update_key(KeyCode::Enter, KeyModifiers::NONE), None);
+        assert!(matches!(app.mode, Mode::InspectNode(_)));
+        app.update_key(KeyCode::Esc, KeyModifiers::NONE);
+        app.update_key(KeyCode::Char('e'), KeyModifiers::NONE);
+        assert!(matches!(
+            app.mode,
+            Mode::Rename {
+                target: RenameTarget::Node {
+                    expected_revision: 7,
+                    ..
+                },
+                ..
+            }
+        ));
+        let effect = app.update_key(KeyCode::Char('n'), KeyModifiers::NONE);
+        assert_eq!(effect, None);
+        let effect = app.update_key(KeyCode::Enter, KeyModifiers::NONE);
+        assert!(
+            matches!(effect, Some(DashboardEffect::Rename { target: RenameTarget::Node { expected_revision: 7, .. }, name }) if name == "n")
+        );
+
+        app.mode = Mode::Normal;
+        app.update_key(KeyCode::Char('t'), KeyModifiers::NONE);
+        assert!(matches!(
+            app.mode,
+            Mode::RetargetNode {
+                expected_revision: 7,
+                ..
+            }
+        ));
+        app.mode = Mode::Normal;
+        app.update_key(KeyCode::Char('x'), KeyModifiers::NONE);
+        assert!(matches!(app.mode, Mode::ConfirmForgetNode(_)));
+        let effect = app.update_key(KeyCode::Char('y'), KeyModifiers::NONE);
+        assert!(
+            matches!(effect, Some(DashboardEffect::ForgetNode { node_id }) if node_id == "00000000-0000-0000-0000-000000000002")
+        );
+    }
+
+    #[test]
+    fn external_workspace_adopt_and_link_actions_are_explicit_and_revision_guarded() {
+        let mut global = workspace("global-1", "canonical");
+        global.coordination = WorkspaceCoordinationView::Global {
+            revision: 6,
+            closing: false,
+            placements: Vec::new(),
+        };
+        let mut external = workspace("owner-1", "external");
+        external.node.id = "00000000-0000-0000-0000-000000000002".into();
+        external.node.alias = "work".into();
+        external.node.local = false;
+        external.coordination = WorkspaceCoordinationView::External {
+            owner_revision: 9,
+            available: true,
+        };
+        let mut app = App::new(vec![global, external], project_context());
+        let external_index = app
+            .workspaces
+            .iter()
+            .position(|workspace| workspace.id == "owner-1")
+            .unwrap();
+        app.workspace_state.select(Some(external_index));
+
+        assert!(matches!(
+            app.adopt_selected_external(),
+            Some(DashboardEffect::AdoptExternalWorkspace {
+                expected_revision: 9,
+                identity: QualifiedIdentity { ref node_id, ref inner_id },
+            }) if node_id == "00000000-0000-0000-0000-000000000002" && inner_id == "owner-1"
+        ));
+        app.link_selected_external();
+        let Mode::LinkWorkspace(picker) = &app.mode else {
+            panic!("expected guarded link picker");
+        };
+        assert_eq!(picker.selected, None);
+        app.update_key(KeyCode::Down, KeyModifiers::NONE);
+        let effect = app.update_key(KeyCode::Enter, KeyModifiers::NONE);
+        assert!(matches!(
+            effect,
+            Some(DashboardEffect::LinkExternalWorkspace {
+                workspace_id,
+                expected_revision: 6,
+                expected_owner_revision: 9,
+                ..
+            }) if workspace_id == "global-1"
+        ));
+    }
+
+    #[test]
+    fn external_workspace_actions_require_owner_placement_capability() {
+        let mut external = workspace("owner-1", "old-peer");
+        external.node.local = false;
+        external.node.workspace_owner_eligible = false;
+        external.node.workspace_owner_unavailable_reason =
+            Some("Node does not support coordinated Workspaces".into());
+        external.coordination = WorkspaceCoordinationView::External {
+            owner_revision: 0,
+            available: true,
+        };
+        let mut app = App::new(vec![external], project_context());
+        assert_eq!(app.adopt_selected_external(), None);
+        app.link_selected_external();
+        assert!(matches!(
+            app.message,
+            Some(Message { ref text, error: true })
+                if text.contains("does not support coordinated Workspaces")
+        ));
+    }
+
+    #[test]
+    fn closing_global_workspace_enter_retries_unresolved_close() {
+        let mut global = workspace("global-1", "closing");
+        global.coordination = WorkspaceCoordinationView::Global {
+            revision: 8,
+            closing: true,
+            placements: Vec::new(),
+        };
+        let mut app = App::new(vec![global], project_context());
+        assert!(matches!(
+            app.update_key(KeyCode::Enter, KeyModifiers::NONE),
+            Some(DashboardEffect::RetryGlobalWorkspaceClose { workspace_id })
+                if workspace_id == "global-1"
+        ));
     }
 
     fn schedule_item() -> WorkspaceItemView {
@@ -7319,6 +8619,7 @@ mod tests {
             "launcher",
             "ready",
             "editor",
+            "work",
             "zeditor --foreground .",
             "feature/workspace-items",
             "linked:workspace-items",
@@ -7330,6 +8631,7 @@ mod tests {
                 Constraint::Length(10),
                 Constraint::Length(8),
                 Constraint::Length(8),
+                Constraint::Length(6),
                 Constraint::Length(24),
                 Constraint::Length(25),
                 Constraint::Length(24),
@@ -7341,9 +8643,10 @@ mod tests {
                 Constraint::Length(8),
                 Constraint::Length(8),
                 Constraint::Length(8),
+                Constraint::Length(6),
                 Constraint::Length(8),
-                Constraint::Length(18),
-                Constraint::Length(13),
+                Constraint::Length(16),
+                Constraint::Length(8),
             ]
         );
     }
@@ -7400,6 +8703,7 @@ mod tests {
             "interrupted",
             "#12",
             "edge-datapipe-support",
+            "work",
             "integration-tests",
             "command",
             "cargo test --all-targets --release",
@@ -7413,6 +8717,7 @@ mod tests {
                 Constraint::Length(12),
                 Constraint::Length(5),
                 Constraint::Length(23),
+                Constraint::Length(6),
                 Constraint::Length(19),
                 Constraint::Length(9),
                 Constraint::Length(36),
@@ -7425,12 +8730,13 @@ mod tests {
             vec![
                 Constraint::Length(10),
                 Constraint::Length(4),
-                Constraint::Length(11),
-                Constraint::Length(10),
+                Constraint::Length(9),
+                Constraint::Length(6),
+                Constraint::Length(7),
                 Constraint::Length(7),
                 Constraint::Length(7),
                 Constraint::Length(12),
-                Constraint::Length(10),
+                Constraint::Length(8),
             ]
         );
     }
@@ -7470,6 +8776,7 @@ mod tests {
             "idle",
             "7h ago",
             "edge-datapipe-support",
+            "work",
             "agent",
             "Check Slack tickets against GitHub releases",
             "fix/confluent-direct-download",
@@ -7482,6 +8789,7 @@ mod tests {
                 Constraint::Length(8),
                 Constraint::Length(9),
                 Constraint::Length(23),
+                Constraint::Length(6),
                 Constraint::Length(7),
                 Constraint::Length(45),
                 Constraint::Length(31),
@@ -7494,8 +8802,9 @@ mod tests {
                 Constraint::Length(8),
                 Constraint::Length(7),
                 Constraint::Length(11),
+                Constraint::Length(6),
                 Constraint::Length(7),
-                Constraint::Length(14),
+                Constraint::Length(7),
                 Constraint::Length(12),
                 Constraint::Length(13),
             ]
@@ -7559,11 +8868,11 @@ mod tests {
     #[test]
     fn numeric_shortcuts_match_primary_tab_order() {
         assert_eq!(
-            ('1'..='4').filter_map(shortcut_tab).collect::<Vec<_>>(),
+            ('1'..='5').filter_map(shortcut_tab).collect::<Vec<_>>(),
             PrimaryTab::ALL
         );
         assert_eq!(shortcut_tab('0'), None);
-        assert_eq!(shortcut_tab('5'), None);
+        assert_eq!(shortcut_tab('6'), None);
     }
 
     #[test]
@@ -7798,7 +9107,7 @@ mod tests {
     }
 
     #[test]
-    fn project_suggestion_creates_workspace_with_default_cwd() {
+    fn project_suggestion_creates_first_placement_on_the_sole_eligible_node() {
         let mut app = app();
         assert!(app.request_add().is_none());
         for character in "alp".chars() {
@@ -7806,12 +9115,46 @@ mod tests {
         }
         assert_eq!(
             handle_mode_key(&mut app, KeyCode::Enter, KeyModifiers::NONE),
-            Some(DashboardEffect::CreateWorkspace {
+            Some(DashboardEffect::CreatePlacedWorkspace {
                 name: "alpha".into(),
-                default_cwd: Some("/tmp/alpha".into()),
+                default_cwd: "/tmp/alpha".into(),
+                node_id: String::new(),
             })
         );
         assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn project_suggestion_requires_explicit_node_when_multiple_are_eligible() {
+        let mut app = app();
+        let mut remote = app.nodes[0].clone();
+        remote.id = "remote-node".into();
+        remote.alias = "remote".into();
+        remote.local = false;
+        app.nodes.push(remote);
+        assert!(app.request_add().is_none());
+        for character in "alp".chars() {
+            handle_mode_key(&mut app, KeyCode::Char(character), KeyModifiers::NONE);
+        }
+        assert_eq!(
+            handle_mode_key(&mut app, KeyCode::Enter, KeyModifiers::NONE),
+            None
+        );
+        let Mode::SelectWorkspaceNode(picker) = &app.mode else {
+            panic!("expected explicit project owner picker");
+        };
+        assert_eq!(picker.selected, None);
+        assert_eq!(picker.project.as_ref().unwrap().0, "alpha");
+        assert_eq!(app.update_key(KeyCode::Down, KeyModifiers::NONE), None);
+        assert!(matches!(
+            app.update_key(KeyCode::Enter, KeyModifiers::NONE),
+            Some(DashboardEffect::CreatePlacedWorkspace {
+                name,
+                default_cwd,
+                ..
+            }) if name == "alpha"
+                && default_cwd.as_path() == std::path::Path::new("/tmp/alpha")
+        ));
     }
 
     #[test]
@@ -7929,6 +9272,8 @@ mod tests {
         agent.agent.as_mut().unwrap().state = AgentDisplayState::Blocked;
         workspace.items[0] = WorkspaceItemView::AgentShell(agent);
         workspace.attention = vec![WorkspaceAttentionView {
+            node_id: String::new(),
+            workspace_id: workspace.id.clone(),
             agent_id: "agent-active".into(),
             shell_id: "term_1".into(),
             agent_name: "review-agent".into(),
@@ -7991,6 +9336,8 @@ mod tests {
     fn command_palette_orders_attention_by_global_urgency() {
         let mut completed = workspace("w1", "first");
         completed.attention = vec![WorkspaceAttentionView {
+            node_id: String::new(),
+            workspace_id: completed.id.clone(),
             agent_id: "completed-agent-id".into(),
             shell_id: "completed-shell".into(),
             agent_name: "completed-agent".into(),
@@ -8000,6 +9347,8 @@ mod tests {
         }];
         let mut blocked = workspace("w2", "second");
         blocked.attention = vec![WorkspaceAttentionView {
+            node_id: String::new(),
+            workspace_id: blocked.id.clone(),
             agent_id: "blocked-agent-id".into(),
             shell_id: "blocked-shell".into(),
             agent_name: "blocked-agent".into(),
@@ -9577,6 +10926,8 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut workspace = workspace("w1", "review");
         workspace.attention = vec![WorkspaceAttentionView {
+            node_id: String::new(),
+            workspace_id: workspace.id.clone(),
             agent_id: "agent-active".into(),
             shell_id: "term_1".into(),
             agent_name: "review-agent".into(),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,7 @@
 use std::io;
 use std::path::PathBuf;
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crossterm::event::{
@@ -845,12 +847,6 @@ pub(crate) enum DashboardEffect {
     Close(CloseTarget),
     CreateWorkspace {
         name: String,
-        default_cwd: Option<PathBuf>,
-    },
-    CreatePlacedWorkspace {
-        name: String,
-        default_cwd: PathBuf,
-        node_id: String,
     },
     CreateShell(QualifiedIdentity),
     CreateGlobalShell {
@@ -919,6 +915,21 @@ pub(crate) enum DashboardEffect {
     },
 }
 
+impl DashboardEffect {
+    fn must_finish_before_quit(&self) -> bool {
+        !matches!(
+            self,
+            Self::Quit
+                | Self::CheckForUpdates
+                | Self::RefreshNode(_)
+                | Self::Refresh
+                | Self::LoadScheduleHistory { .. }
+                | Self::LoadScheduleEditor { .. }
+                | Self::ReadTerminalPreview { .. }
+        )
+    }
+}
+
 pub(crate) enum DashboardEvent {
     KeyPressed {
         code: KeyCode,
@@ -928,6 +939,7 @@ pub(crate) enum DashboardEvent {
     PreviewRequested,
     UpdateCheckCompleted,
     OperationCompleted(Result<String, String>),
+    ShellCreationCompleted(Result<String, String>),
     RefreshCompleted(Result<DashboardState, String>),
     ScheduleHistoryCompleted {
         schedule_id: QualifiedIdentity,
@@ -963,6 +975,104 @@ where
     }
 }
 
+struct DashboardRuntime {
+    effects: Sender<DashboardEffect>,
+    completions: Receiver<(DashboardEffect, DashboardEvent)>,
+    update_check_in_flight: bool,
+    preview_in_flight: bool,
+    operations_in_flight: usize,
+}
+
+impl DashboardRuntime {
+    fn spawn(mut backend: impl DashboardBackend + Send + 'static) -> Self {
+        let (effect_sender, effect_receiver) = mpsc::channel::<DashboardEffect>();
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        thread::spawn(move || {
+            while let Ok(effect) = effect_receiver.recv() {
+                let completed_effect = effect.clone();
+                let event = backend.execute(effect);
+                if completion_sender.send((completed_effect, event)).is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            effects: effect_sender,
+            completions: completion_receiver,
+            update_check_in_flight: false,
+            preview_in_flight: false,
+            operations_in_flight: 0,
+        }
+    }
+
+    fn dispatch(&mut self, effects: Vec<DashboardEffect>) -> io::Result<bool> {
+        for effect in effects {
+            if effect == DashboardEffect::Quit {
+                if self.can_quit() {
+                    return Ok(true);
+                }
+                continue;
+            }
+            if (effect == DashboardEffect::CheckForUpdates && self.update_check_in_flight)
+                || (matches!(effect, DashboardEffect::ReadTerminalPreview { .. })
+                    && self.preview_in_flight)
+            {
+                continue;
+            }
+            match &effect {
+                DashboardEffect::CheckForUpdates => self.update_check_in_flight = true,
+                DashboardEffect::ReadTerminalPreview { .. } => self.preview_in_flight = true,
+                _ => {}
+            }
+            if effect.must_finish_before_quit() {
+                self.operations_in_flight += 1;
+            }
+            self.effects.send(effect).map_err(|_| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "dashboard backend stopped")
+            })?;
+        }
+        Ok(false)
+    }
+
+    fn drain(&mut self, app: &mut App) -> io::Result<bool> {
+        loop {
+            match self.completions.try_recv() {
+                Ok((effect, event)) => {
+                    match effect {
+                        DashboardEffect::CheckForUpdates => self.update_check_in_flight = false,
+                        DashboardEffect::ReadTerminalPreview { .. } => {
+                            self.preview_in_flight = false;
+                        }
+                        _ => {}
+                    }
+                    if effect.must_finish_before_quit() {
+                        self.operations_in_flight = self.operations_in_flight.saturating_sub(1);
+                    }
+                    let effects = app.update(event);
+                    if self.dispatch(effects)? {
+                        return Ok(true);
+                    }
+                }
+                Err(TryRecvError::Empty) => return Ok(false),
+                Err(TryRecvError::Disconnected) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "dashboard backend stopped",
+                    ));
+                }
+            }
+        }
+    }
+
+    fn has_in_flight_effect(&self) -> bool {
+        self.update_check_in_flight || self.preview_in_flight || self.operations_in_flight > 0
+    }
+
+    fn can_quit(&self) -> bool {
+        self.operations_in_flight == 0
+    }
+}
+
 struct App {
     nodes: Vec<NodeView>,
     all_workspaces: Vec<WorkspaceView>,
@@ -982,6 +1092,7 @@ struct App {
     focus: Focus,
     mode: Mode,
     message: Option<Message>,
+    pending_shell_creation: Option<String>,
     pending_close: Option<PendingClose>,
     project_context: ProjectContext,
     terminal_preview: Option<TerminalPreviewState>,
@@ -1147,7 +1258,6 @@ struct WorkspaceNodePicker {
     placements: Vec<WorkspacePlacementView>,
     nodes: Vec<NodeView>,
     selected: Option<usize>,
-    project: Option<(String, PathBuf)>,
 }
 
 impl WorkspaceNodePicker {
@@ -1180,13 +1290,6 @@ impl WorkspaceNodePicker {
         let node = self.nodes.get(self.selected?)?;
         if !node.workspace_owner_eligible {
             return None;
-        }
-        if let Some((name, default_cwd)) = &self.project {
-            return Some(DashboardEffect::CreatePlacedWorkspace {
-                name: name.clone(),
-                default_cwd: default_cwd.clone(),
-                node_id: node.id.clone(),
-            });
         }
         let placement = self
             .placements
@@ -2238,6 +2341,7 @@ impl App {
             focus: Focus::Workspaces,
             mode: Mode::Normal,
             message: None,
+            pending_shell_creation: None,
             pending_close: None,
             project_context,
             terminal_preview: None,
@@ -2911,6 +3015,9 @@ impl App {
                 None
             }
             Focus::Items => {
+                if self.pending_shell_creation.is_some() {
+                    return None;
+                }
                 let workspace = self.selected()?.clone();
                 if let WorkspaceCoordinationView::Global {
                     revision,
@@ -2925,6 +3032,7 @@ impl App {
                         .cloned()
                         .collect::<Vec<_>>();
                     if let [node] = eligible.as_slice() {
+                        self.begin_shell_creation(&workspace.name, &node.alias);
                         return Some(global_shell_effect(&workspace, *revision, placements, node));
                     }
                     self.mode = Mode::SelectWorkspaceNode(WorkspaceNodePicker {
@@ -2934,16 +3042,26 @@ impl App {
                         placements: placements.clone(),
                         nodes: self.nodes.clone(),
                         selected: None,
-                        project: None,
                     });
                     self.message = None;
                     return None;
                 }
-                workspace
+                let effect = workspace
                     .local_actionable()
-                    .then(|| DashboardEffect::CreateShell(workspace.qualify(&workspace.id)))
+                    .then(|| DashboardEffect::CreateShell(workspace.qualify(&workspace.id)));
+                if effect.is_some() {
+                    self.begin_shell_creation(&workspace.name, &workspace.node.alias);
+                }
+                effect
             }
         }
+    }
+
+    fn begin_shell_creation(&mut self, workspace_name: &str, node_alias: &str) {
+        self.message = None;
+        self.pending_shell_creation = Some(format!(
+            "Creating Shell in {workspace_name} on Node {node_alias}..."
+        ));
     }
 
     fn adopt_selected_external(&self) -> Option<DashboardEffect> {
@@ -3007,42 +3125,10 @@ impl App {
         self.message = None;
     }
 
-    fn create_workspace(
-        &mut self,
-        name: &str,
-        default_cwd: Option<PathBuf>,
-    ) -> Option<DashboardEffect> {
-        if let Some(default_cwd) = default_cwd {
-            let eligible = self
-                .nodes
-                .iter()
-                .filter(|node| node.workspace_owner_eligible)
-                .cloned()
-                .collect::<Vec<_>>();
-            if let [node] = eligible.as_slice() {
-                self.mode = Mode::Normal;
-                return Some(DashboardEffect::CreatePlacedWorkspace {
-                    name: name.to_owned(),
-                    default_cwd,
-                    node_id: node.id.clone(),
-                });
-            }
-            self.mode = Mode::SelectWorkspaceNode(WorkspaceNodePicker {
-                workspace_id: String::new(),
-                workspace_name: name.to_owned(),
-                expected_revision: 0,
-                placements: Vec::new(),
-                nodes: self.nodes.clone(),
-                selected: None,
-                project: Some((name.to_owned(), default_cwd)),
-            });
-            self.message = None;
-            return None;
-        }
+    fn create_workspace(&mut self, name: &str) -> Option<DashboardEffect> {
         self.mode = Mode::Normal;
         Some(DashboardEffect::CreateWorkspace {
             name: name.to_owned(),
-            default_cwd: None,
         })
     }
 
@@ -3264,6 +3350,11 @@ impl App {
             }
             DashboardEvent::UpdateCheckCompleted => {}
             DashboardEvent::OperationCompleted(result) => {
+                self.message = Some(Message::from_result(result));
+                return vec![DashboardEffect::Refresh];
+            }
+            DashboardEvent::ShellCreationCompleted(result) => {
+                self.pending_shell_creation = None;
                 self.message = Some(Message::from_result(result));
                 return vec![DashboardEffect::Refresh];
             }
@@ -3567,7 +3658,6 @@ impl App {
             preview.shell_id == shell_id.inner_id
                 && preview.run_id == run_id
                 && preview.output_revision == output_revision
-                && preview.output.is_ok()
         }) {
             return None;
         }
@@ -3914,16 +4004,21 @@ fn item_pending_close(
     }
 }
 
-pub(crate) fn run<B: DashboardBackend>(
+pub(crate) fn run<B: DashboardBackend + Send + 'static>(
     state: DashboardState,
     follow_focused_terminal: bool,
     project_context: ProjectContext,
     play_intro: bool,
     backend: B,
 ) -> io::Result<()> {
-    let mut terminal = ratatui::init();
+    let mut terminal = ratatui::try_init().map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("dashboard requires an interactive terminal: {error}"),
+        )
+    })?;
     if let Err(error) = execute!(io::stdout(), EnableBracketedPaste) {
-        ratatui::restore();
+        let _ = ratatui::try_restore();
         return Err(error);
     }
     let mut app = App::new(state.workspaces, project_context);
@@ -3943,8 +4038,9 @@ pub(crate) fn run<B: DashboardBackend>(
         run_loop(&mut terminal, app, backend)
     };
     let paste_result = execute!(io::stdout(), DisableBracketedPaste);
-    ratatui::restore();
+    let restore_result = ratatui::try_restore();
     paste_result?;
+    restore_result?;
     result
 }
 
@@ -3965,23 +4061,35 @@ fn play_bomb_animation(terminal: &mut ratatui::DefaultTerminal) -> io::Result<()
     }
 }
 
-fn run_loop<B: DashboardBackend>(
-    terminal: &mut ratatui::DefaultTerminal,
-    mut app: App,
-    mut backend: B,
-) -> io::Result<()> {
+fn run_loop<B>(terminal: &mut ratatui::DefaultTerminal, mut app: App, backend: B) -> io::Result<()>
+where
+    B: DashboardBackend + Send + 'static,
+{
+    let mut runtime = DashboardRuntime::spawn(backend);
     let mut last_refresh = Instant::now();
     loop {
+        if runtime.drain(&mut app)? {
+            return Ok(());
+        }
         if last_refresh.elapsed() >= UPDATE_CHECK_INTERVAL {
             let effects = app.update(DashboardEvent::RefreshElapsed);
-            execute_effects(&mut app, &mut backend, effects);
+            if runtime.dispatch(effects)? {
+                return Ok(());
+            }
             last_refresh = Instant::now();
         }
         let effects = app.update(DashboardEvent::PreviewRequested);
-        execute_effects(&mut app, &mut backend, effects);
+        if runtime.dispatch(effects)? {
+            return Ok(());
+        }
         terminal.draw(|frame| render(frame, &mut app))?;
 
-        if !event::poll(Duration::from_millis(250))? {
+        let poll_interval = if runtime.has_in_flight_effect() {
+            INTRO_POLL_INTERVAL
+        } else {
+            UPDATE_CHECK_INTERVAL
+        };
+        if !event::poll(poll_interval)? {
             continue;
         }
         let effects = match event::read()? {
@@ -3995,28 +4103,19 @@ fn run_loop<B: DashboardBackend>(
             _ => continue,
         };
         if effects.contains(&DashboardEffect::Quit) {
-            return Ok(());
-        }
-        if !effects.is_empty() {
-            execute_effects(&mut app, &mut backend, effects);
-        }
-        // Keep navigation responsive by waiting for an idle input window before
-        // performing the next synchronous background refresh.
-        last_refresh = Instant::now();
-    }
-}
-
-fn execute_effects(
-    app: &mut App,
-    backend: &mut impl DashboardBackend,
-    effects: Vec<DashboardEffect>,
-) {
-    let mut pending = effects;
-    while let Some(effect) = pending.pop() {
-        if effect == DashboardEffect::Quit {
+            if runtime.can_quit() {
+                return Ok(());
+            }
+            app.message = Some(Message {
+                text: "Wait for the current operation to finish before quitting".into(),
+                error: false,
+            });
             continue;
         }
-        pending.extend(app.update(backend.execute(effect)));
+        if !effects.is_empty() && runtime.dispatch(effects)? {
+            return Ok(());
+        }
+        last_refresh = Instant::now();
     }
 }
 
@@ -4227,11 +4326,11 @@ fn handle_mode_key(
                     .custom_name()
                     .expect("nonempty workspace name")
                     .to_owned();
-                app.create_workspace(&name, None)
+                app.create_workspace(&name)
             }
             KeyCode::Enter if picker.selected().is_some() => {
                 let project = picker.selected().expect("selected project").clone();
-                app.create_workspace(&project.name, Some(project.path))
+                app.create_workspace(&project.name)
             }
             KeyCode::Enter => {
                 app.mode = Mode::PickProject(picker);
@@ -4272,7 +4371,15 @@ fn handle_mode_key(
         },
         Mode::SelectWorkspaceNode(mut picker) => match key {
             KeyCode::Enter => match picker.effect() {
-                Some(effect) => Some(effect),
+                Some(effect) => {
+                    let node_alias = picker
+                        .selected
+                        .and_then(|selected| picker.nodes.get(selected))
+                        .map(|node| node.alias.clone())
+                        .expect("Shell creation requires a selected Node");
+                    app.begin_shell_creation(&picker.workspace_name, &node_alias);
+                    Some(effect)
+                }
                 None => {
                     app.mode = Mode::SelectWorkspaceNode(picker);
                     None
@@ -5645,6 +5752,26 @@ fn workspace_display_name(workspace: &WorkspaceView) -> String {
     )
 }
 
+fn workspace_table_display_name(workspace: &WorkspaceView, duplicate_name: bool) -> String {
+    if matches!(
+        workspace.coordination,
+        WorkspaceCoordinationView::Global { .. }
+    ) || (workspace.node.local && !duplicate_name)
+    {
+        return workspace.name.clone();
+    }
+    let health = node_health_label(workspace.node.health);
+    let freshness = if workspace.node.stale || !workspace.node.current {
+        " stale"
+    } else {
+        ""
+    };
+    format!(
+        "[{} {health}{freshness}] {}",
+        workspace.node.alias, workspace.name
+    )
+}
+
 fn node_health_label(health: NodeProjectionHealthCode) -> &'static str {
     match health {
         NodeProjectionHealthCode::Unobserved => "unobserved",
@@ -5799,7 +5926,6 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
             Layout::vertical([Constraint::Fill(1), Constraint::Length(preview_height)]).areas(area);
         (table_area, Some(preview_area))
     });
-    let show_node = app.nodes.len() > 1;
     let rows = if app.workspaces.is_empty() {
         vec![Row::new([Cell::from(Span::styled(
             "No workspaces. Press a to create one.",
@@ -5809,37 +5935,21 @@ fn render_workspaces(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
         app.workspaces
             .iter()
             .map(|workspace| {
-                let mut cells = vec![Cell::from(if show_node {
-                    workspace.name.clone()
-                } else {
-                    workspace_display_name(workspace)
-                })];
-                if show_node {
-                    cells.push(Cell::from(match &workspace.coordination {
-                        WorkspaceCoordinationView::Global { placements, .. } => placements
-                            .iter()
-                            .map(|placement| placement.node.alias.as_str())
-                            .collect::<Vec<_>>()
-                            .join(","),
-                        WorkspaceCoordinationView::External { .. } => workspace.node.alias.clone(),
-                    }));
-                }
-                Row::new(cells)
+                let duplicate_name = app
+                    .workspaces
+                    .iter()
+                    .filter(|candidate| candidate.name == workspace.name)
+                    .count()
+                    > 1;
+                Row::new([Cell::from(workspace_table_display_name(
+                    workspace,
+                    duplicate_name,
+                ))])
             })
             .collect()
     };
-    let widths = if show_node {
-        vec![Constraint::Min(8), Constraint::Length(12)]
-    } else {
-        vec![Constraint::Min(8)]
-    };
-    let headers = if show_node {
-        vec!["NAME", "NODE"]
-    } else {
-        vec!["NAME"]
-    };
-    let table = Table::new(rows, widths)
-        .header(Row::new(headers).style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
+    let table = Table::new(rows, [Constraint::Min(8)])
+        .header(Row::new(["NAME"]).style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
         .block(
             Block::bordered()
                 .title(format!(" Workspaces ({}) ", app.workspaces.len()))
@@ -7321,6 +7431,11 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Span::styled("esc", Style::new().fg(RED)),
             Span::raw(" cancel"),
         ])
+    } else if let Some(text) = &app.pending_shell_creation {
+        Line::from(Span::styled(
+            format!(" {text}"),
+            Style::new().fg(YELLOW).add_modifier(Modifier::BOLD),
+        ))
     } else if let Some(message) = &app.message {
         Line::from(Span::styled(
             format!(" {}", message.text),
@@ -7592,6 +7707,102 @@ mod tests {
 
     fn app() -> App {
         App::new(vec![workspace("w1", "boomux")], project_context())
+    }
+
+    #[test]
+    fn blocked_refresh_does_not_delay_navigation_and_remains_single_flight() {
+        let mut app = app();
+        let mut second = app.workspaces[0].items[0].clone();
+        let WorkspaceItemView::Shell(shell) = &mut second else {
+            unreachable!();
+        };
+        shell.id = "term_2".into();
+        shell.name = "second".into();
+        app.workspaces[0].items.push(second);
+        focus_items(&mut app);
+        assert_eq!(app.item_state.selected(), Some(0));
+
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let mut runtime = DashboardRuntime::spawn(move |effect: DashboardEffect| {
+            started_sender.send(effect.clone()).unwrap();
+            release_receiver.recv().unwrap();
+            match effect {
+                DashboardEffect::CheckForUpdates => DashboardEvent::UpdateCheckCompleted,
+                effect => panic!("unexpected effect: {effect:?}"),
+            }
+        });
+
+        assert!(
+            !runtime
+                .dispatch(vec![DashboardEffect::CheckForUpdates])
+                .unwrap()
+        );
+        assert_eq!(
+            started_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap(),
+            DashboardEffect::CheckForUpdates
+        );
+        assert!(
+            !runtime
+                .dispatch(vec![DashboardEffect::CheckForUpdates])
+                .unwrap()
+        );
+
+        let effects = app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Down,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(effects.is_empty());
+        assert_eq!(app.item_state.selected(), Some(1));
+
+        release_sender.send(()).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while runtime.update_check_in_flight && Instant::now() < deadline {
+            runtime.drain(&mut app).unwrap();
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert!(!runtime.update_check_in_flight);
+        assert!(matches!(
+            started_receiver.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn mutation_must_finish_before_dashboard_can_quit() {
+        let mut app = app();
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let mut runtime = DashboardRuntime::spawn(move |effect: DashboardEffect| match effect {
+            DashboardEffect::Rename { .. } => {
+                started_sender.send(()).unwrap();
+                release_receiver.recv().unwrap();
+                DashboardEvent::OperationCompleted(Ok("renamed".into()))
+            }
+            DashboardEffect::Refresh => DashboardEvent::RefreshCompleted(Err("ignored".into())),
+            effect => panic!("unexpected effect: {effect:?}"),
+        });
+
+        runtime
+            .dispatch(vec![DashboardEffect::Rename {
+                target: RenameTarget::Workspace("workspace".into()),
+                name: "renamed".into(),
+            }])
+            .unwrap();
+        started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        assert!(!runtime.can_quit());
+
+        release_sender.send(()).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !runtime.can_quit() && Instant::now() < deadline {
+            runtime.drain(&mut app).unwrap();
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert!(runtime.can_quit());
     }
 
     #[test]
@@ -8063,20 +8274,37 @@ mod tests {
     }
 
     #[test]
-    fn multi_node_workspace_table_uses_an_explicit_node_column() {
-        let local = workspace("local-workspace", "local work");
+    fn multi_node_workspace_table_omits_node_column_and_qualifies_external_names() {
+        let mut local = workspace("global-workspace", "local work");
+        local.coordination = WorkspaceCoordinationView::Global {
+            revision: 1,
+            closing: false,
+            placements: Vec::new(),
+        };
+        let local_external = workspace("local-workspace", "local work");
         let mut remote = workspace("remote-workspace", "remote work");
         remote.node.id = "00000000-0000-0000-0000-000000000002".into();
         remote.node.alias = "work".into();
         remote.node.local = false;
-        let mut app = App::new(vec![local, remote], project_context());
+        let mut app = App::new(vec![local, local_external, remote], project_context());
+        focus_items(&mut app);
 
-        let rendered = rendered_text(&mut app, 180, 24);
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        terminal
+            .draw(|frame| render_workspaces(frame, frame.area(), &mut app))
+            .unwrap();
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
         assert!(rendered.contains("NAME"));
-        assert!(rendered.contains("NODE"));
+        assert!(!rendered.contains("NODE"));
         assert!(rendered.contains("local work"));
-        assert!(rendered.contains("remote work"));
-        assert!(rendered.contains("work"));
+        assert!(rendered.contains("[local online] local work"));
+        assert!(rendered.contains("[work online] remote work"));
     }
 
     #[test]
@@ -8116,9 +8344,18 @@ mod tests {
         assert!(rendered.contains("Node health is unreachable"));
 
         assert_eq!(app.update_key(KeyCode::Down, KeyModifiers::NONE), None);
+        assert_eq!(app.update_key(KeyCode::Down, KeyModifiers::NONE), None);
         let effect = app.update_key(KeyCode::Enter, KeyModifiers::NONE);
         assert!(
-            matches!(effect, Some(DashboardEffect::CreateGlobalShell { node_id, .. }) if node_id == "00000000-0000-0000-0000-000000000001")
+            matches!(effect, Some(DashboardEffect::CreateGlobalShell { node_id, .. }) if node_id == "00000000-0000-0000-0000-000000000002")
+        );
+        assert_eq!(
+            app.pending_shell_creation.as_deref(),
+            Some("Creating Shell in coordinated on Node work...")
+        );
+        assert!(
+            rendered_text(&mut app, 140, 36)
+                .contains("Creating Shell in coordinated on Node work...")
         );
     }
 
@@ -9150,25 +9387,7 @@ mod tests {
     }
 
     #[test]
-    fn project_suggestion_creates_first_placement_on_the_sole_eligible_node() {
-        let mut app = app();
-        assert!(app.request_add().is_none());
-        for character in "alp".chars() {
-            handle_mode_key(&mut app, KeyCode::Char(character), KeyModifiers::NONE);
-        }
-        assert_eq!(
-            handle_mode_key(&mut app, KeyCode::Enter, KeyModifiers::NONE),
-            Some(DashboardEffect::CreatePlacedWorkspace {
-                name: "alpha".into(),
-                default_cwd: "/tmp/alpha".into(),
-                node_id: String::new(),
-            })
-        );
-        assert!(matches!(app.mode, Mode::Normal));
-    }
-
-    #[test]
-    fn project_suggestion_requires_explicit_node_when_multiple_are_eligible() {
+    fn project_suggestion_creates_an_empty_workspace_regardless_of_nodes() {
         let mut app = app();
         let mut remote = app.nodes[0].clone();
         remote.id = "remote-node".into();
@@ -9181,23 +9400,11 @@ mod tests {
         }
         assert_eq!(
             handle_mode_key(&mut app, KeyCode::Enter, KeyModifiers::NONE),
-            None
+            Some(DashboardEffect::CreateWorkspace {
+                name: "alpha".into(),
+            })
         );
-        let Mode::SelectWorkspaceNode(picker) = &app.mode else {
-            panic!("expected explicit project owner picker");
-        };
-        assert_eq!(picker.selected, None);
-        assert_eq!(picker.project.as_ref().unwrap().0, "alpha");
-        assert_eq!(app.update_key(KeyCode::Down, KeyModifiers::NONE), None);
-        assert!(matches!(
-            app.update_key(KeyCode::Enter, KeyModifiers::NONE),
-            Some(DashboardEffect::CreatePlacedWorkspace {
-                name,
-                default_cwd,
-                ..
-            }) if name == "alpha"
-                && default_cwd.as_path() == std::path::Path::new("/tmp/alpha")
-        ));
+        assert!(matches!(app.mode, Mode::Normal));
     }
 
     #[test]
@@ -9214,7 +9421,6 @@ mod tests {
             handle_mode_key(&mut app, KeyCode::Enter, KeyModifiers::NONE),
             Some(DashboardEffect::CreateWorkspace {
                 name: "custom workspace".into(),
-                default_cwd: None,
             })
         );
     }
@@ -9235,7 +9441,6 @@ mod tests {
             handle_mode_key(&mut app, KeyCode::Enter, KeyModifiers::NONE),
             Some(DashboardEffect::CreateWorkspace {
                 name: "alpha".into(),
-                default_cwd: None,
             })
         );
     }
@@ -9658,6 +9863,29 @@ mod tests {
             Some(DashboardEffect::CreateShell("w1".into()))
         );
         assert!(matches!(app.mode, Mode::Normal));
+        assert_eq!(
+            app.pending_shell_creation.as_deref(),
+            Some("Creating Shell in boomux on Node local...")
+        );
+        assert_eq!(app.request_add(), None);
+    }
+
+    #[test]
+    fn shell_creation_completion_replaces_the_pending_indicator_and_refreshes() {
+        let mut app = app();
+        focus_items(&mut app);
+        app.request_add();
+
+        assert_eq!(
+            app.update(DashboardEvent::ShellCreationCompleted(Ok(
+                "Created first on Node local".into()
+            ))),
+            vec![DashboardEffect::Refresh]
+        );
+        assert!(app.pending_shell_creation.is_none());
+        assert!(app.message.as_ref().is_some_and(|message| {
+            !message.error && message.text == "Created first on Node local"
+        }));
     }
 
     #[test]
@@ -10787,6 +11015,29 @@ mod tests {
         assert!(text.contains("following"));
         assert!(text.contains("latest"));
         assert!(text.contains("pgup/dn"));
+    }
+
+    #[test]
+    fn failed_terminal_preview_is_not_retried_without_a_revision_change() {
+        let mut app = app();
+        focus_items(&mut app);
+        let effect = app.terminal_preview_effect().unwrap();
+        let DashboardEffect::ReadTerminalPreview {
+            shell_id,
+            run_id,
+            output_revision,
+        } = effect
+        else {
+            unreachable!();
+        };
+        app.apply_terminal_preview(
+            shell_id.inner_id,
+            run_id,
+            output_revision,
+            Err("preview unavailable".into()),
+        );
+
+        assert!(app.terminal_preview_effect().is_none());
     }
 
     #[test]

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -193,6 +193,11 @@ fn native_daemon_lifecycle() {
     let status: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
     assert_eq!(status["schema"], "boomux.cli/v1");
     assert_eq!(status["data"]["status"], "running");
+    assert_eq!(status["data"]["pid"], daemon.child.as_ref().unwrap().id());
+    assert_eq!(
+        status["data"]["executable"],
+        daemon.executable.display().to_string()
+    );
     assert_eq!(status["data"]["scheduler"]["state"], "active");
     assert_eq!(status["data"]["scheduler"]["active_executions"], 0);
     assert_eq!(status["data"]["scheduler"]["max_concurrent"], 4);

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,10 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 38);
+    assert_eq!(
+        capabilities["data"]["daemon_protocol_version"],
+        protocol::PROTOCOL_VERSION
+    );
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -128,6 +131,7 @@ fn native_daemon_lifecycle() {
         "protocol_36",
         "protocol_37",
         "protocol_38",
+        "protocol_39",
         "node_registration_management",
         "node_projection_sync",
         "bounded_remote_node_projections",
@@ -149,6 +153,7 @@ fn native_daemon_lifecycle() {
         "multi_node_workspace_placements",
         "guarded_workspace_adoption",
         "resumable_workspace_close",
+        "qualified_focused_terminal",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -183,7 +188,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 38"));
+    assert!(status_text.contains(&format!("running (protocol {}", protocol::PROTOCOL_VERSION)));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -948,7 +953,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 38);
+    assert_eq!(handshake.core_protocol_version, protocol::PROTOCOL_VERSION);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -46,7 +46,7 @@ fn native_daemon_lifecycle() {
     let capabilities: serde_json::Value = serde_json::from_slice(&capabilities.stdout).unwrap();
     assert_eq!(capabilities["schema"], "boomux.cli/v1");
     assert_eq!(capabilities["command"], "capabilities");
-    assert_eq!(capabilities["data"]["daemon_protocol_version"], 37);
+    assert_eq!(capabilities["data"]["daemon_protocol_version"], 38);
     assert!(
         capabilities["data"]
             .get("session_transcript_integrations")
@@ -127,6 +127,7 @@ fn native_daemon_lifecycle() {
         "protocol_35",
         "protocol_36",
         "protocol_37",
+        "protocol_38",
         "node_registration_management",
         "node_projection_sync",
         "bounded_remote_node_projections",
@@ -144,6 +145,10 @@ fn native_daemon_lifecycle() {
         "remote_exact_session_resume",
         "remote_agent_schedule_management",
         "remote_scheduled_execution_observation",
+        "global_workspaces",
+        "multi_node_workspace_placements",
+        "guarded_workspace_adoption",
+        "resumable_workspace_close",
         "exact_run_attachment",
         "stable_node_identity",
         "revision_aware_scheduled_execution_wait",
@@ -178,7 +183,7 @@ fn native_daemon_lifecycle() {
         .unwrap();
     assert!(status.status.success());
     let status_text = String::from_utf8_lossy(&status.stdout);
-    assert!(status_text.contains("running (protocol 37"));
+    assert!(status_text.contains("running (protocol 38"));
     assert!(status_text.contains("scheduler active (0/4 active executions)"));
     let status = daemon
         .command()
@@ -938,7 +943,7 @@ fn federation_helper_binds_handshake_and_inner_request_to_one_daemon_socket() {
     let handshake = boomux::federation::read_handshake(&mut stdout).unwrap();
     assert_eq!(handshake.version, boomux::federation::FEDERATION_VERSION);
     assert_eq!(handshake.node_id, node_id);
-    assert_eq!(handshake.core_protocol_version, 37);
+    assert_eq!(handshake.core_protocol_version, 38);
     assert_eq!(
         handshake.connection_mode,
         boomux::federation::FederationConnectionMode::AdHoc

--- a/tests/native_backend/handoff.rs
+++ b/tests/native_backend/handoff.rs
@@ -141,10 +141,19 @@ fn focused_attachment_is_exposed_in_daemon_snapshots() {
     let shell_id = workspace.shells[0].id.clone();
     let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
     assert_eq!(attachment.protocol_version, protocol::PROTOCOL_VERSION);
+    let event_cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
 
     AttachFrame::FocusGained
         .write_to(&mut attachment.stream)
         .unwrap();
+    let focus_events = daemon
+        .client
+        .events(Some(event_cursor), 256, 1_000)
+        .unwrap();
+    assert!(focus_events.events.iter().any(|event| matches!(
+        event.kind,
+        protocol::DaemonEventKind::FocusedTerminalPresentationChanged
+    )));
     wait_until(
         || {
             daemon

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -893,6 +893,7 @@ fn write_fake_combined_snapshot(directory: &Path, workspace_owner_eligible: bool
                     }],
                     workspaces: Vec::new(),
                     external_workspaces: Vec::new(),
+                    focused_terminal: None,
                 },
             },
         ),

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -2,17 +2,622 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
 
 use boomux::client::{ClientError, RemoteError};
-use boomux::protocol::ErrorCode;
+use boomux::protocol::{
+    AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSpec, AgentScheduleState,
+    AgentScheduleTrigger, ErrorCode, Request, Response, ShellSpec, WorkspaceLauncherSpec,
+};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::support::TestDaemon;
 
 fn node_id(value: u128) -> String {
     Uuid::from_u128(value).to_string()
+}
+
+#[test]
+fn coordinator_workspace_migrates_once_and_closes_after_owner_revision_changes() {
+    let mut daemon = TestDaemon::start();
+    let owner = daemon
+        .client
+        .create_workspace("migrated", Vec::new())
+        .unwrap();
+    daemon.stop_with_cli();
+
+    fs::remove_file(
+        daemon
+            .runtime_dir
+            .join("state/boomux/global_workspaces.json"),
+    )
+    .unwrap();
+    daemon.restart();
+
+    let combined = daemon.client.combined_node_snapshot(None).unwrap();
+    assert_eq!(combined.workspaces.len(), 1);
+    assert_eq!(combined.workspaces[0].id, owner.id);
+    assert_eq!(combined.workspaces[0].placements.len(), 1);
+    assert!(combined.external_workspaces.is_empty());
+    let global = combined.workspaces[0].clone();
+
+    daemon
+        .client
+        .create_launcher(
+            &owner.id,
+            WorkspaceLauncherSpec {
+                name: "open-check".into(),
+                cwd: std::env::temp_dir(),
+                command: vec!["/bin/true".into()],
+            },
+        )
+        .unwrap();
+    let opened = daemon
+        .command()
+        .args(["workspace", "open", "migrated"])
+        .output()
+        .unwrap();
+    assert!(
+        opened.status.success(),
+        "global Workspace open failed: {}",
+        String::from_utf8_lossy(&opened.stderr)
+    );
+    assert!(String::from_utf8_lossy(&opened.stdout).contains("Opened 1 launcher(s)"));
+
+    daemon
+        .client
+        .create_shell(
+            &owner.id,
+            ShellSpec {
+                name: "later".into(),
+                command: vec!["/bin/sh".into()],
+                cwd: std::env::temp_dir(),
+            },
+        )
+        .unwrap();
+    let owner_after_mutation = daemon.client.get_workspace(&owner.id).unwrap();
+    assert!(owner_after_mutation.revision > global.placements[0].owner_revision);
+
+    let closed = daemon
+        .client
+        .close_global_workspace(&global.id, global.revision)
+        .unwrap();
+    assert_eq!(closed.placements.len(), 1);
+    assert_eq!(closed.placements[0].status, "closed");
+    assert!(daemon.client.snapshot().unwrap().workspaces.is_empty());
+    assert!(
+        daemon
+            .client
+            .combined_node_snapshot(None)
+            .unwrap()
+            .workspaces
+            .is_empty()
+    );
+}
+
+#[test]
+fn first_resources_atomically_establish_one_exact_owner_placement() {
+    let mut daemon = TestDaemon::start();
+    let global = daemon.client.create_global_workspace("placed").unwrap();
+    let combined = daemon.client.combined_node_snapshot(None).unwrap();
+    let owner = combined
+        .nodes
+        .iter()
+        .find(|node| node.local && node.workspace_owner_eligible)
+        .unwrap();
+    let owner_workspace_id = Uuid::new_v4().to_string();
+    let cwd = std::env::temp_dir();
+    assert!(
+        daemon
+            .client
+            .create_global_workspace_shell(
+                Uuid::new_v4().to_string(),
+                &global.id,
+                global.revision,
+                &owner.node_id,
+                Uuid::new_v4().to_string(),
+                Some(cwd.clone()),
+                Uuid::new_v4().to_string(),
+                ShellSpec {
+                    name: String::new(),
+                    command: Vec::new(),
+                    cwd: cwd.clone(),
+                },
+            )
+            .is_err()
+    );
+    let operation_id = Uuid::new_v4().to_string();
+    let shell_id = Uuid::new_v4().to_string();
+    let shell_spec = ShellSpec {
+        name: "first".into(),
+        command: vec!["/bin/sh".into(), "-lc".into(), "printf '%s' safe".into()],
+        cwd: cwd.clone(),
+    };
+    let (global, shell) = daemon
+        .client
+        .create_global_workspace_shell(
+            &operation_id,
+            &global.id,
+            global.revision,
+            &owner.node_id,
+            &owner_workspace_id,
+            Some(cwd.clone()),
+            &shell_id,
+            shell_spec.clone(),
+        )
+        .unwrap();
+    assert_eq!(global.placements.len(), 1);
+    assert_eq!(global.placements[0].workspace_id, owner_workspace_id);
+    assert_eq!(
+        global.placements[0].owner_workspace_name.as_deref(),
+        Some("placed")
+    );
+    assert_eq!(shell.workspace_id, owner_workspace_id);
+    let (replayed_global, replayed_shell) = daemon
+        .client
+        .create_global_workspace_shell(
+            &operation_id,
+            &global.id,
+            global.revision - 1,
+            &owner.node_id,
+            &owner_workspace_id,
+            Some(cwd.clone()),
+            &shell_id,
+            shell_spec,
+        )
+        .unwrap();
+    assert_eq!(replayed_global, global);
+    assert_eq!(replayed_shell, shell);
+    daemon.crash();
+    daemon.restart();
+    let (restart_replay_global, restart_replay_shell) = daemon
+        .client
+        .create_global_workspace_shell(
+            &operation_id,
+            &global.id,
+            global.revision - 1,
+            &owner.node_id,
+            &owner_workspace_id,
+            Some(cwd.clone()),
+            &shell_id,
+            ShellSpec {
+                name: "first".into(),
+                command: vec!["/bin/sh".into(), "-lc".into(), "printf '%s' safe".into()],
+                cwd: cwd.clone(),
+            },
+        )
+        .unwrap();
+    assert_eq!(restart_replay_global, global);
+    assert_eq!(restart_replay_shell, shell);
+
+    let global = daemon
+        .client
+        .rename_global_workspace(&global.id, global.revision, "renamed globally")
+        .unwrap();
+    assert_eq!(
+        daemon
+            .client
+            .get_workspace(&owner_workspace_id)
+            .unwrap()
+            .name,
+        "placed"
+    );
+
+    let launcher_id = Uuid::new_v4().to_string();
+    let (global, launcher) = daemon
+        .client
+        .create_global_workspace_launcher(
+            Uuid::new_v4().to_string(),
+            &global.id,
+            global.revision,
+            &owner.node_id,
+            &owner_workspace_id,
+            Some(cwd.clone()),
+            &launcher_id,
+            WorkspaceLauncherSpec {
+                name: "exact argv".into(),
+                cwd: cwd.clone(),
+                command: vec!["printf".into(), "%s".into(), "a b;$(private)".into()],
+            },
+        )
+        .unwrap();
+    assert_eq!(launcher.id, launcher_id);
+    assert_eq!(launcher.command[2], "a b;$(private)");
+
+    let schedule_id = Uuid::new_v4().to_string();
+    let (_, schedule) = daemon
+        .client
+        .create_global_workspace_agent_schedule(
+            Uuid::new_v4().to_string(),
+            &global.id,
+            global.revision,
+            &owner.node_id,
+            &owner_workspace_id,
+            Some(cwd.clone()),
+            &schedule_id,
+            AgentScheduleSpec {
+                name: "private".into(),
+                cwd: cwd.clone(),
+                integration: "opencode".into(),
+                prompt: "PRIVATE FIRST PLACEMENT PROMPT".into(),
+                session: AgentScheduleSession::Fresh,
+                trigger: AgentScheduleTrigger {
+                    cron: "0 2 * * *".into(),
+                    timezone: "UTC".into(),
+                },
+                state: AgentScheduleState::Paused,
+                overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            },
+        )
+        .unwrap();
+    assert_eq!(schedule.id, schedule_id);
+    let replay = daemon
+        .client
+        .request(Request::CreateWorkspaceAgentSchedule {
+            workspace_id: owner_workspace_id.clone(),
+            workspace_name: "placed".into(),
+            default_cwd: Some(cwd.clone()),
+            schedule_id: schedule_id.clone(),
+            spec: AgentScheduleSpec {
+                name: "private".into(),
+                cwd: cwd.clone(),
+                integration: "opencode".into(),
+                prompt: "PRIVATE FIRST PLACEMENT PROMPT".into(),
+                session: AgentScheduleSession::Fresh,
+                trigger: AgentScheduleTrigger {
+                    cron: "  0\t2  * * *  ".into(),
+                    timezone: "  UTC\n".into(),
+                },
+                state: AgentScheduleState::Paused,
+                overlap_policy: AgentScheduleOverlapPolicy::Skip,
+            },
+        })
+        .unwrap();
+    let Response::AgentSchedule { schedule: replay } = replay else {
+        panic!("expected exact Schedule replay");
+    };
+    assert_eq!(replay, schedule);
+    let snapshot = daemon.client.snapshot().unwrap();
+    assert_eq!(snapshot.workspaces.len(), 1);
+    assert_eq!(snapshot.workspaces[0].shells.len(), 1);
+    assert_eq!(snapshot.workspaces[0].launchers.len(), 1);
+    assert_eq!(snapshot.workspaces[0].schedules.len(), 1);
+    assert!(
+        !String::from_utf8_lossy(
+            &fs::read(
+                daemon
+                    .runtime_dir
+                    .join("state/boomux/global_workspaces.json")
+            )
+            .unwrap()
+        )
+        .contains("PRIVATE FIRST PLACEMENT PROMPT")
+    );
+}
+
+#[test]
+fn concurrent_first_resources_with_distinct_requested_owners_replay_canonical_successes() {
+    let daemon = TestDaemon::start();
+    let global = daemon
+        .client
+        .create_global_workspace("concurrent-first")
+        .unwrap();
+    let node_id = daemon.client.node_identity().unwrap();
+    let barrier = Arc::new(Barrier::new(3));
+    let mut requests = Vec::new();
+    let mut handles = Vec::new();
+    for offset in 0..2_u128 {
+        let operation_id = Uuid::from_u128(100 + offset).to_string();
+        let requested_owner_id = Uuid::from_u128(200 + offset).to_string();
+        let shell_id = Uuid::from_u128(300 + offset).to_string();
+        let shell = ShellSpec {
+            name: format!("shell-{offset}"),
+            command: Vec::new(),
+            cwd: std::env::temp_dir(),
+        };
+        requests.push((
+            operation_id.clone(),
+            requested_owner_id.clone(),
+            shell_id.clone(),
+            shell.clone(),
+        ));
+        let client = daemon.client.clone();
+        let barrier = Arc::clone(&barrier);
+        let global = global.clone();
+        let node_id = node_id.clone();
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            client
+                .create_global_workspace_shell(
+                    operation_id,
+                    &global.id,
+                    global.revision,
+                    node_id,
+                    requested_owner_id,
+                    Some(std::env::temp_dir()),
+                    shell_id,
+                    shell,
+                )
+                .unwrap()
+        }));
+    }
+    barrier.wait();
+    let first = handles.remove(0).join().unwrap();
+    let second = handles.remove(0).join().unwrap();
+    assert_eq!(first.0.placements.len(), 1);
+    assert_eq!(second.0.placements.len(), 1);
+    assert_eq!(
+        first.0.placements[0].workspace_id,
+        second.0.placements[0].workspace_id
+    );
+    assert_eq!(first.1.workspace_id, second.1.workspace_id);
+    assert_ne!(requests[0].1, requests[1].1);
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.1 == first.1.workspace_id)
+    );
+
+    for (index, (operation_id, requested_owner_id, shell_id, shell)) in
+        requests.into_iter().enumerate()
+    {
+        let replay = daemon
+            .client
+            .create_global_workspace_shell(
+                operation_id,
+                &global.id,
+                global.revision,
+                &node_id,
+                requested_owner_id,
+                Some(std::env::temp_dir()),
+                shell_id,
+                shell,
+            )
+            .unwrap();
+        let original = if index == 0 { &first } else { &second };
+        assert_eq!(&replay, original);
+    }
+}
+
+#[test]
+fn concurrent_identical_workspace_resource_handlers_return_the_same_success() {
+    let daemon = TestDaemon::start();
+    let global = daemon
+        .client
+        .create_global_workspace("same-operation")
+        .unwrap();
+    let node_id = daemon.client.node_identity().unwrap();
+    let operation_id = Uuid::new_v4().to_string();
+    let owner_id = Uuid::new_v4().to_string();
+    let shell_id = Uuid::new_v4().to_string();
+    let shell = ShellSpec {
+        name: "same".into(),
+        command: Vec::new(),
+        cwd: std::env::temp_dir(),
+    };
+    let barrier = Arc::new(Barrier::new(3));
+    let mut handles = Vec::new();
+    for _ in 0..2 {
+        let client = daemon.client.clone();
+        let global = global.clone();
+        let node_id = node_id.clone();
+        let operation_id = operation_id.clone();
+        let owner_id = owner_id.clone();
+        let shell_id = shell_id.clone();
+        let shell = shell.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            client
+                .create_global_workspace_shell(
+                    operation_id,
+                    &global.id,
+                    global.revision,
+                    node_id,
+                    owner_id,
+                    Some(std::env::temp_dir()),
+                    shell_id,
+                    shell,
+                )
+                .unwrap()
+        }));
+    }
+    barrier.wait();
+    let first = handles.remove(0).join().unwrap();
+    let second = handles.remove(0).join().unwrap();
+    assert_eq!(first, second);
+    assert_eq!(
+        daemon.client.snapshot().unwrap().workspaces[0].shells.len(),
+        1
+    );
+}
+
+#[test]
+fn project_workspace_preflight_failure_does_not_reserve_the_name() {
+    let daemon = TestDaemon::start();
+    let local = daemon
+        .client
+        .combined_node_snapshot(None)
+        .unwrap()
+        .nodes
+        .into_iter()
+        .find(|node| node.local)
+        .unwrap();
+    assert!(
+        daemon
+            .client
+            .create_global_workspace_with_shell(
+                Uuid::new_v4().to_string(),
+                Uuid::new_v4().to_string(),
+                "missing-owner-project",
+                Uuid::new_v4().to_string(),
+                Uuid::new_v4().to_string(),
+                "/tmp".into(),
+                Uuid::new_v4().to_string(),
+                ShellSpec {
+                    name: "missing".into(),
+                    cwd: "/tmp".into(),
+                    command: Vec::new(),
+                },
+            )
+            .is_err()
+    );
+    assert!(
+        daemon
+            .client
+            .combined_node_snapshot(None)
+            .unwrap()
+            .workspaces
+            .iter()
+            .all(|workspace| workspace.name != "missing-owner-project")
+    );
+    let (recovered, recovered_shell) = daemon
+        .client
+        .create_global_workspace_with_shell(
+            Uuid::new_v4().to_string(),
+            Uuid::new_v4().to_string(),
+            "missing-owner-project",
+            &local.node_id,
+            Uuid::new_v4().to_string(),
+            "/tmp".into(),
+            Uuid::new_v4().to_string(),
+            ShellSpec {
+                name: "valid-different-semantics".into(),
+                cwd: "/tmp".into(),
+                command: Vec::new(),
+            },
+        )
+        .unwrap();
+    assert_eq!(recovered.placements.len(), 1);
+    assert_eq!(recovered_shell.name, "valid-different-semantics");
+}
+
+#[test]
+fn attempted_project_survives_missing_registration_and_blocks_different_semantics() {
+    let mut daemon = TestDaemon::start();
+    let local_node_id = daemon.client.node_identity().unwrap();
+    daemon.crash();
+
+    let operation_id = Uuid::new_v4().to_string();
+    let global_workspace_id = Uuid::new_v4().to_string();
+    let missing_node_id = Uuid::new_v4().to_string();
+    let owner_workspace_id = Uuid::new_v4().to_string();
+    let shell_id = Uuid::new_v4().to_string();
+    let shell = ShellSpec {
+        name: "ambiguous".into(),
+        cwd: "/tmp".into(),
+        command: Vec::new(),
+    };
+    let request = Request::CreateGlobalWorkspaceWithShell {
+        operation_id: operation_id.clone(),
+        global_workspace_id: global_workspace_id.clone(),
+        name: "attempted-project".into(),
+        node_id: missing_node_id.clone(),
+        owner_workspace_id: owner_workspace_id.clone(),
+        default_cwd: "/tmp".into(),
+        shell_id: shell_id.clone(),
+        shell: shell.clone(),
+    };
+    let request_fingerprint = format!(
+        "{:x}",
+        Sha256::digest(serde_json::to_vec(&request).unwrap())
+    );
+    let path = daemon
+        .runtime_dir
+        .join("state/boomux/global_workspaces.json");
+    fs::write(
+        &path,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "version": 6,
+            "local_migration_complete": true,
+            "workspaces": [{
+                "id": global_workspace_id,
+                "revision": 1,
+                "name": "attempted-project",
+                "closing": false,
+                "placements": []
+            }],
+            "pending_resources": [{
+                "operation_id": operation_id,
+                "creates_workspace": true,
+                "request_fingerprint": request_fingerprint,
+                "semantic_fingerprint": "b".repeat(64),
+                "completion_reservation": " ".repeat(70_000),
+                "owner_attempted": true,
+                "global_workspace_id": global_workspace_id,
+                "expected_global_revision": 1,
+                "node_id": missing_node_id,
+                "requested_owner_workspace_id": owner_workspace_id,
+                "owner_workspace_id": owner_workspace_id,
+                "owner_workspace_name": "attempted-project",
+                "default_cwd": "/tmp",
+                "resource_id": shell_id,
+                "kind": "shell"
+            }],
+            "completed_operations": []
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    daemon.restart();
+
+    assert!(
+        daemon
+            .client
+            .create_global_workspace_with_shell(
+                operation_id,
+                global_workspace_id.clone(),
+                "attempted-project",
+                missing_node_id,
+                owner_workspace_id,
+                "/tmp".into(),
+                shell_id,
+                shell,
+            )
+            .is_err()
+    );
+    let retained = daemon
+        .client
+        .combined_node_snapshot(None)
+        .unwrap()
+        .workspaces
+        .into_iter()
+        .find(|workspace| workspace.id == global_workspace_id)
+        .expect("attempted project must remain pending after registration loss");
+    assert!(retained.placements.is_empty());
+
+    assert!(
+        daemon
+            .client
+            .create_global_workspace_with_shell(
+                Uuid::new_v4().to_string(),
+                Uuid::new_v4().to_string(),
+                "attempted-project",
+                local_node_id,
+                Uuid::new_v4().to_string(),
+                "/tmp".into(),
+                Uuid::new_v4().to_string(),
+                ShellSpec {
+                    name: "different".into(),
+                    cwd: "/tmp".into(),
+                    command: Vec::new(),
+                },
+            )
+            .is_err()
+    );
+    assert!(
+        daemon
+            .client
+            .combined_node_snapshot(None)
+            .unwrap()
+            .workspaces
+            .iter()
+            .any(|workspace| workspace.id == global_workspace_id)
+    );
 }
 
 fn contains_json_key(value: &serde_json::Value, key: &str) -> bool {
@@ -125,33 +730,176 @@ fn malformed_registration_store_preserves_local_daemon_operation() {
     assert_eq!(fs::read(&path).unwrap(), b"not-json");
 }
 
-fn shell_printf(bytes: &[u8]) -> String {
-    let escaped = bytes
-        .iter()
-        .map(|byte| format!("\\{byte:03o}"))
-        .collect::<String>();
-    format!("printf '{escaped}'")
+#[test]
+fn malformed_global_workspace_store_suppresses_capability_and_eligibility() {
+    let mut daemon = TestDaemon::start();
+    daemon.crash();
+    let path = daemon
+        .runtime_dir
+        .join("state/boomux/global_workspaces.json");
+    fs::write(&path, b"not-json").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    daemon.restart();
+
+    daemon.client.ping().unwrap();
+    let combined = daemon.client.combined_node_snapshot(None).unwrap();
+    let local = combined.nodes.iter().find(|node| node.local).unwrap();
+    assert!(!local.workspace_owner_eligible);
+    assert!(
+        local
+            .workspace_owner_unavailable_reason
+            .as_deref()
+            .unwrap()
+            .contains("storage")
+    );
+    assert!(
+        !local
+            .observed_capabilities
+            .iter()
+            .any(|capability| capability == "global_workspaces")
+    );
+    assert!(daemon.client.create_global_workspace("disabled").is_err());
+    assert_eq!(fs::read(&path).unwrap(), b"not-json");
 }
 
-fn fake_ssh(directory: &Path) {
+#[test]
+fn cli_global_close_treats_missing_local_owner_as_already_removed() {
+    let daemon = TestDaemon::start();
+    let global = daemon
+        .client
+        .create_global_workspace("stale-local")
+        .unwrap();
+    let local = daemon
+        .client
+        .combined_node_snapshot(None)
+        .unwrap()
+        .nodes
+        .into_iter()
+        .find(|node| node.local)
+        .unwrap();
+    let owner_workspace_id = Uuid::new_v4().to_string();
+    let (global, _) = daemon
+        .client
+        .create_global_workspace_shell(
+            Uuid::new_v4().to_string(),
+            &global.id,
+            global.revision,
+            &local.node_id,
+            &owner_workspace_id,
+            Some("/tmp".into()),
+            Uuid::new_v4().to_string(),
+            ShellSpec {
+                name: "stale".into(),
+                cwd: "/tmp".into(),
+                command: Vec::new(),
+            },
+        )
+        .unwrap();
+    daemon.client.close_workspace(&owner_workspace_id).unwrap();
+    let close = daemon
+        .command()
+        .env("BOOMUX_SHELL_ID", Uuid::new_v4().to_string())
+        .args(["workspace", "close", &global.id])
+        .output()
+        .unwrap();
+    assert!(
+        close.status.success(),
+        "global close rejected missing local owner: {}",
+        String::from_utf8_lossy(&close.stderr)
+    );
+}
+
+fn write_fake_handshake(directory: &Path, core_protocol_version: u32) {
     use boomux::federation::{
         FEDERATION_VERSION, FederationConnectionMode, FederationHandshake, write_handshake,
     };
+    let handshake = FederationHandshake {
+        version: FEDERATION_VERSION,
+        node_id: node_id(2),
+        helper_version: env!("CARGO_PKG_VERSION").into(),
+        core_protocol_version,
+        connection_mode: FederationConnectionMode::AdHoc,
+    };
+    let mut handshake_bytes = Vec::new();
+    write_handshake(&mut handshake_bytes, &handshake).unwrap();
+    fs::write(directory.join("handshake.bin"), handshake_bytes).unwrap();
+}
+
+fn write_fake_combined_snapshot(directory: &Path, workspace_owner_eligible: bool) {
+    use boomux::protocol::{
+        self, CombinedNode, CombinedNodeSnapshot, Envelope, NodeProjectionHealthCode, Response,
+        SchedulerHealth, SchedulerState, Snapshot, WorkspaceSnapshot,
+    };
+
+    let unavailable_reason =
+        (!workspace_owner_eligible).then(|| "coordinated Workspace storage is unavailable".into());
+    let capabilities = if workspace_owner_eligible {
+        vec!["protocol_38".into(), "global_workspaces".into()]
+    } else {
+        vec!["protocol_38".into()]
+    };
+    let scheduler = SchedulerHealth {
+        state: SchedulerState::Active,
+        max_concurrent: 4,
+        active_executions: 0,
+    };
+    let mut response = Vec::new();
+    protocol::write_message(
+        &mut response,
+        &Envelope::with_version(
+            protocol::PROTOCOL_VERSION,
+            Response::CombinedNodeSnapshot {
+                snapshot: CombinedNodeSnapshot {
+                    nodes: vec![CombinedNode {
+                        node_id: node_id(2),
+                        alias: "local".into(),
+                        local: true,
+                        route: None,
+                        registration_revision: None,
+                        health: NodeProjectionHealthCode::Online,
+                        current: true,
+                        stale: false,
+                        observed_at_ms: 1,
+                        observed_protocol_version: Some(protocol::PROTOCOL_VERSION),
+                        observed_capabilities: capabilities,
+                        workspace_owner_eligible,
+                        workspace_owner_unavailable_reason: unavailable_reason,
+                        scheduler: scheduler.clone(),
+                        local_snapshot: Some(Snapshot {
+                            workspaces: vec![WorkspaceSnapshot {
+                                id: "shared-workspace".into(),
+                                revision: 7,
+                                name: "shared-private".into(),
+                                default_cwd: Some("/remote/private".into()),
+                                shells: Vec::new(),
+                                launchers: Vec::new(),
+                                agents: Vec::new(),
+                                schedules: Vec::new(),
+                            }],
+                            focused_terminal: None,
+                            scheduler: Some(scheduler),
+                        }),
+                        remote_projection: None,
+                    }],
+                    workspaces: Vec::new(),
+                    external_workspaces: Vec::new(),
+                },
+            },
+        ),
+    )
+    .unwrap();
+    fs::write(directory.join("combined.bin"), response).unwrap();
+}
+
+fn fake_ssh(directory: &Path) {
     use boomux::protocol::{
         self, Envelope, EventCursor, NodeProjectionShell, NodeProjectionSnapshot,
         NodeProjectionSync, NodeProjectionSyncMode, NodeProjectionWorkspace, Response,
         SchedulerHealth, SchedulerState, ShellOwner, ShellStatus,
     };
 
-    let handshake = FederationHandshake {
-        version: FEDERATION_VERSION,
-        node_id: node_id(2),
-        helper_version: env!("CARGO_PKG_VERSION").into(),
-        core_protocol_version: protocol::PROTOCOL_VERSION,
-        connection_mode: FederationConnectionMode::AdHoc,
-    };
-    let mut handshake_bytes = Vec::new();
-    write_handshake(&mut handshake_bytes, &handshake).unwrap();
+    write_fake_handshake(directory, protocol::PROTOCOL_VERSION);
+    write_fake_combined_snapshot(directory, true);
     let mut ping = Vec::new();
     protocol::write_message(
         &mut ping,
@@ -201,6 +949,7 @@ fn fake_ssh(directory: &Path) {
                         },
                     },
                     transitions: Vec::new(),
+                    capabilities: vec!["protocol_38".into(), "global_workspaces".into()],
                 },
             },
         ),
@@ -233,11 +982,12 @@ fn fake_ssh(directory: &Path) {
     fs::write(
         &ssh,
         format!(
-            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") {}; python3 -c 'import json,struct,sys; data=sys.stdin.buffer.read(struct.unpack(\">I\",sys.stdin.buffer.read(4))[0]); request=json.loads(data)[\"message\"][\"request\"]; paths={{\"ping\":sys.argv[1],\"sync_node_projection\":sys.argv[2],\"get_workspace\":sys.argv[3]}}; sys.stdout.buffer.write(open(paths[request],\"rb\").read())' \"{}\" \"{}\" \"{}\" ;;\n  *) exit 64 ;;\nesac\n",
-            shell_printf(&handshake_bytes),
+            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") cat \"{}\"; python3 -c 'import json,struct,sys; data=sys.stdin.buffer.read(struct.unpack(\">I\",sys.stdin.buffer.read(4))[0]); request=json.loads(data)[\"message\"][\"request\"]; paths={{\"ping\":sys.argv[1],\"sync_node_projection\":sys.argv[2],\"get_workspace\":sys.argv[3],\"get_combined_node_snapshot\":sys.argv[4]}}; sys.stdout.buffer.write(open(paths[request],\"rb\").read())' \"{}\" \"{}\" \"{}\" \"{}\" ;;\n  *) exit 64 ;;\nesac\n",
+            directory.join("handshake.bin").display(),
             directory.join("pong.bin").display(),
             directory.join("sync.bin").display(),
             directory.join("workspace.bin").display(),
+            directory.join("combined.bin").display(),
         ),
     )
     .unwrap();
@@ -348,6 +1098,39 @@ fn cli_add_and_retarget_pin_verified_identity_without_persisting_helper_path() {
         remote["remote_projection"]["shells"][0]["workspace_id"]["inner_id"],
         "shared-workspace"
     );
+    assert_eq!(remote["workspace_owner_eligible"], true);
+    write_fake_handshake(&directory, 37);
+    let client =
+        boomux::client::Client::from_socket_path(directory.join("runtime/boomux/daemon.sock"));
+    let adopt = client
+        .adopt_node_workspace(
+            boomux::protocol::QualifiedIdentity::new(node_id(2), "shared-workspace"),
+            7,
+        )
+        .unwrap_err();
+    assert!(matches!(
+        adopt,
+        ClientError::Remote(RemoteError {
+            code: Some(ErrorCode::UnsupportedVersion),
+            ..
+        })
+    ));
+    write_fake_handshake(&directory, boomux::protocol::PROTOCOL_VERSION);
+    write_fake_combined_snapshot(&directory, false);
+    let unavailable = client
+        .adopt_node_workspace(
+            boomux::protocol::QualifiedIdentity::new(node_id(2), "shared-workspace"),
+            7,
+        )
+        .unwrap_err();
+    assert!(matches!(
+        unavailable,
+        ClientError::Remote(RemoteError {
+            code: Some(ErrorCode::UnsupportedVersion),
+            ..
+        })
+    ));
+    write_fake_combined_snapshot(&directory, true);
     let cache: serde_json::Value =
         serde_json::from_slice(&fs::read(directory.join("state/boomux/node-cache.json")).unwrap())
             .unwrap();

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -14,7 +14,7 @@ use boomux::protocol::{
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::support::TestDaemon;
+use crate::support::{CONTROL_MASTER_PREFIX, TestDaemon};
 
 fn node_id(value: u128) -> String {
     Uuid::from_u128(value).to_string()
@@ -823,6 +823,16 @@ fn write_fake_handshake(directory: &Path, core_protocol_version: u32) {
     let mut handshake_bytes = Vec::new();
     write_handshake(&mut handshake_bytes, &handshake).unwrap();
     fs::write(directory.join("handshake.bin"), handshake_bytes).unwrap();
+    let mut pong = Vec::new();
+    boomux::protocol::write_message(
+        &mut pong,
+        &boomux::protocol::Envelope::with_version(
+            core_protocol_version,
+            boomux::protocol::Response::Pong,
+        ),
+    )
+    .unwrap();
+    fs::write(directory.join("pong.bin"), pong).unwrap();
 }
 
 fn write_fake_combined_snapshot(directory: &Path, workspace_owner_eligible: bool) {
@@ -982,7 +992,7 @@ fn fake_ssh(directory: &Path) {
     fs::write(
         &ssh,
         format!(
-            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") cat \"{}\"; python3 -c 'import json,struct,sys; data=sys.stdin.buffer.read(struct.unpack(\">I\",sys.stdin.buffer.read(4))[0]); request=json.loads(data)[\"message\"][\"request\"]; paths={{\"ping\":sys.argv[1],\"sync_node_projection\":sys.argv[2],\"get_workspace\":sys.argv[3],\"get_combined_node_snapshot\":sys.argv[4]}}; sys.stdout.buffer.write(open(paths[request],\"rb\").read())' \"{}\" \"{}\" \"{}\" \"{}\" ;;\n  *) exit 64 ;;\nesac\n",
+            "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in *'exec '*) last=${{last##*exec }} ;; esac\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") cat \"{}\"; python3 -c 'import json,struct,sys; data=sys.stdin.buffer.read(struct.unpack(\">I\",sys.stdin.buffer.read(4))[0]); request=json.loads(data)[\"message\"][\"request\"]; paths={{\"ping\":sys.argv[1],\"sync_node_projection\":sys.argv[2],\"get_workspace\":sys.argv[3],\"get_combined_node_snapshot\":sys.argv[4]}}; sys.stdout.buffer.write(open(paths[request],\"rb\").read())' \"{}\" \"{}\" \"{}\" \"{}\" ;;\n  *) exit 64 ;;\nesac\n",
             directory.join("handshake.bin").display(),
             directory.join("pong.bin").display(),
             directory.join("sync.bin").display(),
@@ -1005,7 +1015,7 @@ fn command(directory: &Path) -> Command {
 }
 
 #[test]
-fn cli_add_and_retarget_pin_verified_identity_without_persisting_helper_path() {
+fn cli_add_and_retarget_use_once_verified_identity_without_persisting_helper_path() {
     let id = Uuid::new_v4().simple().to_string();
     let directory = std::env::temp_dir().join(format!("bx-n-{}-{}", std::process::id(), &id[..8]));
     fs::create_dir_all(directory.join("home/.ssh")).unwrap();
@@ -1108,13 +1118,16 @@ fn cli_add_and_retarget_pin_verified_identity_without_persisting_helper_path() {
             7,
         )
         .unwrap_err();
-    assert!(matches!(
-        adopt,
-        ClientError::Remote(RemoteError {
-            code: Some(ErrorCode::UnsupportedVersion),
-            ..
-        })
-    ));
+    assert!(
+        matches!(
+            &adopt,
+            ClientError::Remote(RemoteError {
+                code: Some(ErrorCode::UnsupportedVersion),
+                ..
+            })
+        ),
+        "unexpected adopt error: {adopt:?}"
+    );
     write_fake_handshake(&directory, boomux::protocol::PROTOCOL_VERSION);
     write_fake_combined_snapshot(&directory, false);
     let unavailable = client

--- a/tests/native_backend/notifications.rs
+++ b/tests/native_backend/notifications.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use boomux::protocol::{AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, ShellSpec};
 use uuid::Uuid;
 
-use crate::support::{TestDaemon, process_exists, profile, wait_until};
+use crate::support::{CONTROL_MASTER_PREFIX, TestDaemon, process_exists, profile, wait_until};
 
 struct RemoteSubscriber {
     daemon: TestDaemon,
@@ -641,7 +641,7 @@ fn start_remote_subscriber(owner: &TestDaemon) -> RemoteSubscriber {
         fs::write(
             &ssh,
             format!(
-                "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}\\0' ;;\n  *__federation-stdio*) exec env XDG_RUNTIME_DIR='{}' XDG_STATE_HOME='{}' '{}' __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
+                "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}\\0' ;;\n  *__federation-stdio*) exec env XDG_RUNTIME_DIR='{}' XDG_STATE_HOME='{}' '{}' __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
                 owner.executable.display(),
                 owner.executable.display(),
                 owner.runtime_dir.display(),

--- a/tests/native_backend/remote_attachment.rs
+++ b/tests/native_backend/remote_attachment.rs
@@ -5,7 +5,9 @@ use std::process::Stdio;
 use boomux::protocol::{AttachFrame, QualifiedIdentity, ShellSpec};
 use uuid::Uuid;
 
-use crate::support::{TestDaemon, contains, parse_pid, profile, read_until, wait_until};
+use crate::support::{
+    CONTROL_MASTER_PREFIX, TestDaemon, contains, parse_pid, profile, read_until, wait_until,
+};
 
 fn install_fake_ssh(
     directory: &std::path::Path,
@@ -16,7 +18,7 @@ fn install_fake_ssh(
     fs::write(
         &ssh,
         format!(
-            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}/boomux\\0' ;;\n  *'__federation-stdio'*) exec env -i PATH=/usr/bin:/bin HOME={} XDG_RUNTIME_DIR={} XDG_STATE_HOME={} {} __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
+            "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}/boomux\\0' ;;\n  *'__federation-stdio'*) exec env -i PATH=/usr/bin:/bin HOME={} XDG_RUNTIME_DIR={} XDG_STATE_HOME={} {} __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
             executable.display(),
             directory.display(),
             directory.display(),

--- a/tests/native_backend/remote_attachment.rs
+++ b/tests/native_backend/remote_attachment.rs
@@ -300,6 +300,7 @@ fn two_daemon_remote_attachment_keeps_environment_and_runtime_on_owner() {
     assert!(contains(&output, b"local=unset"));
     let pid = parse_pid(&output, "pid=").expect("remote shell PID");
     let run_id = remote.client.get_shell(&shell.id).unwrap().run.unwrap().id;
+    let local_event_cursor = local.client.events(None, 256, 0).unwrap().cursor;
 
     AttachFrame::Resize {
         rows: 40,
@@ -316,6 +317,47 @@ fn two_daemon_remote_attachment_keeps_environment_and_runtime_on_owner() {
         &read_until(&mut attachment.stream, b"remote-input"),
         b"remote-input"
     ));
+    AttachFrame::FocusGained
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    let focus_events = local
+        .client
+        .events(Some(local_event_cursor), 256, 1_000)
+        .unwrap();
+    assert!(focus_events.events.iter().any(|event| matches!(
+        event.kind,
+        boomux::protocol::DaemonEventKind::FocusedTerminalPresentationChanged
+    )));
+    wait_until(
+        || {
+            remote
+                .client
+                .focused_terminal()
+                .ok()
+                .flatten()
+                .is_some_and(|focused| focused.shell_id == shell.id)
+        },
+        "remote owner did not accept the relayed focus frame",
+    );
+    wait_until(
+        || {
+            local
+                .client
+                .combined_node_snapshot(None)
+                .ok()
+                .and_then(|snapshot| snapshot.focused_terminal)
+                .is_some_and(|focused| {
+                    focused.shell == QualifiedIdentity::new(&remote_node, &shell.id)
+                })
+        },
+        "remote attachment focus was not presented by the local daemon",
+    );
+    let focus_before_handoff = local
+        .client
+        .combined_node_snapshot(None)
+        .unwrap()
+        .focused_terminal
+        .unwrap();
     drop(attachment);
     wait_until(
         || {
@@ -354,6 +396,14 @@ fn two_daemon_remote_attachment_keeps_environment_and_runtime_on_owner() {
         .write_to(&mut reattached.stream)
         .unwrap();
     assert!(restart.wait_with_output().unwrap().status.success());
+    assert_eq!(
+        local
+            .client
+            .combined_node_snapshot(None)
+            .unwrap()
+            .focused_terminal,
+        Some(focus_before_handoff.clone())
+    );
     let mut after_handoff = local
         .client
         .attach_node(
@@ -364,6 +414,20 @@ fn two_daemon_remote_attachment_keeps_environment_and_runtime_on_owner() {
             profile(),
         )
         .unwrap();
+    AttachFrame::FocusGained
+        .write_to(&mut after_handoff.stream)
+        .unwrap();
+    wait_until(
+        || {
+            local
+                .client
+                .combined_node_snapshot(None)
+                .ok()
+                .and_then(|snapshot| snapshot.focused_terminal)
+                .is_some_and(|focused| focused.revision > focus_before_handoff.revision)
+        },
+        "remote focus revision did not advance after local handoff",
+    );
     AttachFrame::Input(b"after-local-handoff\n".to_vec())
         .write_to(&mut after_handoff.stream)
         .unwrap();

--- a/tests/native_backend/remote_attachment.rs
+++ b/tests/native_backend/remote_attachment.rs
@@ -3,6 +3,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::process::Stdio;
 
 use boomux::protocol::{AttachFrame, QualifiedIdentity, ShellSpec};
+use uuid::Uuid;
 
 use crate::support::{TestDaemon, contains, parse_pid, profile, read_until, wait_until};
 
@@ -26,6 +27,224 @@ fn install_fake_ssh(
     )
     .unwrap();
     fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+#[test]
+fn two_daemon_workspace_coordination_adopts_links_places_and_retries_close() {
+    let remote = TestDaemon::start();
+    let adopted_owner = remote
+        .client
+        .create_workspace("remote-adopt", Vec::new())
+        .unwrap();
+    let linked_owner = remote
+        .client
+        .create_workspace("remote-link", Vec::new())
+        .unwrap();
+    let remote_node = remote.client.node_identity().unwrap();
+    let executable = remote.executable.clone();
+    let mut local = TestDaemon::start_with(|command, directory| {
+        install_fake_ssh(directory, &executable, &remote);
+        command.env("PATH", format!("{}:/usr/bin:/bin", directory.display()));
+    });
+    local
+        .client
+        .add_node_registration("work", "fake-target", &remote_node)
+        .unwrap();
+    wait_until(
+        || {
+            local
+                .client
+                .combined_node_snapshot(None)
+                .ok()
+                .and_then(|snapshot| {
+                    snapshot
+                        .nodes
+                        .into_iter()
+                        .find(|node| node.node_id == remote_node)
+                })
+                .is_some_and(|node| node.workspace_owner_eligible)
+        },
+        "remote Node did not become eligible for Workspace placement",
+    );
+
+    let adopt = local
+        .command()
+        .args(["workspace", "adopt", &adopted_owner.id, "--node", "work"])
+        .output()
+        .unwrap();
+    assert!(
+        adopt.status.success(),
+        "CLI remote adopt failed: {}",
+        String::from_utf8_lossy(&adopt.stderr)
+    );
+    let adopted = local
+        .client
+        .combined_node_snapshot(None)
+        .unwrap()
+        .workspaces
+        .into_iter()
+        .find(|workspace| workspace.name == "remote-adopt")
+        .unwrap();
+    assert_eq!(adopted.placements[0].workspace_id, adopted_owner.id);
+
+    let linked = local
+        .client
+        .create_global_workspace("linked-global")
+        .unwrap();
+    let link = local
+        .command()
+        .args([
+            "workspace",
+            "link",
+            &linked.id,
+            &linked_owner.id,
+            "--node",
+            "work",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        link.status.success(),
+        "CLI remote link failed: {}",
+        String::from_utf8_lossy(&link.stderr)
+    );
+    let linked = local
+        .client
+        .combined_node_snapshot(None)
+        .unwrap()
+        .workspaces
+        .into_iter()
+        .find(|workspace| workspace.id == linked.id)
+        .unwrap();
+    assert_eq!(linked.placements[0].workspace_id, linked_owner.id);
+
+    let ssh = local.runtime_dir.join("ssh");
+    let disabled_ssh = local.runtime_dir.join("ssh.disabled");
+    fs::rename(&ssh, &disabled_ssh).unwrap();
+    assert!(
+        local
+            .client
+            .create_global_workspace_with_shell(
+                Uuid::new_v4().to_string(),
+                Uuid::new_v4().to_string(),
+                "restart-project",
+                &remote_node,
+                Uuid::new_v4().to_string(),
+                "/tmp".into(),
+                Uuid::new_v4().to_string(),
+                ShellSpec {
+                    name: "restart-project".into(),
+                    cwd: "/tmp".into(),
+                    command: Vec::new(),
+                },
+            )
+            .is_err()
+    );
+    assert!(
+        local
+            .client
+            .combined_node_snapshot(None)
+            .unwrap()
+            .workspaces
+            .iter()
+            .all(|workspace| workspace.name != "restart-project"),
+        "preflight route failure must not persist empty global metadata"
+    );
+    local.crash();
+    fs::rename(&disabled_ssh, &ssh).unwrap();
+    let local_path = format!("{}:/usr/bin:/bin", local.runtime_dir.display());
+    local.restart_with(|command| {
+        command.env("PATH", local_path);
+    });
+    wait_until(
+        || {
+            local
+                .client
+                .combined_node_snapshot(None)
+                .ok()
+                .and_then(|snapshot| {
+                    snapshot
+                        .nodes
+                        .into_iter()
+                        .find(|node| node.node_id == remote_node)
+                })
+                .is_some_and(|node| node.workspace_owner_eligible)
+        },
+        "remote Node did not recover placement eligibility",
+    );
+    let (recovered_project, recovered_shell) = local
+        .client
+        .create_global_workspace_with_shell(
+            Uuid::new_v4().to_string(),
+            Uuid::new_v4().to_string(),
+            "restart-project",
+            &remote_node,
+            Uuid::new_v4().to_string(),
+            "/tmp".into(),
+            Uuid::new_v4().to_string(),
+            ShellSpec {
+                name: "restart-project".into(),
+                cwd: "/tmp".into(),
+                command: Vec::new(),
+            },
+        )
+        .unwrap();
+    assert_eq!(recovered_project.placements.len(), 1);
+    assert_eq!(recovered_shell.name, "restart-project");
+
+    let placed = local
+        .client
+        .create_global_workspace("remote-placed")
+        .unwrap();
+    let owner_workspace_id = Uuid::new_v4().to_string();
+    let (placed, shell) = local
+        .client
+        .create_global_workspace_shell(
+            Uuid::new_v4().to_string(),
+            &placed.id,
+            placed.revision,
+            &remote_node,
+            &owner_workspace_id,
+            Some("/tmp".into()),
+            Uuid::new_v4().to_string(),
+            ShellSpec {
+                name: "remote-first".into(),
+                cwd: "/tmp".into(),
+                command: vec!["/bin/sh".into(), "-c".into(), "true".into()],
+            },
+        )
+        .unwrap();
+    assert_eq!(shell.workspace_id, owner_workspace_id);
+    let opened = local
+        .client
+        .open_global_workspace(&placed.id, placed.revision)
+        .unwrap();
+    assert_eq!(opened.placements[0].status, "available");
+
+    let ssh = local.runtime_dir.join("ssh");
+    let disabled_ssh = local.runtime_dir.join("ssh.disabled");
+    fs::rename(&ssh, &disabled_ssh).unwrap();
+    let partial = local
+        .client
+        .close_global_workspace(&placed.id, placed.revision)
+        .unwrap();
+    assert_eq!(partial.placements[0].status, "unresolved");
+    assert!(partial.workspace.closing);
+    fs::rename(&disabled_ssh, &ssh).unwrap();
+    let completed = local
+        .client
+        .retry_global_workspace_close(&placed.id)
+        .unwrap();
+    assert_eq!(completed.placements[0].status, "closed");
+    assert!(
+        local
+            .client
+            .combined_node_snapshot(None)
+            .unwrap()
+            .workspaces
+            .iter()
+            .all(|workspace| workspace.id != placed.id)
+    );
 }
 
 #[test]

--- a/tests/native_backend/remote_attachment.rs
+++ b/tests/native_backend/remote_attachment.rs
@@ -69,6 +69,39 @@ fn two_daemon_workspace_coordination_adopts_links_places_and_retries_close() {
         "remote Node did not become eligible for Workspace placement",
     );
 
+    let colliding_local_owner = local
+        .client
+        .create_workspace("remote-adopt", Vec::new())
+        .unwrap();
+
+    for arguments in [
+        vec!["shell", "create", "remote-adopt", "--node", "work"],
+        vec![
+            "launcher",
+            "create",
+            "unsafe",
+            "--workspace",
+            "remote-adopt",
+            "--node",
+            "work",
+            "--",
+            "true",
+        ],
+    ] {
+        let output = local.command().args(arguments).output().unwrap();
+        assert!(!output.status.success());
+        assert!(contains(&output.stderr, b"coordinated Workspace"));
+    }
+    let unchanged_owner = remote.client.get_workspace(&adopted_owner.id).unwrap();
+    assert!(unchanged_owner.shells.is_empty());
+    assert!(unchanged_owner.launchers.is_empty());
+    let unchanged_local_owner = local
+        .client
+        .get_workspace(&colliding_local_owner.id)
+        .unwrap();
+    assert!(unchanged_local_owner.shells.is_empty());
+    assert!(unchanged_local_owner.launchers.is_empty());
+
     let adopt = local
         .command()
         .args(["workspace", "adopt", &adopted_owner.id, "--node", "work"])

--- a/tests/native_backend/remote_bootstrap.rs
+++ b/tests/native_backend/remote_bootstrap.rs
@@ -1,13 +1,24 @@
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::process::CommandExt;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
+use boomux::client::Client;
 use boomux::federation::{
     FEDERATION_VERSION, FederationConnectionMode, FederationHandshake, write_handshake,
 };
 use boomux::protocol::{self, Envelope, Request, Response};
+use boomux::ssh_bootstrap::{
+    REMOTE_INSTALL_ACTIVATE_COMMAND, REMOTE_INSTALL_COMMAND, REMOTE_INSTALL_ROLLBACK_COMMAND,
+};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
+
+const CONTROL_MASTER_PREFIX: &str = "control=; previous=; master=false; check=false; last=; for arg do last=$arg; case \"$previous\" in -S) control=$arg ;; -O) [ \"$arg\" = check ] && check=true ;; esac; case \"$arg\" in ControlPath=*) control=${arg#ControlPath=} ;; -N) master=true ;; esac; previous=$arg; done; if $master; then : > \"$control.ready\"; trap 'rm -f \"$control.ready\"' EXIT HUP INT TERM; while :; do sleep 60; done; fi; if $check; then [ -e \"$control.ready\" ]; exit; fi; case \"$last\" in *'boomux-install-activation-v1'*) cat >/dev/null; printf 'boomux-install-activation-v1\\0activated\\0'; exit ;; *'boomux-install-transaction-v1'*) IFS= read -r boomux_test_txn; printf() { case \"$1\" in boomux-install-transaction-v1*) command printf 'boomux-install-transaction-v1\\0%s\\0' \"$boomux_test_txn\" ;; *) command printf \"$@\" ;; esac; } ;; *'prior_daemon.next'*|*': > \"$transaction/daemon_contacted\"'*|*'lease.next'*) cat >/dev/null; exit ;; esac";
 
 fn shell_printf(bytes: &[u8]) -> String {
     let escaped = bytes
@@ -67,7 +78,7 @@ fn fake_ssh(
     fs::write(
         &ssh,
         format!(
-            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\nprintf '%s\\n' \"$last\" >> '{}'\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") {} ;;\n  *) exit 64 ;;\nesac\n",
+            "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nlast=\nfor arg do last=$arg; done\nprintf '%s|%s\\n' \"$control\" \"$last\" >> '{}'\ncase \"$last\" in *'exec '*) last=${{last##*exec }} ;; esac\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") {} ;;\n  *) exit 64 ;;\nesac\n",
             log.display(),
             executables,
             helper,
@@ -76,6 +87,116 @@ fn fake_ssh(
     .unwrap();
     fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
     ssh
+}
+
+fn fake_old_ssh(directory: &Path) {
+    let log = directory.join("ssh.log");
+    let ssh = directory.join("ssh");
+    fs::write(
+        &ssh,
+        format!(
+            "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nlast=\nfor arg do last=$arg; done\nprintf '%s|%s\\n' \"$control\" \"$last\" >> '{}'\ncase \"$last\" in *'exec '*) last=${{last##*exec }} ;; esac\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") exit 2 ;;\n  \"'/remote/boomux' --version\") printf 'boomux 0.14.2\\n' ;;\n  *) exit 64 ;;\nesac\n",
+            log.display(),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+fn fake_auth_eof_ssh(directory: &Path) {
+    let log = directory.join("ssh.log");
+    let ssh = directory.join("ssh");
+    fs::write(
+        &ssh,
+        format!(
+            "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nlast=\nfor arg do last=$arg; done\nprintf '%s|%s\\n' \"$control\" \"$last\" >> '{}'\ncase \"$last\" in *'exec '*) last=${{last##*exec }} ;; esac\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\" | \"'/remote/boomux' --version\") printf 'Permission denied (publickey).\\n' >&2; exit 255 ;;\n  *) exit 64 ;;\nesac\n",
+            log.display(),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+fn fake_malformed_helper_ssh(directory: &Path) {
+    let ssh = directory.join("ssh");
+    fs::write(
+        &ssh,
+        format!(
+            "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in *'exec '*) last=${{last##*exec }} ;; esac\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  \"'/remote/boomux' __federation-stdio\") printf 'NOTMAGIC' ;;\n  \"'/remote/boomux' --version\") printf 'boomux 0.14.2\\n' ;;\n  *) exit 64 ;;\nesac\n"
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+fn fake_runtime_upgrade_ssh(directory: &Path) {
+    let handshake = FederationHandshake {
+        version: FEDERATION_VERSION,
+        node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+        helper_version: env!("CARGO_PKG_VERSION").into(),
+        core_protocol_version: protocol::PROTOCOL_VERSION,
+        connection_mode: FederationConnectionMode::AdHoc,
+    };
+    let mut handshake_bytes = Vec::new();
+    write_handshake(&mut handshake_bytes, &handshake).unwrap();
+    let mut request = Vec::new();
+    protocol::write_message(
+        &mut request,
+        &Envelope::with_version(protocol::PROTOCOL_VERSION, Request::Ping),
+    )
+    .unwrap();
+    let mut response = Vec::new();
+    protocol::write_message(
+        &mut response,
+        &Envelope::with_version(protocol::PROTOCOL_VERSION, Response::Pong),
+    )
+    .unwrap();
+    let installed = directory.join("installed");
+    let helper_calls = directory.join("helper-calls");
+    let restarted = directory.join("restarted");
+    let committed = directory.join("committed");
+    let socket = directory.join("remote-runtime/boomux/daemon.sock");
+    fs::create_dir_all(socket.parent().unwrap()).unwrap();
+    fs::write(&socket, b"socket").unwrap();
+    let ssh = directory.join("ssh");
+    let script = format!(
+        "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nunset XDG_RUNTIME_DIR\nlast=\nfor arg do last=$arg; done\nrequire_runtime() {{ case \"$last\" in *boomux-runtime-v1*'/run/user/$boomux_uid'*) [ -e {socket} ] ;; *) return 1 ;; esac; }}\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0/remote/boomux\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0/home/remote/.local/bin/boomux\\0' ;;\n  *'boomux-install-transaction-v1'*) cat >/dev/null; : > {installed}; printf 'boomux-install-transaction-v1\\0.boomux.bootstrap.ABC12345\\0' ;;\n  *': > \"$transaction/restarted\"'*) cat >/dev/null; : > {restarted} ;;\n  *'committed=$lock/committed'*) cat >/dev/null; [ -e {restarted} ]; : > {committed}; printf 'boomux-install-commit-v1\\0committed\\0' ;;\n  *'daemon status --json'*) require_runtime || exit 97; printf '%s' '{{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{{\"protocol_version\":21}}}}' ;;\n  *'daemon restart'*) require_runtime || exit 97; printf 'restart\\n' >> {restarted} ;;\n  *\"'/home/remote/.local/bin/boomux' __federation-stdio\" | *\"'/remote/boomux' __federation-stdio\") n=0; [ ! -e {helper_calls} ] || n=$(cat {helper_calls}); n=$((n + 1)); printf '%s' \"$n\" > {helper_calls}; if [ ! -e {installed} ]; then exit 2; fi; require_runtime || exit 97; {handshake}; limit=1; [ \"$n\" -ge 4 ] && limit=2; i=0; while [ \"$i\" -lt \"$limit\" ]; do dd bs=1 count={request_len} of=/dev/null 2>/dev/null || exit; {pong}; i=$((i + 1)); done ;;\n  \"'/remote/boomux' --version\") printf 'boomux 0.14.2\\n' ;;\n  *) exit 64 ;;\nesac\n",
+        socket = socket.display(),
+        installed = installed.display(),
+        helper_calls = helper_calls.display(),
+        restarted = restarted.display(),
+        committed = committed.display(),
+        handshake = shell_printf(&handshake_bytes),
+        request_len = request.len(),
+        pong = shell_printf(&response),
+    );
+    let script = script.replace("/remote/boomux", "/home/remote/.local/bin/boomux");
+    let script = script.replace(
+        "*'daemon status --json'*) require_runtime || exit 97; printf '%s' '{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{\"protocol_version\":21}}' ;;",
+        "*'.boomux.bootstrap.'*'daemon status --json'*) require_runtime || exit 97; printf '%s' '{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{\"protocol_version\":21,\"pid\":123,\"executable\":\"/home/remote/.local/bin/boomux\",\"socket_device\":1,\"socket_inode\":1}}' ;;\n  *'daemon status --json'*) require_runtime || exit 97; printf '%s' '{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{\"protocol_version\":21}}' ;;",
+    );
+    assert!(script.contains("\"pid\":123"));
+    let script = script.replace("limit=1; [ \"$n\" -ge 4 ] && limit=2;", "limit=1;");
+    let script = script.replace(
+        &format!(": > {}", committed.display()),
+        &format!(
+            "/bin/cat {} > {}",
+            helper_calls.display(),
+            committed.display()
+        ),
+    );
+    fs::write(&ssh, script).unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+fn fake_challenge_ssh(directory: &Path) {
+    let ssh = directory.join("ssh");
+    fs::write(
+        &ssh,
+        "#!/bin/sh\ncontrol=; previous=; master=false; check=false\nfor arg do\n  case \"$previous\" in -S) control=$arg ;; -O) [ \"$arg\" = check ] && check=true ;; esac\n  case \"$arg\" in ControlPath=*) control=${arg#ControlPath=} ;; -N) master=true ;; esac\n  previous=$arg\ndone\nif $master; then\n  printf 'To auth' >&2\n  printf 'enticate, visit:\nhttps://login.tailscale.test/challenge\n' >&2\n  : > \"$control.ready\"\n  trap 'rm -f \"$control.ready\"' EXIT HUP INT TERM\n  while :; do sleep 60; done\nfi\nif $check; then [ -e \"$control.ready\" ]; exit; fi\nexit 64\n",
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
 }
 
 fn command(directory: &Path) -> Command {
@@ -92,6 +213,414 @@ fn command(directory: &Path) -> Command {
 fn test_directory() -> std::path::PathBuf {
     let id = Uuid::new_v4().simple().to_string();
     std::env::temp_dir().join(format!("bx-r-{}-{}", std::process::id(), &id[..8]))
+}
+
+fn run_interactive(
+    directory: &Path,
+    arguments: &[&str],
+    input: &[u8],
+) -> (std::process::ExitStatus, Vec<u8>) {
+    let mut master = 0;
+    let mut slave = 0;
+    assert_eq!(
+        unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        },
+        0
+    );
+    let master = unsafe { OwnedFd::from_raw_fd(master) };
+    let slave = unsafe { OwnedFd::from_raw_fd(slave) };
+    let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+    command
+        .args(arguments)
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .stdin(Stdio::from(slave.try_clone().unwrap()))
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 || libc::ioctl(0, libc::TIOCSCTTY, 0) == -1 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    let mut master = fs::File::from(master);
+    master.write_all(input).unwrap();
+    let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+    assert_ne!(flags, -1);
+    assert_ne!(
+        unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) },
+        -1
+    );
+    let mut output = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let mut bytes = [0_u8; 4096];
+        match master.read(&mut bytes) {
+            Ok(count) => output.extend_from_slice(&bytes[..count]),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => {}
+            Err(error) => panic!("PTY read failed: {error}"),
+        }
+        if let Some(status) = child.try_wait().unwrap() {
+            return (status, output);
+        }
+        assert!(
+            Instant::now() < deadline,
+            "interactive command timed out: {}",
+            String::from_utf8_lossy(&output)
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn run_transaction_script(
+    script: &str,
+    home: &Path,
+    runtime: &Path,
+    input: &[u8],
+) -> std::process::Output {
+    let mut child = Command::new("sh")
+        .args(["-c", script])
+        .env("HOME", home)
+        .env("XDG_RUNTIME_DIR", runtime)
+        .env("XDG_STATE_HOME", home.join("state"))
+        .env("PATH", "/usr/bin:/bin")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(input).unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[cfg(target_os = "linux")]
+fn executable_digest(path: &Path) -> Vec<u8> {
+    let mut file = fs::File::open(path).unwrap();
+    let mut digest = Sha256::new();
+    let mut bytes = [0_u8; 64 * 1024];
+    loop {
+        let count = file.read(&mut bytes).unwrap();
+        if count == 0 {
+            return digest.finalize().to_vec();
+        }
+        digest.update(&bytes[..count]);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_for_executable(executable: &Path, excluded: &[u32]) -> Option<u32> {
+    fs::read_dir("/proc")
+        .ok()?
+        .filter_map(Result::ok)
+        .filter_map(|entry| entry.file_name().to_str()?.parse::<u32>().ok())
+        .filter(|pid| !excluded.contains(pid))
+        .find(|pid| fs::read_link(format!("/proc/{pid}/exe")).is_ok_and(|path| path == executable))
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_daemon_executable(executable: &Path, excluded: &[u32]) -> u32 {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(pid) = daemon_pid_for_executable(executable, excluded) {
+            return pid;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "daemon did not execute {}",
+            executable.display()
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn staged_missing_install_refuses_socket_that_appears_before_activation() {
+    let directory = test_directory();
+    let runtime = directory.join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+    fs::create_dir_all(directory.join(".local/bin")).unwrap();
+    let transaction = ".boomux.bootstrap.MISS1234";
+    let mut upload = format!("{transaction}\n").into_bytes();
+    upload.extend_from_slice(&fs::read(env!("CARGO_BIN_EXE_boomux")).unwrap());
+    let output = run_transaction_script(REMOTE_INSTALL_COMMAND, &directory, &runtime, &upload);
+    assert!(output.status.success());
+    assert!(!directory.join(".local/bin/boomux").exists());
+
+    let socket = runtime.join("boomux/daemon.sock");
+    fs::create_dir_all(socket.parent().unwrap()).unwrap();
+    fs::write(&socket, b"stale-or-racing-daemon").unwrap();
+    let activation = run_transaction_script(
+        REMOTE_INSTALL_ACTIVATE_COMMAND,
+        &directory,
+        &runtime,
+        format!("{transaction}\nmissing\nabsent\n\n\n\n\n").as_bytes(),
+    );
+    assert!(activation.status.success());
+    assert_eq!(
+        activation.stdout,
+        b"boomux-install-activation-v1\0daemon_present\0"
+    );
+    assert!(!directory.join(".local/bin/boomux").exists());
+    let rollback = run_transaction_script(
+        REMOTE_INSTALL_ROLLBACK_COMMAND,
+        &directory,
+        &runtime,
+        format!("{transaction}\n").as_bytes(),
+    );
+    assert!(rollback.status.success());
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn staged_upload_and_activation_recover_lost_acknowledgments() {
+    let directory = test_directory();
+    let runtime = directory.join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+    fs::create_dir_all(directory.join(".local/bin")).unwrap();
+    let destination = directory.join(".local/bin/boomux");
+    fs::write(&destination, b"previous").unwrap();
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+    let transaction = ".boomux.bootstrap.ACKS1234";
+    let replacement = fs::read(env!("CARGO_BIN_EXE_boomux")).unwrap();
+    let mut upload = format!("{transaction}\n").into_bytes();
+    upload.extend_from_slice(&replacement);
+
+    let lost_upload_ack = format!("{REMOTE_INSTALL_COMMAND}; exit 255");
+    let first = run_transaction_script(&lost_upload_ack, &directory, &runtime, &upload);
+    assert!(!first.status.success());
+    assert_eq!(fs::read(&destination).unwrap(), b"previous");
+    let retry = run_transaction_script(REMOTE_INSTALL_COMMAND, &directory, &runtime, &upload);
+    assert!(retry.status.success());
+
+    let activation_input = format!("{transaction}\nmissing\nabsent\n\n\n\n\n");
+    let lost_activation_ack = format!("{REMOTE_INSTALL_ACTIVATE_COMMAND}; exit 255");
+    let first = run_transaction_script(
+        &lost_activation_ack,
+        &directory,
+        &runtime,
+        activation_input.as_bytes(),
+    );
+    assert!(!first.status.success());
+    assert_eq!(fs::read(&destination).unwrap(), replacement);
+    let retry = run_transaction_script(
+        REMOTE_INSTALL_ACTIVATE_COMMAND,
+        &directory,
+        &runtime,
+        activation_input.as_bytes(),
+    );
+    assert!(retry.status.success());
+    assert_eq!(retry.stdout, b"boomux-install-activation-v1\0activated\0");
+    let rollback = run_transaction_script(
+        REMOTE_INSTALL_ROLLBACK_COMMAND,
+        &directory,
+        &runtime,
+        format!("{transaction}\n").as_bytes(),
+    );
+    assert!(rollback.status.success());
+    assert_eq!(fs::read(&destination).unwrap(), b"previous");
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn uploaded_only_watchdog_cleans_transaction_without_touching_destination() {
+    let directory = test_directory();
+    let runtime = directory.join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+    fs::create_dir_all(directory.join(".local/bin")).unwrap();
+    let destination = directory.join(".local/bin/boomux");
+    fs::write(&destination, b"previous").unwrap();
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+    let transaction = ".boomux.bootstrap.WDOG1234";
+    let mut upload = format!("{transaction}\n").into_bytes();
+    upload.extend_from_slice(&fs::read(env!("CARGO_BIN_EXE_boomux")).unwrap());
+    let command = REMOTE_INSTALL_COMMAND.replace("lease_limit=180", "lease_limit=1");
+    let output = run_transaction_script(&command, &directory, &runtime, &upload);
+    assert!(output.status.success());
+    let lock = directory.join(".local/bin/.boomux.bootstrap.lock");
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while lock.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(!lock.exists());
+    assert_eq!(fs::read(&destination).unwrap(), b"previous");
+    assert!(!directory.join(".local/bin").join(transaction).exists());
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn live_destination_replacement_and_rollback_select_the_correct_daemon_binary() {
+    let directory = test_directory();
+    let runtime = directory.join("runtime");
+    let state = directory.join("state");
+    let bin = directory.join(".local/bin");
+    let destination = bin.join("boomux");
+    fs::create_dir_all(&runtime).unwrap();
+    fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+    fs::create_dir_all(&state).unwrap();
+    fs::create_dir_all(&bin).unwrap();
+
+    let old_bytes = fs::read(env!("CARGO_BIN_EXE_boomux")).unwrap();
+    fs::write(&destination, &old_bytes).unwrap();
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o755)).unwrap();
+    let old_digest = executable_digest(&destination);
+    let mut replacement_bytes = old_bytes;
+    replacement_bytes.extend_from_slice(b"\nboomux-native-replacement-fixture\n");
+    let replacement_digest = Sha256::digest(&replacement_bytes).to_vec();
+    assert_ne!(old_digest, replacement_digest);
+
+    let mut old_daemon = Command::new(&destination)
+        .args(["daemon", "run"])
+        .env("HOME", &directory)
+        .env("XDG_RUNTIME_DIR", &runtime)
+        .env("XDG_STATE_HOME", &state)
+        .env("SHELL", "/bin/sh")
+        .env("BOOMUX_NATIVE_TEST_HOOKS", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let old_pid = old_daemon.id();
+    let client = Client::from_socket_path(runtime.join("boomux/daemon.sock"));
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while client.ping().is_err() {
+        assert!(
+            Instant::now() < deadline,
+            "old fixture daemon did not start"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(
+        fs::read_link(format!("/proc/{old_pid}/exe")).unwrap(),
+        destination
+    );
+
+    let transaction = ".boomux.bootstrap.ABC12345";
+    let mut upload_input = format!("{transaction}\n").into_bytes();
+    upload_input.extend_from_slice(&replacement_bytes);
+    let install =
+        run_transaction_script(REMOTE_INSTALL_COMMAND, &directory, &runtime, &upload_input);
+    assert!(
+        install.status.success(),
+        "install failed: {}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+    let fields = install.stdout.split(|byte| *byte == 0).collect::<Vec<_>>();
+    assert_eq!(
+        fields.first().copied(),
+        Some(b"boomux-install-transaction-v1".as_slice())
+    );
+    assert_eq!(fields.get(1).copied(), Some(transaction.as_bytes()));
+    let transaction_input = format!("{transaction}\n");
+    let backup = bin.join(transaction).join("backup");
+    assert_eq!(executable_digest(&destination), old_digest);
+    assert!(!backup.exists());
+    let socket_metadata = fs::metadata(runtime.join("boomux/daemon.sock")).unwrap();
+    let activation_input = format!(
+        "{transaction}\nupgrade\n38\n{old_pid}\n{}\n{}\n{}\n",
+        destination.display(),
+        socket_metadata.dev(),
+        socket_metadata.ino()
+    );
+    let activation = run_transaction_script(
+        REMOTE_INSTALL_ACTIVATE_COMMAND,
+        &directory,
+        &runtime,
+        activation_input.as_bytes(),
+    );
+    assert!(
+        activation.status.success(),
+        "activation failed: {}",
+        String::from_utf8_lossy(&activation.stderr)
+    );
+    assert_eq!(executable_digest(&backup), old_digest);
+    assert_eq!(executable_digest(&destination), replacement_digest);
+    assert_eq!(
+        fs::read_link(format!("/proc/{old_pid}/exe")).unwrap(),
+        std::path::PathBuf::from(format!("{} (deleted)", destination.display()))
+    );
+
+    fs::write(bin.join(transaction).join("prior_daemon"), b"38").unwrap();
+    fs::write(bin.join(transaction).join("daemon_contacted"), b"").unwrap();
+    let restart = Command::new(&destination)
+        .args(["daemon", "restart"])
+        .env("HOME", &directory)
+        .env("XDG_RUNTIME_DIR", &runtime)
+        .env("XDG_STATE_HOME", &state)
+        .env("BOOMUX_NATIVE_TEST_HOOKS", "1")
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "replacement restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    assert!(old_daemon.wait().unwrap().success());
+    let replacement_pid = wait_for_daemon_executable(&destination, &[old_pid]);
+    assert_eq!(
+        executable_digest(Path::new(&format!("/proc/{replacement_pid}/exe"))),
+        replacement_digest
+    );
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while client.ping().is_err() {
+        assert!(
+            Instant::now() < deadline,
+            "replacement daemon did not accept requests"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    std::thread::sleep(Duration::from_millis(200));
+
+    let rollback = run_transaction_script(
+        REMOTE_INSTALL_ROLLBACK_COMMAND,
+        &directory,
+        &runtime,
+        transaction_input.as_bytes(),
+    );
+    assert!(
+        rollback.status.success(),
+        "rollback failed: {}",
+        String::from_utf8_lossy(&rollback.stderr)
+    );
+    assert_eq!(executable_digest(&destination), old_digest);
+    let restored_pid = wait_for_daemon_executable(&destination, &[old_pid, replacement_pid]);
+    assert_eq!(
+        executable_digest(Path::new(&format!("/proc/{restored_pid}/exe"))),
+        old_digest
+    );
+
+    let stop = Command::new(&destination)
+        .args(["daemon", "stop"])
+        .env("HOME", &directory)
+        .env("XDG_RUNTIME_DIR", &runtime)
+        .env("XDG_STATE_HOME", &state)
+        .output()
+        .unwrap();
+    assert!(stop.status.success());
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Path::new(&format!("/proc/{restored_pid}")).exists() {
+        assert!(Instant::now() < deadline, "restored daemon did not stop");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    fs::remove_dir_all(directory).unwrap();
 }
 
 #[test]
@@ -111,6 +640,17 @@ fn public_remote_uses_verified_stdio_protocol_channel() {
     assert!(stdout.contains("Connected to Boomux Node 550e8400-e29b-41d4-a716-446655440000"));
     let log = fs::read_to_string(directory.join("ssh.log")).unwrap();
     assert_eq!(log.matches("__federation-stdio").count(), 2);
+    let control_paths = log
+        .lines()
+        .map(|line| line.split_once('|').unwrap().0)
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(control_paths.len(), 1);
+    assert!(
+        fs::read_dir(directory.join("runtime/boomux"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .all(|entry| !entry.file_name().to_string_lossy().starts_with("ssh-"))
+    );
     fs::remove_dir_all(directory).unwrap();
 }
 
@@ -124,8 +664,7 @@ fn noninteractive_remote_refuses_install_without_modification() {
     let output = command(&directory).output().unwrap();
     assert!(!output.status.success());
     assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("noninteractive --remote never modifies remote software")
+        String::from_utf8_lossy(&output.stderr).contains("remote Boomux installation is required")
     );
     let log = fs::read_to_string(directory.join("ssh.log")).unwrap();
     assert_eq!(log.lines().count(), 3);
@@ -135,7 +674,349 @@ fn noninteractive_remote_refuses_install_without_modification() {
 }
 
 #[test]
-fn remote_disconnect_after_handshake_fails_without_hanging() {
+fn json_node_add_reports_install_required_without_remote_mutation() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_ssh(&directory, "", false);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["node", "add", "work", "workbox", "--json"])
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(error["command"], "node.add");
+    assert_eq!(error["error"]["code"], "install_required");
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("interactive terminal")
+    );
+    let log = fs::read_to_string(directory.join("ssh.log")).unwrap();
+    assert_eq!(log.lines().count(), 3);
+    assert!(!log.contains("mktemp"));
+    assert!(!log.contains("daemon restart"));
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn json_node_add_reports_upgrade_required_without_remote_mutation() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_old_ssh(&directory);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["node", "add", "work", "workbox", "--json"])
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(error["error"]["code"], "upgrade_required");
+    let log = fs::read_to_string(directory.join("ssh.log")).unwrap();
+    assert_eq!(log.lines().count(), 5);
+    assert!(!log.contains("mktemp"));
+    assert!(!log.contains("daemon restart"));
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn json_node_add_classifies_authenticated_route_eof_without_mutation() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_auth_eof_ssh(&directory);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["node", "add", "work", "workbox", "--json"])
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(error["error"]["code"], "bootstrap_authentication_failed");
+    let log = fs::read_to_string(directory.join("ssh.log")).unwrap();
+    assert!(!log.contains("mktemp"));
+    assert!(!log.contains("daemon restart"));
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn json_node_add_classifies_malformed_helper_without_mutation() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_malformed_helper_ssh(&directory);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["node", "add", "work", "workbox", "--json"])
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(error["error"]["code"], "bootstrap_malformed_helper");
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn json_node_add_classifies_invalid_framed_executable_paths_as_malformed_helper() {
+    for candidate in [
+        "relative/boomux".to_owned(),
+        "/opt/boomux\nbin".to_owned(),
+        format!("/{}", "x".repeat(4096)),
+    ] {
+        let directory = test_directory();
+        fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+        fs::create_dir_all(directory.join("runtime")).unwrap();
+        fake_ssh(&directory, &format!("{candidate}\\0"), false);
+
+        let output = Command::new(env!("CARGO_BIN_EXE_boomux"))
+            .args(["node", "add", "work", "workbox", "--json"])
+            .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+            .env("HOME", directory.join("home"))
+            .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+            .env("XDG_STATE_HOME", directory.join("state"))
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error"]["code"], "bootstrap_malformed_helper");
+        fs::remove_dir_all(directory).unwrap();
+    }
+}
+
+#[test]
+fn interactive_upgrade_restarts_old_running_daemon_after_compatible_provisional_helper() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_runtime_upgrade_ssh(&directory);
+
+    let mut master = 0;
+    let mut slave = 0;
+    assert_eq!(
+        unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        },
+        0
+    );
+    let master = unsafe { OwnedFd::from_raw_fd(master) };
+    let slave = unsafe { OwnedFd::from_raw_fd(slave) };
+    let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+    command
+        .args(["--remote", "workbox"])
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .stdin(Stdio::from(slave.try_clone().unwrap()))
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 || libc::ioctl(0, libc::TIOCSCTTY, 0) == -1 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    let mut master = fs::File::from(master);
+    master.write_all(b"y\n").unwrap();
+    let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+    assert_ne!(flags, -1);
+    assert_ne!(
+        unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) },
+        -1
+    );
+    let mut output = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let status = loop {
+        let mut bytes = [0_u8; 4096];
+        match master.read(&mut bytes) {
+            Ok(count) => output.extend_from_slice(&bytes[..count]),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => {}
+            Err(error) => panic!("PTY read failed: {error}"),
+        }
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        assert!(Instant::now() < deadline, "interactive upgrade timed out");
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    assert!(
+        status.success(),
+        "interactive upgrade failed with {status}: {}",
+        String::from_utf8_lossy(&output)
+    );
+    assert_eq!(
+        fs::read_to_string(directory.join("restarted")).unwrap(),
+        "restart\n"
+    );
+    assert!(directory.join("committed").exists());
+
+    let _ = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["daemon", "stop"])
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn upgraded_node_add_registers_after_the_precommit_ping_channel_closes() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_runtime_upgrade_ssh(&directory);
+
+    let (status, output) = run_interactive(&directory, &["node", "add", "work", "workbox"], b"y\n");
+    assert!(
+        status.success(),
+        "upgraded node add failed with {status}: {}",
+        String::from_utf8_lossy(&output)
+    );
+    assert_eq!(
+        fs::read_to_string(directory.join("committed")).unwrap(),
+        "4"
+    );
+    let persisted: serde_json::Value = serde_json::from_slice(
+        &fs::read(directory.join("state/boomux/node_registrations.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(persisted["registrations"][0]["alias"], "work");
+    assert_eq!(persisted["registrations"][0]["target"], "workbox");
+    assert_eq!(
+        persisted["registrations"][0]["node_id"],
+        "550e8400-e29b-41d4-a716-446655440000"
+    );
+
+    let stop = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["daemon", "stop"])
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .output()
+        .unwrap();
+    assert!(stop.status.success());
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn guided_node_add_mirrors_master_challenge_and_waits_after_failure() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_challenge_ssh(&directory);
+
+    let mut master = 0;
+    let mut slave = 0;
+    assert_eq!(
+        unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        },
+        0
+    );
+    let master = unsafe { OwnedFd::from_raw_fd(master) };
+    let slave = unsafe { OwnedFd::from_raw_fd(slave) };
+    let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+    command
+        .arg("__guided-node-add")
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .stdin(Stdio::from(slave.try_clone().unwrap()))
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 || libc::ioctl(0, libc::TIOCSCTTY, 0) == -1 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    let mut master = fs::File::from(master);
+    master.write_all(b"work\nworkbox\n").unwrap();
+    let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+    assert_ne!(flags, -1);
+    assert_ne!(
+        unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) },
+        -1
+    );
+    let mut output = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !output
+        .windows(b"Press Enter to close.".len())
+        .any(|window| window == b"Press Enter to close.")
+    {
+        let mut bytes = [0_u8; 1024];
+        match master.read(&mut bytes) {
+            Ok(0) => panic!("guided terminal closed before the outcome hold"),
+            Ok(count) => output.extend_from_slice(&bytes[..count]),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => {}
+            Err(error) => panic!("PTY read failed: {error}"),
+        }
+        assert!(
+            Instant::now() < deadline,
+            "guided challenge timed out: {}",
+            String::from_utf8_lossy(&output)
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let output = String::from_utf8_lossy(&output);
+    assert!(output.contains("To authenticate, visit:"), "{output}");
+    assert!(
+        output.contains("https://login.tailscale.test/challenge"),
+        "{output}"
+    );
+    assert!(output.contains("Node setup failed (exit 1)."), "{output}");
+    assert!(child.try_wait().unwrap().is_none());
+    master.write_all(b"\n").unwrap();
+    assert_eq!(child.wait().unwrap().code(), Some(1));
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn ready_helper_ping_failure_aborts_without_hanging() {
     let directory = test_directory();
     fs::create_dir_all(directory.join("home/.ssh")).unwrap();
     fs::create_dir_all(directory.join("runtime")).unwrap();

--- a/tests/native_backend/remote_bootstrap.rs
+++ b/tests/native_backend/remote_bootstrap.rs
@@ -535,7 +535,8 @@ fn live_destination_replacement_and_rollback_select_the_correct_daemon_binary() 
     assert!(!backup.exists());
     let socket_metadata = fs::metadata(runtime.join("boomux/daemon.sock")).unwrap();
     let activation_input = format!(
-        "{transaction}\nupgrade\n38\n{old_pid}\n{}\n{}\n{}\n",
+        "{transaction}\nupgrade\n{}\n{old_pid}\n{}\n{}\n{}\n",
+        protocol::PROTOCOL_VERSION,
         destination.display(),
         socket_metadata.dev(),
         socket_metadata.ino()
@@ -558,7 +559,11 @@ fn live_destination_replacement_and_rollback_select_the_correct_daemon_binary() 
         std::path::PathBuf::from(format!("{} (deleted)", destination.display()))
     );
 
-    fs::write(bin.join(transaction).join("prior_daemon"), b"38").unwrap();
+    fs::write(
+        bin.join(transaction).join("prior_daemon"),
+        protocol::PROTOCOL_VERSION.to_string(),
+    )
+    .unwrap();
     fs::write(bin.join(transaction).join("daemon_contacted"), b"").unwrap();
     let restart = Command::new(&destination)
         .args(["daemon", "restart"])

--- a/tests/native_backend/remote_host_services.rs
+++ b/tests/native_backend/remote_host_services.rs
@@ -8,7 +8,7 @@ use boomux::protocol::{
     WorkspaceLauncherSpec,
 };
 
-use crate::support::{TestDaemon, profile, wait_until};
+use crate::support::{CONTROL_MASTER_PREFIX, TestDaemon, profile, wait_until};
 
 #[test]
 fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv() {
@@ -65,7 +65,7 @@ fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv(
     fs::write(
         &ssh,
         format!(
-            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}\\0' ;;\n  *__federation-stdio*) exec env XDG_RUNTIME_DIR='{}' XDG_STATE_HOME='{}' '{}' __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
+            "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}\\0' ;;\n  *__federation-stdio*) exec env XDG_RUNTIME_DIR='{}' XDG_STATE_HOME='{}' '{}' __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
             owner.executable.display(),
             owner.executable.display(),
             owner.runtime_dir.display(),
@@ -131,18 +131,16 @@ fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv(
         )
         .unwrap();
     assert!(matches!(invoked, HostServiceResult::LauncherInvoked { .. }));
+    let expected_output = format!(
+        "{}\n{}\ntwo words\n",
+        owner_projects.join("remote-only").display(),
+        exact_argument,
+    );
     wait_until(
-        || output.is_file(),
+        || fs::read_to_string(&output).is_ok_and(|value| value == expected_output),
         "owner-side launcher did not produce its output",
     );
-    assert_eq!(
-        fs::read_to_string(&output).unwrap(),
-        format!(
-            "{}\n{}\ntwo words\n",
-            owner_projects.join("remote-only").display(),
-            exact_argument,
-        )
-    );
+    assert_eq!(fs::read_to_string(&output).unwrap(), expected_output);
     assert!(!root.join("local-pwned").exists());
 
     let session_workspace = owner

--- a/tests/native_backend/remote_schedules.rs
+++ b/tests/native_backend/remote_schedules.rs
@@ -9,14 +9,14 @@ use boomux::protocol::{
 };
 use uuid::Uuid;
 
-use crate::support::{TestDaemon, process_exists, profile, wait_until};
+use crate::support::{CONTROL_MASTER_PREFIX, TestDaemon, process_exists, profile, wait_until};
 
 fn install_fake_ssh(directory: &Path, owner: &TestDaemon) {
     let ssh = directory.join("ssh");
     fs::write(
         &ssh,
         format!(
-            "#!/bin/sh\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}\\0' ;;\n  *__federation-stdio*) exec env XDG_RUNTIME_DIR='{}' XDG_STATE_HOME='{}' '{}' __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
+            "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *boomux-platform-v1*) printf 'boomux-platform-v1\\0Linux\\0x86_64\\0' ;;\n  *boomux-executables-v1*) printf 'boomux-executables-v1\\0{}\\0' ;;\n  *boomux-install-destination-v1*) printf 'boomux-install-destination-v1\\0{}\\0' ;;\n  *__federation-stdio*) exec env XDG_RUNTIME_DIR='{}' XDG_STATE_HOME='{}' '{}' __federation-stdio ;;\n  *) exit 64 ;;\nesac\n",
             owner.executable.display(),
             owner.executable.display(),
             owner.runtime_dir.display(),

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -15,24 +15,17 @@ use crate::support::{
 };
 
 #[test]
-fn workspace_default_cwd_is_inherited_and_survives_handoff() {
+fn legacy_workspace_default_cwd_is_inherited_and_survives_handoff() {
     let mut daemon = TestDaemon::start();
     let project = daemon.runtime_dir.join("project");
     let other = daemon.runtime_dir.join("other");
     fs::create_dir(&project).unwrap();
     fs::create_dir(&other).unwrap();
 
-    let created = daemon
-        .command()
-        .args(["workspace", "create", "project", "--cwd"])
-        .arg(&project)
-        .output()
+    daemon
+        .client
+        .create_workspace_with_default_cwd("project", Some(project.clone()), Vec::new())
         .unwrap();
-    assert!(
-        created.status.success(),
-        "workspace create failed: {}",
-        String::from_utf8_lossy(&created.stderr)
-    );
     let inspected = daemon
         .command()
         .args(["workspace", "inspect", "project", "--json"])

--- a/tests/native_backend/shell_name_suggestion.rs
+++ b/tests/native_backend/shell_name_suggestion.rs
@@ -36,7 +36,10 @@ fn shell_name_suggestion_is_stable_non_mutating_cli_data() {
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value["schema"], "boomux.cli/v1");
     assert_eq!(value["command"], "shell.suggest-name");
-    assert_eq!(value["data"]["node_id"], daemon.client.node_identity().unwrap());
+    assert_eq!(
+        value["data"]["node_id"],
+        daemon.client.node_identity().unwrap()
+    );
     assert_eq!(value["data"]["workspace_id"], workspace.id);
     assert_eq!(value["data"].as_object().unwrap().len(), 3);
     let name = value["data"]["name"].as_str().unwrap();

--- a/tests/native_backend/shell_name_suggestion.rs
+++ b/tests/native_backend/shell_name_suggestion.rs
@@ -36,8 +36,9 @@ fn shell_name_suggestion_is_stable_non_mutating_cli_data() {
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value["schema"], "boomux.cli/v1");
     assert_eq!(value["command"], "shell.suggest-name");
+    assert_eq!(value["data"]["node_id"], daemon.client.node_identity().unwrap());
     assert_eq!(value["data"]["workspace_id"], workspace.id);
-    assert_eq!(value["data"].as_object().unwrap().len(), 2);
+    assert_eq!(value["data"].as_object().unwrap().len(), 3);
     let name = value["data"]["name"].as_str().unwrap();
     assert!(!name.is_empty());
     assert_generated_name(name);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -54,6 +54,7 @@ impl TestDaemon {
         command
             .args(["daemon", "run"])
             .env("XDG_RUNTIME_DIR", &runtime_dir)
+            .env("XDG_CONFIG_HOME", runtime_dir.join("config"))
             .env("XDG_STATE_HOME", runtime_dir.join("state"))
             .env("SHELL", "/bin/sh")
             .env("BOOMUX_NATIVE_TEST_HOOKS", "1")
@@ -75,6 +76,7 @@ impl TestDaemon {
     pub(crate) fn command(&self) -> Command {
         let mut command = Command::new(&self.executable);
         command.env("XDG_RUNTIME_DIR", &self.runtime_dir);
+        command.env("XDG_CONFIG_HOME", self.runtime_dir.join("config"));
         command.env("XDG_STATE_HOME", self.runtime_dir.join("state"));
         command.env("BOOMUX_NATIVE_TEST_HOOKS", "1");
         command

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -11,6 +11,7 @@ use boomux::protocol::{AttachFrame, ErrorCode, TerminalProfile};
 use uuid::Uuid;
 
 pub(crate) const TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const CONTROL_MASTER_PREFIX: &str = "control=; previous=; master=false; check=false; for arg do case \"$previous\" in -S) control=$arg ;; -O) [ \"$arg\" = check ] && check=true ;; esac; case \"$arg\" in ControlPath=*) control=${arg#ControlPath=} ;; -N) master=true ;; esac; previous=$arg; done; if $master; then : > \"$control.ready\"; trap 'rm -f \"$control.ready\"' EXIT HUP INT TERM; while :; do sleep 60; done; fi; if $check; then [ -e \"$control.ready\" ]; exit; fi";
 
 pub(crate) fn assert_generated_name(name: &str) {
     let Some((adjective, noun)) = name.split_once('-') else {


### PR DESCRIPTION
## Summary
- make Workspaces coordinator-owned organizing boundaries across independently authoritative Nodes
- add per-Node placements, explicit owner selection, adoption/linking, and resumable fan-out open/close operations
- add protocol 38, the schema-6 bounded coordinator store, durable exact-operation recovery, and multi-Node TUI/CLI management
- create empty coordinator Workspace metadata before Node and path selection for the first hosted resource
- fail closed when explicit Node placement cannot resolve a coordinated Workspace and gate protocol-38-only commands before lookup
- update CLI help, contracts, README, and bundled Agent Skill for qualified Node/resource identity and current public workflows
- add guided missing/outdated remote-helper bootstrap with visible interactive SSH authentication, phased activation, guarded graceful handoff, and crash-recoverable rollback
- retain Add Node completion/error output until Enter and support ordinary OpenSSH routes over Tailscale IPs

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked` (706 passed)
- `cargo test --test native_backend --locked -- --test-threads=1` (114 passed)
- focused two-daemon fail-closed placement regression after final test strengthening
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js` (59 passed)
- live upgrade through Tailscale SSH while preserving managed processes
- live Node registration and online projection over Tailscale