### PR TITLE
feat(claude): add lifecycle and remote control integration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,6 +125,17 @@ replacement removes authority without deleting or moving durable Agent history.
 Claims are not persisted, projected, event-published, or transferred during
 daemon handoff; surviving TUIs reacquire them from the replacement daemon.
 
+## Claude Remote Control Binding
+
+A bounded ephemeral Node-local association between one exact active Claude
+Agent Instance, its current ShellRun, and a Claude Remote Control bridge session
+observed directly by a Claude hook. It authorizes only presentation of that
+local session's `claude.ai/code` link. It is not an Agent Instance, Agent
+Session, claim, durable resource, event, transcript, or remote Node projection.
+Bindings transfer during graceful daemon handoff while the exact process and
+ShellRun survive, but are absent after cold recovery and disappear when later
+hook evidence clears them or their exact Agent/ShellRun is no longer current.
+
 ## Agent Schedule
 
 A durable workspace-owned definition for recurring prompt-driven Agent work with fixed execution

--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ In Schedules, Left/Right changes between the schedule and history panes, `j`/`k`
 navigates the focused pane, and `[`/`]` also selects retained executions by exact
 execution ID. `Enter` attaches a selected exact Starting or Active run. For a
 completed execution with a canonical session, it resumes that exact session with
-OpenCode or Pi in an unmanaged native terminal, without adding a workspace row.
+OpenCode, Pi, or Claude Code in an unmanaged native terminal, without adding a
+workspace row.
 `e` opens the private definition editor for a paused schedule; it supports name,
 prompt, trigger presets or custom cron, and a searchable IANA timezone selector.
 Type to filter timezone names and use the arrow keys to choose a valid match.
@@ -360,22 +361,31 @@ and troubleshooting.
 
 ## Coding-Agent Integrations
 
-Boomux includes optional lifecycle integrations for OpenCode and Pi. Guided
+Boomux includes optional integrations for OpenCode, Pi, and Claude Code. Guided
 setup previews every file change and asks before installing anything:
 
 ```console
 boomux integration setup opencode
 # or
 boomux integration setup pi
+# or
+boomux integration setup claude
 ```
 
-Restart OpenCode or Pi after installation. For the seamless OpenCode workflow,
+Restart the selected host after installation. For the seamless OpenCode workflow,
 create or open an ordinary managed login Shell and type the bare, zero-argument
 interactive command:
 
 ```console
 opencode
 ```
+
+Eligible bare interactive Claude Code launches enable Remote Control by default.
+When Claude reports an active bridge from an exact current managed Agent, the
+mobile dashboard shows **Open in Claude** and links directly to its
+`claude.ai/code` session. Boomux does not host or proxy Claude's web interface or
+read its transcript. Existing sessions can enable the bridge with
+`/remote-control`; organization policy and Claude authentication still apply.
 
 Only in an eligible Boomux login Shell, a scoped runtime `PATH` shim redirects
 that exact invocation internally to stock `opencode attach` for the Node's
@@ -419,7 +429,8 @@ compatibility test points, not runtime pins.
 
 ### Agent Sessions
 
-Boomux projects canonical OpenCode and Pi sessions into each matching workspace.
+Boomux projects canonical Sessions reported by supported integrations into each
+matching workspace.
 A projected session groups every Boomux Agent occurrence for the same external
 root session. `current` means an occurrence belongs to the current run of a
 running retained shell; `last known` means the session is historical.
@@ -495,11 +506,14 @@ last bound, from 1 through 64, and apply changes with a graceful restart:
 ```toml
 [scheduling]
 max_concurrent = 4
+
+[claude]
+remote_control = true
 ```
 
-OpenCode receives the prompt as the final argument after `--`; Pi receives the
-exact prompt on stdin. Process exit, dispatch failure, cancellation, and cold
-interruption are execution outcomes and never report an Agent as done. Timed
+OpenCode receives the prompt as the final argument after `--`; Pi and Claude Code
+receive the exact prompt on stdin. Process exit, dispatch failure, cancellation,
+and cold interruption are execution outcomes and never report an Agent as done. Timed
 work runs only while the Boomux daemon and user session are active; inspect
 `boomux daemon status` and `boomux doctor` for scheduler health and sampled
 configuration.
@@ -581,6 +595,14 @@ Configuration management is local to this Node. The `boomux config` commands
 never read or mutate a registered remote Node's config; use an interactive Boomux
 client on that owning Node to manage it.
 
+`claude.remote_control` defaults to `true`. On the owning Node, future bare
+interactive Claude Code launches in managed user Shells start with
+`--remote-control`; explicit Claude arguments, scheduled work, launchers, and
+exact recovery or Session resume commands are unchanged. Set it to `false` and
+restart the owning daemon to opt out. Claude Code can still decline Remote
+Control because of authentication, provider, organization, or managed-policy
+restrictions without preventing the local interactive session from starting.
+
 Project roots provide Workspace-name suggestions in the dashboard. Selecting one
 creates empty coordinator metadata using its name; it does not assign a Node or
 persist the discovered path. Choose the Node and working directory when adding
@@ -606,11 +628,11 @@ current selection and pause following; press it again to unpin and catch up to
 the currently focused terminal. Set
 `dashboard.follow_focused_terminal` to `false` to disable this behavior.
 
-After a cold daemon restart, Boomux resumes a uniquely identified OpenCode or Pi
-session when its interrupted shell is next started. Recovery requires a retained
-external session ID reported by the lifecycle integration; ambiguous, completed,
-or heuristic-only Agents fall back to the shell's configured command. Set
-`recovery.resume_agents` to `false` to disable this behavior.
+After a cold daemon restart, Boomux resumes a uniquely identified OpenCode, Pi,
+or Claude session when its interrupted shell is next started. Recovery requires
+a retained external session ID reported by the lifecycle integration; ambiguous,
+completed, or heuristic-only Agents fall back to the shell's configured command.
+Set `recovery.resume_agents` to `false` to disable this behavior.
 
 Terminal history persistence is opt-in because terminal output can contain
 secrets. With `recovery.persist_terminal_history = true`, Boomux checkpoints up

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,10 +29,11 @@
 | `src/mobile_web.rs`, `assets/mobile-web/` | Loopback-only HTTP gateway, Node-qualified Agent projection, exact local attention dismissal, native harness web handoff, and embedded installable web assets |
 | `src/tailscale_serve.rs` | Explicit Tailscale Serve preflight, conflict detection, exact route mutation, and ephemeral ownership cleanup for `boomux web --tailscale` |
 | `src/session_projection.rs` | Projection of daemon Agent state and host catalogs into client-visible sessions |
-| `src/integrations.rs` | Integration identity, display metadata, and optional installation, title/catalog, resume, and foreground capabilities |
+| `src/integrations.rs` | Integration identity, display metadata, and optional installation, title/catalog, resume, schedule-dispatch, and foreground capabilities |
 | `src/host_session_titles.rs` and children | Shared title/catalog policy and host-specific discovery adapters |
 | `src/host_session_source.rs` and children | Canonical host source paths, normalization, and secure source lookup |
 | `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
+| `src/claude_hooks.rs` | Bounded Claude Code hook decoding and root Session lifecycle reduction |
 | `src/process_adapter.rs` | Exact-argv child supervision and fail-open process-bound Agent observation |
 | `src/scheduling.rs` | Bounded canonical cron parsing and occurrence evaluation, IANA timezone and DST policy, prompt bounds, and schedule identity validation |
 | `src/config.rs` | Layered configuration resolution, bounded validation, and transactional active-layer editing |
@@ -156,6 +157,13 @@ projections, events, and handoff; a surviving TUI reacquires after graceful
 replacement. The runtime process identity and generation do transfer.
 Handoff generation 5 accepts generation 4, whose manifest has no shared-runtime
 record.
+Protocol 43 adds `claude_remote_control_bindings`. Claude hooks may associate a
+directly observed bridge session with one exact active local Claude Agent and
+ShellRun. Set and exact-get requests are Node-local and unavailable to routed
+operations. Bindings are bounded, ephemeral, absent from durable state,
+snapshots, events, and remote projections, and add no old-response transform.
+Handoff generation 6 accepts generation 5 and transfers valid bindings without
+descriptors; generation-5 manifests default to no bindings.
 Remote notification presentation reuses protocol-32 atomic reduced transitions,
 so it does not require a later protocol. Node-cache schema 2 adds bounded local
 at-most-once individual and reconnect-digest claims with an explicit schema-1
@@ -253,6 +261,15 @@ reported per Node and do not replay an ambiguous launcher invocation.
 missing setting inherits from the lower layer or the built-in default.
 Configuration is local Node state: it is neither daemon protocol state nor a
 remotely routable mutation.
+
+The Node-local `claude.remote_control` launch policy defaults on and is sampled
+at daemon start. The owning daemon adds `--remote-control` only to an exact
+one-element user Shell command whose executable basename is `claude`; its
+private login-Shell shim applies the same rule only to a zero-argument
+interactive invocation. Stored argv remains unchanged. Schedule-owned work,
+launchers, explicit Claude arguments, and recovery or Session resume vectors
+never receive the flag, and a coordinator's setting cannot govern a remote
+owner's launch.
 
 `boomux config path`, `validate`, and `edit` are human-only local commands and do
 not start the daemon. Validation parses and semantically resolves all configured
@@ -734,10 +751,10 @@ schedule ID. The runner resolves the exact schedule, `BOOMUX_SHELL_ID`, and
 integration-owned argv builders without shell interpretation. The capability is
 persisted with private dispatch input, supplied only to that runner's ephemeral
 environment, removed before the external host is spawned, and required for claim
-resolution and outcome reports. OpenCode
-uses `opencode run [--session exact-id] -- prompt`.
-Pi uses `pi [--session exact-full-id] --print`, receives the exact prompt on
-stdin, and closes stdin; host stdout and stderr remain on the PTY. The runner
+resolution and outcome reports. OpenCode uses `opencode run [--session exact-id]
+-- prompt`. Pi uses `pi [--session exact-full-id] --print`, while Claude Code
+uses `claude --print [--resume exact-id]`; both receive the exact prompt on stdin
+and close stdin. Host stdout and stderr remain on the PTY. The runner
 retries daemon connections through handoff without starting a daemon.
 
 Scheduling is process orchestration, not lifecycle observation. Spawn failure,
@@ -1139,6 +1156,44 @@ exercise only the host fields and ordering Boomux consumes; the record
 deliberately distinguishes those tests from transitions observed in real
 managed sessions.
 
+### Claude Code Lifecycle Integration
+
+The Claude Code descriptor targets `@anthropic-ai/claude-code` `2.1.236` as a
+compatibility test point. It installs the single bundled
+`integrations/claude/.claude-plugin/plugin.json` asset at
+`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/boomux/.claude-plugin/plugin.json`.
+Claude Code discovers that user-scoped skills-directory plugin in place. Its
+inline lifecycle hooks use exec-form `boomux claude hook`, receive bounded JSON
+on stdin, and make no stdout decision. Outside a managed ShellRun the hook is a
+silent no-op. Inside one, Claude's canonical `session_id` and the authoritative
+Boomux environment ensure the exact `(claude, session, shell, run)` Agent key.
+Subagent hooks retain the root `session_id` and therefore reduce into that Agent
+Instance rather than creating separate Agents.
+
+Session start, a completed foreground turn, and an API-error turn report Idle;
+prompts, tool work, denied tool permissions, and subagent activity report
+Working; permission or user-input waits report Blocked; session end reports
+Inactive and never Done. A Stop with reported background tasks or session crons
+remains Working. Reports use LifecycleIntegration authority and reuse the existing
+protocol Agent operations, so lifecycle reporting needs no Claude-specific wire
+request or durable state. Hook failures are fail-open for Claude Code and are
+written only to stderr.
+
+While Remote Control is connected, Claude exposes
+`CLAUDE_CODE_BRIDGE_SESSION_ID` only to hook subprocesses. The hook synchronizes
+that opaque value through protocol 43 after ensuring the exact Agent. Absence
+clears the exact binding, and root SessionEnd always clears it. The daemon
+validates the Claude integration and current Agent/ShellRun, rejects bridge
+collisions, and never persists, event-publishes, or projects the value to another
+Node. A graceful handoff revalidates and transfers bindings after importing the
+surviving ShellRuns; cold startup has none.
+
+The descriptor recognizes the exact `claude` executable and foreground process,
+resumes an exact canonical Session with `claude --resume ID`, and dispatches
+fresh and continuation schedules as `claude --print` and `claude --print
+--resume ID`, respectively, with the prompt on stdin. It advertises no title or
+catalog capability.
+
 ### OpenCode Lifecycle Plugins
 
 The paired bundled plugins target the source-visible OpenCode TUI API and server
@@ -1464,9 +1519,9 @@ and last terminal profiles survive restart. The last run record also preserves
 its identity and outcome. Recovered shells are pending: Boomux does not claim
 that arbitrary processes, mutated environments, or PTYs survive daemon restart
 or crash. When enabled, cold recovery substitutes an integration-native resume
-command for a uniquely identified, lifecycle-authoritative OpenCode or Pi Agent
-from an interrupted run. Ambiguous or invalid candidates use the shell's normal
-command instead.
+command for a uniquely identified, lifecycle-authoritative OpenCode, Pi, or
+Claude Agent from an interrupted run. Ambiguous or invalid candidates use the
+shell's normal command instead.
 
 Plain-text terminal history is a separate opt-in recovery field because output
 can contain secrets. The shadow terminal checkpoints a UTF-8-safe suffix of at

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -241,12 +241,12 @@ The following commands support `--json`:
 - `boomux execution open`
 - `boomux execution cancel`
 - `boomux integration list`
-- `boomux integration status [opencode|pi]`
-- `boomux integration install <opencode|pi>`
+- `boomux integration status [opencode|pi|claude]`
+- `boomux integration install <opencode|pi|claude>`
 - `boomux integration install --all`
-- `boomux integration uninstall <opencode|pi>`
+- `boomux integration uninstall <opencode|pi|claude>`
 - `boomux integration uninstall --all`
-- `boomux integration verify <opencode|pi>`
+- `boomux integration verify <opencode|pi|claude>`
 - `boomux opencode claim ensure`
 - `boomux opencode claim release`
 - `boomux opencode claim report`
@@ -260,8 +260,8 @@ integration install and uninstall support the contract. Other mutation commands
 retain human output. Passing `--json` to an unsupported command fails with
 `invalid_argument` before performing the operation.
 
-`boomux integration setup <opencode|pi>` is intentionally human-oriented and
-does not support `--json`. It composes status inspection, an exact install
+`boomux integration setup <opencode|pi|claude>` is intentionally human-oriented
+and does not support `--json`. It composes status inspection, an exact install
 preview, confirmation, installation when needed, and restart/verification
 guidance. `--yes` skips confirmation for automation; replacing modified content
 also requires `--force`.
@@ -415,8 +415,8 @@ generated name is currently in use, suggestion fails with `already_exists`.
 
 ## Integration Data
 
-Integration arrays are ordered `opencode`, then `pi`. List entries contain
-`name`, `display_name`, `package`, and `validated_version`.
+Integration arrays are ordered `opencode`, then `pi`, then `claude`. List entries
+contain `name`, `display_name`, `package`, and `validated_version`.
 
 Protocol 22 advertises `protocol_22`, `agent_schedule_management`, and
 `durable_agent_schedules`. Protocol 23 adds `protocol_23`,
@@ -456,6 +456,9 @@ Protocol 41 adds `protocol_41`, `observed_node_helper_version`, and
 `node_upgrade_coordination`.
 Protocol 42 adds `protocol_42` and
 `opencode_shared_runtime_claims`.
+Protocol 43 adds `protocol_43` and `claude_remote_control_bindings`. The binding
+operations are private local protocol requests and add no public CLI JSON field,
+snapshot field, event, or remote Node projection field.
 
 Protocol-38 `workspace create` creates empty coordinator metadata without a
 default Node or cwd. First global `shell create`, `launcher create`, or

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -51,6 +51,9 @@ ephemeral refresh remains the fallback for legacy or missed invalidations.
 Remote notification presentation adds no protocol or event kind. It consumes the
 protocol-32 reduced transition batch at the projection-cache boundary and never
 copies owner events into the presenting Node's domain journal.
+Protocol 43 likewise adds no event kind or baseline field. Claude Remote Control
+bindings are ephemeral local handoff presentation state, not durable Agent state
+or reduced Node projection data.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns

--- a/docs/lifecycle-validation.md
+++ b/docs/lifecycle-validation.md
@@ -7,6 +7,26 @@ This record separates observed host behavior from reducer fixtures and intended
 semantics. Host compatibility is not inferred from process names, terminal
 output, or database recency.
 
+## 2026-08-20
+
+Claude Code `2.1.236` was live-validated with the protocol-43 lifecycle plugin
+and Remote Control binding. After the skills-directory plugin was installed and
+Claude was restarted inside an existing managed Bash ShellRun, Claude's
+canonical Session ID produced one exact current Agent at
+`lifecycle_integration` authority and confidence 100. Session start, one user
+prompt, and the completed turn advanced the observation to revision 3 `idle`;
+`boomux integration verify claude --shell ID --json` reported the integration
+as verified with one tracked and zero untracked processes.
+
+The same Claude process enabled Remote Control in-session. A later hook observed
+the ephemeral bridge identity, and the owner-local Boomux web snapshot exposed
+an **Open in Claude** native handoff only on that exact current Agent. The
+gateway then published its dashboard and OpenCode routes through Tailscale, and
+`tailscale serve status --json` confirmed both owner-managed HTTPS proxies.
+The bridge identity itself was not copied into this record. Default-on bare
+launch injection, SessionEnd cleanup, cold absence, and graceful binding
+transfer remain compatibility-test evidence rather than live host validation.
+
 ## 2026-08-19
 
 OpenCode `1.18.18` was live-validated with the protocol-42 Shared Harness

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -40,15 +40,17 @@ The private handoff channel carries a versioned manifest followed by Unix
   revision, including an external Node Shell when that was focused most recently
 - The Shared Harness Runtime generation, strict PID/start/runtime identity, and
   supervision state, without Agent Session Claims
+- Bounded Claude Remote Control bindings for exact transferred Agent/ShellRuns,
+  without additional descriptors
 
 The PTY master is full duplex, so reader and writer duplicates do not need to be
 transferred separately. The replacement cannot inherit Unix parenthood; process
 monitoring and cleanup therefore need an imported-process representation, with
 a Linux pidfd where available.
 
-Bootstrap version 5 starts with the `BOOMUXH5` header, accepts an H4 sender for
-compatibility, and has bounded read/write deadlines. An H4 transfer has no
-Shared Harness Runtime record. The receiver validates the listener path/type,
+Bootstrap version 6 starts with the `BOOMUXH6` header, accepts an H5 sender for
+compatibility, and has bounded read/write deadlines. An H5 transfer has no
+Claude Remote Control binding records. The receiver validates the listener path/type,
 forces nonblocking mode, matches both lock-file inodes, and establishes exclusive
 flock ownership before acknowledging readiness. Explicit abort closes every
 received duplicate without affecting descriptors retained by the old daemon.
@@ -88,6 +90,10 @@ Surviving TUI holders reacquire claims after reconnect; until then the server
 plugin has no ShellRun lifecycle authority. Rollback leaves runtime supervision
 with the old daemon. Cold startup adopts an existing runtime only when every
 identity check matches, and `boomux daemon stop` terminates it.
+Handoff 6 transfers only Claude Remote Control bindings that still identify an
+exact active Claude Agent and transferred ShellRun. The replacement revalidates
+them before `PREPARED`; rollback leaves the old daemon's map intact. The map is
+not durable, and cold startup begins without bindings.
 
 ## Accepted Remote Node Boundary
 

--- a/docs/mobile-web.md
+++ b/docs/mobile-web.md
@@ -137,12 +137,16 @@ the intended authentication boundary.
   current attention or lifecycle observation revision. Durable attention stays
   visible until the daemon confirms acknowledgment; remote and stale requests
   fail closed.
-- An exact native link is included on a card only for a local OpenCode Agent with
+- An exact native OpenCode link is included on a card only for a local OpenCode Agent with
   a canonical external Session ID, UTF-8 working directory, and current Agent
   Session Claim for the Agent's exact ShellRun and Shared Harness Runtime
   generation. The directory is
   base64url-encoded for OpenCode's
   `/<directory>/session/<session-id>` route.
+- An exact **Open in Claude** link is included only for a current local Claude
+  Agent whose exact Agent/ShellRun has a protocol-43 Remote Control binding
+  observed directly by a hook. Its opaque bridge ID is percent-encoded into
+  `https://claude.ai/code/<bridge-id>`. No transcript content is read or proxied.
 - Native links are not produced for projected remote Agents because their
   external Session identity and working directory intentionally remain on the
   owner Node. Remote Agents remain unlinked to this Node's runtime.
@@ -161,8 +165,9 @@ the private access layer. That layer owns TLS, authentication, and ACLs
 appropriate for both the bounded dashboard and OpenCode's
 full-control origin. Public exposure is outside this design.
 
-Native handoff URLs expose the local working-directory encoding and canonical
-Session ID to the authorized dashboard client and destination OpenCode origin.
+Native handoff URLs expose either the local working-directory encoding and
+canonical Session ID to the destination OpenCode origin, or the opaque Claude
+bridge ID to `claude.ai`.
 API responses carry
 `Cache-Control: no-store`. The service worker caches only HTML, JavaScript, CSS,
 the manifest, and the icon; it never handles `/api/` requests. Browser storage
@@ -185,7 +190,7 @@ reverse proxy so this boundary remains visible.
 ## MVP Endpoints
 
 - `GET /api/snapshot` returns the current Node-qualified Agent cards, counts, and
-  optional exact native OpenCode Web handoffs.
+  optional exact native OpenCode or Claude handoffs.
 - `POST /api/attention/dismiss` requires JSON containing the exact local
   `node_id`, `agent_id`, and `observation_revision`. It clears a matching
   ephemeral marker or acknowledges matching durable attention.

--- a/docs/scheduled-agent-work.md
+++ b/docs/scheduled-agent-work.md
@@ -454,8 +454,8 @@ blocked work attaches to its exact run, while completed work resumes only its
 exact canonical Agent Session; neither path selects a newest or nearby identity.
 Durable Agent attention remains independent. Canonical session identity requires
 the exact linked Agent occurrence. Boomux does not read or
-project host transcript and tool content; OpenCode or Pi remains the interface
-for that content.
+project host transcript and tool content; OpenCode, Pi, or Claude Code remains
+the interface for that content.
 
 ## User Control And Permissions
 

--- a/integrations/claude/.claude-plugin/plugin.json
+++ b/integrations/claude/.claude-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "boomux",
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "PreToolUse": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "PermissionRequest": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "PermissionDenied": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "PostToolUse": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "PostToolUseFailure": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "Notification": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "SubagentStart": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "SubagentStop": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "StopFailure": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ],
+    "SessionEnd": [
+      { "hooks": [{ "type": "command", "command": "boomux", "args": ["claude", "hook"], "timeout": 5 }] }
+    ]
+  }
+}

--- a/src/claude_hooks.rs
+++ b/src/claude_hooks.rs
@@ -1,0 +1,274 @@
+use std::io::{self, Read};
+
+use boomux::protocol::AgentState;
+use serde::Deserialize;
+
+pub(crate) const MAX_HOOK_INPUT_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+enum HookEvent {
+    SessionStart,
+    UserPromptSubmit,
+    PreToolUse,
+    PermissionRequest,
+    PermissionDenied,
+    PostToolUse,
+    PostToolUseFailure,
+    Notification,
+    SubagentStart,
+    SubagentStop,
+    Stop,
+    StopFailure,
+    SessionEnd,
+}
+
+#[derive(Debug, Deserialize)]
+struct HookInput {
+    session_id: String,
+    hook_event_name: HookEvent,
+    #[serde(default)]
+    agent_id: Option<String>,
+    #[serde(default)]
+    notification_type: Option<String>,
+    #[serde(default)]
+    background_tasks: Option<Vec<serde_json::Value>>,
+    #[serde(default)]
+    session_crons: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct LifecycleObservation {
+    pub(crate) state: AgentState,
+    pub(crate) evidence: &'static str,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct HookUpdate {
+    pub(crate) session_id: String,
+    pub(crate) observation: Option<LifecycleObservation>,
+    pub(crate) session_ended: bool,
+}
+
+pub(crate) fn read_update(reader: impl Read) -> Result<HookUpdate, Box<dyn std::error::Error>> {
+    let input = read_bounded_input(reader)?;
+    let input: HookInput = serde_json::from_slice(&input).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid Claude hook input: {error}"),
+        )
+    })?;
+    boomux::scheduling::validate_external_session_id(&input.session_id).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid Claude session identity: {error}"),
+        )
+    })?;
+    let session_ended = input.hook_event_name == HookEvent::SessionEnd && input.agent_id.is_none();
+    let session_id = input.session_id.clone();
+    Ok(HookUpdate {
+        session_id,
+        observation: reduce(input),
+        session_ended,
+    })
+}
+
+fn read_bounded_input(mut reader: impl Read) -> io::Result<Vec<u8>> {
+    let mut input = Vec::new();
+    reader
+        .by_ref()
+        .take((MAX_HOOK_INPUT_BYTES + 1) as u64)
+        .read_to_end(&mut input)?;
+    if input.len() > MAX_HOOK_INPUT_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Claude hook input exceeds {MAX_HOOK_INPUT_BYTES} bytes"),
+        ));
+    }
+    Ok(input)
+}
+
+fn reduce(input: HookInput) -> Option<LifecycleObservation> {
+    let in_subagent = input.agent_id.is_some();
+    let (state, evidence) = match input.hook_event_name {
+        HookEvent::SessionStart if in_subagent => {
+            (AgentState::Working, "Claude subagent session started")
+        }
+        HookEvent::SessionStart => (AgentState::Idle, "Claude session idle"),
+        HookEvent::UserPromptSubmit => (AgentState::Working, "Claude processing prompt"),
+        HookEvent::PreToolUse => (AgentState::Working, "Claude using tool"),
+        HookEvent::PermissionRequest => (AgentState::Blocked, "Claude awaiting tool permission"),
+        HookEvent::PermissionDenied => (AgentState::Working, "Claude tool permission denied"),
+        HookEvent::PostToolUse => (AgentState::Working, "Claude tool completed"),
+        HookEvent::PostToolUseFailure => (AgentState::Working, "Claude tool failed"),
+        HookEvent::Notification => match input.notification_type.as_deref() {
+            Some(
+                "permission_prompt"
+                | "elicitation_dialog"
+                | "elicitation_url_dialog"
+                | "agent_needs_input",
+            ) => (AgentState::Blocked, "Claude awaiting user input"),
+            _ => return None,
+        },
+        HookEvent::SubagentStart => (AgentState::Working, "Claude subagent working"),
+        HookEvent::SubagentStop => (AgentState::Working, "Claude subagent stopped"),
+        HookEvent::Stop
+            if input
+                .background_tasks
+                .as_ref()
+                .is_some_and(|tasks| !tasks.is_empty())
+                || input
+                    .session_crons
+                    .as_ref()
+                    .is_some_and(|crons| !crons.is_empty()) =>
+        {
+            (AgentState::Working, "Claude background work active")
+        }
+        HookEvent::Stop => (AgentState::Idle, "Claude session idle"),
+        HookEvent::StopFailure => (AgentState::Idle, "Claude turn failed"),
+        HookEvent::SessionEnd if in_subagent => {
+            (AgentState::Working, "Claude subagent session ended")
+        }
+        HookEvent::SessionEnd => (AgentState::Inactive, "Claude session inactive"),
+    };
+    Some(LifecycleObservation { state, evidence })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn update(json: &str) -> HookUpdate {
+        read_update(json.as_bytes()).unwrap()
+    }
+
+    fn observation(json: &str) -> Option<LifecycleObservation> {
+        update(json).observation
+    }
+
+    #[test]
+    fn lifecycle_events_reduce_to_root_session_observations() {
+        let cases = [
+            ("SessionStart", AgentState::Idle, "Claude session idle"),
+            (
+                "UserPromptSubmit",
+                AgentState::Working,
+                "Claude processing prompt",
+            ),
+            ("PreToolUse", AgentState::Working, "Claude using tool"),
+            (
+                "PermissionRequest",
+                AgentState::Blocked,
+                "Claude awaiting tool permission",
+            ),
+            (
+                "PermissionDenied",
+                AgentState::Working,
+                "Claude tool permission denied",
+            ),
+            ("PostToolUse", AgentState::Working, "Claude tool completed"),
+            (
+                "PostToolUseFailure",
+                AgentState::Working,
+                "Claude tool failed",
+            ),
+            (
+                "SubagentStart",
+                AgentState::Working,
+                "Claude subagent working",
+            ),
+            (
+                "SubagentStop",
+                AgentState::Working,
+                "Claude subagent stopped",
+            ),
+            ("Stop", AgentState::Idle, "Claude session idle"),
+            ("StopFailure", AgentState::Idle, "Claude turn failed"),
+            (
+                "SessionEnd",
+                AgentState::Inactive,
+                "Claude session inactive",
+            ),
+        ];
+        for (event, state, evidence) in cases {
+            let actual = observation(&format!(
+                r#"{{"session_id":"root-session","hook_event_name":"{event}","unknown_future_field":true}}"#
+            ))
+            .unwrap();
+            assert_eq!(actual.state, state, "{event}");
+            assert_eq!(actual.evidence, evidence, "{event}");
+            assert_ne!(actual.state, AgentState::Done);
+        }
+    }
+
+    #[test]
+    fn subagent_session_boundaries_keep_the_root_working() {
+        for event in ["SessionStart", "SessionEnd"] {
+            let update = update(&format!(
+                r#"{{"session_id":"root-session","hook_event_name":"{event}","agent_id":"subagent-1"}}"#
+            ));
+            let actual = update.observation.unwrap();
+            assert_eq!(update.session_id, "root-session");
+            assert_eq!(actual.state, AgentState::Working);
+            assert!(!update.session_ended);
+        }
+    }
+
+    #[test]
+    fn stop_remains_working_while_background_work_exists() {
+        for fields in [
+            r#""background_tasks":[{"id":"task-1"}]"#,
+            r#""session_crons":[{"id":"cron-1"}]"#,
+        ] {
+            assert_eq!(
+                observation(&format!(
+                    r#"{{"session_id":"root","hook_event_name":"Stop",{fields}}}"#
+                )),
+                Some(LifecycleObservation {
+                    state: AgentState::Working,
+                    evidence: "Claude background work active",
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn only_input_notifications_block() {
+        assert_eq!(
+            observation(
+                r#"{"session_id":"root","hook_event_name":"Notification","notification_type":"permission_prompt"}"#
+            )
+            .unwrap()
+            .state,
+            AgentState::Blocked
+        );
+        assert_eq!(
+            observation(
+                r#"{"session_id":"root","hook_event_name":"Notification","notification_type":"auth_success"}"#
+            ),
+            None
+        );
+        assert_eq!(
+            update(
+                r#"{"session_id":"root","hook_event_name":"Notification","notification_type":"auth_success"}"#
+            )
+            .session_id,
+            "root"
+        );
+    }
+
+    #[test]
+    fn hook_input_and_session_identity_are_bounded() {
+        let oversized = vec![b'x'; MAX_HOOK_INPUT_BYTES + 1];
+        assert!(read_update(oversized.as_slice()).is_err());
+        assert!(
+            read_update(
+                format!(
+                    r#"{{"session_id":"{}","hook_event_name":"SessionStart"}}"#,
+                    "x".repeat(boomux::scheduling::MAX_EXTERNAL_SESSION_ID_BYTES + 1)
+                )
+                .as_bytes()
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,10 +15,11 @@ use std::time::Duration;
 
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
-    AgentScheduleSnapshot, AgentScheduleSpec, AgentScheduleUpdate, CombinedNodeSnapshot,
-    DaemonEvent, Envelope, ErrorCode, EventCursor, FocusedTerminalSnapshot, NodeProjectionHealth,
-    NodeRegistrationSnapshot, NotificationDeliveryConfig, OpenCodeSessionClaimSnapshot,
-    OpenCodeSharedRuntimeSnapshot, Request, Response, RoutedOperation, RoutedOperationResult,
+    AgentScheduleSnapshot, AgentScheduleSpec, AgentScheduleUpdate,
+    ClaudeRemoteControlBindingSnapshot, CombinedNodeSnapshot, DaemonEvent, Envelope, ErrorCode,
+    EventCursor, FocusedTerminalSnapshot, NodeProjectionHealth, NodeRegistrationSnapshot,
+    NotificationDeliveryConfig, OpenCodeSessionClaimSnapshot, OpenCodeSharedRuntimeSnapshot,
+    Request, Response, RoutedOperation, RoutedOperationResult,
     ScheduledExecutionScheduleProjection, ScheduledExecutionSnapshot, ScheduledOccurrence,
     ScheduledRunnerResult, ShellSnapshot, ShellSpec, ShellStatus, Snapshot, TerminalPreview,
     TerminalPreviewLine, TerminalPreviewSpan, TerminalProfile, UnixEnvironment,
@@ -1620,6 +1621,40 @@ impl Client {
         }
     }
 
+    pub fn set_claude_remote_control_binding(
+        &self,
+        agent_id: impl Into<String>,
+        shell_id: impl Into<String>,
+        run_id: impl Into<String>,
+        bridge_session_id: Option<String>,
+    ) -> Result<Option<ClaudeRemoteControlBindingSnapshot>> {
+        match self.request(Request::SetClaudeRemoteControlBinding {
+            agent_id: agent_id.into(),
+            shell_id: shell_id.into(),
+            run_id: run_id.into(),
+            bridge_session_id,
+        })? {
+            Response::ClaudeRemoteControlBinding { binding } => Ok(binding),
+            other => unexpected(other),
+        }
+    }
+
+    pub fn get_claude_remote_control_binding(
+        &self,
+        agent_id: impl Into<String>,
+        shell_id: impl Into<String>,
+        run_id: impl Into<String>,
+    ) -> Result<Option<ClaudeRemoteControlBindingSnapshot>> {
+        match self.request(Request::GetClaudeRemoteControlBinding {
+            agent_id: agent_id.into(),
+            shell_id: shell_id.into(),
+            run_id: run_id.into(),
+        })? {
+            Response::ClaudeRemoteControlBinding { binding } => Ok(binding),
+            other => unexpected(other),
+        }
+    }
+
     pub fn report_agent(
         &self,
         agent_id: impl Into<String>,
@@ -2112,6 +2147,9 @@ mod tests {
 
     fn reject_protocol(listener: &UnixListener, attempted: u32, supported: u32) {
         reject_protocol_once(listener, attempted, supported);
+        if attempted == protocol::PROTOCOL_VERSION && supported == 41 {
+            reject_protocol_once(listener, 42, supported);
+        }
     }
 
     fn reject_protocol_once(listener: &UnixListener, attempted: u32, supported: u32) {
@@ -2144,7 +2182,7 @@ mod tests {
         let (client_done_sender, client_done_receiver) = mpsc::channel();
         let server = thread::spawn(move || {
             for _ in 0..2 {
-                reject_protocol_once(&listener, 42, 41);
+                reject_protocol(&listener, protocol::PROTOCOL_VERSION, 41);
                 let (mut stream, _) = listener.accept().unwrap();
                 let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
                 assert_eq!(request.version, 41);
@@ -2167,6 +2205,54 @@ mod tests {
             error,
             ClientError::Protocol(ProtocolError::UnsupportedVersion(_))
         ));
+        client_done_sender.send(()).unwrap();
+
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn protocol_forty_two_daemon_rejects_claude_bindings_before_request() {
+        let directory =
+            env::temp_dir().join(format!("boomux-client-claude-binding-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let (client_done_sender, client_done_receiver) = mpsc::channel();
+        let server = thread::spawn(move || {
+            for _ in 0..3 {
+                reject_protocol_once(&listener, 43, 42);
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                assert_eq!(request.version, 42);
+                assert!(matches!(request.message, Request::Ping));
+                protocol::write_message(&mut stream, &Envelope::with_version(42, Response::Pong))
+                    .unwrap();
+            }
+
+            client_done_receiver.recv().unwrap();
+            listener.set_nonblocking(true).unwrap();
+            assert!(
+                matches!(listener.accept(), Err(error) if error.kind() == io::ErrorKind::WouldBlock)
+            );
+        });
+        let client = Client::from_socket_path(socket);
+
+        assert_eq!(client.protocol_version().unwrap(), 42);
+        for result in [
+            client.set_claude_remote_control_binding(
+                "agent-1",
+                "shell-1",
+                "run-1",
+                Some("bridge-1".into()),
+            ),
+            client.get_claude_remote_control_binding("agent-1", "shell-1", "run-1"),
+        ] {
+            assert!(matches!(
+                result,
+                Err(ClientError::Protocol(ProtocolError::UnsupportedVersion(_)))
+            ));
+        }
         client_done_sender.send(()).unwrap();
 
         server.join().unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,9 @@ pub(crate) const CONFIG_TEMPLATE: &str = r#"# Boomux configuration
 
 [scheduling]
 # max_concurrent = 4
+
+[claude]
+# remote_control = true
 "#;
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -62,6 +65,7 @@ struct RawConfig {
     dashboard: Option<RawDashboardConfig>,
     recovery: Option<RawRecoveryConfig>,
     scheduling: Option<RawSchedulingConfig>,
+    claude: Option<RawClaudeConfig>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -109,6 +113,12 @@ struct RawRecoveryConfig {
 #[serde(default, deny_unknown_fields)]
 struct RawSchedulingConfig {
     max_concurrent: Option<i64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawClaudeConfig {
+    remote_control: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -193,7 +203,7 @@ pub(crate) fn load_snapshot() -> Result<ConfigSnapshot, Box<dyn Error>> {
 pub(crate) fn load_notification_settings()
 -> Result<boomux::daemon::NotificationDeliverySettings, Box<dyn Error>> {
     let (raw, _) = load_raw()?;
-    resolve_daemon_settings(raw.notifications, raw.recovery, raw.scheduling)
+    resolve_daemon_settings(raw.notifications, raw.recovery, raw.scheduling, raw.claude)
 }
 
 fn load_raw() -> Result<(RawConfig, Option<PathBuf>), Box<dyn Error>> {
@@ -736,6 +746,12 @@ fn merge(base: &mut RawConfig, next: RawConfig) {
             scheduling.max_concurrent = next_scheduling.max_concurrent;
         }
     }
+    if let Some(next_claude) = next.claude {
+        let claude = base.claude.get_or_insert_default();
+        if next_claude.remote_control.is_some() {
+            claude.remote_control = next_claude.remote_control;
+        }
+    }
 }
 
 fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Error>> {
@@ -766,7 +782,12 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
         terminal,
         projects: ProjectsConfig { roots, max_depth },
         path,
-        notifications: resolve_daemon_settings(raw.notifications, raw.recovery, raw.scheduling)?,
+        notifications: resolve_daemon_settings(
+            raw.notifications,
+            raw.recovery,
+            raw.scheduling,
+            raw.claude,
+        )?,
         dashboard: DashboardConfig {
             follow_focused_terminal: raw
                 .dashboard
@@ -781,13 +802,14 @@ fn resolve(raw: RawConfig, path: Option<PathBuf>) -> Result<Config, Box<dyn Erro
 fn resolve_notifications(
     raw: Option<RawNotificationsConfig>,
 ) -> boomux::daemon::NotificationDeliverySettings {
-    resolve_daemon_settings(raw, None, None).expect("default scheduling config is valid")
+    resolve_daemon_settings(raw, None, None, None).expect("default scheduling config is valid")
 }
 
 fn resolve_daemon_settings(
     notifications: Option<RawNotificationsConfig>,
     recovery: Option<RawRecoveryConfig>,
     scheduling: Option<RawSchedulingConfig>,
+    claude: Option<RawClaudeConfig>,
 ) -> Result<boomux::daemon::NotificationDeliverySettings, Box<dyn Error>> {
     let raw = notifications.unwrap_or_default();
     let recovery = recovery.unwrap_or_default();
@@ -827,6 +849,7 @@ fn resolve_daemon_settings(
         resume_agents: recovery.resume_agents.unwrap_or(true),
         persist_terminal_history: recovery.persist_terminal_history.unwrap_or(false),
         max_scheduled_execution_concurrency: max_concurrent as u16,
+        claude_remote_control: claude.unwrap_or_default().remote_control.unwrap_or(true),
     })
 }
 
@@ -1032,7 +1055,7 @@ mod tests {
 
     #[test]
     fn recovery_settings_default_and_merge_per_field() {
-        let defaults = resolve_daemon_settings(None, None, None).unwrap();
+        let defaults = resolve_daemon_settings(None, None, None, None).unwrap();
         assert!(defaults.resume_agents);
         assert!(!defaults.persist_terminal_history);
 
@@ -1042,11 +1065,36 @@ mod tests {
         let next: RawConfig = toml::from_str("[recovery]\nresume_agents = true").unwrap();
         merge(&mut base, next);
 
-        let settings =
-            resolve_daemon_settings(base.notifications, base.recovery, base.scheduling).unwrap();
+        let settings = resolve_daemon_settings(
+            base.notifications,
+            base.recovery,
+            base.scheduling,
+            base.claude,
+        )
+        .unwrap();
         assert!(settings.resume_agents);
         assert!(settings.persist_terminal_history);
         assert!(toml::from_str::<RawConfig>("[recovery]\nunknown = true").is_err());
+    }
+
+    #[test]
+    fn claude_remote_control_defaults_on_and_can_be_disabled_per_layer() {
+        let defaults = resolve_daemon_settings(None, None, None, None).unwrap();
+        assert!(defaults.claude_remote_control);
+
+        let mut base: RawConfig = toml::from_str("[claude]\nremote_control = false").unwrap();
+        let next: RawConfig =
+            toml::from_str("[dashboard]\nfollow_focused_terminal = false").unwrap();
+        merge(&mut base, next);
+        let settings = resolve_daemon_settings(
+            base.notifications,
+            base.recovery,
+            base.scheduling,
+            base.claude,
+        )
+        .unwrap();
+        assert!(!settings.claude_remote_control);
+        assert!(toml::from_str::<RawConfig>("[claude]\nunknown = true").is_err());
     }
 
     #[test]
@@ -1079,6 +1127,7 @@ mod tests {
                 resume_agents: true,
                 persist_terminal_history: false,
                 max_scheduled_execution_concurrency: 4,
+                claude_remote_control: true,
             }
         );
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -41,6 +41,7 @@ use crate::node_projection::{
     RemoteNotificationCategory, RemoteNotificationClaim,
 };
 use crate::node_registration::NodeRegistrationManager;
+use crate::protocol::ClaudeRemoteControlBindingSnapshot;
 use crate::protocol::{
     self, AgentAttentionReason, AgentAttentionSnapshot, AgentAuthority, AgentInstanceSnapshot,
     AgentObservationSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
@@ -121,6 +122,12 @@ if [ "$#" -eq 0 ] && [ -t 0 ] && [ -t 1 ] && [ -n "${BOOMUX_SHELL_ID-}" ] && [ -
   exec "$BOOMUX_SHIM_EXECUTABLE" opencode shared
 fi
 exec "$BOOMUX_REAL_OPENCODE" "$@"
+"#;
+const CLAUDE_SHIM: &[u8] = br#"#!/bin/sh
+if [ "${BOOMUX_CLAUDE_REMOTE_CONTROL-0}" = 1 ] && [ "$#" -eq 0 ] && [ -t 0 ] && [ -t 1 ] && [ -n "${BOOMUX_SHELL_ID-}" ] && [ -n "${BOOMUX_RUN_ID-}" ]; then
+  exec "$BOOMUX_REAL_CLAUDE" --remote-control
+fi
+exec "$BOOMUX_REAL_CLAUDE" "$@"
 "#;
 const OPENCODE_BASH_RC: &[u8] = br#"if [ -r "${HOME}/.bashrc" ]; then
   . "${HOME}/.bashrc"
@@ -205,6 +212,7 @@ impl From<NotificationDeliveryConfig> for NotificationDeliverySettings {
             resume_agents: config.resume_agents,
             persist_terminal_history: config.persist_terminal_history,
             max_scheduled_execution_concurrency: config.max_scheduled_execution_concurrency,
+            claude_remote_control: true,
         }
     }
 }
@@ -236,6 +244,7 @@ pub struct NotificationDeliverySettings {
     pub resume_agents: bool,
     pub persist_terminal_history: bool,
     pub max_scheduled_execution_concurrency: u16,
+    pub claude_remote_control: bool,
 }
 
 impl Default for NotificationDeliverySettings {
@@ -246,6 +255,7 @@ impl Default for NotificationDeliverySettings {
             resume_agents: true,
             persist_terminal_history: false,
             max_scheduled_execution_concurrency: 4,
+            claude_remote_control: true,
         }
     }
 }
@@ -316,8 +326,14 @@ pub fn receive_handoff_with_notification_delivery(
             focused_terminal,
             presented_focused_terminal,
             opencode_runtime,
+            claude_remote_control_bindings,
         } => {
             let store = StateStore::from_transferred_lock(state_lock)?;
+            let claude_remote_control = notification_settings.claude_remote_control;
+            let mut notification_settings = (*notifications)
+                .map(Into::into)
+                .unwrap_or(notification_settings);
+            notification_settings.claude_remote_control = claude_remote_control;
             let socket_path = client::socket_path()?;
             run_daemon(
                 listener,
@@ -331,11 +347,10 @@ pub fn receive_handoff_with_notification_delivery(
                     focused_terminal: focused_terminal.map(|focused| *focused),
                     presented_focused_terminal: presented_focused_terminal.map(|focused| *focused),
                     opencode_runtime,
+                    claude_remote_control_bindings,
                 },
                 Some(&mut channel),
-                (*notifications)
-                    .map(Into::into)
-                    .unwrap_or(notification_settings),
+                notification_settings,
             )
         }
     }
@@ -389,6 +404,7 @@ struct TransferredState {
     focused_terminal: Option<FocusedTerminalSnapshot>,
     presented_focused_terminal: Option<QualifiedFocusedTerminalSnapshot>,
     opencode_runtime: Option<handoff::TransferredOpenCodeRuntime>,
+    claude_remote_control_bindings: Vec<ClaudeRemoteControlBindingSnapshot>,
 }
 
 fn run_daemon(
@@ -454,6 +470,7 @@ fn run_daemon(
     registry
         .opencode
         .import_handoff(transferred.opencode_runtime)?;
+    registry.import_claude_remote_control_bindings(transferred.claude_remote_control_bindings)?;
     if let Some(channel) = committed {
         {
             registry.events.transaction()?.reserve(1)?;
@@ -1033,6 +1050,8 @@ fn sanitize_opencode_shim_environment(environment: &UnixEnvironment) -> UnixEnvi
     let user_zdotdir = environment_value(environment, b"BOOMUX_USER_ZDOTDIR");
     let mut sanitized = environment.clone();
     const PRIVATE_NAMES: &[&[u8]] = &[
+        b"BOOMUX_CLAUDE_REMOTE_CONTROL",
+        b"BOOMUX_REAL_CLAUDE",
         b"BOOMUX_REAL_OPENCODE",
         b"BOOMUX_ORIGINAL_PATH",
         b"BOOMUX_OPENCODE_SHIM_DIR",
@@ -1073,6 +1092,14 @@ fn resolve_opencode_executable(
     environment: &UnixEnvironment,
     excluded_directory: Option<&Path>,
 ) -> Option<PathBuf> {
+    resolve_executable(environment, excluded_directory, "opencode")
+}
+
+fn resolve_executable(
+    environment: &UnixEnvironment,
+    excluded_directory: Option<&Path>,
+    executable: &str,
+) -> Option<PathBuf> {
     let path = environment_value(environment, b"PATH")?;
     let current_executable = env::current_exe()
         .ok()
@@ -1081,7 +1108,7 @@ fn resolve_opencode_executable(
         if !directory.is_absolute() || excluded_directory == Some(directory.as_path()) {
             return None;
         }
-        let candidate = directory.join("opencode");
+        let candidate = directory.join(executable);
         let metadata = fs::metadata(&candidate).ok()?;
         if !metadata.is_file() || metadata.permissions().mode() & 0o111 == 0 {
             return None;
@@ -1097,7 +1124,27 @@ fn opencode_shim_eligible(shell: &Shell, effective_command: &[String]) -> bool {
         && effective_command.is_empty()
 }
 
-fn inject_opencode_shim_environment(environment: &UnixEnvironment) -> io::Result<UnixEnvironment> {
+fn claude_remote_control_command(
+    shell: &Shell,
+    effective_command: &[String],
+    recovery_override: bool,
+    enabled: bool,
+) -> Option<Vec<String>> {
+    (enabled
+        && !recovery_override
+        && matches!(shell.owner, ShellOwner::User)
+        && effective_command.len() == 1
+        && Path::new(&effective_command[0])
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            == Some("claude"))
+    .then(|| vec![effective_command[0].clone(), "--remote-control".into()])
+}
+
+fn inject_opencode_shim_environment(
+    environment: &UnixEnvironment,
+    claude_remote_control: bool,
+) -> io::Result<UnixEnvironment> {
     let runtime_root = PathBuf::from(
         environment_value(environment, b"XDG_RUNTIME_DIR").ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, "XDG_RUNTIME_DIR is unavailable")
@@ -1112,13 +1159,14 @@ fn inject_opencode_shim_environment(environment: &UnixEnvironment) -> io::Result
     let shim_dir = runtime_root.join("boomux/shims");
     secure_runtime_dir(&runtime_root.join("boomux"))?;
     secure_runtime_dir(&shim_dir)?;
-    let real_opencode =
-        resolve_opencode_executable(environment, Some(&shim_dir)).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                "OpenCode executable is unavailable",
-            )
-        })?;
+    let real_opencode = resolve_opencode_executable(environment, Some(&shim_dir));
+    let real_claude = resolve_executable(environment, Some(&shim_dir), "claude");
+    if real_opencode.is_none() && real_claude.is_none() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "supported Agent executables are unavailable",
+        ));
+    }
     let boomux = env::current_exe()?.canonicalize()?;
     let boomux_metadata = fs::metadata(&boomux)?;
     if !boomux.is_absolute()
@@ -1131,26 +1179,31 @@ fn inject_opencode_shim_environment(environment: &UnixEnvironment) -> io::Result
         ));
     }
 
-    atomic_runtime_asset(&shim_dir.join("opencode"), OPENCODE_SHIM, 0o700)?;
     atomic_runtime_asset(&shim_dir.join("boomux.bashrc"), OPENCODE_BASH_RC, 0o600)?;
     atomic_runtime_asset(&shim_dir.join(".zshenv"), OPENCODE_ZSH_ENV, 0o600)?;
     atomic_runtime_asset(&shim_dir.join(".zshrc"), OPENCODE_ZSH_RC, 0o600)?;
-    atomic_runtime_asset(&shim_dir.join("boomux-tui.tsx"), OPENCODE_TUI, 0o600)?;
-    atomic_runtime_asset(
-        &shim_dir.join("boomux-tui-core.js"),
-        OPENCODE_TUI_CORE,
-        0o600,
-    )?;
-    atomic_runtime_asset(
-        &shim_dir.join("boomux-tui-runner.js"),
-        OPENCODE_TUI_RUNNER,
-        0o600,
-    )?;
-    atomic_runtime_asset(
-        &shim_dir.join("tui.json"),
-        b"{\n  \"$schema\": \"https://opencode.ai/tui.json\",\n  \"plugin\": [[\"./boomux-tui.tsx\", {}]]\n}\n",
-        0o600,
-    )?;
+    if real_opencode.is_some() {
+        atomic_runtime_asset(&shim_dir.join("opencode"), OPENCODE_SHIM, 0o700)?;
+        atomic_runtime_asset(&shim_dir.join("boomux-tui.tsx"), OPENCODE_TUI, 0o600)?;
+        atomic_runtime_asset(
+            &shim_dir.join("boomux-tui-core.js"),
+            OPENCODE_TUI_CORE,
+            0o600,
+        )?;
+        atomic_runtime_asset(
+            &shim_dir.join("boomux-tui-runner.js"),
+            OPENCODE_TUI_RUNNER,
+            0o600,
+        )?;
+        atomic_runtime_asset(
+            &shim_dir.join("tui.json"),
+            b"{\n  \"$schema\": \"https://opencode.ai/tui.json\",\n  \"plugin\": [[\"./boomux-tui.tsx\", {}]]\n}\n",
+            0o600,
+        )?;
+    }
+    if real_claude.is_some() {
+        atomic_runtime_asset(&shim_dir.join("claude"), CLAUDE_SHIM, 0o700)?;
+    }
 
     let original_path = environment_value(environment, b"PATH").unwrap_or_default();
     let mut paths = vec![shim_dir.clone()];
@@ -1159,11 +1212,30 @@ fn inject_opencode_shim_environment(environment: &UnixEnvironment) -> io::Result
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
     let mut injected = environment.clone();
     set_environment_value(&mut injected, b"PATH", prefixed_path);
-    set_environment_value(
-        &mut injected,
-        b"BOOMUX_REAL_OPENCODE",
-        real_opencode.into_os_string(),
-    );
+    if let Some(real_opencode) = real_opencode {
+        set_environment_value(
+            &mut injected,
+            b"BOOMUX_REAL_OPENCODE",
+            real_opencode.into_os_string(),
+        );
+        set_environment_value(
+            &mut injected,
+            b"BOOMUX_SHIM_EXECUTABLE",
+            boomux.into_os_string(),
+        );
+    }
+    if let Some(real_claude) = real_claude {
+        set_environment_value(
+            &mut injected,
+            b"BOOMUX_REAL_CLAUDE",
+            real_claude.into_os_string(),
+        );
+        set_environment_value(
+            &mut injected,
+            b"BOOMUX_CLAUDE_REMOTE_CONTROL",
+            if claude_remote_control { "1" } else { "0" },
+        );
+    }
     set_environment_value(&mut injected, b"BOOMUX_ORIGINAL_PATH", original_path);
     set_environment_value(
         &mut injected,
@@ -1174,11 +1246,6 @@ fn inject_opencode_shim_environment(environment: &UnixEnvironment) -> io::Result
         &mut injected,
         b"BOOMUX_OPENCODE_TUI_CONFIG",
         shim_dir.join("tui.json").into_os_string(),
-    );
-    set_environment_value(
-        &mut injected,
-        b"BOOMUX_SHIM_EXECUTABLE",
-        boomux.into_os_string(),
     );
     Ok(injected)
 }
@@ -1291,6 +1358,7 @@ fn launch_replacement(
         let focused_terminal = registry.focused_terminal_for_handoff()?;
         let presented_focused_terminal = registry.runtimes.presented_focused_terminal()?;
         let opencode_runtime = registry.opencode.prepare_handoff()?;
+        let claude_remote_control_bindings = registry.export_claude_remote_control_bindings()?;
         launch_replacement_process(
             listener.as_fd(),
             daemon_lock.as_fd(),
@@ -1304,6 +1372,7 @@ fn launch_replacement(
                 notification_settings,
                 startup_environment,
                 opencode_runtime,
+                claude_remote_control_bindings,
             },
         )
         .map_err(DaemonError::from)
@@ -1323,6 +1392,7 @@ struct ReplacementOptions {
     notification_settings: Option<NotificationDeliverySettings>,
     startup_environment: Option<UnixEnvironment>,
     opencode_runtime: Option<OutgoingOpenCodeRuntime>,
+    claude_remote_control_bindings: Vec<ClaudeRemoteControlBindingSnapshot>,
 }
 
 fn launch_replacement_process(
@@ -1340,6 +1410,7 @@ fn launch_replacement_process(
         notification_settings,
         startup_environment,
         opencode_runtime,
+        claude_remote_control_bindings,
     } = options;
     let (mut channel, child_channel) = UnixStream::pair()?;
     let child_channel_fd = child_channel.as_raw_fd();
@@ -1396,6 +1467,7 @@ fn launch_replacement_process(
                 opencode_runtime: opencode_runtime
                     .as_ref()
                     .map(|runtime| runtime.manifest.clone()),
+                claude_remote_control_bindings,
             },
         )?;
         send_descriptor(&channel, listener, handoff::LISTENER_MARKER)?;
@@ -2844,6 +2916,7 @@ struct DaemonService {
     events: EventStream,
     runtimes: ShellRuntimeManager,
     opencode: OpenCodeCoordinator,
+    claude_remote_control: ClaudeRemoteControlBindings,
     remote_attachments: RemoteAttachmentManager,
     host_service_previews: Mutex<HashMap<String, HostServicePreview>>,
     workspace_operation_locks: Mutex<HashMap<String, Weak<Mutex<()>>>>,
@@ -2863,6 +2936,11 @@ struct DaemonService {
 struct HostServicePreview {
     created_at: Instant,
     prepared: PreparedIntegrationMutation,
+}
+
+#[derive(Default)]
+struct ClaudeRemoteControlBindings {
+    state: Mutex<HashMap<String, ClaudeRemoteControlBindingSnapshot>>,
 }
 
 #[derive(Default)]
@@ -7297,6 +7375,7 @@ impl Default for DaemonService {
                 stopping: AtomicBool::new(false),
             },
             opencode: OpenCodeCoordinator::default(),
+            claude_remote_control: ClaudeRemoteControlBindings::default(),
             remote_attachments: RemoteAttachmentManager::default(),
             host_service_previews: Mutex::new(HashMap::new()),
             workspace_operation_locks: Mutex::new(HashMap::new()),
@@ -11392,6 +11471,7 @@ impl DaemonService {
                 profile: &profile,
                 environment: Some(&runner_environment),
                 recovery: RuntimeRecovery::default(),
+                claude_remote_control: false,
             },
         ) {
             Ok(runtime) => runtime,
@@ -12173,6 +12253,118 @@ impl DaemonService {
                 "OpenCode claim Agent is missing or ambiguous",
             )),
         }
+    }
+
+    fn set_claude_remote_control_binding(
+        &self,
+        agent_id: &str,
+        shell_id: &str,
+        run_id: &str,
+        bridge_session_id: Option<String>,
+    ) -> DaemonResult<Option<ClaudeRemoteControlBindingSnapshot>> {
+        if let Some(bridge_session_id) = bridge_session_id.as_deref() {
+            validate_claude_bridge_session_id(bridge_session_id)?;
+        }
+        let _mutation = lock(&self.mutation_lock)?;
+        let durable = lock(&self.durable.state)?;
+        if bridge_session_id.is_some() {
+            validate_claude_binding_authority(&durable, agent_id, shell_id, run_id)?;
+        } else {
+            validate_claude_binding_identity(&durable, agent_id, shell_id, run_id)?;
+        }
+        let mut bindings = lock(&self.claude_remote_control.state)?;
+        prune_claude_bindings(&durable, &mut bindings)?;
+        let Some(bridge_session_id) = bridge_session_id else {
+            bindings.remove(agent_id);
+            return Ok(None);
+        };
+        if bindings.iter().any(|(candidate_agent_id, binding)| {
+            candidate_agent_id != agent_id && binding.bridge_session_id == bridge_session_id
+        }) {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::Busy,
+                "Claude Remote Control session is already bound to another Agent",
+            ));
+        }
+        if !bindings.contains_key(agent_id)
+            && bindings.len() >= protocol::MAX_CLAUDE_REMOTE_CONTROL_BINDINGS
+        {
+            return Err(DaemonError::lifecycle(
+                ErrorCode::Busy,
+                "Claude Remote Control binding capacity is exhausted",
+            ));
+        }
+        let binding = ClaudeRemoteControlBindingSnapshot {
+            agent_id: agent_id.into(),
+            shell_id: shell_id.into(),
+            run_id: run_id.into(),
+            bridge_session_id,
+        };
+        bindings.insert(agent_id.into(), binding.clone());
+        Ok(Some(binding))
+    }
+
+    fn get_claude_remote_control_binding(
+        &self,
+        agent_id: &str,
+        shell_id: &str,
+        run_id: &str,
+    ) -> DaemonResult<Option<ClaudeRemoteControlBindingSnapshot>> {
+        let _mutation = lock(&self.mutation_lock)?;
+        let durable = lock(&self.durable.state)?;
+        validate_claude_binding_authority(&durable, agent_id, shell_id, run_id)?;
+        let mut bindings = lock(&self.claude_remote_control.state)?;
+        prune_claude_bindings(&durable, &mut bindings)?;
+        Ok(bindings
+            .get(agent_id)
+            .cloned()
+            .filter(|binding| binding.shell_id == shell_id && binding.run_id == run_id))
+    }
+
+    fn export_claude_remote_control_bindings(
+        &self,
+    ) -> DaemonResult<Vec<ClaudeRemoteControlBindingSnapshot>> {
+        let durable = lock(&self.durable.state)?;
+        let mut bindings = lock(&self.claude_remote_control.state)?;
+        prune_claude_bindings(&durable, &mut bindings)?;
+        let mut bindings = bindings.values().cloned().collect::<Vec<_>>();
+        bindings.sort_by(|left, right| left.agent_id.cmp(&right.agent_id));
+        Ok(bindings)
+    }
+
+    fn import_claude_remote_control_bindings(
+        &self,
+        transferred: Vec<ClaudeRemoteControlBindingSnapshot>,
+    ) -> io::Result<()> {
+        let durable = lock(&self.durable.state)?;
+        let mut bindings = lock(&self.claude_remote_control.state)?;
+        if !bindings.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "replacement daemon already has Claude Remote Control bindings",
+            ));
+        }
+        for binding in transferred {
+            validate_claude_bridge_session_id(&binding.bridge_session_id)?;
+            validate_claude_binding_authority(
+                &durable,
+                &binding.agent_id,
+                &binding.shell_id,
+                &binding.run_id,
+            )
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+            if bindings
+                .values()
+                .any(|existing| existing.bridge_session_id == binding.bridge_session_id)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "duplicate Claude bridge session ID in handoff",
+                ));
+            }
+            bindings.insert(binding.agent_id.clone(), binding);
+        }
+        Ok(())
     }
 
     fn dispatch(&self, request: Request) -> DaemonResult<Response> {
@@ -13192,6 +13384,21 @@ impl DaemonService {
                 root_session_id,
                 report,
             } => self.report_claimed_opencode_agent(&generation_id, &root_session_id, report),
+            Request::SetClaudeRemoteControlBinding {
+                agent_id,
+                shell_id,
+                run_id,
+                bridge_session_id,
+            } => self
+                .set_claude_remote_control_binding(&agent_id, &shell_id, &run_id, bridge_session_id)
+                .map(|binding| Response::ClaudeRemoteControlBinding { binding }),
+            Request::GetClaudeRemoteControlBinding {
+                agent_id,
+                shell_id,
+                run_id,
+            } => self
+                .get_claude_remote_control_binding(&agent_id, &shell_id, &run_id)
+                .map(|binding| Response::ClaudeRemoteControlBinding { binding }),
             Request::ReportAgent {
                 agent_id,
                 run_id,
@@ -13776,6 +13983,7 @@ impl DaemonService {
                 stopping: AtomicBool::new(false),
             },
             opencode: OpenCodeCoordinator::default(),
+            claude_remote_control: ClaudeRemoteControlBindings::default(),
             remote_attachments: RemoteAttachmentManager::default(),
             host_service_previews: Mutex::new(HashMap::new()),
             workspace_operation_locks: Mutex::new(HashMap::new()),
@@ -16400,6 +16608,7 @@ struct RuntimeStart<'a> {
     profile: &'a TerminalProfile,
     environment: Option<&'a UnixEnvironment>,
     recovery: RuntimeRecovery<'a>,
+    claude_remote_control: bool,
 }
 
 impl ShellRuntimeManager {
@@ -16415,6 +16624,7 @@ impl ShellRuntimeManager {
             profile,
             environment,
             recovery,
+            claude_remote_control,
         } = start;
         let pty = native_pty_system()
             .openpty(PtySize {
@@ -16428,12 +16638,20 @@ impl ShellRuntimeManager {
         let reader = master.try_clone_reader()?;
 
         let selected_command = recovery.effective_command.unwrap_or(&shell.command);
+        let claude_command = claude_remote_control_command(
+            shell,
+            selected_command,
+            recovery.effective_command.is_some(),
+            claude_remote_control,
+        );
+        let selected_command = claude_command.as_deref().unwrap_or(selected_command);
         let original_environment = environment
             .cloned()
             .unwrap_or_else(capture_current_environment);
         let mut child_environment = sanitize_opencode_shim_environment(&original_environment);
         if opencode_shim_eligible(shell, selected_command)
-            && let Ok(injected) = inject_opencode_shim_environment(&child_environment)
+            && let Ok(injected) =
+                inject_opencode_shim_environment(&child_environment, claude_remote_control)
         {
             child_environment = injected;
         }
@@ -17013,6 +17231,7 @@ impl ShellRuntimeManager {
                             effective_command: resume_command.as_deref(),
                             history: restored_history.as_deref(),
                         },
+                        claude_remote_control: registry.notification_settings.claude_remote_control,
                     },
                 ) {
                     Ok(runtime) => runtime,
@@ -18249,6 +18468,124 @@ fn validate_required_agent_string(kind: &str, value: &str, max_bytes: usize) -> 
     Ok(())
 }
 
+fn validate_claude_bridge_session_id(bridge_session_id: &str) -> io::Result<()> {
+    if bridge_session_id.is_empty()
+        || bridge_session_id.len() > protocol::MAX_CLAUDE_BRIDGE_SESSION_ID_BYTES
+        || bridge_session_id.chars().any(char::is_control)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Claude bridge session ID must be nonempty, control-free, and at most {} bytes",
+                protocol::MAX_CLAUDE_BRIDGE_SESSION_ID_BYTES
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_claude_binding_authority(
+    state: &DurableState,
+    agent_id: &str,
+    shell_id: &str,
+    run_id: &str,
+) -> DaemonResult<()> {
+    validate_claude_binding_identity(state, agent_id, shell_id, run_id)?;
+    if !claude_binding_is_current(
+        state,
+        &ClaudeRemoteControlBindingSnapshot {
+            agent_id: agent_id.into(),
+            shell_id: shell_id.into(),
+            run_id: run_id.into(),
+            bridge_session_id: String::new(),
+        },
+    )? {
+        return Err(DaemonError::lifecycle(
+            ErrorCode::RunChanged,
+            "Claude Remote Control binding does not match an active current ShellRun",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_claude_binding_identity(
+    state: &DurableState,
+    agent_id: &str,
+    shell_id: &str,
+    run_id: &str,
+) -> DaemonResult<()> {
+    validate_uuid(agent_id, "Claude Agent ID")?;
+    validate_uuid(shell_id, "Claude Shell ID")?;
+    validate_uuid(run_id, "Claude ShellRun ID")?;
+    let agent = state
+        .agents
+        .get(agent_id)
+        .ok_or_else(|| not_found("agent", agent_id))?;
+    if agent.integration != "claude" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Claude Remote Control binding requires a Claude Agent",
+        )
+        .into());
+    }
+    if agent.shell_id != shell_id || agent.run_id != run_id {
+        return Err(DaemonError::lifecycle(
+            ErrorCode::RunChanged,
+            "Claude Remote Control binding does not match the Agent ShellRun",
+        ));
+    }
+    Ok(())
+}
+
+fn claude_binding_is_current(
+    state: &DurableState,
+    binding: &ClaudeRemoteControlBindingSnapshot,
+) -> io::Result<bool> {
+    let Some(agent) = state.agents.get(&binding.agent_id) else {
+        return Ok(false);
+    };
+    if agent.integration != "claude"
+        || agent.shell_id != binding.shell_id
+        || agent.run_id != binding.run_id
+    {
+        return Ok(false);
+    }
+    let agent_state = lock(&agent.state)?;
+    if agent_state.ended_at_ms.is_some()
+        || matches!(
+            agent_state.observation.state,
+            AgentState::Inactive | AgentState::Done
+        )
+    {
+        return Ok(false);
+    }
+    drop(agent_state);
+    let Some(shell) = state.shells.get(&binding.shell_id) else {
+        return Ok(false);
+    };
+    Ok(matches!(
+        &*lock(&shell.lifecycle)?,
+        ShellLifecycle::Running { run, .. } if run.id == binding.run_id
+    ))
+}
+
+fn prune_claude_bindings(
+    state: &DurableState,
+    bindings: &mut HashMap<String, ClaudeRemoteControlBindingSnapshot>,
+) -> io::Result<()> {
+    let stale = bindings
+        .iter()
+        .map(|(agent_id, binding)| {
+            claude_binding_is_current(state, binding)
+                .map(|current| (!current).then(|| agent_id.clone()))
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    for agent_id in stale.into_iter().flatten() {
+        bindings.remove(&agent_id);
+    }
+    Ok(())
+}
+
 fn validate_persisted_agent(agent: &PersistedAgentInstance) -> io::Result<()> {
     validate_persisted_name(&agent.name)?;
     validate_agent_registration(&AgentRegistrationSpec {
@@ -18404,6 +18741,7 @@ mod tests {
                 profile,
                 environment,
                 recovery,
+                claude_remote_control: true,
             },
         )
     }
@@ -18524,6 +18862,57 @@ mod tests {
     }
 
     #[test]
+    fn claude_remote_control_rewrites_only_bare_user_commands() {
+        let command = create_pending_shell(
+            "workspace",
+            ShellSpec {
+                name: "claude".into(),
+                cwd: env::temp_dir(),
+                command: vec!["/opt/anthropic/bin/claude".into()],
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            claude_remote_control_command(&command, &command.command, false, true),
+            Some(vec![
+                "/opt/anthropic/bin/claude".into(),
+                "--remote-control".into(),
+            ])
+        );
+        for (argv, recovery, enabled) in [
+            (
+                vec!["claude".into(), "--resume".into(), "id".into()],
+                false,
+                true,
+            ),
+            (vec!["claude".into()], true, true),
+            (vec!["claude".into()], false, false),
+            (vec!["claude-wrapper".into()], false, true),
+        ] {
+            assert!(
+                claude_remote_control_command(&command, &argv, recovery, enabled).is_none(),
+                "rewrote {argv:?}"
+            );
+        }
+
+        let mut scheduled = create_pending_shell(
+            "workspace",
+            ShellSpec {
+                name: "scheduled".into(),
+                cwd: env::temp_dir(),
+                command: vec!["claude".into()],
+            },
+        )
+        .unwrap();
+        Arc::get_mut(&mut scheduled).unwrap().owner = ShellOwner::Schedule {
+            schedule_id: "schedule-1".into(),
+        };
+        assert!(
+            claude_remote_control_command(&scheduled, &scheduled.command, false, true).is_none()
+        );
+    }
+
+    #[test]
     fn inherited_opencode_shim_provenance_is_stripped_without_losing_identity() {
         let mut environment = test_environment(&[
             ("PATH", Path::new("/runtime/boomux/shims:/usr/bin")),
@@ -18533,6 +18922,8 @@ mod tests {
                 Path::new("/runtime/boomux/shims"),
             ),
             ("BOOMUX_REAL_OPENCODE", Path::new("/usr/bin/opencode")),
+            ("BOOMUX_REAL_CLAUDE", Path::new("/usr/bin/claude")),
+            ("BOOMUX_CLAUDE_REMOTE_CONTROL", Path::new("1")),
             (
                 "BOOMUX_OPENCODE_TUI_CONFIG",
                 Path::new("/runtime/boomux/shims/tui.json"),
@@ -18563,6 +18954,8 @@ mod tests {
             b"BOOMUX_ORIGINAL_PATH".as_slice(),
             b"BOOMUX_OPENCODE_SHIM_DIR",
             b"BOOMUX_REAL_OPENCODE",
+            b"BOOMUX_REAL_CLAUDE",
+            b"BOOMUX_CLAUDE_REMOTE_CONTROL",
             b"BOOMUX_OPENCODE_TUI_CONFIG",
             b"BOOMUX_SHIM_EXECUTABLE",
             b"BOOMUX_OPENCODE_SHARED_GENERATION",
@@ -18657,9 +19050,12 @@ mod tests {
         let host = bin.join("opencode");
         fs::write(&host, b"#!/bin/sh\nprintf '<%s>\\n' \"$@\"\n").unwrap();
         fs::set_permissions(&host, fs::Permissions::from_mode(0o700)).unwrap();
+        let claude = bin.join("claude");
+        fs::write(&claude, b"#!/bin/sh\nprintf '[%s]\\n' \"$@\"\n").unwrap();
+        fs::set_permissions(&claude, fs::Permissions::from_mode(0o700)).unwrap();
         let environment = test_environment(&[("XDG_RUNTIME_DIR", &runtime), ("PATH", &bin)]);
 
-        let injected = inject_opencode_shim_environment(&environment).unwrap();
+        let injected = inject_opencode_shim_environment(&environment, true).unwrap();
         let shim =
             PathBuf::from(environment_value(&injected, b"BOOMUX_OPENCODE_SHIM_DIR").unwrap())
                 .join("opencode");
@@ -18698,6 +19094,20 @@ mod tests {
                 .unwrap()
                 .contains("exec \"$BOOMUX_SHIM_EXECUTABLE\" opencode shared")
         );
+        let claude_shim = shim.with_file_name("claude");
+        let explicit = Command::new(&claude_shim)
+            .args(["--resume", "exact; id"])
+            .env("BOOMUX_REAL_CLAUDE", &claude)
+            .env("BOOMUX_CLAUDE_REMOTE_CONTROL", "1")
+            .output()
+            .unwrap();
+        assert!(explicit.status.success());
+        assert_eq!(explicit.stdout, b"[--resume]\n[exact; id]\n");
+        assert!(
+            std::str::from_utf8(CLAUDE_SHIM)
+                .unwrap()
+                .contains("exec \"$BOOMUX_REAL_CLAUDE\" --remote-control")
+        );
         fs::remove_dir_all(directory).unwrap();
     }
 
@@ -18710,7 +19120,7 @@ mod tests {
         fs::create_dir_all(&empty_bin).unwrap();
         let environment = test_environment(&[("XDG_RUNTIME_DIR", &runtime), ("PATH", &empty_bin)]);
         let sanitized = sanitize_opencode_shim_environment(&environment);
-        assert!(inject_opencode_shim_environment(&sanitized).is_err());
+        assert!(inject_opencode_shim_environment(&sanitized, true).is_err());
         assert_eq!(sanitized, environment);
         fs::remove_dir_all(directory).unwrap();
     }
@@ -18832,6 +19242,28 @@ mod tests {
                 .is_none()
         );
         assert!(registry.recovery_presentation(&shell.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn interrupted_claude_agent_builds_exact_resume_command() {
+        let registry = DaemonService::default();
+        let (shell, run) = recovery_shell(&registry, vec!["/opt/bin/claude".into()]);
+        let agent_id = add_recovery_agent(&registry, &shell, &run.id, "claude", "claude-exact");
+
+        assert_eq!(
+            registry.snapshot().unwrap().workspaces[0].shells[0]
+                .recovered_agent_id
+                .as_deref(),
+            Some(agent_id.as_str())
+        );
+        assert_eq!(
+            registry.agent_resume_command(&shell, Some(&run)).unwrap(),
+            Some(vec![
+                "/opt/bin/claude".into(),
+                "--resume".into(),
+                "claude-exact".into(),
+            ])
+        );
     }
 
     #[test]
@@ -18980,6 +19412,110 @@ mod tests {
             claims: HashMap::new(),
         };
         generation_id
+    }
+
+    #[test]
+    fn claude_remote_control_binding_requires_exact_active_claude_agent() {
+        let registry = DaemonService::default();
+        let (_, shell, _runtime) = running_shell(&registry);
+        let run_id = match &*lock(&shell.lifecycle).unwrap() {
+            ShellLifecycle::Running { run, .. } => run.id.clone(),
+            _ => unreachable!(),
+        };
+        let Response::Agent { agent } = registry
+            .dispatch(Request::EnsureAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec: AgentRegistrationSpec {
+                    name: "Claude Code".into(),
+                    integration: "claude".into(),
+                    external_session_id: Some("claude-session".into()),
+                    report: agent_report(
+                        AgentState::Idle,
+                        AgentAuthority::LifecycleIntegration,
+                        "Claude session idle",
+                    ),
+                },
+            })
+            .unwrap()
+        else {
+            panic!("unexpected Agent ensure response");
+        };
+        let binding = registry
+            .set_claude_remote_control_binding(
+                &agent.id,
+                &shell.id,
+                &run_id,
+                Some("bridge/exact".into()),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(binding.bridge_session_id, "bridge/exact");
+        assert_eq!(
+            registry
+                .get_claude_remote_control_binding(&agent.id, &shell.id, &run_id)
+                .unwrap(),
+            Some(binding)
+        );
+        assert!(
+            registry
+                .set_claude_remote_control_binding(
+                    &agent.id,
+                    &shell.id,
+                    &Uuid::new_v4().to_string(),
+                    Some("other".into()),
+                )
+                .is_err()
+        );
+        assert!(
+            registry
+                .set_claude_remote_control_binding(
+                    &agent.id,
+                    &shell.id,
+                    &run_id,
+                    Some("bad\nbridge".into()),
+                )
+                .is_err()
+        );
+        registry
+            .dispatch(Request::ReportAgent {
+                agent_id: agent.id.clone(),
+                run_id: run_id.clone(),
+                report: agent_report(
+                    AgentState::Inactive,
+                    AgentAuthority::LifecycleIntegration,
+                    "Claude session inactive",
+                ),
+            })
+            .unwrap();
+        assert!(
+            registry
+                .set_claude_remote_control_binding(
+                    &agent.id,
+                    &shell.id,
+                    &run_id,
+                    Some("inactive".into()),
+                )
+                .is_err()
+        );
+        assert_eq!(
+            registry
+                .set_claude_remote_control_binding(&agent.id, &shell.id, &run_id, None)
+                .unwrap(),
+            None
+        );
+        assert!(
+            lock(&registry.claude_remote_control.state)
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            registry
+                .get_claude_remote_control_binding(&agent.id, &shell.id, &run_id)
+                .unwrap_err()
+                .wire_code(),
+            ErrorCode::RunChanged
+        );
     }
 
     #[test]

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -11,15 +11,15 @@ use serde::{Deserialize, Serialize};
 use crate::client;
 use crate::fd_transfer::receive_descriptor;
 use crate::protocol::{
-    self, DaemonEvent, FocusedTerminalSnapshot, NotificationDeliveryConfig,
-    QualifiedFocusedTerminalSnapshot, TerminalProfile,
+    self, ClaudeRemoteControlBindingSnapshot, DaemonEvent, FocusedTerminalSnapshot,
+    NotificationDeliveryConfig, QualifiedFocusedTerminalSnapshot, TerminalProfile,
 };
 use crate::state_store;
 
 const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 pub(crate) const CHANNEL_FD: RawFd = 198;
-pub(crate) const HEADER: &[u8; 8] = b"BOOMUXH5";
-pub(crate) const OLD_HEADER: &[u8; 8] = b"BOOMUXH4";
+pub(crate) const HEADER: &[u8; 8] = b"BOOMUXH6";
+pub(crate) const OLD_HEADER: &[u8; 8] = b"BOOMUXH5";
 pub(crate) const LISTENER_MARKER: u8 = 1;
 pub(crate) const RUNTIME_LOCK_MARKER: u8 = 2;
 pub(crate) const STATE_LOCK_MARKER: u8 = 3;
@@ -46,6 +46,8 @@ pub(crate) struct Manifest {
     pub(crate) presented_focused_terminal: Option<QualifiedFocusedTerminalSnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) opencode_runtime: Option<OpenCodeRuntimeManifest>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) claude_remote_control_bindings: Vec<ClaudeRemoteControlBindingSnapshot>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -116,6 +118,7 @@ pub(crate) enum Bootstrap {
         focused_terminal: Option<Box<FocusedTerminalSnapshot>>,
         presented_focused_terminal: Option<Box<QualifiedFocusedTerminalSnapshot>>,
         opencode_runtime: Option<TransferredOpenCodeRuntime>,
+        claude_remote_control_bindings: Vec<ClaudeRemoteControlBindingSnapshot>,
     },
 }
 
@@ -135,6 +138,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
     validate_manifest(&manifest)?;
     let event_stream = manifest.event_stream.clone();
     let notifications = manifest.notifications.clone();
+    let claude_remote_control_bindings = manifest.claude_remote_control_bindings.clone();
     let focused_terminal = manifest.focused_terminal.clone().map(Box::new);
     let presented_focused_terminal = manifest.presented_focused_terminal.clone().map(Box::new);
     let listener = receive_descriptor(&channel, LISTENER_MARKER)?;
@@ -217,6 +221,7 @@ pub(crate) fn receive_bootstrap(channel: RawFd) -> io::Result<Bootstrap> {
             focused_terminal,
             presented_focused_terminal,
             opencode_runtime,
+            claude_remote_control_bindings,
         }),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -314,6 +319,31 @@ fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
             io::ErrorKind::InvalidData,
             "handoff manifest contains too many runtimes",
         ));
+    }
+    if manifest.claude_remote_control_bindings.len() > protocol::MAX_CLAUDE_REMOTE_CONTROL_BINDINGS
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "handoff manifest contains too many Claude Remote Control bindings",
+        ));
+    }
+    let mut binding_agent_ids = std::collections::HashSet::new();
+    let mut binding_bridge_ids = std::collections::HashSet::new();
+    for binding in &manifest.claude_remote_control_bindings {
+        if uuid::Uuid::parse_str(&binding.agent_id).is_err()
+            || uuid::Uuid::parse_str(&binding.shell_id).is_err()
+            || uuid::Uuid::parse_str(&binding.run_id).is_err()
+            || binding.bridge_session_id.is_empty()
+            || binding.bridge_session_id.len() > protocol::MAX_CLAUDE_BRIDGE_SESSION_ID_BYTES
+            || binding.bridge_session_id.chars().any(char::is_control)
+            || !binding_agent_ids.insert(&binding.agent_id)
+            || !binding_bridge_ids.insert(&binding.bridge_session_id)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "handoff manifest contains an invalid Claude Remote Control binding",
+            ));
+        }
     }
     let mut shell_ids = std::collections::HashSet::new();
     let mut run_ids = std::collections::HashSet::new();
@@ -500,13 +530,14 @@ mod tests {
         assert!(manifest.focused_terminal.is_none());
         assert!(manifest.presented_focused_terminal.is_none());
         assert!(manifest.opencode_runtime.is_none());
+        assert!(manifest.claude_remote_control_bindings.is_empty());
     }
 
     #[test]
-    fn h4_and_h5_bootstrap_headers_remain_accepted() {
+    fn h5_and_h6_bootstrap_headers_remain_accepted() {
         assert!(supported_header(OLD_HEADER));
         assert!(supported_header(HEADER));
-        assert!(!supported_header(b"BOOMUXH3"));
+        assert!(!supported_header(b"BOOMUXH4"));
     }
 
     #[test]
@@ -531,6 +562,7 @@ mod tests {
                 ),
             }),
             opencode_runtime: None,
+            claude_remote_control_bindings: Vec::new(),
         };
 
         let decoded: Manifest =
@@ -555,6 +587,7 @@ mod tests {
                 port: 4096,
                 pid: 42,
             }),
+            claude_remote_control_bindings: Vec::new(),
         };
 
         validate_manifest(&manifest).unwrap();
@@ -565,6 +598,30 @@ mod tests {
         assert_eq!(runtime.generation_id, generation_id);
         assert_eq!(runtime.port, 4096);
         assert_eq!(runtime.pid, 42);
+    }
+
+    #[test]
+    fn manifest_round_trips_bounded_claude_remote_control_binding() {
+        let binding = ClaudeRemoteControlBindingSnapshot {
+            agent_id: uuid::Uuid::new_v4().to_string(),
+            shell_id: uuid::Uuid::new_v4().to_string(),
+            run_id: uuid::Uuid::new_v4().to_string(),
+            bridge_session_id: "bridge/exact".into(),
+        };
+        let manifest = Manifest {
+            runtimes: Vec::new(),
+            exited: Vec::new(),
+            event_stream: event_stream(),
+            notifications: None,
+            focused_terminal: None,
+            presented_focused_terminal: None,
+            opencode_runtime: None,
+            claude_remote_control_bindings: vec![binding.clone()],
+        };
+        validate_manifest(&manifest).unwrap();
+        let decoded: Manifest =
+            serde_json::from_value(serde_json::to_value(manifest).unwrap()).unwrap();
+        assert_eq!(decoded.claude_remote_control_bindings, [binding]);
     }
 
     #[test]
@@ -589,6 +646,7 @@ mod tests {
                 focused_terminal: None,
                 presented_focused_terminal: None,
                 opencode_runtime: None,
+                claude_remote_control_bindings: Vec::new(),
             };
             assert_eq!(
                 validate_manifest(&manifest).unwrap_err().kind(),

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -31,6 +31,12 @@ pub(crate) const PI_ASSET: &str = boomux::integrations::PI
     .as_ref()
     .expect("Pi installation capability")
     .content;
+#[cfg(test)]
+pub(crate) const CLAUDE_ASSET: &str = boomux::integrations::CLAUDE
+    .installation
+    .as_ref()
+    .expect("Claude installation capability")
+    .content;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct IntegrationId(&'static IntegrationDescriptor);
@@ -42,6 +48,9 @@ impl IntegrationId {
     pub(crate) const Opencode: Self = Self::OPENCODE;
     #[allow(non_upper_case_globals)]
     pub(crate) const Pi: Self = Self::PI;
+    #[cfg(test)]
+    #[allow(non_upper_case_globals)]
+    pub(crate) const Claude: Self = Self(&boomux::integrations::CLAUDE);
 
     pub(crate) const fn spec(self) -> &'static IntegrationDescriptor {
         self.0
@@ -84,6 +93,7 @@ pub(crate) struct Environment {
     home: Option<OsString>,
     xdg_config_home: Option<OsString>,
     pi_coding_agent_dir: Option<OsString>,
+    claude_config_dir: Option<OsString>,
     path: Option<OsString>,
 }
 
@@ -93,6 +103,7 @@ impl Environment {
             home: env::var_os("HOME"),
             xdg_config_home: env::var_os("XDG_CONFIG_HOME"),
             pi_coding_agent_dir: env::var_os("PI_CODING_AGENT_DIR"),
+            claude_config_dir: env::var_os("CLAUDE_CONFIG_DIR"),
             path: env::var_os("PATH"),
         }
     }
@@ -102,12 +113,14 @@ impl Environment {
         home: Option<OsString>,
         xdg_config_home: Option<OsString>,
         pi_coding_agent_dir: Option<OsString>,
+        claude_config_dir: Option<OsString>,
         path: Option<OsString>,
     ) -> Self {
         Self {
             home,
             xdg_config_home,
             pi_coding_agent_dir,
+            claude_config_dir,
             path,
         }
     }
@@ -866,6 +879,10 @@ fn config_root(id: IntegrationId, environment: &Environment) -> Result<PathBuf, 
             environment.pi_coding_agent_dir.clone(),
             environment.home.clone(),
         ),
+        InstallTargetKind::Claude => claude_config_root(
+            environment.claude_config_dir.clone(),
+            environment.home.clone(),
+        ),
     }
 }
 
@@ -879,6 +896,10 @@ fn target_at(id: IntegrationId, config_root: &Path) -> InstallTarget {
             directory: config_root.join("extensions"),
             path: config_root.join("extensions/boomux.js"),
         },
+        InstallTargetKind::Claude => InstallTarget {
+            directory: config_root.join("skills/boomux/.claude-plugin"),
+            path: config_root.join("skills/boomux/.claude-plugin/plugin.json"),
+        },
     }
 }
 
@@ -887,6 +908,7 @@ const fn config_root_name(id: IntegrationId) -> &'static str {
     match id.installation().target {
         InstallTargetKind::OpenCode => "XDG configuration root",
         InstallTargetKind::Pi => "Pi configuration root",
+        InstallTargetKind::Claude => "Claude configuration root",
     }
 }
 
@@ -933,6 +955,24 @@ pub(crate) fn pi_config_root(
         None => home()?.join(".pi/agent"),
     };
     require_absolute_root(&root, "Pi configuration root")?;
+    Ok(root)
+}
+
+pub(crate) fn claude_config_root(
+    claude_config_dir: Option<OsString>,
+    home: Option<OsString>,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let root = match claude_config_dir.filter(|value| !value.is_empty()) {
+        Some(root) => PathBuf::from(root),
+        None => PathBuf::from(home.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "HOME must be set to install the Boomux Claude Code plugin",
+            )
+        })?)
+        .join(".claude"),
+    };
+    require_absolute_root(&root, "Claude configuration root")?;
     Ok(root)
 }
 
@@ -1142,6 +1182,7 @@ mod tests {
             Some(home.as_os_str().to_owned()),
             None,
             None,
+            None,
             Some(OsString::new()),
         )
     }
@@ -1153,6 +1194,22 @@ mod tests {
             "opencode-ai"
         );
         assert_eq!(IntegrationId::Pi.installation().validated_version, "0.84.1");
+        assert_eq!(
+            IntegrationId::Claude.installation().package,
+            "@anthropic-ai/claude-code"
+        );
+        assert_eq!(
+            IntegrationId::Claude.installation().validated_version,
+            "2.1.236"
+        );
+        assert!(IntegrationId::Claude.spec().titles.is_none());
+        assert_eq!(
+            IntegrationId::Claude
+                .spec()
+                .foreground
+                .map(|capability| capability.process_name),
+            Some("claude")
+        );
         assert_ne!(
             IntegrationId::Opencode.spec().key,
             IntegrationId::Pi.spec().key
@@ -1174,6 +1231,81 @@ mod tests {
             Path::new("/home/example/.config/pi")
         );
         assert!(pi_config_root(Some("relative".into()), None).is_err());
+        assert_eq!(
+            claude_config_root(Some("/claude".into()), Some("/home/example".into())).unwrap(),
+            Path::new("/claude")
+        );
+        assert_eq!(
+            claude_config_root(Some(OsString::new()), Some("/home/example".into())).unwrap(),
+            Path::new("/home/example/.claude")
+        );
+        assert!(claude_config_root(Some("relative".into()), None).is_err());
+    }
+
+    #[test]
+    fn claude_plugin_manifest_uses_exec_hooks_for_required_events() {
+        let manifest: serde_json::Value = serde_json::from_str(CLAUDE_ASSET).unwrap();
+        assert_eq!(manifest["name"], "boomux");
+        let hooks = manifest["hooks"].as_object().unwrap();
+        assert_eq!(
+            hooks.keys().map(String::as_str).collect::<Vec<_>>(),
+            [
+                "Notification",
+                "PermissionDenied",
+                "PermissionRequest",
+                "PostToolUse",
+                "PostToolUseFailure",
+                "PreToolUse",
+                "SessionEnd",
+                "SessionStart",
+                "Stop",
+                "StopFailure",
+                "SubagentStart",
+                "SubagentStop",
+                "UserPromptSubmit",
+            ]
+        );
+        for groups in hooks.values() {
+            let handlers = groups[0]["hooks"].as_array().unwrap();
+            assert_eq!(handlers.len(), 1);
+            assert_eq!(handlers[0]["type"], "command");
+            assert_eq!(handlers[0]["command"], "boomux");
+            assert_eq!(handlers[0]["args"], serde_json::json!(["claude", "hook"]));
+            assert_eq!(handlers[0]["timeout"], 5);
+        }
+    }
+
+    #[test]
+    fn claude_status_install_and_uninstall_use_skills_directory_plugin() {
+        let home = TestDirectory::new("claude-install");
+        let config = home.0.join("claude-config");
+        let environment = Environment::for_test(
+            Some(home.0.as_os_str().to_owned()),
+            None,
+            None,
+            Some(config.as_os_str().to_owned()),
+            Some(OsString::new()),
+        );
+        let expected = config.join("skills/boomux/.claude-plugin/plugin.json");
+
+        let missing = inspect(IntegrationId::Claude, &environment, None);
+        assert_eq!(missing.asset.state, AssetState::Missing);
+        assert_eq!(missing.asset.path.as_deref(), expected.to_str());
+
+        let installed = install(IntegrationId::Claude, &environment, false).unwrap();
+        assert_eq!(installed.result, InstallOutcome::Installed);
+        assert_eq!(Path::new(&installed.path), expected);
+        assert_eq!(fs::read_to_string(&expected).unwrap(), CLAUDE_ASSET);
+        assert_eq!(
+            inspect(IntegrationId::Claude, &environment, None)
+                .asset
+                .state,
+            AssetState::Current
+        );
+
+        let removed = uninstall(IntegrationId::Claude, &environment, false).unwrap();
+        assert_eq!(removed.result, UninstallOutcome::Removed);
+        assert!(!expected.exists());
     }
 
     #[test]

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 pub enum InstallTargetKind {
     OpenCode,
     Pi,
+    Claude,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -95,6 +96,21 @@ impl ScheduleDispatchCapability {
                     "--session".into(),
                     external_session_id.clone(),
                     "--print".into(),
+                ]);
+            }
+            ("claude", AgentScheduleSession::Fresh) if self.fresh => {
+                argv.push("--print".into());
+            }
+            (
+                "claude",
+                AgentScheduleSession::Continue {
+                    external_session_id,
+                },
+            ) if self.continuation => {
+                argv.extend([
+                    "--print".into(),
+                    "--resume".into(),
+                    external_session_id.clone(),
                 ]);
             }
             _ => return None,
@@ -207,7 +223,34 @@ pub const PI: IntegrationDescriptor = IntegrationDescriptor {
     foreground: Some(ForegroundCapability { process_name: "pi" }),
 };
 
-pub const ALL: &[IntegrationDescriptor] = &[OPENCODE, PI];
+pub const CLAUDE: IntegrationDescriptor = IntegrationDescriptor {
+    key: "claude",
+    display_name: "Claude Code",
+    installation: Some(InstallationCapability {
+        package: "@anthropic-ai/claude-code",
+        validated_version: "2.1.236",
+        asset_name: "plugin manifest",
+        content: include_str!("../integrations/claude/.claude-plugin/plugin.json"),
+        executable: "claude",
+        reload_message: "Restart any running Claude Code process to activate the plugin",
+        target: InstallTargetKind::Claude,
+    }),
+    titles: None,
+    resume: Some(ResumeCapability {
+        executable: "claude",
+        session_argument: "--resume",
+    }),
+    schedule_dispatch: Some(ScheduleDispatchCapability {
+        fresh: true,
+        continuation: true,
+        prompt_transport: PromptTransport::Stdin,
+    }),
+    foreground: Some(ForegroundCapability {
+        process_name: "claude",
+    }),
+};
+
+pub const ALL: &[IntegrationDescriptor] = &[OPENCODE, PI, CLAUDE];
 
 pub fn by_key(key: &str) -> Option<&'static IntegrationDescriptor> {
     descriptor_by_key(ALL, key)
@@ -362,6 +405,10 @@ mod tests {
                 .command(&["opencode".into(), "--continue".into()], "session-1")
                 .is_none()
         );
+        assert_eq!(
+            CLAUDE.resume.unwrap().command(&[], "session-2"),
+            Some(vec!["claude".into(), "--resume".into(), "session-2".into()])
+        );
     }
 
     #[test]
@@ -398,6 +445,39 @@ mod tests {
                     "exact-full-id".into(),
                     "--print".into(),
                 ],
+                stdin: Some(prompt.as_bytes().to_vec()),
+            }
+        );
+        assert_eq!(
+            CLAUDE
+                .schedule_dispatch
+                .unwrap()
+                .command(
+                    "claude",
+                    &AgentScheduleSession::Continue {
+                        external_session_id: "exact-id".into(),
+                    },
+                    prompt,
+                )
+                .unwrap(),
+            ScheduleDispatchCommand {
+                argv: vec![
+                    "claude".into(),
+                    "--print".into(),
+                    "--resume".into(),
+                    "exact-id".into(),
+                ],
+                stdin: Some(prompt.as_bytes().to_vec()),
+            }
+        );
+        assert_eq!(
+            CLAUDE
+                .schedule_dispatch
+                .unwrap()
+                .command("claude", &AgentScheduleSession::Fresh, prompt)
+                .unwrap(),
+            ScheduleDispatchCommand {
+                argv: vec!["claude".into(), "--print".into()],
                 stdin: Some(prompt.as_bytes().to_vec()),
             }
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ use crate::integration_management::{
 };
 
 mod agent_attention_projection;
+mod claude_hooks;
 mod cli_output;
 mod config;
 mod dashboard_projection;
@@ -280,6 +281,7 @@ const MAX_HOST_CATALOG_DIRECTORIES: usize = 8;
 const NON_PROTOCOL_FEATURES: &[&str] = &[
     "opencode_lifecycle_plugin",
     "pi_lifecycle_extension",
+    "claude_lifecycle_plugin",
     "process_adapters",
     "desktop_notifications",
     "sound_notifications",
@@ -503,6 +505,12 @@ enum Commands {
     Pi {
         #[command(subcommand)]
         command: PiCommands,
+    },
+    /// Receive Claude Code lifecycle hooks
+    #[command(hide = true)]
+    Claude {
+        #[command(subcommand)]
+        command: ClaudeCommands,
     },
     /// Open a shell in a new terminal window
     Open {
@@ -1269,6 +1277,13 @@ enum PiCommands {
 }
 
 #[derive(Subcommand)]
+enum ClaudeCommands {
+    /// Receive one lifecycle event on standard input
+    #[command(hide = true)]
+    Hook,
+}
+
+#[derive(Subcommand)]
 enum IntegrationCommands {
     /// List integrations bundled with this Boomux binary
     List,
@@ -1452,6 +1467,7 @@ command_keys! {
     OpencodeClaimRelease => ("opencode.claim.release", PrivateJson),
     OpencodeClaimReport => ("opencode.claim.report", PrivateJson),
     Pi => ("pi", HumanOnly),
+    ClaudeHook => ("claude.hook", HumanOnly),
     Open => ("open", HumanOnly),
     Prompt => ("prompt", HumanOnly),
     DaemonStatus => ("daemon.status", Json),
@@ -1696,6 +1712,9 @@ impl Cli {
             Some(Commands::Pi {
                 command: PiCommands::Install { .. },
             }) => CommandKey::Pi,
+            Some(Commands::Claude {
+                command: ClaudeCommands::Hook,
+            }) => CommandKey::ClaudeHook,
             Some(Commands::Open { .. }) => CommandKey::Open,
             Some(Commands::Prompt) => CommandKey::Prompt,
             Some(Commands::Attach { .. }) => CommandKey::Attach,
@@ -2041,6 +2060,14 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Pi {
             command: PiCommands::Install { force },
         }) => install_pi(force),
+        Some(Commands::Claude {
+            command: ClaudeCommands::Hook,
+        }) => {
+            if let Err(error) = claude_hook_command() {
+                eprintln!("boomux claude hook: {error}");
+            }
+            Ok(())
+        }
         Some(Commands::Open {
             shell_id,
             node,
@@ -10029,6 +10056,61 @@ fn register_or_ensure_agent(
     Ok(())
 }
 
+fn claude_hook_command() -> Result<(), Box<dyn Error>> {
+    let (shell_id, run_id) = match (
+        env::var("BOOMUX_SHELL_ID").ok(),
+        env::var("BOOMUX_RUN_ID").ok(),
+    ) {
+        (Some(shell_id), Some(run_id)) => {
+            resolve_agent_context(None, None, Some(shell_id), Some(run_id))?
+        }
+        _ => return Ok(()),
+    };
+    let update = claude_hooks::read_update(io::stdin().lock())?;
+    let initial = update.observation.as_ref();
+    let report = AgentReport {
+        state: initial.map_or(AgentState::Unknown, |observation| observation.state),
+        authority: AgentAuthority::LifecycleIntegration,
+        evidence: initial
+            .map_or("Claude lifecycle event", |observation| observation.evidence)
+            .into(),
+        confidence: 100,
+    };
+    let client = client::connect_or_start()?;
+    let agent = client.ensure_agent(
+        &shell_id,
+        &run_id,
+        AgentRegistrationSpec {
+            name: "Claude Code".into(),
+            integration: "claude".into(),
+            external_session_id: Some(update.session_id),
+            report: report.clone(),
+        },
+    )?;
+    if initial.is_some()
+        && agent.ended_at_ms.is_none()
+        && (agent.observation.state != report.state
+            || agent.observation.authority != report.authority
+            || agent.observation.evidence != report.evidence
+            || agent.observation.confidence != report.confidence)
+    {
+        client.report_agent(&agent.id, &run_id, report)?;
+    }
+    let bridge_session_id = if update.session_ended {
+        None
+    } else {
+        match env::var("CLAUDE_CODE_BRIDGE_SESSION_ID") {
+            Ok(value) => Some(value),
+            Err(env::VarError::NotPresent) => None,
+            Err(env::VarError::NotUnicode(_)) => {
+                return Err("CLAUDE_CODE_BRIDGE_SESSION_ID must be valid UTF-8".into());
+            }
+        }
+    };
+    client.set_claude_remote_control_binding(agent.id, shell_id, run_id, bridge_session_id)?;
+    Ok(())
+}
+
 fn resolve_agent_context(
     shell_id: Option<String>,
     run_id: Option<String>,
@@ -13439,6 +13521,19 @@ mod tests {
     }
 
     #[test]
+    fn parses_hidden_claude_hook_command() {
+        let cli = Cli::try_parse_from(["boomux", "claude", "hook"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Claude {
+                command: ClaudeCommands::Hook,
+            })
+        ));
+        assert_eq!(cli.command_descriptor().key, "claude.hook");
+        assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+    }
+
+    #[test]
     fn event_snapshot_json_includes_stable_agent_data() {
         let mut project = workspace("w1", "project", vec![shell("s1", "w1", "shell")]);
         project.agents.push(agent("a1", "w1", "s1"));
@@ -14270,6 +14365,10 @@ mod tests {
         let (_, command) = dashboard_session_resume_plan(&session).unwrap();
         assert_eq!(command, ["opencode", "--session", "ses_exact"]);
 
+        session.integration = "claude".into();
+        let (_, command) = dashboard_session_resume_plan(&session).unwrap();
+        assert_eq!(command, ["claude", "--resume", "ses_exact"]);
+
         session.state_is_current = true;
         assert!(
             dashboard_session_resume_plan(&session)
@@ -14527,6 +14626,62 @@ mod tests {
         ));
         assert_eq!(list.command_descriptor().key, "integration.list");
 
+        for command in ["status", "setup", "install", "uninstall"] {
+            let parsed = Cli::try_parse_from(["boomux", "integration", command, "claude"])
+                .unwrap_or_else(|error| panic!("failed to parse integration {command}: {error}"));
+            match parsed.command.unwrap() {
+                Commands::Integration {
+                    command:
+                        IntegrationCommands::Status {
+                            integration: Some(integration_management::IntegrationId::Claude),
+                            ..
+                        },
+                }
+                | Commands::Integration {
+                    command:
+                        IntegrationCommands::Setup {
+                            integration: integration_management::IntegrationId::Claude,
+                            ..
+                        },
+                }
+                | Commands::Integration {
+                    command:
+                        IntegrationCommands::Install {
+                            integration: Some(integration_management::IntegrationId::Claude),
+                            ..
+                        },
+                }
+                | Commands::Integration {
+                    command:
+                        IntegrationCommands::Uninstall {
+                            integration: Some(integration_management::IntegrationId::Claude),
+                            ..
+                        },
+                } => {}
+                _ => panic!("unexpected parsed Claude integration command"),
+            }
+        }
+
+        let verify = Cli::try_parse_from([
+            "boomux",
+            "integration",
+            "verify",
+            "claude",
+            "--shell",
+            "shell-1",
+        ])
+        .unwrap();
+        assert!(matches!(
+            verify.command,
+            Some(Commands::Integration {
+                command: IntegrationCommands::Verify {
+                    integration: integration_management::IntegrationId::Claude,
+                    shell: Some(shell),
+                    ..
+                }
+            }) if shell == "shell-1"
+        ));
+
         let status = Cli::try_parse_from(["boomux", "integration", "status", "pi"]).unwrap();
         assert!(matches!(
             status.command,
@@ -14705,7 +14860,8 @@ mod tests {
             format_integration_list(&integrations),
             "NAME      PACKAGE                          VALIDATED VERSION\n\
              opencode  opencode-ai                      1.18.18\n\
-             pi        @earendil-works/pi-coding-agent  0.84.1\n"
+             pi        @earendil-works/pi-coding-agent  0.84.1\n\
+             claude    @anthropic-ai/claude-code        2.1.236\n"
         );
 
         let status = integration_management::IntegrationStatus {
@@ -15095,7 +15251,13 @@ mod tests {
                 .validated_version,
             "0.84.1"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 42);
+        assert_eq!(
+            integration_management::IntegrationId::Claude
+                .installation()
+                .validated_version,
+            "2.1.236"
+        );
+        assert_eq!(protocol::PROTOCOL_VERSION, 43);
     }
 
     #[test]

--- a/src/mobile_web.rs
+++ b/src/mobile_web.rs
@@ -733,6 +733,17 @@ fn opencode_handoff(
     }
 }
 
+fn claude_handoff(bridge_session_id: &str) -> NativeWebHandoff {
+    let path = format!("/code/{}", percent_encode_path_segment(bridge_session_id));
+    NativeWebHandoff {
+        integration: "claude",
+        label: "Open in Claude",
+        url: Some(format!("https://claude.ai{path}")),
+        port: None,
+        path,
+    }
+}
+
 fn base64_url(bytes: &[u8]) -> String {
     const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
     let mut encoded = String::with_capacity(bytes.len().div_ceil(3) * 4);
@@ -1246,8 +1257,30 @@ fn project_native_web_handoffs(
     opencode_web_url: Option<&str>,
     opencode_runtime_hint: Option<&OpenCodeRuntimeHint>,
 ) -> HashMap<(String, String), NativeWebHandoff> {
+    let visible_agents = project_visible_agents(combined);
+    let mut handoffs = HashMap::new();
+    for agent in visible_agents.iter().filter(|agent| {
+        agent.node_local && agent.node_current && agent.run_current && agent.integration == "claude"
+    }) {
+        let binding = client.get_claude_remote_control_binding(
+            &agent.agent_id,
+            &agent.shell_id,
+            &agent.run_id,
+        );
+        if let Ok(Some(binding)) = binding
+            && binding.agent_id == agent.agent_id
+            && binding.shell_id == agent.shell_id
+            && binding.run_id == agent.run_id
+        {
+            handoffs.insert(
+                (agent.node_id.clone(), agent.agent_id.clone()),
+                claude_handoff(&binding.bridge_session_id),
+            );
+        }
+    }
+
     let Some(runtime_hint) = opencode_runtime_hint else {
-        return HashMap::new();
+        return handoffs;
     };
     // The startup value is only a generation hint and cannot authorize a stale link.
     let Some(runtime) = client
@@ -1259,11 +1292,10 @@ fn project_native_web_handoffs(
                 && runtime.port == runtime_hint.port
         })
     else {
-        return HashMap::new();
+        return handoffs;
     };
 
-    let mut handoffs = HashMap::new();
-    for agent in project_visible_agents(combined)
+    for agent in visible_agents
         .into_iter()
         .filter(|agent| agent.node_local && agent.integration == "opencode")
     {
@@ -1695,6 +1727,19 @@ mod tests {
         assert_eq!(managed.url, None);
         assert_eq!(managed.port, Some(4097));
         assert_eq!(managed.path, "/L3dvcms/session/session-local");
+    }
+
+    #[test]
+    fn claude_handoff_targets_the_exact_encoded_bridge_session() {
+        let handoff = claude_handoff("bridge/with spaces");
+        assert_eq!(handoff.integration, "claude");
+        assert_eq!(handoff.label, "Open in Claude");
+        assert_eq!(
+            handoff.url.as_deref(),
+            Some("https://claude.ai/code/bridge%2Fwith%20spaces")
+        );
+        assert_eq!(handoff.port, None);
+        assert_eq!(handoff.path, "/code/bridge%2Fwith%20spaces");
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 42;
+pub const PROTOCOL_VERSION: u32 = 43;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -190,6 +190,10 @@ define_protocol_features! {
         "protocol_42",
         "opencode_shared_runtime_claims",
     ]),
+    ClaudeRemoteControlBindings => (43, "Claude Remote Control bindings", [
+        "protocol_43",
+        "claude_remote_control_bindings",
+    ]),
 }
 
 pub const DEFAULT_SCHEDULED_EXECUTION_LIST_LIMIT: u16 = 100;
@@ -200,6 +204,8 @@ pub const MAX_NODE_PROJECTION_TRANSITIONS: u16 = 256;
 pub const MAX_HOST_SERVICE_PROJECTS: usize = 2_000;
 pub const MAX_HOST_SERVICE_WARNINGS: usize = 64;
 pub const MAX_HOST_SERVICE_SESSIONS: usize = 1_000;
+pub const MAX_CLAUDE_REMOTE_CONTROL_BINDINGS: usize = 4_096;
+pub const MAX_CLAUDE_BRIDGE_SESSION_ID_BYTES: usize = 256;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1254,6 +1260,14 @@ pub struct OpenCodeSessionClaimSnapshot {
     pub agent_id: String,
     pub holder_count: u32,
     pub holder_expires_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClaudeRemoteControlBindingSnapshot {
+    pub agent_id: String,
+    pub shell_id: String,
+    pub run_id: String,
+    pub bridge_session_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2349,6 +2363,18 @@ pub enum Request {
         root_session_id: String,
         report: AgentReport,
     },
+    SetClaudeRemoteControlBinding {
+        agent_id: String,
+        shell_id: String,
+        run_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        bridge_session_id: Option<String>,
+    },
+    GetClaudeRemoteControlBinding {
+        agent_id: String,
+        shell_id: String,
+        run_id: String,
+    },
     ReportAgent {
         agent_id: String,
         run_id: String,
@@ -2654,6 +2680,10 @@ impl Request {
             | Self::ReportClaimedOpenCodeAgent { .. } => {
                 Some(ProtocolFeature::OpenCodeSharedRuntimeClaims)
             }
+            Self::SetClaudeRemoteControlBinding { .. }
+            | Self::GetClaudeRemoteControlBinding { .. } => {
+                Some(ProtocolFeature::ClaudeRemoteControlBindings)
+            }
             Self::GetAgent { .. } | Self::RegisterAgent { .. } | Self::ReportAgent { .. } => {
                 Some(ProtocolFeature::AgentInstances)
             }
@@ -2754,6 +2784,9 @@ pub enum Response {
     },
     OpenCodeSessionClaimReleased {
         released: bool,
+    },
+    ClaudeRemoteControlBinding {
+        binding: Option<ClaudeRemoteControlBindingSnapshot>,
     },
     AgentSchedule {
         schedule: AgentScheduleSnapshot,
@@ -3363,8 +3396,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_forty_two_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 42);
+    fn protocol_version_is_forty_three_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 43);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -3640,6 +3673,76 @@ mod tests {
     }
 
     #[test]
+    fn claude_remote_control_binding_messages_require_protocol_forty_three() {
+        let binding = ClaudeRemoteControlBindingSnapshot {
+            agent_id: "agent-1".into(),
+            shell_id: "shell-1".into(),
+            run_id: "run-1".into(),
+            bridge_session_id: "bridge-1".into(),
+        };
+        for request in [
+            Request::SetClaudeRemoteControlBinding {
+                agent_id: binding.agent_id.clone(),
+                shell_id: binding.shell_id.clone(),
+                run_id: binding.run_id.clone(),
+                bridge_session_id: Some(binding.bridge_session_id.clone()),
+            },
+            Request::SetClaudeRemoteControlBinding {
+                agent_id: binding.agent_id.clone(),
+                shell_id: binding.shell_id.clone(),
+                run_id: binding.run_id.clone(),
+                bridge_session_id: None,
+            },
+            Request::GetClaudeRemoteControlBinding {
+                agent_id: binding.agent_id.clone(),
+                shell_id: binding.shell_id.clone(),
+                run_id: binding.run_id.clone(),
+            },
+        ] {
+            let encoded = serde_json::to_value(&request).unwrap();
+            assert!(matches!(
+                encoded["request"].as_str(),
+                Some("set_claude_remote_control_binding" | "get_claude_remote_control_binding")
+            ));
+            if matches!(
+                &request,
+                Request::SetClaudeRemoteControlBinding {
+                    bridge_session_id: None,
+                    ..
+                }
+            ) {
+                assert!(encoded.get("bridge_session_id").is_none());
+            }
+            assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
+            assert_eq!(
+                request.required_feature(),
+                Some(ProtocolFeature::ClaudeRemoteControlBindings)
+            );
+            assert_eq!(request.minimum_protocol_version(), 43);
+        }
+
+        for response in [
+            Response::ClaudeRemoteControlBinding {
+                binding: Some(binding),
+            },
+            Response::ClaudeRemoteControlBinding { binding: None },
+        ] {
+            let encoded = serde_json::to_value(&response).unwrap();
+            assert_eq!(encoded["response"], "claude_remote_control_binding");
+            assert_eq!(
+                serde_json::from_value::<Response>(encoded).unwrap(),
+                response
+            );
+        }
+        assert_eq!(
+            ProtocolFeature::ClaudeRemoteControlBindings.capability_names(),
+            &["protocol_43", "claude_remote_control_bindings"]
+        );
+        assert_eq!(MAX_CLAUDE_REMOTE_CONTROL_BINDINGS, 4_096);
+        assert_eq!(MAX_CLAUDE_BRIDGE_SESSION_ID_BYTES, 256);
+    }
+
+    #[test]
     fn node_projection_sync_is_protocol_thirty_two_and_privacy_allowlisted() {
         let request = Request::SyncNodeProjection {
             after: Some(EventCursor {
@@ -3683,6 +3786,7 @@ mod tests {
             "environment",
             "external_session_id",
             "runner_token",
+            "bridge_session_id",
         ] {
             assert!(!serialized.contains(private));
         }
@@ -4947,6 +5051,7 @@ mod tests {
             (41, &["protocol_41", "observed_node_helper_version"][..]),
             (41, &["node_upgrade_coordination"][..]),
             (42, &["protocol_42", "opencode_shared_runtime_claims"][..]),
+            (43, &["protocol_43", "claude_remote_control_bindings"][..]),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5703,7 +5703,7 @@ fn help_lines(app: &App) -> Vec<Line<'static>> {
                 Line::from("  Left/Right changes schedule/history pane; j/k moves within the focused pane."),
                 Line::from("  [ and ] also select newer/older retained executions by exact execution ID."),
                 Line::from("  The selected schedule's bounded history loads automatically."),
-                Line::from("  Enter attaches an active run or resumes a completed exact OpenCode/Pi session."),
+                Line::from("  Enter attaches an active run or resumes a completed exact Agent Session."),
                 Line::from("  e edits the exact private definition while paused; Ctrl-S saves with revision protection."),
                 Line::from("  u runs now; p pauses/resumes; c cancels only its exact active execution."),
                 Line::from("  No skip-next action exists in protocol 25."),

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -1,7 +1,9 @@
 use std::fs;
+use std::io::Write;
 use std::net::TcpListener;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
+use std::process::Stdio;
 use std::thread;
 use std::time::Duration;
 
@@ -15,6 +17,116 @@ use crate::support::{
     TestDaemon, assert_generated_name, assert_remote_code, contains, ensure_test_opencode_runtime,
     process_exists, profile, wait_until,
 };
+
+#[test]
+fn claude_hook_reports_lifecycle_and_synchronizes_ephemeral_bridge_binding() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "claude-hook",
+            vec![ShellSpec {
+                name: "claude".into(),
+                command: vec!["/bin/sleep".into(), "30".into()],
+                cwd: std::env::temp_dir(),
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+
+    let run_hook = |event: &str, bridge: Option<&str>| {
+        let mut command = daemon.command();
+        command
+            .args(["claude", "hook"])
+            .env("BOOMUX_SHELL_ID", &shell_id)
+            .env("BOOMUX_RUN_ID", &run_id)
+            .stdin(Stdio::piped());
+        if let Some(bridge) = bridge {
+            command.env("CLAUDE_CODE_BRIDGE_SESSION_ID", bridge);
+        } else {
+            command.env_remove("CLAUDE_CODE_BRIDGE_SESSION_ID");
+        }
+        let mut child = command.spawn().unwrap();
+        write!(
+            child.stdin.take().unwrap(),
+            "{{\"session_id\":\"claude-session\",\"hook_event_name\":\"{event}\"}}"
+        )
+        .unwrap();
+        assert!(child.wait().unwrap().success());
+    };
+
+    let event_cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
+    run_hook("SessionStart", Some("bridge-exact"));
+    let snapshot = daemon.client.snapshot().unwrap();
+    let agent = snapshot.workspaces[0].agents[0].clone();
+    assert_eq!(agent.integration, "claude");
+    assert_eq!(agent.external_session_id.as_deref(), Some("claude-session"));
+    assert_eq!(agent.observation.state, AgentState::Idle);
+    assert_eq!(
+        daemon
+            .client
+            .get_claude_remote_control_binding(&agent.id, &shell_id, &run_id)
+            .unwrap()
+            .unwrap()
+            .bridge_session_id,
+        "bridge-exact"
+    );
+    let persisted = fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap();
+    let events = daemon.client.events(Some(event_cursor), 256, 0).unwrap();
+    let events = serde_json::to_vec(&events.events).unwrap();
+    for public_or_durable in [serde_json::to_vec(&snapshot).unwrap(), events, persisted] {
+        assert!(
+            !public_or_durable
+                .windows(b"bridge-exact".len())
+                .any(|window| window == b"bridge-exact")
+        );
+    }
+
+    drop(attachment);
+    daemon.client.restart().unwrap();
+    assert_eq!(
+        daemon
+            .client
+            .get_claude_remote_control_binding(&agent.id, &shell_id, &run_id)
+            .unwrap()
+            .unwrap()
+            .bridge_session_id,
+        "bridge-exact"
+    );
+
+    run_hook("SessionEnd", Some("ignored-on-session-end"));
+    assert_eq!(
+        daemon
+            .client
+            .get_agent(&agent.id)
+            .unwrap()
+            .observation
+            .state,
+        AgentState::Inactive
+    );
+
+    run_hook("UserPromptSubmit", None);
+    assert_eq!(
+        daemon
+            .client
+            .get_agent(&agent.id)
+            .unwrap()
+            .observation
+            .state,
+        AgentState::Working
+    );
+    assert!(
+        daemon
+            .client
+            .get_claude_remote_control_binding(&agent.id, &shell_id, &run_id)
+            .unwrap()
+            .is_none()
+    );
+
+    daemon.stop_with_cli();
+}
 
 #[test]
 fn opencode_shared_runtime_and_claims_are_node_wide_and_ephemeral() {

--- a/tests/native_backend/handoff.rs
+++ b/tests/native_backend/handoff.rs
@@ -87,7 +87,7 @@ fn replacement_bootstrap_receives_listener_and_lock_ownership() {
 
     parent_channel.set_read_timeout(Some(TIMEOUT)).unwrap();
     parent_channel.set_write_timeout(Some(TIMEOUT)).unwrap();
-    parent_channel.write_all(b"BOOMUXH4").unwrap();
+    parent_channel.write_all(b"BOOMUXH5").unwrap();
     protocol::write_message(
         &mut parent_channel,
         &serde_json::json!({

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -243,10 +243,16 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     let bin = root.join("bin");
     let config = root.join("config");
     let pi = root.join("pi");
+    let claude = root.join("claude");
+    let claude_manifest = claude.join("skills/boomux/.claude-plugin/plugin.json");
     let runtime = root.join("runtime");
     fs::create_dir_all(&bin).unwrap();
     fs::create_dir_all(&runtime).unwrap();
-    for (name, version) in [("opencode", "1.18.18"), ("pi", "0.84.1")] {
+    for (name, version) in [
+        ("opencode", "1.18.18"),
+        ("pi", "0.84.1"),
+        ("claude", "2.1.236"),
+    ] {
         let executable = bin.join(name);
         fs::write(
             &executable,
@@ -261,6 +267,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
             .env("HOME", &root)
             .env("XDG_CONFIG_HOME", &config)
             .env("PI_CODING_AGENT_DIR", &pi)
+            .env("CLAUDE_CONFIG_DIR", &claude)
             .env("XDG_RUNTIME_DIR", &runtime)
             .env("PATH", &bin);
         command
@@ -274,7 +281,15 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     let listed: serde_json::Value = serde_json::from_slice(&listed.stdout).unwrap();
     assert_eq!(listed["schema"], "boomux.cli/v1");
     assert_eq!(listed["command"], "integration.list");
-    assert_eq!(listed["data"]["integrations"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        listed["data"]["integrations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|integration| integration["name"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        ["opencode", "pi", "claude"]
+    );
 
     let missing = command()
         .args(["integration", "status", "--json"])
@@ -299,6 +314,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
         .unwrap();
     assert!(!preflight_refused.status.success());
     assert!(!config.join("opencode/plugins/boomux.js").exists());
+    assert!(!claude_manifest.exists());
     fs::remove_file(pi.join("extensions/boomux.js")).unwrap();
 
     let installed = command()
@@ -318,6 +334,10 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     }
     assert!(config.join("opencode/plugins/boomux.js").is_file());
     assert!(pi.join("extensions/boomux.js").is_file());
+    assert!(claude_manifest.is_file());
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&claude_manifest).unwrap()).unwrap();
+    assert_eq!(manifest["name"], "boomux");
 
     for arguments in [["opencode", "install"], ["pi", "install"]] {
         let shortcut = command().args(arguments).output().unwrap();
@@ -333,6 +353,20 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     assert_eq!(
         current["data"]["integrations"][0]["asset"]["state"],
         "current"
+    );
+    let claude_current = command()
+        .args(["integration", "status", "claude", "--json"])
+        .output()
+        .unwrap();
+    assert!(claude_current.status.success());
+    let claude_current: serde_json::Value = serde_json::from_slice(&claude_current.stdout).unwrap();
+    assert_eq!(
+        claude_current["data"]["integrations"][0]["asset"]["state"],
+        "current"
+    );
+    assert_eq!(
+        claude_current["data"]["integrations"][0]["asset"]["path"],
+        claude_manifest.to_str().unwrap()
     );
 
     fs::write(pi.join("extensions/boomux.js"), "custom extension").unwrap();
@@ -351,6 +385,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
         .unwrap();
     assert!(!uninstall_refused.status.success());
     assert!(config.join("opencode/plugins/boomux.js").is_file());
+    assert!(claude_manifest.is_file());
     assert_eq!(
         fs::read_to_string(pi.join("extensions/boomux.js")).unwrap(),
         "custom extension"
@@ -369,8 +404,10 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     }
     assert!(!config.join("opencode/plugins/boomux.js").exists());
     assert!(!pi.join("extensions/boomux.js").exists());
+    assert!(!claude_manifest.exists());
     assert!(config.join("opencode/plugins").is_dir());
     assert!(pi.join("extensions").is_dir());
+    assert!(claude.join("skills/boomux/.claude-plugin").is_dir());
 
     let absent = command()
         .args(["integration", "uninstall", "pi", "--json"])

--- a/tests/native_backend/schedules.rs
+++ b/tests/native_backend/schedules.rs
@@ -727,19 +727,23 @@ fn manual_execution_succeeds_and_duplicate_key_never_spawns_twice() {
     daemon.stop_with_cli();
 }
 
-#[test]
-fn pi_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity() {
+fn assert_stdin_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity(
+    integration: &'static str,
+    continuation_id: &str,
+    expected_fresh_argv: &[u8],
+    expected_continuation_argv: &[u8],
+) {
     let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
         let bin = runtime_dir.join("bin");
         fs::create_dir(&bin).unwrap();
-        let host = bin.join("pi");
+        let host = bin.join(integration);
         fs::write(
             &host,
-            "#!/bin/sh\nprintf '%s\\0' \"$@\" > \"$BOOMUX_PI_ARGV_DIR/$BOOMUX_PI_CASE\"\ncat > \"$BOOMUX_PI_STDIN_DIR/$BOOMUX_PI_CASE\"\nprintf '%s' \"${BOOMUX_SCHEDULE_RUNNER_TOKEN-unset}\" > \"$BOOMUX_PI_TOKEN_DIR/$BOOMUX_PI_CASE\"\n",
+            "#!/bin/sh\nprintf '%s\\0' \"$@\" > \"$BOOMUX_DISPATCH_ARGV_DIR/$BOOMUX_DISPATCH_CASE\"\ncat > \"$BOOMUX_DISPATCH_STDIN_DIR/$BOOMUX_DISPATCH_CASE\"\nprintf '%s' \"${BOOMUX_SCHEDULE_RUNNER_TOKEN-unset}\" > \"$BOOMUX_DISPATCH_TOKEN_DIR/$BOOMUX_DISPATCH_CASE\"\n",
         )
         .unwrap();
         fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
-        for directory in ["pi-argv", "pi-stdin", "pi-token"] {
+        for directory in ["dispatch-argv", "dispatch-stdin", "dispatch-token"] {
             fs::create_dir(runtime_dir.join(directory)).unwrap();
         }
         let mut paths = vec![bin];
@@ -748,15 +752,27 @@ fn pi_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity() {
         ));
         command
             .env("PATH", std::env::join_paths(paths).unwrap())
-            .env("BOOMUX_PI_ARGV_DIR", runtime_dir.join("pi-argv"))
-            .env("BOOMUX_PI_STDIN_DIR", runtime_dir.join("pi-stdin"))
-            .env("BOOMUX_PI_TOKEN_DIR", runtime_dir.join("pi-token"))
-            .env("BOOMUX_PI_CASE", "fresh");
+            .env(
+                "BOOMUX_DISPATCH_ARGV_DIR",
+                runtime_dir.join("dispatch-argv"),
+            )
+            .env(
+                "BOOMUX_DISPATCH_STDIN_DIR",
+                runtime_dir.join("dispatch-stdin"),
+            )
+            .env(
+                "BOOMUX_DISPATCH_TOKEN_DIR",
+                runtime_dir.join("dispatch-token"),
+            )
+            .env("BOOMUX_DISPATCH_CASE", "fresh");
     });
-    let workspace = daemon.client.create_workspace("pi", Vec::new()).unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(integration, Vec::new())
+        .unwrap();
     let prompt = "-@leading\nsecond line\n";
-    let mut fresh_spec = schedule_spec(&daemon, "pi-fresh", prompt);
-    fresh_spec.integration = "pi".into();
+    let mut fresh_spec = schedule_spec(&daemon, &format!("{integration}-fresh"), prompt);
+    fresh_spec.integration = integration.into();
     let fresh = daemon
         .client
         .create_agent_schedule(&workspace.id, fresh_spec)
@@ -772,18 +788,18 @@ fn pi_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity() {
                 .get_scheduled_execution(&execution.id)
                 .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
         },
-        "fresh Pi execution did not exit",
+        "fresh stdin dispatch did not exit",
     );
     assert_eq!(
-        fs::read(daemon.runtime_dir.join("pi-argv/fresh")).unwrap(),
-        b"--print\0"
+        fs::read(daemon.runtime_dir.join("dispatch-argv/fresh")).unwrap(),
+        expected_fresh_argv
     );
     assert_eq!(
-        fs::read(daemon.runtime_dir.join("pi-stdin/fresh")).unwrap(),
+        fs::read(daemon.runtime_dir.join("dispatch-stdin/fresh")).unwrap(),
         prompt.as_bytes()
     );
     assert_eq!(
-        fs::read_to_string(daemon.runtime_dir.join("pi-token/fresh")).unwrap(),
+        fs::read_to_string(daemon.runtime_dir.join("dispatch-token/fresh")).unwrap(),
         "unset"
     );
 
@@ -797,18 +813,31 @@ fn pi_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity() {
             ));
             std::env::join_paths(paths).unwrap()
         })
-        .env("BOOMUX_PI_ARGV_DIR", daemon.runtime_dir.join("pi-argv"))
-        .env("BOOMUX_PI_STDIN_DIR", daemon.runtime_dir.join("pi-stdin"))
-        .env("BOOMUX_PI_TOKEN_DIR", daemon.runtime_dir.join("pi-token"))
-        .env("BOOMUX_PI_CASE", "continue")
+        .env(
+            "BOOMUX_DISPATCH_ARGV_DIR",
+            daemon.runtime_dir.join("dispatch-argv"),
+        )
+        .env(
+            "BOOMUX_DISPATCH_STDIN_DIR",
+            daemon.runtime_dir.join("dispatch-stdin"),
+        )
+        .env(
+            "BOOMUX_DISPATCH_TOKEN_DIR",
+            daemon.runtime_dir.join("dispatch-token"),
+        )
+        .env("BOOMUX_DISPATCH_CASE", "continue")
         .output()
         .unwrap();
     assert!(restart.status.success());
-    let external_id = "exact-pi-session";
-    let mut continuation_spec = schedule_spec(&daemon, "pi-continue", "continued");
-    continuation_spec.integration = "pi".into();
+    let continuation_prompt = "continued\nexact bytes";
+    let mut continuation_spec = schedule_spec(
+        &daemon,
+        &format!("{integration}-continue"),
+        continuation_prompt,
+    );
+    continuation_spec.integration = integration.into();
     continuation_spec.session = AgentScheduleSession::Continue {
-        external_session_id: external_id.into(),
+        external_session_id: continuation_id.into(),
     };
     let continuation = daemon
         .client
@@ -825,17 +854,41 @@ fn pi_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity() {
                 .get_scheduled_execution(&execution.id)
                 .is_ok_and(|execution| execution.state == ScheduledExecutionState::Exited)
         },
-        "continued Pi execution did not exit",
+        "continued stdin dispatch did not exit",
     );
     assert_eq!(
-        fs::read(daemon.runtime_dir.join("pi-argv/continue")).unwrap(),
-        b"--session\0exact-pi-session\0--print\0"
+        fs::read(daemon.runtime_dir.join("dispatch-argv/continue")).unwrap(),
+        expected_continuation_argv
     );
     assert_eq!(
-        fs::read(daemon.runtime_dir.join("pi-stdin/continue")).unwrap(),
-        b"continued"
+        fs::read(daemon.runtime_dir.join("dispatch-stdin/continue")).unwrap(),
+        continuation_prompt.as_bytes()
+    );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("dispatch-token/continue")).unwrap(),
+        "unset"
     );
     daemon.stop_with_cli();
+}
+
+#[test]
+fn pi_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity() {
+    assert_stdin_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity(
+        "pi",
+        "exact-pi-session",
+        b"--print\0",
+        b"--session\0exact-pi-session\0--print\0",
+    );
+}
+
+#[test]
+fn claude_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity() {
+    assert_stdin_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity(
+        "claude",
+        "exact-id",
+        b"--print\0",
+        b"--print\0--resume\0exact-id\0",
+    );
 }
 
 #[test]

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -15,6 +15,122 @@ use crate::support::{
 };
 
 #[test]
+fn bare_claude_command_uses_owner_remote_control_policy_without_rewriting_stored_argv() {
+    for (enabled, expected) in [
+        (true, b"--remote-control\0".as_slice()),
+        (false, b"".as_slice()),
+    ] {
+        let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+            let output = runtime_dir.join("claude-argv");
+            let claude = runtime_dir.join("claude");
+            fs::write(
+                &claude,
+                format!(
+                    "#!/bin/sh\n: > '{}'\nfor arg do printf '%s\\0' \"$arg\" >> '{}'; done\n",
+                    output.display(),
+                    output.display()
+                ),
+            )
+            .unwrap();
+            fs::set_permissions(&claude, fs::Permissions::from_mode(0o700)).unwrap();
+            if !enabled {
+                let config = runtime_dir.join("config.toml");
+                fs::write(&config, "[claude]\nremote_control = false\n").unwrap();
+                command.env("BOOMUX_CONFIG", config);
+            }
+        });
+        let claude = daemon.runtime_dir.join("claude");
+        let workspace = daemon
+            .client
+            .create_workspace(
+                if enabled { "claude-on" } else { "claude-off" },
+                vec![ShellSpec {
+                    name: "claude".into(),
+                    command: vec![claude.display().to_string()],
+                    cwd: daemon.runtime_dir.clone(),
+                }],
+            )
+            .unwrap();
+        let shell_id = &workspace.shells[0].id;
+        let attachment = daemon.client.attach(shell_id, false, profile()).unwrap();
+        wait_until(
+            || fs::read(daemon.runtime_dir.join("claude-argv")).is_ok(),
+            "Claude command did not capture argv",
+        );
+        assert_eq!(
+            fs::read(daemon.runtime_dir.join("claude-argv")).unwrap(),
+            expected
+        );
+        assert_eq!(
+            daemon.client.get_shell(shell_id).unwrap().command,
+            [claude.display().to_string()]
+        );
+        drop(attachment);
+        daemon.stop_with_cli();
+    }
+}
+
+#[test]
+fn bare_claude_typed_in_managed_login_shell_uses_remote_control_shim() {
+    let mut daemon = TestDaemon::start();
+    let bin = daemon.runtime_dir.join("claude-bin");
+    let home = daemon.runtime_dir.join("home");
+    let output = daemon.runtime_dir.join("typed-claude-argv");
+    fs::create_dir(&bin).unwrap();
+    fs::create_dir(&home).unwrap();
+    let claude = bin.join("claude");
+    fs::write(
+        &claude,
+        format!(
+            "#!/bin/sh\n: > '{}'\nfor arg do printf '%s\\0' \"$arg\" >> '{}'; done\n",
+            output.display(),
+            output.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&claude, fs::Permissions::from_mode(0o700)).unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "claude-login",
+            vec![ShellSpec::login("login", &daemon.runtime_dir)],
+        )
+        .unwrap();
+    let environment = UnixEnvironment {
+        variables: [
+            (b"SHELL".as_slice(), std::ffi::OsStr::new("/bin/bash")),
+            (b"HOME".as_slice(), home.as_os_str()),
+            (b"PATH".as_slice(), bin.as_os_str()),
+            (
+                b"XDG_RUNTIME_DIR".as_slice(),
+                daemon.runtime_dir.as_os_str(),
+            ),
+        ]
+        .into_iter()
+        .map(|(name, value)| UnixEnvironmentVariable {
+            name: name.to_vec(),
+            value: value.as_encoded_bytes().to_vec(),
+        })
+        .collect(),
+    };
+    let mut attachment =
+        attach_with_environment(&daemon.client, &workspace.shells[0].id, false, environment);
+    AttachFrame::Input(b"claude\n".to_vec())
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    wait_until(
+        || fs::read(&output).is_ok(),
+        "typed Claude command did not capture argv",
+    );
+    assert_eq!(fs::read(output).unwrap(), b"--remote-control\0");
+    AttachFrame::Input(b"exit\n".to_vec())
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    drop(attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn legacy_workspace_default_cwd_is_inherited_and_survives_handoff() {
     let mut daemon = TestDaemon::start();
     let project = daemon.runtime_dir.join("project");


### PR DESCRIPTION
## Summary

- add a bundled Claude Code lifecycle plugin with exact Session identity, resume, scheduling, recovery, and integration management
- enable configurable default-on Remote Control for eligible bare managed launches and expose exact local `Open in Claude` handoffs
- add protocol 43 ephemeral Remote Control bindings and BOOMUXH6 graceful transfer without persistence, events, or remote Node projection
- document and live-validate Claude Code 2.1.236 lifecycle reporting, Remote Control, mobile projection, and Tailscale publication

## Compatibility and privacy

- preserves explicit Claude argv, scheduled dispatches, recovery resumes, and exact Session resumes
- accepts BOOMUXH5 handoffs while emitting BOOMUXH6
- keeps bridge identities bounded, owner-validated, local-only, event-free, and absent from durable state
- treats Claude process exit and quiet output as nonterminal lifecycle evidence

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked` (786 passed)
- `cargo test --test native_backend --locked -- --test-threads=1` (123 passed)
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js` (72 passed)
- `claude plugin validate integrations/claude` (passed with optional metadata warnings)
- live Claude Code 2.1.236 lifecycle, Remote Control, web handoff, and Tailscale route validation