### PR TITLE
test(ssh): allow upload helper time under load

### DIFF
--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -3953,7 +3953,7 @@ mod tests {
         let output = run_streaming_command_capture(
             command,
             transaction.upload_input(bytes),
-            Duration::from_secs(5),
+            Duration::from_secs(15),
         )
         .unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary
- increase the test-only local SSH upload capture allowance from 5 to 15 seconds
- preserve production deadlines and the transport-loss test synchronization bounds
- prevent the full parallel unit suite from timing out before reaching its commit-cut assertions

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --lib --bins --locked
- cargo test --test native_backend --locked -- --test-threads=1
- bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js