### PR TITLE
feat(web): add tailnet dashboard lifecycle

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -523,22 +523,34 @@ boomux doctor
 when `BOOMUX_SHELL_ID` is set. `boomux doctor` can run in either context.
 
 `boomux web` serves an experimental read-only Agent PWA on
-`127.0.0.1:3737`. Use `--port` to change the loopback port. Boomux leaves remote
-transport, TLS, identity, and access policy to the user's private access layer.
+`127.0.0.1:3737`. Use `--port` to change the loopback port. `--tailscale` is an
+explicit mutation that publishes the dashboard and enabled OpenCode runtime
+through a connected PATH-resolved Tailscale CLI. It reuses compatible routes,
+rejects conflicts, tracks only routes it creates, and removes those exact routes
+on graceful exit or `boomux web stop`; it never resets unrelated Serve state or
+defines tailnet grants and ACLs. Without the flag, remote publication remains
+external.
 It uses the Omarchy presentation model: one current user-Shell
 Agent per exact run plus historical Agents with durable attention, excluding
 schedule-owned Agents. It also presents local working-to-idle transitions as
 gateway-owned ephemeral finished alerts, refreshed even without a connected
-browser. It displays bounded output for an exact current local Shell run, but
-cannot send terminal input, acknowledge attention, or expose remote terminal
-output. It ensures the Node's loopback Shared Harness Runtime and links exact
-local Sessions only while a current Agent Session Claim binds that runtime
-generation to the exact ShellRun. `--opencode-web-url URL` is the public origin
-for that same local runtime, never an unrelated server. `--no-opencode-web`
-disables web-triggered runtime startup and native links. Boomux does not proxy or
-authenticate that full-control service. The private access layer owns TLS,
-authentication, and ACLs. Remote Agents remain unlinked. Never present rendered
-terminal output as a structured conversation transcript.
+browser. Its home page is the complete dashboard and cannot send terminal input
+or acknowledge attention. It ensures the Node's loopback Shared Harness Runtime
+and links exact local Sessions directly from eligible Agent cards only while a
+current Agent Session Claim binds that runtime generation to the exact ShellRun.
+`--opencode-web-url URL` is the public origin for that same local runtime, never
+an unrelated server. `--no-opencode-web` disables web-triggered runtime startup
+and native links. Boomux does not proxy or authenticate that full-control
+service. The private access layer owns TLS, authentication, and ACLs. Remote
+Agents remain unlinked.
+Stop only the default gateway with `boomux web stop`, or an alternate gateway
+with `boomux web stop --port PORT`. This leaves the daemon, managed processes,
+and Shared Harness Runtime running. The command is safe when no matching gateway
+is running.
+Use `boomux web start [--tailscale]` for detached operation and `boomux web
+status` for passive inspection. Start requires an already running daemon, waits
+for readiness, and is idempotent only for equivalent options. Start, status, and
+stop support `--json` as `web.start`, `web.status`, and `web.stop`.
 `OPENCODE_SERVER_PASSWORD` and `OPENCODE_SERVER_USERNAME` are ephemeral
 first-start runtime environment, are never persisted by Boomux, and must remain
 consistent for attached clients.

--- a/README.md
+++ b/README.md
@@ -257,24 +257,32 @@ bounded projections of registered Nodes, keeps stale ownership visible, and
 shows the same current user-Shell Agents and outstanding durable attention as
 the Omarchy Boomux plugin. A locally observed `working` to `idle` transition is
 kept by the gateway as a transient finished alert while that Agent remains idle,
-even when no browser is connected. Local Agent details can show up to 256 KiB of
-rendered output only while the Agent's exact Shell run is still current. Remote
-projections never expose terminal output. The command also ensures the Node's
-Shared Harness Runtime on `127.0.0.1:4097`, so an exact claimed local OpenCode
-Agent links to the same live Session used by its desktop TUI. The TUI can be
-detached while phone events continue; on return it receives those events and is
-synchronized with the phone.
+even when no browser is connected. The home page is the complete dashboard; an
+eligible local OpenCode Agent card links directly to the same live Session used
+by its desktop TUI through the Node's Shared Harness Runtime on
+`127.0.0.1:4097`. Remote Agents remain unlinked. The TUI can be detached while
+phone events continue; on return it receives those events and is synchronized
+with the phone.
 
-Publish both loopback services through a private access layer. For example:
+Stop only the default web gateway with `boomux web stop`. If it was started with
+another HTTP port, use `boomux web stop --port PORT`. This leaves the daemon,
+managed processes, and Shared Harness Runtime running.
+
+Use `boomux web start` for detached background operation and `boomux web status`
+for passive inspection. Start requires the daemon to already be running and is
+idempotent for equivalent options. All three lifecycle commands support `--json`.
+
+Publish both loopback services to a connected Tailscale tailnet explicitly:
 
 ```console
-boomux web
-tailscale serve --https=443 --bg http://127.0.0.1:3737
-tailscale serve --https=4097 --bg http://127.0.0.1:4097
+boomux web --tailscale
+boomux web start --tailscale
 ```
 
-Boomux does not configure or authenticate the private access layer, which owns
-TLS, authentication, and ACLs. The MVP has
+Boomux reuses compatible Serve routes, rejects conflicts, records only routes it
+creates, and removes those exact routes on graceful exit or `boomux web stop`.
+It does not reset unrelated Serve configuration or define Tailscale grants and
+ACLs. Without `--tailscale`, remote publication remains external. The MVP has
 no terminal input, attention acknowledgment, transcript parsing, or cloud
 service. Native OpenCode links leave Boomux and open a full-control service whose
 origin must be protected separately. Add the remote URL

--- a/assets/mobile-web/app.js
+++ b/assets/mobile-web/app.js
@@ -3,20 +3,15 @@
 const POLL_INTERVAL_MS = 2_000;
 const state = {
   snapshot: null,
-  filter: "attention",
+  filter: "all",
   deferredInstallPrompt: null,
   pollTimer: null,
   snapshotRequest: null,
-  detailRequest: null,
   online: true,
 };
 
 const elements = {
-  dashboardView: document.querySelector("#dashboard-view"),
-  detailView: document.querySelector("#detail-view"),
   dashboardState: document.querySelector("#dashboard-state"),
-  detailState: document.querySelector("#detail-state"),
-  detailContent: document.querySelector("#detail-content"),
   agentList: document.querySelector("#agent-list"),
   resultCount: document.querySelector("#result-count"),
   viewerCopy: document.querySelector("#viewer-copy"),
@@ -24,7 +19,6 @@ const elements = {
   connectionStatus: document.querySelector("#connection-status"),
   connectionLabel: document.querySelector("#connection-label"),
   installButton: document.querySelector("#install-button"),
-  refreshDetail: document.querySelector("#refresh-detail"),
   counts: {
     attention: document.querySelector("#count-attention"),
     active: document.querySelector("#count-active"),
@@ -42,17 +36,6 @@ function el(tag, className, text) {
 
 function formatState(value) {
   return String(value || "unknown").replaceAll("_", " ");
-}
-
-function formatTime(timestamp) {
-  if (!Number.isFinite(timestamp)) return "Unknown";
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-  }).format(new Date(timestamp));
 }
 
 function relativeTime(timestamp) {
@@ -96,20 +79,6 @@ function usefulAgentOrder(a, b) {
   return rank(a) - rank(b) || (b.observed_at_ms || 0) - (a.observed_at_ms || 0);
 }
 
-function detailHash(agent) {
-  return `#/agents/${encodeURIComponent(agent.node_id)}/${encodeURIComponent(agent.agent_id)}`;
-}
-
-function routeDetail() {
-  const match = location.hash.match(/^#\/agents\/([^/]+)\/([^/]+)$/);
-  if (!match) return null;
-  try {
-    return { nodeId: decodeURIComponent(match[1]), agentId: decodeURIComponent(match[2]) };
-  } catch {
-    return null;
-  }
-}
-
 function showState(container, title, message, kind = "empty") {
   container.replaceChildren();
   const symbol = el("span", `state-symbol state-symbol-${kind}`, kind === "error" ? "!" : "·");
@@ -134,8 +103,8 @@ function renderSnapshot() {
   elements.counts.agents.textContent = counts.agents ?? snapshot.agents?.length ?? 0;
   elements.counts.stale.textContent = counts.stale_nodes ?? 0;
   elements.viewerCopy.textContent = snapshot.viewer
-    ? `Read-only fleet view for ${snapshot.viewer}.`
-    : "Read-only visibility across the fleet.";
+    ? `Current work and attention for ${snapshot.viewer}.`
+    : "Current work and attention across your Boomux nodes.";
   elements.lastUpdated.textContent = `Snapshot ${relativeTime(snapshot.generated_at_ms)}`;
 
   const filtered = agents.filter((agent) => {
@@ -162,8 +131,7 @@ function renderSnapshot() {
 
 function renderAgentCard(agent) {
   const item = el("li", `agent-card tone-${toneFor(agent)}`);
-  const link = el("a", "agent-card-link");
-  link.href = detailHash(agent);
+  const content = el("article", "agent-card-content");
 
   const rail = el("span", "card-rail");
   rail.setAttribute("aria-hidden", "true");
@@ -198,8 +166,19 @@ function renderAgentCard(agent) {
     body.append(el("p", "stale-callout", "Node data is stale; this status may be out of date."));
   }
   body.append(meta);
-  link.append(rail, body, el("span", "card-arrow", "→"));
-  item.append(link);
+  const nativeUrl = agent.native_web?.url || derivedNativeUrl(agent.native_web);
+  if (nativeUrl) {
+    const actions = el("div", "card-actions");
+    const nativeLink = el("a", "card-native-link", agent.native_web.label || "Open in OpenCode");
+    nativeLink.href = nativeUrl;
+    nativeLink.target = "_blank";
+    nativeLink.rel = "noreferrer";
+    nativeLink.referrerPolicy = "no-referrer";
+    actions.append(nativeLink);
+    body.append(actions);
+  }
+  content.append(rail, body);
+  item.append(content);
   return item;
 }
 
@@ -245,71 +224,6 @@ async function refreshSnapshot() {
   }
 }
 
-function renderDetail(payload) {
-  const agent = payload.agent;
-  document.title = `${agentDisplayName(agent)} · Boomux Agents`;
-  document.querySelector("#detail-title").textContent = agentDisplayName(agent);
-  document.querySelector("#detail-integration").textContent = agent.integration || "Agent";
-  document.querySelector("#detail-location").textContent = `${agent.workspace_name || "Unnamed workspace"} / ${agent.shell_name || "Unnamed shell"}`;
-  document.querySelector("#detail-revision").textContent = `Observation r${agent.observation_revision ?? "?"}`;
-
-  const glyph = document.querySelector("#detail-glyph");
-  glyph.dataset.tone = toneFor(agent);
-  const badge = document.querySelector("#detail-badge");
-  badge.textContent = formatState(agent.state);
-  badge.dataset.tone = toneFor(agent);
-
-  const facts = document.querySelector("#detail-facts");
-  facts.replaceChildren(
-    fact("Node", agent.node_alias || agent.node_id, agent.node_stale ? "Stale" : agent.node_health || "Current"),
-    fact("Started", formatTime(agent.started_at_ms), relativeTime(agent.started_at_ms)),
-    fact("Run ID", agent.run_id || "Unavailable", agent.run_current ? "Current run" : "Historical run"),
-  );
-
-  const timeline = document.querySelector("#timeline");
-  const events = Array.isArray(payload.timeline) ? [...payload.timeline] : [];
-  if (agent.just_completed && !agent.attention) {
-    events.push({
-      kind: "completion",
-      at_ms: agent.observed_at_ms,
-      title: "Turn completed",
-      body: "This local completion was observed from the working-to-idle transition and is ready for review.",
-      tone: "success",
-    });
-  }
-  events.sort((left, right) => (left.at_ms || 0) - (right.at_ms || 0));
-  timeline.replaceChildren(...events.map(renderTimelineEvent));
-  if (!events.length) {
-    const empty = el("li", "timeline-empty", "No timeline events have been observed for this run.");
-    timeline.append(empty);
-  }
-
-  const nativeWeb = payload.native_web;
-  const nativeLink = document.querySelector("#native-handoff-link");
-  const nativeNotice = document.querySelector("#native-handoff-notice");
-  if (nativeLink && nativeNotice) {
-    nativeNotice.textContent = payload.native_web_notice || "Native web handoff is unavailable.";
-    const nativeUrl = nativeWeb?.url || derivedNativeUrl(nativeWeb);
-    nativeLink.hidden = !nativeUrl;
-    nativeLink.removeAttribute("href");
-    nativeLink.textContent = nativeWeb?.label || "Open native interface";
-    if (nativeUrl) nativeLink.href = nativeUrl;
-  }
-
-  const terminal = document.querySelector("#terminal-output");
-  const terminalSection = document.querySelector("#terminal-section");
-  const notice = document.querySelector("#terminal-notice");
-  terminal.textContent = payload.terminal_output || "No rendered terminal output is available.";
-  terminal.classList.toggle("is-empty", !payload.terminal_output);
-  terminalSection.dataset.available = String(Boolean(payload.terminal_available));
-  notice.textContent = payload.notice || (payload.terminal_available
-    ? "The terminal is available, but no output has been rendered yet."
-    : "Terminal output is not available for this agent.");
-
-  elements.detailState.hidden = true;
-  elements.detailContent.hidden = false;
-}
-
 function derivedNativeUrl(nativeWeb) {
   if (!nativeWeb?.port || !nativeWeb?.path) return null;
   const url = new URL(window.location.href);
@@ -320,77 +234,9 @@ function derivedNativeUrl(nativeWeb) {
   return url.href;
 }
 
-function clearNativeHandoff() {
-  const nativeLink = document.querySelector("#native-handoff-link");
-  if (!nativeLink) return;
-  nativeLink.hidden = true;
-  nativeLink.removeAttribute("href");
-}
-
-function fact(label, value, note) {
-  const node = el("div", "fact");
-  node.append(el("small", "", label), el("strong", "", value), el("span", "", note));
-  return node;
-}
-
-function renderTimelineEvent(event) {
-  const item = el("li", "timeline-event");
-  item.dataset.tone = event.tone || "neutral";
-  const marker = el("span", "timeline-marker");
-  marker.setAttribute("aria-hidden", "true");
-  const content = el("div", "timeline-content");
-  const header = el("div", "timeline-header");
-  header.append(el("strong", "", event.title || formatState(event.kind)), el("time", "", formatTime(event.at_ms)));
-  const body = el("p", "", event.body || "No additional detail.");
-  content.append(header, body, el("small", "timeline-kind", formatState(event.kind)));
-  item.append(marker, content);
-  return item;
-}
-
-async function refreshDetail({ announceLoading = false } = {}) {
-  const route = routeDetail();
-  if (!route) return;
-  state.detailRequest?.abort();
-  const controller = new AbortController();
-  state.detailRequest = controller;
-  if (announceLoading || elements.detailContent.hidden) {
-    elements.detailContent.hidden = true;
-    showState(elements.detailState, "Loading agent detail…", "Fetching the latest observation.");
-  }
-  try {
-    const url = `/api/agents/${encodeURIComponent(route.nodeId)}/${encodeURIComponent(route.agentId)}`;
-    const payload = await fetchJson(url, controller.signal);
-    if (routeDetail()?.nodeId === route.nodeId && routeDetail()?.agentId === route.agentId) renderDetail(payload);
-  } catch (error) {
-    if (error.name === "AbortError") return;
-    clearNativeHandoff();
-    if (elements.detailContent.hidden) {
-      showState(elements.detailState, "Agent detail unavailable", "The run may have ended or the node cannot be reached. Return to the fleet or try again.", "error");
-    }
-  } finally {
-    if (state.detailRequest === controller) state.detailRequest = null;
-  }
-}
-
-function applyRoute() {
-  const detail = routeDetail();
-  elements.dashboardView.hidden = Boolean(detail);
-  elements.detailView.hidden = !detail;
-  if (detail) {
-    refreshDetail({ announceLoading: true });
-  } else {
-    state.detailRequest?.abort();
-    document.title = "Boomux Agents";
-    renderSnapshot();
-  }
-  window.scrollTo({ top: 0, behavior: "instant" });
-}
-
 async function poll() {
   if (document.visibilityState !== "visible") return;
-  const requests = [refreshSnapshot()];
-  if (routeDetail()) requests.push(refreshDetail());
-  await Promise.all(requests);
+  await refreshSnapshot();
 }
 
 function restartPolling() {
@@ -411,8 +257,6 @@ document.querySelectorAll(".filter-button").forEach((button) => {
   });
 });
 
-elements.refreshDetail.addEventListener("click", () => refreshDetail({ announceLoading: true }));
-window.addEventListener("hashchange", applyRoute);
 window.addEventListener("focus", restartPolling);
 document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "visible") restartPolling();
@@ -444,5 +288,4 @@ if ("serviceWorker" in navigator) {
   });
 }
 
-applyRoute();
 restartPolling();

--- a/assets/mobile-web/index.html
+++ b/assets/mobile-web/index.html
@@ -16,7 +16,7 @@
   <body>
     <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
-      <a class="brand" href="#/" aria-label="Boomux Agents home">
+      <a class="brand" href="/" aria-label="Boomux Agents home">
         <span class="brand-mark" aria-hidden="true">B<span>∞</span></span>
         <span>
           <strong>BOOMUX</strong>
@@ -33,12 +33,12 @@
     </header>
 
     <main id="main-content" tabindex="-1">
-      <section id="dashboard-view" aria-labelledby="dashboard-title">
+      <section aria-labelledby="dashboard-title">
         <div class="hero">
           <div>
-            <p class="eyebrow">Live operations index</p>
-            <h1 id="dashboard-title">Agents in motion.</h1>
-            <p class="hero-copy" id="viewer-copy">Read-only visibility across the fleet.</p>
+            <p class="eyebrow">Boomux web</p>
+            <h1 id="dashboard-title">Agent activity.</h1>
+            <p class="hero-copy" id="viewer-copy">Current work and attention across your Boomux nodes.</p>
           </div>
           <p class="last-updated" id="last-updated">Waiting for first snapshot</p>
         </div>
@@ -52,9 +52,9 @@
 
         <div class="list-toolbar">
           <div class="filters" role="group" aria-label="Filter agents">
-            <button class="filter-button is-selected" type="button" data-filter="attention" aria-pressed="true">Attention</button>
+            <button class="filter-button is-selected" type="button" data-filter="all" aria-pressed="true">All</button>
+            <button class="filter-button" type="button" data-filter="attention" aria-pressed="false">Attention</button>
             <button class="filter-button" type="button" data-filter="active" aria-pressed="false">Active</button>
-            <button class="filter-button" type="button" data-filter="all" aria-pressed="false">All</button>
           </div>
           <p id="result-count" aria-live="polite"></p>
         </div>
@@ -67,75 +67,6 @@
         <ol class="agent-list" id="agent-list" aria-live="polite" aria-busy="true"></ol>
       </section>
 
-      <section id="detail-view" class="detail-view" aria-labelledby="detail-title" hidden>
-        <nav class="detail-nav" aria-label="Agent detail navigation">
-          <a class="back-link" href="#/">← Fleet</a>
-          <button class="quiet-button" id="refresh-detail" type="button">Refresh</button>
-        </nav>
-        <div id="detail-state" class="state-panel" role="status">
-          <span class="loader" aria-hidden="true"></span>
-          <strong>Loading agent detail…</strong>
-        </div>
-        <article id="detail-content" hidden>
-          <header class="detail-header">
-            <div class="detail-heading">
-              <span class="status-glyph" id="detail-glyph" aria-hidden="true"></span>
-              <div>
-                <p class="eyebrow" id="detail-integration"></p>
-                <h1 id="detail-title"></h1>
-                <p id="detail-location"></p>
-              </div>
-            </div>
-            <span class="state-badge" id="detail-badge"></span>
-          </header>
-
-          <section class="detail-facts" aria-label="Agent facts" id="detail-facts"></section>
-
-          <section class="native-handoff" aria-labelledby="native-handoff-title">
-            <div class="section-heading">
-              <div>
-                <p class="eyebrow">OpenCode</p>
-                <h2 id="native-handoff-title">Continue in OpenCode</h2>
-              </div>
-              <span class="native-handoff-label">Native web</span>
-            </div>
-            <p class="native-handoff-notice" id="native-handoff-notice"></p>
-            <a class="native-handoff-link" id="native-handoff-link" target="_blank" rel="noreferrer" referrerpolicy="no-referrer" hidden></a>
-          </section>
-
-          <section class="activity" aria-labelledby="activity-title">
-            <div class="section-heading">
-              <div>
-                <p class="eyebrow">Observed events</p>
-                <h2 id="activity-title">Activity timeline</h2>
-              </div>
-              <span class="revision" id="detail-revision"></span>
-            </div>
-            <ol class="timeline" id="timeline"></ol>
-          </section>
-
-          <section class="terminal-section" id="terminal-section" aria-labelledby="terminal-title">
-            <div class="section-heading">
-              <div>
-                <p class="eyebrow">Rendered terminal output</p>
-                <h2 id="terminal-title">Terminal preview</h2>
-              </div>
-              <span class="terminal-label">OUTPUT, NOT TRANSCRIPT</span>
-            </div>
-            <p class="terminal-explainer">This is a rendered terminal snapshot. It is not a structured conversation transcript and may contain partial or visual terminal content.</p>
-            <pre id="terminal-output" tabindex="0"></pre>
-            <p class="terminal-notice" id="terminal-notice"></p>
-          </section>
-
-          <footer class="read-only-footer">
-            <div class="read-only-icon" aria-hidden="true">R/O</div>
-            <div>
-              <strong>Watching, not steering</strong>
-              <p>Boomux remains a read-only lifecycle dashboard. A configured native harness link opens a separate full-control application.</p>
-            </div>
-          </footer>
-        </article>
-      </section>
     </main>
 
     <noscript><p class="noscript">JavaScript is required to view the live agent dashboard.</p></noscript>

--- a/assets/mobile-web/service-worker.js
+++ b/assets/mobile-web/service-worker.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const CACHE_NAME = "boomux-agent-watch-v11";
+const CACHE_NAME = "boomux-agent-watch-v14";
 const APP_SHELL = [
   "./",
   "./index.html",

--- a/assets/mobile-web/styles.css
+++ b/assets/mobile-web/styles.css
@@ -121,7 +121,7 @@ a { color: inherit; }
 .connection[data-status="online"] .connection-dot { background: var(--acid); box-shadow: 0 0 0 3px rgba(216, 255, 62, .13); }
 .connection[data-status="offline"] .connection-dot { background: var(--ember); box-shadow: 0 0 0 3px rgba(255, 112, 67, .15); }
 
-.install-button, .quiet-button {
+.install-button {
   min-height: 38px;
   border: 1px solid var(--line);
   color: var(--paper);
@@ -134,8 +134,7 @@ a { color: inherit; }
 }
 
 .install-button { padding: 0 13px; border-color: var(--acid); color: var(--acid); }
-.quiet-button { padding: 0 14px; }
-.install-button:hover, .quiet-button:hover { color: var(--ink); background: var(--acid); border-color: var(--acid); }
+.install-button:hover { color: var(--ink); background: var(--acid); border-color: var(--acid); }
 
 main {
   width: min(1120px, 100%);
@@ -229,14 +228,12 @@ h1 {
   box-shadow: 5px 5px 0 rgba(0, 0, 0, .22);
 }
 
-.agent-card-link {
+.agent-card-content {
   display: grid;
-  grid-template-columns: 7px 1fr auto;
+  grid-template-columns: 7px 1fr;
   min-height: 132px;
-  text-decoration: none;
 }
 
-.agent-card-link:hover { background: #25251f; }
 .card-rail { background: var(--muted); }
 .tone-attention .card-rail { background: var(--ember); }
 .tone-active .card-rail { background: var(--acid); }
@@ -285,8 +282,9 @@ h1 {
 .meta-item small, .meta-item strong { display: block; }
 .meta-item small { margin-bottom: 4px; color: var(--muted); font-size: .57rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
 .meta-item strong { max-width: 220px; overflow: hidden; color: var(--paper-dim); font-size: .72rem; text-overflow: ellipsis; white-space: nowrap; }
-.card-arrow { display: grid; width: 54px; place-items: center; border-left: 1px solid var(--line); color: var(--muted); font-size: 1.2rem; }
-.agent-card-link:hover .card-arrow { color: var(--acid); }
+.card-actions { display: flex; margin-top: 18px; }
+.card-native-link { display: inline-flex; min-height: 42px; padding: 0 16px; border: 1px solid var(--acid); align-items: center; color: var(--ink); background: var(--acid); font-size: .7rem; font-weight: 900; letter-spacing: .09em; text-decoration: none; text-transform: uppercase; }
+.card-native-link:hover { color: var(--acid); background: transparent; }
 
 .state-panel {
   display: grid;
@@ -314,90 +312,6 @@ h1 {
   animation: spin .8s linear infinite;
 }
 
-.detail-view { padding-top: 26px; }
-.detail-nav { display: flex; min-height: 48px; align-items: center; justify-content: space-between; }
-.back-link { color: var(--paper-dim); font-size: .8rem; font-weight: 900; letter-spacing: .08em; text-decoration: none; text-transform: uppercase; }
-.back-link:hover { color: var(--acid); }
-
-.detail-header {
-  display: flex;
-  padding: 40px 0 30px;
-  align-items: start;
-  justify-content: space-between;
-  border-bottom: 1px solid var(--line);
-}
-
-.detail-heading { display: flex; min-width: 0; gap: 18px; align-items: start; }
-.detail-heading h1 { margin-bottom: 10px; font-size: clamp(2.5rem, 8vw, 5rem); }
-.detail-heading p:last-child { margin: 0; color: var(--paper-dim); font-family: Georgia, serif; }
-.status-glyph { flex: none; width: 11px; height: 64px; margin-top: 2px; background: var(--muted); }
-.status-glyph[data-tone="attention"] { background: var(--ember); }
-.status-glyph[data-tone="active"] { background: var(--acid); }
-.status-glyph[data-tone="stale"] { background: repeating-linear-gradient(0deg, var(--muted) 0 5px, transparent 5px 9px); }
-
-.detail-facts { display: grid; grid-template-columns: repeat(3, 1fr); border-bottom: 1px solid var(--line); }
-.fact { min-width: 0; padding: 23px 18px; border-right: 1px solid var(--line); }
-.fact:first-child { padding-left: 0; }
-.fact:last-child { border: 0; }
-.fact small, .fact strong, .fact span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.fact small { margin-bottom: 7px; color: var(--muted); font-size: .6rem; font-weight: 900; letter-spacing: .14em; text-transform: uppercase; }
-.fact strong { font-size: .86rem; }
-.fact span { margin-top: 5px; color: var(--muted); font-size: .7rem; }
-
-.native-handoff, .activity, .terminal-section { padding: 42px 0; border-bottom: 1px solid var(--line); }
-.section-heading { display: flex; margin-bottom: 25px; align-items: end; justify-content: space-between; gap: 20px; }
-.section-heading h2 { margin: 0; font-size: 1.65rem; letter-spacing: -.025em; }
-.revision, .terminal-label, .native-handoff-label { color: var(--muted); font-size: .6rem; font-weight: 900; letter-spacing: .12em; text-transform: uppercase; }
-.terminal-label { color: var(--acid); }
-
-.timeline { position: relative; margin: 0; padding: 0; list-style: none; }
-.timeline::before { position: absolute; top: 11px; bottom: 11px; left: 5px; width: 1px; background: var(--line); content: ""; }
-.timeline-event { position: relative; display: grid; grid-template-columns: 11px 1fr; gap: 18px; padding-bottom: 25px; }
-.timeline-event:last-child { padding-bottom: 0; }
-.timeline-marker { z-index: 1; width: 11px; height: 11px; margin-top: 5px; border: 2px solid var(--ink); border-radius: 50%; background: var(--paper-dim); box-shadow: 0 0 0 1px var(--line); }
-.timeline-event[data-tone="attention"] .timeline-marker, .timeline-event[data-tone="error"] .timeline-marker { background: var(--ember); }
-.timeline-event[data-tone="success"] .timeline-marker, .timeline-event[data-tone="active"] .timeline-marker { background: var(--acid); }
-.timeline-content { padding: 0 0 2px; }
-.timeline-header { display: flex; gap: 20px; align-items: baseline; justify-content: space-between; }
-.timeline-header strong { font-size: .94rem; }
-.timeline-header time { flex: none; color: var(--muted); font-size: .65rem; }
-.timeline-content p { margin: 7px 0; color: var(--paper-dim); font-family: Georgia, serif; font-size: .88rem; line-height: 1.55; white-space: pre-wrap; }
-.timeline-kind { color: var(--muted); font-size: .58rem; font-weight: 900; letter-spacing: .12em; text-transform: uppercase; }
-.timeline-empty { padding: 24px; border: 1px dashed var(--line); color: var(--muted); font-family: Georgia, serif; text-align: center; }
-
-.native-handoff-notice { max-width: 760px; margin: -8px 0 20px; color: var(--paper-dim); font-family: Georgia, serif; font-size: .9rem; line-height: 1.6; }
-.native-handoff-link { display: inline-flex; min-height: 48px; padding: 0 20px; border: 1px solid var(--acid); align-items: center; color: var(--ink); background: var(--acid); font-size: .76rem; font-weight: 900; letter-spacing: .09em; text-decoration: none; text-transform: uppercase; }
-.native-handoff-link:hover { color: var(--acid); background: transparent; }
-
-.terminal-explainer { max-width: 760px; margin-bottom: 16px; color: var(--paper-dim); font-family: Georgia, serif; font-size: .82rem; line-height: 1.55; }
-#terminal-output {
-  max-height: 440px;
-  margin: 0;
-  padding: 20px;
-  overflow: auto;
-  border: 1px solid var(--line);
-  color: #dcd8c7;
-  background: #0e0f0c;
-  box-shadow: inset 4px 0 var(--acid-deep);
-  font: .76rem/1.55 "DejaVu Sans Mono", "Liberation Mono", monospace;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-#terminal-output.is-empty { color: var(--muted); font-style: italic; box-shadow: inset 4px 0 var(--line); }
-.terminal-notice { margin: 10px 0 0; color: var(--muted); font-size: .7rem; }
-
-.read-only-footer {
-  display: flex;
-  margin-top: 32px;
-  padding: 20px;
-  gap: 15px;
-  align-items: start;
-  border: 1px solid var(--line);
-  background: var(--ink-raised);
-}
-.read-only-icon { flex: none; padding: 6px; border: 1px solid var(--acid-deep); color: var(--acid); font-size: .62rem; font-weight: 900; letter-spacing: .08em; }
-.read-only-footer strong { font-size: .82rem; text-transform: uppercase; letter-spacing: .06em; }
-.read-only-footer p { margin: 5px 0 0; color: var(--paper-dim); font-family: Georgia, serif; font-size: .8rem; line-height: 1.5; }
 .noscript { margin: 30px; color: var(--rose); text-align: center; }
 
 @keyframes spin { to { transform: rotate(360deg); } }
@@ -416,28 +330,16 @@ h1 {
   .list-toolbar { min-height: 70px; gap: 8px; }
   .filter-button { padding: 0 10px; font-size: .69rem; }
   #result-count { display: none; }
-  .agent-card-link { grid-template-columns: 6px 1fr; }
+  .agent-card-content { grid-template-columns: 6px 1fr; }
   .card-body { padding: 17px 15px 15px; }
   .card-top { display: block; }
   .state-badge { display: inline-block; margin-top: 11px; }
   .card-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 13px 18px; }
   .meta-item:last-child { grid-column: 1 / -1; }
-  .card-arrow { display: none; }
   .attention-callout { display: block; }
   .attention-callout strong, .attention-callout span { display: block; }
   .attention-callout span { margin-top: 4px; white-space: normal; }
-  .detail-header { display: block; padding-top: 30px; }
-  .detail-header > .state-badge { margin: 22px 0 0 29px; }
-  .detail-facts { grid-template-columns: 1fr; }
-  .fact, .fact:first-child { padding: 17px 0; border-right: 0; border-bottom: 1px solid var(--line); }
-  .fact:last-child { border-bottom: 0; }
-  .native-handoff, .activity, .terminal-section { padding: 34px 0; }
-  .section-heading { display: block; }
-  .revision, .terminal-label, .native-handoff-label { display: inline-block; margin-top: 10px; }
-  .timeline-header { display: block; }
-  .timeline-header time { display: block; margin-top: 4px; }
-  #terminal-output { margin-right: -18px; margin-left: -18px; border-right: 0; border-left: 0; }
-  .native-handoff-link { display: flex; justify-content: center; }
+  .card-native-link { display: flex; width: 100%; justify-content: center; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@
 | `src/terminal_focus.rs` | Stateful parsing and restoration of child focus-reporting mode |
 | `src/tui.rs` | Dashboard state, interaction, palette, polling, and Ratatui rendering; no direct daemon transport |
 | `src/mobile_web.rs`, `assets/mobile-web/` | Loopback-only read-only HTTP gateway, Node-qualified Agent projection, native harness web handoff, and embedded installable web assets |
+| `src/tailscale_serve.rs` | Explicit Tailscale Serve preflight, conflict detection, exact route mutation, and ephemeral ownership cleanup for `boomux web --tailscale` |
 | `src/session_projection.rs` | Projection of daemon Agent state and host catalogs into client-visible sessions |
 | `src/integrations.rs` | Integration identity, display metadata, and optional installation, title/catalog, resume, and foreground capabilities |
 | `src/host_session_titles.rs` and children | Shared title/catalog policy and host-specific discovery adapters |
@@ -527,6 +528,28 @@ projects local authoritative Agents and reduced remote Agents into a deliberatel
 unstable HTTP view model. Every resource retains its exact `(node_id, agent_id)`
 identity, and remote freshness, health, and staleness remain visible.
 
+Each HTTP port owns one Unix control socket in Boomux's private runtime
+directory. The socket answers bounded versioned status requests with the exact
+loopback or tailnet URLs and accepts a versioned stop request. `boomux web start`
+requires a running daemon, launches the foreground gateway in a detached session
+with an owner-only runtime log, and waits for that socket to report readiness.
+Equivalent starts are idempotent and mismatched options fail closed. `boomux web
+stop` waits for graceful shutdown and owner-validated socket cleanup. These
+commands do not signal guessed processes, contact the daemon shutdown path, or
+stop the Shared Harness Runtime.
+
+`--tailscale` is an explicit deployment mutation. The gateway invokes the
+PATH-resolved Tailscale CLI with exact argument vectors, requires a connected
+Node with a MagicDNS name, and preflights the current Serve JSON before changing
+it. A compatible existing route is reused but never claimed. A conflicting root
+handler fails startup before mutation. Missing dashboard HTTPS 443 and OpenCode
+HTTPS runtime-port routes are added independently, and only routes created by
+that gateway are recorded in an owner-only, versioned runtime record. Graceful
+exit removes those exact root routes; `boomux web stop` also reconciles a record
+left by a crashed gateway. Changed or externally owned routes are never removed,
+and Boomux never resets unrelated Serve configuration. Tailscale remains
+responsible for certificates, tailnet identity, grants, and ACL policy.
+
 Agent visibility follows the Omarchy presentation contract rather than exposing
 the complete durable registry. Schedule-owned Agents are excluded. For each
 exact current `(node_id, shell_id, run_id)`, the newest non-inactive and non-done
@@ -542,18 +565,16 @@ disconnected without discarding its last bounded projection or finished markers.
 
 All Boomux routes are read-only. The server has no arbitrary daemon-protocol
 pass-through, terminal attachment, input, attention acknowledgment, Session
-resume, or harness transcript adapter. Local Agent detail may perform one bounded
-rendered Shell read only when the Shell's current run ID still equals the Agent's
-retained run ID. It never substitutes output from a later run. Remote projection
-detail contains no terminal output because the coordinator cache is prompt-free
-and non-authoritative.
+resume, rendered terminal output, Agent detail route, or harness transcript
+adapter. The home-page snapshot is the complete HTTP Agent projection.
 
 `boomux web` ensures the same daemon-supervised Shared Harness Runtime used by
 eligible native OpenCode TUIs. For an authoritative claimed local OpenCode Agent
 with a canonical external Session ID and UTF-8 working directory, Boomux
 base64url-encodes the directory and constructs OpenCode's exact
-`/<directory>/session/<session-id>` route. The browser derives a default public
-origin from its current scheme and hostname plus the stable runtime port.
+`/<directory>/session/<session-id>` route on that Agent's home-page card. The
+browser derives a default public origin from its current scheme and hostname plus
+the stable runtime port.
 `--opencode-web-url` overrides that public origin for the same local runtime; it
 does not select an unrelated server. Boomux does not proxy OpenCode, persist its
 first-start username/password environment, or advertise local Session identity
@@ -577,8 +598,9 @@ and conflicting same-Session Shells therefore have no native link. Remote Agents
 remain unlinked.
 
 HTTP binds to `127.0.0.1` and is intended to sit behind a user-selected private
-access layer. Boomux does not interpret proxy identity headers or configure
-remote transport, TLS, or access policy. Loopback binding prevents LAN or remote
+access layer. Except for the explicit `--tailscale` Serve integration, Boomux
+does not configure remote transport or TLS, and it never defines access policy
+or interprets proxy identity headers. Loopback binding prevents LAN or remote
 peers from bypassing that external boundary. API responses use `no-store`,
 the service worker caches only the public application shell, and a restrictive
 content security policy prevents external script, style, object, and framing

--- a/docs/mobile-web.md
+++ b/docs/mobile-web.md
@@ -9,15 +9,13 @@
 `boomux web` provides a phone-friendly, installable view of the current Agents
 and outstanding Agent attention known to one coordinating Boomux Node. It is a
 read-only presentation layer inspired by mobile agent dashboards: durable
-attention is first, active work remains easy to scan, and an Agent detail page
-presents lifecycle observations alongside bounded rendered terminal output when
-that output is authoritative locally. An optional native handoff opens an exact
-authoritative local OpenCode Session in OpenCode Web.
+attention is first and active work remains easy to scan. Eligible Agent cards
+offer a native handoff that opens the exact authoritative local OpenCode Session
+in OpenCode Web.
 
 Boomux is not an interactive chat client. It does not parse or normalize harness
 transcripts and does not send messages, commands, permission responses, or
 question answers. OpenCode's separate native interface owns those interactions.
-Rendered Shell output remains terminal state and is labeled as such.
 
 ## Start It
 
@@ -27,6 +25,19 @@ Run the gateway on its fixed loopback interface:
 boomux web
 ```
 
+For desktop integrations or normal background use, start it detached and wait
+for readiness:
+
+```console
+boomux web start
+boomux web status
+```
+
+All lifecycle subcommands support the stable JSON envelope with commands
+`web.start`, `web.status`, and `web.stop`. Background start requires an already
+running daemon and never resurrects a stopped daemon. Repeating an equivalent
+start is idempotent; different options on the same HTTP port are rejected.
+
 The default URL is `http://127.0.0.1:3737`. Select another loopback port with
 `--port`. The command also ensures one daemon-supervised Shared Harness Runtime
 generation on `127.0.0.1:4097`; choose another stable loopback port with
@@ -34,6 +45,17 @@ generation on `127.0.0.1:4097`; choose another stable loopback port with
 OpenCode TUIs and the phone. Restarting `boomux web` does not replace that
 generation. Runtime exit withdraws native links until the daemon starts or
 strictly cold-adopts a replacement generation.
+
+Stop the default gateway without stopping the Boomux daemon or any managed
+processes:
+
+```console
+boomux web stop
+```
+
+For a gateway started with another HTTP port, pass the same port to
+`boomux web stop --port PORT`. The command is idempotent when that gateway is not
+running.
 
 Set `OPENCODE_SERVER_PASSWORD` and optionally `OPENCODE_SERVER_USERNAME` before
 the runtime's first start. They are ephemeral startup environment, are never
@@ -65,22 +87,33 @@ events, and is synchronized when the terminal returns. `--pure`, `--mini`,
 absolute paths, modified `PATH`, and otherwise ineligible invocations receive no
 claim or native link.
 
-Remote access remains an external deployment concern. Publish both loopback
-ports through a private access layer. For example, with Tailscale Serve:
+To publish both loopback services to the current Tailscale tailnet, opt in when
+starting the foreground or background gateway:
 
 ```console
-tailscale serve --https=4097 --bg http://127.0.0.1:4097
-tailscale serve --https=443 --bg http://127.0.0.1:3737
+boomux web --tailscale
+boomux web start --tailscale
 ```
 
-Open the HTTPS URL printed by Tailscale on the phone. Use the browser's **Add to
-Home Screen** action to install the progressive web app.
+Boomux requires a connected PATH-resolved Tailscale CLI and MagicDNS name. It
+reuses compatible existing Serve routes, rejects conflicts before mutation, and
+adds only missing root routes for dashboard HTTPS 443 and OpenCode HTTPS on the
+configured runtime port. `Ctrl-C` and `boomux web stop` remove only routes that
+invocation created; unrelated and compatible pre-existing Serve routes remain.
+A later stop reconciles exact owned routes after a gateway crash. Boomux does
+not configure tailnet grants or ACLs.
+
+Open the printed dashboard HTTPS URL on the phone. Use the browser's **Add to
+Home Screen** action to install the progressive web app. OpenCode Web is a
+separate full-control HTTPS origin; restrict both routes to trusted tailnet
+users and configure `OPENCODE_SERVER_PASSWORD` when tailnet policy alone is not
+the intended authentication boundary.
 
 ## Presentation Rules
 
 - Local Agents come from the authoritative local snapshot.
 - Remote Agents come from each registered Node's bounded reduced projection.
-- Every Agent link carries both its owning Node ID and Node-local Agent ID.
+- Every Agent card carries both its owning Node ID and Node-local Agent ID.
 - Schedule-owned Agents are excluded.
 - One newest non-inactive and non-done Agent is selected for each exact current
   Node, Shell, and run identity.
@@ -97,9 +130,10 @@ Home Screen** action to install the progressive web app.
 - Active counts require both a working or blocked observation and an exact match
   to the Shell's current run; retained historical observations never become live
   merely because their state label remains active-looking.
-- Opening an Agent does not acknowledge attention or change lifecycle state.
-- An exact native link is returned only for a local OpenCode Agent with a
-  canonical external Session ID, UTF-8 working directory, and current Agent
+- Opening a native Agent link does not acknowledge attention or change lifecycle
+  state.
+- An exact native link is included on a card only for a local OpenCode Agent with
+  a canonical external Session ID, UTF-8 working directory, and current Agent
   Session Claim for the Agent's exact ShellRun and Shared Harness Runtime
   generation. The directory is
   base64url-encoded for OpenCode's
@@ -107,11 +141,8 @@ Home Screen** action to install the progressive web app.
 - Native links are not produced for projected remote Agents because their
   external Session identity and working directory intentionally remain on the
   owner Node. Remote Agents remain unlinked to this Node's runtime.
-- Local terminal output is capped at 256 KiB and is read only when the durable
-  Shell still has the Agent's exact run as its current run.
-- A historical Agent never displays output from a later run of the same Shell.
-- Remote terminal output, lifecycle evidence, external Session identity, and
-  working directory remain absent from cached projections.
+- Lifecycle evidence, external Session identity, and working directory remain
+  absent from remote cached projections.
 - Browser polling stops while the page is hidden and resumes on visibility or
   focus; the gateway's background projection refresh continues independently.
 - A temporary daemon failure retains the last bounded projection with
@@ -125,13 +156,12 @@ the private access layer. That layer owns TLS, authentication, and ACLs
 appropriate for both the read-only dashboard and OpenCode's
 full-control origin. Public exposure is outside this design.
 
-Terminal output and lifecycle evidence can contain private source, paths,
-commands, prompts, credentials, or model responses. Native handoff URLs expose
-the local working-directory encoding and canonical Session ID to the authorized
-dashboard client and destination OpenCode origin. API responses carry
+Native handoff URLs expose the local working-directory encoding and canonical
+Session ID to the authorized dashboard client and destination OpenCode origin.
+API responses carry
 `Cache-Control: no-store`. The service worker caches only HTML, JavaScript, CSS,
 the manifest, and the icon; it never handles `/api/` requests. Browser storage
-does not persist Agent snapshots or terminal output.
+does not persist Agent snapshots.
 
 The HTTP API is an allowlisted projection. It cannot forward arbitrary daemon
 requests, send terminal input, acquire a Shell controller, resume a Session,
@@ -145,10 +175,8 @@ reverse proxy so this boundary remains visible.
 
 ## MVP Endpoints
 
-- `GET /api/snapshot` returns the current Node-qualified Agent cards and counts.
-- `GET /api/agents/{node_id}/{agent_id}` returns one exact Agent detail and
-  lifecycle timeline, eligible local rendered terminal output, and an optional
-  exact native OpenCode Web handoff.
+- `GET /api/snapshot` returns the current Node-qualified Agent cards, counts, and
+  optional exact native OpenCode Web handoffs.
 
 These shapes are intentionally experimental. Future native handoff for other
 harnesses must preserve each harness's runtime ownership and exact Session

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ mod mobile_web;
 mod process_adapter;
 mod projects;
 mod session_projection;
+mod tailscale_serve;
 mod terminal;
 mod tui;
 
@@ -372,6 +373,8 @@ enum Commands {
     Ui,
     /// Serve the read-only mobile Agent dashboard on loopback
     Web {
+        #[command(subcommand)]
+        command: Option<WebCommands>,
         /// Loopback port for the HTTP server
         #[arg(long, default_value_t = 3737, value_parser = clap::value_parser!(u16).range(1..))]
         port: u16,
@@ -384,6 +387,11 @@ enum Commands {
         /// Do not start or advertise OpenCode Web
         #[arg(long, conflicts_with = "opencode_web_url")]
         no_opencode_web: bool,
+        /// Expose the dashboard and OpenCode Web to the current Tailscale tailnet
+        #[arg(long, conflicts_with = "opencode_web_url")]
+        tailscale: bool,
+        #[arg(long, hide = true)]
+        require_running_daemon: bool,
     },
     /// Check that Boomux's dependencies and daemon are available
     Doctor,
@@ -544,6 +552,40 @@ enum Commands {
         expected_executable: String,
         expected_socket_device: u64,
         expected_socket_inode: u64,
+    },
+}
+
+#[derive(Subcommand)]
+enum WebCommands {
+    /// Start the web dashboard as a detached background process
+    Start {
+        /// Loopback port for the HTTP server
+        #[arg(long, default_value_t = 3737, value_parser = clap::value_parser!(u16).range(1..))]
+        port: u16,
+        /// Public base URL of an authenticated OpenCode Web server
+        #[arg(long, value_name = "URL")]
+        opencode_web_url: Option<String>,
+        /// Loopback port for the managed OpenCode Web server
+        #[arg(long, default_value_t = 4097, value_parser = clap::value_parser!(u16).range(1..))]
+        opencode_web_port: u16,
+        /// Do not start or advertise OpenCode Web
+        #[arg(long, conflicts_with = "opencode_web_url")]
+        no_opencode_web: bool,
+        /// Expose the dashboard and OpenCode Web to the current Tailscale tailnet
+        #[arg(long, conflicts_with = "opencode_web_url")]
+        tailscale: bool,
+    },
+    /// Report web dashboard state without starting it
+    Status {
+        /// Loopback port of the web dashboard
+        #[arg(long, default_value_t = 3737, value_parser = clap::value_parser!(u16).range(1..))]
+        port: u16,
+    },
+    /// Stop the web dashboard without stopping the daemon
+    Stop {
+        /// Loopback port of the web dashboard
+        #[arg(long, default_value_t = 3737, value_parser = clap::value_parser!(u16).range(1..))]
+        port: u16,
     },
 }
 
@@ -1326,6 +1368,9 @@ macro_rules! command_keys {
 command_keys! {
     Ui => ("ui", HumanOnly),
     Web => ("web", HumanOnly),
+    WebStart => ("web.start", Json),
+    WebStatus => ("web.status", Json),
+    WebStop => ("web.stop", Json),
     Doctor => ("doctor", HumanOnly),
     Capabilities => ("capabilities", Json),
     List => ("list", Json),
@@ -1404,6 +1449,18 @@ impl Cli {
 
     fn command_key(&self) -> CommandKey {
         match self.command.as_ref() {
+            Some(Commands::Web {
+                command: Some(WebCommands::Start { .. }),
+                ..
+            }) => CommandKey::WebStart,
+            Some(Commands::Web {
+                command: Some(WebCommands::Status { .. }),
+                ..
+            }) => CommandKey::WebStatus,
+            Some(Commands::Web {
+                command: Some(WebCommands::Stop { .. }),
+                ..
+            }) => CommandKey::WebStop,
             Some(Commands::Web { .. }) => CommandKey::Web,
             Some(Commands::Capabilities) => CommandKey::Capabilities,
             Some(Commands::List) => CommandKey::List,
@@ -1754,17 +1811,68 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             return Ok(CliExit::Success);
         }
         Some(Commands::Web {
+            command: None,
             port,
             opencode_web_url,
             opencode_web_port,
             no_opencode_web,
+            tailscale,
+            require_running_daemon,
         }) => {
             mobile_web::run(
                 *port,
                 opencode_web_url.as_deref(),
                 *opencode_web_port,
                 *no_opencode_web,
+                *tailscale,
+                *require_running_daemon,
             )?;
+            return Ok(CliExit::Success);
+        }
+        Some(Commands::Web {
+            command:
+                Some(WebCommands::Start {
+                    port,
+                    opencode_web_url,
+                    opencode_web_port,
+                    no_opencode_web,
+                    tailscale,
+                }),
+            ..
+        }) => {
+            web_start(
+                *port,
+                opencode_web_url.as_deref(),
+                *opencode_web_port,
+                *no_opencode_web,
+                *tailscale,
+                cli.json,
+            )?;
+            return Ok(CliExit::Success);
+        }
+        Some(Commands::Web {
+            command: Some(WebCommands::Status { port }),
+            ..
+        }) => {
+            web_status(*port, cli.json)?;
+            return Ok(CliExit::Success);
+        }
+        Some(Commands::Web {
+            command: Some(WebCommands::Stop { port }),
+            ..
+        }) => {
+            let stopped = mobile_web::stop(*port)?;
+            tailscale_serve::cleanup_stale(*port)?;
+            if cli.json {
+                print_json(
+                    CommandKey::WebStop,
+                    serde_json::json!({ "running": false, "changed": stopped, "port": port }),
+                )?;
+            } else if stopped {
+                println!("Stopped Boomux web on port {port}");
+            } else {
+                println!("Boomux web is not running on port {port}");
+            }
             return Ok(CliExit::Success);
         }
         Some(Commands::Attach {
@@ -2694,6 +2802,155 @@ fn validate_rekey_confirmation(expected: &str, confirmation: &str) -> io::Result
             "Node rekey confirmation did not match the current Node ID",
         ))
     }
+}
+
+fn web_status(port: u16, json: bool) -> Result<(), Box<dyn Error>> {
+    let status = mobile_web::status(port)?;
+    if json {
+        print_json(
+            CommandKey::WebStatus,
+            status.map_or_else(
+                || serde_json::json!({ "running": false, "port": port }),
+                |status| serde_json::to_value(status).expect("web status serializes"),
+            ),
+        )?;
+    } else if let Some(status) = status {
+        println!("running ({})", status.dashboard_url);
+        if let Some(url) = status.opencode_url {
+            println!("OpenCode Web: {url}");
+        }
+    } else {
+        println!("not running (port {port})");
+    }
+    Ok(())
+}
+
+fn web_start(
+    port: u16,
+    opencode_web_url: Option<&str>,
+    opencode_web_port: u16,
+    no_opencode_web: bool,
+    tailscale: bool,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    let requested_opencode_port = (!no_opencode_web).then_some(opencode_web_port);
+    if let Some(status) = mobile_web::status(port)? {
+        let expected_opencode_url = requested_opencode_port.and_then(|runtime_port| {
+            if tailscale {
+                None
+            } else {
+                Some(opencode_web_url.map_or_else(
+                    || format!("http://127.0.0.1:{runtime_port}"),
+                    |url| url.trim().trim_end_matches('/').to_owned(),
+                ))
+            }
+        });
+        if status.tailscale != tailscale
+            || status.opencode_port != requested_opencode_port
+            || expected_opencode_url
+                .as_deref()
+                .is_some_and(|expected| status.opencode_url.as_deref() != Some(expected))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::AddrInUse,
+                format!("Boomux web is already running with different options on port {port}"),
+            )
+            .into());
+        }
+        return print_web_start(status, false, json);
+    }
+
+    let daemon = client::connect()?;
+    daemon.ping()?;
+    let executable = env::current_exe()?;
+    let socket = client::socket_path()?;
+    let runtime = socket
+        .parent()
+        .ok_or_else(|| io::Error::other("Boomux daemon socket has no runtime directory"))?;
+    let log_path = runtime.join(format!("web-{port}.log"));
+    let log = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(&log_path)?;
+    let metadata = log.metadata()?;
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Boomux web log is not an owner-controlled regular file",
+        )
+        .into());
+    }
+    let stderr = log.try_clone()?;
+    let mut command = Command::new(executable);
+    command
+        .args(["web", "--port", &port.to_string()])
+        .args(["--opencode-web-port", &opencode_web_port.to_string()])
+        .arg("--require-running-daemon")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(stderr));
+    if let Some(url) = opencode_web_url {
+        command.args(["--opencode-web-url", url]);
+    }
+    if no_opencode_web {
+        command.arg("--no-opencode-web");
+    }
+    if tailscale {
+        command.arg("--tailscale");
+    }
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command.spawn()?;
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(15) {
+        if let Some(status) = mobile_web::status(port)? {
+            return print_web_start(status, true, json);
+        }
+        if let Some(exit) = child.try_wait()? {
+            return Err(io::Error::other(format!(
+                "Boomux web exited before becoming ready ({exit}); inspect {}",
+                log_path.display()
+            ))
+            .into());
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!(
+            "Boomux web did not become ready; inspect {}",
+            log_path.display()
+        ),
+    )
+    .into())
+}
+
+fn print_web_start(
+    status: mobile_web::WebStatus,
+    changed: bool,
+    json: bool,
+) -> Result<(), Box<dyn Error>> {
+    if json {
+        let mut value = serde_json::to_value(&status)?;
+        value["changed"] = serde_json::json!(changed);
+        print_json(CommandKey::WebStart, value)?;
+    } else if changed {
+        println!("Started Boomux web: {}", status.dashboard_url);
+    } else {
+        println!("Boomux web is already running: {}", status.dashboard_url);
+    }
+    Ok(())
 }
 
 fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Error>> {
@@ -11912,6 +12169,63 @@ mod tests {
     }
 
     #[test]
+    fn parses_web_serve_and_targeted_stop() {
+        let serve =
+            Cli::try_parse_from(["boomux", "web", "--port", "4040", "--tailscale"]).unwrap();
+        assert!(matches!(
+            serve.command,
+            Some(Commands::Web {
+                command: None,
+                port: 4040,
+                tailscale: true,
+                ..
+            })
+        ));
+        assert!(
+            Cli::try_parse_from([
+                "boomux",
+                "web",
+                "--tailscale",
+                "--opencode-web-url",
+                "https://example.test"
+            ])
+            .is_err()
+        );
+
+        let stop = Cli::try_parse_from(["boomux", "web", "stop", "--port", "4040"]).unwrap();
+        assert!(matches!(
+            stop.command,
+            Some(Commands::Web {
+                command: Some(WebCommands::Stop { port: 4040 }),
+                ..
+            })
+        ));
+        let start =
+            Cli::try_parse_from(["boomux", "web", "start", "--port", "4040", "--tailscale"])
+                .unwrap();
+        assert!(matches!(
+            start.command,
+            Some(Commands::Web {
+                command: Some(WebCommands::Start {
+                    port: 4040,
+                    tailscale: true,
+                    ..
+                }),
+                ..
+            })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "web", "status", "--port", "4040"])
+                .unwrap()
+                .command,
+            Some(Commands::Web {
+                command: Some(WebCommands::Status { port: 4040 }),
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn dashboard_requires_terminal_input_and_output() {
         validate_dashboard_terminal(true, true).unwrap();
         assert_eq!(
@@ -14761,6 +15075,9 @@ mod tests {
         assert_eq!(
             json_commands().collect::<Vec<_>>(),
             [
+                "web.start",
+                "web.status",
+                "web.stop",
                 "capabilities",
                 "list",
                 "shells",

--- a/src/mobile_web.rs
+++ b/src/mobile_web.rs
@@ -1,13 +1,18 @@
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
+use std::fs;
+use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::body::Body;
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::http::header::{
     CACHE_CONTROL, CONTENT_SECURITY_POLICY, CONTENT_TYPE, HeaderValue, REFERRER_POLICY,
     X_CONTENT_TYPE_OPTIONS,
@@ -23,11 +28,16 @@ use boomux::protocol::{
     NodeProjectionHealthCode, OpenCodeSessionClaimSnapshot, OpenCodeSharedRuntimeSnapshot,
     ShellOwner,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use tokio::net::UnixListener;
 
-const TERMINAL_OUTPUT_BYTES: usize = 256 * 1024;
 const PROJECTION_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const PROJECTION_STOP_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const WEB_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+const WEB_STOP_REQUEST: &[u8] = b"boomux-web-stop-v1\n";
+const WEB_STOP_ACK: &[u8] = b"boomux-web-stopping-v1\n";
+const WEB_STATUS_REQUEST: &[u8] = b"boomux-web-status-v1\n";
+const MAX_WEB_CONTROL_RESPONSE: u64 = 16 * 1024;
 const INDEX_HTML: &str = include_str!("../assets/mobile-web/index.html");
 const APP_JS: &str = include_str!("../assets/mobile-web/app.js");
 const STYLES_CSS: &str = include_str!("../assets/mobile-web/styles.css");
@@ -53,6 +63,76 @@ struct OpenCodeRuntimeHint {
 struct OpenCodeWebConfiguration {
     public_url: Option<String>,
     runtime_port: Option<u16>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct WebStatus {
+    pub(crate) running: bool,
+    pub(crate) port: u16,
+    pub(crate) tailscale: bool,
+    pub(crate) dashboard_url: String,
+    pub(crate) opencode_port: Option<u16>,
+    pub(crate) opencode_url: Option<String>,
+}
+
+struct WebControlSocket {
+    listener: Arc<UnixListener>,
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+}
+
+impl WebControlSocket {
+    fn bind(port: u16) -> io::Result<Self> {
+        let path = web_control_socket_path(port)?;
+        if let Ok(metadata) = fs::symlink_metadata(&path) {
+            if !metadata.file_type().is_socket() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!("web control path is not a socket: {}", path.display()),
+                ));
+            }
+            match UnixStream::connect(&path) {
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AddrInUse,
+                        format!("Boomux web is already running on port {port}"),
+                    ));
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::ConnectionRefused | io::ErrorKind::NotFound
+                    ) =>
+                {
+                    fs::remove_file(&path)?;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        let listener = UnixListener::bind(&path)?;
+        let metadata = fs::symlink_metadata(&path)?;
+        Ok(Self {
+            listener: Arc::new(listener),
+            path,
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        })
+    }
+}
+
+impl Drop for WebControlSocket {
+    fn drop(&mut self) {
+        let Ok(metadata) = fs::symlink_metadata(&self.path) else {
+            return;
+        };
+        if metadata.file_type().is_socket()
+            && metadata.dev() == self.device
+            && metadata.ino() == self.inode
+        {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
 }
 
 #[derive(Default)]
@@ -94,6 +174,8 @@ struct AgentCard {
     ended_at_ms: Option<u64>,
     attention: Option<AttentionView>,
     just_completed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    native_web: Option<NativeWebHandoff>,
     #[serde(skip)]
     schedule_owned: bool,
 }
@@ -116,27 +198,7 @@ struct MobileSnapshot {
     agents: Vec<AgentCard>,
 }
 
-#[derive(Debug, Serialize)]
-struct TimelineEntry {
-    kind: &'static str,
-    at_ms: u64,
-    title: String,
-    body: String,
-    tone: &'static str,
-}
-
-#[derive(Debug, Serialize)]
-struct AgentDetail {
-    agent: AgentCard,
-    timeline: Vec<TimelineEntry>,
-    native_web: Option<NativeWebHandoff>,
-    native_web_notice: String,
-    terminal_output: Option<String>,
-    terminal_available: bool,
-    notice: &'static str,
-}
-
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct NativeWebHandoff {
     integration: &'static str,
     label: &'static str,
@@ -172,14 +234,6 @@ impl ApiError {
             message: "Boomux could not refresh Agent state",
         }
     }
-
-    fn not_found() -> Self {
-        Self {
-            status: StatusCode::NOT_FOUND,
-            code: "agent_not_found",
-            message: "The qualified Agent is no longer available",
-        }
-    }
 }
 
 impl IntoResponse for ApiError {
@@ -206,28 +260,127 @@ pub(crate) fn run(
     opencode_web_url: Option<&str>,
     opencode_web_port: u16,
     no_opencode_web: bool,
+    tailscale: bool,
+    require_running_daemon: bool,
 ) -> Result<(), Box<dyn Error>> {
     let configuration =
         opencode_web_configuration(port, opencode_web_url, opencode_web_port, no_opencode_web)?;
-    let client = client::connect_or_start()?;
+    let client = if require_running_daemon {
+        client::connect()?
+    } else {
+        client::connect_or_start()?
+    };
     let opencode_runtime = configuration
         .runtime_port
         .map(|port| client.ensure_opencode_shared_runtime(port))
         .transpose()?;
+    let opencode_web_url = configuration.public_url.map(Arc::from);
+    let opencode_runtime_hint = opencode_runtime.map(|runtime| OpenCodeRuntimeHint {
+        generation_id: Arc::from(runtime.generation_id),
+        port: runtime.port,
+    });
+    let combined = client.combined_node_snapshot(None)?;
+    let native_web = project_native_web_handoffs(
+        &client,
+        &combined,
+        opencode_web_url.as_deref(),
+        opencode_runtime_hint.as_ref(),
+    );
     let mut presentation = PresentationState::default();
-    presentation.update(client.combined_node_snapshot(None)?);
+    presentation.update(combined, native_web);
     let state = AppState {
         client,
         presentation: Arc::new(Mutex::new(presentation)),
-        opencode_web_url: configuration.public_url.map(Arc::from),
-        opencode_runtime_hint: opencode_runtime.map(|runtime| OpenCodeRuntimeHint {
-            generation_id: Arc::from(runtime.generation_id),
-            port: runtime.port,
-        }),
+        opencode_web_url,
+        opencode_runtime_hint,
     };
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
     let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(serve(address, state))
+    runtime.block_on(serve(address, state, tailscale))
+}
+
+pub(crate) fn stop(port: u16) -> Result<bool, Box<dyn Error>> {
+    stop_control_socket(&web_control_socket_path(port)?).map_err(Into::into)
+}
+
+pub(crate) fn status(port: u16) -> Result<Option<WebStatus>, Box<dyn Error>> {
+    status_control_socket(&web_control_socket_path(port)?).map_err(Into::into)
+}
+
+fn status_control_socket(path: &Path) -> io::Result<Option<WebStatus>> {
+    let mut stream = match UnixStream::connect(path) {
+        Ok(stream) => stream,
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+            ) =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
+    };
+    stream.set_read_timeout(Some(WEB_STOP_TIMEOUT))?;
+    stream.set_write_timeout(Some(WEB_STOP_TIMEOUT))?;
+    stream.write_all(WEB_STATUS_REQUEST)?;
+    let mut response = Vec::new();
+    stream
+        .take(MAX_WEB_CONTROL_RESPONSE)
+        .read_to_end(&mut response)?;
+    if response.len() as u64 == MAX_WEB_CONTROL_RESPONSE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux web status response exceeded its bound",
+        ));
+    }
+    serde_json::from_slice(&response)
+        .map(Some)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+fn web_control_socket_path(port: u16) -> io::Result<PathBuf> {
+    client::socket_path()?
+        .parent()
+        .map(|directory| directory.join(format!("web-{port}.sock")))
+        .ok_or_else(|| io::Error::other("Boomux daemon socket has no runtime directory"))
+}
+
+fn stop_control_socket(path: &Path) -> io::Result<bool> {
+    let mut stream = match UnixStream::connect(path) {
+        Ok(stream) => stream,
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+            ) =>
+        {
+            return Ok(false);
+        }
+        Err(error) => return Err(error),
+    };
+    stream.set_read_timeout(Some(WEB_STOP_TIMEOUT))?;
+    stream.set_write_timeout(Some(WEB_STOP_TIMEOUT))?;
+    stream.write_all(WEB_STOP_REQUEST)?;
+    let mut acknowledgement = vec![0; WEB_STOP_ACK.len()];
+    stream.read_exact(&mut acknowledgement)?;
+    if acknowledgement != WEB_STOP_ACK {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Boomux web returned an invalid stop acknowledgement",
+        ));
+    }
+    let started = std::time::Instant::now();
+    while started.elapsed() < WEB_STOP_TIMEOUT {
+        match fs::symlink_metadata(path) {
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(true),
+            Err(error) => return Err(error),
+            Ok(_) => thread::sleep(PROJECTION_STOP_POLL_INTERVAL),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        "Boomux web did not stop before the timeout",
+    ))
 }
 
 fn opencode_web_configuration(
@@ -246,15 +399,66 @@ fn opencode_web_configuration(
     })
 }
 
-async fn serve(address: SocketAddr, state: AppState) -> Result<(), Box<dyn Error>> {
+async fn serve(
+    address: SocketAddr,
+    state: AppState,
+    tailscale: bool,
+) -> Result<(), Box<dyn Error>> {
     let listener = tokio::net::TcpListener::bind(address).await?;
+    let control = WebControlSocket::bind(address.port())?;
+    let tailscale_exposure = tailscale
+        .then(|| {
+            crate::tailscale_serve::Exposure::enable(
+                address.port(),
+                state
+                    .opencode_runtime_hint
+                    .as_ref()
+                    .map(|runtime| runtime.port),
+            )
+        })
+        .transpose()?;
+    let web_status = Arc::new(WebStatus {
+        running: true,
+        port: address.port(),
+        tailscale,
+        dashboard_url: tailscale_exposure.as_ref().map_or_else(
+            || format!("http://{address}"),
+            crate::tailscale_serve::Exposure::dashboard_url,
+        ),
+        opencode_port: state
+            .opencode_runtime_hint
+            .as_ref()
+            .map(|runtime| runtime.port),
+        opencode_url: state.opencode_runtime_hint.as_ref().map(|runtime| {
+            tailscale_exposure.as_ref().map_or_else(
+                || {
+                    state.opencode_web_url.as_deref().map_or_else(
+                        || format!("http://127.0.0.1:{}", runtime.port),
+                        ToOwned::to_owned,
+                    )
+                },
+                |exposure| exposure.opencode_url(runtime.port),
+            )
+        }),
+    });
     let stopping = Arc::new(AtomicBool::new(false));
     let worker = spawn_projection_worker(
         state.client.clone(),
         Arc::clone(&state.presentation),
+        state.opencode_web_url.clone(),
+        state.opencode_runtime_hint.clone(),
         Arc::clone(&stopping),
     )?;
     println!("Boomux mobile dashboard: http://{address}");
+    if let Some(exposure) = &tailscale_exposure {
+        println!("Boomux tailnet dashboard: {}", exposure.dashboard_url());
+        if let Some(runtime) = &state.opencode_runtime_hint {
+            println!(
+                "OpenCode tailnet handoff: {}",
+                exposure.opencode_url(runtime.port)
+            );
+        }
+    }
     if let Some(url) = state.opencode_web_url.as_deref() {
         println!("OpenCode shared runtime public handoff: {url}");
     } else if let Some(runtime) = &state.opencode_runtime_hint {
@@ -274,14 +478,13 @@ async fn serve(address: SocketAddr, state: AppState) -> Result<(), Box<dyn Error
         .route("/icon-192.png", get(icon_192))
         .route("/icon-512.png", get(icon_512))
         .route("/api/snapshot", get(snapshot))
-        .route("/api/agents/{node_id}/{agent_id}", get(agent_detail))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             security_headers,
         ))
         .with_state(state);
     let result = axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(shutdown_signal(Arc::clone(&control.listener), web_status))
         .await;
     stopping.store(true, Ordering::Release);
     worker
@@ -294,6 +497,8 @@ async fn serve(address: SocketAddr, state: AppState) -> Result<(), Box<dyn Error
 fn spawn_projection_worker(
     client: Client,
     presentation: Arc<Mutex<PresentationState>>,
+    opencode_web_url: Option<Arc<str>>,
+    opencode_runtime_hint: Option<OpenCodeRuntimeHint>,
     stopping: Arc<AtomicBool>,
 ) -> Result<thread::JoinHandle<()>, Box<dyn Error>> {
     Ok(thread::Builder::new()
@@ -301,10 +506,18 @@ fn spawn_projection_worker(
         .spawn(move || {
             while !stopping.load(Ordering::Acquire) {
                 match client.combined_node_snapshot(None) {
-                    Ok(combined) => match presentation.lock() {
-                        Ok(mut state) => state.update(combined),
-                        Err(_) => return,
-                    },
+                    Ok(combined) => {
+                        let native_web = project_native_web_handoffs(
+                            &client,
+                            &combined,
+                            opencode_web_url.as_deref(),
+                            opencode_runtime_hint.as_ref(),
+                        );
+                        match presentation.lock() {
+                            Ok(mut state) => state.update(combined, native_web),
+                            Err(_) => return,
+                        }
+                    }
                     Err(error) => match presentation.lock() {
                         Ok(mut state) => {
                             if state.mark_disconnected() {
@@ -327,7 +540,7 @@ fn spawn_projection_worker(
         })?)
 }
 
-async fn shutdown_signal() {
+async fn shutdown_signal(control: Arc<UnixListener>, status: Arc<WebStatus>) {
     let interrupt = async {
         let _ = tokio::signal::ctrl_c().await;
     };
@@ -342,9 +555,56 @@ async fn shutdown_signal() {
     };
     #[cfg(not(unix))]
     let terminate = std::future::pending::<()>();
+    let stop = async move {
+        loop {
+            let Ok((stream, _)) = control.accept().await else {
+                continue;
+            };
+            let mut request = vec![0; WEB_STOP_REQUEST.len().max(WEB_STATUS_REQUEST.len())];
+            let mut received = 0;
+            while received < request.len() && stream.readable().await.is_ok() {
+                match stream.try_read(&mut request[received..]) {
+                    Ok(0) => break,
+                    Ok(count) => {
+                        received += count;
+                        if request[..received].ends_with(b"\n") {
+                            break;
+                        }
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+                    Err(_) => break,
+                }
+            }
+            let request = &request[..received];
+            if request == WEB_STATUS_REQUEST {
+                if let Ok(response) = serde_json::to_vec(status.as_ref()) {
+                    write_control_response(&stream, &response).await;
+                }
+                continue;
+            }
+            if request != WEB_STOP_REQUEST {
+                continue;
+            }
+            write_control_response(&stream, WEB_STOP_ACK).await;
+            return;
+        }
+    };
     tokio::select! {
         _ = interrupt => {},
         _ = terminate => {},
+        _ = stop => {},
+    }
+}
+
+async fn write_control_response(stream: &tokio::net::UnixStream, response: &[u8]) {
+    let mut written = 0;
+    while written < response.len() && stream.writable().await.is_ok() {
+        match stream.try_write(&response[written..]) {
+            Ok(0) => break,
+            Ok(count) => written += count,
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+            Err(_) => break,
+        }
     }
 }
 
@@ -521,44 +781,6 @@ async fn snapshot(State(state): State<AppState>) -> Result<Response, ApiError> {
     Ok(response)
 }
 
-async fn agent_detail(
-    State(state): State<AppState>,
-    Path((node_id, agent_id)): Path<(String, String)>,
-) -> Result<Response, ApiError> {
-    if uuid::Uuid::parse_str(&node_id).is_err() || uuid::Uuid::parse_str(&agent_id).is_err() {
-        return Err(ApiError::not_found());
-    }
-    let client = state.client.clone();
-    let opencode_web_url = state.opencode_web_url.clone();
-    let opencode_runtime_hint = state.opencode_runtime_hint.clone();
-    let mut detail = tokio::task::spawn_blocking(move || {
-        let combined = client
-            .combined_node_snapshot(None)
-            .map_err(|_| ApiError::daemon())?;
-        build_agent_detail(
-            &client,
-            &combined,
-            &node_id,
-            &agent_id,
-            opencode_web_url.as_deref(),
-            opencode_runtime_hint.as_ref(),
-        )
-    })
-    .await
-    .map_err(|_| ApiError::daemon())??;
-    detail.agent.just_completed = state
-        .presentation
-        .lock()
-        .map_err(|_| ApiError::daemon())?
-        .completed_agents
-        .contains(&(detail.agent.node_id.clone(), detail.agent.agent_id.clone()));
-    let mut response = Json(detail).into_response();
-    response
-        .headers_mut()
-        .insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
-    Ok(response)
-}
-
 fn project_snapshot(combined: CombinedNodeSnapshot, viewer: Option<String>) -> MobileSnapshot {
     let stale_nodes = combined.nodes.iter().filter(|node| node.stale).count();
     let mut agents = project_visible_agents(&combined);
@@ -595,12 +817,17 @@ fn project_snapshot(combined: CombinedNodeSnapshot, viewer: Option<String>) -> M
 }
 
 impl PresentationState {
-    fn update(&mut self, combined: CombinedNodeSnapshot) {
+    fn update(
+        &mut self,
+        combined: CombinedNodeSnapshot,
+        mut native_web: HashMap<(String, String), NativeWebHandoff>,
+    ) {
         let mut snapshot = project_snapshot(combined, None);
         let mut next_states = HashMap::new();
         let mut next_completed = HashSet::new();
         for agent in &mut snapshot.agents {
             let key = (agent.node_id.clone(), agent.agent_id.clone());
+            agent.native_web = native_web.remove(&key);
             next_states.insert(key.clone(), agent.state);
             let retained = self.completed_agents.contains(&key)
                 && agent.node_local
@@ -636,6 +863,9 @@ impl PresentationState {
             .is_some_and(|snapshot| snapshot.daemon_connected);
         if let Some(snapshot) = &mut self.snapshot {
             snapshot.daemon_connected = false;
+            for agent in &mut snapshot.agents {
+                agent.native_web = None;
+            }
         }
         was_connected
     }
@@ -704,6 +934,7 @@ fn project_agents(combined: &CombinedNodeSnapshot) -> Vec<AgentCard> {
                             observed_at_ms: attention.observation.observed_at_ms,
                         }),
                         just_completed: false,
+                        native_web: None,
                         schedule_owned: schedule_owned
                             .get(agent.shell_id.as_str())
                             .copied()
@@ -779,6 +1010,7 @@ fn project_agents(combined: &CombinedNodeSnapshot) -> Vec<AgentCard> {
                         observed_at_ms: attention.observed_at_ms,
                     }),
                     just_completed: false,
+                    native_web: None,
                     schedule_owned: schedule_owned
                         .get(agent.shell_id.as_str())
                         .copied()
@@ -841,156 +1073,78 @@ fn project_visible_agents(combined: &CombinedNodeSnapshot) -> Vec<AgentCard> {
         .collect()
 }
 
-fn build_agent_detail(
+fn project_native_web_handoffs(
     client: &Client,
     combined: &CombinedNodeSnapshot,
-    node_id: &str,
-    agent_id: &str,
     opencode_web_url: Option<&str>,
     opencode_runtime_hint: Option<&OpenCodeRuntimeHint>,
-) -> Result<AgentDetail, ApiError> {
-    // Runtime state is deliberately fetched for every detail. The startup value
-    // is only a generation hint and cannot authorize a stale browser link.
-    let current_opencode_runtime = client.get_opencode_shared_runtime().ok().flatten();
-    let agent = project_visible_agents(combined)
-        .into_iter()
-        .find(|agent| agent.node_id == node_id && agent.agent_id == agent_id)
-        .ok_or_else(ApiError::not_found)?;
-    let mut timeline = Vec::new();
-    let local_agent = combined
-        .nodes
-        .iter()
-        .find(|node| node.node_id == agent.node_id)
-        .and_then(|node| node.local_snapshot.as_ref())
-        .and_then(|snapshot| {
-            snapshot
-                .workspaces
-                .iter()
-                .flat_map(|workspace| &workspace.agents)
-                .find(|candidate| candidate.id == agent_id)
+) -> HashMap<(String, String), NativeWebHandoff> {
+    let Some(runtime_hint) = opencode_runtime_hint else {
+        return HashMap::new();
+    };
+    // The startup value is only a generation hint and cannot authorize a stale link.
+    let Some(runtime) = client
+        .get_opencode_shared_runtime()
+        .ok()
+        .flatten()
+        .filter(|runtime| {
+            runtime.generation_id.as_str() == runtime_hint.generation_id.as_ref()
+                && runtime.port == runtime_hint.port
         })
-        .cloned();
-    let evidence = local_agent
-        .as_ref()
-        .map(|candidate| candidate.observation.evidence.clone());
-    timeline.push(TimelineEntry {
-        kind: "status",
-        at_ms: agent.observed_at_ms,
-        title: format!("Agent is {}", state_label(agent.state)),
-        body: evidence.unwrap_or_else(|| {
-            if agent.node_local {
-                "Lifecycle observation has no displayable evidence.".into()
-            } else {
-                "Reduced remote projection; lifecycle evidence remains on the owning Node.".into()
-            }
-        }),
-        tone: state_tone(agent.state),
-    });
-    if let Some(attention) = &agent.attention {
-        timeline.push(TimelineEntry {
-            kind: "attention",
-            at_ms: attention.observed_at_ms,
-            title: match attention.reason {
-                AgentAttentionReason::Blocked => "Needs attention".into(),
-                AgentAttentionReason::Completed => "Completed work".into(),
-            },
-            body: "This durable attention remains until it is explicitly acknowledged.".into(),
-            tone: match attention.reason {
-                AgentAttentionReason::Blocked => "blocked",
-                AgentAttentionReason::Completed => "done",
-            },
-        });
-    }
-    timeline.sort_by_key(|entry| entry.at_ms);
-
-    let (native_web, native_web_notice) = if !agent.node_local {
-        (
-            None,
-            "Native Session links remain on the owning Node and are not stored in remote projections."
-                .into(),
-        )
-    } else if agent.integration != "opencode" {
-        (
-            None,
-            format!(
-                "Native web handoff is not configured for {} Agents.",
-                agent.integration
-            ),
-        )
-    } else if let Some(runtime_hint) = opencode_runtime_hint {
-        if let Some((directory, external_session_id)) = local_agent
-            .as_ref()
-            .and_then(|agent| Some((agent.cwd.as_deref()?, agent.external_session_id.as_deref()?)))
-        {
-            let Some(runtime) = current_opencode_runtime.as_ref().filter(|runtime| {
-                runtime.generation_id.as_str() == runtime_hint.generation_id.as_ref()
-                    && runtime.port == runtime_hint.port
-            }) else {
-                return Ok(agent_detail_without_native_web(
-                    client,
-                    combined,
-                    agent,
-                    timeline,
-                    "The daemon-owned OpenCode shared runtime is unavailable or has been replaced.",
-                ));
-            };
-            let claim = client
-                .resolve_opencode_session_claim(runtime.generation_id.clone(), external_session_id);
-            if !claim.is_ok_and(|(claim, resolved_agent)| {
-                opencode_claim_matches_agent(
-                    runtime_hint,
-                    runtime,
-                    external_session_id,
-                    Some((&claim, &resolved_agent)),
-                    &agent,
-                )
-            }) {
-                (
-                    None,
-                    "This Session is not claimed by the shared runtime. The desktop TUI must be running through a Boomux-managed bare `opencode` launch."
-                        .into(),
-                )
-            } else {
-                match directory.to_str() {
-                Some(directory) => (
-                    Some(opencode_handoff(
-                        opencode_web_url,
-                        opencode_web_url.is_none().then_some(runtime.port),
-                        directory,
-                        external_session_id,
-                    )),
-                    "Open this Session to continue chatting, review tool activity, and respond to OpenCode prompts."
-                        .into(),
-                ),
-                None => (
-                    None,
-                    "This OpenCode Session's working directory cannot be represented in a browser URL."
-                        .into(),
-                ),
-                }
-            }
-        } else {
-            (
-                None,
-                "This Agent has no retained canonical OpenCode Session identity and working directory."
-                    .into(),
-            )
-        }
-    } else {
-        (
-            None,
-            "Native OpenCode Session handoff is disabled for this dashboard.".into(),
-        )
+    else {
+        return HashMap::new();
     };
 
-    Ok(agent_detail_with_terminal(
-        client,
-        combined,
-        agent,
-        timeline,
-        native_web,
-        native_web_notice,
-    ))
+    let mut handoffs = HashMap::new();
+    for agent in project_visible_agents(combined)
+        .into_iter()
+        .filter(|agent| agent.node_local && agent.integration == "opencode")
+    {
+        let Some(local_agent) = combined
+            .nodes
+            .iter()
+            .find(|node| node.node_id == agent.node_id)
+            .and_then(|node| node.local_snapshot.as_ref())
+            .and_then(|snapshot| {
+                snapshot
+                    .workspaces
+                    .iter()
+                    .flat_map(|workspace| &workspace.agents)
+                    .find(|candidate| candidate.id == agent.agent_id)
+            })
+        else {
+            continue;
+        };
+        let Some(directory) = local_agent.cwd.as_deref().and_then(|path| path.to_str()) else {
+            continue;
+        };
+        let Some(external_session_id) = local_agent.external_session_id.as_deref() else {
+            continue;
+        };
+        let resolved = client
+            .resolve_opencode_session_claim(runtime.generation_id.clone(), external_session_id);
+        if !resolved.is_ok_and(|(claim, resolved_agent)| {
+            opencode_claim_matches_agent(
+                runtime_hint,
+                &runtime,
+                external_session_id,
+                Some((&claim, &resolved_agent)),
+                &agent,
+            )
+        }) {
+            continue;
+        }
+        handoffs.insert(
+            (agent.node_id, agent.agent_id),
+            opencode_handoff(
+                opencode_web_url,
+                opencode_web_url.is_none().then_some(runtime.port),
+                directory,
+                external_session_id,
+            ),
+        );
+    }
+    handoffs
 }
 
 fn opencode_claim_matches_agent(
@@ -1015,91 +1169,6 @@ fn opencode_claim_matches_agent(
         && resolved_agent.run_id == agent.run_id
 }
 
-fn agent_detail_without_native_web(
-    client: &Client,
-    combined: &CombinedNodeSnapshot,
-    agent: AgentCard,
-    timeline: Vec<TimelineEntry>,
-    native_web_notice: &str,
-) -> AgentDetail {
-    agent_detail_with_terminal(
-        client,
-        combined,
-        agent,
-        timeline,
-        None,
-        native_web_notice.into(),
-    )
-}
-
-fn agent_detail_with_terminal(
-    client: &Client,
-    combined: &CombinedNodeSnapshot,
-    agent: AgentCard,
-    timeline: Vec<TimelineEntry>,
-    native_web: Option<NativeWebHandoff>,
-    native_web_notice: String,
-) -> AgentDetail {
-    let current_run = combined
-        .nodes
-        .iter()
-        .find(|node| node.node_id == agent.node_id)
-        .and_then(|node| node.local_snapshot.as_ref())
-        .and_then(|snapshot| {
-            snapshot
-                .workspaces
-                .iter()
-                .flat_map(|workspace| &workspace.shells)
-                .find(|shell| shell.id == agent.shell_id)
-        })
-        .and_then(|shell| shell.run.as_ref())
-        .is_some_and(|run| run.id == agent.run_id);
-    let (terminal_output, terminal_read_failed) = if agent.node_local && current_run {
-        match client.read_shell_at(
-            agent.shell_id.clone(),
-            TERMINAL_OUTPUT_BYTES,
-            Some(agent.run_id.clone()),
-            Some(0),
-            0,
-        ) {
-            Ok(output) => (
-                Some(String::from_utf8_lossy(&output.bytes).into_owned()),
-                false,
-            ),
-            Err(error) => {
-                eprintln!(
-                    "boomux: mobile terminal read failed for Agent {} on Shell {}: {error}",
-                    agent.agent_id, agent.shell_id
-                );
-                (None, true)
-            }
-        }
-    } else {
-        (None, false)
-    };
-    let terminal_available = terminal_output.is_some();
-    let notice = if terminal_available {
-        "Rendered Shell output is a bounded terminal view, not a structured conversation transcript."
-    } else if terminal_read_failed {
-        "The exact run-scoped terminal read failed. Refresh after checking the Boomux server log."
-    } else if current_run {
-        "Rendered terminal output is currently unavailable for this local Shell run."
-    } else if agent.node_local {
-        "The Agent's exact Shell run is no longer current, so Boomux will not substitute output from a later run."
-    } else {
-        "Remote cached projections do not contain terminal output; the owning Node remains authoritative."
-    };
-    AgentDetail {
-        agent,
-        timeline,
-        native_web,
-        native_web_notice,
-        terminal_output,
-        terminal_available,
-        notice,
-    }
-}
-
 fn agent_priority(agent: &AgentCard) -> u8 {
     if agent.just_completed {
         return 1;
@@ -1116,26 +1185,6 @@ fn agent_priority(agent: &AgentCard) -> u8 {
             AgentState::Inactive => 6,
             AgentState::Done => 7,
         },
-    }
-}
-
-fn state_label(state: AgentState) -> &'static str {
-    match state {
-        AgentState::Unknown => "unknown",
-        AgentState::Working => "working",
-        AgentState::Blocked => "blocked",
-        AgentState::Idle => "idle",
-        AgentState::Inactive => "inactive",
-        AgentState::Done => "done",
-    }
-}
-
-fn state_tone(state: AgentState) -> &'static str {
-    match state {
-        AgentState::Blocked => "attention",
-        AgentState::Working => "active",
-        AgentState::Done => "success",
-        AgentState::Unknown | AgentState::Idle | AgentState::Inactive => "neutral",
     }
 }
 
@@ -1327,16 +1376,74 @@ mod tests {
         assert!(!INDEX_HTML.contains("<script>"));
         assert!(MANIFEST.contains("\"display\": \"standalone\""));
         assert!(SERVICE_WORKER.contains("/api/"));
-        assert!(INDEX_HTML.contains("id=\"native-handoff-link\""));
-        assert!(APP_JS.contains("payload.native_web"));
-        assert!(APP_JS.contains("if (routeDetail()) requests.push(refreshDetail())"));
-        assert!(APP_JS.contains("clearNativeHandoff();"));
-        assert!(
-            APP_JS
-                .matches("nativeLink.removeAttribute(\"href\");")
-                .count()
-                >= 2
-        );
+        assert!(!INDEX_HTML.contains("detail-view"));
+        assert!(!APP_JS.contains("/api/agents/"));
+        assert!(APP_JS.contains("agent.native_web"));
+        assert!(APP_JS.contains("filter: \"all\""));
+        assert!(INDEX_HTML.contains("data-filter=\"all\" aria-pressed=\"true\""));
+        assert!(INDEX_HTML.contains("Agent activity."));
+        assert!(!INDEX_HTML.contains("Agents in motion."));
+    }
+
+    #[test]
+    fn stop_control_socket_requests_and_waits_for_shutdown() {
+        use std::os::unix::net::UnixListener as StdUnixListener;
+
+        let directory =
+            std::env::temp_dir().join(format!("boomux-web-stop-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("web.sock");
+        let listener = StdUnixListener::bind(&path).unwrap();
+        let server_path = path.clone();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = vec![0; WEB_STOP_REQUEST.len()];
+            stream.read_exact(&mut request).unwrap();
+            assert_eq!(request, WEB_STOP_REQUEST);
+            stream.write_all(WEB_STOP_ACK).unwrap();
+            drop(stream);
+            drop(listener);
+            fs::remove_file(server_path).unwrap();
+        });
+
+        assert!(stop_control_socket(&path).unwrap());
+        server.join().unwrap();
+        assert!(!stop_control_socket(&path).unwrap());
+        fs::remove_dir(directory).unwrap();
+    }
+
+    #[test]
+    fn status_control_socket_returns_bounded_runtime_state() {
+        use std::os::unix::net::UnixListener as StdUnixListener;
+
+        let directory =
+            std::env::temp_dir().join(format!("boomux-web-status-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("web.sock");
+        let listener = StdUnixListener::bind(&path).unwrap();
+        let expected = WebStatus {
+            running: true,
+            port: 3737,
+            tailscale: true,
+            dashboard_url: "https://host.example.ts.net".into(),
+            opencode_port: Some(4097),
+            opencode_url: Some("https://host.example.ts.net:4097".into()),
+        };
+        let response = serde_json::to_vec(&expected).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = vec![0; WEB_STATUS_REQUEST.len()];
+            stream.read_exact(&mut request).unwrap();
+            assert_eq!(request, WEB_STATUS_REQUEST);
+            stream.write_all(&response).unwrap();
+        });
+
+        let status = status_control_socket(&path).unwrap().unwrap();
+        assert_eq!(status.dashboard_url, expected.dashboard_url);
+        assert_eq!(status.opencode_port, Some(4097));
+        server.join().unwrap();
+        fs::remove_file(path).unwrap();
+        fs::remove_dir(directory).unwrap();
     }
 
     #[test]
@@ -1533,6 +1640,40 @@ mod tests {
     }
 
     #[test]
+    fn presentation_attaches_native_handoffs_only_to_the_exact_agent() {
+        let mut native_web = HashMap::new();
+        native_web.insert(
+            (
+                "00000000-0000-0000-0000-000000000001".into(),
+                "00000000-0000-0000-0000-000000000003".into(),
+            ),
+            opencode_handoff(None, Some(4097), "/work", "session-local"),
+        );
+        let mut presentation = PresentationState::default();
+        presentation.update(combined_snapshot(), native_web);
+
+        let snapshot = presentation.snapshot.as_ref().unwrap();
+        assert!(
+            snapshot
+                .agents
+                .iter()
+                .find(|agent| agent.name == "local-active")
+                .unwrap()
+                .native_web
+                .is_some()
+        );
+        assert!(
+            snapshot
+                .agents
+                .iter()
+                .find(|agent| agent.name == "remote-blocked")
+                .unwrap()
+                .native_web
+                .is_none()
+        );
+    }
+
+    #[test]
     fn projection_matches_current_agent_and_attention_visibility() {
         let mut combined = combined_snapshot();
         let workspace = &mut combined.nodes[0]
@@ -1616,7 +1757,7 @@ mod tests {
     #[test]
     fn presentation_tracks_local_completion_only_after_working_baseline() {
         let mut presentation = PresentationState::default();
-        presentation.update(combined_snapshot());
+        presentation.update(combined_snapshot(), HashMap::new());
         assert!(
             presentation
                 .snapshot
@@ -1634,7 +1775,7 @@ mod tests {
         agent.observation.observed_at_ms += 10;
 
         let mut idle_baseline = PresentationState::default();
-        idle_baseline.update(idle.clone());
+        idle_baseline.update(idle.clone(), HashMap::new());
         assert!(
             idle_baseline
                 .snapshot
@@ -1645,7 +1786,7 @@ mod tests {
                 .all(|agent| !agent.just_completed)
         );
 
-        presentation.update(idle.clone());
+        presentation.update(idle.clone(), HashMap::new());
         let completed = presentation
             .snapshot
             .as_ref()
@@ -1656,7 +1797,7 @@ mod tests {
             .unwrap();
         assert!(completed.just_completed);
 
-        presentation.update(idle);
+        presentation.update(idle, HashMap::new());
         assert!(
             presentation
                 .snapshot
@@ -1673,22 +1814,44 @@ mod tests {
         resumed.nodes[0].local_snapshot.as_mut().unwrap().workspaces[0].agents[0]
             .observation
             .observed_at_ms += 20;
-        presentation.update(resumed);
+        presentation.update(resumed, HashMap::new());
         assert!(presentation.completed_agents.is_empty());
     }
 
     #[test]
     fn presentation_retains_snapshot_across_disconnect() {
         let mut presentation = PresentationState::default();
-        presentation.update(combined_snapshot());
+        let native_web = HashMap::from([(
+            (
+                "00000000-0000-0000-0000-000000000001".into(),
+                "00000000-0000-0000-0000-000000000003".into(),
+            ),
+            opencode_handoff(None, Some(4097), "/work", "session-local"),
+        )]);
+        presentation.update(combined_snapshot(), native_web);
+        assert!(
+            presentation
+                .snapshot
+                .as_ref()
+                .unwrap()
+                .agents
+                .iter()
+                .any(|agent| agent.native_web.is_some())
+        );
 
         assert!(presentation.mark_disconnected());
         let snapshot = presentation.snapshot.as_ref().unwrap();
         assert!(!snapshot.daemon_connected);
         assert_eq!(snapshot.counts.agents, 2);
+        assert!(
+            snapshot
+                .agents
+                .iter()
+                .all(|agent| agent.native_web.is_none())
+        );
         assert!(!presentation.mark_disconnected());
 
-        presentation.update(combined_snapshot());
+        presentation.update(combined_snapshot(), HashMap::new());
         assert!(presentation.snapshot.as_ref().unwrap().daemon_connected);
     }
 }

--- a/src/tailscale_serve.rs
+++ b/src/tailscale_serve.rs
@@ -1,0 +1,465 @@
+use std::error::Error;
+use std::ffi::{OsStr, OsString};
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+const OWNERSHIP_VERSION: u32 = 1;
+const MAX_STATUS_BYTES: usize = 1024 * 1024;
+const MAX_ERROR_BYTES: usize = 4096;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct OwnedRoute {
+    https_port: u16,
+    target: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OwnershipRecord {
+    version: u32,
+    dns_name: String,
+    routes: Vec<OwnedRoute>,
+}
+
+#[derive(Debug)]
+struct TailnetStatus {
+    dns_name: String,
+}
+
+pub(crate) struct Exposure {
+    executable: OsString,
+    record_path: PathBuf,
+    record: OwnershipRecord,
+    active: bool,
+}
+
+impl Exposure {
+    pub(crate) fn enable(
+        dashboard_port: u16,
+        opencode_port: Option<u16>,
+    ) -> Result<Self, Box<dyn Error>> {
+        let record_path = ownership_path(dashboard_port)?;
+        cleanup_record_if_present(OsStr::new("tailscale"), &record_path)?;
+        Self::enable_with(
+            OsStr::new("tailscale"),
+            record_path,
+            dashboard_port,
+            opencode_port,
+        )
+    }
+
+    fn enable_with(
+        executable: &OsStr,
+        record_path: PathBuf,
+        dashboard_port: u16,
+        opencode_port: Option<u16>,
+    ) -> Result<Self, Box<dyn Error>> {
+        let tailnet = tailnet_status(executable)?;
+        let serve_status = serve_status(executable)?;
+        let mut desired = vec![OwnedRoute {
+            https_port: 443,
+            target: format!("http://127.0.0.1:{dashboard_port}"),
+        }];
+        if let Some(port) = opencode_port {
+            desired.push(OwnedRoute {
+                https_port: port,
+                target: format!("http://127.0.0.1:{port}"),
+            });
+        }
+
+        let mut missing = Vec::new();
+        for route in desired {
+            match route_state(&serve_status, &tailnet.dns_name, &route) {
+                RouteState::Compatible => {}
+                RouteState::Missing => missing.push(route),
+                RouteState::Conflict => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AddrInUse,
+                        format!(
+                            "Tailscale Serve HTTPS port {} already has a conflicting handler",
+                            route.https_port
+                        ),
+                    )
+                    .into());
+                }
+            }
+        }
+
+        let mut exposure = Self {
+            executable: executable.to_owned(),
+            record_path,
+            record: OwnershipRecord {
+                version: OWNERSHIP_VERSION,
+                dns_name: tailnet.dns_name,
+                routes: Vec::new(),
+            },
+            active: true,
+        };
+        for route in missing {
+            exposure.record.routes.push(route.clone());
+            exposure.persist()?;
+            if let Err(error) = configure_route(executable, &route) {
+                let _ = exposure.cleanup();
+                return Err(error);
+            }
+        }
+        if exposure.record.routes.is_empty() {
+            exposure.active = false;
+        }
+        Ok(exposure)
+    }
+
+    pub(crate) fn dashboard_url(&self) -> String {
+        format!("https://{}", self.record.dns_name)
+    }
+
+    pub(crate) fn opencode_url(&self, port: u16) -> String {
+        format!("https://{}:{port}", self.record.dns_name)
+    }
+
+    fn persist(&self) -> io::Result<()> {
+        write_record(&self.record_path, &self.record)
+    }
+
+    fn cleanup(&mut self) -> Result<(), Box<dyn Error>> {
+        if !self.active {
+            return Ok(());
+        }
+        cleanup_record(&self.executable, &self.record_path, &self.record)?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for Exposure {
+    fn drop(&mut self) {
+        if let Err(error) = self.cleanup() {
+            eprintln!("boomux: failed to remove Tailscale Serve exposure: {error}");
+        }
+    }
+}
+
+pub(crate) fn cleanup_stale(dashboard_port: u16) -> Result<(), Box<dyn Error>> {
+    cleanup_record_if_present(OsStr::new("tailscale"), &ownership_path(dashboard_port)?)
+}
+
+fn ownership_path(dashboard_port: u16) -> io::Result<PathBuf> {
+    boomux::client::socket_path()?
+        .parent()
+        .map(|directory| directory.join(format!("web-{dashboard_port}-tailscale.json")))
+        .ok_or_else(|| io::Error::other("Boomux daemon socket has no runtime directory"))
+}
+
+fn tailnet_status(executable: &OsStr) -> Result<TailnetStatus, Box<dyn Error>> {
+    let output = run(executable, &["status", "--json"])?;
+    let status = successful_json("tailscale status", output)?;
+    if status.get("BackendState").and_then(Value::as_str) != Some("Running")
+        || status.pointer("/Self/Online").and_then(Value::as_bool) != Some(true)
+    {
+        return Err(
+            io::Error::new(io::ErrorKind::NotConnected, "Tailscale is not connected").into(),
+        );
+    }
+    let dns_name = status
+        .pointer("/Self/DNSName")
+        .and_then(Value::as_str)
+        .map(|name| name.trim_end_matches('.'))
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "Tailscale MagicDNS name is unavailable",
+            )
+        })?;
+    Ok(TailnetStatus {
+        dns_name: dns_name.to_owned(),
+    })
+}
+
+fn serve_status(executable: &OsStr) -> Result<Value, Box<dyn Error>> {
+    successful_json(
+        "tailscale serve status",
+        run(executable, &["serve", "status", "--json"])?,
+    )
+}
+
+fn successful_json(context: &str, output: Output) -> Result<Value, Box<dyn Error>> {
+    if !output.status.success() {
+        return Err(command_error(context, &output).into());
+    }
+    if output.stdout.len() > MAX_STATUS_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{context} output exceeded {MAX_STATUS_BYTES} bytes"),
+        )
+        .into());
+    }
+    serde_json::from_slice(&output.stdout).map_err(Into::into)
+}
+
+fn run(executable: &OsStr, arguments: &[&str]) -> io::Result<Output> {
+    Command::new(executable).args(arguments).output()
+}
+
+fn configure_route(executable: &OsStr, route: &OwnedRoute) -> Result<(), Box<dyn Error>> {
+    let https = format!("--https={}", route.https_port);
+    let output = Command::new(executable)
+        .args(["serve", "--bg", "--yes", &https, &route.target])
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(command_error("tailscale serve", &output).into())
+    }
+}
+
+fn remove_route(executable: &OsStr, route: &OwnedRoute) -> Result<(), Box<dyn Error>> {
+    let https = format!("--https={}", route.https_port);
+    let output = Command::new(executable)
+        .args(["serve", &https, "--set-path=/", "off"])
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(command_error("tailscale serve off", &output).into())
+    }
+}
+
+fn command_error(context: &str, output: &Output) -> io::Error {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let detail = stderr
+        .trim()
+        .chars()
+        .take(MAX_ERROR_BYTES)
+        .collect::<String>();
+    io::Error::other(if detail.is_empty() {
+        format!("{context} failed with {}", output.status)
+    } else {
+        format!("{context} failed: {detail}")
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RouteState {
+    Compatible,
+    Missing,
+    Conflict,
+}
+
+fn route_state(status: &Value, dns_name: &str, route: &OwnedRoute) -> RouteState {
+    let web_key = format!("{dns_name}:{}", route.https_port);
+    let proxy = status
+        .get("Web")
+        .and_then(|web| web.get(&web_key))
+        .and_then(|web| web.pointer("/Handlers/~1/Proxy"))
+        .and_then(Value::as_str);
+    if proxy == Some(route.target.as_str()) {
+        return RouteState::Compatible;
+    }
+    if proxy.is_some() {
+        return RouteState::Conflict;
+    }
+    let port = route.https_port.to_string();
+    if let Some(tcp) = status.get("TCP").and_then(|tcp| tcp.get(&port))
+        && tcp.get("HTTPS").and_then(Value::as_bool) != Some(true)
+    {
+        return RouteState::Conflict;
+    }
+    RouteState::Missing
+}
+
+fn cleanup_record_if_present(executable: &OsStr, record_path: &Path) -> Result<(), Box<dyn Error>> {
+    let Some(record) = read_record(record_path)? else {
+        return Ok(());
+    };
+    cleanup_record(executable, record_path, &record)
+}
+
+fn cleanup_record(
+    executable: &OsStr,
+    record_path: &Path,
+    record: &OwnershipRecord,
+) -> Result<(), Box<dyn Error>> {
+    let status = serve_status(executable)?;
+    for route in &record.routes {
+        if route_state(&status, &record.dns_name, route) == RouteState::Compatible {
+            remove_route(executable, route)?;
+        }
+    }
+    match fs::remove_file(record_path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn read_record(path: &Path) -> io::Result<Option<OwnershipRecord>> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    if !metadata.file_type().is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.len() > 64 * 1024
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid Boomux Tailscale ownership record",
+        ));
+    }
+    let record: OwnershipRecord = serde_json::from_slice(&fs::read(path)?)?;
+    if record.version != OWNERSHIP_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unsupported Boomux Tailscale ownership record version",
+        ));
+    }
+    Ok(Some(record))
+}
+
+fn write_record(path: &Path, record: &OwnershipRecord) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("Tailscale ownership record has no parent"))?;
+    let temporary = parent.join(format!(".tailscale-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)?;
+        serde_json::to_writer(&mut file, record)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn status(proxy: Option<&str>) -> Value {
+        let mut value = serde_json::json!({
+            "TCP": {},
+            "Web": {},
+        });
+        if let Some(proxy) = proxy {
+            value["TCP"]["443"] = serde_json::json!({ "HTTPS": true });
+            value["Web"]["host.example.ts.net:443"] = serde_json::json!({
+                "Handlers": { "/": { "Proxy": proxy } }
+            });
+        }
+        value
+    }
+
+    #[test]
+    fn route_planning_preserves_compatible_and_rejects_conflicting_handlers() {
+        let route = OwnedRoute {
+            https_port: 443,
+            target: "http://127.0.0.1:3737".into(),
+        };
+        assert_eq!(
+            route_state(&status(None), "host.example.ts.net", &route),
+            RouteState::Missing
+        );
+        assert_eq!(
+            route_state(
+                &status(Some("http://127.0.0.1:3737")),
+                "host.example.ts.net",
+                &route
+            ),
+            RouteState::Compatible
+        );
+        assert_eq!(
+            route_state(
+                &status(Some("http://127.0.0.1:9000")),
+                "host.example.ts.net",
+                &route
+            ),
+            RouteState::Conflict
+        );
+    }
+
+    #[test]
+    fn ownership_record_is_owner_only_and_versioned() {
+        let directory =
+            std::env::temp_dir().join(format!("boomux-tailscale-record-test-{}", Uuid::new_v4()));
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("record.json");
+        let record = OwnershipRecord {
+            version: OWNERSHIP_VERSION,
+            dns_name: "host.example.ts.net".into(),
+            routes: vec![OwnedRoute {
+                https_port: 4097,
+                target: "http://127.0.0.1:4097".into(),
+            }],
+        };
+
+        write_record(&path, &record).unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o600);
+        let loaded = read_record(&path).unwrap().unwrap();
+        assert_eq!(loaded.version, OWNERSHIP_VERSION);
+        assert_eq!(loaded.routes[0].https_port, 4097);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn exposure_preserves_compatible_routes_and_removes_only_created_routes() {
+        let directory =
+            std::env::temp_dir().join(format!("boomux-tailscale-command-test-{}", Uuid::new_v4()));
+        fs::create_dir(&directory).unwrap();
+        let executable = directory.join("tailscale");
+        let marker = directory.join("opencode-enabled");
+        let log = directory.join("commands.log");
+        let script = format!(
+            "#!/bin/sh\n\
+             printf '%s\\n' \"$*\" >> '{log}'\n\
+             case \"$*\" in\n\
+               'status --json') printf '%s' '{{\"BackendState\":\"Running\",\"Self\":{{\"Online\":true,\"DNSName\":\"host.example.ts.net.\"}}}}' ;;\n\
+               'serve status --json')\n\
+                 if [ -e '{marker}' ]; then\n\
+                   printf '%s' '{{\"TCP\":{{\"443\":{{\"HTTPS\":true}},\"4097\":{{\"HTTPS\":true}}}},\"Web\":{{\"host.example.ts.net:443\":{{\"Handlers\":{{\"/\":{{\"Proxy\":\"http://127.0.0.1:3737\"}}}}}},\"host.example.ts.net:4097\":{{\"Handlers\":{{\"/\":{{\"Proxy\":\"http://127.0.0.1:4097\"}}}}}}}}}}'\n\
+                 else\n\
+                   printf '%s' '{{\"TCP\":{{\"443\":{{\"HTTPS\":true}}}},\"Web\":{{\"host.example.ts.net:443\":{{\"Handlers\":{{\"/\":{{\"Proxy\":\"http://127.0.0.1:3737\"}}}}}}}}}}'\n\
+                 fi ;;\n\
+               'serve --bg --yes --https=4097 http://127.0.0.1:4097') : > '{marker}' ;;\n\
+               'serve --https=4097 --set-path=/ off') rm -f '{marker}' ;;\n\
+               *) exit 64 ;;\n\
+             esac\n",
+            log = log.display(),
+            marker = marker.display(),
+        );
+        fs::write(&executable, script).unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        let record = directory.join("ownership.json");
+
+        let exposure =
+            Exposure::enable_with(executable.as_os_str(), record.clone(), 3737, Some(4097))
+                .unwrap();
+        assert_eq!(exposure.dashboard_url(), "https://host.example.ts.net");
+        assert!(marker.exists());
+        assert!(record.exists());
+        drop(exposure);
+
+        assert!(!marker.exists());
+        assert!(!record.exists());
+        let commands = fs::read_to_string(log).unwrap();
+        assert!(commands.contains("serve --bg --yes --https=4097 http://127.0.0.1:4097"));
+        assert!(commands.contains("serve --https=4097 --set-path=/ off"));
+        assert!(!commands.contains("--https=443 http://127.0.0.1:3737"));
+        fs::remove_dir_all(directory).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- make the Agent dashboard home-only with conditional exact OpenCode handoffs on cards
- add detached `web start`, passive `web status`, and targeted `web stop` JSON lifecycle commands
- add explicit conflict-safe Tailscale Serve exposure with exact owned-route cleanup

## Stack
- builds on #220

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`
- live Tailscale Serve start/status/stop and exact route cleanup