### PR TITLE
ci: parallelize rust validation jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,47 @@ jobs:
       - name: Install Rust toolchain
         run: rustup toolchain install stable --profile minimal --component rustfmt,clippy
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
+  rust-tests:
+    name: Rust unit tests
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
       - name: Run Rust unit tests
         run: cargo test --lib --bins --locked
+
+  rust-native:
+    name: Rust native backend
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Run native backend tests
         run: cargo test --test native_backend --locked -- --test-threads=1


### PR DESCRIPTION
## Summary
- run Rust quality checks, unit tests, and native backend tests as independent jobs
- cache pruned Rust dependency artifacts with a commit-pinned action
- preserve the complete serialized native backend command and existing `Rust` check name

## Baseline
The prior sequential Rust job took about 5m35s: Clippy ~39s, unit tests ~76s, and native backend tests ~205s. Independent jobs should reduce wall time without skipping or parallelizing tests inside the native suite.

## Validation
- `cargo fmt --all -- --check`
- workflow YAML parsed successfully
- `git diff --check`
- focused native bootstrap lifecycle test passed during profiling

## Stack
This PR targets #239 (`refactor/code-quality-pass`) and should merge after it.