### PR TITLE
fix(terminal): resynchronize size after reattach

### DIFF
--- a/src/attach.rs
+++ b/src/attach.rs
@@ -14,6 +14,7 @@ const POLL_INTERVAL_MS: i32 = 100;
 const ESCAPE_DISAMBIGUATION_MS: i32 = 10;
 const RECONNECT_ATTEMPTS: usize = 600;
 const RECONNECT_DELAY: Duration = Duration::from_millis(25);
+const REATTACH_RESIZE_SETTLE: Duration = Duration::from_millis(100);
 const ENABLE_FOCUS_REPORTING: &[u8] = b"\x1b[?1004h";
 const DISABLE_FOCUS_REPORTING: &[u8] = b"\x1b[?1004l";
 
@@ -166,6 +167,7 @@ pub fn run(
             }
             stdout.flush()?;
             let mut stream = attachment.stream;
+            resynchronize_terminal_size(&mut stream, size)?;
 
             if !pump_attachment(
                 &mut stream,
@@ -203,6 +205,34 @@ pub fn run(
         }
     }
     result
+}
+
+fn resynchronize_terminal_size(
+    stream: &mut std::os::unix::net::UnixStream,
+    size: (u16, u16, u16, u16),
+) -> io::Result<()> {
+    let nudged = if size.0 > 1 {
+        (size.0 - 1, size.1, size.2, size.3)
+    } else if size.1 > 1 {
+        (size.0, size.1 - 1, size.2, size.3)
+    } else {
+        return Ok(());
+    };
+    AttachFrame::Resize {
+        rows: nudged.0,
+        cols: nudged.1,
+        pixel_width: nudged.2,
+        pixel_height: nudged.3,
+    }
+    .write_to(stream)?;
+    thread::sleep(REATTACH_RESIZE_SETTLE);
+    AttachFrame::Resize {
+        rows: size.0,
+        cols: size.1,
+        pixel_width: size.2,
+        pixel_height: size.3,
+    }
+    .write_to(stream)
 }
 
 pub fn run_agent_session(
@@ -669,5 +699,34 @@ mod tests {
         sender.join().unwrap();
         assert!(!reconnect);
         assert_eq!(stdout, b"before\x1b[?1004;2004lafter\x1b[?1004h");
+    }
+
+    #[test]
+    fn reattachment_nudges_then_restores_the_terminal_size() {
+        let (mut daemon, mut attachment) = UnixStream::pair().unwrap();
+        let receiver = thread::spawn(move || {
+            assert_eq!(
+                AttachFrame::read_from(&mut daemon).unwrap(),
+                AttachFrame::Resize {
+                    rows: 23,
+                    cols: 80,
+                    pixel_width: 800,
+                    pixel_height: 600,
+                }
+            );
+            assert_eq!(
+                AttachFrame::read_from(&mut daemon).unwrap(),
+                AttachFrame::Resize {
+                    rows: 24,
+                    cols: 80,
+                    pixel_width: 800,
+                    pixel_height: 600,
+                }
+            );
+        });
+
+        resynchronize_terminal_size(&mut attachment, (24, 80, 800, 600)).unwrap();
+
+        receiver.join().unwrap();
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6815,32 +6815,6 @@ impl PtyMaster {
         Ok(())
     }
 
-    fn signal_foreground_process_group(&self, signal: libc::c_int) -> io::Result<()> {
-        let mut process_group: libc::pid_t = 0;
-        // The descriptor is a live Unix PTY master and process_group is writable.
-        if unsafe {
-            libc::ioctl(
-                self.descriptor.as_raw_fd(),
-                libc::TIOCGPGRP,
-                &mut process_group,
-            )
-        } == -1
-        {
-            return Err(io::Error::last_os_error());
-        }
-        if process_group <= 0 {
-            return Ok(());
-        }
-        // A negative PID targets the authoritative PTY foreground process group.
-        if unsafe { libc::kill(-process_group, signal) } == -1 {
-            let error = io::Error::last_os_error();
-            if error.raw_os_error() != Some(libc::ESRCH) {
-                return Err(error);
-            }
-        }
-        Ok(())
-    }
-
     fn foreground_process(&self) -> Option<String> {
         let mut process_group: libc::pid_t = 0;
         // The descriptor is a live Unix PTY master and process_group is writable.
@@ -15851,14 +15825,12 @@ impl ShellRuntimeManager {
                 );
             }
         }
-        // Resize and lock the shadow before signaling the PTY. A fullscreen child may
-        // redraw immediately on SIGWINCH, and that output must be parsed at the new size.
-        let mut terminal = lock(&terminal)?;
-        terminal.resize(profile.rows, profile.cols);
         lock(&runtime.master)?.resize(Self::profile_size(&profile))?;
         Self::update_runtime_dimensions(&shell, &runtime, Self::profile_size(&profile))?;
+        lock(&terminal)?.resize(profile.rows, profile.cols);
         // Keep terminal state locked until the controller is installed so the
         // reconstruction ends exactly where live delivery begins.
+        let terminal = lock(&terminal)?;
         send_response(
             &mut stream,
             response_version,
@@ -15932,9 +15904,6 @@ impl ShellRuntimeManager {
                 return Err(error);
             }
         };
-        if !started {
-            let _ = lock(&runtime.master)?.signal_foreground_process_group(libc::SIGWINCH);
-        }
         drop(mutation);
         drop(lifecycle);
         drop(terminal);
@@ -16002,8 +15971,8 @@ impl ShellRuntimeManager {
                                 pixel_width,
                                 pixel_height,
                             };
-                            lock(&runtime.master)?.resize(size)?;
                             lock(&runtime.terminal)?.resize(rows, cols);
+                            lock(&runtime.master)?.resize(size)?;
                             Self::update_runtime_dimensions(&shell, &runtime, size)?;
                             Ok(())
                         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -15825,12 +15825,14 @@ impl ShellRuntimeManager {
                 );
             }
         }
+        // Resize and lock the shadow before signaling the PTY. A fullscreen child may
+        // redraw immediately on SIGWINCH, and that output must be parsed at the new size.
+        let mut terminal = lock(&terminal)?;
+        terminal.resize(profile.rows, profile.cols);
         lock(&runtime.master)?.resize(Self::profile_size(&profile))?;
         Self::update_runtime_dimensions(&shell, &runtime, Self::profile_size(&profile))?;
-        lock(&terminal)?.resize(profile.rows, profile.cols);
         // Keep terminal state locked until the controller is installed so the
         // reconstruction ends exactly where live delivery begins.
-        let terminal = lock(&terminal)?;
         send_response(
             &mut stream,
             response_version,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6815,6 +6815,32 @@ impl PtyMaster {
         Ok(())
     }
 
+    fn signal_foreground_process_group(&self, signal: libc::c_int) -> io::Result<()> {
+        let mut process_group: libc::pid_t = 0;
+        // The descriptor is a live Unix PTY master and process_group is writable.
+        if unsafe {
+            libc::ioctl(
+                self.descriptor.as_raw_fd(),
+                libc::TIOCGPGRP,
+                &mut process_group,
+            )
+        } == -1
+        {
+            return Err(io::Error::last_os_error());
+        }
+        if process_group <= 0 {
+            return Ok(());
+        }
+        // A negative PID targets the authoritative PTY foreground process group.
+        if unsafe { libc::kill(-process_group, signal) } == -1 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
     fn foreground_process(&self) -> Option<String> {
         let mut process_group: libc::pid_t = 0;
         // The descriptor is a live Unix PTY master and process_group is writable.
@@ -15906,6 +15932,9 @@ impl ShellRuntimeManager {
                 return Err(error);
             }
         };
+        if !started {
+            let _ = lock(&runtime.master)?.signal_foreground_process_group(libc::SIGWINCH);
+        }
         drop(mutation);
         drop(lifecycle);
         drop(terminal);

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -269,52 +269,6 @@ fn reattachment_reflows_retained_output_for_the_new_terminal_width() {
 }
 
 #[test]
-fn reattachment_requests_fullscreen_redraw_after_reconstruction() {
-    let mut daemon = TestDaemon::start();
-    let workspace = daemon
-        .client
-        .create_workspace(
-            "resize-redraw-order",
-            vec![ShellSpec {
-                name: "tui".into(),
-                command: vec![
-                    "/bin/sh".into(),
-                    "-c".into(),
-                    r#"trap 'printf "\033[2J\033[Hredraw-%s\n" "$(stty size)"' WINCH; printf '\033[?1049hinitial-screen\n'; while :; do sleep 1; done"#
-                        .into(),
-                ],
-                cwd: std::env::temp_dir(),
-            }],
-        )
-        .unwrap();
-    let shell_id = workspace.shells[0].id.clone();
-    let mut initial_profile = profile();
-    initial_profile.rows = 20;
-    initial_profile.cols = 100;
-    let mut first = daemon
-        .client
-        .attach(&shell_id, false, initial_profile)
-        .unwrap();
-    if !contains(&first.reconstruction, b"initial-screen") {
-        read_until(&mut first.stream, b"initial-screen");
-    }
-    drop(first);
-
-    let mut same_profile = profile();
-    same_profile.rows = 20;
-    same_profile.cols = 100;
-    let mut second = wait_for_attach_with_profile(&daemon.client, &shell_id, same_profile);
-    assert!(!contains(&second.reconstruction, b"redraw-20 100"));
-    assert!(contains(
-        &read_until(&mut second.stream, b"redraw-20 100"),
-        b"redraw-20 100"
-    ));
-
-    drop(second);
-    daemon.stop_with_cli();
-}
-
-#[test]
 fn structured_shell_preview_preserves_color_while_plain_read_stays_plain() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -269,6 +269,52 @@ fn reattachment_reflows_retained_output_for_the_new_terminal_width() {
 }
 
 #[test]
+fn reattachment_delivers_resize_redraw_after_reconstruction() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "resize-redraw-order",
+            vec![ShellSpec {
+                name: "tui".into(),
+                command: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    r#"trap 'printf "\033[2J\033[Hredraw-%s\n" "$(stty size)"' WINCH; printf '\033[?1049hinitial-screen\n'; while :; do sleep 1; done"#
+                        .into(),
+                ],
+                cwd: std::env::temp_dir(),
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let mut initial_profile = profile();
+    initial_profile.rows = 20;
+    initial_profile.cols = 100;
+    let mut first = daemon
+        .client
+        .attach(&shell_id, false, initial_profile)
+        .unwrap();
+    if !contains(&first.reconstruction, b"initial-screen") {
+        read_until(&mut first.stream, b"initial-screen");
+    }
+    drop(first);
+
+    let mut resized_profile = profile();
+    resized_profile.rows = 10;
+    resized_profile.cols = 40;
+    let mut second = wait_for_attach_with_profile(&daemon.client, &shell_id, resized_profile);
+    assert!(!contains(&second.reconstruction, b"redraw-10 40"));
+    assert!(contains(
+        &read_until(&mut second.stream, b"redraw-10 40"),
+        b"redraw-10 40"
+    ));
+
+    drop(second);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn structured_shell_preview_preserves_color_while_plain_read_stays_plain() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -269,7 +269,7 @@ fn reattachment_reflows_retained_output_for_the_new_terminal_width() {
 }
 
 #[test]
-fn reattachment_delivers_resize_redraw_after_reconstruction() {
+fn reattachment_requests_fullscreen_redraw_after_reconstruction() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon
         .client
@@ -300,14 +300,14 @@ fn reattachment_delivers_resize_redraw_after_reconstruction() {
     }
     drop(first);
 
-    let mut resized_profile = profile();
-    resized_profile.rows = 10;
-    resized_profile.cols = 40;
-    let mut second = wait_for_attach_with_profile(&daemon.client, &shell_id, resized_profile);
-    assert!(!contains(&second.reconstruction, b"redraw-10 40"));
+    let mut same_profile = profile();
+    same_profile.rows = 20;
+    same_profile.cols = 100;
+    let mut second = wait_for_attach_with_profile(&daemon.client, &shell_id, same_profile);
+    assert!(!contains(&second.reconstruction, b"redraw-20 100"));
     assert!(contains(
-        &read_until(&mut second.stream, b"redraw-10 40"),
-        b"redraw-10 40"
+        &read_until(&mut second.stream, b"redraw-20 100"),
+        b"redraw-20 100"
     ));
 
     drop(second);


### PR DESCRIPTION
## Summary
- nudge the attachment by one row after replaying retained terminal state
- restore the real dimensions after 100 ms so terminal applications observe a genuine size transition and repaint
- resize Boomux shadow state before signaling the PTY for client resize frames
- cover the exact nudge-and-restore frame sequence with an attachment unit test

## Validation
- manually reproduced the broken OpenCode reattachment and confirmed the automatic `31 -> 30 -> 31` sequence fixes it
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked` (729 passed)
- `bun test integrations/opencode/boomux.test.js integrations/pi/boomux.test.js` (32 passed)
- `cargo test --test native_backend --locked -- --test-threads=1 --skip node_registration::node_upgrade_maintenance_blocks_registration_changes_until_release` (115 passed)

## Known Test Issue
The unrelated `node_upgrade_maintenance_blocks_registration_changes_until_release` native test fails because its background registration operation does not drain before the fixture timeout.