### PR TITLE
feat(config): add configuration management commands

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boomux
-description: Inspect and manage Boomux Nodes, coordinated persistent terminal Workspaces, launchers, shells, run-scoped agent instances, attention, projected sessions, recurring Agent schedules, notifications, the OpenCode Shared Harness Runtime, process supervision, and integrations. Use when asked to discover Nodes, shells, agents, sessions, or schedules, read terminal output, manage explicitly authorized recurring Agent prompts, supervise an explicitly identified external session, report agent lifecycle state, configure or test notifications, install or remove the OpenCode or Pi integration, create or open Workspaces and shells, inspect status, rename or close targets, or manage the local Boomux daemon.
+description: Inspect and manage Boomux Nodes, coordinated persistent terminal Workspaces, launchers, shells, run-scoped agent instances, attention, projected sessions, recurring Agent schedules, local configuration, notifications, the OpenCode Shared Harness Runtime, process supervision, and integrations. Use when asked to discover Nodes, shells, agents, sessions, or schedules, read terminal output, inspect, validate, or edit local Boomux configuration, manage explicitly authorized recurring Agent prompts, supervise an explicitly identified external session, report agent lifecycle state, configure or test notifications, install or remove the OpenCode or Pi integration, create or open Workspaces and shells, inspect status, rename or close targets, or manage the local Boomux daemon.
 compatibility: Requires boomux on PATH. Federated resource identity is the pair of owning Node ID and Node-local inner ID. Some name operations require Workspace context or an explicit --workspace/--node; agent mutation and supervision require exact shell-run context, and continuation schedules or supervision require caller-supplied exact canonical session identity.
 metadata:
   author: boomux
-  version: "16"
+  version: "17"
 ---
 
 # Boomux
@@ -555,7 +555,8 @@ stop support `--json` as `web.start`, `web.status`, and `web.stop`.
 first-start runtime environment, are never persisted by Boomux, and must remain
 consistent for attached clients.
 
-The dashboard has Workspaces, Agents, Shells, Schedules, and Nodes views. `/` or
+The dashboard has Workspaces, Agents, Shells, Schedules, Nodes, and Settings
+views; `6` opens SETTINGS. `/` or
 `:` opens its action and search palette, `?` shows contextual help, `Enter`
 restores the selected workspace or opens the selected entry, and `x` followed
 by `y` confirms close or removal. Shell previews are bounded and read-only.
@@ -607,9 +608,11 @@ retain their captured definition.
 
 Boomux reads `$XDG_CONFIG_HOME/boomux/config.toml`, falling back to
 `~/.config/boomux/config.toml`. `BOOMUX_CONFIG` points to an additional
-field-level override loaded last. Configuration controls terminal selection,
-project discovery roots and depth, dashboard focus following, schedule
-concurrency, and desktop and sound notifications. Unknown fields are rejected.
+field-level override loaded last. The override is the active writable layer when
+set; otherwise the global file is writable. Omitted active-layer fields inherit
+from the global file or defaults. Configuration controls Terminal, Projects,
+Dashboard, Recovery, Scheduling, Notifications, and Sound groups. Unknown fields
+are rejected.
 Scheduled dispatch-failure and cold-interruption notification categories are
 configured independently as `[notifications] scheduled_dispatch_failed` and
 `scheduled_interrupted`; both default to false and never disclose schedule
@@ -618,6 +621,42 @@ Selecting a discovered project in the dashboard uses its name only and creates
 empty coordinator metadata. Set
 `[dashboard] follow_focused_terminal = false` to disable the default
 focus-following behavior.
+
+Inspect or manage the active local layer without starting the daemon:
+
+```console
+boomux config path
+boomux config validate
+boomux config edit
+```
+
+These commands are human-only and do not support `--json`. `path` prints the
+active writable file and `validate` checks the complete layered result. `edit`
+uses `VISUAL`, then `EDITOR`, then `sensible-editor` with a `vi` fallback. The
+editor setting is parsed into an exact argv and executed without a shell. Boomux
+edits an owner-only temporary copy, validates the bounded candidate, and performs
+an owner-validated atomic replacement. Symlinks, non-regular or wrong-owner
+targets, concurrent target changes, oversized files, and invalid merged config
+are rejected. New files are mode `0600`.
+
+SETTINGS shows `default`, `global`, and `BOOMUX_CONFIG` source labels and writes
+only the active layer. Use `Space` for booleans, `Enter` for text and integers,
+`Delete` to remove an override and inherit again, `Ctrl-S` to validate and save,
+and `Esc` to cancel editing or discard unsaved changes. Project roots have
+separate add/edit rows; Delete removes one root, while Delete on the add row
+resets the list to inheritance.
+
+Terminal, Projects, and Dashboard settings apply live to the current client.
+Recovery, Scheduling, Notifications, and Sound are daemon-owned; saving a change
+offers an explicit graceful restart of the local daemon. Declining leaves a
+restart required. If disabling terminal-history persistence would clear retained
+history, Boomux warns before confirmation. Never infer authorization to restart
+from authorization to save settings.
+
+Configuration management is local Node only. Neither these commands nor SETTINGS
+can inspect or mutate a registered remote Node's config; use an interactive
+Boomux client on the owning Node. Do not attempt remote config mutation through
+SSH, federation, or another public Boomux command.
 
 Discover the same configured projects locally without starting the daemon:
 

--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -555,8 +555,7 @@ stop support `--json` as `web.start`, `web.status`, and `web.stop`.
 first-start runtime environment, are never persisted by Boomux, and must remain
 consistent for attached clients.
 
-The dashboard has Workspaces, Agents, Shells, Schedules, Nodes, and Settings
-views; `6` opens SETTINGS. `/` or
+The dashboard has Workspaces, Agents, Shells, Schedules, and Nodes views. `/` or
 `:` opens its action and search palette, `?` shows contextual help, `Enter`
 restores the selected workspace or opens the selected entry, and `x` followed
 by `y` confirms close or removal. Shell previews are bounded and read-only.
@@ -639,24 +638,10 @@ an owner-validated atomic replacement. Symlinks, non-regular or wrong-owner
 targets, concurrent target changes, oversized files, and invalid merged config
 are rejected. New files are mode `0600`.
 
-SETTINGS shows `default`, `global`, and `BOOMUX_CONFIG` source labels and writes
-only the active layer. Use `Space` for booleans, `Enter` for text and integers,
-`Delete` to remove an override and inherit again, `Ctrl-S` to validate and save,
-and `Esc` to cancel editing or discard unsaved changes. Project roots have
-separate add/edit rows; Delete removes one root, while Delete on the add row
-resets the list to inheritance.
-
-Terminal, Projects, and Dashboard settings apply live to the current client.
-Recovery, Scheduling, Notifications, and Sound are daemon-owned; saving a change
-offers an explicit graceful restart of the local daemon. Declining leaves a
-restart required. If disabling terminal-history persistence would clear retained
-history, Boomux warns before confirmation. Never infer authorization to restart
-from authorization to save settings.
-
-Configuration management is local Node only. Neither these commands nor SETTINGS
-can inspect or mutate a registered remote Node's config; use an interactive
-Boomux client on the owning Node. Do not attempt remote config mutation through
-SSH, federation, or another public Boomux command.
+Configuration management is local Node only. These commands cannot inspect or
+mutate a registered remote Node's config; use an interactive Boomux client on the
+owning Node. Do not attempt remote config mutation through SSH, federation, or
+another public Boomux command.
 
 Discover the same configured projects locally without starting the daemon:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,6 @@ dependencies = [
  "shell-words",
  "tokio",
  "toml",
- "toml_edit",
  "unicode-width",
  "uuid",
  "vt100",
@@ -1576,19 +1575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,9 +1863,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,8 +190,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "shell-words",
  "tokio",
  "toml",
+ "toml_edit",
  "unicode-width",
  "uuid",
  "vt100",
@@ -1574,6 +1576,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1877,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm",
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+shell-words = "1"
 toml = "0.9"
+toml_edit = "0.23"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 uuid = { version = "1", features = ["v4", "v5"] }
 unicode-width = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ serde_json = "1"
 sha2 = "0.10"
 shell-words = "1"
 toml = "0.9"
-toml_edit = "0.23"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 uuid = { version = "1", features = ["v4", "v5"] }
 unicode-width = "0.2"

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ management surface.
 
 ## Dashboard
 
-The dashboard has six primary views: Workspaces, Agents, Shells, Schedules, Nodes, and
-Settings. The
+The dashboard has five primary views: Workspaces, Agents, Shells, Schedules, and
+Nodes. The
 Workspaces view combines the selected workspace's Agents, shells, commands,
 launchers, and schedule definitions in one item table. A `schedule` row represents
 the durable definition, opens its specialized history and controls, and never
@@ -577,27 +577,9 @@ oversized file, invalid TOML, or invalid merged setting is rejected. New config
 files are mode `0600`. These commands are human-only and do not support
 `--json`.
 
-The sixth dashboard tab, SETTINGS (shortcut `6`), exposes Terminal, Projects,
-Dashboard, Recovery, Scheduling, Notifications, and Sound groups for the local
-Node. It shows each effective value's `default`, `global`, or `BOOMUX_CONFIG`
-source and writes only the active layer. `Delete` removes an active override so
-the field inherits again; for project roots it removes the selected root, while
-Delete on the add row resets the roots list to inheritance. Use `Space` to toggle
-booleans, `Enter` to edit text or integers, `Ctrl-S` to validate and atomically
-save, and `Esc` to cancel editing or discard unsaved changes.
-
-Client-owned terminal selection, project discovery, and dashboard focus-following
-settings apply live to the current dashboard. Changes to daemon-owned Recovery,
-Scheduling, Notifications, and Sound settings are saved first, then require an
-explicit confirmation before Boomux gracefully restarts the local daemon. Because
-the running recovery setting is not observable, a restart that applies disabled
-`recovery.persist_terminal_history` conservatively warns that retained terminal
-history will be cleared. Declining leaves the saved setting pending for a later
-restart.
-
-Configuration management is local to this Node. The SETTINGS tab and `boomux
-config` commands never read or mutate a registered remote Node's config; use an
-interactive Boomux client on that owning Node to manage it.
+Configuration management is local to this Node. The `boomux config` commands
+never read or mutate a registered remote Node's config; use an interactive Boomux
+client on that owning Node to manage it.
 
 Project roots provide Workspace-name suggestions in the dashboard. Selecting one
 creates empty coordinator metadata using its name; it does not assign a Node or

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | Open the dashboard | `boomux` or `boomux ui` |
 | Open the mobile dashboard | `boomux web` |
 | Inspect daemon health | `boomux doctor` |
+| Show the writable config file | `boomux config path` |
+| Validate merged configuration | `boomux config validate` |
+| Edit the writable config layer | `boomux config edit` |
 | List recurring Agent work | `boomux schedule list --workspace feature-x` |
 
 Without `--name`, Boomux creates the next `workspace-N` and stores the selected
@@ -216,7 +219,8 @@ management surface.
 
 ## Dashboard
 
-The dashboard has five primary views: Workspaces, Agents, Shells, Schedules, and Nodes. The
+The dashboard has six primary views: Workspaces, Agents, Shells, Schedules, Nodes, and
+Settings. The
 Workspaces view combines the selected workspace's Agents, shells, commands,
 launchers, and schedule definitions in one item table. A `schedule` row represents
 the durable definition, opens its specialized history and controls, and never
@@ -293,7 +297,7 @@ to the phone's home screen to install the progressive web app. See
 
 | Key | Action |
 | --- | --- |
-| `Tab`, `Shift-Tab`, `1`-`5` | Change view. |
+| `Tab`, `Shift-Tab`, `1`-`6` | Change view. |
 | `/` or `:` | Search actions, workspaces, and entries. |
 | `?` | Explain keys plus the selected kind and state. |
 | `h`, `l`, left, right | Move between workspace and entry tables. |
@@ -515,8 +519,10 @@ overwrites local changes to an existing installation.
 ## Configuration
 
 Boomux reads `$XDG_CONFIG_HOME/boomux/config.toml`, falling back to
-`~/.config/boomux/config.toml`. `BOOMUX_CONFIG` can point to an additional file
-that is loaded last and takes precedence.
+`~/.config/boomux/config.toml`. When `BOOMUX_CONFIG` is set, that file is loaded
+after the global file and overrides it field by field. The active writable layer
+is `BOOMUX_CONFIG` when set and the global file otherwise; lower-layer values
+remain inherited when the active layer omits them.
 
 ```toml
 terminal = "Alacritty.desktop"
@@ -532,6 +538,9 @@ follow_focused_terminal = true
 resume_agents = true
 persist_terminal_history = false
 
+[scheduling]
+max_concurrent = 4
+
 [notifications]
 enabled = false
 blocked = true
@@ -546,6 +555,49 @@ completed = "complete"
 scheduled_dispatch_failed = "dialog-warning"
 scheduled_interrupted = "dialog-warning"
 ```
+
+Manage the active writable layer without starting the daemon:
+
+```console
+boomux config path
+boomux config validate
+boomux config edit
+```
+
+`config path` prints the active writable path. `config validate` parses and
+semantically validates the complete layered result. `config edit` selects
+`VISUAL`, then `EDITOR`, then `sensible-editor` with a `vi` fallback. Editor
+settings are split into an exact argument vector and executed directly without
+shell interpretation. Editing uses an owner-only temporary working copy,
+validates the bounded candidate and every layer, and atomically replaces an
+owner-validated regular target. Existing targets are checked for changes
+immediately before replacement, while new targets use atomic no-replace
+creation. A detected target change, symlink, non-regular file, wrong owner,
+oversized file, invalid TOML, or invalid merged setting is rejected. New config
+files are mode `0600`. These commands are human-only and do not support
+`--json`.
+
+The sixth dashboard tab, SETTINGS (shortcut `6`), exposes Terminal, Projects,
+Dashboard, Recovery, Scheduling, Notifications, and Sound groups for the local
+Node. It shows each effective value's `default`, `global`, or `BOOMUX_CONFIG`
+source and writes only the active layer. `Delete` removes an active override so
+the field inherits again; for project roots it removes the selected root, while
+Delete on the add row resets the roots list to inheritance. Use `Space` to toggle
+booleans, `Enter` to edit text or integers, `Ctrl-S` to validate and atomically
+save, and `Esc` to cancel editing or discard unsaved changes.
+
+Client-owned terminal selection, project discovery, and dashboard focus-following
+settings apply live to the current dashboard. Changes to daemon-owned Recovery,
+Scheduling, Notifications, and Sound settings are saved first, then require an
+explicit confirmation before Boomux gracefully restarts the local daemon. Because
+the running recovery setting is not observable, a restart that applies disabled
+`recovery.persist_terminal_history` conservatively warns that retained terminal
+history will be cleared. Declining leaves the saved setting pending for a later
+restart.
+
+Configuration management is local to this Node. The SETTINGS tab and `boomux
+config` commands never read or mutate a registered remote Node's config; use an
+interactive Boomux client on that owning Node to manage it.
 
 Project roots provide Workspace-name suggestions in the dashboard. Selecting one
 creates empty coordinator metadata using its name; it does not assign a Node or
@@ -631,6 +683,7 @@ boomux session --help
 boomux schedule --help
 boomux notification --help
 boomux integration --help
+boomux config --help
 ```
 
 Supported automation commands use the stable `boomux.cli/v1` JSON envelope. See

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,8 @@
 | `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
 | `src/process_adapter.rs` | Exact-argv child supervision and fail-open process-bound Agent observation |
 | `src/scheduling.rs` | Bounded canonical cron parsing and occurrence evaluation, IANA timezone and DST policy, prompt bounds, and schedule identity validation |
-| `src/config.rs`, `src/projects.rs`, `src/git.rs` | Layered configuration, bounded project discovery, and asynchronous Git metadata |
+| `src/config.rs` | Layered configuration resolution, source-aware structured settings, bounded validation, and transactional active-layer editing |
+| `src/projects.rs`, `src/git.rs` | Bounded project discovery and asynchronous Git metadata |
 | `src/cli_output.rs` | Stable `boomux.cli/v1` output and error presentation |
 | `src/desktop_notifications.rs` | Bounded fail-open desktop and sound delivery |
 
@@ -54,8 +55,8 @@
 - **Ephemeral attachment environment:** Daemon and Runtime Semantics sections
   below; startup environment is validated but never persisted or projected.
 - **Exact argument vectors:** workspace launchers, process adapters, terminal
-  launch, and integration management execute argv directly without shell
-  interpretation.
+  launch, integration management, and configuration editor launch execute argv
+  directly without shell interpretation.
 - **Scheduled Agent authority:** [`scheduled-agent-work.md`](scheduled-agent-work.md)
   defines the boundary between manual and timed dispatch, concurrency policy,
   process outcome, and authoritative Agent lifecycle.
@@ -244,6 +245,30 @@ every available placement, using local attachment for the local owner and typed
 Node host services plus Node-qualified attachment for remote owners. Failures are
 reported per Node and do not replay an ambiguous launcher invocation.
 
+### Configuration
+
+`src/config.rs` resolves the global XDG config file first and an optional
+`BOOMUX_CONFIG` file second, merging tables field by field. When present,
+`BOOMUX_CONFIG` is the active writable layer; otherwise the global file is. A
+missing setting inherits from the lower layer or the built-in default. Settings
+inspection retains each field's effective value, active override, and source
+label (`default`, `global`, or `BOOMUX_CONFIG`). Configuration is local Node
+state: it is neither daemon protocol state nor a remotely routable mutation.
+
+`boomux config path`, `validate`, and `edit` are human-only local commands and do
+not start the daemon. Validation parses and semantically resolves all configured
+layers. Editing chooses `VISUAL`, then `EDITOR`, then `sensible-editor` with a
+`vi` fallback. The selected command is parsed into an exact argument vector and
+spawned directly, without a shell.
+
+Both external and SETTINGS edits use a bounded candidate and owner-only temporary
+files. Commit requires an owner-validated regular target and verifies its bytes
+against the edit baseline immediately before one atomic rename. New targets use
+atomic no-replace creation. The candidate is fully validated before commit;
+symlinks and detected changes to either loaded layer are rejected, new files are
+mode `0600`, existing target mode is preserved, and file plus parent directory
+are synchronized after commit.
+
 ### Daemon
 
 `src/daemon.rs` owns all PTY masters and child processes. Its runtime directory
@@ -419,6 +444,24 @@ creates empty coordinator metadata without retaining its path. Older peers
 retain empty local Workspace creation. Git information is still collected
 independently from item directories and cached. Paths do not create
 Workspace-level Git identity, and mixed-directory Workspaces remain valid.
+
+SETTINGS is the sixth top-level dashboard tab and is directly selectable with
+`6`. It edits only this local Node's active writable layer and groups every
+current setting under Terminal, Projects, Dashboard, Recovery, Scheduling,
+Notifications, and Sound. Rows show effective values and per-field sources;
+Delete removes the active override to restore inheritance. Space toggles
+booleans, Enter edits text and integers, Ctrl-S validates and atomically saves,
+and Esc cancels an edit or discards unsaved changes.
+
+Client-owned terminal selection, project discovery, and focused-terminal
+following are refreshed in the running dashboard after save. Recovery,
+Scheduling, desktop notification, and sound settings are daemon-owned. A saved
+change to any of them opens an explicit confirmation before graceful restart of
+the local daemon; declining retains a visible restart requirement. Runtime
+scheduler concurrency is observable, but applied recovery settings are not, so a
+restart that applies disabled terminal-history persistence conservatively warns
+that retained history will be cleared. No SETTINGS action reads or mutates
+configuration on a registered remote Node.
 
 The dashboard establishes an atomic event-stream baseline and treats later
 events as invalidation signals for authoritative snapshot reprojection. It also

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@
 | `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
 | `src/process_adapter.rs` | Exact-argv child supervision and fail-open process-bound Agent observation |
 | `src/scheduling.rs` | Bounded canonical cron parsing and occurrence evaluation, IANA timezone and DST policy, prompt bounds, and schedule identity validation |
-| `src/config.rs` | Layered configuration resolution, source-aware structured settings, bounded validation, and transactional active-layer editing |
+| `src/config.rs` | Layered configuration resolution, bounded validation, and transactional active-layer editing |
 | `src/projects.rs`, `src/git.rs` | Bounded project discovery and asynchronous Git metadata |
 | `src/cli_output.rs` | Stable `boomux.cli/v1` output and error presentation |
 | `src/desktop_notifications.rs` | Bounded fail-open desktop and sound delivery |
@@ -250,10 +250,9 @@ reported per Node and do not replay an ambiguous launcher invocation.
 `src/config.rs` resolves the global XDG config file first and an optional
 `BOOMUX_CONFIG` file second, merging tables field by field. When present,
 `BOOMUX_CONFIG` is the active writable layer; otherwise the global file is. A
-missing setting inherits from the lower layer or the built-in default. Settings
-inspection retains each field's effective value, active override, and source
-label (`default`, `global`, or `BOOMUX_CONFIG`). Configuration is local Node
-state: it is neither daemon protocol state nor a remotely routable mutation.
+missing setting inherits from the lower layer or the built-in default.
+Configuration is local Node state: it is neither daemon protocol state nor a
+remotely routable mutation.
 
 `boomux config path`, `validate`, and `edit` are human-only local commands and do
 not start the daemon. Validation parses and semantically resolves all configured
@@ -261,8 +260,8 @@ layers. Editing chooses `VISUAL`, then `EDITOR`, then `sensible-editor` with a
 `vi` fallback. The selected command is parsed into an exact argument vector and
 spawned directly, without a shell.
 
-Both external and SETTINGS edits use a bounded candidate and owner-only temporary
-files. Commit requires an owner-validated regular target and verifies its bytes
+External edits use a bounded candidate and owner-only temporary files. Commit
+requires an owner-validated regular target and verifies its bytes
 against the edit baseline immediately before one atomic rename. New targets use
 atomic no-replace creation. The candidate is fully validated before commit;
 symlinks and detected changes to either loaded layer are rejected, new files are
@@ -444,24 +443,6 @@ creates empty coordinator metadata without retaining its path. Older peers
 retain empty local Workspace creation. Git information is still collected
 independently from item directories and cached. Paths do not create
 Workspace-level Git identity, and mixed-directory Workspaces remain valid.
-
-SETTINGS is the sixth top-level dashboard tab and is directly selectable with
-`6`. It edits only this local Node's active writable layer and groups every
-current setting under Terminal, Projects, Dashboard, Recovery, Scheduling,
-Notifications, and Sound. Rows show effective values and per-field sources;
-Delete removes the active override to restore inheritance. Space toggles
-booleans, Enter edits text and integers, Ctrl-S validates and atomically saves,
-and Esc cancels an edit or discards unsaved changes.
-
-Client-owned terminal selection, project discovery, and focused-terminal
-following are refreshed in the running dashboard after save. Recovery,
-Scheduling, desktop notification, and sound settings are daemon-owned. A saved
-change to any of them opens an explicit confirmation before graceful restart of
-the local daemon; declining retains a visible restart requirement. Runtime
-scheduler concurrency is observable, but applied recovery settings are not, so a
-restart that applies disabled terminal-history persistence conservatively warns
-that retained history will be cleared. No SETTINGS action reads or mutates
-configuration on a registered remote Node.
 
 The dashboard establishes an atomic event-stream baseline and treats later
 events as invalidation signals for authoritative snapshot reprojection. It also

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -195,8 +195,7 @@ support `--json`; it cannot be routed through federation.
 
 Configuration follows the same local authority boundary. The active writable
 layer is `BOOMUX_CONFIG` when set and the global XDG config file otherwise.
-Neither the config commands nor the dashboard SETTINGS tab can target a
-registered remote Node.
+The config commands cannot target a registered remote Node.
 
 The following commands support `--json`:
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -41,6 +41,12 @@ The `sound_notifications` feature similarly advertises optional direct sound
 delivery through `canberra-gtk-play`. `boomux notification test` is a human-facing
 delivery diagnostic and does not support `--json`.
 
+`boomux config path`, `boomux config validate`, and `boomux config edit` are
+also human-only local configuration commands. They do not support `--json`, do
+not appear in `json_commands`, and do not provide remote configuration mutation.
+`config validate` covers the complete global plus optional `BOOMUX_CONFIG`
+layered result without starting the daemon.
+
 ### Accepted Remote Node Compatibility
 
 Remote Node federation is an incremental extension tracked by #173. Protocol 31
@@ -186,6 +192,11 @@ in [`remote-nodes.md`](remote-nodes.md).
 `boomux node rekey` is an implemented local identity-administration command. It
 requires an interactive terminal and exact current-ID confirmation, and does not
 support `--json`; it cannot be routed through federation.
+
+Configuration follows the same local authority boundary. The active writable
+layer is `BOOMUX_CONFIG` when set and the global XDG config file otherwise.
+Neither the config commands nor the dashboard SETTINGS tab can target a
+registered remote Node.
 
 The following commands support `--json`:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,8 +15,10 @@
   as the default cwd for later shells.
 - [x] Assign shells created without a workspace to the next available
   `workspace-N` container.
-- [x] Load layered TOML configuration from the XDG config directory and an
-  optional `BOOMUX_CONFIG` override.
+- [x] Load field-layered TOML configuration from the XDG config directory and an
+  optional `BOOMUX_CONFIG` override, expose local path/validation/transactional
+  editing commands, and manage source-aware settings from the dashboard with
+  live client application or explicitly confirmed graceful daemon restart.
 - [x] Add plain shells, assign durable shell names, and carry those names into
   the dashboard, window titles, and dynamic Starship prompts.
 - [x] Rename focused workspaces and shells from the dashboard.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,8 +17,7 @@
   `workspace-N` container.
 - [x] Load field-layered TOML configuration from the XDG config directory and an
   optional `BOOMUX_CONFIG` override, expose local path/validation/transactional
-  editing commands, and manage source-aware settings from the dashboard with
-  live client application or explicitly confirmed graceful daemon restart.
+  editing commands, and preserve local Node ownership boundaries.
 - [x] Add plain shells, assign durable shell names, and carry those names into
   the dashboard, window titles, and dynamic Starship prompts.
 - [x] Rename focused workspaces and shells from the dashboard.

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 
 use serde::Deserialize;
-use toml_edit::{Array, DocumentMut, Item, Table, TableLike, Value};
 
 const DEFAULT_PROJECT_SEARCH_DEPTH: usize = 3;
 const MAX_PROJECT_SEARCH_DEPTH: usize = 10;
@@ -140,19 +139,8 @@ struct ConfigCommittedError(String);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ConfigSource {
-    Default,
     Global,
     Environment,
-}
-
-impl ConfigSource {
-    pub(crate) const fn label(self) -> &'static str {
-        match self {
-            Self::Default => "default",
-            Self::Global => "global",
-            Self::Environment => "BOOMUX_CONFIG",
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -168,107 +156,6 @@ pub(crate) struct ConfigSnapshot {
     pub(crate) active_path: PathBuf,
     pub(crate) active_source: ConfigSource,
     pub(crate) layers: Vec<ConfigLayer>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ConfigValues {
-    pub(crate) terminal: Option<String>,
-    pub(crate) project_roots: Vec<String>,
-    pub(crate) project_max_depth: usize,
-    pub(crate) follow_focused_terminal: bool,
-    pub(crate) resume_agents: bool,
-    pub(crate) persist_terminal_history: bool,
-    pub(crate) scheduling_max_concurrent: u16,
-    pub(crate) notifications_enabled: bool,
-    pub(crate) notifications_blocked: bool,
-    pub(crate) notifications_completed: bool,
-    pub(crate) notifications_scheduled_dispatch_failed: bool,
-    pub(crate) notifications_scheduled_interrupted: bool,
-    pub(crate) sound_enabled: bool,
-    pub(crate) sound_blocked: String,
-    pub(crate) sound_completed: String,
-    pub(crate) sound_scheduled_dispatch_failed: String,
-    pub(crate) sound_scheduled_interrupted: String,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub(crate) struct ConfigOverrides {
-    pub(crate) terminal: Option<String>,
-    pub(crate) project_roots: Option<Vec<String>>,
-    pub(crate) project_max_depth: Option<usize>,
-    pub(crate) follow_focused_terminal: Option<bool>,
-    pub(crate) resume_agents: Option<bool>,
-    pub(crate) persist_terminal_history: Option<bool>,
-    pub(crate) scheduling_max_concurrent: Option<u16>,
-    pub(crate) notifications_enabled: Option<bool>,
-    pub(crate) notifications_blocked: Option<bool>,
-    pub(crate) notifications_completed: Option<bool>,
-    pub(crate) notifications_scheduled_dispatch_failed: Option<bool>,
-    pub(crate) notifications_scheduled_interrupted: Option<bool>,
-    pub(crate) sound_enabled: Option<bool>,
-    pub(crate) sound_blocked: Option<String>,
-    pub(crate) sound_completed: Option<String>,
-    pub(crate) sound_scheduled_dispatch_failed: Option<String>,
-    pub(crate) sound_scheduled_interrupted: Option<String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ConfigSettings {
-    pub(crate) active_path: PathBuf,
-    pub(crate) active_source: ConfigSource,
-    pub(crate) inherited_source: ConfigSource,
-    pub(crate) inherited: ConfigValues,
-    pub(crate) inherited_overrides: ConfigOverrides,
-    pub(crate) effective: ConfigValues,
-    pub(crate) overrides: ConfigOverrides,
-    baseline: Option<Vec<u8>>,
-    inherited_baseline: Option<Vec<u8>>,
-}
-
-impl ConfigValues {
-    pub(crate) fn daemon_settings(&self) -> boomux::daemon::NotificationDeliverySettings {
-        boomux::daemon::NotificationDeliverySettings {
-            desktop: boomux::daemon::NotificationSettings {
-                enabled: self.notifications_enabled,
-                blocked: self.notifications_blocked,
-                completed: self.notifications_completed,
-                scheduled_dispatch_failed: self.notifications_scheduled_dispatch_failed,
-                scheduled_interrupted: self.notifications_scheduled_interrupted,
-            },
-            sound: boomux::daemon::NotificationSoundSettings {
-                enabled: self.sound_enabled,
-                blocked: self.sound_blocked.clone(),
-                completed: self.sound_completed.clone(),
-                scheduled_dispatch_failed: self.sound_scheduled_dispatch_failed.clone(),
-                scheduled_interrupted: self.sound_scheduled_interrupted.clone(),
-            },
-            resume_agents: self.resume_agents,
-            persist_terminal_history: self.persist_terminal_history,
-            max_scheduled_execution_concurrency: self.scheduling_max_concurrent,
-        }
-    }
-}
-
-impl ConfigSettings {
-    pub(crate) fn effective_config(&self) -> Result<Config, Box<dyn Error>> {
-        Ok(Config {
-            terminal: self.effective.terminal.clone(),
-            projects: ProjectsConfig {
-                roots: self
-                    .effective
-                    .project_roots
-                    .iter()
-                    .map(|root| expand_root(root))
-                    .collect::<Result<_, _>>()?,
-                max_depth: self.effective.project_max_depth,
-            },
-            path: Some(self.active_path.clone()),
-            notifications: self.effective.daemon_settings(),
-            dashboard: DashboardConfig {
-                follow_focused_terminal: self.effective.follow_focused_terminal,
-            },
-        })
-    }
 }
 
 impl fmt::Display for ConfigError {
@@ -303,52 +190,6 @@ pub(crate) fn load_snapshot() -> Result<ConfigSnapshot, Box<dyn Error>> {
     })
 }
 
-pub(crate) fn load_settings() -> Result<ConfigSettings, Box<dyn Error>> {
-    let paths = ConfigPaths::from_environment()?;
-    let active_path = paths.active()?.to_owned();
-    let baseline = match fs::metadata(&active_path) {
-        Ok(_) => Some(read_bounded(&active_path)?),
-        Err(error) if error.kind() == io::ErrorKind::NotFound && paths.environment.is_none() => {
-            None
-        }
-        Err(error) => return Err(error.into()),
-    };
-    settings_from_paths(&paths, active_path, baseline)
-}
-
-fn settings_from_paths(
-    paths: &ConfigPaths,
-    active_path: PathBuf,
-    baseline: Option<Vec<u8>>,
-) -> Result<ConfigSettings, Box<dyn Error>> {
-    let active_raw = baseline
-        .as_deref()
-        .map(|bytes| parse(&active_path, bytes))
-        .transpose()?
-        .unwrap_or_default();
-    let (effective_raw, loaded_path, _) = load_raw_from_paths(paths, baseline.as_deref())?;
-    let (inherited_raw, inherited_baseline) = load_inherited_raw(paths)?;
-    let effective = resolve(effective_raw.clone(), loaded_path)?;
-    let inherited = preview_values(&inherited_raw);
-    Ok(ConfigSettings {
-        active_path,
-        active_source: paths.active_source(),
-        inherited_source: if paths.has_distinct_environment_layer()
-            && paths.global.as_deref().is_some_and(Path::is_file)
-        {
-            ConfigSource::Global
-        } else {
-            ConfigSource::Default
-        },
-        inherited,
-        inherited_overrides: preview_overrides(inherited_raw),
-        effective: values_from_raw_and_config(effective_raw, &effective),
-        overrides: overrides_from_raw(active_raw)?,
-        baseline,
-        inherited_baseline,
-    })
-}
-
 pub(crate) fn load_notification_settings()
 -> Result<boomux::daemon::NotificationDeliverySettings, Box<dyn Error>> {
     let (raw, _) = load_raw()?;
@@ -368,7 +209,6 @@ struct ConfigPaths {
 }
 
 type RawLoad = (RawConfig, Option<PathBuf>, Vec<ConfigLayer>);
-type InheritedLoad = (RawConfig, Option<Vec<u8>>);
 
 impl ConfigPaths {
     fn from_environment() -> Result<Self, Box<dyn Error>> {
@@ -467,15 +307,14 @@ fn load_raw_from_paths(
     Ok((raw, loaded_path, layers))
 }
 
-fn load_inherited_raw(paths: &ConfigPaths) -> Result<InheritedLoad, Box<dyn Error>> {
+fn load_inherited_baseline(paths: &ConfigPaths) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
     if paths.has_distinct_environment_layer()
         && let Some(global) = paths.global.as_deref()
         && global.is_file()
     {
-        let bytes = read_bounded(global)?;
-        return Ok((parse(global, &bytes)?, Some(bytes)));
+        return read_bounded(global).map(Some);
     }
-    Ok((RawConfig::default(), None))
+    Ok(None)
 }
 
 fn verify_inherited_baseline(
@@ -562,60 +401,6 @@ pub(crate) fn validate() -> Result<ConfigSnapshot, Box<dyn Error>> {
     load_snapshot()
 }
 
-pub(crate) fn save_settings(
-    expected: &ConfigSettings,
-    overrides: &ConfigOverrides,
-) -> Result<ConfigSettings, Box<dyn Error>> {
-    let paths = ConfigPaths::from_environment()?;
-    save_settings_with_paths(&paths, expected, overrides)
-}
-
-fn save_settings_with_paths(
-    paths: &ConfigPaths,
-    expected: &ConfigSettings,
-    overrides: &ConfigOverrides,
-) -> Result<ConfigSettings, Box<dyn Error>> {
-    if paths.active()? != expected.active_path || paths.active_source() != expected.active_source {
-        return Err(
-            ConfigError("active config source changed; reload settings and retry".into()).into(),
-        );
-    }
-    let original = expected
-        .baseline
-        .as_deref()
-        .unwrap_or(CONFIG_TEMPLATE.as_bytes());
-    let text = std::str::from_utf8(original).map_err(|error| {
-        ConfigError(format!(
-            "invalid config {}: {error}",
-            expected.active_path.display()
-        ))
-    })?;
-    let mut document = text.parse::<DocumentMut>().map_err(|error| {
-        ConfigError(format!(
-            "invalid config {}: {error}",
-            expected.active_path.display()
-        ))
-    })?;
-    apply_overrides(&mut document, overrides);
-    let candidate = document.to_string().into_bytes();
-    if candidate.len() as u64 > MAX_CONFIG_BYTES {
-        return Err(ConfigError(format!(
-            "config {} exceeds the {} byte limit",
-            expected.active_path.display(),
-            MAX_CONFIG_BYTES
-        ))
-        .into());
-    }
-    let saved = settings_from_paths(paths, expected.active_path.clone(), Some(candidate.clone()))?;
-    verify_inherited_baseline(paths, expected.inherited_baseline.as_deref())?;
-    commit_candidate(
-        &expected.active_path,
-        expected.baseline.as_deref(),
-        &candidate,
-    )?;
-    Ok(saved)
-}
-
 pub(crate) fn edit() -> Result<(), Box<dyn Error>> {
     let paths = ConfigPaths::from_environment()?;
     let editor = editor_argv()?;
@@ -681,7 +466,7 @@ fn edit_with(
         Err(error) if error.kind() == io::ErrorKind::NotFound => None,
         Err(error) => return Err(error.into()),
     };
-    let (_, inherited_baseline) = load_inherited_raw(paths)?;
+    let inherited_baseline = load_inherited_baseline(paths)?;
 
     let mut builder = fs::DirBuilder::new();
     builder.recursive(true).mode(0o700);
@@ -786,306 +571,6 @@ fn validate_layers(
     let (raw, loaded_path, _) = load_raw_from_paths(paths, active_candidate)?;
     resolve(raw, loaded_path)?;
     Ok(())
-}
-
-fn values_from_raw_and_config(raw: RawConfig, config: &Config) -> ConfigValues {
-    let roots = raw.projects.unwrap_or_default().roots.unwrap_or_default();
-    let notifications = &config.notifications;
-    ConfigValues {
-        terminal: config.terminal.clone(),
-        project_roots: roots,
-        project_max_depth: config.projects.max_depth,
-        follow_focused_terminal: config.dashboard.follow_focused_terminal,
-        resume_agents: notifications.resume_agents,
-        persist_terminal_history: notifications.persist_terminal_history,
-        scheduling_max_concurrent: notifications.max_scheduled_execution_concurrency,
-        notifications_enabled: notifications.desktop.enabled,
-        notifications_blocked: notifications.desktop.blocked,
-        notifications_completed: notifications.desktop.completed,
-        notifications_scheduled_dispatch_failed: notifications.desktop.scheduled_dispatch_failed,
-        notifications_scheduled_interrupted: notifications.desktop.scheduled_interrupted,
-        sound_enabled: notifications.sound.enabled,
-        sound_blocked: notifications.sound.blocked.clone(),
-        sound_completed: notifications.sound.completed.clone(),
-        sound_scheduled_dispatch_failed: notifications.sound.scheduled_dispatch_failed.clone(),
-        sound_scheduled_interrupted: notifications.sound.scheduled_interrupted.clone(),
-    }
-}
-
-fn preview_values(raw: &RawConfig) -> ConfigValues {
-    let defaults = resolve(RawConfig::default(), None).expect("built-in config is valid");
-    let mut values = values_from_raw_and_config(RawConfig::default(), &defaults);
-    if let Some(terminal) = &raw.terminal {
-        values.terminal = Some(terminal.trim().to_owned());
-    }
-    if let Some(projects) = &raw.projects {
-        if let Some(roots) = &projects.roots {
-            values.project_roots.clone_from(roots);
-        }
-        if let Some(max_depth) = projects.max_depth {
-            values.project_max_depth = max_depth;
-        }
-    }
-    if let Some(dashboard) = &raw.dashboard
-        && let Some(value) = dashboard.follow_focused_terminal
-    {
-        values.follow_focused_terminal = value;
-    }
-    if let Some(recovery) = &raw.recovery {
-        values.resume_agents = recovery.resume_agents.unwrap_or(values.resume_agents);
-        values.persist_terminal_history = recovery
-            .persist_terminal_history
-            .unwrap_or(values.persist_terminal_history);
-    }
-    if let Some(max_concurrent) = raw
-        .scheduling
-        .as_ref()
-        .and_then(|scheduling| scheduling.max_concurrent)
-    {
-        values.scheduling_max_concurrent = u16::try_from(max_concurrent).unwrap_or_else(|_| {
-            if max_concurrent.is_negative() {
-                0
-            } else {
-                u16::MAX
-            }
-        });
-    }
-    if let Some(notifications) = &raw.notifications {
-        values.notifications_enabled = notifications
-            .enabled
-            .unwrap_or(values.notifications_enabled);
-        values.notifications_blocked = notifications
-            .blocked
-            .unwrap_or(values.notifications_blocked);
-        values.notifications_completed = notifications
-            .completed
-            .unwrap_or(values.notifications_completed);
-        values.notifications_scheduled_dispatch_failed = notifications
-            .scheduled_dispatch_failed
-            .unwrap_or(values.notifications_scheduled_dispatch_failed);
-        values.notifications_scheduled_interrupted = notifications
-            .scheduled_interrupted
-            .unwrap_or(values.notifications_scheduled_interrupted);
-        if let Some(sound) = &notifications.sound {
-            values.sound_enabled = sound.enabled.unwrap_or(values.sound_enabled);
-            if let Some(value) = &sound.blocked {
-                values.sound_blocked.clone_from(value);
-            }
-            if let Some(value) = &sound.completed {
-                values.sound_completed.clone_from(value);
-            }
-            if let Some(value) = &sound.scheduled_dispatch_failed {
-                values.sound_scheduled_dispatch_failed.clone_from(value);
-            }
-            if let Some(value) = &sound.scheduled_interrupted {
-                values.sound_scheduled_interrupted.clone_from(value);
-            }
-        }
-    }
-    values
-}
-
-fn preview_overrides(raw: RawConfig) -> ConfigOverrides {
-    let projects = raw.projects.unwrap_or_default();
-    let dashboard = raw.dashboard.unwrap_or_default();
-    let recovery = raw.recovery.unwrap_or_default();
-    let scheduling = raw.scheduling.unwrap_or_default();
-    let notifications = raw.notifications.unwrap_or_default();
-    let sound = notifications.sound.unwrap_or_default();
-    ConfigOverrides {
-        terminal: raw.terminal,
-        project_roots: projects.roots,
-        project_max_depth: projects.max_depth,
-        follow_focused_terminal: dashboard.follow_focused_terminal,
-        resume_agents: recovery.resume_agents,
-        persist_terminal_history: recovery.persist_terminal_history,
-        scheduling_max_concurrent: scheduling.max_concurrent.map(|value| {
-            u16::try_from(value).unwrap_or_else(|_| if value.is_negative() { 0 } else { u16::MAX })
-        }),
-        notifications_enabled: notifications.enabled,
-        notifications_blocked: notifications.blocked,
-        notifications_completed: notifications.completed,
-        notifications_scheduled_dispatch_failed: notifications.scheduled_dispatch_failed,
-        notifications_scheduled_interrupted: notifications.scheduled_interrupted,
-        sound_enabled: sound.enabled,
-        sound_blocked: sound.blocked,
-        sound_completed: sound.completed,
-        sound_scheduled_dispatch_failed: sound.scheduled_dispatch_failed,
-        sound_scheduled_interrupted: sound.scheduled_interrupted,
-    }
-}
-
-fn overrides_from_raw(raw: RawConfig) -> Result<ConfigOverrides, Box<dyn Error>> {
-    let projects = raw.projects.unwrap_or_default();
-    let dashboard = raw.dashboard.unwrap_or_default();
-    let recovery = raw.recovery.unwrap_or_default();
-    let scheduling = raw.scheduling.unwrap_or_default();
-    let notifications = raw.notifications.unwrap_or_default();
-    let sound = notifications.sound.unwrap_or_default();
-    Ok(ConfigOverrides {
-        terminal: raw.terminal,
-        project_roots: projects.roots,
-        project_max_depth: projects.max_depth,
-        follow_focused_terminal: dashboard.follow_focused_terminal,
-        resume_agents: recovery.resume_agents,
-        persist_terminal_history: recovery.persist_terminal_history,
-        scheduling_max_concurrent: scheduling
-            .max_concurrent
-            .map(u16::try_from)
-            .transpose()
-            .map_err(|_| ConfigError("scheduling.max_concurrent must fit in u16".into()))?,
-        notifications_enabled: notifications.enabled,
-        notifications_blocked: notifications.blocked,
-        notifications_completed: notifications.completed,
-        notifications_scheduled_dispatch_failed: notifications.scheduled_dispatch_failed,
-        notifications_scheduled_interrupted: notifications.scheduled_interrupted,
-        sound_enabled: sound.enabled,
-        sound_blocked: sound.blocked,
-        sound_completed: sound.completed,
-        sound_scheduled_dispatch_failed: sound.scheduled_dispatch_failed,
-        sound_scheduled_interrupted: sound.scheduled_interrupted,
-    })
-}
-
-fn apply_overrides(document: &mut DocumentMut, overrides: &ConfigOverrides) {
-    set_string(document, &["terminal"], overrides.terminal.as_deref());
-    set_strings(
-        document,
-        &["projects", "roots"],
-        overrides.project_roots.as_deref(),
-    );
-    set_integer(
-        document,
-        &["projects", "max_depth"],
-        overrides.project_max_depth.map(|value| value as i64),
-    );
-    set_bool(
-        document,
-        &["dashboard", "follow_focused_terminal"],
-        overrides.follow_focused_terminal,
-    );
-    set_bool(
-        document,
-        &["recovery", "resume_agents"],
-        overrides.resume_agents,
-    );
-    set_bool(
-        document,
-        &["recovery", "persist_terminal_history"],
-        overrides.persist_terminal_history,
-    );
-    set_integer(
-        document,
-        &["scheduling", "max_concurrent"],
-        overrides.scheduling_max_concurrent.map(i64::from),
-    );
-    for (key, setting) in [
-        ("enabled", overrides.notifications_enabled),
-        ("blocked", overrides.notifications_blocked),
-        ("completed", overrides.notifications_completed),
-        (
-            "scheduled_dispatch_failed",
-            overrides.notifications_scheduled_dispatch_failed,
-        ),
-        (
-            "scheduled_interrupted",
-            overrides.notifications_scheduled_interrupted,
-        ),
-    ] {
-        set_bool(document, &["notifications", key], setting);
-    }
-    set_bool(
-        document,
-        &["notifications", "sound", "enabled"],
-        overrides.sound_enabled,
-    );
-    for (key, setting) in [
-        ("blocked", overrides.sound_blocked.as_deref()),
-        ("completed", overrides.sound_completed.as_deref()),
-        (
-            "scheduled_dispatch_failed",
-            overrides.sound_scheduled_dispatch_failed.as_deref(),
-        ),
-        (
-            "scheduled_interrupted",
-            overrides.sound_scheduled_interrupted.as_deref(),
-        ),
-    ] {
-        set_string(document, &["notifications", "sound", key], setting);
-    }
-}
-
-fn table_for_path<'a>(document: &'a mut DocumentMut, path: &[&str]) -> &'a mut dyn TableLike {
-    let mut table: &mut dyn TableLike = document.as_table_mut();
-    for key in path {
-        let item = table
-            .entry(key)
-            .or_insert_with(|| Item::Table(Table::new()));
-        if !item.is_table_like() {
-            *item = Item::Table(Table::new());
-        }
-        table = item.as_table_like_mut().expect("created table-like item");
-    }
-    table
-}
-
-fn remove_key(document: &mut DocumentMut, path: &[&str]) {
-    let Some((key, parents)) = path.split_last() else {
-        return;
-    };
-    let mut table: &mut dyn TableLike = document.as_table_mut();
-    for parent in parents {
-        let Some(next) = table.get_mut(parent).and_then(Item::as_table_like_mut) else {
-            return;
-        };
-        table = next;
-    }
-    table.remove(key);
-}
-
-fn set_value(document: &mut DocumentMut, path: &[&str], setting: Option<Value>) {
-    let Some((key, parents)) = path.split_last() else {
-        return;
-    };
-    match setting {
-        Some(setting) => {
-            let table = table_for_path(document, parents);
-            let mut setting = setting;
-            if let Some(existing) = table.get_mut(key).and_then(Item::as_value_mut) {
-                setting.decor_mut().clone_from(existing.decor());
-                *existing = setting;
-                return;
-            }
-            table.insert(key, Item::Value(setting));
-        }
-        None => remove_key(document, path),
-    }
-}
-
-fn set_string(document: &mut DocumentMut, path: &[&str], setting: Option<&str>) {
-    set_value(document, path, setting.map(Value::from));
-}
-
-fn set_bool(document: &mut DocumentMut, path: &[&str], setting: Option<bool>) {
-    set_value(document, path, setting.map(Value::from));
-}
-
-fn set_integer(document: &mut DocumentMut, path: &[&str], setting: Option<i64>) {
-    set_value(document, path, setting.map(Value::from));
-}
-
-fn set_strings(document: &mut DocumentMut, path: &[&str], setting: Option<&[String]>) {
-    set_value(
-        document,
-        path,
-        setting.map(|strings| {
-            let mut array = Array::new();
-            for string in strings {
-                array.push(string.as_str());
-            }
-            Value::Array(array)
-        }),
-    );
 }
 
 fn validate_regular_owner(
@@ -1367,23 +852,6 @@ fn home_directory() -> Result<PathBuf, Box<dyn Error>> {
         .map(PathBuf::from)
         .filter(|path| path.is_absolute())
         .ok_or_else(|| ConfigError("HOME must be an absolute path to expand ~".into()).into())
-}
-
-#[cfg(test)]
-pub(crate) fn test_settings() -> ConfigSettings {
-    let effective = resolve(RawConfig::default(), None).expect("default config");
-    let values = values_from_raw_and_config(RawConfig::default(), &effective);
-    ConfigSettings {
-        active_path: PathBuf::from("/tmp/boomux-test-config.toml"),
-        active_source: ConfigSource::Global,
-        inherited_source: ConfigSource::Default,
-        inherited: values.clone(),
-        inherited_overrides: ConfigOverrides::default(),
-        effective: values,
-        overrides: ConfigOverrides::default(),
-        baseline: None,
-        inherited_baseline: None,
-    }
 }
 
 #[cfg(test)]
@@ -1673,63 +1141,6 @@ mod tests {
     }
 
     #[test]
-    fn structured_edits_preserve_comments_and_unrelated_formatting() {
-        let original = r#"# owner note
-terminal = "Alacritty.desktop" # keep inline
-
-[projects] # project note
-roots = [ "/old" ]
-max_depth = 2
-
-[dashboard]
-follow_focused_terminal = true
-"#;
-        let mut document = original.parse::<DocumentMut>().unwrap();
-        let overrides = ConfigOverrides {
-            terminal: Some("com.mitchellh.ghostty.desktop".into()),
-            project_roots: Some(vec!["~/Code".into(), "/srv/work".into()]),
-            project_max_depth: Some(2),
-            follow_focused_terminal: Some(false),
-            ..Default::default()
-        };
-
-        apply_overrides(&mut document, &overrides);
-        let edited = document.to_string();
-
-        assert!(edited.contains("# owner note"));
-        assert!(edited.contains("# keep inline"));
-        assert!(edited.contains("# project note"));
-        assert!(edited.contains("max_depth = 2"));
-        assert!(!edited.contains("follow_focused_terminal = true"));
-        assert!(edited.contains("follow_focused_terminal = false"));
-        assert!(edited.contains("~/Code"));
-        assert!(edited.contains("/srv/work"));
-    }
-
-    #[test]
-    fn structured_edits_preserve_unrelated_inline_table_values() {
-        let original = r#"notifications = { blocked = false, sound = { blocked = "old", completed = "keep" } }
-"#;
-        let mut document = original.parse::<DocumentMut>().unwrap();
-        let overrides = ConfigOverrides {
-            notifications_enabled: Some(true),
-            notifications_blocked: Some(false),
-            sound_blocked: Some("new".into()),
-            sound_completed: Some("keep".into()),
-            ..Default::default()
-        };
-
-        apply_overrides(&mut document, &overrides);
-        let raw: RawConfig = toml::from_str(&document.to_string()).unwrap();
-        let notifications = raw.notifications.unwrap();
-        assert_eq!(notifications.enabled, Some(true));
-        assert_eq!(notifications.blocked, Some(false));
-        let sound = notifications.sound.unwrap();
-        assert_eq!(sound.blocked.as_deref(), Some("new"));
-        assert_eq!(sound.completed.as_deref(), Some("keep"));
-    }
-
-    #[test]
     fn layered_semantics_are_resolved_only_after_field_merge() {
         let mut base: RawConfig =
             toml::from_str("[projects]\nmax_depth = 99\n[scheduling]\nmax_concurrent = 100")
@@ -1745,129 +1156,6 @@ follow_focused_terminal = true
             resolved.notifications.max_scheduled_execution_concurrency,
             8
         );
-    }
-
-    #[test]
-    fn source_labels_distinguish_default_global_and_environment() {
-        assert_eq!(ConfigSource::Default.label(), "default");
-        assert_eq!(ConfigSource::Global.label(), "global");
-        assert_eq!(ConfigSource::Environment.label(), "BOOMUX_CONFIG");
-
-        let global = ConfigPaths {
-            global: Some(PathBuf::from("/tmp/global.toml")),
-            environment: None,
-        };
-        assert_eq!(global.active_source(), ConfigSource::Global);
-        let environment = ConfigPaths {
-            global: global.global,
-            environment: Some(PathBuf::from("/tmp/override.toml")),
-        };
-        assert_eq!(environment.active_source(), ConfigSource::Environment);
-        assert_eq!(
-            environment.active().unwrap(),
-            Path::new("/tmp/override.toml")
-        );
-    }
-
-    #[test]
-    fn settings_load_and_save_allow_active_layer_to_correct_invalid_lower_semantics() {
-        let test = TestDirectory::new();
-        let global = test.0.join("global.toml");
-        let environment = test.0.join("environment.toml");
-        fs::write(
-            &global,
-            "[projects]\nmax_depth = 99\n[scheduling]\nmax_concurrent = 100\n",
-        )
-        .unwrap();
-        fs::write(
-            &environment,
-            "[projects]\nmax_depth = 2\n[scheduling]\nmax_concurrent = 8\n",
-        )
-        .unwrap();
-        fs::set_permissions(&environment, fs::Permissions::from_mode(0o640)).unwrap();
-        let paths = ConfigPaths {
-            global: Some(global.clone()),
-            environment: Some(environment.clone()),
-        };
-
-        let settings = settings_from_paths(
-            &paths,
-            environment.clone(),
-            Some(read_bounded(&environment).unwrap()),
-        )
-        .unwrap();
-        assert_eq!(settings.inherited.project_max_depth, 99);
-        assert_eq!(settings.inherited.scheduling_max_concurrent, 100);
-        assert_eq!(settings.effective.project_max_depth, 2);
-        assert_eq!(settings.effective.scheduling_max_concurrent, 8);
-
-        let mut overrides = settings.overrides.clone();
-        overrides.project_max_depth = Some(3);
-        let saved = save_settings_with_paths(&paths, &settings, &overrides).unwrap();
-        assert_eq!(saved.effective.project_max_depth, 3);
-        assert_eq!(saved.effective.scheduling_max_concurrent, 8);
-        assert_eq!(
-            fs::metadata(&environment).unwrap().permissions().mode() & 0o777,
-            0o640
-        );
-        assert!(
-            fs::read_to_string(global)
-                .unwrap()
-                .contains("max_depth = 99")
-        );
-    }
-
-    #[test]
-    fn settings_save_rejects_a_changed_inherited_layer() {
-        let test = TestDirectory::new();
-        let global = test.0.join("global.toml");
-        let environment = test.0.join("environment.toml");
-        fs::write(&global, "[projects]\nmax_depth = 2\n").unwrap();
-        fs::write(&environment, "[notifications]\nenabled = false\n").unwrap();
-        let paths = ConfigPaths {
-            global: Some(global.clone()),
-            environment: Some(environment.clone()),
-        };
-        let settings = settings_from_paths(
-            &paths,
-            environment.clone(),
-            Some(read_bounded(&environment).unwrap()),
-        )
-        .unwrap();
-        fs::write(&global, "[projects]\nmax_depth = 3\n").unwrap();
-
-        let mut overrides = settings.overrides.clone();
-        overrides.notifications_enabled = Some(true);
-        let error = save_settings_with_paths(&paths, &settings, &overrides)
-            .unwrap_err()
-            .to_string();
-
-        assert!(error.contains("inherited config changed"), "{error}");
-        assert!(fs::read_to_string(environment).unwrap().contains("false"));
-    }
-
-    #[test]
-    fn settings_read_symlink_but_refuse_to_mutate_it() {
-        let test = TestDirectory::new();
-        let real = test.0.join("real.toml");
-        let linked = test.0.join("linked.toml");
-        fs::write(&real, "[projects]\nmax_depth = 2\n").unwrap();
-        std::os::unix::fs::symlink(&real, &linked).unwrap();
-        let paths = ConfigPaths {
-            global: None,
-            environment: Some(linked.clone()),
-        };
-        let settings =
-            settings_from_paths(&paths, linked, Some(read_bounded(&real).unwrap())).unwrap();
-        assert_eq!(settings.effective.project_max_depth, 2);
-
-        let mut overrides = settings.overrides.clone();
-        overrides.project_max_depth = Some(3);
-        let error = save_settings_with_paths(&paths, &settings, &overrides)
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("not a regular file"), "{error}");
-        assert!(fs::read_to_string(real).unwrap().contains("max_depth = 2"));
     }
 
     #[test]
@@ -1900,11 +1188,5 @@ follow_focused_terminal = true
         assert_eq!(resolve(raw, loaded_path).unwrap().projects.max_depth, 2);
         assert_eq!(layers.len(), 1);
         assert_eq!(layers[0].source, ConfigSource::Environment);
-
-        let settings =
-            settings_from_paths(&paths, alias, Some(read_bounded(&path).unwrap())).unwrap();
-        assert_eq!(settings.active_source, ConfigSource::Environment);
-        assert_eq!(settings.inherited_source, ConfigSource::Default);
-        assert_eq!(settings.inherited_overrides, ConfigOverrides::default());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,58 @@
 use std::env;
 use std::error::Error;
+use std::ffi::{CString, OsStr, OsString};
 use std::fmt;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Stdio};
 
 use serde::Deserialize;
+use toml_edit::{Array, DocumentMut, Item, Table, TableLike, Value};
 
 const DEFAULT_PROJECT_SEARCH_DEPTH: usize = 3;
 const MAX_PROJECT_SEARCH_DEPTH: usize = 10;
 const DEFAULT_MAX_SCHEDULED_EXECUTION_CONCURRENCY: u16 = 4;
 const MAX_SCHEDULED_EXECUTION_CONCURRENCY: i64 = 64;
+const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
+const TEMPORARY_CREATE_ATTEMPTS: u8 = 16;
+
+pub(crate) const CONFIG_TEMPLATE: &str = r#"# Boomux configuration
+# Uncomment settings to override their defaults.
+
+# XDG desktop entry used when Boomux opens terminal windows.
+# terminal = "Alacritty.desktop"
+
+[projects]
+# roots = ["~/Projects"]
+# max_depth = 3
+
+[dashboard]
+# follow_focused_terminal = true
+
+[notifications]
+# enabled = false
+# blocked = true
+# completed = true
+# scheduled_dispatch_failed = false
+# scheduled_interrupted = false
+
+[notifications.sound]
+# enabled = false
+# blocked = "message-new-instant"
+# completed = "complete"
+# scheduled_dispatch_failed = "dialog-warning"
+# scheduled_interrupted = "dialog-warning"
+
+[recovery]
+# resume_agents = true
+# persist_terminal_history = false
+
+[scheduling]
+# max_concurrent = 4
+"#;
 
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -69,7 +112,7 @@ struct RawSchedulingConfig {
     max_concurrent: Option<i64>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Config {
     pub(crate) terminal: Option<String>,
     pub(crate) projects: ProjectsConfig,
@@ -78,19 +121,155 @@ pub(crate) struct Config {
     pub(crate) dashboard: DashboardConfig,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ProjectsConfig {
     pub(crate) roots: Vec<PathBuf>,
     pub(crate) max_depth: usize,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DashboardConfig {
     pub(crate) follow_focused_terminal: bool,
 }
 
 #[derive(Debug)]
 struct ConfigError(String);
+
+#[derive(Debug)]
+struct ConfigCommittedError(String);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ConfigSource {
+    Default,
+    Global,
+    Environment,
+}
+
+impl ConfigSource {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Global => "global",
+            Self::Environment => "BOOMUX_CONFIG",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ConfigLayer {
+    pub(crate) source: ConfigSource,
+    pub(crate) path: PathBuf,
+    pub(crate) loaded: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ConfigSnapshot {
+    pub(crate) effective: Config,
+    pub(crate) active_path: PathBuf,
+    pub(crate) active_source: ConfigSource,
+    pub(crate) layers: Vec<ConfigLayer>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ConfigValues {
+    pub(crate) terminal: Option<String>,
+    pub(crate) project_roots: Vec<String>,
+    pub(crate) project_max_depth: usize,
+    pub(crate) follow_focused_terminal: bool,
+    pub(crate) resume_agents: bool,
+    pub(crate) persist_terminal_history: bool,
+    pub(crate) scheduling_max_concurrent: u16,
+    pub(crate) notifications_enabled: bool,
+    pub(crate) notifications_blocked: bool,
+    pub(crate) notifications_completed: bool,
+    pub(crate) notifications_scheduled_dispatch_failed: bool,
+    pub(crate) notifications_scheduled_interrupted: bool,
+    pub(crate) sound_enabled: bool,
+    pub(crate) sound_blocked: String,
+    pub(crate) sound_completed: String,
+    pub(crate) sound_scheduled_dispatch_failed: String,
+    pub(crate) sound_scheduled_interrupted: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ConfigOverrides {
+    pub(crate) terminal: Option<String>,
+    pub(crate) project_roots: Option<Vec<String>>,
+    pub(crate) project_max_depth: Option<usize>,
+    pub(crate) follow_focused_terminal: Option<bool>,
+    pub(crate) resume_agents: Option<bool>,
+    pub(crate) persist_terminal_history: Option<bool>,
+    pub(crate) scheduling_max_concurrent: Option<u16>,
+    pub(crate) notifications_enabled: Option<bool>,
+    pub(crate) notifications_blocked: Option<bool>,
+    pub(crate) notifications_completed: Option<bool>,
+    pub(crate) notifications_scheduled_dispatch_failed: Option<bool>,
+    pub(crate) notifications_scheduled_interrupted: Option<bool>,
+    pub(crate) sound_enabled: Option<bool>,
+    pub(crate) sound_blocked: Option<String>,
+    pub(crate) sound_completed: Option<String>,
+    pub(crate) sound_scheduled_dispatch_failed: Option<String>,
+    pub(crate) sound_scheduled_interrupted: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ConfigSettings {
+    pub(crate) active_path: PathBuf,
+    pub(crate) active_source: ConfigSource,
+    pub(crate) inherited_source: ConfigSource,
+    pub(crate) inherited: ConfigValues,
+    pub(crate) inherited_overrides: ConfigOverrides,
+    pub(crate) effective: ConfigValues,
+    pub(crate) overrides: ConfigOverrides,
+    baseline: Option<Vec<u8>>,
+    inherited_baseline: Option<Vec<u8>>,
+}
+
+impl ConfigValues {
+    pub(crate) fn daemon_settings(&self) -> boomux::daemon::NotificationDeliverySettings {
+        boomux::daemon::NotificationDeliverySettings {
+            desktop: boomux::daemon::NotificationSettings {
+                enabled: self.notifications_enabled,
+                blocked: self.notifications_blocked,
+                completed: self.notifications_completed,
+                scheduled_dispatch_failed: self.notifications_scheduled_dispatch_failed,
+                scheduled_interrupted: self.notifications_scheduled_interrupted,
+            },
+            sound: boomux::daemon::NotificationSoundSettings {
+                enabled: self.sound_enabled,
+                blocked: self.sound_blocked.clone(),
+                completed: self.sound_completed.clone(),
+                scheduled_dispatch_failed: self.sound_scheduled_dispatch_failed.clone(),
+                scheduled_interrupted: self.sound_scheduled_interrupted.clone(),
+            },
+            resume_agents: self.resume_agents,
+            persist_terminal_history: self.persist_terminal_history,
+            max_scheduled_execution_concurrency: self.scheduling_max_concurrent,
+        }
+    }
+}
+
+impl ConfigSettings {
+    pub(crate) fn effective_config(&self) -> Result<Config, Box<dyn Error>> {
+        Ok(Config {
+            terminal: self.effective.terminal.clone(),
+            projects: ProjectsConfig {
+                roots: self
+                    .effective
+                    .project_roots
+                    .iter()
+                    .map(|root| expand_root(root))
+                    .collect::<Result<_, _>>()?,
+                max_depth: self.effective.project_max_depth,
+            },
+            path: Some(self.active_path.clone()),
+            notifications: self.effective.daemon_settings(),
+            dashboard: DashboardConfig {
+                follow_focused_terminal: self.effective.follow_focused_terminal,
+            },
+        })
+    }
+}
 
 impl fmt::Display for ConfigError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -100,9 +279,74 @@ impl fmt::Display for ConfigError {
 
 impl Error for ConfigError {}
 
+impl fmt::Display for ConfigCommittedError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl Error for ConfigCommittedError {}
+
 pub(crate) fn load() -> Result<Config, Box<dyn Error>> {
     let (raw, loaded_path) = load_raw()?;
     resolve(raw, loaded_path)
+}
+
+pub(crate) fn load_snapshot() -> Result<ConfigSnapshot, Box<dyn Error>> {
+    let paths = ConfigPaths::from_environment()?;
+    let (raw, loaded_path, layers) = load_raw_from_paths(&paths, None)?;
+    Ok(ConfigSnapshot {
+        effective: resolve(raw, loaded_path)?,
+        active_path: paths.active()?.to_owned(),
+        active_source: paths.active_source(),
+        layers,
+    })
+}
+
+pub(crate) fn load_settings() -> Result<ConfigSettings, Box<dyn Error>> {
+    let paths = ConfigPaths::from_environment()?;
+    let active_path = paths.active()?.to_owned();
+    let baseline = match fs::metadata(&active_path) {
+        Ok(_) => Some(read_bounded(&active_path)?),
+        Err(error) if error.kind() == io::ErrorKind::NotFound && paths.environment.is_none() => {
+            None
+        }
+        Err(error) => return Err(error.into()),
+    };
+    settings_from_paths(&paths, active_path, baseline)
+}
+
+fn settings_from_paths(
+    paths: &ConfigPaths,
+    active_path: PathBuf,
+    baseline: Option<Vec<u8>>,
+) -> Result<ConfigSettings, Box<dyn Error>> {
+    let active_raw = baseline
+        .as_deref()
+        .map(|bytes| parse(&active_path, bytes))
+        .transpose()?
+        .unwrap_or_default();
+    let (effective_raw, loaded_path, _) = load_raw_from_paths(paths, baseline.as_deref())?;
+    let (inherited_raw, inherited_baseline) = load_inherited_raw(paths)?;
+    let effective = resolve(effective_raw.clone(), loaded_path)?;
+    let inherited = preview_values(&inherited_raw);
+    Ok(ConfigSettings {
+        active_path,
+        active_source: paths.active_source(),
+        inherited_source: if paths.has_distinct_environment_layer()
+            && paths.global.as_deref().is_some_and(Path::is_file)
+        {
+            ConfigSource::Global
+        } else {
+            ConfigSource::Default
+        },
+        inherited,
+        inherited_overrides: preview_overrides(inherited_raw),
+        effective: values_from_raw_and_config(effective_raw, &effective),
+        overrides: overrides_from_raw(active_raw)?,
+        baseline,
+        inherited_baseline,
+    })
 }
 
 pub(crate) fn load_notification_settings()
@@ -112,27 +356,151 @@ pub(crate) fn load_notification_settings()
 }
 
 fn load_raw() -> Result<(RawConfig, Option<PathBuf>), Box<dyn Error>> {
-    let global_path = global_config_path();
+    let paths = ConfigPaths::from_environment()?;
+    let (raw, loaded_path, _) = load_raw_from_paths(&paths, None)?;
+    Ok((raw, loaded_path))
+}
+
+#[derive(Clone, Debug)]
+struct ConfigPaths {
+    global: Option<PathBuf>,
+    environment: Option<PathBuf>,
+}
+
+type RawLoad = (RawConfig, Option<PathBuf>, Vec<ConfigLayer>);
+type InheritedLoad = (RawConfig, Option<Vec<u8>>);
+
+impl ConfigPaths {
+    fn from_environment() -> Result<Self, Box<dyn Error>> {
+        let environment = env::var_os("BOOMUX_CONFIG")
+            .map(|path| {
+                if path.is_empty() {
+                    Err(ConfigError("BOOMUX_CONFIG cannot be empty".into()))
+                } else {
+                    Ok(PathBuf::from(path))
+                }
+            })
+            .transpose()?;
+        Ok(Self {
+            global: global_config_path(),
+            environment,
+        })
+    }
+
+    fn active(&self) -> Result<&Path, Box<dyn Error>> {
+        self.environment
+            .as_deref()
+            .or(self.global.as_deref())
+            .ok_or_else(|| {
+                ConfigError(
+                    "cannot resolve config path: XDG_CONFIG_HOME or HOME must be absolute".into(),
+                )
+                .into()
+            })
+    }
+
+    fn active_source(&self) -> ConfigSource {
+        if self.environment.is_some() {
+            ConfigSource::Environment
+        } else {
+            ConfigSource::Global
+        }
+    }
+
+    fn has_distinct_environment_layer(&self) -> bool {
+        let (Some(global), Some(environment)) = (&self.global, &self.environment) else {
+            return false;
+        };
+        if global == environment {
+            return false;
+        }
+        match (fs::metadata(global), fs::metadata(environment)) {
+            (Ok(global), Ok(environment)) => {
+                global.dev() != environment.dev() || global.ino() != environment.ino()
+            }
+            _ => true,
+        }
+    }
+}
+
+fn load_raw_from_paths(
+    paths: &ConfigPaths,
+    active_candidate: Option<&[u8]>,
+) -> Result<RawLoad, Box<dyn Error>> {
     let mut raw = RawConfig::default();
     let mut loaded_path = None;
+    let mut layers = Vec::new();
 
-    if let Some(path) = global_path.as_deref()
-        && path.is_file()
+    if let Some(path) = paths
+        .global
+        .as_deref()
+        .filter(|_| !paths.environment.is_some() || paths.has_distinct_environment_layer())
     {
-        merge(&mut raw, read(path)?);
-        loaded_path = Some(path.to_owned());
-    }
-
-    if let Some(path) = env::var_os("BOOMUX_CONFIG") {
-        let path = PathBuf::from(path);
-        if path.as_os_str().is_empty() {
-            return Err(ConfigError("BOOMUX_CONFIG cannot be empty".into()).into());
+        let loaded = active_candidate.is_some() && paths.environment.is_none() || path.is_file();
+        if loaded {
+            let next = if paths.environment.is_none() {
+                active_candidate.map_or_else(|| read(path), |bytes| parse(path, bytes))?
+            } else {
+                read(path)?
+            };
+            merge(&mut raw, next);
+            loaded_path = Some(path.to_owned());
         }
-        merge(&mut raw, read(&path)?);
-        loaded_path = Some(path);
+        layers.push(ConfigLayer {
+            source: ConfigSource::Global,
+            path: path.to_owned(),
+            loaded,
+        });
     }
 
-    Ok((raw, loaded_path))
+    if let Some(path) = paths.environment.as_deref() {
+        let next = active_candidate.map_or_else(|| read(path), |bytes| parse(path, bytes))?;
+        merge(&mut raw, next);
+        loaded_path = Some(path.to_owned());
+        layers.push(ConfigLayer {
+            source: ConfigSource::Environment,
+            path: path.to_owned(),
+            loaded: true,
+        });
+    }
+
+    Ok((raw, loaded_path, layers))
+}
+
+fn load_inherited_raw(paths: &ConfigPaths) -> Result<InheritedLoad, Box<dyn Error>> {
+    if paths.has_distinct_environment_layer()
+        && let Some(global) = paths.global.as_deref()
+        && global.is_file()
+    {
+        let bytes = read_bounded(global)?;
+        return Ok((parse(global, &bytes)?, Some(bytes)));
+    }
+    Ok((RawConfig::default(), None))
+}
+
+fn verify_inherited_baseline(
+    paths: &ConfigPaths,
+    baseline: Option<&[u8]>,
+) -> Result<(), Box<dyn Error>> {
+    if !paths.has_distinct_environment_layer() {
+        return Ok(());
+    }
+    let Some(global) = paths.global.as_deref() else {
+        return Ok(());
+    };
+    let current = if global.is_file() {
+        Some(read_bounded(global)?)
+    } else {
+        None
+    };
+    if current.as_deref() != baseline {
+        return Err(ConfigError(format!(
+            "inherited config changed while settings were being edited: {}",
+            global.display()
+        ))
+        .into());
+    }
+    Ok(())
 }
 
 pub(crate) fn global_config_path() -> Option<PathBuf> {
@@ -149,10 +517,668 @@ pub(crate) fn global_config_path() -> Option<PathBuf> {
 }
 
 fn read(path: &Path) -> Result<RawConfig, Box<dyn Error>> {
-    let contents = fs::read_to_string(path)
-        .map_err(|error| ConfigError(format!("could not read {}: {error}", path.display())))?;
-    toml::from_str(&contents)
+    let bytes = read_bounded(path)?;
+    parse(path, &bytes)
+}
+
+fn parse(path: &Path, bytes: &[u8]) -> Result<RawConfig, Box<dyn Error>> {
+    let contents = std::str::from_utf8(bytes)
+        .map_err(|error| ConfigError(format!("invalid config {}: {error}", path.display())))?;
+    toml::from_str(contents)
         .map_err(|error| ConfigError(format!("invalid config {}: {error}", path.display())).into())
+}
+
+fn read_bounded(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
+    let file = File::open(path)
+        .map_err(|error| ConfigError(format!("could not read {}: {error}", path.display())))?;
+    if file.metadata()?.len() > MAX_CONFIG_BYTES {
+        return Err(ConfigError(format!(
+            "config {} exceeds the {} byte limit",
+            path.display(),
+            MAX_CONFIG_BYTES
+        ))
+        .into());
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_CONFIG_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_CONFIG_BYTES {
+        return Err(ConfigError(format!(
+            "config {} exceeds the {} byte limit",
+            path.display(),
+            MAX_CONFIG_BYTES
+        ))
+        .into());
+    }
+    Ok(bytes)
+}
+
+pub(crate) fn active_path() -> Result<PathBuf, Box<dyn Error>> {
+    Ok(ConfigPaths::from_environment()?.active()?.to_owned())
+}
+
+pub(crate) fn validate() -> Result<ConfigSnapshot, Box<dyn Error>> {
+    let paths = ConfigPaths::from_environment()?;
+    validate_layers(&paths, None)?;
+    load_snapshot()
+}
+
+pub(crate) fn save_settings(
+    expected: &ConfigSettings,
+    overrides: &ConfigOverrides,
+) -> Result<ConfigSettings, Box<dyn Error>> {
+    let paths = ConfigPaths::from_environment()?;
+    save_settings_with_paths(&paths, expected, overrides)
+}
+
+fn save_settings_with_paths(
+    paths: &ConfigPaths,
+    expected: &ConfigSettings,
+    overrides: &ConfigOverrides,
+) -> Result<ConfigSettings, Box<dyn Error>> {
+    if paths.active()? != expected.active_path || paths.active_source() != expected.active_source {
+        return Err(
+            ConfigError("active config source changed; reload settings and retry".into()).into(),
+        );
+    }
+    let original = expected
+        .baseline
+        .as_deref()
+        .unwrap_or(CONFIG_TEMPLATE.as_bytes());
+    let text = std::str::from_utf8(original).map_err(|error| {
+        ConfigError(format!(
+            "invalid config {}: {error}",
+            expected.active_path.display()
+        ))
+    })?;
+    let mut document = text.parse::<DocumentMut>().map_err(|error| {
+        ConfigError(format!(
+            "invalid config {}: {error}",
+            expected.active_path.display()
+        ))
+    })?;
+    apply_overrides(&mut document, overrides);
+    let candidate = document.to_string().into_bytes();
+    if candidate.len() as u64 > MAX_CONFIG_BYTES {
+        return Err(ConfigError(format!(
+            "config {} exceeds the {} byte limit",
+            expected.active_path.display(),
+            MAX_CONFIG_BYTES
+        ))
+        .into());
+    }
+    let saved = settings_from_paths(paths, expected.active_path.clone(), Some(candidate.clone()))?;
+    verify_inherited_baseline(paths, expected.inherited_baseline.as_deref())?;
+    commit_candidate(
+        &expected.active_path,
+        expected.baseline.as_deref(),
+        &candidate,
+    )?;
+    Ok(saved)
+}
+
+pub(crate) fn edit() -> Result<(), Box<dyn Error>> {
+    let paths = ConfigPaths::from_environment()?;
+    let editor = editor_argv()?;
+    edit_with(&paths, |working| run_editor(&editor, working), || {})
+}
+
+fn editor_argv() -> Result<Vec<OsString>, Box<dyn Error>> {
+    for name in ["VISUAL", "EDITOR"] {
+        if let Some(value) = env::var_os(name) {
+            let value = value.into_string().map_err(|_| {
+                ConfigError(format!("{name} must contain valid UTF-8 command arguments"))
+            })?;
+            let words = shell_words::split(&value)
+                .map_err(|error| ConfigError(format!("invalid {name}: {error}")))?;
+            if words.is_empty() {
+                return Err(ConfigError(format!("{name} cannot be empty")).into());
+            }
+            return Ok(words.into_iter().map(OsString::from).collect());
+        }
+    }
+    Ok(vec![OsString::from("sensible-editor")])
+}
+
+fn run_editor(editor: &[OsString], working: &Path) -> Result<ExitStatus, Box<dyn Error>> {
+    let mut command = Command::new(&editor[0]);
+    command
+        .args(&editor[1..])
+        .arg(working)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    match command.status() {
+        Err(error)
+            if error.kind() == io::ErrorKind::NotFound
+                && editor.first().is_some_and(|word| word == "sensible-editor") =>
+        {
+            Ok(Command::new("vi")
+                .arg(working)
+                .stdin(Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .status()?)
+        }
+        result => Ok(result?),
+    }
+}
+
+fn edit_with(
+    paths: &ConfigPaths,
+    run: impl FnOnce(&Path) -> Result<ExitStatus, Box<dyn Error>>,
+    before_commit: impl FnOnce(),
+) -> Result<(), Box<dyn Error>> {
+    let target = paths.active()?;
+    let parent = target
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let baseline = match fs::symlink_metadata(target) {
+        Ok(metadata) => {
+            validate_regular_owner(target, &metadata, "config target")?;
+            Some(read_bounded(target)?)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+    let (_, inherited_baseline) = load_inherited_raw(paths)?;
+
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700);
+    builder.create(parent)?;
+    let (mut working_file, working_path) = create_working_file(parent, target.file_name())?;
+    let working = TemporaryPath(Some(working_path));
+    working_file.write_all(baseline.as_deref().unwrap_or(CONFIG_TEMPLATE.as_bytes()))?;
+    working_file.sync_all()?;
+    drop(working_file);
+
+    let status = run(working.path())?;
+    if !status.success() {
+        return Err(ConfigError(format!("editor exited with {status}")).into());
+    }
+    let candidate_metadata = fs::symlink_metadata(working.path())?;
+    validate_regular_owner(working.path(), &candidate_metadata, "edited config")?;
+    let candidate = read_bounded(working.path())?;
+    validate_layers(paths, Some(&candidate))?;
+
+    before_commit();
+    verify_inherited_baseline(paths, inherited_baseline.as_deref())?;
+    match commit_candidate(target, baseline.as_deref(), &candidate) {
+        Ok(()) => Ok(()),
+        Err(error) if error.downcast_ref::<ConfigCommittedError>().is_some() => {
+            if read_bounded(target).ok().as_deref() == Some(candidate.as_slice()) {
+                Ok(())
+            } else {
+                Err(error)
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn commit_candidate(
+    target: &Path,
+    baseline: Option<&[u8]>,
+    candidate: &[u8],
+) -> Result<(), Box<dyn Error>> {
+    let parent = target
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700);
+    builder.create(parent)?;
+    let (mut working_file, working_path) = create_working_file(parent, target.file_name())?;
+    let mut working = TemporaryPath(Some(working_path));
+    working_file.write_all(candidate)?;
+    working_file.sync_all()?;
+    drop(working_file);
+
+    match baseline {
+        None => {
+            fs::set_permissions(working.path(), fs::Permissions::from_mode(0o600))?;
+            rename_noreplace(working.path(), target).map_err(|error| {
+                if error.raw_os_error() == Some(libc::EEXIST) {
+                    ConfigError(format!(
+                        "config target changed while it was being edited: {}",
+                        target.display()
+                    ))
+                    .into()
+                } else {
+                    Box::<dyn Error>::from(error)
+                }
+            })?;
+            working.disarm();
+        }
+        Some(baseline) => {
+            let current = fs::symlink_metadata(target)?;
+            validate_regular_owner(target, &current, "config target")?;
+            if read_bounded(target)? != baseline {
+                return Err(ConfigError(format!(
+                    "config target changed while it was being edited: {}",
+                    target.display()
+                ))
+                .into());
+            }
+            fs::set_permissions(
+                working.path(),
+                fs::Permissions::from_mode(current.mode() & 0o7777),
+            )?;
+            fs::rename(working.path(), target)?;
+            working.disarm();
+        }
+    }
+    File::open(target)
+        .and_then(|file| file.sync_all())
+        .and_then(|()| File::open(parent)?.sync_all())
+        .map_err(|error| {
+            ConfigCommittedError(format!(
+                "config was committed but could not be synchronized: {error}"
+            ))
+        })?;
+    Ok(())
+}
+
+fn validate_layers(
+    paths: &ConfigPaths,
+    active_candidate: Option<&[u8]>,
+) -> Result<(), Box<dyn Error>> {
+    let (raw, loaded_path, _) = load_raw_from_paths(paths, active_candidate)?;
+    resolve(raw, loaded_path)?;
+    Ok(())
+}
+
+fn values_from_raw_and_config(raw: RawConfig, config: &Config) -> ConfigValues {
+    let roots = raw.projects.unwrap_or_default().roots.unwrap_or_default();
+    let notifications = &config.notifications;
+    ConfigValues {
+        terminal: config.terminal.clone(),
+        project_roots: roots,
+        project_max_depth: config.projects.max_depth,
+        follow_focused_terminal: config.dashboard.follow_focused_terminal,
+        resume_agents: notifications.resume_agents,
+        persist_terminal_history: notifications.persist_terminal_history,
+        scheduling_max_concurrent: notifications.max_scheduled_execution_concurrency,
+        notifications_enabled: notifications.desktop.enabled,
+        notifications_blocked: notifications.desktop.blocked,
+        notifications_completed: notifications.desktop.completed,
+        notifications_scheduled_dispatch_failed: notifications.desktop.scheduled_dispatch_failed,
+        notifications_scheduled_interrupted: notifications.desktop.scheduled_interrupted,
+        sound_enabled: notifications.sound.enabled,
+        sound_blocked: notifications.sound.blocked.clone(),
+        sound_completed: notifications.sound.completed.clone(),
+        sound_scheduled_dispatch_failed: notifications.sound.scheduled_dispatch_failed.clone(),
+        sound_scheduled_interrupted: notifications.sound.scheduled_interrupted.clone(),
+    }
+}
+
+fn preview_values(raw: &RawConfig) -> ConfigValues {
+    let defaults = resolve(RawConfig::default(), None).expect("built-in config is valid");
+    let mut values = values_from_raw_and_config(RawConfig::default(), &defaults);
+    if let Some(terminal) = &raw.terminal {
+        values.terminal = Some(terminal.trim().to_owned());
+    }
+    if let Some(projects) = &raw.projects {
+        if let Some(roots) = &projects.roots {
+            values.project_roots.clone_from(roots);
+        }
+        if let Some(max_depth) = projects.max_depth {
+            values.project_max_depth = max_depth;
+        }
+    }
+    if let Some(dashboard) = &raw.dashboard
+        && let Some(value) = dashboard.follow_focused_terminal
+    {
+        values.follow_focused_terminal = value;
+    }
+    if let Some(recovery) = &raw.recovery {
+        values.resume_agents = recovery.resume_agents.unwrap_or(values.resume_agents);
+        values.persist_terminal_history = recovery
+            .persist_terminal_history
+            .unwrap_or(values.persist_terminal_history);
+    }
+    if let Some(max_concurrent) = raw
+        .scheduling
+        .as_ref()
+        .and_then(|scheduling| scheduling.max_concurrent)
+    {
+        values.scheduling_max_concurrent = u16::try_from(max_concurrent).unwrap_or_else(|_| {
+            if max_concurrent.is_negative() {
+                0
+            } else {
+                u16::MAX
+            }
+        });
+    }
+    if let Some(notifications) = &raw.notifications {
+        values.notifications_enabled = notifications
+            .enabled
+            .unwrap_or(values.notifications_enabled);
+        values.notifications_blocked = notifications
+            .blocked
+            .unwrap_or(values.notifications_blocked);
+        values.notifications_completed = notifications
+            .completed
+            .unwrap_or(values.notifications_completed);
+        values.notifications_scheduled_dispatch_failed = notifications
+            .scheduled_dispatch_failed
+            .unwrap_or(values.notifications_scheduled_dispatch_failed);
+        values.notifications_scheduled_interrupted = notifications
+            .scheduled_interrupted
+            .unwrap_or(values.notifications_scheduled_interrupted);
+        if let Some(sound) = &notifications.sound {
+            values.sound_enabled = sound.enabled.unwrap_or(values.sound_enabled);
+            if let Some(value) = &sound.blocked {
+                values.sound_blocked.clone_from(value);
+            }
+            if let Some(value) = &sound.completed {
+                values.sound_completed.clone_from(value);
+            }
+            if let Some(value) = &sound.scheduled_dispatch_failed {
+                values.sound_scheduled_dispatch_failed.clone_from(value);
+            }
+            if let Some(value) = &sound.scheduled_interrupted {
+                values.sound_scheduled_interrupted.clone_from(value);
+            }
+        }
+    }
+    values
+}
+
+fn preview_overrides(raw: RawConfig) -> ConfigOverrides {
+    let projects = raw.projects.unwrap_or_default();
+    let dashboard = raw.dashboard.unwrap_or_default();
+    let recovery = raw.recovery.unwrap_or_default();
+    let scheduling = raw.scheduling.unwrap_or_default();
+    let notifications = raw.notifications.unwrap_or_default();
+    let sound = notifications.sound.unwrap_or_default();
+    ConfigOverrides {
+        terminal: raw.terminal,
+        project_roots: projects.roots,
+        project_max_depth: projects.max_depth,
+        follow_focused_terminal: dashboard.follow_focused_terminal,
+        resume_agents: recovery.resume_agents,
+        persist_terminal_history: recovery.persist_terminal_history,
+        scheduling_max_concurrent: scheduling.max_concurrent.map(|value| {
+            u16::try_from(value).unwrap_or_else(|_| if value.is_negative() { 0 } else { u16::MAX })
+        }),
+        notifications_enabled: notifications.enabled,
+        notifications_blocked: notifications.blocked,
+        notifications_completed: notifications.completed,
+        notifications_scheduled_dispatch_failed: notifications.scheduled_dispatch_failed,
+        notifications_scheduled_interrupted: notifications.scheduled_interrupted,
+        sound_enabled: sound.enabled,
+        sound_blocked: sound.blocked,
+        sound_completed: sound.completed,
+        sound_scheduled_dispatch_failed: sound.scheduled_dispatch_failed,
+        sound_scheduled_interrupted: sound.scheduled_interrupted,
+    }
+}
+
+fn overrides_from_raw(raw: RawConfig) -> Result<ConfigOverrides, Box<dyn Error>> {
+    let projects = raw.projects.unwrap_or_default();
+    let dashboard = raw.dashboard.unwrap_or_default();
+    let recovery = raw.recovery.unwrap_or_default();
+    let scheduling = raw.scheduling.unwrap_or_default();
+    let notifications = raw.notifications.unwrap_or_default();
+    let sound = notifications.sound.unwrap_or_default();
+    Ok(ConfigOverrides {
+        terminal: raw.terminal,
+        project_roots: projects.roots,
+        project_max_depth: projects.max_depth,
+        follow_focused_terminal: dashboard.follow_focused_terminal,
+        resume_agents: recovery.resume_agents,
+        persist_terminal_history: recovery.persist_terminal_history,
+        scheduling_max_concurrent: scheduling
+            .max_concurrent
+            .map(u16::try_from)
+            .transpose()
+            .map_err(|_| ConfigError("scheduling.max_concurrent must fit in u16".into()))?,
+        notifications_enabled: notifications.enabled,
+        notifications_blocked: notifications.blocked,
+        notifications_completed: notifications.completed,
+        notifications_scheduled_dispatch_failed: notifications.scheduled_dispatch_failed,
+        notifications_scheduled_interrupted: notifications.scheduled_interrupted,
+        sound_enabled: sound.enabled,
+        sound_blocked: sound.blocked,
+        sound_completed: sound.completed,
+        sound_scheduled_dispatch_failed: sound.scheduled_dispatch_failed,
+        sound_scheduled_interrupted: sound.scheduled_interrupted,
+    })
+}
+
+fn apply_overrides(document: &mut DocumentMut, overrides: &ConfigOverrides) {
+    set_string(document, &["terminal"], overrides.terminal.as_deref());
+    set_strings(
+        document,
+        &["projects", "roots"],
+        overrides.project_roots.as_deref(),
+    );
+    set_integer(
+        document,
+        &["projects", "max_depth"],
+        overrides.project_max_depth.map(|value| value as i64),
+    );
+    set_bool(
+        document,
+        &["dashboard", "follow_focused_terminal"],
+        overrides.follow_focused_terminal,
+    );
+    set_bool(
+        document,
+        &["recovery", "resume_agents"],
+        overrides.resume_agents,
+    );
+    set_bool(
+        document,
+        &["recovery", "persist_terminal_history"],
+        overrides.persist_terminal_history,
+    );
+    set_integer(
+        document,
+        &["scheduling", "max_concurrent"],
+        overrides.scheduling_max_concurrent.map(i64::from),
+    );
+    for (key, setting) in [
+        ("enabled", overrides.notifications_enabled),
+        ("blocked", overrides.notifications_blocked),
+        ("completed", overrides.notifications_completed),
+        (
+            "scheduled_dispatch_failed",
+            overrides.notifications_scheduled_dispatch_failed,
+        ),
+        (
+            "scheduled_interrupted",
+            overrides.notifications_scheduled_interrupted,
+        ),
+    ] {
+        set_bool(document, &["notifications", key], setting);
+    }
+    set_bool(
+        document,
+        &["notifications", "sound", "enabled"],
+        overrides.sound_enabled,
+    );
+    for (key, setting) in [
+        ("blocked", overrides.sound_blocked.as_deref()),
+        ("completed", overrides.sound_completed.as_deref()),
+        (
+            "scheduled_dispatch_failed",
+            overrides.sound_scheduled_dispatch_failed.as_deref(),
+        ),
+        (
+            "scheduled_interrupted",
+            overrides.sound_scheduled_interrupted.as_deref(),
+        ),
+    ] {
+        set_string(document, &["notifications", "sound", key], setting);
+    }
+}
+
+fn table_for_path<'a>(document: &'a mut DocumentMut, path: &[&str]) -> &'a mut dyn TableLike {
+    let mut table: &mut dyn TableLike = document.as_table_mut();
+    for key in path {
+        let item = table
+            .entry(key)
+            .or_insert_with(|| Item::Table(Table::new()));
+        if !item.is_table_like() {
+            *item = Item::Table(Table::new());
+        }
+        table = item.as_table_like_mut().expect("created table-like item");
+    }
+    table
+}
+
+fn remove_key(document: &mut DocumentMut, path: &[&str]) {
+    let Some((key, parents)) = path.split_last() else {
+        return;
+    };
+    let mut table: &mut dyn TableLike = document.as_table_mut();
+    for parent in parents {
+        let Some(next) = table.get_mut(parent).and_then(Item::as_table_like_mut) else {
+            return;
+        };
+        table = next;
+    }
+    table.remove(key);
+}
+
+fn set_value(document: &mut DocumentMut, path: &[&str], setting: Option<Value>) {
+    let Some((key, parents)) = path.split_last() else {
+        return;
+    };
+    match setting {
+        Some(setting) => {
+            let table = table_for_path(document, parents);
+            let mut setting = setting;
+            if let Some(existing) = table.get_mut(key).and_then(Item::as_value_mut) {
+                setting.decor_mut().clone_from(existing.decor());
+                *existing = setting;
+                return;
+            }
+            table.insert(key, Item::Value(setting));
+        }
+        None => remove_key(document, path),
+    }
+}
+
+fn set_string(document: &mut DocumentMut, path: &[&str], setting: Option<&str>) {
+    set_value(document, path, setting.map(Value::from));
+}
+
+fn set_bool(document: &mut DocumentMut, path: &[&str], setting: Option<bool>) {
+    set_value(document, path, setting.map(Value::from));
+}
+
+fn set_integer(document: &mut DocumentMut, path: &[&str], setting: Option<i64>) {
+    set_value(document, path, setting.map(Value::from));
+}
+
+fn set_strings(document: &mut DocumentMut, path: &[&str], setting: Option<&[String]>) {
+    set_value(
+        document,
+        path,
+        setting.map(|strings| {
+            let mut array = Array::new();
+            for string in strings {
+                array.push(string.as_str());
+            }
+            Value::Array(array)
+        }),
+    );
+}
+
+fn validate_regular_owner(
+    path: &Path,
+    metadata: &fs::Metadata,
+    description: &str,
+) -> Result<(), Box<dyn Error>> {
+    if !metadata.file_type().is_file() {
+        return Err(ConfigError(format!(
+            "{description} is not a regular file: {}",
+            path.display()
+        ))
+        .into());
+    }
+    if metadata.uid() != unsafe { libc::geteuid() } {
+        return Err(ConfigError(format!(
+            "{description} is not owned by the current user: {}",
+            path.display()
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+fn create_working_file(
+    parent: &Path,
+    target_name: Option<&OsStr>,
+) -> Result<(File, PathBuf), Box<dyn Error>> {
+    let target_name = target_name.unwrap_or_else(|| OsStr::new("config.toml"));
+    for _ in 0..TEMPORARY_CREATE_ATTEMPTS {
+        let name = format!(
+            ".{}.edit-{}",
+            target_name.to_string_lossy(),
+            uuid::Uuid::new_v4()
+        );
+        let path = parent.join(name);
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+        {
+            Ok(file) => return Ok((file, path)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Err(ConfigError("could not allocate a temporary config working copy".into()).into())
+}
+
+struct TemporaryPath(Option<PathBuf>);
+
+impl TemporaryPath {
+    fn path(&self) -> &Path {
+        self.0.as_deref().expect("temporary path is armed")
+    }
+
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for TemporaryPath {
+    fn drop(&mut self) {
+        if let Some(path) = self.0.take() {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+    renameat2(from, to, libc::RENAME_NOREPLACE)
+}
+
+fn renameat2(from: &Path, to: &Path, flags: u32) -> io::Result<()> {
+    let from = CString::new(from.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+    let to = CString::new(to.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+    let result = unsafe {
+        libc::renameat2(
+            libc::AT_FDCWD,
+            from.as_ptr(),
+            libc::AT_FDCWD,
+            to.as_ptr(),
+            flags,
+        )
+    };
+    if result == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 fn merge(base: &mut RawConfig, next: RawConfig) {
@@ -344,8 +1370,45 @@ fn home_directory() -> Result<PathBuf, Box<dyn Error>> {
 }
 
 #[cfg(test)]
+pub(crate) fn test_settings() -> ConfigSettings {
+    let effective = resolve(RawConfig::default(), None).expect("default config");
+    let values = values_from_raw_and_config(RawConfig::default(), &effective);
+    ConfigSettings {
+        active_path: PathBuf::from("/tmp/boomux-test-config.toml"),
+        active_source: ConfigSource::Global,
+        inherited_source: ConfigSource::Default,
+        inherited: values.clone(),
+        inherited_overrides: ConfigOverrides::default(),
+        effective: values,
+        overrides: ConfigOverrides::default(),
+        baseline: None,
+        inherited_baseline: None,
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let path = env::temp_dir().join(format!(
+                "boomux-config-test-{}-{}",
+                std::process::id(),
+                uuid::Uuid::new_v4()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
 
     #[test]
     fn parses_project_settings() {
@@ -607,5 +1670,241 @@ mod tests {
             assert!(resolve(raw, None).is_err());
         }
         assert!(toml::from_str::<RawConfig>("[scheduling]\nunknown = 1").is_err());
+    }
+
+    #[test]
+    fn structured_edits_preserve_comments_and_unrelated_formatting() {
+        let original = r#"# owner note
+terminal = "Alacritty.desktop" # keep inline
+
+[projects] # project note
+roots = [ "/old" ]
+max_depth = 2
+
+[dashboard]
+follow_focused_terminal = true
+"#;
+        let mut document = original.parse::<DocumentMut>().unwrap();
+        let overrides = ConfigOverrides {
+            terminal: Some("com.mitchellh.ghostty.desktop".into()),
+            project_roots: Some(vec!["~/Code".into(), "/srv/work".into()]),
+            project_max_depth: Some(2),
+            follow_focused_terminal: Some(false),
+            ..Default::default()
+        };
+
+        apply_overrides(&mut document, &overrides);
+        let edited = document.to_string();
+
+        assert!(edited.contains("# owner note"));
+        assert!(edited.contains("# keep inline"));
+        assert!(edited.contains("# project note"));
+        assert!(edited.contains("max_depth = 2"));
+        assert!(!edited.contains("follow_focused_terminal = true"));
+        assert!(edited.contains("follow_focused_terminal = false"));
+        assert!(edited.contains("~/Code"));
+        assert!(edited.contains("/srv/work"));
+    }
+
+    #[test]
+    fn structured_edits_preserve_unrelated_inline_table_values() {
+        let original = r#"notifications = { blocked = false, sound = { blocked = "old", completed = "keep" } }
+"#;
+        let mut document = original.parse::<DocumentMut>().unwrap();
+        let overrides = ConfigOverrides {
+            notifications_enabled: Some(true),
+            notifications_blocked: Some(false),
+            sound_blocked: Some("new".into()),
+            sound_completed: Some("keep".into()),
+            ..Default::default()
+        };
+
+        apply_overrides(&mut document, &overrides);
+        let raw: RawConfig = toml::from_str(&document.to_string()).unwrap();
+        let notifications = raw.notifications.unwrap();
+        assert_eq!(notifications.enabled, Some(true));
+        assert_eq!(notifications.blocked, Some(false));
+        let sound = notifications.sound.unwrap();
+        assert_eq!(sound.blocked.as_deref(), Some("new"));
+        assert_eq!(sound.completed.as_deref(), Some("keep"));
+    }
+
+    #[test]
+    fn layered_semantics_are_resolved_only_after_field_merge() {
+        let mut base: RawConfig =
+            toml::from_str("[projects]\nmax_depth = 99\n[scheduling]\nmax_concurrent = 100")
+                .unwrap();
+        let override_layer: RawConfig =
+            toml::from_str("[projects]\nmax_depth = 4\n[scheduling]\nmax_concurrent = 8").unwrap();
+
+        assert!(resolve(base.clone(), None).is_err());
+        merge(&mut base, override_layer);
+        let resolved = resolve(base, None).unwrap();
+        assert_eq!(resolved.projects.max_depth, 4);
+        assert_eq!(
+            resolved.notifications.max_scheduled_execution_concurrency,
+            8
+        );
+    }
+
+    #[test]
+    fn source_labels_distinguish_default_global_and_environment() {
+        assert_eq!(ConfigSource::Default.label(), "default");
+        assert_eq!(ConfigSource::Global.label(), "global");
+        assert_eq!(ConfigSource::Environment.label(), "BOOMUX_CONFIG");
+
+        let global = ConfigPaths {
+            global: Some(PathBuf::from("/tmp/global.toml")),
+            environment: None,
+        };
+        assert_eq!(global.active_source(), ConfigSource::Global);
+        let environment = ConfigPaths {
+            global: global.global,
+            environment: Some(PathBuf::from("/tmp/override.toml")),
+        };
+        assert_eq!(environment.active_source(), ConfigSource::Environment);
+        assert_eq!(
+            environment.active().unwrap(),
+            Path::new("/tmp/override.toml")
+        );
+    }
+
+    #[test]
+    fn settings_load_and_save_allow_active_layer_to_correct_invalid_lower_semantics() {
+        let test = TestDirectory::new();
+        let global = test.0.join("global.toml");
+        let environment = test.0.join("environment.toml");
+        fs::write(
+            &global,
+            "[projects]\nmax_depth = 99\n[scheduling]\nmax_concurrent = 100\n",
+        )
+        .unwrap();
+        fs::write(
+            &environment,
+            "[projects]\nmax_depth = 2\n[scheduling]\nmax_concurrent = 8\n",
+        )
+        .unwrap();
+        fs::set_permissions(&environment, fs::Permissions::from_mode(0o640)).unwrap();
+        let paths = ConfigPaths {
+            global: Some(global.clone()),
+            environment: Some(environment.clone()),
+        };
+
+        let settings = settings_from_paths(
+            &paths,
+            environment.clone(),
+            Some(read_bounded(&environment).unwrap()),
+        )
+        .unwrap();
+        assert_eq!(settings.inherited.project_max_depth, 99);
+        assert_eq!(settings.inherited.scheduling_max_concurrent, 100);
+        assert_eq!(settings.effective.project_max_depth, 2);
+        assert_eq!(settings.effective.scheduling_max_concurrent, 8);
+
+        let mut overrides = settings.overrides.clone();
+        overrides.project_max_depth = Some(3);
+        let saved = save_settings_with_paths(&paths, &settings, &overrides).unwrap();
+        assert_eq!(saved.effective.project_max_depth, 3);
+        assert_eq!(saved.effective.scheduling_max_concurrent, 8);
+        assert_eq!(
+            fs::metadata(&environment).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+        assert!(
+            fs::read_to_string(global)
+                .unwrap()
+                .contains("max_depth = 99")
+        );
+    }
+
+    #[test]
+    fn settings_save_rejects_a_changed_inherited_layer() {
+        let test = TestDirectory::new();
+        let global = test.0.join("global.toml");
+        let environment = test.0.join("environment.toml");
+        fs::write(&global, "[projects]\nmax_depth = 2\n").unwrap();
+        fs::write(&environment, "[notifications]\nenabled = false\n").unwrap();
+        let paths = ConfigPaths {
+            global: Some(global.clone()),
+            environment: Some(environment.clone()),
+        };
+        let settings = settings_from_paths(
+            &paths,
+            environment.clone(),
+            Some(read_bounded(&environment).unwrap()),
+        )
+        .unwrap();
+        fs::write(&global, "[projects]\nmax_depth = 3\n").unwrap();
+
+        let mut overrides = settings.overrides.clone();
+        overrides.notifications_enabled = Some(true);
+        let error = save_settings_with_paths(&paths, &settings, &overrides)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("inherited config changed"), "{error}");
+        assert!(fs::read_to_string(environment).unwrap().contains("false"));
+    }
+
+    #[test]
+    fn settings_read_symlink_but_refuse_to_mutate_it() {
+        let test = TestDirectory::new();
+        let real = test.0.join("real.toml");
+        let linked = test.0.join("linked.toml");
+        fs::write(&real, "[projects]\nmax_depth = 2\n").unwrap();
+        std::os::unix::fs::symlink(&real, &linked).unwrap();
+        let paths = ConfigPaths {
+            global: None,
+            environment: Some(linked.clone()),
+        };
+        let settings =
+            settings_from_paths(&paths, linked, Some(read_bounded(&real).unwrap())).unwrap();
+        assert_eq!(settings.effective.project_max_depth, 2);
+
+        let mut overrides = settings.overrides.clone();
+        overrides.project_max_depth = Some(3);
+        let error = save_settings_with_paths(&paths, &settings, &overrides)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not a regular file"), "{error}");
+        assert!(fs::read_to_string(real).unwrap().contains("max_depth = 2"));
+    }
+
+    #[test]
+    fn readable_non_owned_files_are_readable_but_not_mutable() {
+        let path = Path::new("/etc/passwd");
+        let metadata = fs::metadata(path).unwrap();
+        if metadata.uid() == unsafe { libc::geteuid() } {
+            return;
+        }
+
+        assert!(!read_bounded(path).unwrap().is_empty());
+        let error = validate_regular_owner(path, &metadata, "config target")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not owned by the current user"), "{error}");
+    }
+
+    #[test]
+    fn canonical_global_environment_path_is_loaded_once_as_environment() {
+        let test = TestDirectory::new();
+        let path = test.0.join("config.toml");
+        fs::write(&path, "[projects]\nmax_depth = 2\n").unwrap();
+        let alias = path.parent().unwrap().join(".").join("config.toml");
+        let paths = ConfigPaths {
+            global: Some(path.clone()),
+            environment: Some(alias.clone()),
+        };
+
+        let (raw, loaded_path, layers) = load_raw_from_paths(&paths, None).unwrap();
+        assert_eq!(resolve(raw, loaded_path).unwrap().projects.max_depth, 2);
+        assert_eq!(layers.len(), 1);
+        assert_eq!(layers[0].source, ConfigSource::Environment);
+
+        let settings =
+            settings_from_paths(&paths, alias, Some(read_bounded(&path).unwrap())).unwrap();
+        assert_eq!(settings.active_source, ConfigSource::Environment);
+        assert_eq!(settings.inherited_source, ConfigSource::Default);
+        assert_eq!(settings.inherited_overrides, ConfigOverrides::default());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,6 +424,11 @@ enum Commands {
     },
     /// Close a shell by name or shell ID
     Close { target: String },
+    /// Inspect and edit layered Boomux configuration
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommands,
+    },
     /// Discover configured projects
     Project {
         #[command(subcommand)]
@@ -597,6 +602,16 @@ enum ProjectCommands {
         #[arg(long)]
         node: Option<String>,
     },
+}
+
+#[derive(Subcommand)]
+enum ConfigCommands {
+    /// Print the active writable configuration path
+    Path,
+    /// Validate all configured layers
+    Validate,
+    /// Edit and transactionally replace the active writable layer
+    Edit,
 }
 
 #[derive(Subcommand)]
@@ -1378,6 +1393,9 @@ command_keys! {
     Read => ("read", Json),
     Events => ("events", Json),
     Close => ("close", HumanOnly),
+    ConfigPath => ("config.path", HumanOnly),
+    ConfigValidate => ("config.validate", HumanOnly),
+    ConfigEdit => ("config.edit", HumanOnly),
     ProjectList => ("project.list", Json),
     WorkspaceList => ("workspace.list", Json),
     WorkspaceInspect => ("workspace.inspect", Json),
@@ -1467,6 +1485,15 @@ impl Cli {
             Some(Commands::Shells) => CommandKey::Shells,
             Some(Commands::Read { .. }) => CommandKey::Read,
             Some(Commands::Events { .. }) => CommandKey::Events,
+            Some(Commands::Config {
+                command: ConfigCommands::Path,
+            }) => CommandKey::ConfigPath,
+            Some(Commands::Config {
+                command: ConfigCommands::Validate,
+            }) => CommandKey::ConfigValidate,
+            Some(Commands::Config {
+                command: ConfigCommands::Edit,
+            }) => CommandKey::ConfigEdit,
             Some(Commands::Project {
                 command: ProjectCommands::List { .. },
             }) => CommandKey::ProjectList,
@@ -1975,6 +2002,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             wait_ms,
         }) => read_events(after.as_deref(), limit, wait_ms, cli.json),
         Some(Commands::Close { target }) => close_shell(&target),
+        Some(Commands::Config { command }) => config_command(command),
         Some(Commands::Project {
             command: ProjectCommands::List { node },
         }) => list_projects(cli.json, node.as_deref()),
@@ -3161,6 +3189,33 @@ fn should_open_new_window(new_window: bool, terminal: Option<&str>) -> bool {
     new_window || terminal.is_some()
 }
 
+fn config_command(command: ConfigCommands) -> Result<(), Box<dyn Error>> {
+    match command {
+        ConfigCommands::Path => println!("{}", config::active_path()?.display()),
+        ConfigCommands::Validate => {
+            let snapshot = config::validate()?;
+            let loaded = snapshot.layers.iter().filter(|layer| layer.loaded).count();
+            let source = match snapshot.active_source {
+                config::ConfigSource::Default => "default",
+                config::ConfigSource::Global => "global",
+                config::ConfigSource::Environment => "BOOMUX_CONFIG",
+            };
+            let effective = snapshot
+                .effective
+                .path
+                .as_deref()
+                .map_or_else(|| "defaults".into(), |path| path.display().to_string());
+            println!(
+                "Configuration is valid ({loaded} loaded layer{}; effective: {effective}; active {source}: {})",
+                if loaded == 1 { "" } else { "s" },
+                snapshot.active_path.display()
+            );
+        }
+        ConfigCommands::Edit => config::edit()?,
+    }
+    Ok(())
+}
+
 fn effective_terminal(override_entry: Option<&str>) -> Result<Option<String>, Box<dyn Error>> {
     if let Some(entry) = override_entry {
         return Ok(Some(entry.to_owned()));
@@ -3179,27 +3234,34 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     let mut refresh = DashboardRefresh::baseline(&client)?;
     let snapshot = refresh.snapshot().clone();
     let combined = combined_node_snapshot_for_dashboard(&client)?;
-    let config = config::load()?;
-    let terminal = terminal_override
+    let settings = config::load_settings()?;
+    let config = settings.effective_config()?;
+    let terminal_is_overridden = terminal_override.is_some();
+    let mut terminal = terminal_override
         .map(str::to_owned)
         .or_else(|| config.terminal.clone());
-    let roots_configured = !config.projects.roots.is_empty();
-    let discovery = projects::discover(&config.projects);
-    let project_context = tui::ProjectContext {
-        projects: discovery
-            .projects
-            .into_iter()
-            .map(|project| tui::ProjectView {
-                name: project.name,
-                path: project.path,
-                group: project.group,
-                group_order: project.group_order,
-            })
-            .collect(),
-        config_path: config.path.or_else(config::global_config_path),
-        warning: (!discovery.warnings.is_empty()).then(|| discovery.warnings.join("; ")),
-        roots_configured,
-    };
+    let project_context = dashboard_project_context(&config);
+    let mut settings_snapshot = settings.clone();
+
+    fn dashboard_project_context(config: &config::Config) -> tui::ProjectContext {
+        let roots_configured = !config.projects.roots.is_empty();
+        let discovery = projects::discover(&config.projects);
+        tui::ProjectContext {
+            projects: discovery
+                .projects
+                .into_iter()
+                .map(|project| tui::ProjectView {
+                    name: project.name,
+                    path: project.path,
+                    group: project.group,
+                    group_order: project.group_order,
+                })
+                .collect(),
+            config_path: config.path.clone().or_else(config::global_config_path),
+            warning: (!discovery.warnings.is_empty()).then(|| discovery.warnings.join("; ")),
+            roots_configured,
+        }
+    }
 
     let initial_state = dashboard_state(
         snapshot,
@@ -3213,6 +3275,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
         initial_state,
         config.dashboard.follow_focused_terminal,
         project_context,
+        settings,
         true,
         move |effect| match effect {
             tui::DashboardEffect::Quit => unreachable!("quit is handled by the dashboard runtime"),
@@ -3704,6 +3767,34 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     ))
                 })();
                 tui::DashboardEvent::RefreshCompleted(result)
+            }
+            tui::DashboardEffect::SaveSettings(overrides) => {
+                let result = (|| {
+                    let saved = match config::save_settings(&settings_snapshot, &overrides) {
+                        Ok(saved) => saved,
+                        Err(error) => match config::load_settings() {
+                            Ok(current) if current.overrides == overrides => current,
+                            _ => return Err(error.to_string()),
+                        },
+                    };
+                    let effective = saved
+                        .effective_config()
+                        .map_err(|error| error.to_string())?;
+                    if !terminal_is_overridden {
+                        terminal = effective.terminal.clone();
+                    }
+                    let project_context = dashboard_project_context(&effective);
+                    settings_snapshot = saved.clone();
+                    Ok((saved, project_context))
+                })();
+                tui::DashboardEvent::SettingsSaved(Box::new(result))
+            }
+            tui::DashboardEffect::RestartDaemon(applied) => {
+                let result = client
+                    .restart_with_notification_config(applied.daemon_settings().into())
+                    .map_err(|error| error.to_string())
+                    .map(|()| "Gracefully restarted daemon with saved settings".into());
+                tui::DashboardEvent::DaemonRestarted { applied, result }
             }
             tui::DashboardEffect::RunSchedule(schedule_id) => {
                 let result =
@@ -12166,6 +12257,19 @@ mod tests {
                 ..
             }) if run_id == "r1"
         ));
+    }
+
+    #[test]
+    fn config_commands_are_human_only() {
+        for (subcommand, key) in [
+            ("path", "config.path"),
+            ("validate", "config.validate"),
+            ("edit", "config.edit"),
+        ] {
+            let cli = Cli::try_parse_from(["boomux", "config", subcommand]).unwrap();
+            assert_eq!(cli.command_descriptor().key, key);
+            assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3196,7 +3196,6 @@ fn config_command(command: ConfigCommands) -> Result<(), Box<dyn Error>> {
             let snapshot = config::validate()?;
             let loaded = snapshot.layers.iter().filter(|layer| layer.loaded).count();
             let source = match snapshot.active_source {
-                config::ConfigSource::Default => "default",
                 config::ConfigSource::Global => "global",
                 config::ConfigSource::Environment => "BOOMUX_CONFIG",
             };
@@ -3234,34 +3233,27 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     let mut refresh = DashboardRefresh::baseline(&client)?;
     let snapshot = refresh.snapshot().clone();
     let combined = combined_node_snapshot_for_dashboard(&client)?;
-    let settings = config::load_settings()?;
-    let config = settings.effective_config()?;
-    let terminal_is_overridden = terminal_override.is_some();
-    let mut terminal = terminal_override
+    let config = config::load()?;
+    let terminal = terminal_override
         .map(str::to_owned)
         .or_else(|| config.terminal.clone());
-    let project_context = dashboard_project_context(&config);
-    let mut settings_snapshot = settings.clone();
-
-    fn dashboard_project_context(config: &config::Config) -> tui::ProjectContext {
-        let roots_configured = !config.projects.roots.is_empty();
-        let discovery = projects::discover(&config.projects);
-        tui::ProjectContext {
-            projects: discovery
-                .projects
-                .into_iter()
-                .map(|project| tui::ProjectView {
-                    name: project.name,
-                    path: project.path,
-                    group: project.group,
-                    group_order: project.group_order,
-                })
-                .collect(),
-            config_path: config.path.clone().or_else(config::global_config_path),
-            warning: (!discovery.warnings.is_empty()).then(|| discovery.warnings.join("; ")),
-            roots_configured,
-        }
-    }
+    let roots_configured = !config.projects.roots.is_empty();
+    let discovery = projects::discover(&config.projects);
+    let project_context = tui::ProjectContext {
+        projects: discovery
+            .projects
+            .into_iter()
+            .map(|project| tui::ProjectView {
+                name: project.name,
+                path: project.path,
+                group: project.group,
+                group_order: project.group_order,
+            })
+            .collect(),
+        config_path: config.path.or_else(config::global_config_path),
+        warning: (!discovery.warnings.is_empty()).then(|| discovery.warnings.join("; ")),
+        roots_configured,
+    };
 
     let initial_state = dashboard_state(
         snapshot,
@@ -3275,7 +3267,6 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
         initial_state,
         config.dashboard.follow_focused_terminal,
         project_context,
-        settings,
         true,
         move |effect| match effect {
             tui::DashboardEffect::Quit => unreachable!("quit is handled by the dashboard runtime"),
@@ -3767,34 +3758,6 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     ))
                 })();
                 tui::DashboardEvent::RefreshCompleted(result)
-            }
-            tui::DashboardEffect::SaveSettings(overrides) => {
-                let result = (|| {
-                    let saved = match config::save_settings(&settings_snapshot, &overrides) {
-                        Ok(saved) => saved,
-                        Err(error) => match config::load_settings() {
-                            Ok(current) if current.overrides == overrides => current,
-                            _ => return Err(error.to_string()),
-                        },
-                    };
-                    let effective = saved
-                        .effective_config()
-                        .map_err(|error| error.to_string())?;
-                    if !terminal_is_overridden {
-                        terminal = effective.terminal.clone();
-                    }
-                    let project_context = dashboard_project_context(&effective);
-                    settings_snapshot = saved.clone();
-                    Ok((saved, project_context))
-                })();
-                tui::DashboardEvent::SettingsSaved(Box::new(result))
-            }
-            tui::DashboardEffect::RestartDaemon(applied) => {
-                let result = client
-                    .restart_with_notification_config(applied.daemon_settings().into())
-                    .map_err(|error| error.to_string())
-                    .map(|()| "Gracefully restarted daemon with saved settings".into());
-                tui::DashboardEvent::DaemonRestarted { applied, result }
             }
             tui::DashboardEffect::RunSchedule(schedule_id) => {
                 let result =

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -20,6 +20,7 @@ use ratatui::widgets::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::agent_attention_projection::AgentStateCounts;
+use crate::config::{ConfigOverrides, ConfigSettings, ConfigSource, ConfigValues};
 use crate::protocol::{
     NodeProjectionHealthCode, QualifiedIdentity, SchedulerHealth, TerminalColor, TerminalPreview,
     TerminalPreviewLine, TerminalStyle,
@@ -897,6 +898,8 @@ pub(crate) enum DashboardEffect {
     RefreshNode(String),
     RestoreDismissedShells(String),
     Refresh,
+    SaveSettings(ConfigOverrides),
+    RestartDaemon(ConfigValues),
     RunSchedule(QualifiedIdentity),
     PauseSchedule(QualifiedIdentity),
     ResumeSchedule(QualifiedIdentity),
@@ -950,6 +953,11 @@ pub(crate) enum DashboardEvent {
     OperationCompleted(Result<String, String>),
     ShellCreationCompleted(Result<String, String>),
     RefreshCompleted(Result<DashboardState, String>),
+    SettingsSaved(Box<Result<(ConfigSettings, ProjectContext), String>>),
+    DaemonRestarted {
+        applied: ConfigValues,
+        result: Result<String, String>,
+    },
     ScheduleHistoryCompleted {
         schedule_id: QualifiedIdentity,
         result: Result<(Vec<ExecutionView>, bool), String>,
@@ -1098,6 +1106,7 @@ struct App {
     item_state: TableState,
     global_state: TableState,
     node_state: TableState,
+    settings: Option<SettingsState>,
     primary_tab: PrimaryTab,
     focus: Focus,
     mode: Mode,
@@ -1132,15 +1141,17 @@ enum PrimaryTab {
     Shells,
     Schedules,
     Nodes,
+    Settings,
 }
 
 impl PrimaryTab {
-    const ALL: [Self; 5] = [
+    const ALL: [Self; 6] = [
         Self::Workspaces,
         Self::Agents,
         Self::Shells,
         Self::Schedules,
         Self::Nodes,
+        Self::Settings,
     ];
 
     fn kind(self) -> Option<ItemKind> {
@@ -1150,6 +1161,7 @@ impl PrimaryTab {
             Self::Shells => Some(ItemKind::Shell),
             Self::Schedules => None,
             Self::Nodes => None,
+            Self::Settings => None,
         }
     }
 
@@ -1160,6 +1172,7 @@ impl PrimaryTab {
             Self::Shells => "SHELLS",
             Self::Schedules => "SCHEDULES",
             Self::Nodes => "NODES",
+            Self::Settings => "SETTINGS",
         }
     }
 }
@@ -1253,6 +1266,541 @@ enum Mode {
     },
     ConfirmForgetNode(NodeView),
     EditSchedule(ScheduleEditor),
+    ConfirmDaemonRestart {
+        clears_history: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SettingsField {
+    Terminal,
+    ProjectRoot(usize),
+    AddProjectRoot,
+    ProjectMaxDepth,
+    FollowFocusedTerminal,
+    ResumeAgents,
+    PersistTerminalHistory,
+    SchedulingMaxConcurrent,
+    NotificationsEnabled,
+    NotificationsBlocked,
+    NotificationsCompleted,
+    NotificationsScheduledDispatchFailed,
+    NotificationsScheduledInterrupted,
+    SoundEnabled,
+    SoundBlocked,
+    SoundCompleted,
+    SoundScheduledDispatchFailed,
+    SoundScheduledInterrupted,
+}
+
+struct SettingsEdit {
+    field: SettingsField,
+    input: String,
+}
+
+struct SettingsState {
+    loaded: ConfigSettings,
+    daemon_applied: ConfigValues,
+    working: ConfigOverrides,
+    selected: usize,
+    edit: Option<SettingsEdit>,
+    error: Option<String>,
+    saving: bool,
+    restart_required: bool,
+    restart_clears_history: bool,
+}
+
+impl SettingsState {
+    fn new(loaded: ConfigSettings, running_scheduler_maximum: Option<u16>) -> Self {
+        let mut daemon_applied = loaded.effective.clone();
+        if let Some(maximum) = running_scheduler_maximum {
+            daemon_applied.scheduling_max_concurrent = maximum;
+        }
+        let restart_required = daemon_settings_changed(&daemon_applied, &loaded.effective);
+        let restart_clears_history = restart_required && !loaded.effective.persist_terminal_history;
+        Self {
+            daemon_applied,
+            working: loaded.overrides.clone(),
+            loaded,
+            selected: 0,
+            edit: None,
+            error: None,
+            saving: false,
+            restart_required,
+            restart_clears_history,
+        }
+    }
+
+    fn roots(&self) -> &[String] {
+        self.working
+            .project_roots
+            .as_deref()
+            .unwrap_or(&self.loaded.inherited.project_roots)
+    }
+
+    fn fields(&self) -> Vec<SettingsField> {
+        let mut fields = vec![SettingsField::Terminal];
+        fields.extend((0..self.roots().len()).map(SettingsField::ProjectRoot));
+        fields.extend([
+            SettingsField::AddProjectRoot,
+            SettingsField::ProjectMaxDepth,
+            SettingsField::FollowFocusedTerminal,
+            SettingsField::ResumeAgents,
+            SettingsField::PersistTerminalHistory,
+            SettingsField::SchedulingMaxConcurrent,
+            SettingsField::NotificationsEnabled,
+            SettingsField::NotificationsBlocked,
+            SettingsField::NotificationsCompleted,
+            SettingsField::NotificationsScheduledDispatchFailed,
+            SettingsField::NotificationsScheduledInterrupted,
+            SettingsField::SoundEnabled,
+            SettingsField::SoundBlocked,
+            SettingsField::SoundCompleted,
+            SettingsField::SoundScheduledDispatchFailed,
+            SettingsField::SoundScheduledInterrupted,
+        ]);
+        fields
+    }
+
+    fn selected_field(&self) -> SettingsField {
+        let fields = self.fields();
+        fields[self.selected.min(fields.len() - 1)]
+    }
+
+    fn move_selection(&mut self, forwards: bool) {
+        let count = self.fields().len();
+        self.selected = if forwards {
+            (self.selected + 1) % count
+        } else if self.selected == 0 {
+            count - 1
+        } else {
+            self.selected - 1
+        };
+        self.error = None;
+    }
+
+    fn dirty(&self) -> bool {
+        self.working != self.loaded.overrides
+    }
+
+    fn discard(&mut self) {
+        self.working = self.loaded.overrides.clone();
+        self.edit = None;
+        self.error = None;
+    }
+
+    fn begin_save(&mut self) -> Option<DashboardEffect> {
+        if self.saving || !self.dirty() {
+            return None;
+        }
+        self.saving = true;
+        self.error = None;
+        Some(DashboardEffect::SaveSettings(self.working.clone()))
+    }
+
+    fn effective_bool(&self, field: SettingsField) -> bool {
+        let inherited = &self.loaded.inherited;
+        match field {
+            SettingsField::FollowFocusedTerminal => self
+                .working
+                .follow_focused_terminal
+                .unwrap_or(inherited.follow_focused_terminal),
+            SettingsField::ResumeAgents => self
+                .working
+                .resume_agents
+                .unwrap_or(inherited.resume_agents),
+            SettingsField::PersistTerminalHistory => self
+                .working
+                .persist_terminal_history
+                .unwrap_or(inherited.persist_terminal_history),
+            SettingsField::NotificationsEnabled => self
+                .working
+                .notifications_enabled
+                .unwrap_or(inherited.notifications_enabled),
+            SettingsField::NotificationsBlocked => self
+                .working
+                .notifications_blocked
+                .unwrap_or(inherited.notifications_blocked),
+            SettingsField::NotificationsCompleted => self
+                .working
+                .notifications_completed
+                .unwrap_or(inherited.notifications_completed),
+            SettingsField::NotificationsScheduledDispatchFailed => self
+                .working
+                .notifications_scheduled_dispatch_failed
+                .unwrap_or(inherited.notifications_scheduled_dispatch_failed),
+            SettingsField::NotificationsScheduledInterrupted => self
+                .working
+                .notifications_scheduled_interrupted
+                .unwrap_or(inherited.notifications_scheduled_interrupted),
+            SettingsField::SoundEnabled => self
+                .working
+                .sound_enabled
+                .unwrap_or(inherited.sound_enabled),
+            _ => false,
+        }
+    }
+
+    fn toggle_selected(&mut self) {
+        let field = self.selected_field();
+        let value = !self.effective_bool(field);
+        match field {
+            SettingsField::FollowFocusedTerminal => {
+                self.working.follow_focused_terminal = Some(value)
+            }
+            SettingsField::ResumeAgents => self.working.resume_agents = Some(value),
+            SettingsField::PersistTerminalHistory => {
+                self.working.persist_terminal_history = Some(value)
+            }
+            SettingsField::NotificationsEnabled => self.working.notifications_enabled = Some(value),
+            SettingsField::NotificationsBlocked => self.working.notifications_blocked = Some(value),
+            SettingsField::NotificationsCompleted => {
+                self.working.notifications_completed = Some(value)
+            }
+            SettingsField::NotificationsScheduledDispatchFailed => {
+                self.working.notifications_scheduled_dispatch_failed = Some(value);
+            }
+            SettingsField::NotificationsScheduledInterrupted => {
+                self.working.notifications_scheduled_interrupted = Some(value);
+            }
+            SettingsField::SoundEnabled => self.working.sound_enabled = Some(value),
+            _ => return,
+        }
+        self.error = None;
+    }
+
+    fn begin_edit(&mut self) {
+        let field = self.selected_field();
+        let inherited = &self.loaded.inherited;
+        let input = match field {
+            SettingsField::Terminal => self
+                .working
+                .terminal
+                .clone()
+                .or_else(|| inherited.terminal.clone())
+                .unwrap_or_default(),
+            SettingsField::ProjectRoot(index) => {
+                self.roots().get(index).cloned().unwrap_or_default()
+            }
+            SettingsField::AddProjectRoot => String::new(),
+            SettingsField::ProjectMaxDepth => self
+                .working
+                .project_max_depth
+                .unwrap_or(inherited.project_max_depth)
+                .to_string(),
+            SettingsField::SchedulingMaxConcurrent => self
+                .working
+                .scheduling_max_concurrent
+                .unwrap_or(inherited.scheduling_max_concurrent)
+                .to_string(),
+            SettingsField::SoundBlocked => self
+                .working
+                .sound_blocked
+                .clone()
+                .unwrap_or_else(|| inherited.sound_blocked.clone()),
+            SettingsField::SoundCompleted => self
+                .working
+                .sound_completed
+                .clone()
+                .unwrap_or_else(|| inherited.sound_completed.clone()),
+            SettingsField::SoundScheduledDispatchFailed => self
+                .working
+                .sound_scheduled_dispatch_failed
+                .clone()
+                .unwrap_or_else(|| inherited.sound_scheduled_dispatch_failed.clone()),
+            SettingsField::SoundScheduledInterrupted => self
+                .working
+                .sound_scheduled_interrupted
+                .clone()
+                .unwrap_or_else(|| inherited.sound_scheduled_interrupted.clone()),
+            _ => return,
+        };
+        self.edit = Some(SettingsEdit { field, input });
+        self.error = None;
+    }
+
+    fn apply_edit(&mut self) -> bool {
+        let Some(edit) = self.edit.take() else {
+            return true;
+        };
+        let result = match edit.field {
+            SettingsField::Terminal => {
+                let value = edit.input.trim();
+                if value.is_empty() {
+                    Err("Terminal desktop entry cannot be empty; use Delete to inherit".into())
+                } else if let Err(error) = crate::terminal::validate_desktop_entry(value) {
+                    Err(error.to_string())
+                } else {
+                    self.working.terminal = Some(value.into());
+                    Ok(())
+                }
+            }
+            SettingsField::ProjectRoot(_) | SettingsField::AddProjectRoot => {
+                let value = edit.input.trim();
+                if value.is_empty()
+                    || !(value == "~"
+                        || value.starts_with("~/")
+                        || PathBuf::from(value).is_absolute())
+                {
+                    Err("Project root must be absolute or start with ~".into())
+                } else {
+                    let mut roots = self.roots().to_vec();
+                    if let SettingsField::ProjectRoot(index) = edit.field {
+                        if let Some(root) = roots.get_mut(index) {
+                            *root = value.into();
+                        }
+                    } else {
+                        roots.push(value.into());
+                        self.selected = self.selected.saturating_add(1);
+                    }
+                    self.working.project_roots = Some(roots);
+                    Ok(())
+                }
+            }
+            SettingsField::ProjectMaxDepth => match edit.input.parse::<usize>() {
+                Ok(value @ 1..=10) => {
+                    self.working.project_max_depth = Some(value);
+                    Ok(())
+                }
+                _ => Err("Project max depth must be an integer from 1 to 10".into()),
+            },
+            SettingsField::SchedulingMaxConcurrent => match edit.input.parse::<u16>() {
+                Ok(value @ 1..=64) => {
+                    self.working.scheduling_max_concurrent = Some(value);
+                    Ok(())
+                }
+                _ => Err("Scheduling max concurrent must be an integer from 1 to 64".into()),
+            },
+            SettingsField::SoundBlocked
+            | SettingsField::SoundCompleted
+            | SettingsField::SoundScheduledDispatchFailed
+            | SettingsField::SoundScheduledInterrupted => {
+                let value = edit.input.trim();
+                if value.is_empty() || value.chars().any(char::is_control) {
+                    Err("Sound event ID must be nonempty and contain no control characters".into())
+                } else {
+                    match edit.field {
+                        SettingsField::SoundBlocked => {
+                            self.working.sound_blocked = Some(value.into())
+                        }
+                        SettingsField::SoundCompleted => {
+                            self.working.sound_completed = Some(value.into())
+                        }
+                        SettingsField::SoundScheduledDispatchFailed => {
+                            self.working.sound_scheduled_dispatch_failed = Some(value.into());
+                        }
+                        SettingsField::SoundScheduledInterrupted => {
+                            self.working.sound_scheduled_interrupted = Some(value.into());
+                        }
+                        _ => unreachable!(),
+                    }
+                    Ok(())
+                }
+            }
+            _ => Ok(()),
+        };
+        match result {
+            Ok(()) => {
+                self.error = None;
+                true
+            }
+            Err(error) => {
+                self.error = Some(error);
+                self.edit = Some(edit);
+                false
+            }
+        }
+    }
+
+    fn reset_selected(&mut self) {
+        match self.selected_field() {
+            SettingsField::Terminal => self.working.terminal = None,
+            SettingsField::ProjectRoot(index) => {
+                let mut roots = self.roots().to_vec();
+                if index < roots.len() {
+                    roots.remove(index);
+                    self.working.project_roots = Some(roots);
+                    self.selected = self.selected.min(self.fields().len() - 1);
+                }
+            }
+            SettingsField::AddProjectRoot => self.working.project_roots = None,
+            SettingsField::ProjectMaxDepth => self.working.project_max_depth = None,
+            SettingsField::FollowFocusedTerminal => self.working.follow_focused_terminal = None,
+            SettingsField::ResumeAgents => self.working.resume_agents = None,
+            SettingsField::PersistTerminalHistory => self.working.persist_terminal_history = None,
+            SettingsField::SchedulingMaxConcurrent => self.working.scheduling_max_concurrent = None,
+            SettingsField::NotificationsEnabled => self.working.notifications_enabled = None,
+            SettingsField::NotificationsBlocked => self.working.notifications_blocked = None,
+            SettingsField::NotificationsCompleted => self.working.notifications_completed = None,
+            SettingsField::NotificationsScheduledDispatchFailed => {
+                self.working.notifications_scheduled_dispatch_failed = None;
+            }
+            SettingsField::NotificationsScheduledInterrupted => {
+                self.working.notifications_scheduled_interrupted = None;
+            }
+            SettingsField::SoundEnabled => self.working.sound_enabled = None,
+            SettingsField::SoundBlocked => self.working.sound_blocked = None,
+            SettingsField::SoundCompleted => self.working.sound_completed = None,
+            SettingsField::SoundScheduledDispatchFailed => {
+                self.working.sound_scheduled_dispatch_failed = None;
+            }
+            SettingsField::SoundScheduledInterrupted => {
+                self.working.sound_scheduled_interrupted = None
+            }
+        }
+        self.error = None;
+    }
+
+    fn overridden(&self, field: SettingsField) -> bool {
+        overrides_field(&self.working, field)
+    }
+
+    fn inherited_overridden(&self, field: SettingsField) -> bool {
+        overrides_field(&self.loaded.inherited_overrides, field)
+    }
+
+    fn source(&self, field: SettingsField) -> ConfigSource {
+        if self.overridden(field) {
+            self.loaded.active_source
+        } else if self.inherited_overridden(field) {
+            self.loaded.inherited_source
+        } else {
+            ConfigSource::Default
+        }
+    }
+
+    fn value(&self, field: SettingsField) -> String {
+        let inherited = &self.loaded.inherited;
+        match field {
+            SettingsField::Terminal => self
+                .working
+                .terminal
+                .as_ref()
+                .or(inherited.terminal.as_ref())
+                .cloned()
+                .unwrap_or_else(|| "automatic".into()),
+            SettingsField::ProjectRoot(index) => {
+                self.roots().get(index).cloned().unwrap_or_default()
+            }
+            SettingsField::AddProjectRoot => "+ add root".into(),
+            SettingsField::ProjectMaxDepth => self
+                .working
+                .project_max_depth
+                .unwrap_or(inherited.project_max_depth)
+                .to_string(),
+            SettingsField::SchedulingMaxConcurrent => self
+                .working
+                .scheduling_max_concurrent
+                .unwrap_or(inherited.scheduling_max_concurrent)
+                .to_string(),
+            SettingsField::SoundBlocked => self
+                .working
+                .sound_blocked
+                .as_ref()
+                .unwrap_or(&inherited.sound_blocked)
+                .clone(),
+            SettingsField::SoundCompleted => self
+                .working
+                .sound_completed
+                .as_ref()
+                .unwrap_or(&inherited.sound_completed)
+                .clone(),
+            SettingsField::SoundScheduledDispatchFailed => self
+                .working
+                .sound_scheduled_dispatch_failed
+                .as_ref()
+                .unwrap_or(&inherited.sound_scheduled_dispatch_failed)
+                .clone(),
+            SettingsField::SoundScheduledInterrupted => self
+                .working
+                .sound_scheduled_interrupted
+                .as_ref()
+                .unwrap_or(&inherited.sound_scheduled_interrupted)
+                .clone(),
+            field => if self.effective_bool(field) {
+                "on"
+            } else {
+                "off"
+            }
+            .into(),
+        }
+    }
+}
+
+fn overrides_field(overrides: &ConfigOverrides, field: SettingsField) -> bool {
+    match field {
+        SettingsField::Terminal => overrides.terminal.is_some(),
+        SettingsField::ProjectRoot(_) | SettingsField::AddProjectRoot => {
+            overrides.project_roots.is_some()
+        }
+        SettingsField::ProjectMaxDepth => overrides.project_max_depth.is_some(),
+        SettingsField::FollowFocusedTerminal => overrides.follow_focused_terminal.is_some(),
+        SettingsField::ResumeAgents => overrides.resume_agents.is_some(),
+        SettingsField::PersistTerminalHistory => overrides.persist_terminal_history.is_some(),
+        SettingsField::SchedulingMaxConcurrent => overrides.scheduling_max_concurrent.is_some(),
+        SettingsField::NotificationsEnabled => overrides.notifications_enabled.is_some(),
+        SettingsField::NotificationsBlocked => overrides.notifications_blocked.is_some(),
+        SettingsField::NotificationsCompleted => overrides.notifications_completed.is_some(),
+        SettingsField::NotificationsScheduledDispatchFailed => {
+            overrides.notifications_scheduled_dispatch_failed.is_some()
+        }
+        SettingsField::NotificationsScheduledInterrupted => {
+            overrides.notifications_scheduled_interrupted.is_some()
+        }
+        SettingsField::SoundEnabled => overrides.sound_enabled.is_some(),
+        SettingsField::SoundBlocked => overrides.sound_blocked.is_some(),
+        SettingsField::SoundCompleted => overrides.sound_completed.is_some(),
+        SettingsField::SoundScheduledDispatchFailed => {
+            overrides.sound_scheduled_dispatch_failed.is_some()
+        }
+        SettingsField::SoundScheduledInterrupted => overrides.sound_scheduled_interrupted.is_some(),
+    }
+}
+
+fn settings_field_labels(field: SettingsField) -> (&'static str, String) {
+    match field {
+        SettingsField::Terminal => ("Terminal", "desktop entry".into()),
+        SettingsField::ProjectRoot(index) => ("Projects", format!("root {}", index + 1)),
+        SettingsField::AddProjectRoot => ("Projects", "roots".into()),
+        SettingsField::ProjectMaxDepth => ("Projects", "max depth".into()),
+        SettingsField::FollowFocusedTerminal => ("Dashboard", "follow focused terminal".into()),
+        SettingsField::ResumeAgents => ("Recovery", "resume agents".into()),
+        SettingsField::PersistTerminalHistory => ("Recovery", "persist terminal history".into()),
+        SettingsField::SchedulingMaxConcurrent => ("Scheduling", "max concurrent".into()),
+        SettingsField::NotificationsEnabled => ("Notifications", "enabled".into()),
+        SettingsField::NotificationsBlocked => ("Notifications", "blocked".into()),
+        SettingsField::NotificationsCompleted => ("Notifications", "completed".into()),
+        SettingsField::NotificationsScheduledDispatchFailed => {
+            ("Notifications", "scheduled dispatch failed".into())
+        }
+        SettingsField::NotificationsScheduledInterrupted => {
+            ("Notifications", "scheduled interrupted".into())
+        }
+        SettingsField::SoundEnabled => ("Sound", "enabled".into()),
+        SettingsField::SoundBlocked => ("Sound", "blocked event ID".into()),
+        SettingsField::SoundCompleted => ("Sound", "completed event ID".into()),
+        SettingsField::SoundScheduledDispatchFailed => {
+            ("Sound", "scheduled dispatch failed ID".into())
+        }
+        SettingsField::SoundScheduledInterrupted => ("Sound", "scheduled interrupted ID".into()),
+    }
+}
+
+fn daemon_settings_changed(before: &ConfigValues, after: &ConfigValues) -> bool {
+    before.resume_agents != after.resume_agents
+        || before.persist_terminal_history != after.persist_terminal_history
+        || before.scheduling_max_concurrent != after.scheduling_max_concurrent
+        || before.notifications_enabled != after.notifications_enabled
+        || before.notifications_blocked != after.notifications_blocked
+        || before.notifications_completed != after.notifications_completed
+        || before.notifications_scheduled_dispatch_failed
+            != after.notifications_scheduled_dispatch_failed
+        || before.notifications_scheduled_interrupted != after.notifications_scheduled_interrupted
+        || before.sound_enabled != after.sound_enabled
+        || before.sound_blocked != after.sound_blocked
+        || before.sound_completed != after.sound_completed
+        || before.sound_scheduled_dispatch_failed != after.sound_scheduled_dispatch_failed
+        || before.sound_scheduled_interrupted != after.sound_scheduled_interrupted
 }
 
 struct LinkWorkspacePicker {
@@ -1708,6 +2256,7 @@ enum PaletteKindGroup {
     Schedules,
     ScheduleNotices,
     Dashboard,
+    Settings,
 }
 
 impl PaletteKindGroup {
@@ -1724,6 +2273,7 @@ impl PaletteKindGroup {
             Self::Schedules => "SCHEDULES",
             Self::ScheduleNotices => "SCHEDULE NOTICES",
             Self::Dashboard => "DASHBOARD",
+            Self::Settings => "SETTINGS",
         }
     }
 }
@@ -1733,6 +2283,7 @@ enum PaletteCommand {
     AddNode,
     CreateWorkspace,
     ShowHelp,
+    ShowSettings,
     Workspace {
         workspace_id: QualifiedIdentity,
         action: WorkspacePaletteAction,
@@ -1927,6 +2478,14 @@ impl CommandPalette {
                 detail: "keys, kinds, states, and attention".into(),
                 keywords: "explain keyboard shortcuts question".into(),
                 command: PaletteCommand::ShowHelp,
+            },
+            PaletteEntry {
+                action_group: PaletteActionGroup::GoTo,
+                kind_group: PaletteKindGroup::Settings,
+                label: "Open settings".into(),
+                detail: "edit local Node configuration".into(),
+                keywords: "config preferences terminal notifications recovery scheduling".into(),
+                command: PaletteCommand::ShowSettings,
             },
         ];
         let mut attention_entries = Vec::new();
@@ -2349,6 +2908,7 @@ impl App {
             item_state,
             global_state: TableState::default(),
             node_state: TableState::default().with_selected(has_nodes.then_some(0)),
+            settings: None,
             primary_tab: PrimaryTab::Workspaces,
             focus: Focus::Workspaces,
             mode: Mode::Normal,
@@ -2614,6 +3174,11 @@ impl App {
             self.message = None;
             return;
         }
+        if tab == PrimaryTab::Settings {
+            self.focus = Focus::Items;
+            self.message = None;
+            return;
+        }
         self.focus = if tab == PrimaryTab::Schedules {
             Focus::Workspaces
         } else {
@@ -2641,6 +3206,12 @@ impl App {
     }
 
     fn next(&mut self) {
+        if self.primary_tab == PrimaryTab::Settings {
+            if let Some(settings) = &mut self.settings {
+                settings.move_selection(true);
+            }
+            return;
+        }
         if self.primary_tab == PrimaryTab::Schedules && self.focus == Focus::Items {
             self.cycle_execution(true);
             return;
@@ -2699,6 +3270,12 @@ impl App {
     }
 
     fn previous(&mut self) {
+        if self.primary_tab == PrimaryTab::Settings {
+            if let Some(settings) = &mut self.settings {
+                settings.move_selection(false);
+            }
+            return;
+        }
         if self.primary_tab == PrimaryTab::Schedules && self.focus == Focus::Items {
             self.cycle_execution(false);
             return;
@@ -3392,6 +3969,59 @@ impl App {
                         .collect();
                 }
             }
+            DashboardEvent::SettingsSaved(result) => match *result {
+                Ok((loaded, project_context)) => {
+                    let Some(settings) = &mut self.settings else {
+                        return Vec::new();
+                    };
+                    let daemon_changed =
+                        daemon_settings_changed(&settings.daemon_applied, &loaded.effective);
+                    let clears_history =
+                        daemon_changed && !loaded.effective.persist_terminal_history;
+                    settings.saving = false;
+                    settings.loaded = loaded;
+                    settings.working = settings.loaded.overrides.clone();
+                    settings.error = None;
+                    self.project_context = project_context;
+                    self.follow_focused_terminal =
+                        settings.loaded.effective.follow_focused_terminal;
+                    if !self.follow_focused_terminal {
+                        self.selection_pinned = false;
+                    }
+                    settings.restart_required = daemon_changed;
+                    settings.restart_clears_history = clears_history;
+                    if daemon_changed {
+                        self.mode = Mode::ConfirmDaemonRestart { clears_history };
+                    } else {
+                        self.message = Some(Message {
+                            text: "Settings saved and applied to this dashboard".into(),
+                            error: false,
+                        });
+                    }
+                }
+                Err(text) => {
+                    if let Some(settings) = &mut self.settings {
+                        settings.saving = false;
+                        settings.error = Some(text.clone());
+                    }
+                    self.message = Some(Message { text, error: true });
+                }
+            },
+            DashboardEvent::DaemonRestarted { applied, result } => {
+                if result.is_ok()
+                    && let Some(settings) = &mut self.settings
+                {
+                    settings.daemon_applied = applied;
+                    settings.restart_required = daemon_settings_changed(
+                        &settings.daemon_applied,
+                        &settings.loaded.effective,
+                    );
+                    settings.restart_clears_history = settings.restart_required
+                        && !settings.loaded.effective.persist_terminal_history;
+                }
+                self.message = Some(Message::from_result(result));
+                return vec![DashboardEffect::Refresh];
+            }
             DashboardEvent::ScheduleHistoryCompleted {
                 schedule_id,
                 result,
@@ -3461,6 +4091,13 @@ impl App {
             DashboardEvent::TextPasted(text) => {
                 if let Mode::EditSchedule(editor) = &mut self.mode {
                     editor.insert_text(&text);
+                } else if let Some(edit) = self
+                    .settings
+                    .as_mut()
+                    .filter(|settings| !settings.saving)
+                    .and_then(|settings| settings.edit.as_mut())
+                {
+                    edit.input.push_str(&text.replace(['\n', '\r'], ""));
                 }
             }
             DashboardEvent::TerminalPreviewCompleted {
@@ -3476,6 +4113,14 @@ impl App {
     fn update_key(&mut self, code: KeyCode, modifiers: KeyModifiers) -> Option<DashboardEffect> {
         if modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c') {
             return Some(DashboardEffect::Quit);
+        }
+        if self.primary_tab == PrimaryTab::Settings
+            && self
+                .settings
+                .as_ref()
+                .is_some_and(|settings| settings.edit.is_some())
+        {
+            return self.handle_settings_edit_key(code, modifiers);
         }
         if self.pending_close.is_some() {
             if !modifiers.is_empty() {
@@ -3501,7 +4146,67 @@ impl App {
         if !matches!(self.mode, Mode::Normal) {
             return handle_mode_key(self, code, modifiers);
         }
+        if self
+            .settings
+            .as_ref()
+            .is_some_and(|settings| settings.dirty())
+            && (code == KeyCode::Char('q')
+                || (code == KeyCode::Esc && self.primary_tab != PrimaryTab::Settings))
+        {
+            self.select_tab(PrimaryTab::Settings);
+            self.message = Some(Message {
+                text: "Unsaved settings: Ctrl-S saves; Esc discards; Ctrl-C force quits".into(),
+                error: false,
+            });
+            return None;
+        }
         if !normal_mode_modifiers_supported(code, modifiers) {
+            if self.primary_tab == PrimaryTab::Settings
+                && modifiers == KeyModifiers::CONTROL
+                && code == KeyCode::Char('s')
+            {
+                let settings = self.settings.as_mut()?;
+                if settings.dirty() {
+                    return settings.begin_save();
+                }
+                if settings.restart_required {
+                    self.mode = Mode::ConfirmDaemonRestart {
+                        clears_history: settings.restart_clears_history,
+                    };
+                }
+                return None;
+            }
+            return None;
+        }
+        if self.primary_tab == PrimaryTab::Settings {
+            let settings = self.settings.as_mut()?;
+            if settings.saving {
+                return None;
+            }
+            match code {
+                KeyCode::Char('q') => return Some(DashboardEffect::Quit),
+                KeyCode::Esc if settings.dirty() => {
+                    settings.discard();
+                    self.message = Some(Message {
+                        text: "Discarded unsaved settings changes".into(),
+                        error: false,
+                    });
+                }
+                KeyCode::Esc => {}
+                KeyCode::Down | KeyCode::Char('j') => settings.move_selection(true),
+                KeyCode::Up | KeyCode::Char('k') => settings.move_selection(false),
+                KeyCode::Char(' ') => settings.toggle_selected(),
+                KeyCode::Enter => settings.begin_edit(),
+                KeyCode::Delete => settings.reset_selected(),
+                KeyCode::Char('/' | ':') => self.open_palette(),
+                KeyCode::Char('?') => self.mode = Mode::Help,
+                KeyCode::Tab => self.cycle_tab(false),
+                KeyCode::BackTab => self.cycle_tab(true),
+                KeyCode::Char(key) if shortcut_tab(key).is_some() => {
+                    self.select_tab(shortcut_tab(key).expect("validated tab shortcut"));
+                }
+                _ => {}
+            }
             return None;
         }
         match code {
@@ -3637,6 +4342,45 @@ impl App {
                 return self.selected_schedule_history_effect();
             }
             key if self.handle_focus_key(key) => {}
+            _ => {}
+        }
+        None
+    }
+
+    fn handle_settings_edit_key(
+        &mut self,
+        code: KeyCode,
+        modifiers: KeyModifiers,
+    ) -> Option<DashboardEffect> {
+        let settings = self.settings.as_mut()?;
+        if settings.saving {
+            return None;
+        }
+        let save = modifiers == KeyModifiers::CONTROL && code == KeyCode::Char('s');
+        if save {
+            if settings.apply_edit() {
+                return settings.begin_save();
+            }
+            return None;
+        }
+        if !modifiers.difference(KeyModifiers::SHIFT).is_empty() {
+            return None;
+        }
+        match code {
+            KeyCode::Esc => settings.edit = None,
+            KeyCode::Enter => {
+                settings.apply_edit();
+            }
+            KeyCode::Backspace => {
+                if let Some(edit) = &mut settings.edit {
+                    edit.input.pop();
+                }
+            }
+            KeyCode::Char(character) => {
+                if let Some(edit) = &mut settings.edit {
+                    edit.input.push(character);
+                }
+            }
             _ => {}
         }
         None
@@ -4076,6 +4820,7 @@ pub(crate) fn run<B: DashboardBackend + Send + 'static>(
     state: DashboardState,
     follow_focused_terminal: bool,
     project_context: ProjectContext,
+    settings: ConfigSettings,
     play_intro: bool,
     backend: B,
 ) -> io::Result<()> {
@@ -4090,6 +4835,19 @@ pub(crate) fn run<B: DashboardBackend + Send + 'static>(
         return Err(error);
     }
     let mut app = App::new(state.workspaces, project_context);
+    app.settings = Some(SettingsState::new(
+        settings,
+        match &state.scheduling {
+            SchedulingView::Active { maximum, .. } | SchedulingView::Offline { maximum, .. }
+                if *maximum > 0 =>
+            {
+                Some(*maximum)
+            }
+            SchedulingView::Unsupported { .. }
+            | SchedulingView::Active { .. }
+            | SchedulingView::Offline { .. } => None,
+        },
+    ));
     app.nodes = state.nodes;
     app.node_state.select((!app.nodes.is_empty()).then_some(0));
     app.all_schedules = state.schedules.clone();
@@ -4197,6 +4955,10 @@ fn execute_palette_command(app: &mut App, command: PaletteCommand) -> Option<Das
         }
         PaletteCommand::ShowHelp => {
             app.mode = Mode::Help;
+            None
+        }
+        PaletteCommand::ShowSettings => {
+            app.select_tab(PrimaryTab::Settings);
             None
         }
         PaletteCommand::Workspace {
@@ -4547,6 +5309,27 @@ fn handle_mode_key(
                 None
             }
         },
+        Mode::ConfirmDaemonRestart { clears_history } => {
+            match key {
+                KeyCode::Char('y') => app.settings.as_ref().map(|settings| {
+                    DashboardEffect::RestartDaemon(settings.loaded.effective.clone())
+                }),
+                KeyCode::Char('n') | KeyCode::Esc => {
+                    if let Some(settings) = &mut app.settings {
+                        settings.restart_required = true;
+                    }
+                    app.message = Some(Message {
+                    text: "Settings saved; daemon restart still required to apply daemon-owned fields".into(),
+                    error: false,
+                });
+                    None
+                }
+                _ => {
+                    app.mode = Mode::ConfirmDaemonRestart { clears_history };
+                    None
+                }
+            }
+        }
         Mode::Rename { target, mut input } => match key {
             KeyCode::Enter if !input.trim().is_empty() => {
                 let name = input.trim().to_owned();
@@ -4677,6 +5460,8 @@ fn render(frame: &mut Frame, app: &mut App) {
         render_nodes(frame, dashboard_area, app);
     } else if app.primary_tab == PrimaryTab::Schedules {
         render_schedules(frame, dashboard_area, app);
+    } else if app.primary_tab == PrimaryTab::Settings {
+        render_settings(frame, dashboard_area, app);
     } else if app.primary_tab != PrimaryTab::Workspaces {
         render_global_items(frame, dashboard_area, app);
     } else if dashboard_area.width >= 114 {
@@ -4702,8 +5487,121 @@ fn render(frame: &mut Frame, app: &mut App) {
         Mode::RetargetNode { input, .. } => render_node_retarget(frame, area, input),
         Mode::ConfirmForgetNode(node) => render_node_forget_confirmation(frame, area, node),
         Mode::EditSchedule(editor) => render_schedule_editor(frame, area, editor),
+        Mode::ConfirmDaemonRestart { clears_history } => {
+            render_daemon_restart_confirmation(frame, area, *clears_history)
+        }
         Mode::Normal | Mode::Rename { .. } => {}
     }
+}
+
+fn render_daemon_restart_confirmation(frame: &mut Frame, area: Rect, clears_history: bool) {
+    let popup = centered_rect(area, 68, 28);
+    frame.render_widget(Clear, popup);
+    let warning = if clears_history {
+        "\n\nWARNING: applying disabled persist_terminal_history clears retained terminal history."
+    } else {
+        ""
+    };
+    frame.render_widget(
+        Paragraph::new(format!(
+            "Daemon-owned settings changed. Gracefully restart the local Boomux daemon now?{warning}\n\ny restart  n/esc keep restart required"
+        ))
+        .block(
+            Block::bordered()
+                .title(" Apply daemon settings ")
+                .border_style(Style::new().fg(YELLOW)),
+        )
+        .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn render_settings(frame: &mut Frame, area: Rect, app: &mut App) {
+    let Some(settings) = &mut app.settings else {
+        frame.render_widget(Paragraph::new("Settings unavailable"), area);
+        return;
+    };
+    let [source_area, table_area, status_area] = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Fill(1),
+        Constraint::Length(2),
+    ])
+    .areas(area);
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(vec![
+                Span::styled("Writable local Node layer  ", Style::new().fg(SUBTEXT)),
+                Span::styled(settings.loaded.active_source.label(), Style::new().fg(TEAL)),
+                Span::raw("  "),
+                Span::raw(settings.loaded.active_path.display().to_string()),
+            ]),
+            Line::from(Span::styled(
+                "Values marked default/global are inherited; Delete removes the active override.",
+                Style::new().fg(SUBTEXT),
+            )),
+        ]),
+        source_area,
+    );
+    let fields = settings.fields();
+    let rows = fields.iter().map(|field| {
+        let (group, name) = settings_field_labels(*field);
+        let source = if *field == SettingsField::AddProjectRoot {
+            if settings.overridden(*field) {
+                settings.loaded.active_source.label()
+            } else {
+                "action"
+            }
+        } else {
+            settings.source(*field).label()
+        };
+        Row::new([
+            group.to_owned(),
+            name,
+            settings.value(*field),
+            source.to_owned(),
+        ])
+    });
+    let mut state = TableState::default().with_selected(Some(settings.selected));
+    frame.render_stateful_widget(
+        Table::new(
+            rows,
+            [
+                Constraint::Length(16),
+                Constraint::Length(30),
+                Constraint::Min(24),
+                Constraint::Length(14),
+            ],
+        )
+        .header(Row::new(["GROUP", "SETTING", "VALUE", "SOURCE"]).style(Style::new().fg(BLUE)))
+        .row_highlight_style(Style::new().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("> "),
+        table_area,
+        &mut state,
+    );
+    let status = if let Some(edit) = &settings.edit {
+        format!(
+            "Edit: {}_  Enter apply  Ctrl-S apply and save  Esc cancel",
+            edit.input
+        )
+    } else if let Some(error) = &settings.error {
+        error.clone()
+    } else if settings.saving {
+        "Saving settings...".into()
+    } else if settings.restart_required {
+        "Daemon restart required; Ctrl-S saves further changes, then confirm restart".into()
+    } else if settings.dirty() {
+        "Unsaved changes".into()
+    } else {
+        "All settings saved".into()
+    };
+    frame.render_widget(
+        Paragraph::new(status).style(Style::new().fg(if settings.error.is_some() {
+            RED
+        } else {
+            YELLOW
+        })),
+        status_area,
+    );
 }
 
 fn render_node_inspection(frame: &mut Frame, area: Rect, node: &NodeView) {
@@ -5679,7 +6577,7 @@ fn help_lines(app: &App) -> Vec<Line<'static>> {
         Line::from("  attention filter palette results to outstanding durable attention"),
         Line::from("  Enter    restore a workspace, open an item, or inspect a schedule"),
         Line::from("  a/e/x    add, rename, or request confirmed close/remove"),
-        Line::from("  Tab/1-4 change view; h/l change pane; j/k navigate"),
+        Line::from("  Tab/1-6 change view; h/l change pane; j/k navigate"),
         Line::from(""),
         Line::from(Span::styled(
             "SELECTED CONTEXT",
@@ -5696,7 +6594,15 @@ fn help_lines(app: &App) -> Vec<Line<'static>> {
             }),
         );
     }
-    if app.primary_tab == PrimaryTab::Schedules {
+    if app.primary_tab == PrimaryTab::Settings {
+        lines.extend([
+            Line::from("  SETTINGS edits the active writable layer for this local Node."),
+            Line::from("  Space toggles booleans; Enter edits text and integers."),
+            Line::from("  Project roots provide add/edit rows; Delete removes a root or resets a field."),
+            Line::from("  Ctrl-S validates and atomically saves; Esc cancels editing or discards dirty changes."),
+            Line::from("  Daemon-owned changes offer an explicit graceful restart after save."),
+        ]);
+    } else if app.primary_tab == PrimaryTab::Schedules {
         if let Some(schedule) = app.selected_schedule() {
             lines.extend([
                 Line::from(format!("  schedule: {} / {}", schedule.workspace, schedule.name)),
@@ -5913,6 +6819,7 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                     }
                     PrimaryTab::Schedules => app.schedules.len(),
                     PrimaryTab::Nodes => app.nodes.len(),
+                    PrimaryTab::Settings => 0,
                     PrimaryTab::Workspaces => unreachable!("workspace tab is rendered separately"),
                 };
                 let style = if *tab == app.primary_tab {
@@ -5921,7 +6828,14 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                     Style::new().fg(SUBTEXT)
                 };
                 [
-                    Span::styled(format!("{} {} {count}", index + 1, tab.label()), style),
+                    Span::styled(
+                        if *tab == PrimaryTab::Settings {
+                            format!("{} {}", index + 1, tab.label())
+                        } else {
+                            format!("{} {} {count}", index + 1, tab.label())
+                        },
+                        style,
+                    ),
                     Span::raw("  "),
                 ]
             }),
@@ -7526,6 +8440,34 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Style::new().fg(if message.error { RED } else { GREEN }),
         ))
     } else {
+        if app.primary_tab == PrimaryTab::Settings {
+            let dirty = app.settings.as_ref().is_some_and(SettingsState::dirty);
+            let line = Line::from(vec![
+                Span::styled(" j/k", Style::new().fg(TEAL)),
+                Span::styled(" navigate  ", Style::new().fg(SUBTEXT)),
+                Span::styled("space", Style::new().fg(BLUE)),
+                Span::styled(" toggle  ", Style::new().fg(SUBTEXT)),
+                Span::styled("enter", Style::new().fg(GREEN)),
+                Span::styled(" edit/add  ", Style::new().fg(SUBTEXT)),
+                Span::styled("delete", Style::new().fg(RED)),
+                Span::styled(" remove/reset  ", Style::new().fg(SUBTEXT)),
+                Span::styled(
+                    "Ctrl-S",
+                    Style::new().fg(if dirty { GREEN } else { SUBTEXT }),
+                ),
+                Span::styled(" save  ", Style::new().fg(SUBTEXT)),
+                Span::styled("esc", Style::new().fg(RED)),
+                Span::styled(" discard  ", Style::new().fg(SUBTEXT)),
+                Span::styled("?", Style::new().fg(BLUE)),
+                Span::styled(" help  ", Style::new().fg(SUBTEXT)),
+                Span::styled("1-6", Style::new().fg(TEAL)),
+                Span::styled(" views  ", Style::new().fg(SUBTEXT)),
+                Span::styled("q", Style::new().fg(RED)),
+                Span::styled(" quit", Style::new().fg(SUBTEXT)),
+            ]);
+            frame.render_widget(Paragraph::new(line), area);
+            return;
+        }
         let launcher_selected = matches!(app.selected_item(), Some(WorkspaceItemView::Launcher(_)));
         let offline_shell_selected =
             app.selected_item_location()
@@ -7567,7 +8509,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 Span::styled(" forget  ", Style::new().fg(SUBTEXT)),
                 Span::styled("tab/shift-tab", Style::new().fg(TEAL)),
                 Span::styled(" views  ", Style::new().fg(SUBTEXT)),
-                Span::styled("1-5", Style::new().fg(TEAL)),
+                Span::styled("1-6", Style::new().fg(TEAL)),
                 Span::styled(" select view  ", Style::new().fg(SUBTEXT)),
                 Span::styled("/", Style::new().fg(TEAL)),
                 Span::styled(" palette  ", Style::new().fg(SUBTEXT)),
@@ -7670,7 +8612,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 if app.primary_tab == PrimaryTab::Workspaces {
                     " navigate  tab/shift-tab views  h/l panes  "
                 } else {
-                    " navigate  tab/shift-tab views  1-5 select view  "
+                    " navigate  tab/shift-tab views  1-6 select view  "
                 },
                 Style::new().fg(SUBTEXT),
             ),
@@ -7814,7 +8756,346 @@ mod tests {
     use ratatui::backend::TestBackend;
 
     fn app() -> App {
-        App::new(vec![workspace("w1", "boomux")], project_context())
+        let mut app = App::new(vec![workspace("w1", "boomux")], project_context());
+        app.settings = Some(SettingsState::new(crate::config::test_settings(), None));
+        app
+    }
+
+    fn select_setting(app: &mut App, field: SettingsField) {
+        app.select_tab(PrimaryTab::Settings);
+        let settings = app.settings.as_mut().unwrap();
+        settings.selected = settings
+            .fields()
+            .iter()
+            .position(|candidate| *candidate == field)
+            .unwrap();
+    }
+
+    #[test]
+    fn settings_is_the_sixth_tab_and_renders_grouped_source_aware_fields() {
+        let mut app = app();
+        app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Char('6'),
+            modifiers: KeyModifiers::NONE,
+        });
+        assert_eq!(app.primary_tab, PrimaryTab::Settings);
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 34)).unwrap();
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let buffer = terminal.backend().buffer();
+        let text = (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        for expected in [
+            "6 SETTINGS",
+            "Writable local Node layer",
+            "/tmp/boomux-test-config.toml",
+            "Projects",
+            "Dashboard",
+            "Recovery",
+            "Scheduling",
+            "Notifications",
+            "Sound",
+            "default",
+        ] {
+            assert!(text.contains(expected), "missing {expected:?}\n{text}");
+        }
+    }
+
+    #[test]
+    fn settings_sources_are_tracked_per_field() {
+        let mut app = app();
+        let settings = app.settings.as_mut().unwrap();
+        settings.loaded.active_source = ConfigSource::Environment;
+        settings.loaded.inherited_source = ConfigSource::Global;
+        settings.loaded.inherited_overrides.follow_focused_terminal = Some(true);
+
+        assert_eq!(
+            settings.source(SettingsField::FollowFocusedTerminal),
+            ConfigSource::Global
+        );
+        assert_eq!(
+            settings.source(SettingsField::NotificationsEnabled),
+            ConfigSource::Default
+        );
+        settings.working.notifications_enabled = Some(true);
+        assert_eq!(
+            settings.source(SettingsField::NotificationsEnabled),
+            ConfigSource::Environment
+        );
+    }
+
+    #[test]
+    fn settings_boolean_toggle_save_and_discard_are_typed() {
+        let mut app = app();
+        select_setting(&mut app, SettingsField::FollowFocusedTerminal);
+        app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Char(' '),
+            modifiers: KeyModifiers::NONE,
+        });
+        assert_eq!(
+            app.settings
+                .as_ref()
+                .unwrap()
+                .working
+                .follow_focused_terminal,
+            Some(false)
+        );
+        let effects = app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Char('s'),
+            modifiers: KeyModifiers::CONTROL,
+        });
+        assert!(
+            matches!(effects.as_slice(), [DashboardEffect::SaveSettings(overrides)] if overrides.follow_focused_terminal == Some(false))
+        );
+        assert!(app.settings.as_ref().unwrap().saving);
+
+        app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Char(' '),
+            modifiers: KeyModifiers::NONE,
+        });
+        assert_eq!(
+            app.settings
+                .as_ref()
+                .unwrap()
+                .working
+                .follow_focused_terminal,
+            Some(false)
+        );
+        let mut terminal = Terminal::new(TestBackend::new(120, 34)).unwrap();
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let buffer = terminal.backend().buffer();
+        let text = (0..buffer.area.height)
+            .flat_map(|y| (0..buffer.area.width).map(move |x| buffer[(x, y)].symbol()))
+            .collect::<String>();
+        assert!(text.contains("Saving settings..."));
+
+        app.update(DashboardEvent::SettingsSaved(Box::new(Err(
+            "save failed".into()
+        ))));
+        assert!(!app.settings.as_ref().unwrap().saving);
+
+        app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Esc,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(!app.settings.as_ref().unwrap().dirty());
+    }
+
+    #[test]
+    fn dirty_settings_redirect_quit_and_escape_until_explicitly_discarded() {
+        let mut app = app();
+        select_setting(&mut app, SettingsField::FollowFocusedTerminal);
+        app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Char(' '),
+            modifiers: KeyModifiers::NONE,
+        });
+        app.select_tab(PrimaryTab::Workspaces);
+
+        let effects = app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Char('q'),
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(effects.is_empty());
+        assert_eq!(app.primary_tab, PrimaryTab::Settings);
+        assert!(app.message.as_ref().unwrap().text.contains("Ctrl-S saves"));
+
+        let effects = app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Char('q'),
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(effects.is_empty());
+        assert!(app.settings.as_ref().unwrap().dirty());
+
+        app.select_tab(PrimaryTab::Workspaces);
+        app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Esc,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert_eq!(app.primary_tab, PrimaryTab::Settings);
+        assert!(app.settings.as_ref().unwrap().dirty());
+
+        app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Esc,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(!app.settings.as_ref().unwrap().dirty());
+    }
+
+    #[test]
+    fn running_scheduler_difference_requires_restart_at_startup() {
+        let settings = SettingsState::new(crate::config::test_settings(), Some(2));
+        assert_eq!(settings.daemon_applied.scheduling_max_concurrent, 2);
+        assert_eq!(settings.loaded.effective.scheduling_max_concurrent, 4);
+        assert!(settings.restart_required);
+        assert!(settings.restart_clears_history);
+    }
+
+    #[test]
+    fn unknown_applied_recovery_state_warns_before_disabling_history() {
+        let mut app = app();
+        let mut saved = crate::config::test_settings();
+        saved.effective.notifications_enabled = true;
+        saved.effective.persist_terminal_history = false;
+
+        app.update(DashboardEvent::SettingsSaved(Box::new(Ok((
+            saved,
+            project_context(),
+        )))));
+
+        assert!(matches!(
+            app.mode,
+            Mode::ConfirmDaemonRestart {
+                clears_history: true
+            }
+        ));
+    }
+
+    #[test]
+    fn settings_text_and_numeric_editing_validate_before_save() {
+        let mut app = app();
+        select_setting(&mut app, SettingsField::Terminal);
+        app.settings.as_mut().unwrap().begin_edit();
+        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "invalid".into();
+        assert!(!app.settings.as_mut().unwrap().apply_edit());
+        assert!(app.settings.as_ref().unwrap().error.is_some());
+        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "Alacritty.desktop".into();
+        assert!(app.settings.as_mut().unwrap().apply_edit());
+
+        select_setting(&mut app, SettingsField::ProjectMaxDepth);
+        app.settings.as_mut().unwrap().begin_edit();
+        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "11".into();
+        assert!(!app.settings.as_mut().unwrap().apply_edit());
+        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "4".into();
+        assert!(app.settings.as_mut().unwrap().apply_edit());
+        assert_eq!(
+            app.settings.as_ref().unwrap().working.project_max_depth,
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn project_roots_support_add_edit_remove_and_reset_to_inheritance() {
+        let mut app = app();
+        select_setting(&mut app, SettingsField::AddProjectRoot);
+        app.settings.as_mut().unwrap().begin_edit();
+        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "~/Code".into();
+        assert!(app.settings.as_mut().unwrap().apply_edit());
+        assert_eq!(app.settings.as_ref().unwrap().roots(), ["~/Code"]);
+
+        select_setting(&mut app, SettingsField::ProjectRoot(0));
+        app.settings.as_mut().unwrap().begin_edit();
+        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "/srv/code".into();
+        assert!(app.settings.as_mut().unwrap().apply_edit());
+        assert_eq!(app.settings.as_ref().unwrap().roots(), ["/srv/code"]);
+        app.settings.as_mut().unwrap().reset_selected();
+        assert!(app.settings.as_ref().unwrap().roots().is_empty());
+
+        select_setting(&mut app, SettingsField::AddProjectRoot);
+        app.settings.as_mut().unwrap().reset_selected();
+        assert!(
+            app.settings
+                .as_ref()
+                .unwrap()
+                .working
+                .project_roots
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn settings_save_failure_and_restart_confirmation_are_explicit() {
+        let mut app = app();
+        app.update(DashboardEvent::SettingsSaved(Box::new(Err(
+            "config target changed while it was being edited".into(),
+        ))));
+        assert!(app.message.as_ref().is_some_and(|message| message.error));
+        assert!(
+            app.settings
+                .as_ref()
+                .unwrap()
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("changed"))
+        );
+
+        app.settings
+            .as_mut()
+            .unwrap()
+            .daemon_applied
+            .persist_terminal_history = true;
+        let mut saved = crate::config::test_settings();
+        saved.effective.persist_terminal_history = false;
+        saved.effective.notifications_enabled = true;
+        app.update(DashboardEvent::SettingsSaved(Box::new(Ok((
+            saved,
+            project_context(),
+        )))));
+        assert!(matches!(
+            app.mode,
+            Mode::ConfirmDaemonRestart {
+                clears_history: true
+            }
+        ));
+        app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Char('n'),
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(app.settings.as_ref().unwrap().restart_required);
+        assert!(
+            app.message
+                .as_ref()
+                .unwrap()
+                .text
+                .contains("restart still required")
+        );
+
+        app.mode = Mode::ConfirmDaemonRestart {
+            clears_history: false,
+        };
+        let effects = app.update(DashboardEvent::KeyPressed {
+            code: KeyCode::Char('y'),
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(matches!(
+            effects.as_slice(),
+            [DashboardEffect::RestartDaemon(settings)]
+                if !settings.persist_terminal_history && settings.notifications_enabled
+        ));
+        let DashboardEffect::RestartDaemon(applied) = effects.into_iter().next().unwrap() else {
+            unreachable!();
+        };
+        app.update(DashboardEvent::DaemonRestarted {
+            applied: applied.clone(),
+            result: Ok("restarted".into()),
+        });
+        assert_eq!(app.settings.as_ref().unwrap().daemon_applied, applied);
+        assert!(!app.settings.as_ref().unwrap().restart_required);
+    }
+
+    #[test]
+    fn reverting_pending_daemon_settings_clears_restart_requirement() {
+        let mut app = app();
+        let mut changed = crate::config::test_settings();
+        changed.effective.notifications_enabled = true;
+        app.update(DashboardEvent::SettingsSaved(Box::new(Ok((
+            changed,
+            project_context(),
+        )))));
+        assert!(app.settings.as_ref().unwrap().restart_required);
+
+        app.mode = Mode::Normal;
+        app.update(DashboardEvent::SettingsSaved(Box::new(Ok((
+            crate::config::test_settings(),
+            project_context(),
+        )))));
+        assert!(!app.settings.as_ref().unwrap().restart_required);
+        assert!(matches!(app.mode, Mode::Normal));
     }
 
     #[test]
@@ -9298,11 +10579,11 @@ mod tests {
     #[test]
     fn numeric_shortcuts_match_primary_tab_order() {
         assert_eq!(
-            ('1'..='5').filter_map(shortcut_tab).collect::<Vec<_>>(),
+            ('1'..='6').filter_map(shortcut_tab).collect::<Vec<_>>(),
             PrimaryTab::ALL
         );
         assert_eq!(shortcut_tab('0'), None);
-        assert_eq!(shortcut_tab('6'), None);
+        assert_eq!(shortcut_tab('7'), None);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -20,7 +20,6 @@ use ratatui::widgets::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::agent_attention_projection::AgentStateCounts;
-use crate::config::{ConfigOverrides, ConfigSettings, ConfigSource, ConfigValues};
 use crate::protocol::{
     NodeProjectionHealthCode, QualifiedIdentity, SchedulerHealth, TerminalColor, TerminalPreview,
     TerminalPreviewLine, TerminalStyle,
@@ -898,8 +897,6 @@ pub(crate) enum DashboardEffect {
     RefreshNode(String),
     RestoreDismissedShells(String),
     Refresh,
-    SaveSettings(ConfigOverrides),
-    RestartDaemon(ConfigValues),
     RunSchedule(QualifiedIdentity),
     PauseSchedule(QualifiedIdentity),
     ResumeSchedule(QualifiedIdentity),
@@ -953,11 +950,6 @@ pub(crate) enum DashboardEvent {
     OperationCompleted(Result<String, String>),
     ShellCreationCompleted(Result<String, String>),
     RefreshCompleted(Result<DashboardState, String>),
-    SettingsSaved(Box<Result<(ConfigSettings, ProjectContext), String>>),
-    DaemonRestarted {
-        applied: ConfigValues,
-        result: Result<String, String>,
-    },
     ScheduleHistoryCompleted {
         schedule_id: QualifiedIdentity,
         result: Result<(Vec<ExecutionView>, bool), String>,
@@ -1106,7 +1098,6 @@ struct App {
     item_state: TableState,
     global_state: TableState,
     node_state: TableState,
-    settings: Option<SettingsState>,
     primary_tab: PrimaryTab,
     focus: Focus,
     mode: Mode,
@@ -1141,17 +1132,15 @@ enum PrimaryTab {
     Shells,
     Schedules,
     Nodes,
-    Settings,
 }
 
 impl PrimaryTab {
-    const ALL: [Self; 6] = [
+    const ALL: [Self; 5] = [
         Self::Workspaces,
         Self::Agents,
         Self::Shells,
         Self::Schedules,
         Self::Nodes,
-        Self::Settings,
     ];
 
     fn kind(self) -> Option<ItemKind> {
@@ -1161,7 +1150,6 @@ impl PrimaryTab {
             Self::Shells => Some(ItemKind::Shell),
             Self::Schedules => None,
             Self::Nodes => None,
-            Self::Settings => None,
         }
     }
 
@@ -1172,7 +1160,6 @@ impl PrimaryTab {
             Self::Shells => "SHELLS",
             Self::Schedules => "SCHEDULES",
             Self::Nodes => "NODES",
-            Self::Settings => "SETTINGS",
         }
     }
 }
@@ -1266,541 +1253,6 @@ enum Mode {
     },
     ConfirmForgetNode(NodeView),
     EditSchedule(ScheduleEditor),
-    ConfirmDaemonRestart {
-        clears_history: bool,
-    },
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SettingsField {
-    Terminal,
-    ProjectRoot(usize),
-    AddProjectRoot,
-    ProjectMaxDepth,
-    FollowFocusedTerminal,
-    ResumeAgents,
-    PersistTerminalHistory,
-    SchedulingMaxConcurrent,
-    NotificationsEnabled,
-    NotificationsBlocked,
-    NotificationsCompleted,
-    NotificationsScheduledDispatchFailed,
-    NotificationsScheduledInterrupted,
-    SoundEnabled,
-    SoundBlocked,
-    SoundCompleted,
-    SoundScheduledDispatchFailed,
-    SoundScheduledInterrupted,
-}
-
-struct SettingsEdit {
-    field: SettingsField,
-    input: String,
-}
-
-struct SettingsState {
-    loaded: ConfigSettings,
-    daemon_applied: ConfigValues,
-    working: ConfigOverrides,
-    selected: usize,
-    edit: Option<SettingsEdit>,
-    error: Option<String>,
-    saving: bool,
-    restart_required: bool,
-    restart_clears_history: bool,
-}
-
-impl SettingsState {
-    fn new(loaded: ConfigSettings, running_scheduler_maximum: Option<u16>) -> Self {
-        let mut daemon_applied = loaded.effective.clone();
-        if let Some(maximum) = running_scheduler_maximum {
-            daemon_applied.scheduling_max_concurrent = maximum;
-        }
-        let restart_required = daemon_settings_changed(&daemon_applied, &loaded.effective);
-        let restart_clears_history = restart_required && !loaded.effective.persist_terminal_history;
-        Self {
-            daemon_applied,
-            working: loaded.overrides.clone(),
-            loaded,
-            selected: 0,
-            edit: None,
-            error: None,
-            saving: false,
-            restart_required,
-            restart_clears_history,
-        }
-    }
-
-    fn roots(&self) -> &[String] {
-        self.working
-            .project_roots
-            .as_deref()
-            .unwrap_or(&self.loaded.inherited.project_roots)
-    }
-
-    fn fields(&self) -> Vec<SettingsField> {
-        let mut fields = vec![SettingsField::Terminal];
-        fields.extend((0..self.roots().len()).map(SettingsField::ProjectRoot));
-        fields.extend([
-            SettingsField::AddProjectRoot,
-            SettingsField::ProjectMaxDepth,
-            SettingsField::FollowFocusedTerminal,
-            SettingsField::ResumeAgents,
-            SettingsField::PersistTerminalHistory,
-            SettingsField::SchedulingMaxConcurrent,
-            SettingsField::NotificationsEnabled,
-            SettingsField::NotificationsBlocked,
-            SettingsField::NotificationsCompleted,
-            SettingsField::NotificationsScheduledDispatchFailed,
-            SettingsField::NotificationsScheduledInterrupted,
-            SettingsField::SoundEnabled,
-            SettingsField::SoundBlocked,
-            SettingsField::SoundCompleted,
-            SettingsField::SoundScheduledDispatchFailed,
-            SettingsField::SoundScheduledInterrupted,
-        ]);
-        fields
-    }
-
-    fn selected_field(&self) -> SettingsField {
-        let fields = self.fields();
-        fields[self.selected.min(fields.len() - 1)]
-    }
-
-    fn move_selection(&mut self, forwards: bool) {
-        let count = self.fields().len();
-        self.selected = if forwards {
-            (self.selected + 1) % count
-        } else if self.selected == 0 {
-            count - 1
-        } else {
-            self.selected - 1
-        };
-        self.error = None;
-    }
-
-    fn dirty(&self) -> bool {
-        self.working != self.loaded.overrides
-    }
-
-    fn discard(&mut self) {
-        self.working = self.loaded.overrides.clone();
-        self.edit = None;
-        self.error = None;
-    }
-
-    fn begin_save(&mut self) -> Option<DashboardEffect> {
-        if self.saving || !self.dirty() {
-            return None;
-        }
-        self.saving = true;
-        self.error = None;
-        Some(DashboardEffect::SaveSettings(self.working.clone()))
-    }
-
-    fn effective_bool(&self, field: SettingsField) -> bool {
-        let inherited = &self.loaded.inherited;
-        match field {
-            SettingsField::FollowFocusedTerminal => self
-                .working
-                .follow_focused_terminal
-                .unwrap_or(inherited.follow_focused_terminal),
-            SettingsField::ResumeAgents => self
-                .working
-                .resume_agents
-                .unwrap_or(inherited.resume_agents),
-            SettingsField::PersistTerminalHistory => self
-                .working
-                .persist_terminal_history
-                .unwrap_or(inherited.persist_terminal_history),
-            SettingsField::NotificationsEnabled => self
-                .working
-                .notifications_enabled
-                .unwrap_or(inherited.notifications_enabled),
-            SettingsField::NotificationsBlocked => self
-                .working
-                .notifications_blocked
-                .unwrap_or(inherited.notifications_blocked),
-            SettingsField::NotificationsCompleted => self
-                .working
-                .notifications_completed
-                .unwrap_or(inherited.notifications_completed),
-            SettingsField::NotificationsScheduledDispatchFailed => self
-                .working
-                .notifications_scheduled_dispatch_failed
-                .unwrap_or(inherited.notifications_scheduled_dispatch_failed),
-            SettingsField::NotificationsScheduledInterrupted => self
-                .working
-                .notifications_scheduled_interrupted
-                .unwrap_or(inherited.notifications_scheduled_interrupted),
-            SettingsField::SoundEnabled => self
-                .working
-                .sound_enabled
-                .unwrap_or(inherited.sound_enabled),
-            _ => false,
-        }
-    }
-
-    fn toggle_selected(&mut self) {
-        let field = self.selected_field();
-        let value = !self.effective_bool(field);
-        match field {
-            SettingsField::FollowFocusedTerminal => {
-                self.working.follow_focused_terminal = Some(value)
-            }
-            SettingsField::ResumeAgents => self.working.resume_agents = Some(value),
-            SettingsField::PersistTerminalHistory => {
-                self.working.persist_terminal_history = Some(value)
-            }
-            SettingsField::NotificationsEnabled => self.working.notifications_enabled = Some(value),
-            SettingsField::NotificationsBlocked => self.working.notifications_blocked = Some(value),
-            SettingsField::NotificationsCompleted => {
-                self.working.notifications_completed = Some(value)
-            }
-            SettingsField::NotificationsScheduledDispatchFailed => {
-                self.working.notifications_scheduled_dispatch_failed = Some(value);
-            }
-            SettingsField::NotificationsScheduledInterrupted => {
-                self.working.notifications_scheduled_interrupted = Some(value);
-            }
-            SettingsField::SoundEnabled => self.working.sound_enabled = Some(value),
-            _ => return,
-        }
-        self.error = None;
-    }
-
-    fn begin_edit(&mut self) {
-        let field = self.selected_field();
-        let inherited = &self.loaded.inherited;
-        let input = match field {
-            SettingsField::Terminal => self
-                .working
-                .terminal
-                .clone()
-                .or_else(|| inherited.terminal.clone())
-                .unwrap_or_default(),
-            SettingsField::ProjectRoot(index) => {
-                self.roots().get(index).cloned().unwrap_or_default()
-            }
-            SettingsField::AddProjectRoot => String::new(),
-            SettingsField::ProjectMaxDepth => self
-                .working
-                .project_max_depth
-                .unwrap_or(inherited.project_max_depth)
-                .to_string(),
-            SettingsField::SchedulingMaxConcurrent => self
-                .working
-                .scheduling_max_concurrent
-                .unwrap_or(inherited.scheduling_max_concurrent)
-                .to_string(),
-            SettingsField::SoundBlocked => self
-                .working
-                .sound_blocked
-                .clone()
-                .unwrap_or_else(|| inherited.sound_blocked.clone()),
-            SettingsField::SoundCompleted => self
-                .working
-                .sound_completed
-                .clone()
-                .unwrap_or_else(|| inherited.sound_completed.clone()),
-            SettingsField::SoundScheduledDispatchFailed => self
-                .working
-                .sound_scheduled_dispatch_failed
-                .clone()
-                .unwrap_or_else(|| inherited.sound_scheduled_dispatch_failed.clone()),
-            SettingsField::SoundScheduledInterrupted => self
-                .working
-                .sound_scheduled_interrupted
-                .clone()
-                .unwrap_or_else(|| inherited.sound_scheduled_interrupted.clone()),
-            _ => return,
-        };
-        self.edit = Some(SettingsEdit { field, input });
-        self.error = None;
-    }
-
-    fn apply_edit(&mut self) -> bool {
-        let Some(edit) = self.edit.take() else {
-            return true;
-        };
-        let result = match edit.field {
-            SettingsField::Terminal => {
-                let value = edit.input.trim();
-                if value.is_empty() {
-                    Err("Terminal desktop entry cannot be empty; use Delete to inherit".into())
-                } else if let Err(error) = crate::terminal::validate_desktop_entry(value) {
-                    Err(error.to_string())
-                } else {
-                    self.working.terminal = Some(value.into());
-                    Ok(())
-                }
-            }
-            SettingsField::ProjectRoot(_) | SettingsField::AddProjectRoot => {
-                let value = edit.input.trim();
-                if value.is_empty()
-                    || !(value == "~"
-                        || value.starts_with("~/")
-                        || PathBuf::from(value).is_absolute())
-                {
-                    Err("Project root must be absolute or start with ~".into())
-                } else {
-                    let mut roots = self.roots().to_vec();
-                    if let SettingsField::ProjectRoot(index) = edit.field {
-                        if let Some(root) = roots.get_mut(index) {
-                            *root = value.into();
-                        }
-                    } else {
-                        roots.push(value.into());
-                        self.selected = self.selected.saturating_add(1);
-                    }
-                    self.working.project_roots = Some(roots);
-                    Ok(())
-                }
-            }
-            SettingsField::ProjectMaxDepth => match edit.input.parse::<usize>() {
-                Ok(value @ 1..=10) => {
-                    self.working.project_max_depth = Some(value);
-                    Ok(())
-                }
-                _ => Err("Project max depth must be an integer from 1 to 10".into()),
-            },
-            SettingsField::SchedulingMaxConcurrent => match edit.input.parse::<u16>() {
-                Ok(value @ 1..=64) => {
-                    self.working.scheduling_max_concurrent = Some(value);
-                    Ok(())
-                }
-                _ => Err("Scheduling max concurrent must be an integer from 1 to 64".into()),
-            },
-            SettingsField::SoundBlocked
-            | SettingsField::SoundCompleted
-            | SettingsField::SoundScheduledDispatchFailed
-            | SettingsField::SoundScheduledInterrupted => {
-                let value = edit.input.trim();
-                if value.is_empty() || value.chars().any(char::is_control) {
-                    Err("Sound event ID must be nonempty and contain no control characters".into())
-                } else {
-                    match edit.field {
-                        SettingsField::SoundBlocked => {
-                            self.working.sound_blocked = Some(value.into())
-                        }
-                        SettingsField::SoundCompleted => {
-                            self.working.sound_completed = Some(value.into())
-                        }
-                        SettingsField::SoundScheduledDispatchFailed => {
-                            self.working.sound_scheduled_dispatch_failed = Some(value.into());
-                        }
-                        SettingsField::SoundScheduledInterrupted => {
-                            self.working.sound_scheduled_interrupted = Some(value.into());
-                        }
-                        _ => unreachable!(),
-                    }
-                    Ok(())
-                }
-            }
-            _ => Ok(()),
-        };
-        match result {
-            Ok(()) => {
-                self.error = None;
-                true
-            }
-            Err(error) => {
-                self.error = Some(error);
-                self.edit = Some(edit);
-                false
-            }
-        }
-    }
-
-    fn reset_selected(&mut self) {
-        match self.selected_field() {
-            SettingsField::Terminal => self.working.terminal = None,
-            SettingsField::ProjectRoot(index) => {
-                let mut roots = self.roots().to_vec();
-                if index < roots.len() {
-                    roots.remove(index);
-                    self.working.project_roots = Some(roots);
-                    self.selected = self.selected.min(self.fields().len() - 1);
-                }
-            }
-            SettingsField::AddProjectRoot => self.working.project_roots = None,
-            SettingsField::ProjectMaxDepth => self.working.project_max_depth = None,
-            SettingsField::FollowFocusedTerminal => self.working.follow_focused_terminal = None,
-            SettingsField::ResumeAgents => self.working.resume_agents = None,
-            SettingsField::PersistTerminalHistory => self.working.persist_terminal_history = None,
-            SettingsField::SchedulingMaxConcurrent => self.working.scheduling_max_concurrent = None,
-            SettingsField::NotificationsEnabled => self.working.notifications_enabled = None,
-            SettingsField::NotificationsBlocked => self.working.notifications_blocked = None,
-            SettingsField::NotificationsCompleted => self.working.notifications_completed = None,
-            SettingsField::NotificationsScheduledDispatchFailed => {
-                self.working.notifications_scheduled_dispatch_failed = None;
-            }
-            SettingsField::NotificationsScheduledInterrupted => {
-                self.working.notifications_scheduled_interrupted = None;
-            }
-            SettingsField::SoundEnabled => self.working.sound_enabled = None,
-            SettingsField::SoundBlocked => self.working.sound_blocked = None,
-            SettingsField::SoundCompleted => self.working.sound_completed = None,
-            SettingsField::SoundScheduledDispatchFailed => {
-                self.working.sound_scheduled_dispatch_failed = None;
-            }
-            SettingsField::SoundScheduledInterrupted => {
-                self.working.sound_scheduled_interrupted = None
-            }
-        }
-        self.error = None;
-    }
-
-    fn overridden(&self, field: SettingsField) -> bool {
-        overrides_field(&self.working, field)
-    }
-
-    fn inherited_overridden(&self, field: SettingsField) -> bool {
-        overrides_field(&self.loaded.inherited_overrides, field)
-    }
-
-    fn source(&self, field: SettingsField) -> ConfigSource {
-        if self.overridden(field) {
-            self.loaded.active_source
-        } else if self.inherited_overridden(field) {
-            self.loaded.inherited_source
-        } else {
-            ConfigSource::Default
-        }
-    }
-
-    fn value(&self, field: SettingsField) -> String {
-        let inherited = &self.loaded.inherited;
-        match field {
-            SettingsField::Terminal => self
-                .working
-                .terminal
-                .as_ref()
-                .or(inherited.terminal.as_ref())
-                .cloned()
-                .unwrap_or_else(|| "automatic".into()),
-            SettingsField::ProjectRoot(index) => {
-                self.roots().get(index).cloned().unwrap_or_default()
-            }
-            SettingsField::AddProjectRoot => "+ add root".into(),
-            SettingsField::ProjectMaxDepth => self
-                .working
-                .project_max_depth
-                .unwrap_or(inherited.project_max_depth)
-                .to_string(),
-            SettingsField::SchedulingMaxConcurrent => self
-                .working
-                .scheduling_max_concurrent
-                .unwrap_or(inherited.scheduling_max_concurrent)
-                .to_string(),
-            SettingsField::SoundBlocked => self
-                .working
-                .sound_blocked
-                .as_ref()
-                .unwrap_or(&inherited.sound_blocked)
-                .clone(),
-            SettingsField::SoundCompleted => self
-                .working
-                .sound_completed
-                .as_ref()
-                .unwrap_or(&inherited.sound_completed)
-                .clone(),
-            SettingsField::SoundScheduledDispatchFailed => self
-                .working
-                .sound_scheduled_dispatch_failed
-                .as_ref()
-                .unwrap_or(&inherited.sound_scheduled_dispatch_failed)
-                .clone(),
-            SettingsField::SoundScheduledInterrupted => self
-                .working
-                .sound_scheduled_interrupted
-                .as_ref()
-                .unwrap_or(&inherited.sound_scheduled_interrupted)
-                .clone(),
-            field => if self.effective_bool(field) {
-                "on"
-            } else {
-                "off"
-            }
-            .into(),
-        }
-    }
-}
-
-fn overrides_field(overrides: &ConfigOverrides, field: SettingsField) -> bool {
-    match field {
-        SettingsField::Terminal => overrides.terminal.is_some(),
-        SettingsField::ProjectRoot(_) | SettingsField::AddProjectRoot => {
-            overrides.project_roots.is_some()
-        }
-        SettingsField::ProjectMaxDepth => overrides.project_max_depth.is_some(),
-        SettingsField::FollowFocusedTerminal => overrides.follow_focused_terminal.is_some(),
-        SettingsField::ResumeAgents => overrides.resume_agents.is_some(),
-        SettingsField::PersistTerminalHistory => overrides.persist_terminal_history.is_some(),
-        SettingsField::SchedulingMaxConcurrent => overrides.scheduling_max_concurrent.is_some(),
-        SettingsField::NotificationsEnabled => overrides.notifications_enabled.is_some(),
-        SettingsField::NotificationsBlocked => overrides.notifications_blocked.is_some(),
-        SettingsField::NotificationsCompleted => overrides.notifications_completed.is_some(),
-        SettingsField::NotificationsScheduledDispatchFailed => {
-            overrides.notifications_scheduled_dispatch_failed.is_some()
-        }
-        SettingsField::NotificationsScheduledInterrupted => {
-            overrides.notifications_scheduled_interrupted.is_some()
-        }
-        SettingsField::SoundEnabled => overrides.sound_enabled.is_some(),
-        SettingsField::SoundBlocked => overrides.sound_blocked.is_some(),
-        SettingsField::SoundCompleted => overrides.sound_completed.is_some(),
-        SettingsField::SoundScheduledDispatchFailed => {
-            overrides.sound_scheduled_dispatch_failed.is_some()
-        }
-        SettingsField::SoundScheduledInterrupted => overrides.sound_scheduled_interrupted.is_some(),
-    }
-}
-
-fn settings_field_labels(field: SettingsField) -> (&'static str, String) {
-    match field {
-        SettingsField::Terminal => ("Terminal", "desktop entry".into()),
-        SettingsField::ProjectRoot(index) => ("Projects", format!("root {}", index + 1)),
-        SettingsField::AddProjectRoot => ("Projects", "roots".into()),
-        SettingsField::ProjectMaxDepth => ("Projects", "max depth".into()),
-        SettingsField::FollowFocusedTerminal => ("Dashboard", "follow focused terminal".into()),
-        SettingsField::ResumeAgents => ("Recovery", "resume agents".into()),
-        SettingsField::PersistTerminalHistory => ("Recovery", "persist terminal history".into()),
-        SettingsField::SchedulingMaxConcurrent => ("Scheduling", "max concurrent".into()),
-        SettingsField::NotificationsEnabled => ("Notifications", "enabled".into()),
-        SettingsField::NotificationsBlocked => ("Notifications", "blocked".into()),
-        SettingsField::NotificationsCompleted => ("Notifications", "completed".into()),
-        SettingsField::NotificationsScheduledDispatchFailed => {
-            ("Notifications", "scheduled dispatch failed".into())
-        }
-        SettingsField::NotificationsScheduledInterrupted => {
-            ("Notifications", "scheduled interrupted".into())
-        }
-        SettingsField::SoundEnabled => ("Sound", "enabled".into()),
-        SettingsField::SoundBlocked => ("Sound", "blocked event ID".into()),
-        SettingsField::SoundCompleted => ("Sound", "completed event ID".into()),
-        SettingsField::SoundScheduledDispatchFailed => {
-            ("Sound", "scheduled dispatch failed ID".into())
-        }
-        SettingsField::SoundScheduledInterrupted => ("Sound", "scheduled interrupted ID".into()),
-    }
-}
-
-fn daemon_settings_changed(before: &ConfigValues, after: &ConfigValues) -> bool {
-    before.resume_agents != after.resume_agents
-        || before.persist_terminal_history != after.persist_terminal_history
-        || before.scheduling_max_concurrent != after.scheduling_max_concurrent
-        || before.notifications_enabled != after.notifications_enabled
-        || before.notifications_blocked != after.notifications_blocked
-        || before.notifications_completed != after.notifications_completed
-        || before.notifications_scheduled_dispatch_failed
-            != after.notifications_scheduled_dispatch_failed
-        || before.notifications_scheduled_interrupted != after.notifications_scheduled_interrupted
-        || before.sound_enabled != after.sound_enabled
-        || before.sound_blocked != after.sound_blocked
-        || before.sound_completed != after.sound_completed
-        || before.sound_scheduled_dispatch_failed != after.sound_scheduled_dispatch_failed
-        || before.sound_scheduled_interrupted != after.sound_scheduled_interrupted
 }
 
 struct LinkWorkspacePicker {
@@ -2256,7 +1708,6 @@ enum PaletteKindGroup {
     Schedules,
     ScheduleNotices,
     Dashboard,
-    Settings,
 }
 
 impl PaletteKindGroup {
@@ -2273,7 +1724,6 @@ impl PaletteKindGroup {
             Self::Schedules => "SCHEDULES",
             Self::ScheduleNotices => "SCHEDULE NOTICES",
             Self::Dashboard => "DASHBOARD",
-            Self::Settings => "SETTINGS",
         }
     }
 }
@@ -2283,7 +1733,6 @@ enum PaletteCommand {
     AddNode,
     CreateWorkspace,
     ShowHelp,
-    ShowSettings,
     Workspace {
         workspace_id: QualifiedIdentity,
         action: WorkspacePaletteAction,
@@ -2478,14 +1927,6 @@ impl CommandPalette {
                 detail: "keys, kinds, states, and attention".into(),
                 keywords: "explain keyboard shortcuts question".into(),
                 command: PaletteCommand::ShowHelp,
-            },
-            PaletteEntry {
-                action_group: PaletteActionGroup::GoTo,
-                kind_group: PaletteKindGroup::Settings,
-                label: "Open settings".into(),
-                detail: "edit local Node configuration".into(),
-                keywords: "config preferences terminal notifications recovery scheduling".into(),
-                command: PaletteCommand::ShowSettings,
             },
         ];
         let mut attention_entries = Vec::new();
@@ -2908,7 +2349,6 @@ impl App {
             item_state,
             global_state: TableState::default(),
             node_state: TableState::default().with_selected(has_nodes.then_some(0)),
-            settings: None,
             primary_tab: PrimaryTab::Workspaces,
             focus: Focus::Workspaces,
             mode: Mode::Normal,
@@ -3174,11 +2614,6 @@ impl App {
             self.message = None;
             return;
         }
-        if tab == PrimaryTab::Settings {
-            self.focus = Focus::Items;
-            self.message = None;
-            return;
-        }
         self.focus = if tab == PrimaryTab::Schedules {
             Focus::Workspaces
         } else {
@@ -3206,12 +2641,6 @@ impl App {
     }
 
     fn next(&mut self) {
-        if self.primary_tab == PrimaryTab::Settings {
-            if let Some(settings) = &mut self.settings {
-                settings.move_selection(true);
-            }
-            return;
-        }
         if self.primary_tab == PrimaryTab::Schedules && self.focus == Focus::Items {
             self.cycle_execution(true);
             return;
@@ -3270,12 +2699,6 @@ impl App {
     }
 
     fn previous(&mut self) {
-        if self.primary_tab == PrimaryTab::Settings {
-            if let Some(settings) = &mut self.settings {
-                settings.move_selection(false);
-            }
-            return;
-        }
         if self.primary_tab == PrimaryTab::Schedules && self.focus == Focus::Items {
             self.cycle_execution(false);
             return;
@@ -3969,59 +3392,6 @@ impl App {
                         .collect();
                 }
             }
-            DashboardEvent::SettingsSaved(result) => match *result {
-                Ok((loaded, project_context)) => {
-                    let Some(settings) = &mut self.settings else {
-                        return Vec::new();
-                    };
-                    let daemon_changed =
-                        daemon_settings_changed(&settings.daemon_applied, &loaded.effective);
-                    let clears_history =
-                        daemon_changed && !loaded.effective.persist_terminal_history;
-                    settings.saving = false;
-                    settings.loaded = loaded;
-                    settings.working = settings.loaded.overrides.clone();
-                    settings.error = None;
-                    self.project_context = project_context;
-                    self.follow_focused_terminal =
-                        settings.loaded.effective.follow_focused_terminal;
-                    if !self.follow_focused_terminal {
-                        self.selection_pinned = false;
-                    }
-                    settings.restart_required = daemon_changed;
-                    settings.restart_clears_history = clears_history;
-                    if daemon_changed {
-                        self.mode = Mode::ConfirmDaemonRestart { clears_history };
-                    } else {
-                        self.message = Some(Message {
-                            text: "Settings saved and applied to this dashboard".into(),
-                            error: false,
-                        });
-                    }
-                }
-                Err(text) => {
-                    if let Some(settings) = &mut self.settings {
-                        settings.saving = false;
-                        settings.error = Some(text.clone());
-                    }
-                    self.message = Some(Message { text, error: true });
-                }
-            },
-            DashboardEvent::DaemonRestarted { applied, result } => {
-                if result.is_ok()
-                    && let Some(settings) = &mut self.settings
-                {
-                    settings.daemon_applied = applied;
-                    settings.restart_required = daemon_settings_changed(
-                        &settings.daemon_applied,
-                        &settings.loaded.effective,
-                    );
-                    settings.restart_clears_history = settings.restart_required
-                        && !settings.loaded.effective.persist_terminal_history;
-                }
-                self.message = Some(Message::from_result(result));
-                return vec![DashboardEffect::Refresh];
-            }
             DashboardEvent::ScheduleHistoryCompleted {
                 schedule_id,
                 result,
@@ -4091,13 +3461,6 @@ impl App {
             DashboardEvent::TextPasted(text) => {
                 if let Mode::EditSchedule(editor) = &mut self.mode {
                     editor.insert_text(&text);
-                } else if let Some(edit) = self
-                    .settings
-                    .as_mut()
-                    .filter(|settings| !settings.saving)
-                    .and_then(|settings| settings.edit.as_mut())
-                {
-                    edit.input.push_str(&text.replace(['\n', '\r'], ""));
                 }
             }
             DashboardEvent::TerminalPreviewCompleted {
@@ -4113,14 +3476,6 @@ impl App {
     fn update_key(&mut self, code: KeyCode, modifiers: KeyModifiers) -> Option<DashboardEffect> {
         if modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c') {
             return Some(DashboardEffect::Quit);
-        }
-        if self.primary_tab == PrimaryTab::Settings
-            && self
-                .settings
-                .as_ref()
-                .is_some_and(|settings| settings.edit.is_some())
-        {
-            return self.handle_settings_edit_key(code, modifiers);
         }
         if self.pending_close.is_some() {
             if !modifiers.is_empty() {
@@ -4146,67 +3501,7 @@ impl App {
         if !matches!(self.mode, Mode::Normal) {
             return handle_mode_key(self, code, modifiers);
         }
-        if self
-            .settings
-            .as_ref()
-            .is_some_and(|settings| settings.dirty())
-            && (code == KeyCode::Char('q')
-                || (code == KeyCode::Esc && self.primary_tab != PrimaryTab::Settings))
-        {
-            self.select_tab(PrimaryTab::Settings);
-            self.message = Some(Message {
-                text: "Unsaved settings: Ctrl-S saves; Esc discards; Ctrl-C force quits".into(),
-                error: false,
-            });
-            return None;
-        }
         if !normal_mode_modifiers_supported(code, modifiers) {
-            if self.primary_tab == PrimaryTab::Settings
-                && modifiers == KeyModifiers::CONTROL
-                && code == KeyCode::Char('s')
-            {
-                let settings = self.settings.as_mut()?;
-                if settings.dirty() {
-                    return settings.begin_save();
-                }
-                if settings.restart_required {
-                    self.mode = Mode::ConfirmDaemonRestart {
-                        clears_history: settings.restart_clears_history,
-                    };
-                }
-                return None;
-            }
-            return None;
-        }
-        if self.primary_tab == PrimaryTab::Settings {
-            let settings = self.settings.as_mut()?;
-            if settings.saving {
-                return None;
-            }
-            match code {
-                KeyCode::Char('q') => return Some(DashboardEffect::Quit),
-                KeyCode::Esc if settings.dirty() => {
-                    settings.discard();
-                    self.message = Some(Message {
-                        text: "Discarded unsaved settings changes".into(),
-                        error: false,
-                    });
-                }
-                KeyCode::Esc => {}
-                KeyCode::Down | KeyCode::Char('j') => settings.move_selection(true),
-                KeyCode::Up | KeyCode::Char('k') => settings.move_selection(false),
-                KeyCode::Char(' ') => settings.toggle_selected(),
-                KeyCode::Enter => settings.begin_edit(),
-                KeyCode::Delete => settings.reset_selected(),
-                KeyCode::Char('/' | ':') => self.open_palette(),
-                KeyCode::Char('?') => self.mode = Mode::Help,
-                KeyCode::Tab => self.cycle_tab(false),
-                KeyCode::BackTab => self.cycle_tab(true),
-                KeyCode::Char(key) if shortcut_tab(key).is_some() => {
-                    self.select_tab(shortcut_tab(key).expect("validated tab shortcut"));
-                }
-                _ => {}
-            }
             return None;
         }
         match code {
@@ -4342,45 +3637,6 @@ impl App {
                 return self.selected_schedule_history_effect();
             }
             key if self.handle_focus_key(key) => {}
-            _ => {}
-        }
-        None
-    }
-
-    fn handle_settings_edit_key(
-        &mut self,
-        code: KeyCode,
-        modifiers: KeyModifiers,
-    ) -> Option<DashboardEffect> {
-        let settings = self.settings.as_mut()?;
-        if settings.saving {
-            return None;
-        }
-        let save = modifiers == KeyModifiers::CONTROL && code == KeyCode::Char('s');
-        if save {
-            if settings.apply_edit() {
-                return settings.begin_save();
-            }
-            return None;
-        }
-        if !modifiers.difference(KeyModifiers::SHIFT).is_empty() {
-            return None;
-        }
-        match code {
-            KeyCode::Esc => settings.edit = None,
-            KeyCode::Enter => {
-                settings.apply_edit();
-            }
-            KeyCode::Backspace => {
-                if let Some(edit) = &mut settings.edit {
-                    edit.input.pop();
-                }
-            }
-            KeyCode::Char(character) => {
-                if let Some(edit) = &mut settings.edit {
-                    edit.input.push(character);
-                }
-            }
             _ => {}
         }
         None
@@ -4820,7 +4076,6 @@ pub(crate) fn run<B: DashboardBackend + Send + 'static>(
     state: DashboardState,
     follow_focused_terminal: bool,
     project_context: ProjectContext,
-    settings: ConfigSettings,
     play_intro: bool,
     backend: B,
 ) -> io::Result<()> {
@@ -4835,19 +4090,6 @@ pub(crate) fn run<B: DashboardBackend + Send + 'static>(
         return Err(error);
     }
     let mut app = App::new(state.workspaces, project_context);
-    app.settings = Some(SettingsState::new(
-        settings,
-        match &state.scheduling {
-            SchedulingView::Active { maximum, .. } | SchedulingView::Offline { maximum, .. }
-                if *maximum > 0 =>
-            {
-                Some(*maximum)
-            }
-            SchedulingView::Unsupported { .. }
-            | SchedulingView::Active { .. }
-            | SchedulingView::Offline { .. } => None,
-        },
-    ));
     app.nodes = state.nodes;
     app.node_state.select((!app.nodes.is_empty()).then_some(0));
     app.all_schedules = state.schedules.clone();
@@ -4955,10 +4197,6 @@ fn execute_palette_command(app: &mut App, command: PaletteCommand) -> Option<Das
         }
         PaletteCommand::ShowHelp => {
             app.mode = Mode::Help;
-            None
-        }
-        PaletteCommand::ShowSettings => {
-            app.select_tab(PrimaryTab::Settings);
             None
         }
         PaletteCommand::Workspace {
@@ -5309,27 +4547,6 @@ fn handle_mode_key(
                 None
             }
         },
-        Mode::ConfirmDaemonRestart { clears_history } => {
-            match key {
-                KeyCode::Char('y') => app.settings.as_ref().map(|settings| {
-                    DashboardEffect::RestartDaemon(settings.loaded.effective.clone())
-                }),
-                KeyCode::Char('n') | KeyCode::Esc => {
-                    if let Some(settings) = &mut app.settings {
-                        settings.restart_required = true;
-                    }
-                    app.message = Some(Message {
-                    text: "Settings saved; daemon restart still required to apply daemon-owned fields".into(),
-                    error: false,
-                });
-                    None
-                }
-                _ => {
-                    app.mode = Mode::ConfirmDaemonRestart { clears_history };
-                    None
-                }
-            }
-        }
         Mode::Rename { target, mut input } => match key {
             KeyCode::Enter if !input.trim().is_empty() => {
                 let name = input.trim().to_owned();
@@ -5460,8 +4677,6 @@ fn render(frame: &mut Frame, app: &mut App) {
         render_nodes(frame, dashboard_area, app);
     } else if app.primary_tab == PrimaryTab::Schedules {
         render_schedules(frame, dashboard_area, app);
-    } else if app.primary_tab == PrimaryTab::Settings {
-        render_settings(frame, dashboard_area, app);
     } else if app.primary_tab != PrimaryTab::Workspaces {
         render_global_items(frame, dashboard_area, app);
     } else if dashboard_area.width >= 114 {
@@ -5487,121 +4702,8 @@ fn render(frame: &mut Frame, app: &mut App) {
         Mode::RetargetNode { input, .. } => render_node_retarget(frame, area, input),
         Mode::ConfirmForgetNode(node) => render_node_forget_confirmation(frame, area, node),
         Mode::EditSchedule(editor) => render_schedule_editor(frame, area, editor),
-        Mode::ConfirmDaemonRestart { clears_history } => {
-            render_daemon_restart_confirmation(frame, area, *clears_history)
-        }
         Mode::Normal | Mode::Rename { .. } => {}
     }
-}
-
-fn render_daemon_restart_confirmation(frame: &mut Frame, area: Rect, clears_history: bool) {
-    let popup = centered_rect(area, 68, 28);
-    frame.render_widget(Clear, popup);
-    let warning = if clears_history {
-        "\n\nWARNING: applying disabled persist_terminal_history clears retained terminal history."
-    } else {
-        ""
-    };
-    frame.render_widget(
-        Paragraph::new(format!(
-            "Daemon-owned settings changed. Gracefully restart the local Boomux daemon now?{warning}\n\ny restart  n/esc keep restart required"
-        ))
-        .block(
-            Block::bordered()
-                .title(" Apply daemon settings ")
-                .border_style(Style::new().fg(YELLOW)),
-        )
-        .wrap(Wrap { trim: false }),
-        popup,
-    );
-}
-
-fn render_settings(frame: &mut Frame, area: Rect, app: &mut App) {
-    let Some(settings) = &mut app.settings else {
-        frame.render_widget(Paragraph::new("Settings unavailable"), area);
-        return;
-    };
-    let [source_area, table_area, status_area] = Layout::vertical([
-        Constraint::Length(2),
-        Constraint::Fill(1),
-        Constraint::Length(2),
-    ])
-    .areas(area);
-    frame.render_widget(
-        Paragraph::new(vec![
-            Line::from(vec![
-                Span::styled("Writable local Node layer  ", Style::new().fg(SUBTEXT)),
-                Span::styled(settings.loaded.active_source.label(), Style::new().fg(TEAL)),
-                Span::raw("  "),
-                Span::raw(settings.loaded.active_path.display().to_string()),
-            ]),
-            Line::from(Span::styled(
-                "Values marked default/global are inherited; Delete removes the active override.",
-                Style::new().fg(SUBTEXT),
-            )),
-        ]),
-        source_area,
-    );
-    let fields = settings.fields();
-    let rows = fields.iter().map(|field| {
-        let (group, name) = settings_field_labels(*field);
-        let source = if *field == SettingsField::AddProjectRoot {
-            if settings.overridden(*field) {
-                settings.loaded.active_source.label()
-            } else {
-                "action"
-            }
-        } else {
-            settings.source(*field).label()
-        };
-        Row::new([
-            group.to_owned(),
-            name,
-            settings.value(*field),
-            source.to_owned(),
-        ])
-    });
-    let mut state = TableState::default().with_selected(Some(settings.selected));
-    frame.render_stateful_widget(
-        Table::new(
-            rows,
-            [
-                Constraint::Length(16),
-                Constraint::Length(30),
-                Constraint::Min(24),
-                Constraint::Length(14),
-            ],
-        )
-        .header(Row::new(["GROUP", "SETTING", "VALUE", "SOURCE"]).style(Style::new().fg(BLUE)))
-        .row_highlight_style(Style::new().add_modifier(Modifier::REVERSED))
-        .highlight_symbol("> "),
-        table_area,
-        &mut state,
-    );
-    let status = if let Some(edit) = &settings.edit {
-        format!(
-            "Edit: {}_  Enter apply  Ctrl-S apply and save  Esc cancel",
-            edit.input
-        )
-    } else if let Some(error) = &settings.error {
-        error.clone()
-    } else if settings.saving {
-        "Saving settings...".into()
-    } else if settings.restart_required {
-        "Daemon restart required; Ctrl-S saves further changes, then confirm restart".into()
-    } else if settings.dirty() {
-        "Unsaved changes".into()
-    } else {
-        "All settings saved".into()
-    };
-    frame.render_widget(
-        Paragraph::new(status).style(Style::new().fg(if settings.error.is_some() {
-            RED
-        } else {
-            YELLOW
-        })),
-        status_area,
-    );
 }
 
 fn render_node_inspection(frame: &mut Frame, area: Rect, node: &NodeView) {
@@ -6577,7 +5679,7 @@ fn help_lines(app: &App) -> Vec<Line<'static>> {
         Line::from("  attention filter palette results to outstanding durable attention"),
         Line::from("  Enter    restore a workspace, open an item, or inspect a schedule"),
         Line::from("  a/e/x    add, rename, or request confirmed close/remove"),
-        Line::from("  Tab/1-6 change view; h/l change pane; j/k navigate"),
+        Line::from("  Tab/1-4 change view; h/l change pane; j/k navigate"),
         Line::from(""),
         Line::from(Span::styled(
             "SELECTED CONTEXT",
@@ -6594,15 +5696,7 @@ fn help_lines(app: &App) -> Vec<Line<'static>> {
             }),
         );
     }
-    if app.primary_tab == PrimaryTab::Settings {
-        lines.extend([
-            Line::from("  SETTINGS edits the active writable layer for this local Node."),
-            Line::from("  Space toggles booleans; Enter edits text and integers."),
-            Line::from("  Project roots provide add/edit rows; Delete removes a root or resets a field."),
-            Line::from("  Ctrl-S validates and atomically saves; Esc cancels editing or discards dirty changes."),
-            Line::from("  Daemon-owned changes offer an explicit graceful restart after save."),
-        ]);
-    } else if app.primary_tab == PrimaryTab::Schedules {
+    if app.primary_tab == PrimaryTab::Schedules {
         if let Some(schedule) = app.selected_schedule() {
             lines.extend([
                 Line::from(format!("  schedule: {} / {}", schedule.workspace, schedule.name)),
@@ -6819,7 +5913,6 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                     }
                     PrimaryTab::Schedules => app.schedules.len(),
                     PrimaryTab::Nodes => app.nodes.len(),
-                    PrimaryTab::Settings => 0,
                     PrimaryTab::Workspaces => unreachable!("workspace tab is rendered separately"),
                 };
                 let style = if *tab == app.primary_tab {
@@ -6828,14 +5921,7 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                     Style::new().fg(SUBTEXT)
                 };
                 [
-                    Span::styled(
-                        if *tab == PrimaryTab::Settings {
-                            format!("{} {}", index + 1, tab.label())
-                        } else {
-                            format!("{} {} {count}", index + 1, tab.label())
-                        },
-                        style,
-                    ),
+                    Span::styled(format!("{} {} {count}", index + 1, tab.label()), style),
                     Span::raw("  "),
                 ]
             }),
@@ -8440,34 +7526,6 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             Style::new().fg(if message.error { RED } else { GREEN }),
         ))
     } else {
-        if app.primary_tab == PrimaryTab::Settings {
-            let dirty = app.settings.as_ref().is_some_and(SettingsState::dirty);
-            let line = Line::from(vec![
-                Span::styled(" j/k", Style::new().fg(TEAL)),
-                Span::styled(" navigate  ", Style::new().fg(SUBTEXT)),
-                Span::styled("space", Style::new().fg(BLUE)),
-                Span::styled(" toggle  ", Style::new().fg(SUBTEXT)),
-                Span::styled("enter", Style::new().fg(GREEN)),
-                Span::styled(" edit/add  ", Style::new().fg(SUBTEXT)),
-                Span::styled("delete", Style::new().fg(RED)),
-                Span::styled(" remove/reset  ", Style::new().fg(SUBTEXT)),
-                Span::styled(
-                    "Ctrl-S",
-                    Style::new().fg(if dirty { GREEN } else { SUBTEXT }),
-                ),
-                Span::styled(" save  ", Style::new().fg(SUBTEXT)),
-                Span::styled("esc", Style::new().fg(RED)),
-                Span::styled(" discard  ", Style::new().fg(SUBTEXT)),
-                Span::styled("?", Style::new().fg(BLUE)),
-                Span::styled(" help  ", Style::new().fg(SUBTEXT)),
-                Span::styled("1-6", Style::new().fg(TEAL)),
-                Span::styled(" views  ", Style::new().fg(SUBTEXT)),
-                Span::styled("q", Style::new().fg(RED)),
-                Span::styled(" quit", Style::new().fg(SUBTEXT)),
-            ]);
-            frame.render_widget(Paragraph::new(line), area);
-            return;
-        }
         let launcher_selected = matches!(app.selected_item(), Some(WorkspaceItemView::Launcher(_)));
         let offline_shell_selected =
             app.selected_item_location()
@@ -8509,7 +7567,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 Span::styled(" forget  ", Style::new().fg(SUBTEXT)),
                 Span::styled("tab/shift-tab", Style::new().fg(TEAL)),
                 Span::styled(" views  ", Style::new().fg(SUBTEXT)),
-                Span::styled("1-6", Style::new().fg(TEAL)),
+                Span::styled("1-5", Style::new().fg(TEAL)),
                 Span::styled(" select view  ", Style::new().fg(SUBTEXT)),
                 Span::styled("/", Style::new().fg(TEAL)),
                 Span::styled(" palette  ", Style::new().fg(SUBTEXT)),
@@ -8612,7 +7670,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 if app.primary_tab == PrimaryTab::Workspaces {
                     " navigate  tab/shift-tab views  h/l panes  "
                 } else {
-                    " navigate  tab/shift-tab views  1-6 select view  "
+                    " navigate  tab/shift-tab views  1-5 select view  "
                 },
                 Style::new().fg(SUBTEXT),
             ),
@@ -8756,346 +7814,7 @@ mod tests {
     use ratatui::backend::TestBackend;
 
     fn app() -> App {
-        let mut app = App::new(vec![workspace("w1", "boomux")], project_context());
-        app.settings = Some(SettingsState::new(crate::config::test_settings(), None));
-        app
-    }
-
-    fn select_setting(app: &mut App, field: SettingsField) {
-        app.select_tab(PrimaryTab::Settings);
-        let settings = app.settings.as_mut().unwrap();
-        settings.selected = settings
-            .fields()
-            .iter()
-            .position(|candidate| *candidate == field)
-            .unwrap();
-    }
-
-    #[test]
-    fn settings_is_the_sixth_tab_and_renders_grouped_source_aware_fields() {
-        let mut app = app();
-        app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Char('6'),
-            modifiers: KeyModifiers::NONE,
-        });
-        assert_eq!(app.primary_tab, PrimaryTab::Settings);
-
-        let mut terminal = Terminal::new(TestBackend::new(120, 34)).unwrap();
-        terminal.draw(|frame| render(frame, &mut app)).unwrap();
-        let buffer = terminal.backend().buffer();
-        let text = (0..buffer.area.height)
-            .map(|y| {
-                (0..buffer.area.width)
-                    .map(|x| buffer[(x, y)].symbol())
-                    .collect::<String>()
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-        for expected in [
-            "6 SETTINGS",
-            "Writable local Node layer",
-            "/tmp/boomux-test-config.toml",
-            "Projects",
-            "Dashboard",
-            "Recovery",
-            "Scheduling",
-            "Notifications",
-            "Sound",
-            "default",
-        ] {
-            assert!(text.contains(expected), "missing {expected:?}\n{text}");
-        }
-    }
-
-    #[test]
-    fn settings_sources_are_tracked_per_field() {
-        let mut app = app();
-        let settings = app.settings.as_mut().unwrap();
-        settings.loaded.active_source = ConfigSource::Environment;
-        settings.loaded.inherited_source = ConfigSource::Global;
-        settings.loaded.inherited_overrides.follow_focused_terminal = Some(true);
-
-        assert_eq!(
-            settings.source(SettingsField::FollowFocusedTerminal),
-            ConfigSource::Global
-        );
-        assert_eq!(
-            settings.source(SettingsField::NotificationsEnabled),
-            ConfigSource::Default
-        );
-        settings.working.notifications_enabled = Some(true);
-        assert_eq!(
-            settings.source(SettingsField::NotificationsEnabled),
-            ConfigSource::Environment
-        );
-    }
-
-    #[test]
-    fn settings_boolean_toggle_save_and_discard_are_typed() {
-        let mut app = app();
-        select_setting(&mut app, SettingsField::FollowFocusedTerminal);
-        app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Char(' '),
-            modifiers: KeyModifiers::NONE,
-        });
-        assert_eq!(
-            app.settings
-                .as_ref()
-                .unwrap()
-                .working
-                .follow_focused_terminal,
-            Some(false)
-        );
-        let effects = app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Char('s'),
-            modifiers: KeyModifiers::CONTROL,
-        });
-        assert!(
-            matches!(effects.as_slice(), [DashboardEffect::SaveSettings(overrides)] if overrides.follow_focused_terminal == Some(false))
-        );
-        assert!(app.settings.as_ref().unwrap().saving);
-
-        app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Char(' '),
-            modifiers: KeyModifiers::NONE,
-        });
-        assert_eq!(
-            app.settings
-                .as_ref()
-                .unwrap()
-                .working
-                .follow_focused_terminal,
-            Some(false)
-        );
-        let mut terminal = Terminal::new(TestBackend::new(120, 34)).unwrap();
-        terminal.draw(|frame| render(frame, &mut app)).unwrap();
-        let buffer = terminal.backend().buffer();
-        let text = (0..buffer.area.height)
-            .flat_map(|y| (0..buffer.area.width).map(move |x| buffer[(x, y)].symbol()))
-            .collect::<String>();
-        assert!(text.contains("Saving settings..."));
-
-        app.update(DashboardEvent::SettingsSaved(Box::new(Err(
-            "save failed".into()
-        ))));
-        assert!(!app.settings.as_ref().unwrap().saving);
-
-        app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Esc,
-            modifiers: KeyModifiers::NONE,
-        });
-        assert!(!app.settings.as_ref().unwrap().dirty());
-    }
-
-    #[test]
-    fn dirty_settings_redirect_quit_and_escape_until_explicitly_discarded() {
-        let mut app = app();
-        select_setting(&mut app, SettingsField::FollowFocusedTerminal);
-        app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Char(' '),
-            modifiers: KeyModifiers::NONE,
-        });
-        app.select_tab(PrimaryTab::Workspaces);
-
-        let effects = app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Char('q'),
-            modifiers: KeyModifiers::NONE,
-        });
-        assert!(effects.is_empty());
-        assert_eq!(app.primary_tab, PrimaryTab::Settings);
-        assert!(app.message.as_ref().unwrap().text.contains("Ctrl-S saves"));
-
-        let effects = app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Char('q'),
-            modifiers: KeyModifiers::NONE,
-        });
-        assert!(effects.is_empty());
-        assert!(app.settings.as_ref().unwrap().dirty());
-
-        app.select_tab(PrimaryTab::Workspaces);
-        app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Esc,
-            modifiers: KeyModifiers::NONE,
-        });
-        assert_eq!(app.primary_tab, PrimaryTab::Settings);
-        assert!(app.settings.as_ref().unwrap().dirty());
-
-        app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Esc,
-            modifiers: KeyModifiers::NONE,
-        });
-        assert!(!app.settings.as_ref().unwrap().dirty());
-    }
-
-    #[test]
-    fn running_scheduler_difference_requires_restart_at_startup() {
-        let settings = SettingsState::new(crate::config::test_settings(), Some(2));
-        assert_eq!(settings.daemon_applied.scheduling_max_concurrent, 2);
-        assert_eq!(settings.loaded.effective.scheduling_max_concurrent, 4);
-        assert!(settings.restart_required);
-        assert!(settings.restart_clears_history);
-    }
-
-    #[test]
-    fn unknown_applied_recovery_state_warns_before_disabling_history() {
-        let mut app = app();
-        let mut saved = crate::config::test_settings();
-        saved.effective.notifications_enabled = true;
-        saved.effective.persist_terminal_history = false;
-
-        app.update(DashboardEvent::SettingsSaved(Box::new(Ok((
-            saved,
-            project_context(),
-        )))));
-
-        assert!(matches!(
-            app.mode,
-            Mode::ConfirmDaemonRestart {
-                clears_history: true
-            }
-        ));
-    }
-
-    #[test]
-    fn settings_text_and_numeric_editing_validate_before_save() {
-        let mut app = app();
-        select_setting(&mut app, SettingsField::Terminal);
-        app.settings.as_mut().unwrap().begin_edit();
-        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "invalid".into();
-        assert!(!app.settings.as_mut().unwrap().apply_edit());
-        assert!(app.settings.as_ref().unwrap().error.is_some());
-        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "Alacritty.desktop".into();
-        assert!(app.settings.as_mut().unwrap().apply_edit());
-
-        select_setting(&mut app, SettingsField::ProjectMaxDepth);
-        app.settings.as_mut().unwrap().begin_edit();
-        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "11".into();
-        assert!(!app.settings.as_mut().unwrap().apply_edit());
-        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "4".into();
-        assert!(app.settings.as_mut().unwrap().apply_edit());
-        assert_eq!(
-            app.settings.as_ref().unwrap().working.project_max_depth,
-            Some(4)
-        );
-    }
-
-    #[test]
-    fn project_roots_support_add_edit_remove_and_reset_to_inheritance() {
-        let mut app = app();
-        select_setting(&mut app, SettingsField::AddProjectRoot);
-        app.settings.as_mut().unwrap().begin_edit();
-        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "~/Code".into();
-        assert!(app.settings.as_mut().unwrap().apply_edit());
-        assert_eq!(app.settings.as_ref().unwrap().roots(), ["~/Code"]);
-
-        select_setting(&mut app, SettingsField::ProjectRoot(0));
-        app.settings.as_mut().unwrap().begin_edit();
-        app.settings.as_mut().unwrap().edit.as_mut().unwrap().input = "/srv/code".into();
-        assert!(app.settings.as_mut().unwrap().apply_edit());
-        assert_eq!(app.settings.as_ref().unwrap().roots(), ["/srv/code"]);
-        app.settings.as_mut().unwrap().reset_selected();
-        assert!(app.settings.as_ref().unwrap().roots().is_empty());
-
-        select_setting(&mut app, SettingsField::AddProjectRoot);
-        app.settings.as_mut().unwrap().reset_selected();
-        assert!(
-            app.settings
-                .as_ref()
-                .unwrap()
-                .working
-                .project_roots
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn settings_save_failure_and_restart_confirmation_are_explicit() {
-        let mut app = app();
-        app.update(DashboardEvent::SettingsSaved(Box::new(Err(
-            "config target changed while it was being edited".into(),
-        ))));
-        assert!(app.message.as_ref().is_some_and(|message| message.error));
-        assert!(
-            app.settings
-                .as_ref()
-                .unwrap()
-                .error
-                .as_deref()
-                .is_some_and(|error| error.contains("changed"))
-        );
-
-        app.settings
-            .as_mut()
-            .unwrap()
-            .daemon_applied
-            .persist_terminal_history = true;
-        let mut saved = crate::config::test_settings();
-        saved.effective.persist_terminal_history = false;
-        saved.effective.notifications_enabled = true;
-        app.update(DashboardEvent::SettingsSaved(Box::new(Ok((
-            saved,
-            project_context(),
-        )))));
-        assert!(matches!(
-            app.mode,
-            Mode::ConfirmDaemonRestart {
-                clears_history: true
-            }
-        ));
-        app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Char('n'),
-            modifiers: KeyModifiers::NONE,
-        });
-        assert!(app.settings.as_ref().unwrap().restart_required);
-        assert!(
-            app.message
-                .as_ref()
-                .unwrap()
-                .text
-                .contains("restart still required")
-        );
-
-        app.mode = Mode::ConfirmDaemonRestart {
-            clears_history: false,
-        };
-        let effects = app.update(DashboardEvent::KeyPressed {
-            code: KeyCode::Char('y'),
-            modifiers: KeyModifiers::NONE,
-        });
-        assert!(matches!(
-            effects.as_slice(),
-            [DashboardEffect::RestartDaemon(settings)]
-                if !settings.persist_terminal_history && settings.notifications_enabled
-        ));
-        let DashboardEffect::RestartDaemon(applied) = effects.into_iter().next().unwrap() else {
-            unreachable!();
-        };
-        app.update(DashboardEvent::DaemonRestarted {
-            applied: applied.clone(),
-            result: Ok("restarted".into()),
-        });
-        assert_eq!(app.settings.as_ref().unwrap().daemon_applied, applied);
-        assert!(!app.settings.as_ref().unwrap().restart_required);
-    }
-
-    #[test]
-    fn reverting_pending_daemon_settings_clears_restart_requirement() {
-        let mut app = app();
-        let mut changed = crate::config::test_settings();
-        changed.effective.notifications_enabled = true;
-        app.update(DashboardEvent::SettingsSaved(Box::new(Ok((
-            changed,
-            project_context(),
-        )))));
-        assert!(app.settings.as_ref().unwrap().restart_required);
-
-        app.mode = Mode::Normal;
-        app.update(DashboardEvent::SettingsSaved(Box::new(Ok((
-            crate::config::test_settings(),
-            project_context(),
-        )))));
-        assert!(!app.settings.as_ref().unwrap().restart_required);
-        assert!(matches!(app.mode, Mode::Normal));
+        App::new(vec![workspace("w1", "boomux")], project_context())
     }
 
     #[test]
@@ -10579,11 +9298,11 @@ mod tests {
     #[test]
     fn numeric_shortcuts_match_primary_tab_order() {
         assert_eq!(
-            ('1'..='6').filter_map(shortcut_tab).collect::<Vec<_>>(),
+            ('1'..='5').filter_map(shortcut_tab).collect::<Vec<_>>(),
             PrimaryTab::ALL
         );
         assert_eq!(shortcut_tab('0'), None);
-        assert_eq!(shortcut_tab('7'), None);
+        assert_eq!(shortcut_tab('6'), None);
     }
 
     #[test]

--- a/tests/config_cli.rs
+++ b/tests/config_cli.rs
@@ -1,0 +1,301 @@
+use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use uuid::Uuid;
+
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "boomux-config-cli-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+        command
+            .env("HOME", self.path())
+            .env("XDG_CONFIG_HOME", self.path().join("xdg"))
+            .env("XDG_RUNTIME_DIR", self.path().join("runtime"))
+            .env_remove("BOOMUX_CONFIG")
+            .env_remove("VISUAL")
+            .env_remove("EDITOR");
+        command
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+#[test]
+fn path_uses_environment_override_then_canonical_global_path() {
+    let test = TestDirectory::new();
+    let global = test.path().join("xdg/boomux/config.toml");
+    let output = test.command().args(["config", "path"]).output().unwrap();
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim(),
+        global.display().to_string()
+    );
+
+    let override_path = test.path().join("override.toml");
+    let output = test
+        .command()
+        .env("BOOMUX_CONFIG", &override_path)
+        .args(["config", "path"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim(),
+        override_path.display().to_string()
+    );
+}
+
+#[test]
+fn validate_resolves_semantics_after_layer_merge_without_starting_a_daemon() {
+    let test = TestDirectory::new();
+    let global = test.path().join("xdg/boomux/config.toml");
+    let override_path = test.path().join("override.toml");
+    fs::create_dir_all(global.parent().unwrap()).unwrap();
+    fs::write(&global, "[projects]\nmax_depth = 99\n").unwrap();
+    fs::write(&override_path, "[projects]\nmax_depth = 2\n").unwrap();
+
+    let valid_override = test
+        .command()
+        .env("BOOMUX_CONFIG", &override_path)
+        .args(["config", "validate"])
+        .output()
+        .unwrap();
+    assert_success(&valid_override);
+    assert!(String::from_utf8_lossy(&valid_override.stdout).contains("2 loaded layers"));
+    assert!(!test.path().join("runtime/boomux/daemon.sock").exists());
+
+    fs::write(
+        &override_path,
+        "[dashboard]\nfollow_focused_terminal = false\n",
+    )
+    .unwrap();
+    let invalid_merged = test
+        .command()
+        .env("BOOMUX_CONFIG", &override_path)
+        .args(["config", "validate"])
+        .output()
+        .unwrap();
+    assert!(!invalid_merged.status.success());
+    assert!(
+        String::from_utf8_lossy(&invalid_merged.stderr)
+            .contains("projects.max_depth must be between 1 and 10")
+    );
+
+    let json = test
+        .command()
+        .args(["config", "validate", "--json"])
+        .output()
+        .unwrap();
+    assert!(!json.status.success());
+    assert!(
+        String::from_utf8_lossy(&json.stdout).contains("--json is not supported")
+            || String::from_utf8_lossy(&json.stderr).contains("--json is not supported")
+    );
+}
+
+#[test]
+fn canonical_global_environment_override_is_one_loaded_layer() {
+    let test = TestDirectory::new();
+    let global = test.path().join("xdg/boomux/config.toml");
+    fs::create_dir_all(global.parent().unwrap()).unwrap();
+    fs::write(&global, "[projects]\nmax_depth = 2\n").unwrap();
+
+    let output = test
+        .command()
+        .env("BOOMUX_CONFIG", &global)
+        .args(["config", "validate"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("1 loaded layer"), "{stdout}");
+    assert!(stdout.contains("active BOOMUX_CONFIG"), "{stdout}");
+}
+
+#[test]
+fn edit_creates_comprehensive_private_template() {
+    let test = TestDirectory::new();
+    let target = test.path().join("nested/config.toml");
+    let editor = test.path().join("editor");
+    write_executable(&editor, "#!/bin/sh\nexit 0\n");
+
+    let output = test
+        .command()
+        .env("BOOMUX_CONFIG", &target)
+        .env("VISUAL", &editor)
+        .args(["config", "edit"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let contents = fs::read_to_string(&target).unwrap();
+    for section in [
+        "[projects]",
+        "[dashboard]",
+        "[notifications]",
+        "[notifications.sound]",
+        "[recovery]",
+        "[scheduling]",
+    ] {
+        assert!(
+            contents.contains(section),
+            "missing template section {section}"
+        );
+    }
+    assert!(contents.contains("# terminal ="));
+    assert_eq!(
+        fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+}
+
+#[test]
+fn editor_arguments_are_exact_and_shell_metacharacters_are_not_interpreted() {
+    let test = TestDirectory::new();
+    let target = test.path().join("config.toml");
+    let editor = test.path().join("editor");
+    let capture = test.path().join("arguments");
+    let injected = test.path().join("injected");
+    fs::write(&target, "# original comment\n[projects]\nmax_depth = 2\n").unwrap();
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o640)).unwrap();
+    write_executable(
+        &editor,
+        "#!/bin/sh\nprintf '%s\\n%s\\n' \"$1\" \"$2\" > \"$CAPTURE\"\nprintf '\\n# editor comment\\n' >> \"$3\"\n",
+    );
+    let visual = format!(
+        "'{}' 'argument with spaces' '$(touch {})'",
+        editor.display(),
+        injected.display()
+    );
+
+    let output = test
+        .command()
+        .env("BOOMUX_CONFIG", &target)
+        .env("VISUAL", visual)
+        .env("CAPTURE", &capture)
+        .args(["config", "edit"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    assert_eq!(
+        fs::read_to_string(capture).unwrap(),
+        format!("argument with spaces\n$(touch {})\n", injected.display())
+    );
+    assert!(!injected.exists());
+    let contents = fs::read_to_string(&target).unwrap();
+    assert!(contents.contains("# original comment"));
+    assert!(contents.contains("# editor comment"));
+    assert_eq!(
+        fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+        0o640
+    );
+}
+
+#[test]
+fn invalid_candidate_and_concurrent_target_change_leave_target_unreplaced() {
+    let test = TestDirectory::new();
+    let target = test.path().join("config.toml");
+    let editor = test.path().join("editor");
+    let original = "# original\n[projects]\nmax_depth = 2\n";
+    fs::write(&target, original).unwrap();
+    write_executable(
+        &editor,
+        "#!/bin/sh\nprintf '[projects]\\nmax_depth = 99\\n' > \"$1\"\n",
+    );
+    let invalid = test
+        .command()
+        .env("BOOMUX_CONFIG", &target)
+        .env("VISUAL", &editor)
+        .args(["config", "edit"])
+        .output()
+        .unwrap();
+    assert!(!invalid.status.success());
+    assert_eq!(fs::read_to_string(&target).unwrap(), original);
+
+    write_executable(
+        &editor,
+        "#!/bin/sh\nprintf '# candidate\\n[projects]\\nmax_depth = 3\\n' > \"$1\"\nprintf '# concurrent\\n[projects]\\nmax_depth = 4\\n' > \"$TARGET\"\n",
+    );
+    let concurrent = test
+        .command()
+        .env("BOOMUX_CONFIG", &target)
+        .env("VISUAL", &editor)
+        .env("TARGET", &target)
+        .args(["config", "edit"])
+        .output()
+        .unwrap();
+    assert!(!concurrent.status.success());
+    assert!(
+        String::from_utf8_lossy(&concurrent.stderr).contains("changed while it was being edited")
+    );
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        "# concurrent\n[projects]\nmax_depth = 4\n"
+    );
+}
+
+#[test]
+fn bounded_reads_and_unsafe_targets_are_rejected() {
+    let test = TestDirectory::new();
+    let oversized = test.path().join("oversized.toml");
+    fs::write(&oversized, vec![b'#'; 1024 * 1024 + 1]).unwrap();
+    let output = test
+        .command()
+        .env("BOOMUX_CONFIG", &oversized)
+        .args(["config", "validate"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("exceeds the 1048576 byte limit"));
+
+    let real = test.path().join("real.toml");
+    let linked = test.path().join("linked.toml");
+    let editor = test.path().join("editor");
+    fs::write(&real, "# unchanged\n").unwrap();
+    symlink(&real, &linked).unwrap();
+    write_executable(&editor, "#!/bin/sh\nexit 0\n");
+    let output = test
+        .command()
+        .env("BOOMUX_CONFIG", &linked)
+        .env("VISUAL", &editor)
+        .args(["config", "edit"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("not a regular file"));
+    assert_eq!(fs::read_to_string(real).unwrap(), "# unchanged\n");
+}


### PR DESCRIPTION
## Summary
- add `boomux config path`, `boomux config validate`, and `boomux config edit` as human-only local configuration commands
- preserve field-layered global plus `BOOMUX_CONFIG` semantics while validating only after the complete merge
- edit through exact editor argv, bounded owner-only working copies, detected layer-change conflicts, and atomic replacement
- document local configuration ownership and the CLI JSON boundary

## Compatibility
- no TUI settings editor or additional dashboard tab
- no daemon protocol version change
- no durable state schema change
- configuration mutation remains local to the owning Node

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`