### PR TITLE
fix(web): allow dismissing agent attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,13 +251,15 @@ outstanding attention item.
 
 ### Mobile Dashboard
 
-`boomux web` serves an installable, read-only Agent dashboard at
+`boomux web` serves an installable Agent dashboard at
 `http://127.0.0.1:3737`. It combines local authoritative Agent state with the
 bounded projections of registered Nodes, keeps stale ownership visible, and
 shows the same current user-Shell Agents and outstanding durable attention as
 the Omarchy Boomux plugin. A locally observed `working` to `idle` transition is
 kept by the gateway as a transient finished alert while that Agent remains idle,
-even when no browser is connected. The home page is the complete dashboard; an
+even when no browser is connected. Local alert cards provide an exact
+revision-conditional **Dismiss** action; remote attention remains read-only. The
+home page is the complete dashboard; an
 eligible local OpenCode Agent card links directly to the same live Session used
 by its desktop TUI through the Node's Shared Harness Runtime on
 `127.0.0.1:4097`. Remote Agents remain unlinked. The TUI can be detached while
@@ -283,9 +285,9 @@ Boomux reuses compatible Serve routes, rejects conflicts, records only routes it
 creates, and removes those exact routes on graceful exit or `boomux web stop`.
 It does not reset unrelated Serve configuration or define Tailscale grants and
 ACLs. Without `--tailscale`, remote publication remains external. The MVP has
-no terminal input, attention acknowledgment, transcript parsing, or cloud
-service. Native OpenCode links leave Boomux and open a full-control service whose
-origin must be protected separately. Add the remote URL
+no terminal input, transcript parsing, or cloud service. Its only mutation is
+exact local attention dismissal. Native OpenCode links leave Boomux and open a
+full-control service whose origin must be protected separately. Add the remote URL
 to the phone's home screen to install the progressive web app. See
 [`docs/mobile-web.md`](docs/mobile-web.md) for the security and privacy boundary.
 
@@ -645,8 +647,8 @@ Revision-aware output reads and daemon event cursors are documented in
   reconstructed when a terminal reconnects.
 - One terminal window controls input for a shell at a time. Taking control from
   another window disconnects the previous window from that shell.
-- The mobile dashboard is read-only and displays bounded rendered terminal
-  output, not structured Agent conversation history.
+- The mobile dashboard does not expose terminal output or structured Agent
+  conversation history; its only mutation is exact local attention dismissal.
 - Seamless shared OpenCode requires a bare zero-argument interactive invocation
   in an eligible managed login Shell; `--pure`, `--mini`, absolute paths,
   modified `PATH`, and conflicting same-Session Shells fail closed.

--- a/assets/mobile-web/app.js
+++ b/assets/mobile-web/app.js
@@ -167,14 +167,23 @@ function renderAgentCard(agent) {
   }
   body.append(meta);
   const nativeUrl = agent.native_web?.url || derivedNativeUrl(agent.native_web);
-  if (nativeUrl) {
+  const dismissible = agent.node_local && hasAlert(agent);
+  if (nativeUrl || dismissible) {
     const actions = el("div", "card-actions");
-    const nativeLink = el("a", "card-native-link", agent.native_web.label || "Open in OpenCode");
-    nativeLink.href = nativeUrl;
-    nativeLink.target = "_blank";
-    nativeLink.rel = "noreferrer";
-    nativeLink.referrerPolicy = "no-referrer";
-    actions.append(nativeLink);
+    if (nativeUrl) {
+      const nativeLink = el("a", "card-native-link", agent.native_web.label || "Open in OpenCode");
+      nativeLink.href = nativeUrl;
+      nativeLink.target = "_blank";
+      nativeLink.rel = "noreferrer";
+      nativeLink.referrerPolicy = "no-referrer";
+      actions.append(nativeLink);
+    }
+    if (dismissible) {
+      const dismissButton = el("button", "card-dismiss-button", "Dismiss");
+      dismissButton.type = "button";
+      dismissButton.addEventListener("click", () => dismissAttention(agent, dismissButton));
+      actions.append(dismissButton);
+    }
     body.append(actions);
   }
   content.append(rail, body);
@@ -196,6 +205,31 @@ async function fetchJson(url, signal) {
   });
   if (!response.ok) throw new Error(`Request failed (${response.status})`);
   return response.json();
+}
+
+async function dismissAttention(agent, button) {
+  button.disabled = true;
+  button.textContent = "Dismissing...";
+  try {
+    const response = await fetch("/api/attention/dismiss", {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        node_id: agent.node_id,
+        agent_id: agent.agent_id,
+        observation_revision: agent.attention?.observation_revision ?? agent.observation_revision,
+      }),
+    });
+    if (!response.ok) throw new Error(`Request failed (${response.status})`);
+    await refreshSnapshot();
+  } catch (_) {
+    button.disabled = false;
+    button.textContent = "Retry dismiss";
+  }
 }
 
 async function refreshSnapshot() {

--- a/assets/mobile-web/service-worker.js
+++ b/assets/mobile-web/service-worker.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const CACHE_NAME = "boomux-agent-watch-v16";
+const CACHE_NAME = "boomux-agent-watch-v17";
 const APP_SHELL = [
   "./",
   "./index.html",

--- a/assets/mobile-web/styles.css
+++ b/assets/mobile-web/styles.css
@@ -303,9 +303,12 @@ h1 {
 .meta-item small, .meta-item strong { display: block; }
 .meta-item small { margin-bottom: 4px; color: var(--muted); font-size: .57rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
 .meta-item strong { max-width: 220px; overflow: hidden; color: var(--paper-dim); font-size: .72rem; text-overflow: ellipsis; white-space: nowrap; }
-.card-actions { display: flex; margin-top: 18px; }
+.card-actions { display: flex; margin-top: 18px; flex-wrap: wrap; gap: 9px; }
 .card-native-link { display: inline-flex; min-height: 42px; padding: 0 16px; border: 1px solid var(--acid); align-items: center; color: var(--ink); background: var(--acid); box-shadow: inset 0 -4px rgba(168, 90, 18, .42); font-size: .7rem; font-weight: 900; letter-spacing: .09em; text-decoration: none; text-transform: uppercase; }
 .card-native-link:hover { color: var(--acid); background: transparent; }
+.card-dismiss-button { min-height: 42px; padding: 0 16px; border: 1px solid var(--line); color: var(--paper-dim); background: transparent; cursor: pointer; font: inherit; font-size: .7rem; font-weight: 900; letter-spacing: .09em; text-transform: uppercase; }
+.card-dismiss-button:hover { border-color: var(--ember); color: var(--rose); }
+.card-dismiss-button:disabled { cursor: wait; opacity: .55; }
 
 .state-panel {
   display: grid;
@@ -363,7 +366,7 @@ h1 {
   .attention-callout { display: block; }
   .attention-callout strong, .attention-callout span { display: block; }
   .attention-callout span { margin-top: 4px; white-space: normal; }
-  .card-native-link { display: flex; width: 100%; justify-content: center; }
+  .card-native-link, .card-dismiss-button { display: flex; width: 100%; align-items: center; justify-content: center; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@
 | `src/terminal_state.rs` | Shadow VT parsing, bounded reconstruction, logical output, and structured previews |
 | `src/terminal_focus.rs` | Stateful parsing and restoration of child focus-reporting mode |
 | `src/tui.rs` | Dashboard state, interaction, palette, polling, and Ratatui rendering; no direct daemon transport |
-| `src/mobile_web.rs`, `assets/mobile-web/` | Loopback-only read-only HTTP gateway, Node-qualified Agent projection, native harness web handoff, and embedded installable web assets |
+| `src/mobile_web.rs`, `assets/mobile-web/` | Loopback-only HTTP gateway, Node-qualified Agent projection, exact local attention dismissal, native harness web handoff, and embedded installable web assets |
 | `src/tailscale_serve.rs` | Explicit Tailscale Serve preflight, conflict detection, exact route mutation, and ephemeral ownership cleanup for `boomux web --tailscale` |
 | `src/session_projection.rs` | Projection of daemon Agent state and host catalogs into client-visible sessions |
 | `src/integrations.rs` | Integration identity, display metadata, and optional installation, title/catalog, resume, and foreground capabilities |
@@ -563,10 +563,15 @@ when the Agent leaves idle, ceases to own the exact current run, or the gateway
 process restarts. A temporary daemon failure marks the cached response
 disconnected without discarding its last bounded projection or finished markers.
 
-All Boomux routes are read-only. The server has no arbitrary daemon-protocol
-pass-through, terminal attachment, input, attention acknowledgment, Session
-resume, rendered terminal output, Agent detail route, or harness transcript
-adapter. The home-page snapshot is the complete HTTP Agent projection.
+The only mutation route dismisses an exact local Agent alert. It requires a
+same-origin JSON request carrying the exact Node ID, Agent ID, and current
+attention or lifecycle observation revision. Durable attention is hidden only
+after the daemon confirms revision-conditional acknowledgment; an ephemeral
+finished marker is cleared only in the gateway that observed it. Remote
+projected attention and stale revisions fail closed. The server has no arbitrary
+daemon-protocol pass-through, terminal attachment, input, Session resume,
+rendered terminal output, Agent detail route, or harness transcript adapter.
+The home-page snapshot is the complete HTTP Agent projection.
 
 `boomux web` ensures the same daemon-supervised Shared Harness Runtime used by
 eligible native OpenCode TUIs. For an authoritative claimed local OpenCode Agent

--- a/docs/mobile-web.md
+++ b/docs/mobile-web.md
@@ -8,10 +8,10 @@
 
 `boomux web` provides a phone-friendly, installable view of the current Agents
 and outstanding Agent attention known to one coordinating Boomux Node. It is a
-read-only presentation layer inspired by mobile agent dashboards: durable
-attention is first and active work remains easy to scan. Eligible Agent cards
-offer a native handoff that opens the exact authoritative local OpenCode Session
-in OpenCode Web.
+bounded presentation layer inspired by mobile agent dashboards: durable
+attention is first and active work remains easy to scan. Its only mutation
+dismisses an exact local alert. Eligible Agent cards offer a native handoff that
+opens the exact authoritative local OpenCode Session in OpenCode Web.
 
 Boomux is not an interactive chat client. It does not parse or normalize harness
 transcripts and does not send messages, commands, permission responses, or
@@ -132,6 +132,11 @@ the intended authentication boundary.
   merely because their state label remains active-looking.
 - Opening a native Agent link does not acknowledge attention or change lifecycle
   state.
+- Dismiss is available only for a local Agent with durable attention or a
+  gateway-owned finished marker. It carries the exact Node ID, Agent ID, and
+  current attention or lifecycle observation revision. Durable attention stays
+  visible until the daemon confirms acknowledgment; remote and stale requests
+  fail closed.
 - An exact native link is included on a card only for a local OpenCode Agent with
   a canonical external Session ID, UTF-8 working directory, and current Agent
   Session Claim for the Agent's exact ShellRun and Shared Harness Runtime
@@ -153,7 +158,7 @@ the intended authentication boundary.
 The gateway and Shared Harness Runtime bind only to `127.0.0.1`; there is no
 option to bind a LAN or tailnet address. Boomux does not configure or authenticate
 the private access layer. That layer owns TLS, authentication, and ACLs
-appropriate for both the read-only dashboard and OpenCode's
+appropriate for both the bounded dashboard and OpenCode's
 full-control origin. Public exposure is outside this design.
 
 Native handoff URLs expose the local working-directory encoding and canonical
@@ -163,9 +168,13 @@ API responses carry
 the manifest, and the icon; it never handles `/api/` requests. Browser storage
 does not persist Agent snapshots.
 
-The HTTP API is an allowlisted projection. It cannot forward arbitrary daemon
-requests, send terminal input, acquire a Shell controller, resume a Session,
-acknowledge attention, stop processes, or mutate Node registration.
+The HTTP API is allowlisted. Its sole mutation accepts same-origin JSON and
+either clears the gateway's exact local finished marker or submits the existing
+revision-conditional daemon attention acknowledgment. Cross-origin JSON receives
+no CORS authorization, non-JSON requests are rejected, and remote projected
+Agents cannot be mutated. The API cannot forward arbitrary daemon requests, send
+terminal input, acquire a Shell controller, resume a Session, stop processes, or
+mutate Node registration.
 
 The OpenCode origin is a separate full-control application. Set a nonempty
 `OPENCODE_SERVER_PASSWORD` unless the private access layer provides the intended
@@ -177,6 +186,9 @@ reverse proxy so this boundary remains visible.
 
 - `GET /api/snapshot` returns the current Node-qualified Agent cards, counts, and
   optional exact native OpenCode Web handoffs.
+- `POST /api/attention/dismiss` requires JSON containing the exact local
+  `node_id`, `agent_id`, and `observation_revision`. It clears a matching
+  ephemeral marker or acknowledges matching durable attention.
 
 These shapes are intentionally experimental. Future native handoff for other
 harnesses must preserve each harness's runtime ownership and exact Session

--- a/src/mobile_web.rs
+++ b/src/mobile_web.rs
@@ -20,7 +20,7 @@ use axum::http::header::{
 use axum::http::{Request, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::{Html, IntoResponse, Response};
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use boomux::client::{self, Client};
 use boomux::protocol::{
@@ -198,6 +198,25 @@ struct MobileSnapshot {
     agents: Vec<AgentCard>,
 }
 
+#[derive(Debug, Deserialize)]
+struct DismissAttentionRequest {
+    node_id: String,
+    agent_id: String,
+    observation_revision: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct DismissAttentionResponse {
+    changed: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DismissTarget {
+    None,
+    Marker,
+    DurableAttention,
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct NativeWebHandoff {
     integration: &'static str,
@@ -220,6 +239,7 @@ struct ErrorBody {
     message: &'static str,
 }
 
+#[derive(Debug)]
 struct ApiError {
     status: StatusCode,
     code: &'static str,
@@ -232,6 +252,52 @@ impl ApiError {
             status: StatusCode::BAD_GATEWAY,
             code: "daemon_unavailable",
             message: "Boomux could not refresh Agent state",
+        }
+    }
+
+    fn not_found() -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "agent_not_found",
+            message: "The Agent is no longer available",
+        }
+    }
+
+    fn local_only() -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code: "local_agent_required",
+            message: "Attention can be dismissed only on a local Agent",
+        }
+    }
+
+    fn revision_changed() -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "revision_changed",
+            message: "Agent attention changed; refresh before dismissing it",
+        }
+    }
+
+    fn from_client(error: client::ClientError) -> Self {
+        match error {
+            client::ClientError::Remote(remote)
+                if remote.code == Some(boomux::protocol::ErrorCode::NotFound) =>
+            {
+                Self::not_found()
+            }
+            client::ClientError::Remote(remote)
+                if matches!(
+                    remote.code,
+                    Some(
+                        boomux::protocol::ErrorCode::RevisionAhead
+                            | boomux::protocol::ErrorCode::RevisionChanged
+                    )
+                ) =>
+            {
+                Self::revision_changed()
+            }
+            _ => Self::daemon(),
         }
     }
 }
@@ -478,6 +544,7 @@ async fn serve(
         .route("/icon-192.png", get(icon_192))
         .route("/icon-512.png", get(icon_512))
         .route("/api/snapshot", get(snapshot))
+        .route("/api/attention/dismiss", post(dismiss_attention))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             security_headers,
@@ -781,6 +848,43 @@ async fn snapshot(State(state): State<AppState>) -> Result<Response, ApiError> {
     Ok(response)
 }
 
+async fn dismiss_attention(
+    State(state): State<AppState>,
+    Json(request): Json<DismissAttentionRequest>,
+) -> Result<Json<DismissAttentionResponse>, ApiError> {
+    {
+        let mut presentation = state.presentation.lock().map_err(|_| ApiError::daemon())?;
+        match presentation.dismiss_target(&request)? {
+            DismissTarget::None => {
+                return Ok(Json(DismissAttentionResponse { changed: false }));
+            }
+            DismissTarget::Marker => {
+                let changed = presentation.clear_alert(&request);
+                return Ok(Json(DismissAttentionResponse { changed }));
+            }
+            DismissTarget::DurableAttention => {}
+        }
+    }
+
+    let client = state.client.clone();
+    let agent_id = request.agent_id.clone();
+    let observation_revision = request.observation_revision;
+    let acknowledgement = tokio::task::spawn_blocking(move || {
+        client.acknowledge_agent_attention(agent_id, observation_revision)
+    })
+    .await
+    .map_err(|_| ApiError::daemon())?
+    .map_err(ApiError::from_client)?;
+    let presentation_changed = state
+        .presentation
+        .lock()
+        .map_err(|_| ApiError::daemon())?
+        .clear_alert(&request);
+    Ok(Json(DismissAttentionResponse {
+        changed: acknowledgement.changed || presentation_changed,
+    }))
+}
+
 fn project_snapshot(combined: CombinedNodeSnapshot, viewer: Option<String>) -> MobileSnapshot {
     let stale_nodes = combined.nodes.iter().filter(|node| node.stale).count();
     let mut agents = project_visible_agents(&combined);
@@ -817,6 +921,69 @@ fn project_snapshot(combined: CombinedNodeSnapshot, viewer: Option<String>) -> M
 }
 
 impl PresentationState {
+    fn dismiss_target(&self, request: &DismissAttentionRequest) -> Result<DismissTarget, ApiError> {
+        let agent = self
+            .snapshot
+            .as_ref()
+            .and_then(|snapshot| {
+                snapshot.agents.iter().find(|agent| {
+                    agent.node_id == request.node_id && agent.agent_id == request.agent_id
+                })
+            })
+            .ok_or_else(ApiError::not_found)?;
+        if !agent.node_local {
+            return Err(ApiError::local_only());
+        }
+        let current_revision = agent
+            .attention
+            .as_ref()
+            .map_or(agent.observation_revision, |attention| {
+                attention.observation_revision
+            });
+        if request.observation_revision != current_revision {
+            return Err(ApiError::revision_changed());
+        }
+        if agent.attention.is_some() {
+            Ok(DismissTarget::DurableAttention)
+        } else if agent.just_completed {
+            Ok(DismissTarget::Marker)
+        } else {
+            Ok(DismissTarget::None)
+        }
+    }
+
+    fn clear_alert(&mut self, request: &DismissAttentionRequest) -> bool {
+        let Some(snapshot) = &mut self.snapshot else {
+            return false;
+        };
+        let Some(agent) = snapshot
+            .agents
+            .iter_mut()
+            .find(|agent| agent.node_id == request.node_id && agent.agent_id == request.agent_id)
+        else {
+            return false;
+        };
+        let current_revision = agent
+            .attention
+            .as_ref()
+            .map_or(agent.observation_revision, |attention| {
+                attention.observation_revision
+            });
+        if !agent.node_local || request.observation_revision != current_revision {
+            return false;
+        }
+        let changed = agent.attention.take().is_some() || agent.just_completed;
+        agent.just_completed = false;
+        self.completed_agents
+            .remove(&(request.node_id.clone(), request.agent_id.clone()));
+        snapshot.counts.attention = snapshot
+            .agents
+            .iter()
+            .filter(|agent| agent.attention.is_some())
+            .count();
+        changed
+    }
+
     fn update(
         &mut self,
         combined: CombinedNodeSnapshot,
@@ -1387,6 +1554,10 @@ mod tests {
         assert!(ICON.contains("Boomux pixel bomb"));
         assert!(STYLES_CSS.contains(".brand-wordmark"));
         assert!(STYLES_CSS.contains("flex: 0 0 28ch"));
+        assert!(APP_JS.contains("/api/attention/dismiss"));
+        assert!(APP_JS.contains("method: \"POST\""));
+        assert!(APP_JS.contains("\"Content-Type\": \"application/json\""));
+        assert!(APP_JS.contains("card-dismiss-button"));
     }
 
     #[test]
@@ -1820,6 +1991,93 @@ mod tests {
             .observed_at_ms += 20;
         presentation.update(resumed, HashMap::new());
         assert!(presentation.completed_agents.is_empty());
+    }
+
+    #[test]
+    fn presentation_dismisses_only_exact_local_alerts() {
+        let mut presentation = PresentationState::default();
+        presentation.update(combined_snapshot(), HashMap::new());
+        let mut idle = combined_snapshot();
+        let agent = &mut idle.nodes[0].local_snapshot.as_mut().unwrap().workspaces[0].agents[0];
+        agent.observation.state = AgentState::Idle;
+        agent.observation.revision = 3;
+        agent.observation.observed_at_ms += 10;
+        presentation.update(idle.clone(), HashMap::new());
+
+        let request = DismissAttentionRequest {
+            node_id: "00000000-0000-0000-0000-000000000001".into(),
+            agent_id: "00000000-0000-0000-0000-000000000003".into(),
+            observation_revision: 3,
+        };
+        assert_eq!(
+            presentation.dismiss_target(&request).unwrap(),
+            DismissTarget::Marker
+        );
+        assert!(presentation.clear_alert(&request));
+        assert_eq!(
+            presentation.dismiss_target(&request).unwrap(),
+            DismissTarget::None
+        );
+        presentation.update(idle, HashMap::new());
+        assert!(
+            !presentation
+                .snapshot
+                .as_ref()
+                .unwrap()
+                .agents
+                .iter()
+                .find(|agent| agent.agent_id == request.agent_id)
+                .unwrap()
+                .just_completed
+        );
+
+        let stale = DismissAttentionRequest {
+            observation_revision: 2,
+            ..request
+        };
+        assert_eq!(
+            presentation.dismiss_target(&stale).unwrap_err().status,
+            StatusCode::CONFLICT
+        );
+
+        let remote = DismissAttentionRequest {
+            node_id: "00000000-0000-0000-0000-000000000008".into(),
+            agent_id: "00000000-0000-0000-0000-000000000012".into(),
+            observation_revision: 3,
+        };
+        assert_eq!(
+            presentation.dismiss_target(&remote).unwrap_err().status,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[test]
+    fn presentation_routes_durable_attention_to_daemon_acknowledgement() {
+        let mut combined = combined_snapshot();
+        let agent = &mut combined.nodes[0]
+            .local_snapshot
+            .as_mut()
+            .unwrap()
+            .workspaces[0]
+            .agents[0];
+        agent.attention = Some(AgentAttentionSnapshot {
+            reason: AgentAttentionReason::Blocked,
+            observation: agent.observation.clone(),
+        });
+        let mut presentation = PresentationState::default();
+        presentation.update(combined, HashMap::new());
+        let request = DismissAttentionRequest {
+            node_id: "00000000-0000-0000-0000-000000000001".into(),
+            agent_id: "00000000-0000-0000-0000-000000000003".into(),
+            observation_revision: 2,
+        };
+
+        assert_eq!(
+            presentation.dismiss_target(&request).unwrap(),
+            DismissTarget::DurableAttention
+        );
+        assert!(presentation.clear_alert(&request));
+        assert_eq!(presentation.snapshot.unwrap().counts.attention, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- distinguish gateway-owned finished markers from durable Agent attention
- add an exact local-only Dismiss action to Agent alert cards
- acknowledge durable attention through the daemon before hiding it
- reject remote Agents, stale revisions, unknown Agents, and non-JSON mutations
- update the mobile web security and endpoint documentation

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`
- live Tailnet snapshot, asset, JSON endpoint, and non-JSON rejection checks