### PR TITLE
feat(codex): add lifecycle integration

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: boomux
-description: Inspect and manage Boomux Nodes, coordinated persistent terminal Workspaces, launchers, shells, run-scoped agent instances, attention, projected sessions, recurring Agent schedules, local configuration, notifications, the OpenCode Shared Harness Runtime, process supervision, and integrations. Use when asked to discover Nodes, shells, agents, sessions, or schedules, read terminal output, inspect, validate, or edit local Boomux configuration, manage explicitly authorized recurring Agent prompts, supervise an explicitly identified external session, report agent lifecycle state, configure or test notifications, install or remove the OpenCode or Pi integration, create or open Workspaces and shells, inspect status, rename or close targets, or manage the local Boomux daemon.
+description: Inspect and manage Boomux Nodes, coordinated persistent terminal Workspaces, launchers, shells, run-scoped agent instances, attention, projected sessions, recurring Agent schedules, local configuration, notifications, the OpenCode Shared Harness Runtime, process supervision, and integrations. Use when asked to discover Nodes, shells, agents, sessions, or schedules, read terminal output, inspect, validate, or edit local Boomux configuration, manage explicitly authorized recurring Agent prompts, supervise an explicitly identified external session, report agent lifecycle state, configure or test notifications, install or remove an OpenCode, Pi, Claude Code, or Codex integration, create or open Workspaces and shells, inspect status, rename or close targets, or manage the local Boomux daemon.
 compatibility: Requires boomux on PATH. Federated resource identity is the pair of owning Node ID and Node-local inner ID. Some name operations require Workspace context or an explicit --workspace/--node; agent mutation and supervision require exact shell-run context, and continuation schedules or supervision require caller-supplied exact canonical session identity.
 metadata:
   author: boomux
@@ -119,6 +119,7 @@ Inspect bundled lifecycle integrations with:
 boomux integration list --json
 boomux integration status --json
 boomux integration status opencode --json
+boomux integration status codex --json
 ```
 
 Mutation commands include:
@@ -130,6 +131,8 @@ boomux integration uninstall opencode --json
 boomux integration uninstall --all --json
 boomux integration setup opencode
 boomux integration verify opencode --json
+boomux integration setup codex
+boomux integration verify codex --json
 ```
 
 Host, asset, and runtime status are independent. `unvalidated` compatibility is
@@ -139,7 +142,8 @@ are untrusted.
 
 Never install, replace, or remove integration files unless the user explicitly
 asks. With that authorization, use `boomux integration install opencode --json`,
-`boomux integration install pi --json`, or `boomux integration install --all
+`boomux integration install pi --json`, `boomux integration install codex
+--json`, or `boomux integration install --all
 --json`; add `--force` only when the user also authorizes replacing a modified
 asset. Use `--dry-run` to inspect exact paths and actions. Previewing replacement
 of modified content requires `--force --dry-run`, which does not write files.
@@ -159,7 +163,8 @@ after an explicit yes response; noninteractive replacement requires both
 `--yes` and `--force`.
 
 After the user restarts a host, verify authoritative reporting with `boomux
-integration verify opencode --json` or `boomux integration verify pi --json`.
+integration verify opencode --json`, `boomux integration verify pi --json`, or
+`boomux integration verify codex --json`.
 Verification requires a running foreground host and current-run
 `lifecycle-integration` evidence. If multiple hosts match, pass `--shell
 "<exact-shell-id>"`; shell names are not accepted.
@@ -247,8 +252,8 @@ blocked = "message-new-instant"
 completed = "complete"
 ```
 
-Cold recovery resumes only a unique OpenCode or Pi external session reported by
-the lifecycle integration. An eligible recovered OpenCode Session attaches to
+Cold recovery resumes only a unique OpenCode, Pi, Claude, or Codex external
+session reported by the lifecycle integration. An eligible recovered OpenCode Session attaches to
 the Shared Harness Runtime and establishes a fresh claim for its replacement
 ShellRun; if shared launch preparation is unavailable, exact Session recovery
 continues standalone without a web link. Persisted terminal history is disabled by default
@@ -271,8 +276,8 @@ the invoking client's resolved notification settings, even when the old daemon
 inherited a different config environment.
 
 Session discovery is not limited to daemon metadata. It may execute the
-PATH-resolved OpenCode CLI and inspect host catalogs in workspace-derived
-directories, exposing sanitized but potentially private session titles.
+PATH-resolved OpenCode or Codex CLI and inspect host catalogs in
+workspace-derived directories, exposing sanitized but potentially private session titles.
 Require authorization appropriate to the host-history metadata before listing
 or inspecting sessions.
 
@@ -292,8 +297,8 @@ Use the exact opaque session ID returned by `session list`. Never guess or
 resolve it from an external session ID, description, shell ID, or Agent ID.
 Session state is marked current only when an occurrence is active on the current
 run of a running retained shell; otherwise it is last-known. Catalog-only
-OpenCode history has state `unknown`, no fabricated occurrence, and a sanitized
-host title. Registered-session descriptions remain durable Agent names.
+OpenCode or Codex history has state `unknown`, no fabricated occurrence, and a
+sanitized host title. Registered-session descriptions remain durable Agent names.
 Protocol-13 sessions retain a `source_cwd` after shell removal so an exact
 canonical session can be resumed in its original context. Resume launches a
 native host process and requires authorization. A remote Session ID is exact
@@ -586,8 +591,8 @@ workspace rows and process counts.
 In Schedules, Left/Right changes between the schedule and history panes, `j`/`k`
 navigates the focused pane, and `[`/`]` also selects retained executions by exact
 execution ID. `Enter` attaches an exact Starting or Active run. For a completed
-execution with a canonical session, it resumes that exact OpenCode or Pi session
-in an unmanaged native terminal without adding a workspace row. `u` runs now with a fresh dispatch key, `p`
+execution with a canonical session, it resumes that exact OpenCode, Pi, Claude,
+or Codex session in an unmanaged native terminal without adding a workspace row. `u` runs now with a fresh dispatch key, `p`
 pauses or resumes future timed work, `c` then
 `y` confirms cancellation of the selected exact active execution. Selecting a
 schedule automatically loads bounded exact-schedule history. `x` then `y`
@@ -693,7 +698,7 @@ establish membership.
 Schedules and persisted prompts, retained terminal state, and Agent/attention
 records after each owner confirms removal. A coordinated close can remain
 `closing`; unresolved membership is retained until `workspace retry` or repeated
-close succeeds. Canonical OpenCode or Pi host data is not deleted. A Workspace
+close succeeds. Canonical OpenCode, Pi, or Codex host data is not deleted. A Workspace
 cannot close itself from one of its own Shells. Confirm the exact target and full
 multi-Node removal scope first.
 
@@ -886,6 +891,29 @@ final assistant error reports `blocked` and a successful settle reports `idle`.
 Session shutdown reports `inactive` because Pi sessions are resumable and makes
 one bounded retry. Inactive records remain durable but do not occupy dashboard
 Agent rows. Reporting is serialized and fail-open.
+
+## Codex Integration
+
+Use `boomux integration setup codex` for status, preview, consent, restart, and
+verification guidance. The target is `${CODEX_HOME:-$HOME/.codex}/hooks.json`.
+Installation and uninstall merge only exact `boomux codex hook` handlers and
+preserve unrelated JSON and hooks. Modified Boomux handlers require explicitly
+authorized `--force`; never replace the whole file. Restart Codex after a change,
+then review and trust the Boomux hook with `/hooks`.
+
+In a managed ShellRun, bare Codex chat, `codex resume`, and `codex exec` are
+routed through an internal launcher that enables hooks only while the installed
+handlers are current. The hook's `session_id` is the canonical thread identity.
+Prompt, tool, compaction, and subagent activity report `working`; permission
+waits report `blocked`; Stop reports `idle`; SessionEnd reports `inactive`; no
+Codex hook reports `done`. Other subcommands and unscoped processes remain
+untracked rather than guessing ownership.
+
+Codex catalog discovery may execute the experimental PATH-resolved `codex
+app-server --stdio` interface in workspace-derived directories. It is bounded,
+sanitizes names or previews, excludes ephemeral threads, and fails open. Exact
+resume uses `codex resume <thread-id>`. Boomux exposes no Codex Remote link because
+there is no documented exact thread-specific Remote URL.
 
 ## Environment And Integration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ exercise process, socket, PTY, and daemon lifecycle behavior.
 | PTY, attachment, or process lifecycle | Colocated unit tests plus serial `native_backend` scenarios |
 | Graceful handoff | Serial native tests covering rollback, reconnect, PID preservation, and later cleanup |
 | TUI state or rendering | Focused `tui.rs` model, input, and rendering tests |
-| OpenCode or Pi reducer | The corresponding Bun integration test, including `boomux-tui.test.js` for OpenCode TUI claims |
+| OpenCode, Pi, Claude, or Codex reducer | The corresponding focused reducer tests, including `boomux-tui.test.js` for OpenCode TUI claims |
 | Host compatibility claim | Focused fixtures plus an update to `docs/lifecycle-validation.md` when validated live |
 
 ## Safety And Compatibility

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -95,8 +95,8 @@ external integration authority.
 Inactive means a resumable external session is not currently active. It remains durable and can
 return to idle or working, but does not decorate a dashboard shell. Done is permanent completion.
 A foreground process hint is not an Agent Instance and is presented as Untracked, never Idle.
-Catalog-only OpenCode history is a client-side projected session with Unknown state and no
-fabricated Agent occurrence.
+Catalog-only OpenCode or Codex history is a client-side projected session with Unknown state and
+no fabricated Agent occurrence.
 
 ## Agent Session
 

--- a/README.md
+++ b/README.md
@@ -317,8 +317,8 @@ In Schedules, Left/Right changes between the schedule and history panes, `j`/`k`
 navigates the focused pane, and `[`/`]` also selects retained executions by exact
 execution ID. `Enter` attaches a selected exact Starting or Active run. For a
 completed execution with a canonical session, it resumes that exact session with
-OpenCode, Pi, or Claude Code in an unmanaged native terminal, without adding a
-workspace row.
+OpenCode, Pi, Claude Code, or Codex in an unmanaged native terminal, without
+adding a workspace row.
 `e` opens the private definition editor for a paused schedule; it supports name,
 prompt, trigger presets or custom cron, and a searchable IANA timezone selector.
 Type to filter timezone names and use the arrow keys to choose a valid match.
@@ -366,7 +366,7 @@ and troubleshooting.
 
 ## Coding-Agent Integrations
 
-Boomux includes optional integrations for OpenCode, Pi, and Claude Code. Guided
+Boomux includes optional integrations for OpenCode, Pi, Claude Code, and Codex. Guided
 setup previews every file change and asks before installing anything:
 
 ```console
@@ -375,6 +375,8 @@ boomux integration setup opencode
 boomux integration setup pi
 # or
 boomux integration setup claude
+# or
+boomux integration setup codex
 ```
 
 Restart the selected host after installation. For the seamless OpenCode workflow,
@@ -391,6 +393,14 @@ mobile dashboard shows **Open in Claude** and links directly to its
 `claude.ai/code` session. Boomux does not host or proxy Claude's web interface or
 read its transcript. Existing sessions can enable the bridge with
 `/remote-control`; organization policy and Claude authentication still apply.
+
+Managed Codex chat, resume, and `exec` launches enable Codex hooks through an
+internal run-scoped launcher. The hook's canonical `session_id` is the Codex
+thread ID used for lifecycle identity and exact resume. After installation,
+restart Codex and review and trust the Boomux hook with `/hooks`. Other Codex
+commands run unchanged and untracked; Boomux does not invent a Codex Remote URL.
+Explicit `codex --remote` clients are also untracked because their app-server
+environment does not prove the current Boomux ShellRun.
 
 Only in an eligible Boomux login Shell, a scoped runtime `PATH` shim redirects
 that exact invocation internally to stock `opencode attach` for the Node's
@@ -439,8 +449,8 @@ matching workspace.
 A projected session groups every Boomux Agent occurrence for the same external
 root session. `current` means an occurrence belongs to the current run of a
 running retained shell; `last known` means the session is historical.
-Catalog-only host history can appear without a fabricated Boomux Agent
-occurrence.
+Catalog-only OpenCode and Codex host history can appear without a fabricated
+Boomux Agent occurrence.
 
 Discover and inspect sessions with exact IDs returned by `session list`:
 
@@ -516,8 +526,10 @@ max_concurrent = 4
 remote_control = true
 ```
 
-OpenCode receives the prompt as the final argument after `--`; Pi and Claude Code
-receive the exact prompt on stdin. Process exit, dispatch failure, cancellation,
+OpenCode receives the prompt as the final argument after `--`; Pi, Claude Code,
+and Codex receive the exact prompt on stdin. Codex dispatch uses `codex exec -`
+for fresh work and `codex exec resume <thread-id> -` for continuation. Process
+exit, dispatch failure, cancellation,
 and cold interruption are execution outcomes and never report an Agent as done. Timed
 work runs only while the Boomux daemon and user session are active; inspect
 `boomux daemon status` and `boomux doctor` for scheduler health and sampled
@@ -634,7 +646,7 @@ the currently focused terminal. Set
 `dashboard.follow_focused_terminal` to `false` to disable this behavior.
 
 After a cold daemon restart, Boomux resumes a uniquely identified OpenCode, Pi,
-or Claude session when its interrupted shell is next started. Recovery requires
+Claude, or Codex session when its interrupted shell is next started. Recovery requires
 a retained external session ID reported by the lifecycle integration; ambiguous,
 completed, or heuristic-only Agents fall back to the shell's configured command.
 Recovered OpenCode Sessions attach to the Shared Harness Runtime and establish a
@@ -718,6 +730,10 @@ Revision-aware output reads and daemon event cursors are documented in
 - Seamless shared OpenCode requires a bare zero-argument interactive invocation
   in an eligible managed login Shell; `--pure`, `--mini`, absolute paths,
   modified `PATH`, and conflicting same-Session Shells fail closed.
+- Pi and Codex Agents have no Open Web action in the mobile dashboard. Pi has
+  no native web handoff, while Codex Remote does not document an exact
+  thread-specific browser or mobile deep link that Boomux can derive
+  authoritatively.
 - Slow viewers may miss live output rather than block the managed process.
 - The native backend currently targets Unix/Linux desktop environments and is
   primarily exercised on Omarchy.

--- a/docs/adr/0006-bind-codex-hooks-to-managed-runs.md
+++ b/docs/adr/0006-bind-codex-hooks-to-managed-runs.md
@@ -1,0 +1,42 @@
+# Bind Codex Hooks To Managed Runs
+
+Status: Accepted
+
+Codex hooks are configured globally, so hook execution alone does not prove
+which Boomux ShellRun owns a thread. Hook `session_id` is authoritative thread
+identity only after the current host process has run-scoped authority. Boomux
+therefore accepts Codex lifecycle reports only when a managed Codex launcher
+explicitly sets `BOOMUX_CODEX_RUN_SCOPED=1` alongside the exact Shell and run
+environment.
+
+Eligible bare chat, `resume`, and `exec` invocations in managed login Shells pass
+through a scoped executable shim and hidden launcher. When Boomux's installed
+hook handlers are current, that launcher prepends `--enable hooks` and sets the
+run-scoped marker. Option-led invocations including explicit `--remote`, other
+subcommands, use outside a managed ShellRun, and absent or modified hook
+installation run stock Codex without lifecycle authority. A configured primary
+Codex command retains its exact executable through `BOOMUX_REAL_CODEX` while the
+launcher adds hooks. Scheduled dispatch and cold recovery use the same launcher
+while retaining their exact descriptor argument vectors and stdin.
+
+The integration merges only exact `boomux codex hook` handlers into Codex's
+shared `hooks.json`. It preserves unrelated fields and handlers, requires force
+to replace modified Boomux handlers, and removes only Boomux-owned entries on
+uninstall. Users must restart Codex and explicitly review and trust the hook with
+`/hooks`; file installation is not treated as runtime trust.
+
+Rejected alternatives were:
+
+- Accept every global Codex hook, because an inherited daemon environment could
+  assign lifecycle evidence to the wrong ShellRun.
+- Infer ownership from process ID, working directory, thread recency, or catalog
+  state, because none proves the exact current run.
+- Replace the complete hooks file, because it is shared user configuration and
+  Boomux does not own unrelated handlers.
+- Construct a Codex Remote URL from the thread ID, because Codex documents no
+  authoritative thread-specific Remote handoff contract.
+
+The bounded experimental app-server catalog remains presentation-only. It may
+project historical threads with Unknown state, but cannot grant lifecycle
+authority. This design reuses existing Agent, Session, Schedule, and recovery
+contracts and adds no protocol or durable-state representation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@
 | `src/host_session_titles.rs` and children | Shared title/catalog policy and host-specific discovery adapters |
 | `src/host_session_source.rs` and children | Canonical host source paths, normalization, and secure source lookup |
 | `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
-| `src/claude_hooks.rs` | Bounded Claude Code hook decoding and root Session lifecycle reduction |
+| `src/claude_hooks.rs`, `src/codex_hooks.rs` | Bounded Claude Code and Codex hook decoding and root Session lifecycle reduction |
 | `src/process_adapter.rs` | Exact-argv child supervision and fail-open process-bound Agent observation |
 | `src/scheduling.rs` | Bounded canonical cron parsing and occurrence evaluation, IANA timezone and DST policy, prompt bounds, and schedule identity validation |
 | `src/config.rs` | Layered configuration resolution, bounded validation, and transactional active-layer editing |
@@ -671,7 +671,7 @@ external ID. It retains original shell/run identity and observations even when a
 shell no longer exists. UUID v5 IDs use a fixed namespace and a versioned,
 length-prefixed encoding of workspace ID, integration, and the external-or-agent
 grouping identity. IDs are globally unique and deterministic but opaque to
-consumers. Bounded OpenCode root-session catalogs add historical, `unknown`
+consumers. Bounded OpenCode root-session and Codex thread catalogs add historical, `unknown`
 sessions without fabricating Agent occurrences and merge with a later durable
 registration under the same stable ID. Catalog records associate to each
 workspace that references their exact normalized directory. The dashboard maps
@@ -682,7 +682,7 @@ The integration descriptor registry is the authority for integration keys,
 display names, and optional typed capabilities. A title capability selects its
 host adapter and independently declares catalog support. The shared title layer
 owns asynchronous cache, refresh, deduplication, sanitization, and fallback
-policy; OpenCode and Pi modules own host command execution and title extraction.
+policy; OpenCode, Pi, and Codex modules own host command execution and title extraction.
 Neutral host source modules own shared path normalization and secure catalog
 discovery. Title and catalog support remain independent from installation,
 foreground recognition, and recovery eligibility, so a future harness can
@@ -704,7 +704,8 @@ active instances match one run, the most recently observed instance is shown
 with an Agent-ID tie-break. Completed, stale-run, and orphaned Agent records
 remain available through CLI inspection but do not occupy dashboard rows. A
 running shell snapshot may also expose its PTY foreground process name. The
-dashboard recognizes exact `opencode` and `pi` as presentation-only agent-shell hints
+dashboard recognizes exact registered host processes, including `opencode`, `pi`,
+`claude`, and `codex`, as presentation-only agent-shell hints
 before a canonical Agent session exists; this hint creates no AgentInstance,
 durable state observation, persistence, or events. It displays `untracked` until
 lifecycle data exists, then yields to that authoritative observation. `doctor`
@@ -1168,6 +1169,49 @@ exercise only the host fields and ordering Boomux consumes; the record
 deliberately distinguishes those tests from transitions observed in real
 managed sessions.
 
+### Codex Lifecycle Integration
+
+The Codex descriptor targets `@openai/codex` `0.147.0` as a compatibility test
+point. Installation merges exact `boomux codex hook` handlers into
+`${CODEX_HOME:-$HOME/.codex}/hooks.json`. Unrelated top-level fields, event
+groups, and handlers remain untouched. Reads are bounded and reject symlinks and
+non-regular targets; writes atomically verify the inspected baseline and retain
+the existing mode. A modified Boomux handler requires force repair. Uninstall
+removes only Boomux handlers and deletes the file only when no unrelated content
+remains. Codex must be restarted and the hook reviewed and trusted with `/hooks`.
+
+Eligible managed Codex invocations pass through a Shell-scoped executable shim
+and hidden launcher. Bare chat, `resume`, and `exec` are considered managed chat;
+when the installed handlers are current, the launcher prepends `--enable hooks`
+and exports `BOOMUX_CODEX_RUN_SCOPED=1`. Option-led invocations including
+explicit `--remote`, other Codex subcommands, an absent or modified installation,
+and use outside Boomux remain untracked. An exact configured primary executable
+is forwarded through `BOOMUX_REAL_CODEX`; typing an absolute path in a login
+Shell bypasses the scoped shim. Hooks silently do nothing unless the run-scoped
+marker and exact `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID` are present. An explicitly
+remote TUI therefore cannot claim authority inherited from its app-server.
+
+Codex hook `session_id` is the canonical thread identity and ensures the exact
+`(codex, thread, shell, run)` Agent key. SessionStart reports Idle, except compact
+starts remain Working; prompt, tool, compaction, and subagent activity report
+Working; PermissionRequest reports Blocked; Stop reports Idle; and SessionEnd
+reports Inactive. Codex hooks never report Done. Input, identity, and reporting
+are bounded and fail open for the host.
+
+Exact resume uses `codex resume <thread-id>`. Scheduled fresh and continuation
+work use `codex exec -` and `codex exec resume <thread-id> -`, respectively,
+with exact prompt bytes on stdin; the internal launcher supplies hook enablement
+without changing the persisted descriptor argv. The experimental catalog
+adapter starts bounded `codex app-server --stdio`, completes `initialize` and
+`initialized`, then requests `thread/list` for the exact normalized workspace
+directory. It filters ephemeral or invalid threads, sanitizes name or preview
+titles, bounds output, count, and runtime, and fails open without changing Agent
+authority. These additions reuse existing protocol Agent, schedule, session,
+and capability shapes, so they require no protocol or durable-state version
+change. Boomux exposes no Codex Remote handoff because Codex documents no exact
+thread-specific Remote URL; it does not reinterpret `codex://threads/ID` as a
+phone-accessible Remote destination.
+
 ### Claude Code Lifecycle Integration
 
 The Claude Code descriptor targets `@anthropic-ai/claude-code` `2.1.236` as a
@@ -1531,8 +1575,8 @@ and last terminal profiles survive restart. The last run record also preserves
 its identity and outcome. Recovered shells are pending: Boomux does not claim
 that arbitrary processes, mutated environments, or PTYs survive daemon restart
 or crash. When enabled, cold recovery substitutes an integration-native resume
-command for a uniquely identified, lifecycle-authoritative OpenCode, Pi, or
-Claude Agent from an interrupted run. Ambiguous or invalid candidates use the
+command for a uniquely identified, lifecycle-authoritative OpenCode, Pi, Claude,
+or Codex Agent from an interrupted run. Ambiguous or invalid candidates use the
 shell's normal command instead. OpenCode recovery routes the exact Session
 through the Shared Harness Runtime so its replacement ShellRun can establish a
 fresh claim; shared-launch preparation failure retains the standalone native

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -241,12 +241,12 @@ The following commands support `--json`:
 - `boomux execution open`
 - `boomux execution cancel`
 - `boomux integration list`
-- `boomux integration status [opencode|pi|claude]`
-- `boomux integration install <opencode|pi|claude>`
+- `boomux integration status [opencode|pi|claude|codex]`
+- `boomux integration install <opencode|pi|claude|codex>`
 - `boomux integration install --all`
-- `boomux integration uninstall <opencode|pi|claude>`
+- `boomux integration uninstall <opencode|pi|claude|codex>`
 - `boomux integration uninstall --all`
-- `boomux integration verify <opencode|pi|claude>`
+- `boomux integration verify <opencode|pi|claude|codex>`
 - `boomux opencode claim ensure`
 - `boomux opencode claim release`
 - `boomux opencode claim report`
@@ -260,7 +260,8 @@ integration install and uninstall support the contract. Other mutation commands
 retain human output. Passing `--json` to an unsupported command fails with
 `invalid_argument` before performing the operation.
 
-`boomux integration setup <opencode|pi|claude>` is intentionally human-oriented
+`boomux integration setup <opencode|pi|claude|codex>` is intentionally
+human-oriented
 and does not support `--json`. It composes status inspection, an exact install
 preview, confirmation, installation when needed, and restart/verification
 guidance. `--yes` skips confirmation for automation; replacing modified content
@@ -369,7 +370,9 @@ Command payloads are:
   instead contains `current_state`, the planned `action`, `path`, and
   `restart_required`. Each target is changed atomically; `--all` is not a
   transaction across hosts, but every target is preflighted before the first
-  write.
+  write. Codex merges only exact Boomux handlers into
+  `${CODEX_HOME:-$HOME/.codex}/hooks.json`, preserving unrelated fields and
+  handlers; modified Boomux handlers require `--force`.
 - `integration.uninstall`: an `integrations` array containing `removed` or
   `not_installed` results, target paths, and whether a host restart is required.
   Every target is preflighted before the first removal.
@@ -415,8 +418,9 @@ generated name is currently in use, suggestion fails with `already_exists`.
 
 ## Integration Data
 
-Integration arrays are ordered `opencode`, then `pi`, then `claude`. List entries
-contain `name`, `display_name`, `package`, and `validated_version`.
+Integration arrays are ordered `opencode`, then `pi`, then `claude`, then
+`codex`. List entries contain `name`, `display_name`, `package`, and
+`validated_version`.
 
 Protocol 22 advertises `protocol_22`, `agent_schedule_management`, and
 `durable_agent_schedules`. Protocol 23 adds `protocol_23`,
@@ -748,8 +752,8 @@ Session summaries contain `id`, `workspace_id`, `workspace_name`, `description`,
 `integration`, `external_session_id`, `state`, `state_is_current`,
 `started_at_ms`, `last_at_ms`, and `occurrence_count`. Registered-session
 `description` is the latest stored Boomux Agent registration name. Catalog-only
-OpenCode sessions use the sanitized host title, state `unknown`, and zero
-occurrences. Missing optional values are JSON `null`.
+OpenCode or Codex sessions use the sanitized host title, state `unknown`, and
+zero occurrences. Missing optional values are JSON `null`.
 
 Inspect includes all summary fields, session-level `source_cwd`, and ordered
 `occurrences`. Each occurrence
@@ -764,8 +768,8 @@ use the same spellings documented for Agent observations.
 
 Projection groups Agent instances only when workspace, integration, and external
 session ID match. An Agent without an external session ID forms its own session.
-Bounded OpenCode catalogs add root sessions to workspaces that reference the
-same normalized directory. A matching durable Agent merges into the same stable
+Bounded OpenCode and Codex catalogs add root sessions to workspaces that
+reference the same normalized directory. A matching durable Agent merges into the same stable
 ID and supplies authoritative lifecycle state and occurrences.
 Current state is selected from occurrences that are incomplete, non-inactive,
 and bound to the current run of a running retained shell; otherwise state is the

--- a/docs/lifecycle-validation.md
+++ b/docs/lifecycle-validation.md
@@ -9,6 +9,14 @@ output, or database recency.
 
 ## 2026-08-20
 
+Codex CLI `0.147.0` was inspected against the documented hooks and experimental
+app-server interfaces. Repository tests validate bounded hook decoding,
+run-scoped authority, lifecycle reduction, exact schedule and recovery argv,
+merged hook installation, and catalog projection. This is fixture and interface
+compatibility evidence only: no live authenticated Codex turn, permission wait,
+hook trust flow, or app-server catalog was exercised. No Codex Remote handoff is
+claimed because the host does not document an exact thread-specific Remote URL.
+
 Claude Code `2.1.236` was live-validated with the protocol-43 lifecycle plugin
 and Remote Control binding. After the skills-directory plugin was installed and
 Claude was restarted inside an existing managed Bash ShellRun, Claude's

--- a/docs/mobile-web.md
+++ b/docs/mobile-web.md
@@ -163,6 +163,9 @@ the intended authentication boundary.
   Agent whose exact Agent/ShellRun has a protocol-43 Remote Control binding
   observed directly by a hook. Its opaque bridge ID is percent-encoded into
   `https://claude.ai/code/<bridge-id>`. No transcript content is read or proxied.
+- Codex Agents have no native handoff. Codex does not document an authoritative
+  thread-specific Remote URL, and `codex://threads/<thread-id>` is not treated as
+  a phone-accessible Remote destination.
 - Native links are not produced for projected remote Agents because their
   external Session identity and working directory intentionally remain on the
   owner Node. Remote Agents remain unlinked to this Node's runtime.
@@ -206,7 +209,8 @@ reverse proxy so this boundary remains visible.
 ## MVP Endpoints
 
 - `GET /api/snapshot` returns the current Node-qualified Agent cards, counts, and
-  optional exact native OpenCode or Claude handoffs.
+  optional exact native OpenCode or Claude handoffs. Codex cards are deliberately
+  unlinked.
 - `POST /api/attention/dismiss` requires JSON containing the exact local
   `node_id`, `agent_id`, and `observation_revision`. It clears a matching
   ephemeral marker or acknowledges matching durable attention.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,6 +53,9 @@
 - [x] Share one daemon-supervised Node-local OpenCode runtime across eligible
   native TUIs and OpenCode Web, with exact ShellRun claims for lifecycle and
   native Session links.
+- [x] Add first-class Codex hooks, run-scoped managed launches, exact resume and
+  scheduling, bounded thread catalogs, foreground hints, and safe merged
+  installation without fabricating a Codex Remote handoff.
 
 ## Workspace Control
 
@@ -121,7 +124,8 @@ eternal process.
 
 ### Near-Term Priorities
 
-1. [Partially validated; see `lifecycle-validation.md`] Validate the OpenCode and Pi lifecycle integrations during normal work before
+1. [Partially validated; see `lifecycle-validation.md`] Validate the OpenCode,
+   Pi, Claude Code, and Codex lifecycle integrations during normal work before
    expanding the observation model. Confirm reload identity, session switching,
    root/subagent aggregation where available, blocked prompts, idle transitions,
    explicit completion semantics, and graceful daemon replacement against real
@@ -156,9 +160,10 @@ eternal process.
    in the Boomux UI without attaching directory-wide history to untracked
    process hints. Keep full inactive and completed workspace history available
    through the session CLI with integration, canonical identity, associated
-   shell and run, lifecycle state, and timestamps. Bounded host catalogs also project pre-registration OpenCode
-   root-session history without fabricated Agent occurrences, while asynchronous
-   adapters provide OpenCode generated titles and Pi names or first-user-message summaries.
+   shell and run, lifecycle state, and timestamps. Bounded host catalogs also
+   project pre-registration OpenCode and Codex root-session history without
+   fabricated Agent occurrences, while asynchronous adapters provide OpenCode
+   and Codex generated titles and Pi names or first-user-message summaries.
 8. [Complete, transcript portion later removed] Separate OpenCode and Pi title and transcript adapters from shared
    cache, pagination, cursor, and output policy so future harness support can be
    added through isolated modules and explicit capability registries.

--- a/docs/scheduled-agent-work.md
+++ b/docs/scheduled-agent-work.md
@@ -136,6 +136,12 @@ errors. Setup and inspection must disclose the selected adapter's transport.
 Boomux never places prompt text in the stable internal runner argv or an
 environment variable, and it does not claim to redact host-owned content.
 
+Codex receives the exact prompt on stdin. Fresh work executes `codex exec -`;
+continuation executes `codex exec resume <thread-id> -`. Both are routed through
+the same internal launcher as managed Codex chat so hooks are enabled and bound
+to the exact schedule-owned ShellRun. The external thread ID is an argv element,
+never shell-interpolated or selected by recency.
+
 Every manual or timed Scheduled Execution uses the daemon's startup environment
 as ephemeral process input. It is validated for child startup but never
 persisted, projected, copied into a schedule revision, or replaced by the
@@ -454,7 +460,7 @@ blocked work attaches to its exact run, while completed work resumes only its
 exact canonical Agent Session; neither path selects a newest or nearby identity.
 Durable Agent attention remains independent. Canonical session identity requires
 the exact linked Agent occurrence. Boomux does not read or
-project host transcript and tool content; OpenCode, Pi, or Claude Code remains
+project host transcript and tool content; OpenCode, Pi, Claude Code, or Codex remains
 the interface for that content.
 
 ## User Control And Permissions

--- a/integrations/codex/hooks.json
+++ b/integrations/codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Report Codex lifecycle state to Boomux for managed ShellRuns.",
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "SessionEnd": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 3 }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "PreToolUse": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "PermissionRequest": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "PostToolUse": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "PreCompact": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "PostCompact": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "SubagentStart": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "SubagentStop": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }]
+  }
+}

--- a/src/codex_hooks.rs
+++ b/src/codex_hooks.rs
@@ -1,0 +1,159 @@
+use std::io::{self, Read};
+
+use boomux::protocol::AgentState;
+use serde::Deserialize;
+
+const MAX_HOOK_INPUT_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+enum HookEvent {
+    SessionStart,
+    SessionEnd,
+    UserPromptSubmit,
+    PreToolUse,
+    PermissionRequest,
+    PostToolUse,
+    PreCompact,
+    PostCompact,
+    SubagentStart,
+    SubagentStop,
+    Stop,
+}
+
+#[derive(Debug, Deserialize)]
+struct HookInput {
+    session_id: String,
+    hook_event_name: HookEvent,
+    #[serde(default)]
+    source: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct LifecycleObservation {
+    pub(crate) state: AgentState,
+    pub(crate) evidence: &'static str,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct HookUpdate {
+    pub(crate) session_id: String,
+    pub(crate) observation: LifecycleObservation,
+}
+
+pub(crate) fn read_update(reader: impl Read) -> Result<HookUpdate, Box<dyn std::error::Error>> {
+    let input = read_bounded_input(reader)?;
+    let input: HookInput = serde_json::from_slice(&input).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid Codex hook input: {error}"),
+        )
+    })?;
+    boomux::scheduling::validate_external_session_id(&input.session_id).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid Codex thread identity: {error}"),
+        )
+    })?;
+    let observation = reduce(&input);
+    Ok(HookUpdate {
+        session_id: input.session_id,
+        observation,
+    })
+}
+
+fn read_bounded_input(mut reader: impl Read) -> io::Result<Vec<u8>> {
+    let mut input = Vec::new();
+    reader
+        .by_ref()
+        .take((MAX_HOOK_INPUT_BYTES + 1) as u64)
+        .read_to_end(&mut input)?;
+    if input.len() > MAX_HOOK_INPUT_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Codex hook input exceeds {MAX_HOOK_INPUT_BYTES} bytes"),
+        ));
+    }
+    Ok(input)
+}
+
+fn reduce(input: &HookInput) -> LifecycleObservation {
+    let (state, evidence) = match input.hook_event_name {
+        HookEvent::SessionStart if input.source.as_deref() == Some("compact") => {
+            (AgentState::Working, "Codex compacting session")
+        }
+        HookEvent::SessionStart => (AgentState::Idle, "Codex session idle"),
+        HookEvent::SessionEnd => (AgentState::Inactive, "Codex session inactive"),
+        HookEvent::UserPromptSubmit => (AgentState::Working, "Codex processing prompt"),
+        HookEvent::PreToolUse => (AgentState::Working, "Codex using tool"),
+        HookEvent::PermissionRequest => (AgentState::Blocked, "Codex awaiting permission"),
+        HookEvent::PostToolUse => (AgentState::Working, "Codex tool completed"),
+        HookEvent::PreCompact => (AgentState::Working, "Codex compacting session"),
+        HookEvent::PostCompact => (AgentState::Working, "Codex session compacted"),
+        HookEvent::SubagentStart => (AgentState::Working, "Codex subagent working"),
+        HookEvent::SubagentStop => (AgentState::Working, "Codex subagent stopped"),
+        HookEvent::Stop => (AgentState::Idle, "Codex session idle"),
+    };
+    LifecycleObservation { state, evidence }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn update(event: &str, extra: &str) -> HookUpdate {
+        read_update(
+            format!(
+                r#"{{"session_id":"thread-1","hook_event_name":"{event}"{extra},"unknown":true}}"#
+            )
+            .as_bytes(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn lifecycle_events_reduce_to_root_thread_observations() {
+        let cases = [
+            ("SessionStart", AgentState::Idle),
+            ("SessionEnd", AgentState::Inactive),
+            ("UserPromptSubmit", AgentState::Working),
+            ("PreToolUse", AgentState::Working),
+            ("PermissionRequest", AgentState::Blocked),
+            ("PostToolUse", AgentState::Working),
+            ("PreCompact", AgentState::Working),
+            ("PostCompact", AgentState::Working),
+            ("SubagentStart", AgentState::Working),
+            ("SubagentStop", AgentState::Working),
+            ("Stop", AgentState::Idle),
+        ];
+        for (event, state) in cases {
+            let update = update(event, "");
+            assert_eq!(update.session_id, "thread-1");
+            assert_eq!(update.observation.state, state, "{event}");
+            assert_ne!(update.observation.state, AgentState::Done);
+        }
+    }
+
+    #[test]
+    fn compact_session_start_remains_working() {
+        assert_eq!(
+            update("SessionStart", r#", "source":"compact""#)
+                .observation
+                .state,
+            AgentState::Working
+        );
+    }
+
+    #[test]
+    fn hook_input_and_thread_identity_are_bounded() {
+        let oversized = vec![b'x'; MAX_HOOK_INPUT_BYTES + 1];
+        assert!(read_update(oversized.as_slice()).is_err());
+        assert!(
+            read_update(br#"{"session_id":"bad\nid","hook_event_name":"Stop"}"#.as_slice())
+                .is_err()
+        );
+        assert!(
+            read_update(br#"{"session_id":"thread","hook_event_name":"Future"}"#.as_slice())
+                .is_err()
+        );
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -129,6 +129,9 @@ if [ "${BOOMUX_CLAUDE_REMOTE_CONTROL-0}" = 1 ] && [ "$#" -eq 0 ] && [ -t 0 ] && 
 fi
 exec "$BOOMUX_REAL_CLAUDE" "$@"
 "#;
+const CODEX_SHIM: &[u8] = br#"#!/bin/sh
+exec "$BOOMUX_SHIM_EXECUTABLE" codex launch -- "$@"
+"#;
 const OPENCODE_BASH_RC: &[u8] = br#"if [ -r "${HOME}/.bashrc" ]; then
   . "${HOME}/.bashrc"
 fi
@@ -1052,7 +1055,9 @@ fn sanitize_opencode_shim_environment(environment: &UnixEnvironment) -> UnixEnvi
     const PRIVATE_NAMES: &[&[u8]] = &[
         b"BOOMUX_CLAUDE_REMOTE_CONTROL",
         b"BOOMUX_REAL_CLAUDE",
+        b"BOOMUX_REAL_CODEX",
         b"BOOMUX_REAL_OPENCODE",
+        b"BOOMUX_CODEX_RUN_SCOPED",
         b"BOOMUX_ORIGINAL_PATH",
         b"BOOMUX_OPENCODE_SHIM_DIR",
         b"BOOMUX_OPENCODE_TUI_CONFIG",
@@ -1095,6 +1100,13 @@ fn resolve_opencode_executable(
     resolve_executable(environment, excluded_directory, "opencode")
 }
 
+fn resolve_codex_executable(
+    environment: &UnixEnvironment,
+    excluded_directory: Option<&Path>,
+) -> Option<PathBuf> {
+    resolve_executable(environment, excluded_directory, "codex")
+}
+
 fn resolve_executable(
     environment: &UnixEnvironment,
     excluded_directory: Option<&Path>,
@@ -1122,6 +1134,20 @@ fn opencode_shim_eligible(shell: &Shell, effective_command: &[String]) -> bool {
     matches!(shell.owner, ShellOwner::User)
         && shell.command.is_empty()
         && effective_command.is_empty()
+}
+
+fn codex_launch_eligible(shell: &Shell, effective_command: &[String]) -> bool {
+    matches!(shell.owner, ShellOwner::User)
+        && effective_command.first().is_some_and(|executable| {
+            Path::new(executable)
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                == Some("codex")
+        })
+        && (effective_command.len() == 1
+            || effective_command
+                .get(1)
+                .is_some_and(|argument| matches!(argument.as_str(), "resume" | "exec")))
 }
 
 fn claude_remote_control_command(
@@ -1161,7 +1187,8 @@ fn inject_opencode_shim_environment(
     secure_runtime_dir(&shim_dir)?;
     let real_opencode = resolve_opencode_executable(environment, Some(&shim_dir));
     let real_claude = resolve_executable(environment, Some(&shim_dir), "claude");
-    if real_opencode.is_none() && real_claude.is_none() {
+    let real_codex = resolve_codex_executable(environment, Some(&shim_dir));
+    if real_opencode.is_none() && real_claude.is_none() && real_codex.is_none() {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
             "supported Agent executables are unavailable",
@@ -1204,6 +1231,9 @@ fn inject_opencode_shim_environment(
     if real_claude.is_some() {
         atomic_runtime_asset(&shim_dir.join("claude"), CLAUDE_SHIM, 0o700)?;
     }
+    if real_codex.is_some() {
+        atomic_runtime_asset(&shim_dir.join("codex"), CODEX_SHIM, 0o700)?;
+    }
 
     let original_path = environment_value(environment, b"PATH").unwrap_or_default();
     let mut paths = vec![shim_dir.clone()];
@@ -1212,16 +1242,16 @@ fn inject_opencode_shim_environment(
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
     let mut injected = environment.clone();
     set_environment_value(&mut injected, b"PATH", prefixed_path);
+    set_environment_value(
+        &mut injected,
+        b"BOOMUX_SHIM_EXECUTABLE",
+        boomux.into_os_string(),
+    );
     if let Some(real_opencode) = real_opencode {
         set_environment_value(
             &mut injected,
             b"BOOMUX_REAL_OPENCODE",
             real_opencode.into_os_string(),
-        );
-        set_environment_value(
-            &mut injected,
-            b"BOOMUX_SHIM_EXECUTABLE",
-            boomux.into_os_string(),
         );
     }
     if let Some(real_claude) = real_claude {
@@ -1234,6 +1264,13 @@ fn inject_opencode_shim_environment(
             &mut injected,
             b"BOOMUX_CLAUDE_REMOTE_CONTROL",
             if claude_remote_control { "1" } else { "0" },
+        );
+    }
+    if let Some(real_codex) = real_codex {
+        set_environment_value(
+            &mut injected,
+            b"BOOMUX_REAL_CODEX",
+            real_codex.into_os_string(),
         );
     }
     set_environment_value(&mut injected, b"BOOMUX_ORIGINAL_PATH", original_path);
@@ -16648,11 +16685,13 @@ impl ShellRuntimeManager {
             claude_remote_control,
         );
         let selected_command = claude_command.as_deref().unwrap_or(selected_command);
+        let codex_launch = codex_launch_eligible(shell, selected_command);
         let original_environment = environment
             .cloned()
             .unwrap_or_else(capture_current_environment);
         let mut child_environment = sanitize_opencode_shim_environment(&original_environment);
         let mut shared_recovery_command = None;
+        let mut codex_launch_command = None;
         if let Some(session_id) = recovery.opencode_session_id
             && let Ok(injected) =
                 inject_opencode_shim_environment(&child_environment, claude_remote_control)
@@ -16684,6 +16723,38 @@ impl ShellRuntimeManager {
                     session_id.into(),
                 ]);
             }
+        } else if codex_launch
+            && let Ok(injected) =
+                inject_opencode_shim_environment(&child_environment, claude_remote_control)
+        {
+            child_environment = injected;
+            let selected_executable = Path::new(&selected_command[0]);
+            let exact_executable = if selected_executable.is_absolute() {
+                Some(selected_executable.to_path_buf())
+            } else if selected_executable.components().count() > 1 {
+                Some(shell.cwd.join(selected_executable))
+            } else {
+                None
+            };
+            if let Some(executable) = exact_executable {
+                set_environment_value(
+                    &mut child_environment,
+                    b"BOOMUX_REAL_CODEX",
+                    executable.into_os_string(),
+                );
+            }
+            if let Some(executable) =
+                environment_value(&child_environment, b"BOOMUX_SHIM_EXECUTABLE")
+            {
+                let mut command = vec![
+                    executable.to_string_lossy().into_owned(),
+                    "codex".into(),
+                    "launch".into(),
+                    "--".into(),
+                ];
+                command.extend(selected_command[1..].iter().cloned());
+                codex_launch_command = Some(command);
+            }
         } else if opencode_shim_eligible(shell, selected_command)
             && let Ok(injected) =
                 inject_opencode_shim_environment(&child_environment, claude_remote_control)
@@ -16692,6 +16763,7 @@ impl ShellRuntimeManager {
         }
         let selected_command = shared_recovery_command
             .as_deref()
+            .or(codex_launch_command.as_deref())
             .unwrap_or(selected_command);
         let client_shell = child_environment
             .variables
@@ -18056,8 +18128,8 @@ fn validate_schedule_capability(
             )
         })?;
     let supported = match session {
-        AgentScheduleSession::Fresh => capability.fresh,
-        AgentScheduleSession::Continue { .. } => capability.continuation,
+        AgentScheduleSession::Fresh => capability.fresh.is_some(),
+        AgentScheduleSession::Continue { .. } => capability.continuation.is_some(),
     };
     if !supported {
         return Err(io::Error::new(
@@ -18957,6 +19029,33 @@ mod tests {
     }
 
     #[test]
+    fn codex_launcher_accepts_only_managed_chat_shapes() {
+        let shell = create_pending_shell(
+            "workspace",
+            ShellSpec {
+                name: "codex".into(),
+                cwd: env::temp_dir(),
+                command: vec!["/opt/openai/codex".into()],
+            },
+        )
+        .unwrap();
+        for argv in [
+            vec!["/opt/openai/codex".into()],
+            vec!["/opt/openai/codex".into(), "resume".into(), "exact".into()],
+            vec!["/opt/openai/codex".into(), "exec".into(), "-".into()],
+        ] {
+            assert!(codex_launch_eligible(&shell, &argv));
+        }
+        for argv in [
+            vec!["codex".into(), "remote-control".into()],
+            vec!["codex".into(), "--remote".into(), "unix://".into()],
+            vec!["codex-wrapper".into()],
+        ] {
+            assert!(!codex_launch_eligible(&shell, &argv));
+        }
+    }
+
+    #[test]
     fn inherited_opencode_shim_provenance_is_stripped_without_losing_identity() {
         let mut environment = test_environment(&[
             ("PATH", Path::new("/runtime/boomux/shims:/usr/bin")),
@@ -18967,6 +19066,8 @@ mod tests {
             ),
             ("BOOMUX_REAL_OPENCODE", Path::new("/usr/bin/opencode")),
             ("BOOMUX_REAL_CLAUDE", Path::new("/usr/bin/claude")),
+            ("BOOMUX_REAL_CODEX", Path::new("/usr/bin/codex")),
+            ("BOOMUX_CODEX_RUN_SCOPED", Path::new("1")),
             ("BOOMUX_CLAUDE_REMOTE_CONTROL", Path::new("1")),
             (
                 "BOOMUX_OPENCODE_TUI_CONFIG",
@@ -18999,6 +19100,8 @@ mod tests {
             b"BOOMUX_OPENCODE_SHIM_DIR",
             b"BOOMUX_REAL_OPENCODE",
             b"BOOMUX_REAL_CLAUDE",
+            b"BOOMUX_REAL_CODEX",
+            b"BOOMUX_CODEX_RUN_SCOPED",
             b"BOOMUX_CLAUDE_REMOTE_CONTROL",
             b"BOOMUX_OPENCODE_TUI_CONFIG",
             b"BOOMUX_SHIM_EXECUTABLE",
@@ -19097,6 +19200,9 @@ mod tests {
         let claude = bin.join("claude");
         fs::write(&claude, b"#!/bin/sh\nprintf '[%s]\\n' \"$@\"\n").unwrap();
         fs::set_permissions(&claude, fs::Permissions::from_mode(0o700)).unwrap();
+        let codex = bin.join("codex");
+        fs::write(&codex, b"#!/bin/sh\nprintf '{%s}\\n' \"$@\"\n").unwrap();
+        fs::set_permissions(&codex, fs::Permissions::from_mode(0o700)).unwrap();
         let environment = test_environment(&[("XDG_RUNTIME_DIR", &runtime), ("PATH", &bin)]);
 
         let injected = inject_opencode_shim_environment(&environment, true).unwrap();
@@ -19151,6 +19257,20 @@ mod tests {
             std::str::from_utf8(CLAUDE_SHIM)
                 .unwrap()
                 .contains("exec \"$BOOMUX_REAL_CLAUDE\" --remote-control")
+        );
+        let codex_shim = shim.with_file_name("codex");
+        assert_eq!(
+            fs::metadata(&codex_shim).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            environment_value(&injected, b"BOOMUX_REAL_CODEX").as_deref(),
+            Some(codex.as_os_str())
+        );
+        assert!(
+            std::str::from_utf8(CODEX_SHIM)
+                .unwrap()
+                .contains("codex launch -- \"$@\"")
         );
         fs::remove_dir_all(directory).unwrap();
     }
@@ -19313,6 +19433,25 @@ mod tests {
         assert_eq!(
             resumable.command,
             ["/opt/bin/claude", "--resume", "claude-exact"]
+        );
+    }
+
+    #[test]
+    fn interrupted_codex_agent_builds_exact_resume_subcommand() {
+        let registry = DaemonService::default();
+        let (shell, run) = recovery_shell(&registry, vec!["/opt/bin/codex".into()]);
+        let agent_id = add_recovery_agent(&registry, &shell, &run.id, "codex", "codex-exact");
+
+        let resumable = registry
+            .resumable_agent(&shell, Some(&run))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resumable.agent_id, agent_id);
+        assert_eq!(resumable.integration, "codex");
+        assert_eq!(resumable.external_session_id, "codex-exact");
+        assert_eq!(
+            resumable.command,
+            ["/opt/bin/codex", "resume", "codex-exact"]
         );
     }
 

--- a/src/host_session_titles.rs
+++ b/src/host_session_titles.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 
 use boomux::integrations::{self, TitleProvider};
 
+mod codex;
 mod opencode;
 mod pi;
 
@@ -197,6 +198,7 @@ fn adapter(integration: &str) -> Option<&'static dyn TitleAdapter> {
     match integrations::by_key(integration)?.titles?.provider {
         TitleProvider::OpenCode => Some(opencode::ADAPTER),
         TitleProvider::Pi => Some(pi::ADAPTER),
+        TitleProvider::Codex => Some(codex::ADAPTER),
     }
 }
 
@@ -576,7 +578,10 @@ mod tests {
 
     #[test]
     fn adapters_declare_catalog_support() {
-        assert_eq!(catalog_integrations().collect::<Vec<_>>(), ["opencode"]);
+        assert_eq!(
+            catalog_integrations().collect::<Vec<_>>(),
+            ["opencode", "codex"]
+        );
         assert!(catalog("pi", Path::new("/repo")).is_none());
         assert!(adapter("missing").is_none());
     }

--- a/src/host_session_titles/codex.rs
+++ b/src/host_session_titles/codex.rs
@@ -1,0 +1,256 @@
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{HostSession, Inspection, MAX_SESSIONS, TitleAdapter, sanitize_title};
+use crate::host_session_source::normalize_absolute;
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(15);
+const MAX_STDOUT_BYTES: u64 = 1024 * 1024;
+
+struct CodexAdapter;
+
+pub(super) static ADAPTER: &dyn TitleAdapter = &CodexAdapter;
+
+impl TitleAdapter for CodexAdapter {
+    fn inspect(&self, directory: &Path) -> Option<Inspection> {
+        inspect_catalog(directory)
+    }
+}
+
+fn inspect_catalog(directory: &Path) -> Option<Inspection> {
+    let directory = normalize_absolute(directory)?;
+    let stdout = run(&directory)?;
+    parse_catalog(&stdout, &directory)
+}
+
+fn run(directory: &Path) -> Option<Vec<u8>> {
+    let mut child = Command::new("codex")
+        .args(["app-server", "--stdio"])
+        .current_dir(directory)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let mut stdin = child.stdin.take()?;
+    let stdout = child.stdout.take()?;
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || stream_stdout(stdout, sender));
+    let deadline = Instant::now() + COMMAND_TIMEOUT;
+    let result = (|| {
+        write_request(
+            &mut stdin,
+            &serde_json::json!({
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "clientInfo": {
+                    "name": "boomux",
+                    "title": "Boomux",
+                    "version": env!("CARGO_PKG_VERSION"),
+                }
+            }
+            }),
+        )?;
+        wait_for_response(&receiver, 1, deadline)?;
+        write_request(
+            &mut stdin,
+            &serde_json::json!({ "method": "initialized", "params": {} }),
+        )?;
+        write_request(
+            &mut stdin,
+            &serde_json::json!({
+            "method": "thread/list",
+            "id": 2,
+            "params": {
+                "limit": MAX_SESSIONS,
+                "cwd": directory,
+                "useStateDbOnly": true,
+                "modelProviders": [],
+                "sourceKinds": ["cli", "vscode", "exec", "appServer", "unknown"],
+            }
+            }),
+        )?;
+        wait_for_response(&receiver, 2, deadline)
+    })();
+    drop(stdin);
+    let _ = child.kill();
+    let _ = child.wait();
+    result
+}
+
+fn stream_stdout(stdout: impl Read, sender: mpsc::Sender<io::Result<Vec<u8>>>) {
+    let mut reader = BufReader::new(stdout);
+    let mut total = 0u64;
+    loop {
+        let mut line = Vec::new();
+        let remaining = MAX_STDOUT_BYTES.saturating_sub(total) + 1;
+        match reader.by_ref().take(remaining).read_until(b'\n', &mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                total = total.saturating_add(line.len() as u64);
+                if total > MAX_STDOUT_BYTES {
+                    let _ = sender.send(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Codex app-server output exceeded its size limit",
+                    )));
+                    break;
+                }
+                if sender.send(Ok(line)).is_err() {
+                    break;
+                }
+            }
+            Err(error) => {
+                let _ = sender.send(Err(error));
+                break;
+            }
+        }
+    }
+}
+
+fn write_request(stdin: &mut impl Write, request: &Value) -> Option<()> {
+    serde_json::to_writer(&mut *stdin, request).ok()?;
+    stdin.write_all(b"\n").ok()?;
+    stdin.flush().ok()
+}
+
+fn wait_for_response(
+    receiver: &mpsc::Receiver<io::Result<Vec<u8>>>,
+    id: u64,
+    deadline: Instant,
+) -> Option<Vec<u8>> {
+    loop {
+        let remaining = deadline.checked_duration_since(Instant::now())?;
+        let line = receiver.recv_timeout(remaining).ok()?.ok()?;
+        let message = serde_json::from_slice::<Value>(&line).ok()?;
+        if message.get("id").and_then(Value::as_u64) == Some(id) {
+            return message.get("error").is_none().then_some(line);
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ListResponse {
+    id: u64,
+    #[serde(default)]
+    result: Option<ListResult>,
+}
+
+#[derive(Deserialize)]
+struct ListResult {
+    data: Vec<CodexThread>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexThread {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    preview: String,
+    #[serde(default)]
+    ephemeral: bool,
+    created_at: u64,
+    updated_at: u64,
+}
+
+fn parse_catalog(output: &[u8], directory: &Path) -> Option<Inspection> {
+    if output.len() as u64 > MAX_STDOUT_BYTES {
+        return None;
+    }
+    let directory = normalize_absolute(directory)?;
+    let response = output.split(|byte| *byte == b'\n').find_map(|line| {
+        let response = serde_json::from_slice::<ListResponse>(line).ok()?;
+        (response.id == 2).then_some(response)
+    })?;
+    let mut catalog = Vec::new();
+    for thread in response.result?.data.into_iter().take(MAX_SESSIONS) {
+        if thread.id.is_empty() || thread.ephemeral {
+            continue;
+        }
+        if boomux::scheduling::validate_external_session_id(&thread.id).is_err() {
+            continue;
+        }
+        let Some(title) = thread
+            .name
+            .as_deref()
+            .and_then(sanitize_title)
+            .or_else(|| sanitize_title(&thread.preview))
+        else {
+            continue;
+        };
+        let (Some(created_at_ms), Some(updated_at_ms)) = (
+            thread.created_at.checked_mul(1000),
+            thread.updated_at.checked_mul(1000),
+        ) else {
+            continue;
+        };
+        catalog.push(HostSession {
+            integration: boomux::integrations::CODEX.key.into(),
+            root_id: thread.id,
+            title,
+            directory: directory.clone(),
+            created_at_ms,
+            updated_at_ms,
+        });
+    }
+    let titles = catalog
+        .iter()
+        .map(|session| (session.root_id.clone(), session.title.clone()))
+        .collect();
+    Some(Inspection { titles, catalog })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bounded_thread_list_with_name_and_preview_fallback() {
+        let output = br#"{"id":1,"result":{"userAgent":"codex"}}
+{"id":2,"result":{"data":[{"id":"thread-1","name":" Named thread ","preview":"ignored","ephemeral":false,"createdAt":10,"updatedAt":20},{"id":"thread-2","name":null,"preview":" Preview thread ","ephemeral":false,"createdAt":30,"updatedAt":40},{"id":"ephemeral","preview":"ignored","ephemeral":true,"createdAt":1,"updatedAt":1}],"nextCursor":null}}
+"#;
+        let inspection = parse_catalog(output, Path::new("/repo/./src/..")).unwrap();
+        assert_eq!(inspection.catalog.len(), 2);
+        assert_eq!(inspection.catalog[0].root_id, "thread-1");
+        assert_eq!(inspection.catalog[0].title, "Named thread");
+        assert_eq!(inspection.catalog[0].directory, Path::new("/repo"));
+        assert_eq!(inspection.catalog[0].created_at_ms, 10_000);
+        assert_eq!(inspection.titles["thread-2"], "Preview thread");
+    }
+
+    #[test]
+    fn malformed_missing_and_oversized_responses_fail_open() {
+        assert!(parse_catalog(b"not json", Path::new("/repo")).is_none());
+        assert!(parse_catalog(br#"{"id":1,"result":{}}"#, Path::new("/repo")).is_none());
+        assert!(
+            parse_catalog(
+                &vec![b'x'; MAX_STDOUT_BYTES as usize + 1],
+                Path::new("/repo")
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn stdout_reader_bounds_a_line_without_a_newline() {
+        let (sender, receiver) = mpsc::channel();
+        stream_stdout(
+            io::Cursor::new(vec![b'x'; MAX_STDOUT_BYTES as usize + 2]),
+            sender,
+        );
+
+        assert_eq!(
+            receiver.recv().unwrap().unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Read, Write};
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 use serde::{Serialize, Serializer};
+use serde_json::{Map, Value};
 use uuid::Uuid;
 
 use boomux::integrations::{InstallTargetKind, InstallationCapability, IntegrationDescriptor};
@@ -18,6 +19,21 @@ use boomux::protocol::{AgentAuthority, ShellStatus, Snapshot};
 
 const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_VERSION_OUTPUT_BYTES: u64 = 4096;
+const MAX_CODEX_HOOKS_BYTES: u64 = 1024 * 1024;
+const CODEX_HOOK_COMMAND: &str = "boomux codex hook";
+const CODEX_HOOK_EVENTS: &[&str] = &[
+    "SessionStart",
+    "SessionEnd",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PermissionRequest",
+    "PostToolUse",
+    "PreCompact",
+    "PostCompact",
+    "SubagentStart",
+    "SubagentStop",
+    "Stop",
+];
 
 #[cfg(test)]
 pub(crate) const OPENCODE_ASSET: &str = boomux::integrations::OPENCODE
@@ -37,6 +53,12 @@ pub(crate) const CLAUDE_ASSET: &str = boomux::integrations::CLAUDE
     .as_ref()
     .expect("Claude installation capability")
     .content;
+#[cfg(test)]
+pub(crate) const CODEX_ASSET: &str = boomux::integrations::CODEX
+    .installation
+    .as_ref()
+    .expect("Codex installation capability")
+    .content;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct IntegrationId(&'static IntegrationDescriptor);
@@ -44,10 +66,14 @@ pub(crate) struct IntegrationId(&'static IntegrationDescriptor);
 impl IntegrationId {
     pub(crate) const OPENCODE: Self = Self(&boomux::integrations::OPENCODE);
     pub(crate) const PI: Self = Self(&boomux::integrations::PI);
+    pub(crate) const CODEX: Self = Self(&boomux::integrations::CODEX);
     #[allow(non_upper_case_globals)]
     pub(crate) const Opencode: Self = Self::OPENCODE;
     #[allow(non_upper_case_globals)]
     pub(crate) const Pi: Self = Self::PI;
+    #[cfg(test)]
+    #[allow(non_upper_case_globals)]
+    pub(crate) const Codex: Self = Self::CODEX;
     #[cfg(test)]
     #[allow(non_upper_case_globals)]
     pub(crate) const Claude: Self = Self(&boomux::integrations::CLAUDE);
@@ -94,6 +120,7 @@ pub(crate) struct Environment {
     xdg_config_home: Option<OsString>,
     pi_coding_agent_dir: Option<OsString>,
     claude_config_dir: Option<OsString>,
+    codex_home: Option<OsString>,
     path: Option<OsString>,
 }
 
@@ -104,6 +131,7 @@ impl Environment {
             xdg_config_home: env::var_os("XDG_CONFIG_HOME"),
             pi_coding_agent_dir: env::var_os("PI_CODING_AGENT_DIR"),
             claude_config_dir: env::var_os("CLAUDE_CONFIG_DIR"),
+            codex_home: env::var_os("CODEX_HOME"),
             path: env::var_os("PATH"),
         }
     }
@@ -121,6 +149,7 @@ impl Environment {
             xdg_config_home,
             pi_coding_agent_dir,
             claude_config_dir,
+            codex_home: None,
             path,
         }
     }
@@ -428,7 +457,13 @@ fn inspect_asset(
         .parent()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "install path has no parent"))
         .and_then(validate_existing_directory_chain)
-        .and_then(|()| inspect_existing_asset(&path, installation.content));
+        .and_then(|()| {
+            if id == IntegrationId::CODEX {
+                inspect_codex_hooks(&path)
+            } else {
+                inspect_existing_asset(&path, installation.content)
+            }
+        });
     match result {
         Ok(ExistingAsset::Missing) => AssetStatus {
             state: AssetState::Missing,
@@ -749,7 +784,11 @@ pub(crate) fn install(
     let installation = id.installation();
     let target = install_target(id, environment)?;
     let directory = ensure_safe_directory(&target.directory)?;
-    let result = install_asset_at(&directory, &target.path, installation.content, force)?;
+    let result = if id == IntegrationId::CODEX {
+        install_codex_hooks(&directory, &target.path, force)?
+    } else {
+        install_asset_at(&directory, &target.path, installation.content, force)?
+    };
     Ok(InstallResult {
         integration: id,
         name: descriptor.key,
@@ -768,7 +807,11 @@ pub(crate) fn plan_install(
     let installation = id.installation();
     let target = install_target(id, environment)?;
     validate_existing_directory_chain(&target.directory)?;
-    let existing = inspect_existing_asset(&target.path, installation.content)?;
+    let existing = if id == IntegrationId::CODEX {
+        inspect_codex_hooks(&target.path)?
+    } else {
+        inspect_existing_asset(&target.path, installation.content)?
+    };
     let (current_state, action) = match existing {
         ExistingAsset::Missing => (AssetState::Missing, InstallAction::Install),
         ExistingAsset::Current => (AssetState::Current, InstallAction::Unchanged),
@@ -793,9 +836,12 @@ pub(crate) fn preflight_uninstall(
     let installation = id.installation();
     let target = install_target(id, environment)?;
     validate_existing_directory_chain(&target.directory)?;
-    if inspect_existing_asset(&target.path, installation.content)? == ExistingAsset::Modified
-        && !force
-    {
+    let existing = if id == IntegrationId::CODEX {
+        inspect_codex_hooks(&target.path)?
+    } else {
+        inspect_existing_asset(&target.path, installation.content)?
+    };
+    if existing == ExistingAsset::Modified && !force {
         return Err(modified_uninstall_error(&target.path).into());
     }
     Ok(())
@@ -810,11 +856,19 @@ pub(crate) fn uninstall(
     let installation = id.installation();
     let target = install_target(id, environment)?;
     validate_existing_directory_chain(&target.directory)?;
-    let existing = inspect_existing_asset(&target.path, installation.content)?;
+    let existing = if id == IntegrationId::CODEX {
+        inspect_codex_hooks(&target.path)?
+    } else {
+        inspect_existing_asset(&target.path, installation.content)?
+    };
     let result = match existing {
         ExistingAsset::Missing => UninstallOutcome::NotInstalled,
         ExistingAsset::Modified if !force => {
             return Err(modified_uninstall_error(&target.path).into());
+        }
+        ExistingAsset::Current | ExistingAsset::Modified if id == IntegrationId::CODEX => {
+            uninstall_codex_hooks(&target.directory, &target.path)?;
+            UninstallOutcome::Removed
         }
         ExistingAsset::Current | ExistingAsset::Modified => {
             fs::remove_file(&target.path)?;
@@ -841,7 +895,11 @@ pub(crate) fn install_at(
     let installation = id.installation();
     let target = target_at(id, config_root);
     let directory = ensure_safe_directory(&target.directory)?;
-    let result = install_asset_at(&directory, &target.path, installation.content, force)?;
+    let result = if id == IntegrationId::CODEX {
+        install_codex_hooks(&directory, &target.path, force)?
+    } else {
+        install_asset_at(&directory, &target.path, installation.content, force)?
+    };
     Ok(InstallResult {
         integration: id,
         name: descriptor.key,
@@ -883,6 +941,9 @@ fn config_root(id: IntegrationId, environment: &Environment) -> Result<PathBuf, 
             environment.claude_config_dir.clone(),
             environment.home.clone(),
         ),
+        InstallTargetKind::Codex => {
+            codex_config_root(environment.codex_home.clone(), environment.home.clone())
+        }
     }
 }
 
@@ -900,6 +961,10 @@ fn target_at(id: IntegrationId, config_root: &Path) -> InstallTarget {
             directory: config_root.join("skills/boomux/.claude-plugin"),
             path: config_root.join("skills/boomux/.claude-plugin/plugin.json"),
         },
+        InstallTargetKind::Codex => InstallTarget {
+            directory: config_root.to_owned(),
+            path: config_root.join("hooks.json"),
+        },
     }
 }
 
@@ -909,6 +974,7 @@ const fn config_root_name(id: IntegrationId) -> &'static str {
         InstallTargetKind::OpenCode => "XDG configuration root",
         InstallTargetKind::Pi => "Pi configuration root",
         InstallTargetKind::Claude => "Claude configuration root",
+        InstallTargetKind::Codex => "Codex configuration root",
     }
 }
 
@@ -973,6 +1039,24 @@ pub(crate) fn claude_config_root(
         .join(".claude"),
     };
     require_absolute_root(&root, "Claude configuration root")?;
+    Ok(root)
+}
+
+pub(crate) fn codex_config_root(
+    codex_home: Option<OsString>,
+    home: Option<OsString>,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let root = match codex_home.filter(|value| !value.is_empty()) {
+        Some(root) => PathBuf::from(root),
+        None => PathBuf::from(home.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "HOME must be set to install the Boomux Codex hooks",
+            )
+        })?)
+        .join(".codex"),
+    };
+    require_absolute_root(&root, "Codex configuration root")?;
     Ok(root)
 }
 
@@ -1042,6 +1126,327 @@ enum ExistingAsset {
     Missing,
     Current,
     Modified,
+}
+
+fn inspect_codex_hooks(path: &Path) -> io::Result<ExistingAsset> {
+    let Some((document, _, _)) = read_codex_hooks(path)? else {
+        return Ok(ExistingAsset::Missing);
+    };
+    codex_hooks_state(&document)
+}
+
+fn read_codex_hooks(path: &Path) -> io::Result<Option<(Value, Vec<u8>, u32)>> {
+    let mut file = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("install path is not a regular file: {}", path.display()),
+        ));
+    }
+    if metadata.len() > MAX_CODEX_HOOKS_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Codex hooks file exceeds {MAX_CODEX_HOOKS_BYTES} bytes: {}",
+                path.display()
+            ),
+        ));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    Read::by_ref(&mut file)
+        .take(MAX_CODEX_HOOKS_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_CODEX_HOOKS_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Codex hooks file exceeded its size limit while reading",
+        ));
+    }
+    let document = serde_json::from_slice::<Value>(&bytes).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid Codex hooks JSON: {error}"),
+        )
+    })?;
+    if !document.is_object() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Codex hooks file must contain a JSON object",
+        ));
+    }
+    Ok(Some((
+        document,
+        bytes,
+        metadata.permissions().mode() & 0o777,
+    )))
+}
+
+fn codex_hooks_state(document: &Value) -> io::Result<ExistingAsset> {
+    let Some(hooks) = document.get("hooks") else {
+        return Ok(ExistingAsset::Missing);
+    };
+    let hooks = hooks.as_object().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Codex hooks field must contain a JSON object",
+        )
+    })?;
+    let mut found = false;
+    let mut invalid = false;
+    let mut valid_events = std::collections::HashSet::new();
+    for (event, groups) in hooks {
+        let Some(groups) = groups.as_array() else {
+            if CODEX_HOOK_EVENTS.contains(&event.as_str()) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Codex {event} hooks must contain an array"),
+                ));
+            }
+            continue;
+        };
+        for group in groups {
+            let Some(handlers) = group.get("hooks").and_then(Value::as_array) else {
+                continue;
+            };
+            for handler in handlers {
+                if handler.get("command").and_then(Value::as_str) != Some(CODEX_HOOK_COMMAND) {
+                    continue;
+                }
+                found = true;
+                if CODEX_HOOK_EVENTS.contains(&event.as_str())
+                    && group.get("matcher").is_none()
+                    && handler == &codex_hook_handler(event)
+                    && valid_events.insert(event.as_str())
+                {
+                    continue;
+                }
+                invalid = true;
+            }
+        }
+    }
+    Ok(if !found {
+        ExistingAsset::Missing
+    } else if !invalid && valid_events.len() == CODEX_HOOK_EVENTS.len() {
+        ExistingAsset::Current
+    } else {
+        ExistingAsset::Modified
+    })
+}
+
+fn codex_hook_handler(event: &str) -> Value {
+    serde_json::json!({
+        "type": "command",
+        "command": CODEX_HOOK_COMMAND,
+        "timeout": if event == "SessionEnd" { 3 } else { 5 },
+    })
+}
+
+fn install_codex_hooks(
+    directory: &Path,
+    path: &Path,
+    force: bool,
+) -> Result<InstallOutcome, Box<dyn Error>> {
+    let existing = read_codex_hooks(path)?;
+    let state = existing
+        .as_ref()
+        .map(|(document, _, _)| codex_hooks_state(document))
+        .transpose()?
+        .unwrap_or(ExistingAsset::Missing);
+    match state {
+        ExistingAsset::Current => return Ok(InstallOutcome::Unchanged),
+        ExistingAsset::Modified if !force => return Err(existing_asset_error(path).into()),
+        ExistingAsset::Missing | ExistingAsset::Modified => {}
+    }
+    let outcome = match state {
+        ExistingAsset::Missing => InstallOutcome::Installed,
+        ExistingAsset::Modified => InstallOutcome::Replaced,
+        ExistingAsset::Current => unreachable!("current Codex hooks returned early"),
+    };
+    let (mut document, baseline, mode) = existing.unwrap_or_else(|| {
+        (
+            serde_json::from_str(CODEX_ASSET_FALLBACK).expect("bundled Codex hooks are valid"),
+            Vec::new(),
+            0o600,
+        )
+    });
+    replace_codex_handlers(&mut document)?;
+    let content = codex_hooks_content(&document)?;
+    write_merged_asset_atomically(
+        directory,
+        path,
+        &content,
+        (!baseline.is_empty()).then_some(baseline.as_slice()),
+        mode,
+    )?;
+    Ok(outcome)
+}
+
+const CODEX_ASSET_FALLBACK: &str = include_str!("../integrations/codex/hooks.json");
+
+fn replace_codex_handlers(document: &mut Value) -> io::Result<()> {
+    let root = document
+        .as_object_mut()
+        .expect("validated Codex hooks object");
+    let hooks = root
+        .entry("hooks")
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Codex hooks field must contain a JSON object",
+            )
+        })?;
+    for groups in hooks.values_mut() {
+        let Some(groups) = groups.as_array_mut() else {
+            continue;
+        };
+        for group in groups.iter_mut() {
+            if let Some(handlers) = group.get_mut("hooks").and_then(Value::as_array_mut) {
+                handlers.retain(|handler| {
+                    handler.get("command").and_then(Value::as_str) != Some(CODEX_HOOK_COMMAND)
+                });
+            }
+        }
+        groups.retain(|group| {
+            group
+                .get("hooks")
+                .and_then(Value::as_array)
+                .is_none_or(|handlers| !handlers.is_empty())
+        });
+    }
+    for event in CODEX_HOOK_EVENTS {
+        let groups = hooks
+            .entry((*event).to_owned())
+            .or_insert_with(|| Value::Array(Vec::new()))
+            .as_array_mut()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Codex {event} hooks must contain an array"),
+                )
+            })?;
+        groups.push(serde_json::json!({ "hooks": [codex_hook_handler(event)] }));
+    }
+    Ok(())
+}
+
+fn uninstall_codex_hooks(directory: &Path, path: &Path) -> io::Result<()> {
+    let Some((mut document, baseline, mode)) = read_codex_hooks(path)? else {
+        return Ok(());
+    };
+    remove_codex_handlers(&mut document)?;
+    if codex_document_is_boomux_only(&document) {
+        verify_asset_baseline(path, Some(&baseline))?;
+        fs::remove_file(path)?;
+        fs::File::open(directory)?.sync_all()?;
+        return Ok(());
+    }
+    let content = codex_hooks_content(&document)?;
+    write_merged_asset_atomically(directory, path, &content, Some(&baseline), mode)
+}
+
+fn remove_codex_handlers(document: &mut Value) -> io::Result<()> {
+    let Some(hooks) = document.get_mut("hooks") else {
+        return Ok(());
+    };
+    let hooks = hooks.as_object_mut().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Codex hooks field must contain a JSON object",
+        )
+    })?;
+    for groups in hooks.values_mut() {
+        let Some(groups) = groups.as_array_mut() else {
+            continue;
+        };
+        for group in groups.iter_mut() {
+            if let Some(handlers) = group.get_mut("hooks").and_then(Value::as_array_mut) {
+                handlers.retain(|handler| {
+                    handler.get("command").and_then(Value::as_str) != Some(CODEX_HOOK_COMMAND)
+                });
+            }
+        }
+        groups.retain(|group| {
+            group
+                .get("hooks")
+                .and_then(Value::as_array)
+                .is_none_or(|handlers| !handlers.is_empty())
+        });
+    }
+    hooks.retain(|_, groups| groups.as_array().is_none_or(|groups| !groups.is_empty()));
+    Ok(())
+}
+
+fn codex_document_is_boomux_only(document: &Value) -> bool {
+    let Some(root) = document.as_object() else {
+        return false;
+    };
+    root.iter().all(|(key, value)| match key.as_str() {
+        "description" => {
+            value.as_str() == Some("Report Codex lifecycle state to Boomux for managed ShellRuns.")
+        }
+        "hooks" => value.as_object().is_some_and(Map::is_empty),
+        _ => false,
+    })
+}
+
+fn codex_hooks_content(document: &Value) -> io::Result<String> {
+    let mut content = serde_json::to_string_pretty(document)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    content.push('\n');
+    Ok(content)
+}
+
+fn write_merged_asset_atomically(
+    directory: &Path,
+    path: &Path,
+    content: &str,
+    baseline: Option<&[u8]>,
+    mode: u32,
+) -> io::Result<()> {
+    let temporary = directory.join(format!(".boomux-install-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(mode)
+            .open(&temporary)?;
+        file.set_permissions(fs::Permissions::from_mode(mode))?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        verify_asset_baseline(path, baseline)?;
+        fs::rename(&temporary, path)?;
+        fs::File::open(directory)?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn verify_asset_baseline(path: &Path, baseline: Option<&[u8]>) -> io::Result<()> {
+    let current = read_codex_hooks(path)?.map(|(_, bytes, _)| bytes);
+    if current.as_deref() != baseline {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!(
+                "{} changed while the integration was being updated",
+                path.display()
+            ),
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn regular_file_matches(path: &Path, expected: &str) -> io::Result<Option<bool>> {
@@ -1202,6 +1607,11 @@ mod tests {
             IntegrationId::Claude.installation().validated_version,
             "2.1.236"
         );
+        assert_eq!(IntegrationId::Codex.installation().package, "@openai/codex");
+        assert_eq!(
+            IntegrationId::Codex.installation().validated_version,
+            "0.147.0"
+        );
         assert!(IntegrationId::Claude.spec().titles.is_none());
         assert_eq!(
             IntegrationId::Claude
@@ -1240,6 +1650,15 @@ mod tests {
             Path::new("/home/example/.claude")
         );
         assert!(claude_config_root(Some("relative".into()), None).is_err());
+        assert_eq!(
+            codex_config_root(Some("/codex".into()), Some("/home/example".into())).unwrap(),
+            Path::new("/codex")
+        );
+        assert_eq!(
+            codex_config_root(Some(OsString::new()), Some("/home/example".into())).unwrap(),
+            Path::new("/home/example/.codex")
+        );
+        assert!(codex_config_root(Some("relative".into()), None).is_err());
     }
 
     #[test]
@@ -1306,6 +1725,138 @@ mod tests {
         let removed = uninstall(IntegrationId::Claude, &environment, false).unwrap();
         assert_eq!(removed.result, UninstallOutcome::Removed);
         assert!(!expected.exists());
+    }
+
+    #[test]
+    fn codex_asset_defines_required_non_deciding_hooks() {
+        let document: Value = serde_json::from_str(CODEX_ASSET).unwrap();
+        assert_eq!(
+            codex_hooks_state(&document).unwrap(),
+            ExistingAsset::Current
+        );
+        let hooks = document["hooks"].as_object().unwrap();
+        assert_eq!(hooks.len(), CODEX_HOOK_EVENTS.len());
+        for event in CODEX_HOOK_EVENTS {
+            let handler = &hooks[*event][0]["hooks"][0];
+            assert_eq!(handler["type"], "command");
+            assert_eq!(handler["command"], CODEX_HOOK_COMMAND);
+            assert_eq!(
+                handler["timeout"],
+                if *event == "SessionEnd" { 3 } else { 5 }
+            );
+        }
+    }
+
+    #[test]
+    fn codex_asset_requires_each_hook_event_exactly_once() {
+        let mut document: Value = serde_json::from_str(CODEX_ASSET).unwrap();
+        let duplicate = document["hooks"]["PreToolUse"][0].clone();
+        document["hooks"]["PermissionRequest"] = Value::Array(Vec::new());
+        document["hooks"]["PreToolUse"]
+            .as_array_mut()
+            .unwrap()
+            .push(duplicate);
+
+        assert_eq!(
+            codex_hooks_state(&document).unwrap(),
+            ExistingAsset::Modified
+        );
+    }
+
+    #[test]
+    fn codex_install_and_uninstall_preserve_unrelated_hooks() {
+        let home = TestDirectory::new("codex-merge");
+        let config = home.0.join("codex-home");
+        fs::create_dir(&config).unwrap();
+        let path = config.join("hooks.json");
+        fs::write(
+            &path,
+            r#"{
+  "description": "user hooks",
+  "custom": true,
+  "hooks": {
+    "PreToolUse": [{"matcher":"Bash","hooks":[{"type":"command","command":"user policy","timeout":30}]}]
+  }
+}
+"#,
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
+        let mut environment = environment(&home.0);
+        environment.codex_home = Some(config.clone().into_os_string());
+
+        let before = inspect(IntegrationId::Codex, &environment, None);
+        assert_eq!(before.asset.state, AssetState::Missing);
+        let installed = install(IntegrationId::Codex, &environment, false).unwrap();
+        assert_eq!(installed.result, InstallOutcome::Installed);
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+        let installed_document: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(installed_document["description"], "user hooks");
+        assert_eq!(installed_document["custom"], true);
+        assert_eq!(
+            installed_document["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            "user policy"
+        );
+        assert_eq!(
+            codex_hooks_state(&installed_document).unwrap(),
+            ExistingAsset::Current
+        );
+        assert_eq!(
+            install(IntegrationId::Codex, &environment, false)
+                .unwrap()
+                .result,
+            InstallOutcome::Unchanged
+        );
+
+        let removed = uninstall(IntegrationId::Codex, &environment, false).unwrap();
+        assert_eq!(removed.result, UninstallOutcome::Removed);
+        let remaining: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(remaining["description"], "user hooks");
+        assert_eq!(remaining["custom"], true);
+        assert_eq!(
+            remaining["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            "user policy"
+        );
+        assert_eq!(
+            codex_hooks_state(&remaining).unwrap(),
+            ExistingAsset::Missing
+        );
+    }
+
+    #[test]
+    fn codex_force_repairs_only_boomux_handlers_and_standalone_uninstall_removes_file() {
+        let home = TestDirectory::new("codex-repair");
+        let mut environment = environment(&home.0);
+        environment.codex_home = Some(home.0.join("codex-home").into_os_string());
+        let installed = install(IntegrationId::Codex, &environment, false).unwrap();
+        let path = PathBuf::from(&installed.path);
+        let mut document: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        document["hooks"]["Stop"][0]["hooks"][0]["timeout"] = Value::from(99);
+        fs::write(&path, codex_hooks_content(&document).unwrap()).unwrap();
+
+        assert_eq!(
+            inspect(IntegrationId::Codex, &environment, None)
+                .asset
+                .state,
+            AssetState::Modified
+        );
+        assert!(install(IntegrationId::Codex, &environment, false).is_err());
+        assert_eq!(
+            install(IntegrationId::Codex, &environment, true)
+                .unwrap()
+                .result,
+            InstallOutcome::Replaced
+        );
+        assert_eq!(
+            uninstall(IntegrationId::Codex, &environment, false)
+                .unwrap()
+                .result,
+            UninstallOutcome::Removed
+        );
+        assert!(!path.exists());
     }
 
     #[test]

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -5,6 +5,7 @@ pub enum InstallTargetKind {
     OpenCode,
     Pi,
     Claude,
+    Codex,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -22,6 +23,7 @@ pub struct InstallationCapability {
 pub enum TitleProvider {
     OpenCode,
     Pi,
+    Codex,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -33,7 +35,7 @@ pub struct TitleCapability {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ResumeCapability {
     pub executable: &'static str,
-    pub session_argument: &'static str,
+    pub arguments_before_session: &'static [&'static str],
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -43,9 +45,16 @@ pub enum PromptTransport {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScheduleArgument {
+    Literal(&'static str),
+    ExternalSessionId,
+    Prompt,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ScheduleDispatchCapability {
-    pub fresh: bool,
-    pub continuation: bool,
+    pub fresh: Option<&'static [ScheduleArgument]>,
+    pub continuation: Option<&'static [ScheduleArgument]>,
     pub prompt_transport: PromptTransport,
 }
 
@@ -64,56 +73,19 @@ impl ScheduleDispatchCapability {
     ) -> Option<ScheduleDispatchCommand> {
         use crate::protocol::AgentScheduleSession;
 
+        let (template, external_session_id) = match session {
+            AgentScheduleSession::Fresh => (self.fresh?, None),
+            AgentScheduleSession::Continue {
+                external_session_id,
+            } => (self.continuation?, Some(external_session_id.as_str())),
+        };
         let mut argv = vec![integration.to_owned()];
-        match (integration, session) {
-            ("opencode", AgentScheduleSession::Fresh) if self.fresh => {
-                argv.extend(["run".into(), "--".into(), prompt.into()]);
-            }
-            (
-                "opencode",
-                AgentScheduleSession::Continue {
-                    external_session_id,
-                },
-            ) if self.continuation => {
-                argv.extend([
-                    "run".into(),
-                    "--session".into(),
-                    external_session_id.clone(),
-                    "--".into(),
-                    prompt.into(),
-                ]);
-            }
-            ("pi", AgentScheduleSession::Fresh) if self.fresh => {
-                argv.push("--print".into());
-            }
-            (
-                "pi",
-                AgentScheduleSession::Continue {
-                    external_session_id,
-                },
-            ) if self.continuation => {
-                argv.extend([
-                    "--session".into(),
-                    external_session_id.clone(),
-                    "--print".into(),
-                ]);
-            }
-            ("claude", AgentScheduleSession::Fresh) if self.fresh => {
-                argv.push("--print".into());
-            }
-            (
-                "claude",
-                AgentScheduleSession::Continue {
-                    external_session_id,
-                },
-            ) if self.continuation => {
-                argv.extend([
-                    "--print".into(),
-                    "--resume".into(),
-                    external_session_id.clone(),
-                ]);
-            }
-            _ => return None,
+        for argument in template {
+            argv.push(match argument {
+                ScheduleArgument::Literal(value) => (*value).to_owned(),
+                ScheduleArgument::ExternalSessionId => external_session_id?.to_owned(),
+                ScheduleArgument::Prompt => prompt.to_owned(),
+            });
         }
         Some(ScheduleDispatchCommand {
             argv,
@@ -141,11 +113,14 @@ impl ResumeCapability {
         } else {
             return None;
         };
-        Some(vec![
-            executable,
-            self.session_argument.to_owned(),
-            external_session_id.to_owned(),
-        ])
+        let mut command = vec![executable];
+        command.extend(
+            self.arguments_before_session
+                .iter()
+                .map(|argument| (*argument).to_owned()),
+        );
+        command.push(external_session_id.to_owned());
+        Some(command)
     }
 }
 
@@ -183,11 +158,21 @@ pub const OPENCODE: IntegrationDescriptor = IntegrationDescriptor {
     }),
     resume: Some(ResumeCapability {
         executable: "opencode",
-        session_argument: "--session",
+        arguments_before_session: &["--session"],
     }),
     schedule_dispatch: Some(ScheduleDispatchCapability {
-        fresh: true,
-        continuation: true,
+        fresh: Some(&[
+            ScheduleArgument::Literal("run"),
+            ScheduleArgument::Literal("--"),
+            ScheduleArgument::Prompt,
+        ]),
+        continuation: Some(&[
+            ScheduleArgument::Literal("run"),
+            ScheduleArgument::Literal("--session"),
+            ScheduleArgument::ExternalSessionId,
+            ScheduleArgument::Literal("--"),
+            ScheduleArgument::Prompt,
+        ]),
         prompt_transport: PromptTransport::Argument,
     }),
     foreground: Some(ForegroundCapability {
@@ -213,11 +198,15 @@ pub const PI: IntegrationDescriptor = IntegrationDescriptor {
     }),
     resume: Some(ResumeCapability {
         executable: "pi",
-        session_argument: "--session",
+        arguments_before_session: &["--session"],
     }),
     schedule_dispatch: Some(ScheduleDispatchCapability {
-        fresh: true,
-        continuation: true,
+        fresh: Some(&[ScheduleArgument::Literal("--print")]),
+        continuation: Some(&[
+            ScheduleArgument::Literal("--session"),
+            ScheduleArgument::ExternalSessionId,
+            ScheduleArgument::Literal("--print"),
+        ]),
         prompt_transport: PromptTransport::Stdin,
     }),
     foreground: Some(ForegroundCapability { process_name: "pi" }),
@@ -238,11 +227,15 @@ pub const CLAUDE: IntegrationDescriptor = IntegrationDescriptor {
     titles: None,
     resume: Some(ResumeCapability {
         executable: "claude",
-        session_argument: "--resume",
+        arguments_before_session: &["--resume"],
     }),
     schedule_dispatch: Some(ScheduleDispatchCapability {
-        fresh: true,
-        continuation: true,
+        fresh: Some(&[ScheduleArgument::Literal("--print")]),
+        continuation: Some(&[
+            ScheduleArgument::Literal("--print"),
+            ScheduleArgument::Literal("--resume"),
+            ScheduleArgument::ExternalSessionId,
+        ]),
         prompt_transport: PromptTransport::Stdin,
     }),
     foreground: Some(ForegroundCapability {
@@ -250,7 +243,45 @@ pub const CLAUDE: IntegrationDescriptor = IntegrationDescriptor {
     }),
 };
 
-pub const ALL: &[IntegrationDescriptor] = &[OPENCODE, PI, CLAUDE];
+pub const CODEX: IntegrationDescriptor = IntegrationDescriptor {
+    key: "codex",
+    display_name: "Codex",
+    installation: Some(InstallationCapability {
+        package: "@openai/codex",
+        validated_version: "0.147.0",
+        asset_name: "hooks",
+        content: include_str!("../integrations/codex/hooks.json"),
+        executable: "codex",
+        reload_message: "Restart Codex, then review and trust the Boomux hook with /hooks",
+        target: InstallTargetKind::Codex,
+    }),
+    titles: Some(TitleCapability {
+        provider: TitleProvider::Codex,
+        provides_catalog: true,
+    }),
+    resume: Some(ResumeCapability {
+        executable: "codex",
+        arguments_before_session: &["resume"],
+    }),
+    schedule_dispatch: Some(ScheduleDispatchCapability {
+        fresh: Some(&[
+            ScheduleArgument::Literal("exec"),
+            ScheduleArgument::Literal("-"),
+        ]),
+        continuation: Some(&[
+            ScheduleArgument::Literal("exec"),
+            ScheduleArgument::Literal("resume"),
+            ScheduleArgument::ExternalSessionId,
+            ScheduleArgument::Literal("-"),
+        ]),
+        prompt_transport: PromptTransport::Stdin,
+    }),
+    foreground: Some(ForegroundCapability {
+        process_name: "codex",
+    }),
+};
+
+pub const ALL: &[IntegrationDescriptor] = &[OPENCODE, PI, CLAUDE, CODEX];
 
 pub fn by_key(key: &str) -> Option<&'static IntegrationDescriptor> {
     descriptor_by_key(ALL, key)
@@ -365,8 +396,8 @@ mod tests {
             assert_eq!(by_key(descriptor.key), Some(descriptor));
             assert_eq!(display_name(descriptor.key), descriptor.display_name);
             let dispatch = descriptor.schedule_dispatch.expect("dispatch capability");
-            assert!(dispatch.fresh);
-            assert!(dispatch.continuation);
+            assert!(dispatch.fresh.is_some());
+            assert!(dispatch.continuation.is_some());
         }
     }
 
@@ -379,7 +410,7 @@ mod tests {
             titles: None,
             resume: Some(ResumeCapability {
                 executable: "resume-only",
-                session_argument: "--session",
+                arguments_before_session: &["--session"],
             }),
             schedule_dispatch: None,
             foreground: None,
@@ -408,6 +439,14 @@ mod tests {
         assert_eq!(
             CLAUDE.resume.unwrap().command(&[], "session-2"),
             Some(vec!["claude".into(), "--resume".into(), "session-2".into()])
+        );
+        assert_eq!(
+            CODEX.resume.unwrap().command(&[], "thread-literal"),
+            Some(vec![
+                "codex".into(),
+                "resume".into(),
+                "thread-literal".into()
+            ])
         );
     }
 
@@ -466,6 +505,29 @@ mod tests {
                     "--print".into(),
                     "--resume".into(),
                     "exact-id".into(),
+                ],
+                stdin: Some(prompt.as_bytes().to_vec()),
+            }
+        );
+        assert_eq!(
+            CODEX
+                .schedule_dispatch
+                .unwrap()
+                .command(
+                    "codex",
+                    &AgentScheduleSession::Continue {
+                        external_session_id: "thread; literal".into(),
+                    },
+                    prompt,
+                )
+                .unwrap(),
+            ScheduleDispatchCommand {
+                argv: vec![
+                    "codex".into(),
+                    "exec".into(),
+                    "resume".into(),
+                    "thread; literal".into(),
+                    "-".into(),
                 ],
                 stdin: Some(prompt.as_bytes().to_vec()),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ use crate::integration_management::{
 mod agent_attention_projection;
 mod claude_hooks;
 mod cli_output;
+mod codex_hooks;
 mod config;
 mod dashboard_projection;
 mod generated_names;
@@ -511,6 +512,12 @@ enum Commands {
     Claude {
         #[command(subcommand)]
         command: ClaudeCommands,
+    },
+    /// Receive Codex lifecycle hooks
+    #[command(hide = true)]
+    Codex {
+        #[command(subcommand)]
+        command: CodexCommands,
     },
     /// Open a shell in a new terminal window
     Open {
@@ -1289,6 +1296,19 @@ enum ClaudeCommands {
 }
 
 #[derive(Subcommand)]
+enum CodexCommands {
+    /// Receive one lifecycle event on standard input
+    #[command(hide = true)]
+    Hook,
+    /// Launch Codex with run-scoped lifecycle authority
+    #[command(hide = true)]
+    Launch {
+        #[arg(last = true, allow_hyphen_values = true)]
+        arguments: Vec<OsString>,
+    },
+}
+
+#[derive(Subcommand)]
 enum IntegrationCommands {
     /// List integrations bundled with this Boomux binary
     List,
@@ -1473,6 +1493,8 @@ command_keys! {
     OpencodeClaimReport => ("opencode.claim.report", PrivateJson),
     Pi => ("pi", HumanOnly),
     ClaudeHook => ("claude.hook", HumanOnly),
+    CodexHook => ("codex.hook", HumanOnly),
+    CodexLaunch => ("codex.launch", HumanOnly),
     Open => ("open", HumanOnly),
     Prompt => ("prompt", HumanOnly),
     DaemonStatus => ("daemon.status", Json),
@@ -1720,6 +1742,12 @@ impl Cli {
             Some(Commands::Claude {
                 command: ClaudeCommands::Hook,
             }) => CommandKey::ClaudeHook,
+            Some(Commands::Codex {
+                command: CodexCommands::Hook,
+            }) => CommandKey::CodexHook,
+            Some(Commands::Codex {
+                command: CodexCommands::Launch { .. },
+            }) => CommandKey::CodexLaunch,
             Some(Commands::Open { .. }) => CommandKey::Open,
             Some(Commands::Prompt) => CommandKey::Prompt,
             Some(Commands::Attach { .. }) => CommandKey::Attach,
@@ -2073,6 +2101,17 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             }
             Ok(())
         }
+        Some(Commands::Codex {
+            command: CodexCommands::Hook,
+        }) => {
+            if let Err(error) = codex_hook_command() {
+                eprintln!("boomux codex hook: {error}");
+            }
+            Ok(())
+        }
+        Some(Commands::Codex {
+            command: CodexCommands::Launch { arguments },
+        }) => launch_codex(arguments),
         Some(Commands::Open {
             shell_id,
             node,
@@ -9179,8 +9218,16 @@ fn scheduled_runner(schedule_id: &str) -> Result<process_adapter::ProcessExit, B
             &claim.prompt,
         )
         .ok_or_else(|| io::Error::other("scheduled integration mode is unavailable"))?;
-    let mut command = Command::new(&dispatch.argv[0]);
+    let codex_dispatch = claim.execution.integration == "codex";
+    let mut command = if codex_dispatch {
+        Command::new(env::current_exe()?)
+    } else {
+        Command::new(&dispatch.argv[0])
+    };
     sanitize_inherited_opencode_shim(&mut command);
+    if codex_dispatch {
+        command.args(["codex", "launch", "--"]);
+    }
     command
         .args(&dispatch.argv[1..])
         .current_dir(&claim.execution.cwd)
@@ -9394,7 +9441,7 @@ fn create_coordinated_schedule(
         boomux::scheduling::validate_external_session_id(&external_session_id)?;
         if !integration
             .schedule_dispatch
-            .is_some_and(|dispatch| dispatch.continuation)
+            .is_some_and(|dispatch| dispatch.continuation.is_some())
         {
             return Err(cli_output::failure(
                 "unsupported_integration",
@@ -9407,7 +9454,7 @@ fn create_coordinated_schedule(
     } else {
         if !integration
             .schedule_dispatch
-            .is_some_and(|dispatch| dispatch.fresh)
+            .is_some_and(|dispatch| dispatch.fresh.is_some())
         {
             return Err(cli_output::failure(
                 "unsupported_integration",
@@ -9527,7 +9574,7 @@ fn create_schedule(
         boomux::scheduling::validate_external_session_id(external_session_id)?;
         if !integration
             .schedule_dispatch
-            .is_some_and(|dispatch| dispatch.continuation)
+            .is_some_and(|dispatch| dispatch.continuation.is_some())
         {
             return Err(cli_output::failure(
                 "unsupported_integration",
@@ -9540,7 +9587,7 @@ fn create_schedule(
     } else {
         if !integration
             .schedule_dispatch
-            .is_some_and(|dispatch| dispatch.fresh)
+            .is_some_and(|dispatch| dispatch.fresh.is_some())
         {
             return Err(cli_output::failure(
                 "unsupported_integration",
@@ -10125,6 +10172,100 @@ fn claude_hook_command() -> Result<(), Box<dyn Error>> {
     };
     client.set_claude_remote_control_binding(agent.id, shell_id, run_id, bridge_session_id)?;
     Ok(())
+}
+
+fn codex_hook_command() -> Result<(), Box<dyn Error>> {
+    if env::var("BOOMUX_CODEX_RUN_SCOPED").as_deref() != Ok("1") {
+        return Ok(());
+    }
+    let (shell_id, run_id) = match (
+        env::var("BOOMUX_SHELL_ID").ok(),
+        env::var("BOOMUX_RUN_ID").ok(),
+    ) {
+        (Some(shell_id), Some(run_id)) => {
+            resolve_agent_context(None, None, Some(shell_id), Some(run_id))?
+        }
+        _ => return Ok(()),
+    };
+    let update = codex_hooks::read_update(io::stdin().lock())?;
+    let observation = update.observation;
+    let report = AgentReport {
+        state: observation.state,
+        authority: AgentAuthority::LifecycleIntegration,
+        evidence: observation.evidence.into(),
+        confidence: 100,
+    };
+    let client = client::connect_or_start()?;
+    let agent = client.ensure_agent(
+        &shell_id,
+        &run_id,
+        AgentRegistrationSpec {
+            name: "Codex".into(),
+            integration: "codex".into(),
+            external_session_id: Some(update.session_id),
+            report: report.clone(),
+        },
+    )?;
+    if agent.ended_at_ms.is_none()
+        && (agent.observation.state != report.state
+            || agent.observation.authority != report.authority
+            || agent.observation.evidence != report.evidence
+            || agent.observation.confidence != report.confidence)
+    {
+        client.report_agent(&agent.id, &run_id, report)?;
+    }
+    Ok(())
+}
+
+fn launch_codex(arguments: Vec<OsString>) -> Result<(), Box<dyn Error>> {
+    let executable = resolve_real_codex()?;
+    let managed_chat = arguments.is_empty()
+        || arguments
+            .first()
+            .is_some_and(|argument| argument == "resume" || argument == "exec");
+    let environment = integration_management::Environment::from_process();
+    let hooks_current = integration_management::inspect_without_host_probe(
+        integration_management::IntegrationId::CODEX,
+        &environment,
+        None,
+    )
+    .asset
+    .state
+        == integration_management::AssetState::Current;
+    let mut command = Command::new(executable);
+    sanitize_inherited_opencode_shim(&mut command);
+    if managed_chat && hooks_current {
+        command
+            .args(["--enable", "hooks"])
+            .env("BOOMUX_CODEX_RUN_SCOPED", "1");
+    } else {
+        command.env_remove("BOOMUX_CODEX_RUN_SCOPED");
+    }
+    command.args(arguments);
+    Err(command.exec().into())
+}
+
+fn resolve_real_codex() -> io::Result<PathBuf> {
+    if let Some(path) = env::var_os("BOOMUX_REAL_CODEX").map(PathBuf::from) {
+        let metadata = fs::metadata(&path)?;
+        if path.is_absolute() && metadata.is_file() && metadata.permissions().mode() & 0o111 != 0 {
+            return Ok(path);
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "BOOMUX_REAL_CODEX must identify an absolute regular executable",
+        ));
+    }
+    let shim_dir = env::var_os("BOOMUX_OPENCODE_SHIM_DIR").map(PathBuf::from);
+    env::split_paths(&env::var_os("PATH").unwrap_or_default())
+        .filter(|directory| shim_dir.as_deref() != Some(directory.as_path()))
+        .map(|directory| directory.join("codex"))
+        .find(|candidate| {
+            fs::metadata(candidate).is_ok_and(|metadata| {
+                metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+            })
+        })
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Codex executable was not found"))
 }
 
 fn resolve_agent_context(
@@ -10756,6 +10897,8 @@ fn sanitize_inherited_opencode_shim(command: &mut Command) {
     }
     for name in [
         "BOOMUX_REAL_OPENCODE",
+        "BOOMUX_REAL_CODEX",
+        "BOOMUX_CODEX_RUN_SCOPED",
         "BOOMUX_ORIGINAL_PATH",
         "BOOMUX_OPENCODE_SHIM_DIR",
         "BOOMUX_OPENCODE_TUI_CONFIG",
@@ -13625,6 +13768,40 @@ mod tests {
     }
 
     #[test]
+    fn parses_hidden_codex_hook_command() {
+        let cli = Cli::try_parse_from(["boomux", "codex", "hook"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Codex {
+                command: CodexCommands::Hook,
+            })
+        ));
+        assert_eq!(cli.command_descriptor().key, "codex.hook");
+        assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+    }
+
+    #[test]
+    fn parses_hidden_codex_launch_command_without_interpreting_arguments() {
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "codex",
+            "launch",
+            "--",
+            "resume",
+            "thread; literal",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Codex {
+                command: CodexCommands::Launch { ref arguments },
+            }) if arguments.as_slice()
+                == [OsString::from("resume"), OsString::from("thread; literal")].as_slice()
+        ));
+        assert_eq!(cli.command_descriptor().key, "codex.launch");
+    }
+
+    #[test]
     fn event_snapshot_json_includes_stable_agent_data() {
         let mut project = workspace("w1", "project", vec![shell("s1", "w1", "shell")]);
         project.agents.push(agent("a1", "w1", "s1"));
@@ -14121,6 +14298,21 @@ mod tests {
     }
 
     #[test]
+    fn workspace_view_hints_exact_codex_foreground_process_before_first_prompt() {
+        let mut hinted = shell("s1", "w1", "terminal");
+        hinted.foreground_process = Some("codex".into());
+        let workspace = workspace("w1", "project", vec![hinted]);
+
+        let views = dashboard_views(&[workspace], &mut git::Cache::default());
+
+        let tui::WorkspaceItemView::AgentShell(item) = &views[0].items[0] else {
+            panic!("expected hinted agent-shell item");
+        };
+        assert_eq!(item.shell.name, "terminal");
+        assert!(item.agent.is_none());
+    }
+
+    #[test]
     fn workspace_view_does_not_hint_an_inactive_pi_session() {
         let mut hinted = shell("s1", "w1", "terminal");
         hinted.foreground_process = Some("pi".into());
@@ -14459,6 +14651,10 @@ mod tests {
         session.integration = "claude".into();
         let (_, command) = dashboard_session_resume_plan(&session).unwrap();
         assert_eq!(command, ["claude", "--resume", "ses_exact"]);
+
+        session.integration = "codex".into();
+        let (_, command) = dashboard_session_resume_plan(&session).unwrap();
+        assert_eq!(command, ["codex", "resume", "ses_exact"]);
 
         session.state_is_current = true;
         assert!(
@@ -14975,7 +15171,8 @@ mod tests {
             "NAME      PACKAGE                          VALIDATED VERSION\n\
              opencode  opencode-ai                      1.18.18\n\
              pi        @earendil-works/pi-coding-agent  0.84.1\n\
-             claude    @anthropic-ai/claude-code        2.1.236\n"
+             claude    @anthropic-ai/claude-code        2.1.236\n\
+             codex     @openai/codex                    0.147.0\n"
         );
 
         let status = integration_management::IntegrationStatus {

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -129,6 +129,218 @@ fn claude_hook_reports_lifecycle_and_synchronizes_ephemeral_bridge_binding() {
 }
 
 #[test]
+fn codex_hook_requires_run_scoped_launch_and_reuses_exact_thread_agent() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "codex-hook",
+            vec![ShellSpec {
+                name: "codex".into(),
+                command: vec!["/bin/sleep".into(), "30".into()],
+                cwd: std::env::temp_dir(),
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let _attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+
+    let run_hook = |event: &str, run_scoped: bool| {
+        let mut command = daemon.command();
+        command
+            .args(["codex", "hook"])
+            .env("BOOMUX_SHELL_ID", &shell_id)
+            .env("BOOMUX_RUN_ID", &run_id)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped());
+        if run_scoped {
+            command.env("BOOMUX_CODEX_RUN_SCOPED", "1");
+        } else {
+            command.env_remove("BOOMUX_CODEX_RUN_SCOPED");
+        }
+        let mut child = command.spawn().unwrap();
+        write!(
+            child.stdin.take().unwrap(),
+            "{{\"session_id\":\"codex-thread\",\"hook_event_name\":\"{event}\"}}"
+        )
+        .unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(output.status.success());
+        assert!(output.stdout.is_empty());
+    };
+
+    run_hook("SessionStart", false);
+    assert!(
+        daemon.client.snapshot().unwrap().workspaces[0]
+            .agents
+            .is_empty()
+    );
+
+    for (event, expected) in [
+        ("SessionStart", AgentState::Idle),
+        ("UserPromptSubmit", AgentState::Working),
+        ("PermissionRequest", AgentState::Blocked),
+        ("PostToolUse", AgentState::Working),
+        ("Stop", AgentState::Idle),
+        ("SessionEnd", AgentState::Inactive),
+    ] {
+        run_hook(event, true);
+        let agents = &daemon.client.snapshot().unwrap().workspaces[0].agents;
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].integration, "codex");
+        assert_eq!(
+            agents[0].external_session_id.as_deref(),
+            Some("codex-thread")
+        );
+        assert_eq!(agents[0].observation.state, expected, "{event}");
+        assert_ne!(agents[0].observation.state, AgentState::Done);
+    }
+
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn codex_app_server_catalog_projects_named_historical_threads_without_agents() {
+    let mut daemon = TestDaemon::start();
+    let bin = daemon.runtime_dir.join("codex-catalog-bin");
+    fs::create_dir(&bin).unwrap();
+    let codex = bin.join("codex");
+    fs::write(
+        &codex,
+        "#!/bin/sh\n[ \"$1\" = app-server ] || exit 64\nIFS= read -r line || exit 65\nprintf '%s\\n' '{\"id\":1,\"result\":{}}'\nIFS= read -r line || exit 66\nIFS= read -r line || exit 67\nprintf '%s\\n' '{\"id\":2,\"result\":{\"data\":[{\"id\":\"codex-history\",\"name\":\"Historical Codex thread\",\"preview\":\"fallback\",\"ephemeral\":false,\"createdAt\":10,\"updatedAt\":20}],\"nextCursor\":null}}'\n",
+    )
+    .unwrap();
+    fs::set_permissions(&codex, fs::Permissions::from_mode(0o755)).unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "codex-catalog",
+            vec![ShellSpec::login("shell", &daemon.runtime_dir)],
+        )
+        .unwrap();
+
+    let output = daemon
+        .command()
+        .args(["session", "list", "--workspace", &workspace.id, "--json"])
+        .env("PATH", &bin)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let sessions = output["data"]["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0]["integration"], "codex");
+    assert_eq!(sessions[0]["external_session_id"], "codex-history");
+    assert_eq!(sessions[0]["description"], "Historical Codex thread");
+    assert_eq!(sessions[0]["state"], "unknown");
+    assert_eq!(sessions[0]["occurrence_count"], 0);
+
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn cold_recovery_resumes_exact_codex_thread_with_run_scoped_hooks() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("codex-bin");
+        let codex_home = runtime_dir.join("codex-home");
+        fs::create_dir(&bin).unwrap();
+        fs::create_dir(&codex_home).unwrap();
+        fs::write(
+            codex_home.join("hooks.json"),
+            include_str!("../../integrations/codex/hooks.json"),
+        )
+        .unwrap();
+        let codex = bin.join("codex");
+        fs::write(
+            &codex,
+            "#!/bin/sh\n: > \"$CODEX_RECOVERY_CAPTURE\"\nfor arg do printf '%s\\0' \"$arg\" >> \"$CODEX_RECOVERY_CAPTURE\"; done\n[ \"${3-unset}\" = resume ] || /bin/sleep 30\n",
+        )
+        .unwrap();
+        fs::set_permissions(&codex, fs::Permissions::from_mode(0o700)).unwrap();
+        command
+            .env("PATH", &bin)
+            .env("CODEX_HOME", &codex_home)
+            .env(
+                "CODEX_RECOVERY_CAPTURE",
+                runtime_dir.join("codex-recovery-argv"),
+            );
+    });
+    let codex = daemon.runtime_dir.join("codex-bin/codex");
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "codex-recovery",
+            vec![ShellSpec {
+                name: "codex".into(),
+                command: vec![codex.display().to_string()],
+                cwd: daemon.runtime_dir.clone(),
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    wait_until(
+        || fs::read(daemon.runtime_dir.join("codex-recovery-argv")).is_ok(),
+        "initial Codex run did not launch",
+    );
+    let first_run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+    let agent = daemon
+        .client
+        .register_agent(
+            &shell_id,
+            &first_run.id,
+            AgentRegistrationSpec {
+                name: "Codex".into(),
+                integration: "codex".into(),
+                external_session_id: Some("exact-recovery-thread".into()),
+                report: AgentReport {
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "Codex session idle".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+
+    daemon.crash();
+    drop(attachment.stream);
+    let bin = daemon.runtime_dir.join("codex-bin");
+    let codex_home = daemon.runtime_dir.join("codex-home");
+    let capture = daemon.runtime_dir.join("codex-recovery-argv");
+    daemon.restart_with(move |command| {
+        command
+            .env("PATH", bin)
+            .env("CODEX_HOME", codex_home)
+            .env("CODEX_RECOVERY_CAPTURE", capture);
+    });
+    let recovered = daemon.client.get_shell(&shell_id).unwrap();
+    assert_eq!(
+        recovered.recovered_agent_id.as_deref(),
+        Some(agent.id.as_str())
+    );
+
+    let recovered_attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    wait_until(
+        || {
+            fs::read(daemon.runtime_dir.join("codex-recovery-argv"))
+                .is_ok_and(|argv| argv == b"--enable\0hooks\0resume\0exact-recovery-thread\0")
+        },
+        "recovered Codex run did not resume the exact thread with hooks",
+    );
+    let second_run = daemon.client.get_shell(&shell_id).unwrap().run.unwrap();
+    assert_ne!(second_run.id, first_run.id);
+
+    drop(recovered_attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn opencode_shared_runtime_and_claims_are_node_wide_and_ephemeral() {
     let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
         let bin = runtime_dir.join("bin");

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -71,6 +71,14 @@ fn native_daemon_lifecycle() {
         capabilities["data"]["integration_hosts"]["pi"]["package"],
         "@earendil-works/pi-coding-agent"
     );
+    assert_eq!(
+        capabilities["data"]["integration_hosts"]["codex"]["validated_version"],
+        "0.147.0"
+    );
+    assert_eq!(
+        capabilities["data"]["integration_hosts"]["codex"]["package"],
+        "@openai/codex"
+    );
     let json_commands = capabilities["data"]["json_commands"].as_array().unwrap();
     for command in [
         "events",

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -245,6 +245,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     let pi = root.join("pi");
     let claude = root.join("claude");
     let claude_manifest = claude.join("skills/boomux/.claude-plugin/plugin.json");
+    let codex_hooks = root.join(".codex/hooks.json");
     let runtime = root.join("runtime");
     fs::create_dir_all(&bin).unwrap();
     fs::create_dir_all(&runtime).unwrap();
@@ -252,6 +253,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
         ("opencode", "1.18.18"),
         ("pi", "0.84.1"),
         ("claude", "2.1.236"),
+        ("codex", "0.147.0"),
     ] {
         let executable = bin.join(name);
         fs::write(
@@ -288,7 +290,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
             .iter()
             .map(|integration| integration["name"].as_str().unwrap())
             .collect::<Vec<_>>(),
-        ["opencode", "pi", "claude"]
+        ["opencode", "pi", "claude", "codex"]
     );
 
     let missing = command()
@@ -315,6 +317,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     assert!(!preflight_refused.status.success());
     assert!(!config.join("opencode/plugins/boomux.js").exists());
     assert!(!claude_manifest.exists());
+    assert!(!codex_hooks.exists());
     fs::remove_file(pi.join("extensions/boomux.js")).unwrap();
 
     let installed = command()
@@ -335,9 +338,16 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     assert!(config.join("opencode/plugins/boomux.js").is_file());
     assert!(pi.join("extensions/boomux.js").is_file());
     assert!(claude_manifest.is_file());
+    assert!(codex_hooks.is_file());
     let manifest: serde_json::Value =
         serde_json::from_slice(&fs::read(&claude_manifest).unwrap()).unwrap();
     assert_eq!(manifest["name"], "boomux");
+    let hooks: serde_json::Value =
+        serde_json::from_slice(&fs::read(&codex_hooks).unwrap()).unwrap();
+    assert_eq!(
+        hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"],
+        "boomux codex hook"
+    );
 
     for arguments in [["opencode", "install"], ["pi", "install"]] {
         let shortcut = command().args(arguments).output().unwrap();
@@ -386,6 +396,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     assert!(!uninstall_refused.status.success());
     assert!(config.join("opencode/plugins/boomux.js").is_file());
     assert!(claude_manifest.is_file());
+    assert!(codex_hooks.is_file());
     assert_eq!(
         fs::read_to_string(pi.join("extensions/boomux.js")).unwrap(),
         "custom extension"
@@ -405,9 +416,11 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     assert!(!config.join("opencode/plugins/boomux.js").exists());
     assert!(!pi.join("extensions/boomux.js").exists());
     assert!(!claude_manifest.exists());
+    assert!(!codex_hooks.exists());
     assert!(config.join("opencode/plugins").is_dir());
     assert!(pi.join("extensions").is_dir());
     assert!(claude.join("skills/boomux/.claude-plugin").is_dir());
+    assert!(root.join(".codex").is_dir());
 
     let absent = command()
         .args(["integration", "uninstall", "pi", "--json"])
@@ -472,6 +485,70 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     let invalid_environment: serde_json::Value =
         serde_json::from_slice(&invalid_environment.stderr).unwrap();
     assert_eq!(invalid_environment["error"]["code"], "invalid_argument");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn codex_hidden_launcher_scopes_chat_hooks_and_passes_service_commands_through() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-codex-launcher-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = root.join("bin");
+    let codex_home = root.join("codex-home");
+    fs::create_dir_all(&bin).unwrap();
+    fs::create_dir(&codex_home).unwrap();
+    fs::write(
+        codex_home.join("hooks.json"),
+        include_str!("../../integrations/codex/hooks.json"),
+    )
+    .unwrap();
+    let codex = bin.join("codex");
+    fs::write(
+        &codex,
+        "#!/bin/sh\n: > \"$BOOMUX_CODEX_CAPTURE\"\nfor arg do printf '%s\\0' \"$arg\" >> \"$BOOMUX_CODEX_CAPTURE\"; done\nprintf '%s' \"${BOOMUX_CODEX_RUN_SCOPED-unset}\" > \"$BOOMUX_CODEX_MARKER\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&codex, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let run = |arguments: &[&str], case: &str| {
+        let capture = root.join(format!("{case}-argv"));
+        let marker = root.join(format!("{case}-marker"));
+        let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+        command
+            .args(["codex", "launch", "--"])
+            .args(arguments)
+            .env("PATH", &bin)
+            .env("CODEX_HOME", &codex_home)
+            .env("BOOMUX_CODEX_CAPTURE", &capture)
+            .env("BOOMUX_CODEX_MARKER", &marker)
+            .env("BOOMUX_SHELL_ID", "shell-1")
+            .env("BOOMUX_RUN_ID", "run-1");
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        (
+            fs::read(capture).unwrap(),
+            fs::read_to_string(marker).unwrap(),
+        )
+    };
+
+    let (argv, marker) = run(&["resume", "thread; literal"], "resume");
+    assert_eq!(argv, b"--enable\0hooks\0resume\0thread; literal\0");
+    assert_eq!(marker, "1");
+
+    let (argv, marker) = run(&["remote-control", "start", "--json"], "service");
+    assert_eq!(argv, b"remote-control\0start\0--json\0");
+    assert_eq!(marker, "unset");
+
+    let (argv, marker) = run(&["--remote", "unix:///tmp/codex.sock"], "remote");
+    assert_eq!(argv, b"--remote\0unix:///tmp/codex.sock\0");
+    assert_eq!(marker, "unset");
 
     fs::remove_dir_all(root).unwrap();
 }

--- a/tests/native_backend/mobile_web.rs
+++ b/tests/native_backend/mobile_web.rs
@@ -82,6 +82,47 @@ fn web_starts_without_opencode_and_repeats_idempotently() {
     .unwrap();
     assert!(hook.wait().unwrap().success());
 
+    let codex_workspace = daemon
+        .client
+        .create_workspace(
+            "codex-web-without-handoff",
+            vec![ShellSpec {
+                name: "codex".into(),
+                command: vec!["/bin/sleep".into(), "30".into()],
+                cwd: std::env::temp_dir(),
+            }],
+        )
+        .unwrap();
+    let codex_shell_id = codex_workspace.shells[0].id.clone();
+    let _codex_attachment = daemon
+        .client
+        .attach(&codex_shell_id, false, profile())
+        .unwrap();
+    let codex_run_id = daemon
+        .client
+        .get_shell(&codex_shell_id)
+        .unwrap()
+        .run
+        .unwrap()
+        .id;
+    let mut codex_hook = daemon.command();
+    codex_hook
+        .args(["codex", "hook"])
+        .env("BOOMUX_SHELL_ID", &codex_shell_id)
+        .env("BOOMUX_RUN_ID", &codex_run_id)
+        .env("BOOMUX_CODEX_RUN_SCOPED", "1")
+        .stdin(Stdio::piped());
+    let mut codex_hook = codex_hook.spawn().unwrap();
+    codex_hook
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(
+            b"{\"session_id\":\"codex-without-handoff\",\"hook_event_name\":\"SessionStart\"}",
+        )
+        .unwrap();
+    assert!(codex_hook.wait().unwrap().success());
+
     let dashboard_port = unused_port();
     let opencode_port = unused_port();
     assert_ne!(dashboard_port, opencode_port);
@@ -146,6 +187,13 @@ fn web_starts_without_opencode_and_repeats_idempotently() {
         claude["native_web"]["url"],
         "https://claude.ai/code/bridge-without-opencode"
     );
+    let codex = snapshot["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|agent| agent["integration"] == "codex")
+        .unwrap();
+    assert!(codex.get("native_web").is_none());
 
     let repeated = run_web(&daemon, &arguments, &empty_path);
     assert!(repeated.status.success());

--- a/tests/native_backend/schedules.rs
+++ b/tests/native_backend/schedules.rs
@@ -735,15 +735,27 @@ fn assert_stdin_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identit
 ) {
     let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
         let bin = runtime_dir.join("bin");
+        let codex_home = runtime_dir.join("codex-home");
         fs::create_dir(&bin).unwrap();
+        fs::create_dir(&codex_home).unwrap();
+        fs::write(
+            codex_home.join("hooks.json"),
+            include_str!("../../integrations/codex/hooks.json"),
+        )
+        .unwrap();
         let host = bin.join(integration);
         fs::write(
             &host,
-            "#!/bin/sh\nprintf '%s\\0' \"$@\" > \"$BOOMUX_DISPATCH_ARGV_DIR/$BOOMUX_DISPATCH_CASE\"\ncat > \"$BOOMUX_DISPATCH_STDIN_DIR/$BOOMUX_DISPATCH_CASE\"\nprintf '%s' \"${BOOMUX_SCHEDULE_RUNNER_TOKEN-unset}\" > \"$BOOMUX_DISPATCH_TOKEN_DIR/$BOOMUX_DISPATCH_CASE\"\n",
+            "#!/bin/sh\nprintf '%s\\0' \"$@\" > \"$BOOMUX_DISPATCH_ARGV_DIR/$BOOMUX_DISPATCH_CASE\"\ncat > \"$BOOMUX_DISPATCH_STDIN_DIR/$BOOMUX_DISPATCH_CASE\"\nprintf '%s' \"${BOOMUX_SCHEDULE_RUNNER_TOKEN-unset}\" > \"$BOOMUX_DISPATCH_TOKEN_DIR/$BOOMUX_DISPATCH_CASE\"\nprintf '%s' \"${BOOMUX_CODEX_RUN_SCOPED-unset}\" > \"$BOOMUX_DISPATCH_CODEX_MARKER_DIR/$BOOMUX_DISPATCH_CASE\"\n",
         )
         .unwrap();
         fs::set_permissions(&host, fs::Permissions::from_mode(0o755)).unwrap();
-        for directory in ["dispatch-argv", "dispatch-stdin", "dispatch-token"] {
+        for directory in [
+            "dispatch-argv",
+            "dispatch-stdin",
+            "dispatch-token",
+            "dispatch-codex-marker",
+        ] {
             fs::create_dir(runtime_dir.join(directory)).unwrap();
         }
         let mut paths = vec![bin];
@@ -764,6 +776,11 @@ fn assert_stdin_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identit
                 "BOOMUX_DISPATCH_TOKEN_DIR",
                 runtime_dir.join("dispatch-token"),
             )
+            .env(
+                "BOOMUX_DISPATCH_CODEX_MARKER_DIR",
+                runtime_dir.join("dispatch-codex-marker"),
+            )
+            .env("CODEX_HOME", codex_home)
             .env("BOOMUX_DISPATCH_CASE", "fresh");
     });
     let workspace = daemon
@@ -802,6 +819,10 @@ fn assert_stdin_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identit
         fs::read_to_string(daemon.runtime_dir.join("dispatch-token/fresh")).unwrap(),
         "unset"
     );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("dispatch-codex-marker/fresh")).unwrap(),
+        if integration == "codex" { "1" } else { "unset" }
+    );
 
     let restart = daemon
         .command()
@@ -825,6 +846,11 @@ fn assert_stdin_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identit
             "BOOMUX_DISPATCH_TOKEN_DIR",
             daemon.runtime_dir.join("dispatch-token"),
         )
+        .env(
+            "BOOMUX_DISPATCH_CODEX_MARKER_DIR",
+            daemon.runtime_dir.join("dispatch-codex-marker"),
+        )
+        .env("CODEX_HOME", daemon.runtime_dir.join("codex-home"))
         .env("BOOMUX_DISPATCH_CASE", "continue")
         .output()
         .unwrap();
@@ -868,6 +894,10 @@ fn assert_stdin_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identit
         fs::read_to_string(daemon.runtime_dir.join("dispatch-token/continue")).unwrap(),
         "unset"
     );
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("dispatch-codex-marker/continue")).unwrap(),
+        if integration == "codex" { "1" } else { "unset" }
+    );
     daemon.stop_with_cli();
 }
 
@@ -888,6 +918,16 @@ fn claude_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity() {
         "exact-id",
         b"--print\0",
         b"--print\0--resume\0exact-id\0",
+    );
+}
+
+#[test]
+fn codex_dispatch_preserves_exact_exec_argv_stdin_eof_and_thread_identity() {
+    assert_stdin_dispatch_preserves_exact_argv_stdin_eof_and_continuation_identity(
+        "codex",
+        "exact-codex-thread",
+        b"--enable\0hooks\0exec\0-\0",
+        b"--enable\0hooks\0exec\0resume\0exact-codex-thread\0-\0",
     );
 }
 

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -71,6 +71,67 @@ fn bare_claude_command_uses_owner_remote_control_policy_without_rewriting_stored
 }
 
 #[test]
+fn bare_codex_command_uses_run_scoped_hooks_without_rewriting_stored_argv() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("codex-bin");
+        let codex_home = runtime_dir.join("codex-home");
+        fs::create_dir(&bin).unwrap();
+        fs::create_dir(&codex_home).unwrap();
+        fs::write(
+            codex_home.join("hooks.json"),
+            include_str!("../../integrations/codex/hooks.json"),
+        )
+        .unwrap();
+        let codex = bin.join("codex");
+        fs::write(
+            &codex,
+            format!(
+                "#!/bin/sh\n: > '{}'\nfor arg do printf '%s\\0' \"$arg\" >> '{}'; done\nprintf '%s' \"${{BOOMUX_CODEX_RUN_SCOPED-unset}}\" > '{}'\nprintf '%s' \"${{CODEX_HOME-unset}}\" > '{}'\n",
+                runtime_dir.join("codex-argv").display(),
+                runtime_dir.join("codex-argv").display(),
+                runtime_dir.join("codex-marker").display(),
+                runtime_dir.join("codex-home-value").display(),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&codex, fs::Permissions::from_mode(0o700)).unwrap();
+        command.env("CODEX_HOME", codex_home).env("PATH", &bin);
+    });
+    let codex = daemon.runtime_dir.join("codex-bin/codex");
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "codex",
+            vec![ShellSpec {
+                name: "codex".into(),
+                command: vec![codex.display().to_string()],
+                cwd: daemon.runtime_dir.clone(),
+            }],
+        )
+        .unwrap();
+    let shell_id = &workspace.shells[0].id;
+    let attachment = daemon.client.attach(shell_id, false, profile()).unwrap();
+    wait_until(
+        || fs::read(daemon.runtime_dir.join("codex-marker")).is_ok(),
+        "Codex command did not capture its launch",
+    );
+    let marker = fs::read_to_string(daemon.runtime_dir.join("codex-marker")).unwrap();
+    let codex_home = fs::read_to_string(daemon.runtime_dir.join("codex-home-value")).unwrap();
+    assert_eq!(
+        fs::read(daemon.runtime_dir.join("codex-argv")).unwrap(),
+        b"--enable\0hooks\0",
+        "marker={marker} CODEX_HOME={codex_home}"
+    );
+    assert_eq!(marker, "1");
+    assert_eq!(
+        daemon.client.get_shell(shell_id).unwrap().command,
+        [codex.display().to_string()]
+    );
+    drop(attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn bare_claude_typed_in_managed_login_shell_uses_remote_control_shim() {
     let mut daemon = TestDaemon::start();
     let bin = daemon.runtime_dir.join("claude-bin");
@@ -123,6 +184,76 @@ fn bare_claude_typed_in_managed_login_shell_uses_remote_control_shim() {
         "typed Claude command did not capture argv",
     );
     assert_eq!(fs::read(output).unwrap(), b"--remote-control\0");
+    AttachFrame::Input(b"exit\n".to_vec())
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    drop(attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn bare_codex_typed_in_managed_login_shell_uses_run_scoped_hooks() {
+    let mut daemon = TestDaemon::start();
+    let bin = daemon.runtime_dir.join("codex-login-bin");
+    let home = daemon.runtime_dir.join("codex-login-home");
+    let codex_home = home.join(".codex");
+    let argv_output = daemon.runtime_dir.join("typed-codex-argv");
+    let marker_output = daemon.runtime_dir.join("typed-codex-marker");
+    fs::create_dir(&bin).unwrap();
+    fs::create_dir_all(&codex_home).unwrap();
+    fs::write(
+        codex_home.join("hooks.json"),
+        include_str!("../../integrations/codex/hooks.json"),
+    )
+    .unwrap();
+    let codex = bin.join("codex");
+    fs::write(
+        &codex,
+        format!(
+            "#!/bin/sh\n: > '{}'\nfor arg do printf '%s\\0' \"$arg\" >> '{}'; done\nprintf '%s' \"${{BOOMUX_CODEX_RUN_SCOPED-unset}}\" > '{}'\n",
+            argv_output.display(),
+            argv_output.display(),
+            marker_output.display(),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&codex, fs::Permissions::from_mode(0o700)).unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "codex-login",
+            vec![ShellSpec::login("login", &daemon.runtime_dir)],
+        )
+        .unwrap();
+    let environment = UnixEnvironment {
+        variables: [
+            (b"SHELL".as_slice(), std::ffi::OsStr::new("/bin/bash")),
+            (b"HOME".as_slice(), home.as_os_str()),
+            (b"CODEX_HOME".as_slice(), codex_home.as_os_str()),
+            (b"PATH".as_slice(), bin.as_os_str()),
+            (
+                b"XDG_RUNTIME_DIR".as_slice(),
+                daemon.runtime_dir.as_os_str(),
+            ),
+        ]
+        .into_iter()
+        .map(|(name, value)| UnixEnvironmentVariable {
+            name: name.to_vec(),
+            value: value.as_encoded_bytes().to_vec(),
+        })
+        .collect(),
+    };
+    let mut attachment =
+        attach_with_environment(&daemon.client, &workspace.shells[0].id, false, environment);
+    AttachFrame::Input(b"codex\n".to_vec())
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    wait_until(
+        || fs::read(&marker_output).is_ok(),
+        "typed Codex command did not capture its launch",
+    );
+    assert_eq!(fs::read(argv_output).unwrap(), b"--enable\0hooks\0");
+    assert_eq!(fs::read_to_string(marker_output).unwrap(), "1");
     AttachFrame::Input(b"exit\n".to_vec())
         .write_to(&mut attachment.stream)
         .unwrap();

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -42,6 +42,8 @@ fn remove_boomux_shim_environment(command: &mut Command) {
     for name in [
         "BOOMUX_CLAUDE_REMOTE_CONTROL",
         "BOOMUX_REAL_CLAUDE",
+        "BOOMUX_REAL_CODEX",
+        "BOOMUX_CODEX_RUN_SCOPED",
         "BOOMUX_REAL_OPENCODE",
         "BOOMUX_ORIGINAL_PATH",
         "BOOMUX_OPENCODE_SHIM_DIR",


### PR DESCRIPTION
## Summary
- add run-scoped Codex lifecycle hooks, managed launch shims, exact resume, scheduling, cold recovery, and foreground detection
- merge Boomux handlers safely into Codex hooks.json and project bounded app-server thread catalogs
- document setup, authority, compatibility, and the absence of Pi/Codex Open Web handoffs without an authoritative destination

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --lib --bins --locked
- cargo test --test native_backend --locked -- --test-threads=1
- bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js