### PR TITLE
fix(web): make opencode hosting resilient

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -248,7 +248,10 @@ completed = "complete"
 ```
 
 Cold recovery resumes only a unique OpenCode or Pi external session reported by
-the lifecycle integration. Persisted terminal history is disabled by default
+the lifecycle integration. An eligible recovered OpenCode Session attaches to
+the Shared Harness Runtime and establishes a fresh claim for its replacement
+ShellRun; if shared launch preparation is unavailable, exact Session recovery
+continues standalone without a web link. Persisted terminal history is disabled by default
 because output can contain secrets; enabling it stores up to 256 KiB of
 plain-text history per shell in Boomux's user-only state file.
 
@@ -535,9 +538,12 @@ Agent per exact run plus historical Agents with durable attention, excluding
 schedule-owned Agents. It also presents local working-to-idle transitions as
 gateway-owned ephemeral finished alerts, refreshed even without a connected
 browser. Its home page is the complete dashboard and cannot send terminal input
-or acknowledge attention. It ensures the Node's loopback Shared Harness Runtime
-and links exact local Sessions directly from eligible Agent cards only while a
-current Agent Session Claim binds that runtime generation to the exact ShellRun.
+or acknowledge attention. It attempts to ensure the Node's loopback Shared
+Harness Runtime and links exact local Sessions directly from eligible Agent cards
+only while a current Agent Session Claim binds that runtime generation to the
+exact ShellRun. If OpenCode is not installed, web startup continues without that
+runtime or its Tailscale route; Claude and other presentation remain available.
+Conflicts and failures from an installed runtime remain fatal.
 `--opencode-web-url URL` is the public origin for that same local runtime, never
 an unrelated server. `--no-opencode-web` disables web-triggered runtime startup
 and native links. Boomux does not proxy or authenticate that full-control

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,9 +109,11 @@ external session identity, but it owns no process, PTY, or lifecycle observation
 One ephemeral Node-local, daemon-supervised generation of an external harness
 server shared by native clients. It is not a Shell, Command, Launcher, Agent,
 Session, or durable resource. The first bare interactive `opencode` in an
-eligible managed login Shell, or `boomux web`, starts it. It survives terminal
-detach, `boomux web` restart, and graceful daemon handoff. Cold adoption requires
-strict runtime identity, and `boomux daemon stop` stops it.
+eligible managed login Shell starts it. `boomux web` also starts it when the
+OpenCode host is available, but remains a complete Agent dashboard when that
+optional host is absent. The runtime survives terminal detach, `boomux web`
+restart, and graceful daemon handoff. Cold adoption requires strict runtime
+identity, and `boomux daemon stop` stops it.
 
 ## Agent Session Claim
 
@@ -123,7 +125,10 @@ Session, process, controller, projection, event, or durable identity.
 Expiry, final-holder release, ShellRun replacement, or runtime-generation
 replacement removes authority without deleting or moving durable Agent history.
 Claims are not persisted, projected, event-published, or transferred during
-daemon handoff; surviving TUIs reacquire them from the replacement daemon.
+daemon handoff; surviving TUIs reacquire them from the replacement daemon. When
+cold recovery resumes one exact OpenCode Session on a replacement ShellRun, its
+daemon-generated launch attaches to the Shared Harness Runtime so the new TUI
+can establish a fresh claim rather than inheriting the invalid prior-run claim.
 
 ## Claude Remote Control Binding
 

--- a/README.md
+++ b/README.md
@@ -266,9 +266,12 @@ revision-conditional **Dismiss** action; remote attention remains read-only. The
 home page is the complete dashboard; an
 eligible local OpenCode Agent card links directly to the same live Session used
 by its desktop TUI through the Node's Shared Harness Runtime on
-`127.0.0.1:4097`. Remote Agents remain unlinked. The TUI can be detached while
-phone events continue; on return it receives those events and is synchronized
-with the phone.
+`127.0.0.1:4097`. Missing OpenCode is treated as an optional capability: the
+dashboard still starts, reports no active OpenCode runtime, and retains other
+native links such as **Open in Claude**. Port conflicts, runtime failures, and
+protocol or transport errors remain startup failures. Remote Agents remain
+unlinked. The TUI can be detached while phone events continue; on return it
+receives those events and is synchronized with the phone.
 
 Stop only the default web gateway with `boomux web stop`. If it was started with
 another HTTP port, use `boomux web stop --port PORT`. This leaves the daemon,
@@ -278,7 +281,8 @@ Use `boomux web start` for detached background operation and `boomux web status`
 for passive inspection. Start requires the daemon to already be running and is
 idempotent for equivalent options. All three lifecycle commands support `--json`.
 
-Publish both loopback services to a connected Tailscale tailnet explicitly:
+Publish the dashboard and any active OpenCode runtime to a connected Tailscale
+tailnet explicitly:
 
 ```console
 boomux web --tailscale
@@ -287,6 +291,7 @@ boomux web start --tailscale
 
 Boomux reuses compatible Serve routes, rejects conflicts, records only routes it
 creates, and removes those exact routes on graceful exit or `boomux web stop`.
+When OpenCode is unavailable, only the dashboard route is published.
 It does not reset unrelated Serve configuration or define Tailscale grants and
 ACLs. Without `--tailscale`, remote publication remains external. The MVP has
 no terminal input, transcript parsing, or cloud service. Its only mutation is
@@ -632,6 +637,10 @@ After a cold daemon restart, Boomux resumes a uniquely identified OpenCode, Pi,
 or Claude session when its interrupted shell is next started. Recovery requires
 a retained external session ID reported by the lifecycle integration; ambiguous,
 completed, or heuristic-only Agents fall back to the shell's configured command.
+Recovered OpenCode Sessions attach to the Shared Harness Runtime and establish a
+fresh claim for the replacement ShellRun, preserving eligible OpenCode Web
+handoffs across run generations. If shared preparation is unavailable, recovery
+continues with the standalone exact-Session command.
 Set `recovery.resume_agents` to `false` to disable this behavior.
 
 Terminal history persistence is opt-in because terminal output can contain

--- a/docs/adr/0005-bind-shared-harness-sessions-to-shell-runs.md
+++ b/docs/adr/0005-bind-shared-harness-sessions-to-shell-runs.md
@@ -47,3 +47,10 @@ and generation but not claims; TUI holders reacquire them. Cold adoption require
 strict identity, and daemon stop terminates the runtime. The loopback OpenCode
 origin remains full-control and must sit behind a private access layer that owns
 TLS, authentication, and ACLs.
+
+Cold recovery of one exact resumable OpenCode Agent starts a replacement
+ShellRun through the internal shared launcher with that canonical Session ID.
+The prior claim remains invalid; the replacement TUI establishes a new claim for
+the new run. If shared preparation is unavailable, recovery falls back to the
+standalone exact-Session command. This does not broaden the scoped user shim:
+argument-bearing user invocations still execute stock OpenCode unchanged.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -374,6 +374,12 @@ and web-client restart. Graceful handoff transfers its strict PID/start/runtime
 identity and generation; cold startup adopts only an exactly matching runtime.
 Daemon stop terminates it. A hidden shared launcher establishes a scoped `PATH`
 only for eligible Boomux login Shells and is not stable public automation.
+When cold recovery selects one exact resumable OpenCode Agent, the replacement
+ShellRun uses that same hidden launcher with the canonical Session ID. The TUI
+therefore attaches to the current Shared Harness Runtime generation and creates
+a fresh exact-run claim. Failure to prepare the shared launch falls back to the
+existing standalone exact-Session recovery rather than making the Shell
+unopenable. Explicit argument-bearing user invocations remain unchanged.
 
 ### Attachment
 
@@ -583,10 +589,10 @@ stop the Shared Harness Runtime.
 PATH-resolved Tailscale CLI with exact argument vectors, requires a connected
 Node with a MagicDNS name, and preflights the current Serve JSON before changing
 it. A compatible existing route is reused but never claimed. A conflicting root
-handler fails startup before mutation. Missing dashboard HTTPS 443 and OpenCode
-HTTPS runtime-port routes are added independently, and only routes created by
-that gateway are recorded in an owner-only, versioned runtime record. Graceful
-exit removes those exact root routes; `boomux web stop` also reconciles a record
+handler fails startup before mutation. Missing dashboard HTTPS 443 and an active
+OpenCode HTTPS runtime-port route are added independently, and only routes
+created by that gateway are recorded in an owner-only, versioned runtime record.
+Graceful exit removes those exact root routes; `boomux web stop` also reconciles a record
 left by a crashed gateway. Changed or externally owned routes are never removed,
 and Boomux never resets unrelated Serve configuration. Tailscale remains
 responsible for certificates, tailnet identity, grants, and ACL policy.
@@ -614,9 +620,15 @@ daemon-protocol pass-through, terminal attachment, input, Session resume,
 rendered terminal output, Agent detail route, or harness transcript adapter.
 The home-page snapshot is the complete HTTP Agent projection.
 
-`boomux web` ensures the same daemon-supervised Shared Harness Runtime used by
-eligible native OpenCode TUIs. For an authoritative claimed local OpenCode Agent
-with a canonical external Session ID and UTF-8 working directory, Boomux
+`boomux web` attempts to ensure the same daemon-supervised Shared Harness Runtime
+used by eligible native OpenCode TUIs. A typed missing OpenCode executable is an
+optional-capability result: the dashboard starts without a runtime or OpenCode
+route, while Claude and other presentation remain available. Port conflicts,
+runtime exit or timeout, protocol incompatibility, and daemon transport failures
+still fail startup. Requested OpenCode configuration is retained separately from
+actual runtime availability so detached equivalent starts remain idempotent.
+For an authoritative claimed local OpenCode Agent with a canonical external
+Session ID and UTF-8 working directory, Boomux
 base64url-encodes the directory and constructs OpenCode's exact
 `/<directory>/session/<session-id>` route on that Agent's home-page card. The
 browser derives a default public origin from its current scheme and hostname plus
@@ -1521,7 +1533,10 @@ that arbitrary processes, mutated environments, or PTYs survive daemon restart
 or crash. When enabled, cold recovery substitutes an integration-native resume
 command for a uniquely identified, lifecycle-authoritative OpenCode, Pi, or
 Claude Agent from an interrupted run. Ambiguous or invalid candidates use the
-shell's normal command instead.
+shell's normal command instead. OpenCode recovery routes the exact Session
+through the Shared Harness Runtime so its replacement ShellRun can establish a
+fresh claim; shared-launch preparation failure retains the standalone native
+resume fallback.
 
 Plain-text terminal history is a separate opt-in recovery field because output
 can contain secrets. The shadow terminal checkpoints a UTF-8-safe suffix of at

--- a/docs/mobile-web.md
+++ b/docs/mobile-web.md
@@ -36,15 +36,21 @@ boomux web status
 All lifecycle subcommands support the stable JSON envelope with commands
 `web.start`, `web.status`, and `web.stop`. Background start requires an already
 running daemon and never resurrects a stopped daemon. Repeating an equivalent
-start is idempotent; different options on the same HTTP port are rejected.
+start is idempotent, including when the requested OpenCode host is unavailable;
+different options on the same HTTP port are rejected. Status reports requested
+OpenCode port/URL separately from the active runtime port/URL.
 
 The default URL is `http://127.0.0.1:3737`. Select another loopback port with
-`--port`. The command also ensures one daemon-supervised Shared Harness Runtime
-generation on `127.0.0.1:4097`; choose another stable loopback port with
-`--opencode-web-port`. The same Node-local generation is used by eligible native
-OpenCode TUIs and the phone. Restarting `boomux web` does not replace that
-generation. Runtime exit withdraws native links until the daemon starts or
-strictly cold-adopts a replacement generation.
+`--port`. The command also attempts to ensure one daemon-supervised Shared
+Harness Runtime generation on `127.0.0.1:4097`; choose another stable loopback
+port with `--opencode-web-port`. If the OpenCode executable is absent, the
+dashboard starts without OpenCode links and continues to expose other eligible
+native handoffs such as Claude Remote Control. Port conflicts, installed-runtime
+startup failures, readiness timeouts, and daemon/protocol failures remain fatal.
+The same Node-local generation is used by eligible native OpenCode TUIs and the
+phone. Restarting `boomux web` does not replace that generation. Runtime exit
+withdraws native links until the daemon starts or strictly cold-adopts a
+replacement generation.
 
 Stop the default gateway without stopping the Boomux daemon or any managed
 processes:
@@ -87,8 +93,17 @@ events, and is synchronized when the terminal returns. `--pure`, `--mini`,
 absolute paths, modified `PATH`, and otherwise ineligible invocations receive no
 claim or native link.
 
-To publish both loopback services to the current Tailscale tailnet, opt in when
-starting the foreground or background gateway:
+An interrupted ShellRun never transfers its claim to a replacement run. When
+cold recovery has one exact resumable OpenCode Agent, Boomux instead resumes its
+canonical Session through the Shared Harness Runtime and the replacement TUI
+establishes a fresh claim for the new run. If shared launch preparation is
+unavailable, exact Session recovery remains fail-open as a standalone TUI and
+the native link remains absent. User-entered argument-bearing commands such as
+`opencode --continue` and `opencode --session ID` continue to bypass the scoped
+shim.
+
+To publish the dashboard and any active OpenCode runtime to the current
+Tailscale tailnet, opt in when starting the foreground or background gateway:
 
 ```console
 boomux web --tailscale
@@ -98,7 +113,8 @@ boomux web start --tailscale
 Boomux requires a connected PATH-resolved Tailscale CLI and MagicDNS name. It
 reuses compatible existing Serve routes, rejects conflicts before mutation, and
 adds only missing root routes for dashboard HTTPS 443 and OpenCode HTTPS on the
-configured runtime port. `Ctrl-C` and `boomux web stop` remove only routes that
+active runtime port. When OpenCode is unavailable, only the dashboard route is
+published. `Ctrl-C` and `boomux web stop` remove only routes that
 invocation created; unrelated and compatible pre-existing Serve routes remain.
 A later stop reconciles exact owned routes after a gateway crash. Boomux does
 not configure tailnet grants or ACLs.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1542,7 +1542,31 @@ impl Client {
             Response::OpenCodeSharedRuntime {
                 runtime: Some(runtime),
             } => Ok(runtime),
+            Response::OpenCodeSharedRuntime { runtime: None } => {
+                Err(ClientError::Validation(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "OpenCode executable is unavailable",
+                )))
+            }
             other => unexpected(other),
+        }
+    }
+
+    pub fn try_ensure_opencode_shared_runtime(
+        &self,
+        port: u16,
+    ) -> Result<Option<OpenCodeSharedRuntimeSnapshot>> {
+        match self.request(Request::EnsureOpenCodeSharedRuntime {
+            port,
+            environment: Some(current_environment()),
+        }) {
+            Ok(Response::OpenCodeSharedRuntime { runtime }) => Ok(runtime),
+            Err(ClientError::Remote(RemoteError {
+                code: Some(ErrorCode::NotFound),
+                ..
+            })) => Ok(None),
+            Err(error) => Err(error),
+            Ok(other) => unexpected(other),
         }
     }
 
@@ -2171,6 +2195,50 @@ mod tests {
             ),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn optional_runtime_accepts_legacy_typed_absence_without_changing_required_callers() {
+        let directory = env::temp_dir().join(format!("boomux-client-runtime-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                assert_eq!(request.version, protocol::PROTOCOL_VERSION);
+                assert!(matches!(
+                    request.message,
+                    Request::EnsureOpenCodeSharedRuntime { .. }
+                ));
+                protocol::write_message(
+                    &mut stream,
+                    &Envelope::new(Response::Error {
+                        message: "OpenCode executable is unavailable outside the Boomux shim"
+                            .into(),
+                        code: Some(ErrorCode::NotFound),
+                    }),
+                )
+                .unwrap();
+            }
+        });
+        let client = Client::from_socket_path(socket);
+
+        assert_eq!(
+            client.try_ensure_opencode_shared_runtime(4097).unwrap(),
+            None
+        );
+        assert!(matches!(
+            client.ensure_opencode_shared_runtime(4097).unwrap_err(),
+            ClientError::Remote(RemoteError {
+                code: Some(ErrorCode::NotFound),
+                ..
+            })
+        ));
+
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4991,7 +4991,7 @@ impl DurableRegistry {
         &self,
         shell: &Shell,
         previous_run: &PersistedShellRun,
-    ) -> io::Result<Option<(String, Vec<String>)>> {
+    ) -> io::Result<Option<ResumableAgent>> {
         let state = lock(&self.state)?;
         let mut candidates = Vec::new();
         for agent in state.agents.values() {
@@ -5034,7 +5034,12 @@ impl DurableRegistry {
         Ok(crate::integrations::by_key(integration)
             .and_then(|descriptor| descriptor.resume)
             .and_then(|resume| resume.command(&shell.command, external_session_id))
-            .map(|command| (agent_id.clone(), command)))
+            .map(|command| ResumableAgent {
+                agent_id: agent_id.clone(),
+                integration: integration.clone(),
+                external_session_id: external_session_id.clone(),
+                command,
+            }))
     }
 
     fn notification_context(&self, workspace_id: &str, shell_id: &str) -> (String, String) {
@@ -11156,21 +11161,11 @@ impl DaemonService {
     #[cfg(not(debug_assertions))]
     fn wait_for_native_outcome_barrier(&self) {}
 
-    fn agent_resume_command(
-        &self,
-        shell: &Shell,
-        previous_run: Option<&PersistedShellRun>,
-    ) -> io::Result<Option<Vec<String>>> {
-        Ok(self
-            .resumable_agent(shell, previous_run)?
-            .map(|(_, command)| command))
-    }
-
     fn resumable_agent(
         &self,
         shell: &Shell,
         previous_run: Option<&PersistedShellRun>,
-    ) -> io::Result<Option<(String, Vec<String>)>> {
+    ) -> io::Result<Option<ResumableAgent>> {
         if !self.notification_settings.resume_agents {
             return Ok(None);
         }
@@ -14919,14 +14914,14 @@ impl DaemonService {
         let Some(previous_run) = previous_run.as_ref() else {
             return Ok(None);
         };
-        let Some((agent_id, _)) = self.resumable_agent(&shell, Some(previous_run))? else {
+        let Some(resumable) = self.resumable_agent(&shell, Some(previous_run))? else {
             return Ok(None);
         };
         if !matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending) {
             return Ok(None);
         }
         Ok(Some((
-            agent_id,
+            resumable.agent_id,
             ShellRunSnapshot {
                 id: previous_run.id.clone(),
                 generation: previous_run.generation,
@@ -16599,7 +16594,15 @@ fn initial_terminal_state(
 #[derive(Default)]
 struct RuntimeRecovery<'a> {
     effective_command: Option<&'a [String]>,
+    opencode_session_id: Option<&'a str>,
     history: Option<&'a str>,
+}
+
+struct ResumableAgent {
+    agent_id: String,
+    integration: String,
+    external_session_id: String,
+    command: Vec<String>,
 }
 
 struct RuntimeStart<'a> {
@@ -16649,12 +16652,47 @@ impl ShellRuntimeManager {
             .cloned()
             .unwrap_or_else(capture_current_environment);
         let mut child_environment = sanitize_opencode_shim_environment(&original_environment);
-        if opencode_shim_eligible(shell, selected_command)
+        let mut shared_recovery_command = None;
+        if let Some(session_id) = recovery.opencode_session_id
+            && let Ok(injected) =
+                inject_opencode_shim_environment(&child_environment, claude_remote_control)
+        {
+            child_environment = injected;
+            let selected_executable = Path::new(&selected_command[0]);
+            let exact_executable = if selected_executable.is_absolute() {
+                Some(selected_executable.to_path_buf())
+            } else if selected_executable.components().count() > 1 {
+                Some(shell.cwd.join(selected_executable))
+            } else {
+                None
+            };
+            if let Some(executable) = exact_executable {
+                set_environment_value(
+                    &mut child_environment,
+                    b"BOOMUX_REAL_OPENCODE",
+                    executable.into_os_string(),
+                );
+            }
+            if let Some(executable) =
+                environment_value(&child_environment, b"BOOMUX_SHIM_EXECUTABLE")
+            {
+                shared_recovery_command = Some(vec![
+                    executable.to_string_lossy().into_owned(),
+                    "opencode".into(),
+                    "shared".into(),
+                    "--session".into(),
+                    session_id.into(),
+                ]);
+            }
+        } else if opencode_shim_eligible(shell, selected_command)
             && let Ok(injected) =
                 inject_opencode_shim_environment(&child_environment, claude_remote_control)
         {
             child_environment = injected;
         }
+        let selected_command = shared_recovery_command
+            .as_deref()
+            .unwrap_or(selected_command);
         let client_shell = child_environment
             .variables
             .iter()
@@ -17177,8 +17215,8 @@ impl ShellRuntimeManager {
         }
         let previous_run = lock(&shell.last_run)?.clone();
         let needs_start = matches!(*lock(&shell.lifecycle)?, ShellLifecycle::Pending);
-        let resume_command = needs_start
-            .then(|| registry.agent_resume_command(&shell, previous_run.as_ref()))
+        let resumable_agent = needs_start
+            .then(|| registry.resumable_agent(&shell, previous_run.as_ref()))
             .transpose()?
             .flatten();
         let restored_history = needs_start
@@ -17228,7 +17266,13 @@ impl ShellRuntimeManager {
                             environment.as_ref()
                         },
                         recovery: RuntimeRecovery {
-                            effective_command: resume_command.as_deref(),
+                            effective_command: resumable_agent
+                                .as_ref()
+                                .map(|resumable| resumable.command.as_slice()),
+                            opencode_session_id: resumable_agent
+                                .as_ref()
+                                .filter(|resumable| resumable.integration == "opencode")
+                                .map(|resumable| resumable.external_session_id.as_str()),
                             history: restored_history.as_deref(),
                         },
                         claude_remote_control: registry.notification_settings.claude_remote_control,
@@ -19219,13 +19263,16 @@ mod tests {
             Some(agent_id.as_str())
         );
 
+        let resumable = registry
+            .resumable_agent(&shell, Some(&run))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resumable.agent_id, agent_id);
+        assert_eq!(resumable.integration, "opencode");
+        assert_eq!(resumable.external_session_id, "session-1");
         assert_eq!(
-            registry.agent_resume_command(&shell, Some(&run)).unwrap(),
-            Some(vec![
-                "/opt/bin/opencode".into(),
-                "--session".into(),
-                "session-1".into()
-            ])
+            resumable.command,
+            ["/opt/bin/opencode", "--session", "session-1"]
         );
 
         let agent = lock(&registry.durable.state)
@@ -19237,7 +19284,7 @@ mod tests {
         lock(&agent.state).unwrap().observation.authority = AgentAuthority::TerminalHeuristic;
         assert!(
             registry
-                .agent_resume_command(&shell, Some(&run))
+                .resumable_agent(&shell, Some(&run))
                 .unwrap()
                 .is_none()
         );
@@ -19256,13 +19303,16 @@ mod tests {
                 .as_deref(),
             Some(agent_id.as_str())
         );
+        let resumable = registry
+            .resumable_agent(&shell, Some(&run))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resumable.agent_id, agent_id);
+        assert_eq!(resumable.integration, "claude");
+        assert_eq!(resumable.external_session_id, "claude-exact");
         assert_eq!(
-            registry.agent_resume_command(&shell, Some(&run)).unwrap(),
-            Some(vec![
-                "/opt/bin/claude".into(),
-                "--resume".into(),
-                "claude-exact".into(),
-            ])
+            resumable.command,
+            ["/opt/bin/claude", "--resume", "claude-exact"]
         );
     }
 
@@ -19275,7 +19325,7 @@ mod tests {
 
         assert!(
             registry
-                .agent_resume_command(&shell, Some(&run))
+                .resumable_agent(&shell, Some(&run))
                 .unwrap()
                 .is_none()
         );
@@ -19288,7 +19338,7 @@ mod tests {
         registry.notification_settings.resume_agents = false;
         assert!(
             registry
-                .agent_resume_command(&shell, Some(&run))
+                .resumable_agent(&shell, Some(&run))
                 .unwrap()
                 .is_none()
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1217,7 +1217,12 @@ enum OpenCodeCommands {
     },
     /// Internal entry point for a scoped bare OpenCode invocation
     #[command(hide = true)]
-    Shared,
+    Shared {
+        #[arg(long, hide = true)]
+        session: Option<String>,
+        #[arg(long, hide = true, default_value_t = 4097)]
+        port: u16,
+    },
     /// Coordinate OpenCode TUI selection claims
     #[command(hide = true)]
     Claim {
@@ -2052,8 +2057,8 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             command: OpenCodeCommands::Install { force },
         }) => install_opencode(force),
         Some(Commands::Opencode {
-            command: OpenCodeCommands::Shared,
-        }) => launch_shared_opencode(),
+            command: OpenCodeCommands::Shared { session, port },
+        }) => launch_shared_opencode(session.as_deref(), port),
         Some(Commands::Opencode {
             command: OpenCodeCommands::Claim { command },
         }) => opencode_claim_command(command, cli.json),
@@ -2873,6 +2878,8 @@ fn web_status(port: u16, json: bool) -> Result<(), Box<dyn Error>> {
         println!("running ({})", status.dashboard_url);
         if let Some(url) = status.opencode_url {
             println!("OpenCode Web: {url}");
+        } else if status.opencode_requested_port.is_some() {
+            println!("OpenCode Web: unavailable");
         }
     } else {
         println!("not running (port {port})");
@@ -2900,11 +2907,17 @@ fn web_start(
                 ))
             }
         });
+        let status_requested_opencode_port =
+            status.opencode_requested_port.or(status.opencode_port);
+        let status_requested_opencode_url = status
+            .opencode_requested_url
+            .as_deref()
+            .or(status.opencode_url.as_deref());
         if status.tailscale != tailscale
-            || status.opencode_port != requested_opencode_port
+            || status_requested_opencode_port != requested_opencode_port
             || expected_opencode_url
                 .as_deref()
-                .is_some_and(|expected| status.opencode_url.as_deref() != Some(expected))
+                .is_some_and(|expected| status_requested_opencode_url != Some(expected))
         {
             return Err(io::Error::new(
                 io::ErrorKind::AddrInUse,
@@ -3004,6 +3017,9 @@ fn print_web_start(
         println!("Started Boomux web: {}", status.dashboard_url);
     } else {
         println!("Boomux web is already running: {}", status.dashboard_url);
+    }
+    if !json && status.opencode_requested_port.is_some() && status.opencode_port.is_none() {
+        eprintln!("boomux: OpenCode is unavailable; continuing without OpenCode handoffs");
     }
     Ok(())
 }
@@ -11016,28 +11032,48 @@ struct SharedOpenCodeLaunch {
     holder: String,
     tui_config: PathBuf,
     original_path: Option<OsString>,
+    session: Option<String>,
 }
 
-impl SharedOpenCodeLaunch {
-    fn argv(&self) -> Vec<OsString> {
-        vec![
-            "attach".into(),
-            self.url.clone().into(),
-            "--dir".into(),
-            self.cwd.clone().into_os_string(),
-        ]
-    }
-}
-
-fn shared_opencode_launch(
+struct SharedOpenCodeLaunchInput {
     shell_id: Option<OsString>,
     run_id: Option<OsString>,
     executable: Option<OsString>,
     tui_config: Option<OsString>,
     original_path: Option<OsString>,
     cwd: PathBuf,
+    session: Option<String>,
     runtime: protocol::OpenCodeSharedRuntimeSnapshot,
+}
+
+impl SharedOpenCodeLaunch {
+    fn argv(&self) -> Vec<OsString> {
+        let mut argv = vec![
+            "attach".into(),
+            self.url.clone().into(),
+            "--dir".into(),
+            self.cwd.clone().into_os_string(),
+        ];
+        if let Some(session) = &self.session {
+            argv.extend(["--session".into(), session.into()]);
+        }
+        argv
+    }
+}
+
+fn shared_opencode_launch(
+    input: SharedOpenCodeLaunchInput,
 ) -> Result<SharedOpenCodeLaunch, Box<dyn Error>> {
+    let SharedOpenCodeLaunchInput {
+        shell_id,
+        run_id,
+        executable,
+        tui_config,
+        original_path,
+        cwd,
+        session,
+        runtime,
+    } = input;
     for (name, value) in [("BOOMUX_SHELL_ID", shell_id), ("BOOMUX_RUN_ID", run_id)] {
         if value.as_ref().is_none_or(|value| value.is_empty()) {
             return Err(format!("{name} is required").into());
@@ -11070,6 +11106,9 @@ fn shared_opencode_launch(
     if !cwd.is_absolute() {
         return Err("current working directory must be absolute".into());
     }
+    if session.as_deref().is_some_and(str::is_empty) {
+        return Err("OpenCode Session ID must not be empty".into());
+    }
     Ok(SharedOpenCodeLaunch {
         executable,
         url: runtime.url,
@@ -11078,10 +11117,42 @@ fn shared_opencode_launch(
         holder: Uuid::new_v4().to_string(),
         tui_config,
         original_path,
+        session,
     })
 }
 
-fn launch_shared_opencode() -> Result<(), Box<dyn Error>> {
+fn launch_standalone_recovered_opencode(
+    session: &str,
+    shared_error: &dyn std::fmt::Display,
+) -> Result<(), Box<dyn Error>> {
+    if session.is_empty() {
+        return Err("OpenCode Session ID must not be empty".into());
+    }
+    let executable = env::var_os("BOOMUX_REAL_OPENCODE")
+        .ok_or("BOOMUX_REAL_OPENCODE is required for standalone recovery")?;
+    eprintln!(
+        "boomux: shared OpenCode recovery is unavailable ({shared_error}); continuing standalone"
+    );
+    let mut command = Command::new(executable);
+    command
+        .args(["--session", session])
+        .env_remove("BOOMUX_OPENCODE_SHARED_GENERATION")
+        .env_remove("BOOMUX_OPENCODE_CLAIM_HOLDER")
+        .env_remove("BOOMUX_REAL_OPENCODE")
+        .env_remove("BOOMUX_ORIGINAL_PATH")
+        .env_remove("BOOMUX_OPENCODE_SHIM_DIR")
+        .env_remove("BOOMUX_OPENCODE_TUI_CONFIG")
+        .env_remove("BOOMUX_SHIM_EXECUTABLE")
+        .env_remove("BOOMUX_REAL_CLAUDE")
+        .env_remove("BOOMUX_CLAUDE_REMOTE_CONTROL")
+        .env_remove("BOOMUX_USER_ZDOTDIR");
+    if let Some(path) = env::var_os("BOOMUX_ORIGINAL_PATH") {
+        command.env("PATH", path);
+    }
+    Err(command.exec().into())
+}
+
+fn launch_shared_opencode(session: Option<&str>, port: u16) -> Result<(), Box<dyn Error>> {
     let shell_id = env::var_os("BOOMUX_SHELL_ID");
     let run_id = env::var_os("BOOMUX_RUN_ID");
     for (name, value) in [
@@ -11092,20 +11163,40 @@ fn launch_shared_opencode() -> Result<(), Box<dyn Error>> {
             return Err(format!("{name} is required").into());
         }
     }
-    let client = client::connect_or_start()?;
-    let runtime = match client.get_opencode_shared_runtime()? {
-        Some(runtime) => runtime,
-        None => client.ensure_opencode_shared_runtime(4097)?,
+    let runtime = (|| {
+        let client = client::connect_or_start()?;
+        match client.get_opencode_shared_runtime()? {
+            Some(runtime) => Ok(runtime),
+            None => match client.ensure_opencode_shared_runtime(port) {
+                Ok(runtime) => Ok(runtime),
+                Err(error) => client.get_opencode_shared_runtime()?.ok_or(error),
+            },
+        }
+    })();
+    let runtime = match runtime {
+        Ok(runtime) => runtime,
+        Err(error) if session.is_some() => {
+            return launch_standalone_recovered_opencode(session.unwrap(), &error);
+        }
+        Err(error) => return Err(error.into()),
     };
-    let launch = shared_opencode_launch(
+    let launch = shared_opencode_launch(SharedOpenCodeLaunchInput {
         shell_id,
         run_id,
-        env::var_os("BOOMUX_REAL_OPENCODE"),
-        env::var_os("BOOMUX_OPENCODE_TUI_CONFIG"),
-        env::var_os("BOOMUX_ORIGINAL_PATH"),
-        env::current_dir()?,
+        executable: env::var_os("BOOMUX_REAL_OPENCODE"),
+        tui_config: env::var_os("BOOMUX_OPENCODE_TUI_CONFIG"),
+        original_path: env::var_os("BOOMUX_ORIGINAL_PATH"),
+        cwd: env::current_dir()?,
+        session: session.map(str::to_owned),
         runtime,
-    )?;
+    });
+    let launch = match launch {
+        Ok(launch) => launch,
+        Err(error) if session.is_some() => {
+            return launch_standalone_recovered_opencode(session.unwrap(), error.as_ref());
+        }
+        Err(error) => return Err(error),
+    };
     let mut command = Command::new(&launch.executable);
     command
         .args(launch.argv())
@@ -14551,8 +14642,28 @@ mod tests {
         assert!(matches!(
             shared.command,
             Some(Commands::Opencode {
-                command: OpenCodeCommands::Shared,
+                command: OpenCodeCommands::Shared {
+                    session: None,
+                    port: 4097,
+                },
             })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from([
+                "boomux",
+                "opencode",
+                "shared",
+                "--session",
+                "session-exact"
+            ])
+            .unwrap()
+            .command,
+            Some(Commands::Opencode {
+                command: OpenCodeCommands::Shared {
+                    session: Some(ref session),
+                    port: 4097,
+                },
+            }) if session == "session-exact"
         ));
         assert!(Cli::try_parse_from(["boomux", "opencode", "attach", "agent-exact"]).is_err());
     }
@@ -14581,20 +14692,21 @@ mod tests {
         fs::write(&executable, b"#!/bin/sh\n").unwrap();
         fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
         fs::write(&tui_config, b"{}\n").unwrap();
-        let launch = shared_opencode_launch(
-            Some("shell-1".into()),
-            Some("run-1".into()),
-            Some(executable.clone().into_os_string()),
-            Some(tui_config.clone().into_os_string()),
-            Some("/original/bin".into()),
-            directory.clone(),
-            protocol::OpenCodeSharedRuntimeSnapshot {
+        let launch = shared_opencode_launch(SharedOpenCodeLaunchInput {
+            shell_id: Some("shell-1".into()),
+            run_id: Some("run-1".into()),
+            executable: Some(executable.clone().into_os_string()),
+            tui_config: Some(tui_config.clone().into_os_string()),
+            original_path: Some("/original/bin".into()),
+            cwd: directory.clone(),
+            session: Some("session-exact".into()),
+            runtime: protocol::OpenCodeSharedRuntimeSnapshot {
                 generation_id: "generation-1".into(),
                 url: "http://127.0.0.1:4097".into(),
                 port: 4097,
                 pid: Some(42),
             },
-        )
+        })
         .unwrap();
         assert_eq!(launch.executable, executable);
         assert_eq!(launch.url, "http://127.0.0.1:4097");
@@ -14610,6 +14722,8 @@ mod tests {
                 OsString::from("http://127.0.0.1:4097"),
                 OsString::from("--dir"),
                 launch.cwd.clone().into_os_string(),
+                OsString::from("--session"),
+                OsString::from("session-exact"),
             ]
         );
         fs::remove_dir_all(&launch.cwd).unwrap();

--- a/src/mobile_web.rs
+++ b/src/mobile_web.rs
@@ -50,6 +50,7 @@ const ICON_512: &[u8] = include_bytes!("../assets/mobile-web/icon-512.png");
 struct AppState {
     client: Client,
     presentation: Arc<Mutex<PresentationState>>,
+    opencode_requested_port: Option<u16>,
     opencode_web_url: Option<Arc<str>>,
     opencode_runtime_hint: Option<OpenCodeRuntimeHint>,
 }
@@ -71,6 +72,10 @@ pub(crate) struct WebStatus {
     pub(crate) port: u16,
     pub(crate) tailscale: bool,
     pub(crate) dashboard_url: String,
+    #[serde(default)]
+    pub(crate) opencode_requested_port: Option<u16>,
+    #[serde(default)]
+    pub(crate) opencode_requested_url: Option<String>,
     pub(crate) opencode_port: Option<u16>,
     pub(crate) opencode_url: Option<String>,
 }
@@ -336,10 +341,13 @@ pub(crate) fn run(
     } else {
         client::connect_or_start()?
     };
-    let opencode_runtime = configuration
-        .runtime_port
-        .map(|port| client.ensure_opencode_shared_runtime(port))
-        .transpose()?;
+    let opencode_runtime = match configuration.runtime_port {
+        Some(port) => client.try_ensure_opencode_shared_runtime(port)?,
+        None => None,
+    };
+    if configuration.runtime_port.is_some() && opencode_runtime.is_none() {
+        eprintln!("boomux: OpenCode is unavailable; continuing without OpenCode handoffs");
+    }
     let opencode_web_url = configuration.public_url.map(Arc::from);
     let opencode_runtime_hint = opencode_runtime.map(|runtime| OpenCodeRuntimeHint {
         generation_id: Arc::from(runtime.generation_id),
@@ -357,6 +365,7 @@ pub(crate) fn run(
     let state = AppState {
         client,
         presentation: Arc::new(Mutex::new(presentation)),
+        opencode_requested_port: configuration.runtime_port,
         opencode_web_url,
         opencode_runtime_hint,
     };
@@ -491,6 +500,15 @@ async fn serve(
             || format!("http://{address}"),
             crate::tailscale_serve::Exposure::dashboard_url,
         ),
+        opencode_requested_port: state.opencode_requested_port,
+        opencode_requested_url: state.opencode_requested_port.and_then(|port| {
+            (!tailscale).then(|| {
+                state
+                    .opencode_web_url
+                    .as_deref()
+                    .map_or_else(|| format!("http://127.0.0.1:{port}"), ToOwned::to_owned)
+            })
+        }),
         opencode_port: state
             .opencode_runtime_hint
             .as_ref()
@@ -1633,6 +1651,8 @@ mod tests {
             port: 3737,
             tailscale: true,
             dashboard_url: "https://host.example.ts.net".into(),
+            opencode_requested_port: Some(4097),
+            opencode_requested_url: None,
             opencode_port: Some(4097),
             opencode_url: Some("https://host.example.ts.net:4097".into()),
         };
@@ -1647,10 +1667,22 @@ mod tests {
 
         let status = status_control_socket(&path).unwrap().unwrap();
         assert_eq!(status.dashboard_url, expected.dashboard_url);
+        assert_eq!(status.opencode_requested_port, Some(4097));
         assert_eq!(status.opencode_port, Some(4097));
         server.join().unwrap();
         fs::remove_file(path).unwrap();
         fs::remove_dir(directory).unwrap();
+    }
+
+    #[test]
+    fn old_web_status_defaults_requested_opencode_configuration() {
+        let status: WebStatus = serde_json::from_str(
+            r#"{"running":true,"port":3737,"tailscale":false,"dashboard_url":"http://127.0.0.1:3737","opencode_port":4097,"opencode_url":"http://127.0.0.1:4097"}"#,
+        )
+        .unwrap();
+        assert_eq!(status.opencode_requested_port, None);
+        assert_eq!(status.opencode_requested_url, None);
+        assert_eq!(status.opencode_port, Some(4097));
     }
 
     #[test]

--- a/src/tailscale_serve.rs
+++ b/src/tailscale_serve.rs
@@ -462,4 +462,47 @@ mod tests {
         assert!(!commands.contains("--https=443 http://127.0.0.1:3737"));
         fs::remove_dir_all(directory).unwrap();
     }
+
+    #[test]
+    fn exposure_without_opencode_publishes_only_the_dashboard() {
+        let directory = std::env::temp_dir().join(format!(
+            "boomux-tailscale-dashboard-only-test-{}",
+            Uuid::new_v4()
+        ));
+        fs::create_dir(&directory).unwrap();
+        let executable = directory.join("tailscale");
+        let log = directory.join("commands.log");
+        let marker = directory.join("dashboard-enabled");
+        let script = format!(
+            "#!/bin/sh\n\
+             printf '%s\\n' \"$*\" >> '{log}'\n\
+             case \"$*\" in\n\
+               'status --json') printf '%s' '{{\"BackendState\":\"Running\",\"Self\":{{\"Online\":true,\"DNSName\":\"host.example.ts.net.\"}}}}' ;;\n\
+               'serve status --json')\n\
+                 if [ -e '{marker}' ]; then\n\
+                   printf '%s' '{{\"TCP\":{{\"443\":{{\"HTTPS\":true}}}},\"Web\":{{\"host.example.ts.net:443\":{{\"Handlers\":{{\"/\":{{\"Proxy\":\"http://127.0.0.1:3737\"}}}}}}}}}}'\n\
+                 else\n\
+                   printf '%s' '{{\"TCP\":{{}},\"Web\":{{}}}}'\n\
+                 fi ;;\n\
+               'serve --bg --yes --https=443 http://127.0.0.1:3737') : > '{marker}' ;;\n\
+               'serve --https=443 --set-path=/ off') rm -f '{marker}' ;;\n\
+               *) exit 64 ;;\n\
+             esac\n",
+            log = log.display(),
+            marker = marker.display(),
+        );
+        fs::write(&executable, script).unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        let record = directory.join("ownership.json");
+
+        let exposure = Exposure::enable_with(executable.as_os_str(), record, 3737, None).unwrap();
+        assert_eq!(exposure.dashboard_url(), "https://host.example.ts.net");
+        drop(exposure);
+
+        let commands = fs::read_to_string(log).unwrap();
+        assert!(commands.contains("serve --bg --yes --https=443 http://127.0.0.1:3737"));
+        assert!(commands.contains("serve --https=443 --set-path=/ off"));
+        assert!(!commands.contains("4097"));
+        fs::remove_dir_all(directory).unwrap();
+    }
 }

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -8,6 +8,8 @@ mod daemon_lifecycle;
 mod handoff;
 #[path = "native_backend/launchers_integrations.rs"]
 mod launchers_integrations;
+#[path = "native_backend/mobile_web.rs"]
+mod mobile_web;
 #[path = "native_backend/node_registration.rs"]
 mod node_registration;
 #[path = "native_backend/notifications.rs"]

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -324,6 +324,194 @@ fn opencode_runtime_receives_exact_ephemeral_environment_and_cold_adopts() {
 }
 
 #[test]
+fn cold_recovery_attaches_opencode_session_to_shared_runtime_and_new_run() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let runtime_bin = runtime_dir.join("bin");
+        let shell_bin = runtime_dir.join("shell-bin");
+        fs::create_dir(&runtime_bin).unwrap();
+        fs::create_dir(&shell_bin).unwrap();
+        let runtime_opencode = runtime_bin.join("opencode");
+        fs::write(
+            &runtime_opencode,
+            "#!/bin/sh\ncase \"${1-}\" in\n  serve) exec python3 -c 'import socket,sys,time; s=socket.socket(); s.bind((\"127.0.0.1\", int(sys.argv[5]))); s.listen(); time.sleep(60)' \"$@\" ;;\n  attach) printf 'path-decoy\\n' > \"$CAPTURE\"; exit 1 ;;\n  *) while :; do sleep 60; done ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&runtime_opencode, fs::Permissions::from_mode(0o700)).unwrap();
+        let shell_opencode = shell_bin.join("opencode");
+        fs::write(
+            &shell_opencode,
+            "#!/bin/sh\ncase \"${1-}\" in\n  attach) { for arg do printf 'arg:%s\\n' \"$arg\"; done; printf 'generation:%s\\nholder:%s\\nshell:%s\\nrun:%s\\n' \"$BOOMUX_OPENCODE_SHARED_GENERATION\" \"$BOOMUX_OPENCODE_CLAIM_HOLDER\" \"$BOOMUX_SHELL_ID\" \"$BOOMUX_RUN_ID\"; } > \"$CAPTURE\"; while :; do sleep 60; done ;;\n  *) while :; do sleep 60; done ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&shell_opencode, fs::Permissions::from_mode(0o700)).unwrap();
+        command
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    runtime_bin.display(),
+                    std::env::var("PATH").unwrap()
+                ),
+            )
+            .env("CAPTURE", runtime_dir.join("recovered-opencode"));
+    });
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let runtime = ensure_test_opencode_runtime(&daemon, port).unwrap();
+    let opencode_directory = daemon.runtime_dir.join("shell-bin");
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "recover-shared-opencode",
+            vec![ShellSpec {
+                name: "opencode".into(),
+                command: vec!["./opencode".into()],
+                cwd: opencode_directory,
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let first_run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+    daemon
+        .client
+        .register_agent(
+            &shell_id,
+            &first_run.id,
+            AgentRegistrationSpec {
+                name: "OpenCode".into(),
+                integration: "opencode".into(),
+                external_session_id: Some("ses_recovered_exact".into()),
+                report: AgentReport {
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "idle before interruption".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+
+    daemon.crash();
+    drop(attachment.stream);
+    let path = format!(
+        "{}:{}",
+        daemon.runtime_dir.join("bin").display(),
+        std::env::var("PATH").unwrap()
+    );
+    let capture = daemon.runtime_dir.join("recovered-opencode");
+    let restart_capture = capture.clone();
+    daemon.restart_with(|command| {
+        command.env("PATH", path).env("CAPTURE", restart_capture);
+    });
+    let recovered_attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    wait_until(
+        || capture.is_file(),
+        "recovered OpenCode did not attach to the shared runtime",
+    );
+    let second_run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+    assert_eq!(second_run.generation, first_run.generation + 1);
+    assert_ne!(second_run.id, first_run.id);
+    let captured = fs::read_to_string(&capture).unwrap();
+    assert!(captured.contains("arg:attach\n"));
+    assert!(captured.contains(&format!("arg:{}\n", runtime.url)));
+    assert!(captured.contains("arg:--session\narg:ses_recovered_exact\n"));
+    assert!(captured.contains(&format!("generation:{}\n", runtime.generation_id)));
+    assert!(captured.contains(&format!("shell:{shell_id}\n")));
+    assert!(captured.contains(&format!("run:{}\n", second_run.id)));
+    let holder = captured
+        .lines()
+        .find_map(|line| line.strip_prefix("holder:"))
+        .filter(|holder| !holder.is_empty())
+        .unwrap();
+    let registration = AgentRegistrationSpec {
+        name: "OpenCode".into(),
+        integration: "opencode".into(),
+        external_session_id: Some("ses_recovered_exact".into()),
+        report: AgentReport {
+            state: AgentState::Unknown,
+            authority: AgentAuthority::LifecycleIntegration,
+            evidence: "direct recovered TUI selection".into(),
+            confidence: 100,
+        },
+    };
+    let (claim, agent) = daemon
+        .client
+        .ensure_opencode_session_claim(
+            &runtime.generation_id,
+            holder,
+            "ses_recovered_exact",
+            &shell_id,
+            &second_run.id,
+            registration,
+        )
+        .unwrap();
+    assert_eq!(claim.run_id, second_run.id);
+    assert_eq!(agent.run_id, second_run.id);
+    assert_eq!(
+        daemon
+            .client
+            .resolve_opencode_session_claim(&runtime.generation_id, "ses_recovered_exact")
+            .unwrap()
+            .0,
+        claim
+    );
+
+    drop(recovered_attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn recovered_opencode_fallback_preserves_user_environment_and_exact_session() {
+    let mut daemon = TestDaemon::start();
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let empty_bin = daemon.runtime_dir.join("empty-bin");
+    fs::create_dir(&empty_bin).unwrap();
+    let capture = daemon.runtime_dir.join("standalone-recovery");
+    let fallback = daemon.runtime_dir.join("fallback-opencode");
+    fs::write(
+        &fallback,
+        "#!/bin/sh\n{ for arg do printf 'arg:%s\\n' \"$arg\"; done; printf 'path:%s\\ntui:%s\\nreal:%s\\noriginal:%s\\nshim:%s\\nprivate-tui:%s\\nclaude:%s\\nclaude-policy:%s\\nzdot:%s\\n' \"$PATH\" \"${OPENCODE_TUI_CONFIG-unset}\" \"${BOOMUX_REAL_OPENCODE-unset}\" \"${BOOMUX_ORIGINAL_PATH-unset}\" \"${BOOMUX_SHIM_EXECUTABLE-unset}\" \"${BOOMUX_OPENCODE_TUI_CONFIG-unset}\" \"${BOOMUX_REAL_CLAUDE-unset}\" \"${BOOMUX_CLAUDE_REMOTE_CONTROL-unset}\" \"${BOOMUX_USER_ZDOTDIR-unset}\"; } > \"$CAPTURE\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&fallback, fs::Permissions::from_mode(0o700)).unwrap();
+    let output = daemon
+        .command()
+        .args([
+            "opencode",
+            "shared",
+            "--session",
+            "ses_fallback_exact",
+            "--port",
+            &port.to_string(),
+        ])
+        .env("PATH", &empty_bin)
+        .env("CAPTURE", &capture)
+        .env("BOOMUX_SHELL_ID", "shell-exact")
+        .env("BOOMUX_RUN_ID", "run-exact")
+        .env("BOOMUX_REAL_OPENCODE", &fallback)
+        .env("BOOMUX_ORIGINAL_PATH", "/user/original-bin")
+        .env("BOOMUX_SHIM_EXECUTABLE", &daemon.executable)
+        .env("BOOMUX_OPENCODE_TUI_CONFIG", "/private/tui.json")
+        .env("OPENCODE_TUI_CONFIG", "/user/tui.json")
+        .env("BOOMUX_REAL_CLAUDE", "/private/claude")
+        .env("BOOMUX_CLAUDE_REMOTE_CONTROL", "1")
+        .env("BOOMUX_USER_ZDOTDIR", "/user/zdotdir")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("continuing standalone"));
+    assert_eq!(
+        fs::read_to_string(capture).unwrap(),
+        "arg:--session\narg:ses_fallback_exact\npath:/user/original-bin\ntui:/user/tui.json\nreal:unset\noriginal:unset\nshim:unset\nprivate-tui:unset\nclaude:unset\nclaude-policy:unset\nzdot:unset\n"
+    );
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn agent_runtime_is_revisioned_durable_and_version_compatible() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon

--- a/tests/native_backend/mobile_web.rs
+++ b/tests/native_backend/mobile_web.rs
@@ -1,0 +1,200 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use boomux::protocol::ShellSpec;
+
+use crate::support::{TestDaemon, profile};
+
+struct WebCleanup {
+    executable: PathBuf,
+    runtime_dir: PathBuf,
+    port: String,
+}
+
+impl WebCleanup {
+    fn new(daemon: &TestDaemon, port: String) -> Self {
+        Self {
+            executable: daemon.executable.clone(),
+            runtime_dir: daemon.runtime_dir.clone(),
+            port,
+        }
+    }
+}
+
+impl Drop for WebCleanup {
+    fn drop(&mut self) {
+        let _ = Command::new(&self.executable)
+            .args(["web", "stop", "--port", &self.port, "--json"])
+            .env("XDG_RUNTIME_DIR", &self.runtime_dir)
+            .env("XDG_CONFIG_HOME", self.runtime_dir.join("config"))
+            .env("XDG_STATE_HOME", self.runtime_dir.join("state"))
+            .output();
+    }
+}
+
+fn unused_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn run_web(daemon: &TestDaemon, arguments: &[&str], path: &Path) -> std::process::Output {
+    let mut command = daemon.command();
+    command.args(arguments).env("PATH", path);
+    command.output().unwrap()
+}
+
+#[test]
+fn web_starts_without_opencode_and_repeats_idempotently() {
+    let mut daemon = TestDaemon::start();
+    let empty_path = daemon.runtime_dir.join("empty-path");
+    fs::create_dir(&empty_path).unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "claude-web-without-opencode",
+            vec![ShellSpec {
+                name: "claude".into(),
+                command: vec!["/bin/sleep".into(), "30".into()],
+                cwd: std::env::temp_dir(),
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let _attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+    let mut hook = daemon.command();
+    hook.args(["claude", "hook"])
+        .env("BOOMUX_SHELL_ID", &shell_id)
+        .env("BOOMUX_RUN_ID", &run_id)
+        .env("CLAUDE_CODE_BRIDGE_SESSION_ID", "bridge-without-opencode")
+        .stdin(Stdio::piped());
+    let mut hook = hook.spawn().unwrap();
+    write!(
+        hook.stdin.take().unwrap(),
+        "{{\"session_id\":\"claude-without-opencode\",\"hook_event_name\":\"SessionStart\"}}"
+    )
+    .unwrap();
+    assert!(hook.wait().unwrap().success());
+
+    let dashboard_port = unused_port();
+    let opencode_port = unused_port();
+    assert_ne!(dashboard_port, opencode_port);
+    let dashboard_port_value = dashboard_port;
+    let opencode_port_value = opencode_port;
+    let dashboard_port = dashboard_port_value.to_string();
+    let opencode_port = opencode_port_value.to_string();
+    let arguments = [
+        "web",
+        "start",
+        "--port",
+        &dashboard_port,
+        "--opencode-web-port",
+        &opencode_port,
+        "--json",
+    ];
+    let cleanup = WebCleanup::new(&daemon, dashboard_port.clone());
+
+    let started = run_web(&daemon, &arguments, &empty_path);
+    assert!(
+        started.status.success(),
+        "web start failed: {}",
+        String::from_utf8_lossy(&started.stderr)
+    );
+    let started: serde_json::Value = serde_json::from_slice(&started.stdout).unwrap();
+    assert_eq!(started["data"]["running"], true);
+    assert_eq!(started["data"]["changed"], true);
+    assert_eq!(
+        started["data"]["opencode_requested_port"],
+        opencode_port_value
+    );
+    assert_eq!(
+        started["data"]["opencode_requested_url"],
+        format!("http://127.0.0.1:{opencode_port}")
+    );
+    assert!(
+        started["data"]["opencode_port"].is_null(),
+        "unexpected OpenCode runtime: {started}"
+    );
+    assert!(started["data"]["opencode_url"].is_null());
+    assert!(TcpListener::bind(("127.0.0.1", dashboard_port_value)).is_err());
+    let mut stream = TcpStream::connect(("127.0.0.1", dashboard_port_value)).unwrap();
+    stream
+        .write_all(b"GET /api/snapshot HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+        .unwrap();
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).unwrap();
+    let body = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|index| &response[index + 4..])
+        .unwrap();
+    let snapshot: serde_json::Value = serde_json::from_slice(body).unwrap();
+    let claude = snapshot["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|agent| agent["integration"] == "claude")
+        .unwrap();
+    assert_eq!(claude["native_web"]["label"], "Open in Claude");
+    assert_eq!(
+        claude["native_web"]["url"],
+        "https://claude.ai/code/bridge-without-opencode"
+    );
+
+    let repeated = run_web(&daemon, &arguments, &empty_path);
+    assert!(repeated.status.success());
+    let repeated: serde_json::Value = serde_json::from_slice(&repeated.stdout).unwrap();
+    assert_eq!(repeated["data"]["changed"], false);
+
+    let stopped = run_web(
+        &daemon,
+        &["web", "stop", "--port", &dashboard_port, "--json"],
+        &empty_path,
+    );
+    assert!(stopped.status.success());
+    drop(cleanup);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn web_keeps_an_opencode_port_conflict_fatal() {
+    let mut daemon = TestDaemon::start();
+    let empty_path = daemon.runtime_dir.join("empty-path");
+    fs::create_dir(&empty_path).unwrap();
+    let dashboard_port = unused_port();
+    let occupied = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let dashboard_port = dashboard_port.to_string();
+    let opencode_port = occupied.local_addr().unwrap().port().to_string();
+    let cleanup = WebCleanup::new(&daemon, dashboard_port.clone());
+
+    let output = run_web(
+        &daemon,
+        &[
+            "web",
+            "start",
+            "--port",
+            &dashboard_port,
+            "--opencode-web-port",
+            &opencode_port,
+            "--json",
+        ],
+        &empty_path,
+    );
+    assert!(!output.status.success());
+    let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("exited before becoming ready")
+    );
+
+    drop(cleanup);
+    daemon.stop_with_cli();
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fs;
 use std::io;
 use std::os::unix::net::UnixStream;
@@ -33,6 +34,43 @@ pub(crate) struct TestDaemon {
     pub(crate) client: Client,
 }
 
+fn remove_boomux_shim_environment(command: &mut Command) {
+    let original_path = env::var_os("BOOMUX_ORIGINAL_PATH");
+    let shim_dir = env::var_os("BOOMUX_OPENCODE_SHIM_DIR").map(PathBuf::from);
+    let user_zdotdir = env::var_os("BOOMUX_USER_ZDOTDIR");
+    let private_tui_config = env::var_os("BOOMUX_OPENCODE_TUI_CONFIG");
+    for name in [
+        "BOOMUX_CLAUDE_REMOTE_CONTROL",
+        "BOOMUX_REAL_CLAUDE",
+        "BOOMUX_REAL_OPENCODE",
+        "BOOMUX_ORIGINAL_PATH",
+        "BOOMUX_OPENCODE_SHIM_DIR",
+        "BOOMUX_OPENCODE_TUI_CONFIG",
+        "BOOMUX_SHIM_EXECUTABLE",
+        "BOOMUX_OPENCODE_SHARED_GENERATION",
+        "BOOMUX_OPENCODE_CLAIM_HOLDER",
+        "BOOMUX_USER_ZDOTDIR",
+    ] {
+        command.env_remove(name);
+    }
+    if let Some(path) = original_path {
+        command.env("PATH", path);
+    } else if let (Some(path), Some(shim_dir)) = (env::var_os("PATH"), shim_dir) {
+        let filtered = env::split_paths(&path)
+            .filter(|entry| entry != &shim_dir)
+            .collect::<Vec<_>>();
+        if let Ok(path) = env::join_paths(filtered) {
+            command.env("PATH", path);
+        }
+    }
+    if let Some(zdotdir) = user_zdotdir {
+        command.env("ZDOTDIR", zdotdir);
+    }
+    if private_tui_config.is_some() && env::var_os("OPENCODE_TUI_CONFIG") == private_tui_config {
+        command.env_remove("OPENCODE_TUI_CONFIG");
+    }
+}
+
 impl TestDaemon {
     pub(crate) fn start() -> Self {
         Self::start_with(|command, _| {
@@ -64,6 +102,7 @@ impl TestDaemon {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
+        remove_boomux_shim_environment(&mut command);
         configure(&mut command, &runtime_dir);
         let child = command.spawn().unwrap();
         let client = Client::from_socket_path(runtime_dir.join("boomux/daemon.sock"));
@@ -82,6 +121,7 @@ impl TestDaemon {
         command.env("XDG_CONFIG_HOME", self.runtime_dir.join("config"));
         command.env("XDG_STATE_HOME", self.runtime_dir.join("state"));
         command.env("BOOMUX_NATIVE_TEST_HOOKS", "1");
+        remove_boomux_shim_environment(&mut command);
         command
     }
 


### PR DESCRIPTION
## Summary
- keep the Agent dashboard, Claude handoffs, detached startup, and dashboard-only Tailscale publication available when the OpenCode executable is absent
- resume uniquely recoverable OpenCode Sessions through the Shared Harness Runtime so replacement ShellRuns establish fresh web handoff claims
- preserve the existing typed missing-runtime wire contract, retain standalone recovery fallback, and isolate native tests from inherited Boomux shim environment

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`
