### PR TITLE
perf(shell): accelerate local create and open

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | Edit the writable config layer | `boomux config edit` |
 | List recurring Agent work | `boomux schedule list --workspace feature-x` |
 
+`shell create --open` starts presenting the native terminal while coordinated
+creation is being durably committed. Attachment remains gated until creation
+succeeds, so a failed create cannot start a ShellRun. The initial local ShellRun
+uses the same bounded journal rather than waiting for a full state-file rewrite.
+
 Without `--name`, Boomux creates the next `workspace-N` and stores the selected
 path as its default for later shells. With `--name`, it adds a shell to an
 existing exact-name Node-local workspace or creates one with that default. This

--- a/docs/adr/0008-control-current-agent-shells-through-web-terminal.md
+++ b/docs/adr/0008-control-current-agent-shells-through-web-terminal.md
@@ -26,7 +26,7 @@ may submit serialized whole input frames. The primary remains sole PTY resize
 authority; browser viewport changes do not alter its logical grid and browser
 resize frames are ignored. Browser background or closure releases only that
 collaborator without stopping the Agent or displacing the native terminal.
-Explicit ordinary takeover reconnects the prior primary and detaches every
+Explicit ordinary takeover detaches the prior primary and every
 collaborator. Daemon graceful replacement quiesces every participant through the
 existing reconnect boundary and each browser reacquires only the same exact
 ShellRun.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@
 | `src/daemon.rs` | `DaemonService` coordination over durable registry, event-stream, shell-runtime, persistence, and handoff owners |
 | `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
 | `src/global_workspace_store.rs` | Independently versioned coordinator Workspace metadata, placement membership, initialization and schema migration, prepared resource recovery, and resumable close progress |
+| `src/local_shell_journal.rs` | Checksummed owner-only commit journal for local coordinated Shell creation and initial run start across owner and coordinator checkpoints |
 | `src/node_identity.rs` | Stable Node identity persistence, federation admission leases, and bounded rekey drain |
 | `src/node_registration.rs` | Independently versioned remote Node registrations, identity pinning, admission drain, validation, and atomic storage |
 | `src/node_projection.rs` | Disposable owner-only remote projection cache, deterministic bounds, health, generation CAS, quarantine, and atomic storage |
@@ -328,6 +329,11 @@ transition frontier, retained event state, durable collection, then applicable
 shell/runtime locks. Paths that need only a suffix of that order start at the
 first required owner; PTY output releases runtime locks before entering the
 `EventStream` publication boundary.
+The local coordinated Shell transaction extends the nested order with the
+global Workspace stage before durable collection mutation and the journal append
+after both staged projections are validated. Checkpointing retains the mutation
+and persistence gates but captures durable and global snapshots without nesting
+their internal locks before clearing the journal.
 
 Request handling uses `DaemonError` to retain validation, lifecycle, persistence,
 protocol, and internal failure classes until the wire boundary. Stable protocol
@@ -460,6 +466,13 @@ the attachment handshake. While holding the ordinary attachment mutation and
 shell lifecycle boundary, the daemon returns `run_changed` unless the shell is
 currently running that exact run. It cannot restart or take over a later run.
 Ordinary shell attachments retain their existing restart behavior.
+
+`shell create --open` prepares and spawns the terminal before the coordinated
+creation request so window presentation overlaps durable coordinator work. The
+hidden attachment waits on an owner-only runtime socket and receives success
+only after the parent has received the completed creation response. Creation
+failure closes the gate without attaching, so a ShellRun cannot start before
+coordinator completion and the waiter never polls or interprets `not_found`.
 
 Node-qualified opens still launch local `xdg-terminal-exec` presentation. Their
 hidden `__attach` command carries the exact owner Node ID and unchanged inner
@@ -952,8 +965,13 @@ evicts oldest completed outcomes as needed and rejects insufficient capacity
 before owner mutation. Preparing a distinct placement atomically expands every
 related pending reservation for the additional possible placement, preserving
 concurrent shared-revision creation without under-reserving either completion.
-Schema 6 adds a durable `owner_attempted` dispatch boundary. It is persisted
-within the completion reservation immediately before owner mutation. Schemas 1
+Schema 6 adds a durable `owner_attempted` dispatch boundary. Creating a resource
+in an existing Workspace persists it in the same prepared-state replacement,
+after owner preflight and immediately before owner mutation. Retried schema-6
+records that still carry `owner_attempted = false` cross that boundary before
+dispatch. The retained compound first-Workspace-and-Shell primitive keeps its
+separate preparation and attempted replacements so a proven pre-dispatch failure
+can still remove newly reserved Workspace metadata. Schemas 1
 through 5 migrate explicitly to schema 6;
 unknown legacy owner names are learned from a fresh owner read,
 schema-2 pending resource UUIDs become their operation identities, and a
@@ -976,7 +994,8 @@ owner-revision-guarded closes. Confirmed and already-absent owners are removed
 from coordinator metadata individually. Unreachable or ambiguous outcomes remain
 persisted for explicit retry, and the global record is removed only after every
 owner is confirmed. A Workspace with no placements completes close immediately.
-Resource creation first persists a prompt-free prepared operation containing
+Remote owner creation and non-Shell resource creation first persist a prompt-free
+prepared-and-attempted operation containing
 stable operation, requested and effective owner Workspace, and resource UUIDs,
 plus a hash of the complete request. Concurrent operations retain separate
 pending records; cancellation and completion target only the exact operation
@@ -1003,6 +1022,32 @@ observed. A definitive synchronous owner rejection may cancel only its serialize
 operation. Schedule
 prompts remain only in the transient owner request, and launcher and Shell argv
 remain arrays throughout routing.
+
+When the coordinator and selected owner are the same Node, ordinary coordinated
+Shell creation uses the independently versioned
+`local_shell_transactions.log` as its cross-owner commit authority. The daemon
+stages the exact owner Workspace/Shell and coordinator completion under the
+mutation, persistence, event, and global-store lock order, appends one
+checksummed bounded creation record to the pre-created owner-only journal, and
+calls `fdatasync` before installing either staged result or publishing creation
+events. If immediate attachment starts that still-journaled Shell, a contiguous
+run-start record is likewise synchronized before `RunStarted` publication or
+attachment success; cold replay records that untransferred run as interrupted.
+`state.json` and `global_workspaces.json` are asynchronous checkpoints for that
+committed record. A delayed worker checkpoints and clears committed records; any
+later ordinary request establishes the same replay frontier before applying new
+semantics. Protocol negotiation, snapshots, event reads, and a combined snapshot
+with no pending coordinator reconciliation may proceed without checkpointing, so
+an immediate fresh attachment can consume the run-start journal path despite
+dashboard or web projection reads. Graceful restart establishes the frontier
+before handoff. Cold startup
+validates and replays exact records into both checkpoints before one-time local Workspace
+migration and before accepting requests, then clears the journal without
+publishing historical creation events. A torn unterminated final append is
+discarded, while a malformed, unsupported, insecure, oversized, or
+checksum-invalid committed record fails startup closed. Remote owner creation
+retains the prepared coordinator and exact owner readback protocol because no
+local journal can commit another Node's authority.
 Protocol 39 adds an optional Node-qualified focused Shell and presentation
 revision to the combined Node snapshot. Protocol-38 responses omit the field.
 The value is live daemon memory, is returned only while the selected combined

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -422,13 +422,11 @@ ordinary shells do not receive synthetic escape input. Child mode changes are
 tracked across output chunks and reconstruction while Boomux keeps physical
 reporting enabled. Each focus gain is also reported through the
 participant-authorized attach stream. RAII cleanup restores terminal and
-focus-reporting modes when the attachment exits. Explicit takeover sends the
-existing reconnect boundary to the displaced controller. Its automatic
-reacquisition never requests takeover; a `busy` response means the new attachment
-still owns control, so the native client waits without displacing it and
-reconstructs terminal state when control becomes available. Other transport
-failures retain the bounded reconnect deadline, and an exact-run change remains
-permanent.
+focus-reporting modes when the attachment exits. Explicit takeover detaches the
+displaced controller so only the newly opened native terminal remains. Graceful
+daemon handoff uses the reconnect boundary and reconstructs terminal state after
+the replacement daemon becomes available. Other transport failures retain the
+bounded reconnect deadline, and an exact-run change remains permanent.
 
 The daemon keeps a bounded output queue per active primary and collaborator. PTY
 output fans out without blocking; a slow or disconnected collaborator removes
@@ -436,7 +434,7 @@ only itself, while a slow primary retains the existing primary-disconnect
 behavior. Primary and collaborator input frames are written under one runtime
 serialization boundary so bytes within a frame cannot interleave. Collaborative
 resize is ignored; only the primary can update the PTY and retained terminal
-dimensions. Explicit takeover reconnects the prior primary and detaches all
+dimensions. Explicit takeover detaches the prior primary and all
 collaborators; graceful handoff instead reconnects and awaits every participant.
 The listener admits at most 64 concurrent connection handlers and closes newly
 accepted sockets while that capacity is exhausted. Management responses and

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -89,11 +89,27 @@ eligibility alone cannot authorize either mutation. The retained internal
 compound first-placement request performs the same live capability preflight
 before persisting empty metadata; definitive
 pre-owner rejection cancels only an existing exact preparation durably marked as
-never attempted. Immediately before owner mutation the coordinator persists an
-attempted phase. Once set, later capability, registration, identity, owner-error,
+never attempted. After preflight, remote creation persists preparation, then
+crosses the attempted boundary in a separate replacement immediately before
+owner mutation. The compound first-Workspace-and-Shell primitive uses the same
+separate boundaries so proven pre-dispatch failure can remove its newly reserved
+metadata. A retry of an older never-attempted
+preparation crosses the durable attempted boundary before dispatch. Once set,
+later capability, registration, identity, owner-error,
 or exact-absence results retain the pending operation and Workspace name because
 they cannot disprove an earlier transport-ambiguous mutation. Ambiguous or
 network outcomes likewise retain any already-prepared recovery state.
+
+An ordinary Shell whose coordinator and owner are the same Node may instead use
+the local cross-owner transaction journal. One checksummed synchronized creation
+record commits the owner Shell and coordinator completion; an immediately
+attached initial run uses a second synchronized record before attachment
+success. The two JSON stores are replayable checkpoints. Subsequent ordinary
+requests and graceful handoff checkpoint earlier records before changing their
+semantics; protocol negotiation, snapshots, event reads, and mutation-free
+combined projection reads are the exceptions needed by immediate attachment. This local
+optimization does not apply to remote owner mutations, which retain the durable
+prepared-operation and exact-readback sequence above.
 
 ## Identity And Ownership
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -18363,14 +18363,7 @@ impl ShellRuntimeManager {
         } else {
             let mut controller = lock(&runtime.controller)?;
             if let Some(previous) = controller.take() {
-                let (written, _) = mpsc::sync_channel(1);
-                if previous
-                    .output
-                    .try_send(ControllerOutput::Reconnect(written))
-                    .is_err()
-                {
-                    let _ = previous.connection.shutdown(std::net::Shutdown::Both);
-                }
+                drop(previous);
             }
             if takeover {
                 Self::displace_collaborators(&runtime)?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -35,6 +35,9 @@ use crate::global_workspace_store::{
 };
 use crate::handoff;
 use crate::host_services::{self, PreparedIntegrationMutation};
+use crate::local_shell_journal::{
+    LocalShellJournal, LocalShellJournalRecord, LocalShellStartTransaction, LocalShellTransaction,
+};
 use crate::node_identity::{NodeIdentityLease, NodeIdentityManager};
 use crate::node_projection::{
     NodeProjectionCache, ProjectionCommit, ProjectionObservation, RemoteDigestClaim,
@@ -440,18 +443,21 @@ fn run_daemon(
     registry.node_registrations = Some(registrations);
     registry.node_projection_cache = Some(NodeProjectionCache::load_from_environment());
     registry.global_workspaces = match GlobalWorkspaceStore::load_from_environment() {
-        Ok(store) => {
-            if let Some(identity) = registry.node_identity.as_ref() {
-                let node_id = identity.id()?;
-                store.initialize_local_once(&node_id, &registry.snapshot()?)?;
-            }
-            Some(store)
-        }
+        Ok(store) => Some(store),
         Err(error) => {
             eprintln!("boomux: global Workspace coordination disabled: {error}");
             None
         }
     };
+    registry.local_shell_journal = Some(LocalShellJournal::load_from_environment()?);
+    registry.replay_local_shell_transactions()?;
+    if let (Some(identity), Some(global_workspaces)) = (
+        registry.node_identity.as_ref(),
+        registry.global_workspaces.as_ref(),
+    ) {
+        let node_id = identity.id()?;
+        global_workspaces.initialize_local_once(&node_id, &registry.snapshot()?)?;
+    }
     registry.startup_environment =
         sanitize_opencode_shim_environment(&capture_current_environment());
     registry.configure_scheduler_clock()?;
@@ -1995,6 +2001,18 @@ fn handle_connection_inner(
                 return send_response(&mut stream, response_version, error.into_response());
             }
         }
+        if let Err(error) = registry.checkpoint_local_shell_transactions() {
+            transition.store(TRANSITION_IDLE, Ordering::Release);
+            return send_response(
+                &mut stream,
+                response_version,
+                DaemonError::persistence_context(
+                    error,
+                    "could not checkpoint local Shell transactions before restart",
+                )
+                .into_response(),
+            );
+        }
         let (reply, response) = mpsc::sync_channel(1);
         if restart_sender
             .send(RestartRequest {
@@ -2067,7 +2085,7 @@ fn handle_connection_inner(
     if schedule_semantics_changed && !matches!(response, Response::Error { .. }) {
         registry.wake_scheduler();
     }
-    send_response(
+    let result = send_response(
         &mut stream,
         response_version,
         response_for_version_with_schedule_shells(
@@ -2077,7 +2095,23 @@ fn handle_connection_inner(
                 .schedule_shell_ids_for_downgrade()
                 .unwrap_or_default(),
         ),
-    )
+    );
+    if result.is_ok()
+        && registry
+            .local_shell_journal
+            .as_ref()
+            .is_some_and(|journal| journal.is_empty().is_ok_and(|empty| !empty))
+    {
+        let registry = Arc::clone(&registry);
+        let delay = registry.local_shell_checkpoint_delay();
+        thread::spawn(move || {
+            thread::sleep(delay);
+            if let Err(error) = registry.checkpoint_local_shell_transactions() {
+                eprintln!("boomux: local Shell transaction checkpoint failed: {error}");
+            }
+        });
+    }
+    result
 }
 
 fn validate_notification_delivery_settings(
@@ -3014,6 +3048,7 @@ struct DaemonService {
     node_registrations: Option<NodeRegistrationManager>,
     node_projection_cache: Option<NodeProjectionCache>,
     global_workspaces: Option<GlobalWorkspaceStore>,
+    local_shell_journal: Option<LocalShellJournal>,
     durable: DurableRegistry,
     events: EventStream,
     runtimes: ShellRuntimeManager,
@@ -5393,6 +5428,69 @@ impl DurableRegistry {
         ))
     }
 
+    fn replay_interrupted_shell_start(
+        &self,
+        shell_id: &str,
+        mut run: PersistedShellRun,
+    ) -> io::Result<()> {
+        validate_uuid(shell_id, "journal Shell ID")?;
+        validate_uuid(&run.id, "journal ShellRun ID")?;
+        validate_terminal_profile(&run.profile)?;
+        if run.generation == 0 || run.ended_at_ms.is_some() || run.exit_reason.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "local Shell start journal contains an invalid active run",
+            ));
+        }
+        let state = lock(&self.state)?;
+        let shell = state
+            .shells
+            .get(shell_id)
+            .cloned()
+            .ok_or_else(|| not_found("journal Shell", shell_id))?;
+        let shells = state.shells.values().cloned().collect::<Vec<_>>();
+        drop(state);
+        if shells.iter().any(|candidate| {
+            candidate.id != shell_id
+                && candidate
+                    .last_run
+                    .lock()
+                    .is_ok_and(|last_run| last_run.as_ref().is_some_and(|last| last.id == run.id))
+        }) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "local Shell start journal reuses a ShellRun ID",
+            ));
+        }
+        let mut last_run = lock(&shell.last_run)?;
+        if let Some(existing) = last_run.as_ref() {
+            if existing.generation == run.generation {
+                if existing.id == run.id
+                    && existing.started_at_ms == run.started_at_ms
+                    && existing.output_revision >= run.output_revision
+                    && existing.environment_has_run_id == run.environment_has_run_id
+                    && existing.profile.term == run.profile.term
+                    && existing.profile.colorterm == run.profile.colorterm
+                    && existing.profile.term_program == run.profile.term_program
+                    && existing.profile.term_program_version == run.profile.term_program_version
+                {
+                    return Ok(());
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "local Shell start journal conflicts with persisted run history",
+                ));
+            }
+            if existing.generation > run.generation {
+                return Ok(());
+            }
+        }
+        run.ended_at_ms = Some(unix_time_ms().max(run.started_at_ms));
+        run.exit_reason = Some(ShellRunExitReason::Interrupted);
+        *last_run = Some(run);
+        Ok(())
+    }
+
     fn create_schedule_shell(
         &self,
         schedule: &Arc<AgentSchedule>,
@@ -7560,6 +7658,7 @@ impl Default for DaemonService {
             node_registrations: None,
             node_projection_cache: None,
             global_workspaces: None,
+            local_shell_journal: None,
             durable: DurableRegistry {
                 state: Mutex::new(DurableState::default()),
                 store: None,
@@ -9008,6 +9107,141 @@ impl DaemonService {
         })
     }
 
+    fn local_shell_journal(&self) -> DaemonResult<&LocalShellJournal> {
+        self.local_shell_journal.as_ref().ok_or_else(|| {
+            DaemonError::lifecycle(
+                ErrorCode::PersistenceFailed,
+                "local Shell transaction journal is unavailable",
+            )
+        })
+    }
+
+    fn local_shell_checkpoint_delay(&self) -> Duration {
+        #[cfg(debug_assertions)]
+        if self.native_test_hooks_enabled()
+            && let Some(variable) = self.startup_environment.variables.iter().find(|variable| {
+                variable.name == b"BOOMUX_NATIVE_TEST_LOCAL_SHELL_CHECKPOINT_DELAY_MS"
+            })
+            && let Ok(value) = std::str::from_utf8(&variable.value)
+            && let Ok(milliseconds) = value.parse::<u64>()
+        {
+            return Duration::from_millis(milliseconds.min(60_000));
+        }
+        Duration::from_millis(100)
+    }
+
+    fn replay_local_shell_transactions(&self) -> io::Result<()> {
+        let Some(journal) = &self.local_shell_journal else {
+            return Ok(());
+        };
+        let records = journal.records()?;
+        if records.is_empty() {
+            return Ok(());
+        }
+        let global_workspaces = self
+            .global_workspaces()
+            .map_err(|error| io::Error::other(error.to_string()))?;
+        for record in records.iter().filter_map(|record| match record {
+            LocalShellJournalRecord::Create(record) => Some(record),
+            LocalShellJournalRecord::Start(_) => None,
+        }) {
+            let (_, workspace_undo) = self.durable.create_workspace_exact(
+                &record.owner_workspace_id,
+                record.owner_workspace_name.clone(),
+                record.default_cwd.clone(),
+            )?;
+            let (_, shell_undo) = self.durable.create_shell_exact(
+                &record.owner_workspace_id,
+                &record.shell_id,
+                record.shell.clone(),
+            )?;
+            drop(workspace_undo);
+            drop(shell_undo);
+        }
+        let mut latest_starts = HashMap::new();
+        for record in records.iter().filter_map(|record| match record {
+            LocalShellJournalRecord::Create(_) => None,
+            LocalShellJournalRecord::Start(record) => Some(record.as_ref()),
+        }) {
+            latest_starts.insert(record.shell_id.as_str(), record);
+        }
+        for record in latest_starts.into_values() {
+            self.durable
+                .replay_interrupted_shell_start(&record.shell_id, record.run.clone())?;
+        }
+        let saved = self.durable.capture_persisted_state()?;
+        self.durable.write_persisted_state(saved)?;
+        for record in records.iter().filter_map(|record| match record {
+            LocalShellJournalRecord::Create(record) => Some(record),
+            LocalShellJournalRecord::Start(_) => None,
+        }) {
+            let mut owner = self
+                .durable
+                .workspace(&record.owner_workspace_id)?
+                .snapshot(&self.durable)?;
+            owner.revision = record.owner_revision;
+            let resource = RoutedOperationResult::Shell {
+                shell: record.result_shell.clone(),
+            };
+            let transaction = global_workspaces.transaction()?;
+            match transaction.prepare_resource_for_attempt(
+                &record.global_workspace_id,
+                &record.operation_id,
+                &record.request_fingerprint,
+                record.request_bytes,
+                record.expected_global_revision,
+                &record.node_id,
+                &record.requested_owner_workspace_id,
+                &record.owner_workspace_name,
+                record.default_cwd.clone(),
+                &record.shell_id,
+                PendingResourceKind::Shell,
+            )? {
+                PreparedWorkspaceResource::Completed(_) => {}
+                PreparedWorkspaceResource::Pending { pending, .. } => {
+                    if pending.owner_workspace_id != record.owner_workspace_id {
+                        return Err(io::Error::new(
+                            io::ErrorKind::AlreadyExists,
+                            "journal owner Workspace conflicts with coordinator preparation",
+                        ));
+                    }
+                    transaction.complete_resource(&pending, &owner, &resource)?;
+                }
+            }
+            transaction.commit()?;
+        }
+        global_workspaces.checkpoint()?;
+        journal.clear()
+    }
+
+    fn checkpoint_local_shell_transactions(&self) -> io::Result<()> {
+        let Some(journal) = &self.local_shell_journal else {
+            return Ok(());
+        };
+        if journal.is_empty()? {
+            return Ok(());
+        }
+        let _mutation = lock(&self.mutation_lock)?;
+        self.checkpoint_local_shell_transactions_with_mutation()
+    }
+
+    fn checkpoint_local_shell_transactions_with_mutation(&self) -> io::Result<()> {
+        let Some(journal) = &self.local_shell_journal else {
+            return Ok(());
+        };
+        if journal.is_empty()? {
+            return Ok(());
+        }
+        let _persistence = lock(&self.durable.persist_lock)?;
+        let saved = self.durable.capture_persisted_state()?;
+        self.durable.write_persisted_state(saved)?;
+        self.global_workspaces()
+            .map_err(|error| io::Error::other(error.to_string()))?
+            .checkpoint()?;
+        journal.clear()?;
+        Ok(())
+    }
+
     fn handle_session_resume(
         &self,
         mut stream: UnixStream,
@@ -10108,6 +10342,269 @@ impl DaemonService {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn create_local_global_workspace_shell(
+        &self,
+        operation_id: &str,
+        request_fingerprint: &str,
+        request_bytes: usize,
+        global_workspace_id: &str,
+        expected_global_revision: u64,
+        node_id: &str,
+        requested_owner_workspace_id: &str,
+        default_cwd: Option<PathBuf>,
+        shell_id: &str,
+        shell_spec: ShellSpec,
+    ) -> DaemonResult<(protocol::GlobalWorkspaceSnapshot, RoutedOperationResult)> {
+        self.with_workspace_operation_lock(operation_id, || {
+            if let Some(completed) = self
+                .global_workspaces()?
+                .completed_operation(operation_id, request_fingerprint)
+                .map_err(global_workspace_error)?
+            {
+                return Ok((completed.workspace, completed.resource));
+            }
+            // Admit the revision guard before the slower Node eligibility probe so
+            // concurrent first resources can share the owner chosen by the winner.
+            let global = self
+                .global_workspaces()?
+                .get(global_workspace_id)
+                .map_err(global_workspace_error)?;
+            require_guard(
+                global.revision,
+                expected_global_revision,
+                "global Workspace",
+            )?;
+            if global.closing {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::Busy,
+                    "global Workspace close is in progress",
+                ));
+            }
+            let selected = self.combined_node_snapshot(Some(node_id))?;
+            let node = selected
+                .nodes
+                .iter()
+                .find(|node| node.node_id == node_id)
+                .ok_or_else(|| {
+                    DaemonError::lifecycle(ErrorCode::NotFound, "selected Node not found")
+                })?;
+            if !node.workspace_owner_eligible {
+                return Err(DaemonError::lifecycle(
+                    ErrorCode::Busy,
+                    node.workspace_owner_unavailable_reason
+                        .clone()
+                        .unwrap_or_else(|| "selected Node is unavailable".into()),
+                ));
+            }
+            let existing = global
+                .placements
+                .iter()
+                .find(|placement| placement.node_id == node_id);
+            let owner = existing
+                .map(|placement| {
+                    self.owner_workspace(&protocol::QualifiedIdentity::new(
+                        node_id,
+                        &placement.workspace_id,
+                    ))
+                })
+                .transpose()?;
+            let owner_name = owner
+                .as_ref()
+                .map(|owner| owner.name.as_str())
+                .unwrap_or(&global.name)
+                .to_owned();
+            let owner_cwd = owner
+                .as_ref()
+                .map(|owner| owner.default_cwd.clone())
+                .unwrap_or(default_cwd);
+
+            let _mutation = lock(&self.mutation_lock)?;
+            self.ensure_running()?;
+            self.flush_pending()?;
+            let _persistence = lock(&self.durable.persist_lock)?;
+            let mut event_transaction = self.events.transaction()?;
+            let global_transaction = self.global_workspaces()?.transaction()?;
+            let current_global = global_transaction
+                .get(global_workspace_id)
+                .map_err(global_workspace_error)?;
+            let concurrent_first_placement = current_global.revision
+                == global.revision.saturating_add(1)
+                && current_global.name == global.name
+                && current_global.closing == global.closing
+                && current_global.placements.len() == global.placements.len() + 1
+                && global
+                    .placements
+                    .iter()
+                    .all(|placement| current_global.placements.contains(placement))
+                && current_global.placements.iter().any(|placement| {
+                    placement.node_id == node_id && !global.placements.contains(placement)
+                });
+            let concurrent_owner = concurrent_first_placement.then(|| {
+                current_global
+                    .placements
+                    .iter()
+                    .find(|placement| {
+                        placement.node_id == node_id && !global.placements.contains(placement)
+                    })
+                    .expect("concurrent placement was validated")
+            });
+            let admitted_revision = concurrent_owner
+                .map(|_| current_global.revision)
+                .unwrap_or(expected_global_revision);
+            let admitted_owner_name = concurrent_owner
+                .and_then(|placement| placement.owner_workspace_name.as_deref())
+                .unwrap_or(&owner_name);
+            let admitted_owner_cwd = concurrent_owner
+                .map(|placement| placement.default_cwd.clone())
+                .unwrap_or(owner_cwd);
+            let prepared = global_transaction
+                .prepare_resource_for_attempt(
+                    global_workspace_id,
+                    operation_id,
+                    request_fingerprint,
+                    request_bytes,
+                    admitted_revision,
+                    node_id,
+                    requested_owner_workspace_id,
+                    admitted_owner_name,
+                    admitted_owner_cwd,
+                    shell_id,
+                    PendingResourceKind::Shell,
+                )
+                .map_err(global_workspace_error)?;
+            let pending = match prepared {
+                PreparedWorkspaceResource::Completed(completed) => {
+                    let completed = *completed;
+                    return Ok((completed.workspace, completed.resource));
+                }
+                PreparedWorkspaceResource::Pending { pending, .. } => *pending,
+            };
+            let mut undo = DurableUndoLog::default();
+            let (workspace, workspace_undo) = self.durable.create_workspace_exact(
+                &pending.owner_workspace_id,
+                pending.owner_workspace_name.clone(),
+                pending.default_cwd.clone(),
+            )?;
+            let workspace_created = workspace_undo.is_some();
+            if let Some(record) = workspace_undo {
+                undo.record(record);
+            }
+            let (shell, shell_undo) = match self.durable.create_shell_exact(
+                &pending.owner_workspace_id,
+                &pending.resource_id,
+                shell_spec.clone(),
+            ) {
+                Ok(created) => created,
+                Err(error) => {
+                    return Err(Self::mutation_failure(
+                        error.into(),
+                        undo.rollback(&self.durable),
+                    ));
+                }
+            };
+            let shell_created = shell_undo.is_some();
+            if let Some(record) = shell_undo {
+                undo.record(record);
+            }
+            let mut events = Vec::new();
+            if workspace_created {
+                events.push(DaemonEventKind::WorkspaceCreated {
+                    workspace_id: workspace.id,
+                    name: workspace.name,
+                });
+            }
+            if shell_created {
+                events.push(DaemonEventKind::ShellCreated {
+                    workspace_id: pending.owner_workspace_id.clone(),
+                    shell_id: shell.id.clone(),
+                    name: shell.name.clone(),
+                });
+            }
+            if let Err(error) = event_transaction.reserve_with_pending(events.len()) {
+                return Err(Self::mutation_failure(
+                    error.into(),
+                    undo.rollback(&self.durable),
+                ));
+            }
+            let owner = match self
+                .durable
+                .workspace(&pending.owner_workspace_id)
+                .and_then(|workspace| workspace.snapshot(&self.durable))
+            {
+                Ok(owner) => owner,
+                Err(error) => {
+                    return Err(Self::mutation_failure(
+                        error.into(),
+                        undo.rollback(&self.durable),
+                    ));
+                }
+            };
+            let resource = RoutedOperationResult::Shell {
+                shell: shell.clone(),
+            };
+            let completed = match global_transaction.complete_resource(&pending, &owner, &resource)
+            {
+                Ok(completed) => completed,
+                Err(error) => {
+                    return Err(Self::mutation_failure(
+                        global_workspace_error(error),
+                        undo.rollback(&self.durable),
+                    ));
+                }
+            };
+            let saved = match self.capture_persisted_state() {
+                Ok(saved) => saved,
+                Err(error) => {
+                    return Err(Self::mutation_failure(
+                        error.into(),
+                        undo.rollback(&self.durable),
+                    ));
+                }
+            };
+            event_transaction.begin_persistence(events.len());
+            drop(event_transaction);
+            let transaction = LocalShellTransaction {
+                operation_id: operation_id.to_owned(),
+                request_fingerprint: request_fingerprint.to_owned(),
+                request_bytes,
+                global_workspace_id: global_workspace_id.to_owned(),
+                expected_global_revision: admitted_revision,
+                node_id: node_id.to_owned(),
+                requested_owner_workspace_id: requested_owner_workspace_id.to_owned(),
+                owner_workspace_id: pending.owner_workspace_id.clone(),
+                owner_workspace_name: pending.owner_workspace_name.clone(),
+                owner_revision: owner.revision,
+                default_cwd: pending.default_cwd.clone(),
+                shell_id: shell_id.to_owned(),
+                shell: shell_spec,
+                result_shell: shell.clone(),
+            };
+            if let Err(error) = self
+                .local_shell_journal()?
+                .append(LocalShellJournalRecord::Create(Box::new(transaction)))
+            {
+                let error = Self::mutation_failure(
+                    DaemonError::persistence(error),
+                    undo.rollback(&self.durable),
+                );
+                let mut transaction = self.events.transaction()?;
+                transaction.finish_persistence();
+                return Err(error);
+            }
+            global_transaction
+                .commit()
+                .map_err(DaemonError::persistence)?;
+            let mut transaction = self.events.transaction()?;
+            transaction.replace_committed_executions(saved.executions);
+            transaction.append_batch(events);
+            transaction.finish_persistence();
+            drop(transaction);
+            self.events.notify();
+            Ok((completed.workspace, completed.resource))
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn create_global_workspace_resource_inner(
         &self,
         operation_id: &str,
@@ -10134,17 +10631,6 @@ impl DaemonService {
             .global_workspaces()?
             .get(global_workspace_id)
             .map_err(global_workspace_error)?;
-        require_guard(
-            global.revision,
-            expected_global_revision,
-            "global Workspace",
-        )?;
-        if global.closing {
-            return Err(DaemonError::lifecycle(
-                ErrorCode::Busy,
-                "global Workspace close is in progress",
-            ));
-        }
         if !owner_preflight_complete {
             let selected = self.combined_node_snapshot(Some(node_id))?;
             let node = selected
@@ -10183,6 +10669,7 @@ impl DaemonService {
             .as_ref()
             .map(|owner| owner.default_cwd.clone())
             .unwrap_or(default_cwd);
+        let local_node_id = self.node_identity()?.id()?;
         let prepared = self
             .global_workspaces()?
             .prepare_resource(
@@ -10221,7 +10708,6 @@ impl DaemonService {
                 .map_err(global_workspace_error)?;
             return Ok((completed.workspace, completed.resource));
         }
-        let local_node_id = self.node_identity()?.id()?;
         pending = self
             .global_workspaces()?
             .mark_owner_attempted(&pending)
@@ -12565,6 +13051,26 @@ impl DaemonService {
     }
 
     fn dispatch(&self, request: Request) -> DaemonResult<Response> {
+        let reconcile_combined_snapshot =
+            if matches!(&request, Request::GetCombinedNodeSnapshot { .. }) {
+                self.global_workspaces
+                    .as_ref()
+                    .map(|store| store.pending_resources().map(|pending| !pending.is_empty()))
+                    .transpose()
+                    .map_err(global_workspace_error)?
+                    .unwrap_or(false)
+            } else {
+                false
+            };
+        let skip_local_shell_frontier = match &request {
+            Request::Ping | Request::Snapshot | Request::Events { .. } => true,
+            Request::GetCombinedNodeSnapshot { .. } => !reconcile_combined_snapshot,
+            _ => false,
+        };
+        if !skip_local_shell_frontier {
+            self.checkpoint_local_shell_transactions()
+                .map_err(DaemonError::persistence)?;
+        }
         let (workspace_request_fingerprint, workspace_semantic_fingerprint) =
             workspace_operation_fingerprints(&request)?;
         let _dispatch_eligibility = matches!(
@@ -12723,7 +13229,9 @@ impl DaemonService {
                 Ok(Response::NodeProjectionHealth { health })
             }
             Request::GetCombinedNodeSnapshot { selector } => {
-                self.reconcile_pending_workspace_resources();
+                if reconcile_combined_snapshot {
+                    self.reconcile_pending_workspace_resources();
+                }
                 Ok(Response::CombinedNodeSnapshot {
                     snapshot: self.combined_node_snapshot(selector.as_deref())?,
                 })
@@ -12840,25 +13348,40 @@ impl DaemonService {
                 let request = workspace_request_fingerprint
                     .as_ref()
                     .expect("Workspace resource request has a fingerprint");
-                let (workspace, resource) = self.create_global_workspace_resource(
-                    &operation_id,
-                    &request.digest,
-                    request.bytes,
-                    &global_workspace_id,
-                    expected_global_revision,
-                    &node_id,
-                    &owner_workspace_id,
-                    default_cwd,
-                    &shell_id,
-                    PendingResourceKind::Shell,
-                    move |pending| RoutedOperation::CreateWorkspaceShell {
-                        workspace_id: pending.owner_workspace_id.clone(),
-                        workspace_name: pending.owner_workspace_name.clone(),
-                        default_cwd: pending.default_cwd.clone(),
-                        shell_id: pending.resource_id.clone(),
+                let (workspace, resource) = if self.node_identity()?.id()? == node_id {
+                    self.create_local_global_workspace_shell(
+                        &operation_id,
+                        &request.digest,
+                        request.bytes,
+                        &global_workspace_id,
+                        expected_global_revision,
+                        &node_id,
+                        &owner_workspace_id,
+                        default_cwd,
+                        &shell_id,
                         shell,
-                    },
-                )?;
+                    )?
+                } else {
+                    self.create_global_workspace_resource(
+                        &operation_id,
+                        &request.digest,
+                        request.bytes,
+                        &global_workspace_id,
+                        expected_global_revision,
+                        &node_id,
+                        &owner_workspace_id,
+                        default_cwd,
+                        &shell_id,
+                        PendingResourceKind::Shell,
+                        move |pending| RoutedOperation::CreateWorkspaceShell {
+                            workspace_id: pending.owner_workspace_id.clone(),
+                            workspace_name: pending.owner_workspace_name.clone(),
+                            default_cwd: pending.default_cwd.clone(),
+                            shell_id: pending.resource_id.clone(),
+                            shell,
+                        },
+                    )?
+                };
                 Ok(Response::GlobalWorkspaceResource {
                     workspace,
                     resource,
@@ -12931,7 +13454,9 @@ impl DaemonService {
                             request.bytes,
                             true,
                             &prepared_workspace.id,
-                            prepared_workspace.revision,
+                            // Equivalent compound requests retain the revision that
+                            // originally authorized their shared preparation.
+                            pending.expected_global_revision,
                             &pending.node_id,
                             &pending.requested_owner_workspace_id,
                             pending.default_cwd.clone(),
@@ -14167,6 +14692,7 @@ impl DaemonService {
             node_registrations: None,
             node_projection_cache: None,
             global_workspaces: None,
+            local_shell_journal: None,
             durable: DurableRegistry {
                 state: Mutex::new(state),
                 store: Some(store),
@@ -14402,6 +14928,8 @@ impl DaemonService {
         operation: impl FnOnce(&mut DurableUndoLog) -> DaemonResult<DurableMutation<T>>,
     ) -> DaemonResult<T> {
         let mutation = lock(&self.mutation_lock)?;
+        self.checkpoint_local_shell_transactions_with_mutation()
+            .map_err(DaemonError::persistence)?;
         self.ensure_running()?;
         self.flush_pending()?;
         let persistence = lock(&self.durable.persist_lock)?;
@@ -15359,6 +15887,8 @@ impl DaemonService {
         committed_events: impl FnOnce(&[Arc<Shell>]) -> Vec<DaemonEventKind>,
     ) -> DaemonResult<()> {
         let _mutation = lock(&self.mutation_lock)?;
+        self.checkpoint_local_shell_transactions_with_mutation()
+            .map_err(DaemonError::persistence)?;
         if stopping {
             if !self.runtimes.begin_stopping() {
                 return Ok(());
@@ -17495,6 +18025,16 @@ impl ShellRuntimeManager {
                     .flatten()
             })
             .flatten();
+        let journaled_start = if needs_start {
+            registry
+                .local_shell_journal
+                .as_ref()
+                .map(|journal| journal.contains_create(shell_id))
+                .transpose()?
+                .unwrap_or(false)
+        } else {
+            false
+        };
         if needs_start && let Err(error) = registry.flush_pending() {
             return send_daemon_error(&mut stream, response_version, error);
         }
@@ -17633,34 +18173,79 @@ impl ShellRuntimeManager {
         };
         let mut committed_executions = None;
         if started {
-            let saved = registry.capture_persisted_state()?;
             event_transaction
                 .as_mut()
                 .expect("start event transaction is locked")
                 .begin_persistence(1);
             drop(event_transaction);
-            committed_executions = Some(match registry.write_persisted_state(saved) {
-                Ok(committed) => committed,
-                Err(error) => {
-                    let cleanup = self.kill(&shell);
-                    self.reset_pending(&shell)?;
-                    let mut transaction = registry.events.transaction()?;
-                    transaction.finish_persistence();
-                    let message = cleanup.map_or_else(
-                        |cleanup| {
-                            format!(
-                                "could not persist started shell: {error}; process cleanup also failed: {cleanup}"
-                            )
+            let persistence_result = if journaled_start {
+                let run = lock(&shell.last_run)?
+                    .clone()
+                    .ok_or_else(|| io::Error::other("started shell has no persisted run"))?;
+                let journal_result = registry
+                    .local_shell_journal
+                    .as_ref()
+                    .ok_or_else(|| io::Error::other("local Shell journal is unavailable"))?
+                    .append(LocalShellJournalRecord::Start(Box::new(
+                        LocalShellStartTransaction {
+                            shell_id: shell.id.clone(),
+                            run,
                         },
-                        |()| format!("could not persist started shell: {error}"),
-                    );
-                    return send_daemon_error(
-                        &mut stream,
-                        response_version,
-                        DaemonError::persistence_context(error, message),
-                    );
+                    )));
+                match journal_result {
+                    Ok(()) => Ok(()),
+                    Err(journal_error) => (|| {
+                        let saved = registry.capture_persisted_state()?;
+                        let committed = registry.write_persisted_state(saved)?;
+                        registry
+                            .global_workspaces
+                            .as_ref()
+                            .ok_or_else(|| io::Error::other("global Workspace store is unavailable"))?
+                            .checkpoint()?;
+                        registry
+                            .local_shell_journal
+                            .as_ref()
+                            .ok_or_else(|| io::Error::other("local Shell journal is unavailable"))?
+                            .reset_after_full_checkpoint()?;
+                        Ok(committed)
+                    })()
+                        .map(|committed| {
+                            committed_executions = Some(committed);
+                        })
+                        .map_err(|state_error: io::Error| {
+                            io::Error::new(
+                                state_error.kind(),
+                                format!(
+                                    "local Shell start journal failed: {journal_error}; state fallback also failed: {state_error}"
+                                ),
+                            )
+                        }),
                 }
-            });
+            } else {
+                let saved = registry.capture_persisted_state()?;
+                registry.write_persisted_state(saved).map(|committed| {
+                    committed_executions = Some(committed);
+                })
+            };
+            if let Err(error) = persistence_result {
+                let cleanup = self.kill(&shell);
+                self.reset_pending(&shell)?;
+                let mut transaction = registry.events.transaction()?;
+                transaction.finish_persistence();
+                let message = cleanup.map_or_else(
+                    |cleanup| {
+                        format!(
+                            "could not persist started shell: {error}; process cleanup also failed: {cleanup}"
+                        )
+                    },
+                    |()| format!("could not persist started shell: {error}"),
+                );
+                return send_daemon_error(
+                    &mut stream,
+                    response_version,
+                    DaemonError::persistence_context(error, message),
+                );
+            }
             event_transaction = Some(registry.events.transaction()?);
         }
         if started {
@@ -17671,9 +18256,9 @@ impl ShellRuntimeManager {
             let transaction = event_transaction
                 .as_mut()
                 .expect("start event transaction is locked");
-            transaction.replace_committed_executions(
-                committed_executions.expect("persisted shell start has committed executions"),
-            );
+            if let Some(committed_executions) = committed_executions {
+                transaction.replace_committed_executions(committed_executions);
+            }
             transaction.append_batch(vec![DaemonEventKind::RunStarted {
                 workspace_id: shell.workspace_id.clone(),
                 shell_id: shell.id.clone(),

--- a/src/global_workspace_store.rs
+++ b/src/global_workspace_store.rs
@@ -26,6 +26,12 @@ const COMPLETION_RESERVATION_OVERHEAD: usize = 64 * 1024;
 pub(crate) struct GlobalWorkspaceStore {
     path: PathBuf,
     state: Mutex<PersistedGlobalWorkspaces>,
+    persist: bool,
+}
+
+pub(crate) struct GlobalWorkspaceTransaction<'a> {
+    target: std::sync::MutexGuard<'a, PersistedGlobalWorkspaces>,
+    staged: GlobalWorkspaceStore,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -151,7 +157,24 @@ impl GlobalWorkspaceStore {
         Ok(Self {
             path,
             state: Mutex::new(state),
+            persist: true,
         })
+    }
+
+    pub(crate) fn transaction(&self) -> io::Result<GlobalWorkspaceTransaction<'_>> {
+        let target = self.lock()?;
+        let staged = Self {
+            path: self.path.clone(),
+            state: Mutex::new(target.clone()),
+            persist: false,
+        };
+        Ok(GlobalWorkspaceTransaction { target, staged })
+    }
+
+    pub(crate) fn checkpoint(&self) -> io::Result<()> {
+        let state = self.lock()?;
+        validate(&state)?;
+        save(&self.path, &state)
     }
 
     pub(crate) fn initialize_local_once(
@@ -356,6 +379,69 @@ impl GlobalWorkspaceStore {
         resource_id: &str,
         kind: PendingResourceKind,
     ) -> io::Result<PreparedWorkspaceResource> {
+        self.prepare_resource_inner(
+            global_id,
+            operation_id,
+            request_fingerprint,
+            request_bytes,
+            expected_global_revision,
+            node_id,
+            requested_owner_workspace_id,
+            owner_workspace_name,
+            default_cwd,
+            resource_id,
+            kind,
+            false,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn prepare_resource_for_attempt(
+        &self,
+        global_id: &str,
+        operation_id: &str,
+        request_fingerprint: &str,
+        request_bytes: usize,
+        expected_global_revision: u64,
+        node_id: &str,
+        requested_owner_workspace_id: &str,
+        owner_workspace_name: &str,
+        default_cwd: Option<PathBuf>,
+        resource_id: &str,
+        kind: PendingResourceKind,
+    ) -> io::Result<PreparedWorkspaceResource> {
+        self.prepare_resource_inner(
+            global_id,
+            operation_id,
+            request_fingerprint,
+            request_bytes,
+            expected_global_revision,
+            node_id,
+            requested_owner_workspace_id,
+            owner_workspace_name,
+            default_cwd,
+            resource_id,
+            kind,
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_resource_inner(
+        &self,
+        global_id: &str,
+        operation_id: &str,
+        request_fingerprint: &str,
+        request_bytes: usize,
+        expected_global_revision: u64,
+        node_id: &str,
+        requested_owner_workspace_id: &str,
+        owner_workspace_name: &str,
+        default_cwd: Option<PathBuf>,
+        resource_id: &str,
+        kind: PendingResourceKind,
+        owner_attempted: bool,
+    ) -> io::Result<PreparedWorkspaceResource> {
         validate_name(owner_workspace_name)?;
         self.mutate(|state| {
             if let Some(completed) = state
@@ -408,6 +494,9 @@ impl GlobalWorkspaceStore {
                     let reservation = completion_reservation_bytes(&projected, request_bytes)?;
                     state.pending_resources[index].completion_reservation = " ".repeat(reservation);
                     compact_prepared_state(state)?;
+                }
+                if owner_attempted {
+                    state.pending_resources[index].owner_attempted = true;
                 }
                 return Ok(PreparedWorkspaceResource::Pending {
                     pending: Box::new(state.pending_resources[index].clone()),
@@ -475,7 +564,7 @@ impl GlobalWorkspaceStore {
                 request_fingerprint: Some(request_fingerprint.to_owned()),
                 semantic_fingerprint: None,
                 completion_reservation: String::new(),
-                owner_attempted: false,
+                owner_attempted,
                 global_workspace_id: global_id.to_owned(),
                 expected_global_revision,
                 node_id: node_id.to_owned(),
@@ -760,29 +849,6 @@ impl GlobalWorkspaceStore {
         })
     }
 
-    pub(crate) fn mark_owner_attempted(
-        &self,
-        pending: &PendingWorkspaceResource,
-    ) -> io::Result<PendingWorkspaceResource> {
-        self.mutate(|state| {
-            let index = state
-                .pending_resources
-                .iter()
-                .position(|candidate| candidate.operation_id == pending.operation_id)
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::NotFound,
-                        "pending Workspace resource not found",
-                    )
-                })?;
-            if state.pending_resources[index].request_fingerprint != pending.request_fingerprint {
-                return Err(operation_conflict());
-            }
-            state.pending_resources[index].owner_attempted = true;
-            Ok(state.pending_resources[index].clone())
-        })
-    }
-
     pub(crate) fn complete_resource(
         &self,
         pending: &PendingWorkspaceResource,
@@ -889,6 +955,29 @@ impl GlobalWorkspaceStore {
             state.pending_resources.remove(pending_index);
             push_completed(state, completed.clone())?;
             Ok(completed)
+        })
+    }
+
+    pub(crate) fn mark_owner_attempted(
+        &self,
+        pending: &PendingWorkspaceResource,
+    ) -> io::Result<PendingWorkspaceResource> {
+        self.mutate(|state| {
+            let index = state
+                .pending_resources
+                .iter()
+                .position(|candidate| candidate.operation_id == pending.operation_id)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "pending Workspace resource not found",
+                    )
+                })?;
+            if state.pending_resources[index].request_fingerprint != pending.request_fingerprint {
+                return Err(operation_conflict());
+            }
+            state.pending_resources[index].owner_attempted = true;
+            Ok(state.pending_resources[index].clone())
         })
     }
 
@@ -1032,7 +1121,9 @@ impl GlobalWorkspaceStore {
         let mut replacement = state.clone();
         let result = operation(&mut replacement)?;
         validate(&replacement)?;
-        save(&self.path, &replacement)?;
+        if self.persist {
+            save(&self.path, &replacement)?;
+        }
         *state = replacement;
         Ok(result)
     }
@@ -1041,6 +1132,62 @@ impl GlobalWorkspaceStore {
         self.state
             .lock()
             .map_err(|_| io::Error::other("global Workspace store lock is poisoned"))
+    }
+}
+
+impl GlobalWorkspaceTransaction<'_> {
+    pub(crate) fn get(&self, id: &str) -> io::Result<GlobalWorkspaceSnapshot> {
+        self.staged.get(id)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn prepare_resource_for_attempt(
+        &self,
+        global_id: &str,
+        operation_id: &str,
+        request_fingerprint: &str,
+        request_bytes: usize,
+        expected_global_revision: u64,
+        node_id: &str,
+        requested_owner_workspace_id: &str,
+        owner_workspace_name: &str,
+        default_cwd: Option<PathBuf>,
+        resource_id: &str,
+        kind: PendingResourceKind,
+    ) -> io::Result<PreparedWorkspaceResource> {
+        self.staged.prepare_resource_for_attempt(
+            global_id,
+            operation_id,
+            request_fingerprint,
+            request_bytes,
+            expected_global_revision,
+            node_id,
+            requested_owner_workspace_id,
+            owner_workspace_name,
+            default_cwd,
+            resource_id,
+            kind,
+        )
+    }
+
+    pub(crate) fn complete_resource(
+        &self,
+        pending: &PendingWorkspaceResource,
+        owner: &WorkspaceSnapshot,
+        resource: &RoutedOperationResult,
+    ) -> io::Result<CompletedWorkspaceOperation> {
+        self.staged.complete_resource(pending, owner, resource)
+    }
+
+    pub(crate) fn commit(mut self) -> io::Result<()> {
+        let replacement = self
+            .staged
+            .state
+            .into_inner()
+            .map_err(|_| io::Error::other("staged global Workspace lock is poisoned"))?;
+        validate(&replacement)?;
+        *self.target = replacement;
+        Ok(())
     }
 }
 
@@ -1934,6 +2081,194 @@ mod tests {
     }
 
     #[test]
+    fn preparation_for_dispatch_persists_attempted_boundary_once() {
+        let root = std::env::temp_dir().join(format!("boomux-global-attempt-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let node = Uuid::from_u128(1).to_string();
+        let owner = snapshot(&Uuid::from_u128(2).to_string(), "owner", 1);
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        store
+            .initialize_local_once(&node, &daemon_snapshot(vec![owner.clone()]))
+            .unwrap();
+        let global = store.list().unwrap().remove(0);
+        let prepared = store
+            .prepare_resource_for_attempt(
+                &global.id,
+                &Uuid::from_u128(3).to_string(),
+                &fingerprint(4),
+                1024,
+                global.revision,
+                &node,
+                &owner.id,
+                &owner.name,
+                owner.default_cwd.clone(),
+                &Uuid::from_u128(5).to_string(),
+                PendingResourceKind::Shell,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending { pending, .. } = prepared else {
+            panic!("expected pending operation");
+        };
+        assert!(pending.owner_attempted);
+        drop(store);
+        assert!(
+            GlobalWorkspaceStore::load_at(path)
+                .unwrap()
+                .pending_resources()
+                .unwrap()[0]
+                .owner_attempted
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn compound_alias_retry_uses_its_original_guard_after_revision_advances() {
+        let root = std::env::temp_dir().join(format!("boomux-global-alias-{}", Uuid::new_v4()));
+        let store =
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap();
+        store
+            .initialize_local_once(
+                &Uuid::from_u128(1).to_string(),
+                &daemon_snapshot(Vec::new()),
+            )
+            .unwrap();
+        let node = Uuid::from_u128(2).to_string();
+        let operation_a = Uuid::from_u128(3).to_string();
+        let global_a = Uuid::from_u128(4).to_string();
+        let owner_a = Uuid::from_u128(5).to_string();
+        let shell_a = Uuid::from_u128(6).to_string();
+        let semantic = fingerprint(7);
+        let prepared_a = store
+            .prepare_workspace_shell(
+                &operation_a,
+                &fingerprint(8),
+                1024,
+                &semantic,
+                &global_a,
+                "project",
+                &node,
+                &owner_a,
+                "/owner/project".into(),
+                &shell_a,
+            )
+            .unwrap();
+        let PreparedWorkspaceShell::Pending {
+            pending: pending_a, ..
+        } = prepared_a
+        else {
+            panic!("expected first pending operation");
+        };
+        let operation_b = Uuid::from_u128(9).to_string();
+        let prepared_b = store
+            .prepare_workspace_shell(
+                &operation_b,
+                &fingerprint(10),
+                1024,
+                &semantic,
+                &Uuid::from_u128(11).to_string(),
+                "project",
+                &node,
+                &Uuid::from_u128(12).to_string(),
+                "/owner/project".into(),
+                &Uuid::from_u128(13).to_string(),
+            )
+            .unwrap();
+        let PreparedWorkspaceShell::Pending {
+            workspace,
+            pending: pending_b,
+        } = prepared_b
+        else {
+            panic!("expected alias pending operation");
+        };
+        let attempted_b = store
+            .prepare_resource_for_attempt(
+                &pending_b.global_workspace_id,
+                &pending_b.operation_id,
+                pending_b.request_fingerprint.as_deref().unwrap(),
+                1024,
+                pending_b.expected_global_revision,
+                &pending_b.node_id,
+                &pending_b.requested_owner_workspace_id,
+                &pending_b.owner_workspace_name,
+                pending_b.default_cwd.clone(),
+                &pending_b.resource_id,
+                pending_b.kind,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending {
+            pending: attempted_b,
+            ..
+        } = attempted_b
+        else {
+            panic!("expected attempted alias");
+        };
+        let owner = snapshot(&attempted_b.owner_workspace_id, "project", 1);
+        let resource = shell_result(&attempted_b.resource_id, &owner.id);
+        let completed_b = store
+            .complete_resource(&attempted_b, &owner, &resource)
+            .unwrap();
+        assert!(completed_b.workspace.revision > workspace.revision);
+
+        let retried_a = store
+            .prepare_workspace_shell(
+                &operation_a,
+                &fingerprint(8),
+                1024,
+                &semantic,
+                &global_a,
+                "project",
+                &node,
+                &owner_a,
+                "/owner/project".into(),
+                &shell_a,
+            )
+            .unwrap();
+        let PreparedWorkspaceShell::Pending {
+            workspace,
+            pending: retried_a,
+        } = retried_a
+        else {
+            panic!("expected exact pending retry");
+        };
+        assert_eq!(
+            retried_a.expected_global_revision,
+            pending_a.expected_global_revision
+        );
+        assert!(workspace.revision > retried_a.expected_global_revision);
+        let attempted_a = store
+            .prepare_resource_for_attempt(
+                &retried_a.global_workspace_id,
+                &retried_a.operation_id,
+                retried_a.request_fingerprint.as_deref().unwrap(),
+                1024,
+                retried_a.expected_global_revision,
+                &retried_a.node_id,
+                &retried_a.requested_owner_workspace_id,
+                &retried_a.owner_workspace_name,
+                retried_a.default_cwd.clone(),
+                &retried_a.resource_id,
+                retried_a.kind,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending {
+            pending: attempted_a,
+            ..
+        } = attempted_a
+        else {
+            panic!("expected attempted exact retry");
+        };
+        assert!(attempted_a.owner_attempted);
+        assert_eq!(
+            store
+                .complete_resource(&attempted_a, &owner, &resource)
+                .unwrap()
+                .resource,
+            resource
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn malformed_future_and_insecure_stores_fail_closed_without_replacement() {
         for (label, bytes, mode) in [
             ("malformed", b"not-json".to_vec(), 0o600),
@@ -2441,7 +2776,28 @@ mod tests {
         let PreparedWorkspaceShell::Pending { pending, .. } = prepared else {
             panic!("expected pending project");
         };
-        let attempted = store.mark_owner_attempted(&pending).unwrap();
+        let attempted = store
+            .prepare_resource_for_attempt(
+                &pending.global_workspace_id,
+                &pending.operation_id,
+                pending.request_fingerprint.as_deref().unwrap(),
+                1024,
+                pending.expected_global_revision,
+                &pending.node_id,
+                &pending.requested_owner_workspace_id,
+                &pending.owner_workspace_name,
+                pending.default_cwd.clone(),
+                &pending.resource_id,
+                pending.kind,
+            )
+            .unwrap();
+        let PreparedWorkspaceResource::Pending {
+            pending: attempted, ..
+        } = attempted
+        else {
+            panic!("expected pending attempted project");
+        };
+        let attempted = *attempted;
         assert!(attempted.owner_attempted);
 
         // A later capability, admission, identity, or not-found failure cannot

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod host_session_titles;
 #[allow(dead_code)]
 mod integration_management;
 pub mod integrations;
+mod local_shell_journal;
 mod node_identity;
 mod node_projection;
 mod node_registration;

--- a/src/local_shell_journal.rs
+++ b/src/local_shell_journal.rs
@@ -1,0 +1,484 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::protocol::{ShellSnapshot, ShellSpec};
+use crate::state_store::{
+    PersistedShellRun, effective_uid, secure_state_dir, state_directory_from_environment,
+};
+
+const VERSION: u32 = 1;
+const MAX_BYTES: u64 = 8 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LocalShellTransaction {
+    pub(crate) operation_id: String,
+    pub(crate) request_fingerprint: String,
+    pub(crate) request_bytes: usize,
+    pub(crate) global_workspace_id: String,
+    pub(crate) expected_global_revision: u64,
+    pub(crate) node_id: String,
+    pub(crate) requested_owner_workspace_id: String,
+    pub(crate) owner_workspace_id: String,
+    pub(crate) owner_workspace_name: String,
+    pub(crate) owner_revision: u64,
+    pub(crate) default_cwd: Option<PathBuf>,
+    pub(crate) shell_id: String,
+    pub(crate) shell: ShellSpec,
+    pub(crate) result_shell: ShellSnapshot,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LocalShellStartTransaction {
+    pub(crate) shell_id: String,
+    pub(crate) run: PersistedShellRun,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum LocalShellJournalRecord {
+    Create(Box<LocalShellTransaction>),
+    Start(Box<LocalShellStartTransaction>),
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JournalEntry {
+    version: u32,
+    record: LocalShellJournalRecord,
+    checksum: String,
+}
+
+struct JournalState {
+    file: File,
+    records: Vec<LocalShellJournalRecord>,
+    failed: bool,
+}
+
+pub(crate) struct LocalShellJournal {
+    state: Mutex<JournalState>,
+}
+
+impl LocalShellJournal {
+    pub(crate) fn load_from_environment() -> io::Result<Self> {
+        let directory = state_directory_from_environment()?;
+        Self::load_at(directory)
+    }
+
+    fn load_at(directory: PathBuf) -> io::Result<Self> {
+        secure_state_dir(&directory)?;
+        let path = directory.join("local_shell_transactions.log");
+        let existed = path.exists();
+        let mut file = OpenOptions::new()
+            .read(true)
+            .create(true)
+            .append(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&path)?;
+        let metadata = file.metadata()?;
+        if !metadata.is_file() || metadata.uid() != effective_uid() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "local Shell transaction journal is not an owned regular file",
+            ));
+        }
+        if metadata.mode() & 0o077 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "local Shell transaction journal is not owner-only",
+            ));
+        }
+        if metadata.len() > MAX_BYTES {
+            return Err(invalid(
+                "local Shell transaction journal exceeds the size limit",
+            ));
+        }
+        if !existed {
+            file.sync_all()?;
+            File::open(&directory)?.sync_all()?;
+        }
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        file.seek(SeekFrom::Start(0))?;
+        file.take(MAX_BYTES + 1).read_to_end(&mut bytes)?;
+        if bytes.len() as u64 > MAX_BYTES {
+            return Err(invalid(
+                "local Shell transaction journal exceeds the size limit",
+            ));
+        }
+        let (records, valid_bytes) = parse_records(&bytes)?;
+        file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&path)?;
+        if valid_bytes < bytes.len() {
+            file.set_len(valid_bytes as u64)?;
+            file.sync_data()?;
+        }
+        Ok(Self {
+            state: Mutex::new(JournalState {
+                file,
+                records,
+                failed: false,
+            }),
+        })
+    }
+
+    pub(crate) fn records(&self) -> io::Result<Vec<LocalShellJournalRecord>> {
+        let state = self.lock()?;
+        ensure_usable(&state)?;
+        Ok(state.records.clone())
+    }
+
+    pub(crate) fn append(&self, record: LocalShellJournalRecord) -> io::Result<()> {
+        let payload = serde_json::to_vec(&record).map_err(io::Error::other)?;
+        let entry = JournalEntry {
+            version: VERSION,
+            checksum: format!("{:x}", Sha256::digest(&payload)),
+            record: record.clone(),
+        };
+        let mut bytes = serde_json::to_vec(&entry).map_err(io::Error::other)?;
+        bytes.push(b'\n');
+        let mut state = self.lock()?;
+        ensure_usable(&state)?;
+        let mut candidate = state.records.clone();
+        candidate.push(record.clone());
+        validate_sequence(&candidate)?;
+        let current = state.file.metadata()?.len();
+        if current.saturating_add(bytes.len() as u64) > MAX_BYTES {
+            return Err(invalid(
+                "local Shell transaction journal exceeds the size limit",
+            ));
+        }
+        if let Err(error) = state
+            .file
+            .write_all(&bytes)
+            .and_then(|()| state.file.sync_data())
+        {
+            if let Err(rollback) = state
+                .file
+                .set_len(current)
+                .and_then(|()| state.file.seek(SeekFrom::End(0)).map(|_| ()))
+                .and_then(|()| state.file.sync_data())
+            {
+                state.failed = true;
+                return Err(io::Error::new(
+                    error.kind(),
+                    format!(
+                        "local Shell journal append failed: {error}; rollback also failed: {rollback}"
+                    ),
+                ));
+            }
+            return Err(error);
+        }
+        state.records.push(record);
+        Ok(())
+    }
+
+    pub(crate) fn contains_create(&self, shell_id: &str) -> io::Result<bool> {
+        let state = self.lock()?;
+        ensure_usable(&state)?;
+        Ok(state.records.iter().any(|record| {
+            matches!(record, LocalShellJournalRecord::Create(transaction) if transaction.shell_id == shell_id)
+        }))
+    }
+
+    pub(crate) fn clear(&self) -> io::Result<()> {
+        let mut state = self.lock()?;
+        ensure_usable(&state)?;
+        clear_state(&mut state)
+    }
+
+    pub(crate) fn reset_after_full_checkpoint(&self) -> io::Result<()> {
+        let mut state = self.lock()?;
+        clear_state(&mut state)?;
+        state.failed = false;
+        Ok(())
+    }
+
+    pub(crate) fn is_empty(&self) -> io::Result<bool> {
+        let state = self.lock()?;
+        ensure_usable(&state)?;
+        Ok(state.records.is_empty())
+    }
+
+    fn lock(&self) -> io::Result<MutexGuard<'_, JournalState>> {
+        self.state
+            .lock()
+            .map_err(|_| io::Error::other("local Shell transaction journal lock is poisoned"))
+    }
+}
+
+fn clear_state(state: &mut JournalState) -> io::Result<()> {
+    state.file.set_len(0)?;
+    state.file.seek(SeekFrom::Start(0))?;
+    state.file.sync_data()?;
+    state.records.clear();
+    Ok(())
+}
+
+fn ensure_usable(state: &JournalState) -> io::Result<()> {
+    if state.failed {
+        Err(io::Error::other(
+            "local Shell transaction journal has an ambiguous failed append",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn parse_records(bytes: &[u8]) -> io::Result<(Vec<LocalShellJournalRecord>, usize)> {
+    let mut records = Vec::new();
+    let mut offset = 0;
+    for line in bytes.split_inclusive(|byte| *byte == b'\n') {
+        if !line.ends_with(b"\n") {
+            break;
+        }
+        offset += line.len();
+        let entry: JournalEntry =
+            serde_json::from_slice(&line[..line.len() - 1]).map_err(|error| {
+                invalid(format!("could not parse local Shell transaction: {error}"))
+            })?;
+        if entry.version != VERSION {
+            return Err(invalid(format!(
+                "unsupported local Shell transaction version {}; expected {VERSION}",
+                entry.version
+            )));
+        }
+        let payload = serde_json::to_vec(&entry.record).map_err(io::Error::other)?;
+        let checksum = format!("{:x}", Sha256::digest(&payload));
+        if entry.checksum != checksum {
+            return Err(invalid("local Shell transaction checksum does not match"));
+        }
+        records.push(entry.record);
+    }
+    validate_sequence(&records)?;
+    Ok((records, offset))
+}
+
+fn validate_sequence(records: &[LocalShellJournalRecord]) -> io::Result<()> {
+    let mut generations = HashMap::<&str, u64>::new();
+    let mut run_ids = HashSet::<&str>::new();
+    for record in records {
+        match record {
+            LocalShellJournalRecord::Create(transaction) => {
+                if generations
+                    .insert(transaction.shell_id.as_str(), 0)
+                    .is_some()
+                {
+                    return Err(invalid("local Shell journal contains a duplicate creation"));
+                }
+            }
+            LocalShellJournalRecord::Start(transaction) => {
+                let Some(generation) = generations.get_mut(transaction.shell_id.as_str()) else {
+                    return Err(invalid(
+                        "local Shell journal start does not follow its creation",
+                    ));
+                };
+                let expected = generation
+                    .checked_add(1)
+                    .ok_or_else(|| invalid("local Shell journal run generation exhausted"))?;
+                if transaction.run.generation != expected
+                    || transaction.run.ended_at_ms.is_some()
+                    || transaction.run.exit_reason.is_some()
+                    || !run_ids.insert(&transaction.run.id)
+                {
+                    return Err(invalid(
+                        "local Shell journal contains an invalid run sequence",
+                    ));
+                }
+                *generation = expected;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn invalid(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+    use uuid::Uuid;
+
+    fn transaction() -> LocalShellTransaction {
+        LocalShellTransaction {
+            operation_id: Uuid::from_u128(1).to_string(),
+            request_fingerprint: format!("{:064x}", 2),
+            request_bytes: 1024,
+            global_workspace_id: Uuid::from_u128(3).to_string(),
+            expected_global_revision: 1,
+            node_id: Uuid::from_u128(4).to_string(),
+            requested_owner_workspace_id: Uuid::from_u128(5).to_string(),
+            owner_workspace_id: Uuid::from_u128(5).to_string(),
+            owner_workspace_name: "project".into(),
+            owner_revision: 2,
+            default_cwd: Some("/tmp".into()),
+            shell_id: Uuid::from_u128(6).to_string(),
+            shell: ShellSpec::login("shell", "/tmp"),
+            result_shell: ShellSnapshot {
+                id: Uuid::from_u128(6).to_string(),
+                revision: 1,
+                workspace_id: Uuid::from_u128(5).to_string(),
+                name: "shell".into(),
+                cwd: "/tmp".into(),
+                command: Vec::new(),
+                owner: crate::protocol::ShellOwner::User,
+                status: crate::protocol::ShellStatus::Pending,
+                run: None,
+                recovered_agent_id: None,
+                foreground_process: None,
+            },
+        }
+    }
+
+    fn create_record() -> LocalShellJournalRecord {
+        LocalShellJournalRecord::Create(Box::new(transaction()))
+    }
+
+    fn start_record() -> LocalShellJournalRecord {
+        LocalShellJournalRecord::Start(Box::new(LocalShellStartTransaction {
+            shell_id: transaction().shell_id,
+            run: PersistedShellRun {
+                id: Uuid::from_u128(7).to_string(),
+                generation: 1,
+                started_at_ms: 1,
+                ended_at_ms: None,
+                exit_reason: None,
+                output_revision: 0,
+                environment_has_run_id: true,
+                profile: crate::protocol::TerminalProfile {
+                    term: Some("xterm-256color".into()),
+                    colorterm: None,
+                    term_program: None,
+                    term_program_version: None,
+                    rows: 24,
+                    cols: 80,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                },
+                terminal_history: None,
+            },
+        }))
+    }
+
+    #[test]
+    fn records_are_checksummed_and_torn_tail_is_ignored() {
+        let record = create_record();
+        let payload = serde_json::to_vec(&record).unwrap();
+        let entry = JournalEntry {
+            version: VERSION,
+            record: record.clone(),
+            checksum: format!("{:x}", Sha256::digest(payload)),
+        };
+        let mut bytes = serde_json::to_vec(&entry).unwrap();
+        bytes.push(b'\n');
+        let valid = bytes.len();
+        bytes.extend_from_slice(b"{\"version\":");
+
+        let (records, consumed) = parse_records(&bytes).unwrap();
+        assert_eq!(records, vec![record]);
+        assert_eq!(consumed, valid);
+    }
+
+    #[test]
+    fn checksum_mismatch_fails_closed() {
+        let entry = JournalEntry {
+            version: VERSION,
+            record: create_record(),
+            checksum: "0".repeat(64),
+        };
+        let mut bytes = serde_json::to_vec(&entry).unwrap();
+        bytes.push(b'\n');
+        assert_eq!(
+            parse_records(&bytes).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn start_records_require_creation_and_contiguous_unique_runs() {
+        let root =
+            std::env::temp_dir().join(format!("boomux-local-shell-sequence-{}", Uuid::new_v4()));
+        let journal = LocalShellJournal::load_at(root.clone()).unwrap();
+        assert_eq!(
+            journal.append(start_record()).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        journal.append(create_record()).unwrap();
+        let mut skipped = start_record();
+        let LocalShellJournalRecord::Start(transaction) = &mut skipped else {
+            unreachable!();
+        };
+        transaction.run.generation = 2;
+        assert_eq!(
+            journal.append(skipped).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        journal.append(start_record()).unwrap();
+        assert_eq!(
+            journal.append(start_record()).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn journal_round_trips_owner_only_and_clears() {
+        let root =
+            std::env::temp_dir().join(format!("boomux-local-shell-journal-{}", Uuid::new_v4()));
+        let journal = LocalShellJournal::load_at(root.clone()).unwrap();
+        journal.append(create_record()).unwrap();
+        journal.append(start_record()).unwrap();
+        assert_eq!(
+            journal.records().unwrap(),
+            vec![create_record(), start_record()]
+        );
+        assert!(journal.contains_create(&transaction().shell_id).unwrap());
+        let path = root.join("local_shell_transactions.log");
+        assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o600);
+        drop(journal);
+
+        let journal = LocalShellJournal::load_at(root.clone()).unwrap();
+        assert_eq!(
+            journal.records().unwrap(),
+            vec![create_record(), start_record()]
+        );
+        journal.clear().unwrap();
+        assert!(journal.records().unwrap().is_empty());
+        assert_eq!(fs::metadata(path).unwrap().len(), 0);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn load_truncates_only_an_incomplete_final_record() {
+        let root =
+            std::env::temp_dir().join(format!("boomux-torn-shell-journal-{}", Uuid::new_v4()));
+        let journal = LocalShellJournal::load_at(root.clone()).unwrap();
+        journal.append(create_record()).unwrap();
+        drop(journal);
+        let path = root.join("local_shell_transactions.log");
+        let valid = fs::metadata(&path).unwrap().len();
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(b"{\"version\":").unwrap();
+        file.sync_data().unwrap();
+
+        let journal = LocalShellJournal::load_at(root.clone()).unwrap();
+        assert_eq!(journal.records().unwrap(), vec![create_record()]);
+        assert_eq!(fs::metadata(path).unwrap().len(), valid);
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,6 +562,14 @@ enum Commands {
         #[arg(long)]
         expected_run_id: Option<String>,
     },
+    #[command(name = "__await-attach", hide = true)]
+    AwaitAttach {
+        shell_id: String,
+        #[arg(long)]
+        gate: PathBuf,
+        #[arg(long)]
+        node: Option<String>,
+    },
     #[command(name = "__scheduled-runner", hide = true)]
     ScheduledRunner { schedule_id: String },
     #[command(name = "__resume-session", hide = true)]
@@ -1795,7 +1803,7 @@ impl Cli {
             }) => CommandKey::KiroLaunch,
             Some(Commands::Open { .. }) => CommandKey::Open,
             Some(Commands::Prompt) => CommandKey::Prompt,
-            Some(Commands::Attach { .. }) => CommandKey::Attach,
+            Some(Commands::Attach { .. } | Commands::AwaitAttach { .. }) => CommandKey::Attach,
             Some(Commands::ResumeSession { .. }) => CommandKey::ResumeSessionInternal,
             Some(Commands::ScheduledRunner { .. }) => CommandKey::Attach,
             Some(Commands::FederationStdio) => CommandKey::Attach,
@@ -2015,6 +2023,15 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             )?;
             return Ok(CliExit::Success);
         }
+        Some(Commands::AwaitAttach {
+            shell_id,
+            gate,
+            node,
+        }) => {
+            terminal::await_open_gate(gate)?;
+            attach::run(shell_id, node.as_deref(), false, true, None)?;
+            return Ok(CliExit::Success);
+        }
         Some(Commands::ScheduledRunner { schedule_id }) => {
             return scheduled_runner(schedule_id).map(CliExit::Child);
         }
@@ -2187,7 +2204,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         }
         Some(Commands::Prompt) => print_prompt_label(),
         Some(Commands::Daemon { command }) => daemon_control(command, cli.json),
-        Some(Commands::Attach { .. }) => unreachable!(),
+        Some(Commands::Attach { .. } | Commands::AwaitAttach { .. }) => unreachable!(),
         Some(Commands::ResumeSession { .. }) => unreachable!(),
         Some(Commands::ScheduledRunner { .. }) => unreachable!(),
         Some(Commands::FederationStdio) => unreachable!(),
@@ -5318,42 +5335,6 @@ fn selected_workspace_id() -> Result<Option<String>, Box<dyn Error>> {
         .map(|selection| selection.workspace_id().to_owned()))
 }
 
-fn required_workspace_target(
-    client: &client::Client,
-    explicit: Option<&str>,
-    node_requested: bool,
-) -> Result<String, Box<dyn Error>> {
-    if let Some(explicit) = explicit {
-        return Ok(explicit.to_owned());
-    }
-    if let Some(owner_workspace_id) = managed_owner_workspace_id(client)? {
-        if !node_requested {
-            return Ok(owner_workspace_id);
-        }
-        let workspace = coordinated_workspace_for_local_owner(client, &owner_workspace_id)?
-            .ok_or_else(|| {
-                cli_output::failure(
-                    "context_required",
-                    "the current owner Workspace is not linked to a coordinated Workspace; provide one explicitly",
-                )
-            })?;
-        return Ok(workspace.id);
-    }
-    let workspace = selected_global_workspace(client)?.ok_or_else(|| {
-        cli_output::failure(
-            "context_required",
-            "workspace is required; provide it explicitly or run `boomux workspace select WORKSPACE`",
-        )
-    })?;
-    if workspace.closing {
-        return Err(cli_output::failure(
-            "invalid_argument",
-            "the selected Workspace is closing",
-        ));
-    }
-    Ok(workspace.id)
-}
-
 fn managed_owner_workspace_id(client: &client::Client) -> Result<Option<String>, Box<dyn Error>> {
     if let Some(shell_id) = env::var("BOOMUX_SHELL_ID")
         .ok()
@@ -5700,6 +5681,139 @@ struct CoordinatedOwnerSelection {
     default_cwd: Option<PathBuf>,
 }
 
+struct WorkspaceCreationContext {
+    global_workspaces_supported: bool,
+    combined: Option<protocol::CombinedNodeSnapshot>,
+}
+
+impl WorkspaceCreationContext {
+    fn load(client: &client::Client) -> Result<Self, Box<dyn Error>> {
+        let global_workspaces_supported =
+            client.supports(protocol::ProtocolFeature::GlobalWorkspaces)?;
+        let combined = global_workspaces_supported
+            .then(|| client.combined_node_snapshot(None))
+            .transpose()?;
+        Ok(Self {
+            global_workspaces_supported,
+            combined,
+        })
+    }
+
+    fn required_target(
+        &self,
+        client: &client::Client,
+        explicit: Option<&str>,
+        node_requested: bool,
+    ) -> Result<String, Box<dyn Error>> {
+        if let Some(explicit) = explicit {
+            return Ok(explicit.to_owned());
+        }
+        if let Some(owner_workspace_id) = managed_owner_workspace_id(client)? {
+            if !node_requested {
+                return Ok(owner_workspace_id);
+            }
+            let workspace = self
+                .coordinated_workspace_for_local_owner(&owner_workspace_id)?
+                .ok_or_else(|| {
+                    cli_output::failure(
+                        "context_required",
+                        "the current owner Workspace is not linked to a coordinated Workspace; provide one explicitly",
+                    )
+                })?;
+            return Ok(workspace.id.clone());
+        }
+        let selected_id = selected_workspace_id()?.ok_or_else(|| {
+            cli_output::failure(
+                "context_required",
+                "workspace is required; provide it explicitly or run `boomux workspace select WORKSPACE`",
+            )
+        })?;
+        if !self.global_workspaces_supported {
+            return Err(cli_output::failure(
+                "unsupported_version",
+                format!(
+                    "{} requires daemon protocol {} or newer",
+                    protocol::ProtocolFeature::GlobalWorkspaces.requirement(),
+                    protocol::ProtocolFeature::GlobalWorkspaces.minimum_version()
+                ),
+            ));
+        }
+        let workspace = find_global_workspace_by_id(
+            &self.combined.as_ref().expect("supported snapshot").workspaces,
+            &selected_id,
+        )
+        .ok_or_else(|| {
+            cli_output::failure(
+                "not_found",
+                format!(
+                    "selected Workspace {selected_id} no longer exists; run `boomux workspace clear`"
+                ),
+            )
+        })?;
+        if workspace.closing {
+            return Err(cli_output::failure(
+                "invalid_argument",
+                "the selected Workspace is closing",
+            ));
+        }
+        Ok(workspace.id.clone())
+    }
+
+    fn coordinated_workspace_for_local_owner(
+        &self,
+        owner_workspace_id: &str,
+    ) -> Result<Option<&protocol::GlobalWorkspaceSnapshot>, Box<dyn Error>> {
+        let combined = self.combined.as_ref().ok_or_else(|| {
+            cli_output::failure(
+                "unsupported_version",
+                "cross-Node Workspace placement requires global Workspace support",
+            )
+        })?;
+        let local_node_id = combined
+            .nodes
+            .iter()
+            .find(|node| node.local)
+            .map(|node| node.node_id.as_str())
+            .ok_or_else(|| cli_output::failure("internal", "local Node identity is unavailable"))?;
+        Ok(combined.workspaces.iter().find(|workspace| {
+            workspace.placements.iter().any(|placement| {
+                placement.node_id == local_node_id && placement.workspace_id == owner_workspace_id
+            })
+        }))
+    }
+
+    fn coordinated_owner(
+        &self,
+        workspace_target: &str,
+        node_selector: Option<&str>,
+    ) -> Result<Option<CoordinatedOwnerSelection>, Box<dyn Error>> {
+        let Some(combined) = &self.combined else {
+            return Ok(None);
+        };
+        let Some(workspace) =
+            resolve_global_workspace_target(&combined.workspaces, workspace_target).cloned()
+        else {
+            return Ok(None);
+        };
+        let node = select_eligible_workspace_owner(&combined.nodes, node_selector)?;
+        let placement = workspace
+            .placements
+            .iter()
+            .find(|placement| placement.node_id == node.node_id);
+        let owner_workspace_id = placement.map_or_else(
+            || Uuid::new_v4().to_string(),
+            |placement| placement.workspace_id.clone(),
+        );
+        let default_cwd = placement.and_then(|placement| placement.default_cwd.clone());
+        Ok(Some(CoordinatedOwnerSelection {
+            workspace,
+            node,
+            owner_workspace_id,
+            default_cwd,
+        }))
+    }
+}
+
 fn require_protocol_feature(
     client: &client::Client,
     feature: protocol::ProtocolFeature,
@@ -5738,38 +5852,6 @@ fn require_explicit_coordinated_owner<T>(
         "invalid_argument",
         "--node can create a Shell or launcher only in a coordinated Workspace; adopt or link an external Workspace first",
     ))
-}
-
-fn select_coordinated_owner(
-    client: &client::Client,
-    workspace_target: &str,
-    node_selector: Option<&str>,
-) -> Result<Option<CoordinatedOwnerSelection>, Box<dyn Error>> {
-    if !client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
-        return Ok(None);
-    }
-    let combined = client.combined_node_snapshot(None)?;
-    let Some(workspace) =
-        resolve_global_workspace_target(&combined.workspaces, workspace_target).cloned()
-    else {
-        return Ok(None);
-    };
-    let node = select_eligible_workspace_owner(&combined.nodes, node_selector)?;
-    let placement = workspace
-        .placements
-        .iter()
-        .find(|placement| placement.node_id == node.node_id);
-    let owner_workspace_id = placement.map_or_else(
-        || Uuid::new_v4().to_string(),
-        |placement| placement.workspace_id.clone(),
-    );
-    let default_cwd = placement.and_then(|placement| placement.default_cwd.clone());
-    Ok(Some(CoordinatedOwnerSelection {
-        workspace,
-        node,
-        owner_workspace_id,
-        default_cwd,
-    }))
 }
 
 fn resolve_owner_directory(
@@ -7748,15 +7830,14 @@ fn shell_command(
             open,
             command,
         } => {
+            let context = WorkspaceCreationContext::load(&client)?;
             let workspace =
-                required_workspace_target(&client, workspace.as_deref(), node.is_some())?;
-            let global_workspaces_supported =
-                client.supports(protocol::ProtocolFeature::GlobalWorkspaces)?;
-            let selection = select_coordinated_owner(&client, &workspace, node.as_deref())?;
+                context.required_target(&client, workspace.as_deref(), node.is_some())?;
+            let selection = context.coordinated_owner(&workspace, node.as_deref())?;
             if let Some(selection) = require_explicit_coordinated_owner(
                 selection,
                 node.as_deref(),
-                global_workspaces_supported,
+                context.global_workspaces_supported,
             )? {
                 let requested_cwd = cwd
                     .or_else(|| selection.default_cwd.clone())
@@ -7766,6 +7847,25 @@ fn shell_command(
                     Some(name) => cli_name(name, "shell")?,
                     None => generated_shell_name(std::iter::empty())?,
                 };
+                let shell_id = Uuid::new_v4().to_string();
+                let title = if selection.node.local {
+                    format!("{} - {name}", selection.workspace.name)
+                } else {
+                    format!(
+                        "[{}] {} - {name}",
+                        selection.node.alias, selection.workspace.name
+                    )
+                };
+                let gate = open
+                    .then(|| {
+                        terminal::open_waiting(
+                            terminal_override,
+                            (!selection.node.local).then_some(selection.node.node_id.as_str()),
+                            &shell_id,
+                            &title,
+                        )
+                    })
+                    .transpose()?;
                 let owner_default_cwd = selection.default_cwd.clone().or_else(|| Some(cwd.clone()));
                 let (_, shell) = client.create_global_workspace_shell(
                     Uuid::new_v4().to_string(),
@@ -7774,33 +7874,21 @@ fn shell_command(
                     &selection.node.node_id,
                     selection.owner_workspace_id,
                     owner_default_cwd,
-                    Uuid::new_v4().to_string(),
+                    shell_id,
                     shell_spec(name, &cwd, &command),
                 )?;
                 println!(
                     "Created pending shell {} ({}) in {} on Node {}",
                     shell.name, shell.id, selection.workspace.name, selection.node.alias
                 );
-                if open {
-                    let title = if selection.node.local {
-                        format!("{} - {}", selection.workspace.name, shell.name)
-                    } else {
-                        format!(
-                            "[{}] {} - {}",
-                            selection.node.alias, selection.workspace.name, shell.name
-                        )
-                    };
-                    if selection.node.local {
-                        open_terminal(&shell.id, &title, false, terminal_override)?;
-                    } else {
-                        terminal::open_remote(
-                            terminal_override,
-                            &selection.node.node_id,
-                            &shell.id,
-                            &title,
-                            false,
-                        )?;
-                    }
+                if let Some(gate) = gate
+                    && let Err(error) = gate.release()
+                {
+                    return Err(format!(
+                        "Shell {} was created but its terminal could not attach: {error}",
+                        shell.id
+                    )
+                    .into());
                 }
                 return Ok(());
             }
@@ -7939,16 +8027,15 @@ fn launcher_command(command: LauncherCommands, json: bool) -> Result<(), Box<dyn
             cwd,
             command,
         } => {
+            let context = WorkspaceCreationContext::load(&client)?;
             let workspace =
-                required_workspace_target(&client, workspace.as_deref(), node.is_some())?;
+                context.required_target(&client, workspace.as_deref(), node.is_some())?;
             let name = cli_name(name, "workspace launcher")?;
-            let global_workspaces_supported =
-                client.supports(protocol::ProtocolFeature::GlobalWorkspaces)?;
-            let selection = select_coordinated_owner(&client, &workspace, node.as_deref())?;
+            let selection = context.coordinated_owner(&workspace, node.as_deref())?;
             if let Some(selection) = require_explicit_coordinated_owner(
                 selection,
                 node.as_deref(),
-                global_workspaces_supported,
+                context.global_workspaces_supported,
             )? {
                 let cwd = resolve_owner_directory(&client, &selection.node, cwd)?;
                 let owner_default_cwd = selection.default_cwd.clone().or_else(|| Some(cwd.clone()));
@@ -8561,22 +8648,34 @@ fn remote_session_command(
 
 fn schedule_command(mut command: ScheduleCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
+    let creation_context = if matches!(&command, ScheduleCommands::Create(_)) {
+        Some(WorkspaceCreationContext::load(&client)?)
+    } else {
+        None
+    };
     if let ScheduleCommands::Create(arguments) = &mut command {
-        arguments.workspace = Some(required_workspace_target(
-            &client,
-            arguments.workspace.as_deref(),
-            arguments.node.is_some(),
-        )?);
+        arguments.workspace = Some(
+            creation_context
+                .as_ref()
+                .expect("create context was loaded")
+                .required_target(
+                    &client,
+                    arguments.workspace.as_deref(),
+                    arguments.node.is_some(),
+                )?,
+        );
     }
     if let ScheduleCommands::Create(arguments) = &command
-        && let Some(selection) = select_coordinated_owner(
-            &client,
-            arguments
-                .workspace
-                .as_deref()
-                .expect("create workspace was resolved"),
-            arguments.node.as_deref(),
-        )?
+        && let Some(selection) = creation_context
+            .as_ref()
+            .expect("create context was loaded")
+            .coordinated_owner(
+                arguments
+                    .workspace
+                    .as_deref()
+                    .expect("create workspace was resolved"),
+                arguments.node.as_deref(),
+            )?
     {
         let ScheduleCommands::Create(arguments) = command else {
             unreachable!()
@@ -13077,6 +13176,24 @@ mod tests {
                 ..
             }) if run_id == "r1"
         ));
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "__await-attach",
+            "s1",
+            "--gate",
+            "/run/user/1/gate",
+            "--node",
+            "node-1",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::AwaitAttach {
+                shell_id,
+                gate,
+                node: Some(node),
+            }) if shell_id == "s1" && gate == Path::new("/run/user/1/gate") && node == "node-1"
+        ));
     }
 
     #[test]
@@ -13602,6 +13719,56 @@ mod tests {
                 .node_id,
             "remote-id"
         );
+
+        let context = WorkspaceCreationContext {
+            global_workspaces_supported: true,
+            combined: Some(protocol::CombinedNodeSnapshot {
+                nodes: vec![
+                    combined_node("local-id", "local", true),
+                    combined_node("remote-id", "work", true),
+                ],
+                workspaces: vec![protocol::GlobalWorkspaceSnapshot {
+                    id: "global-id".into(),
+                    revision: 2,
+                    name: "project".into(),
+                    closing: false,
+                    placements: vec![
+                        protocol::WorkspacePlacementSnapshot {
+                            node_id: "local-id".into(),
+                            workspace_id: "local-owner".into(),
+                            owner_workspace_name: Some("project".into()),
+                            owner_revision: 1,
+                            default_cwd: Some("/local".into()),
+                            state: protocol::WorkspacePlacementState::Active,
+                        },
+                        protocol::WorkspacePlacementSnapshot {
+                            node_id: "remote-id".into(),
+                            workspace_id: "remote-owner".into(),
+                            owner_workspace_name: Some("project".into()),
+                            owner_revision: 1,
+                            default_cwd: Some("/remote".into()),
+                            state: protocol::WorkspacePlacementState::Active,
+                        },
+                    ],
+                }],
+                external_workspaces: Vec::new(),
+                focused_terminal: None,
+            }),
+        };
+        assert_eq!(
+            context
+                .coordinated_workspace_for_local_owner("local-owner")
+                .unwrap()
+                .unwrap()
+                .id,
+            "global-id"
+        );
+        let selected = context
+            .coordinated_owner("project", Some("work"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(selected.owner_workspace_id, "remote-owner");
+        assert_eq!(selected.default_cwd.as_deref(), Some(Path::new("/remote")));
     }
 
     #[test]

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -258,7 +258,7 @@ struct VersionNinePersistedAgentSchedule {
     execution_shell_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct PersistedShellRun {
     pub(crate) id: String,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -4,11 +4,83 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
 use std::os::unix::process::CommandExt;
+use std::os::unix::{fs::PermissionsExt, net::UnixListener, net::UnixStream};
 use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
 
 static TEMPORARY_DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
+const OPEN_GATE_TIMEOUT: Duration = Duration::from_secs(10);
+const OPEN_GATE_RETRY: Duration = Duration::from_millis(10);
+
+pub(crate) struct OpenGate {
+    listener: UnixListener,
+    path: PathBuf,
+    released: bool,
+}
+
+impl OpenGate {
+    fn new() -> io::Result<Self> {
+        let parent = crate::client::socket_path()?
+            .parent()
+            .ok_or_else(|| io::Error::other("Boomux runtime socket has no parent"))?
+            .to_owned();
+        let id = Uuid::new_v4().simple().to_string();
+        let path = parent.join(format!("open-{}.sock", &id[..16]));
+        Self::bind(path)
+    }
+
+    fn bind(path: PathBuf) -> io::Result<Self> {
+        let listener = UnixListener::bind(&path)?;
+        let gate = Self {
+            listener,
+            path,
+            released: false,
+        };
+        fs::set_permissions(&gate.path, fs::Permissions::from_mode(0o600))?;
+        gate.listener.set_nonblocking(true)?;
+        Ok(gate)
+    }
+
+    pub(crate) fn release(mut self) -> io::Result<()> {
+        let deadline = Instant::now() + OPEN_GATE_TIMEOUT;
+        loop {
+            match self.listener.accept() {
+                Ok((mut stream, _)) => {
+                    use std::io::Write;
+                    stream.write_all(&[1])?;
+                    self.released = true;
+                    return Ok(());
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "terminal did not become ready for the created Shell",
+                        ));
+                    }
+                    thread::sleep(OPEN_GATE_RETRY);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+}
+
+impl Drop for OpenGate {
+    fn drop(&mut self) {
+        if !self.released
+            && let Ok((mut stream, _)) = self.listener.accept()
+        {
+            use std::io::Write;
+            let _ = stream.write_all(&[0]);
+        }
+        let _ = fs::remove_file(&self.path);
+    }
+}
 
 pub(crate) fn validate_desktop_entry(entry: &str) -> Result<(), Box<dyn Error>> {
     let (desktop_entry, action) = entry
@@ -57,6 +129,38 @@ pub(crate) fn open_remote(
         takeover,
         None,
     )
+}
+
+pub(crate) fn open_waiting(
+    desktop_entry: Option<&str>,
+    node_id: Option<&str>,
+    shell_id: &str,
+    title: &str,
+) -> Result<OpenGate, Box<dyn Error>> {
+    let gate = OpenGate::new()?;
+    let executable = attachment_executable()?;
+    let arguments = waiting_attachment_arguments(&gate.path, shell_id, node_id);
+    launch(
+        desktop_entry,
+        title,
+        None,
+        executable.as_os_str(),
+        &arguments,
+    )?;
+    Ok(gate)
+}
+
+pub(crate) fn await_open_gate(path: &Path) -> io::Result<()> {
+    use std::io::Read;
+
+    let mut stream = UnixStream::connect(path)?;
+    let mut status = [0];
+    stream.read_exact(&mut status)?;
+    if status == [1] {
+        Ok(())
+    } else {
+        Err(io::Error::other("Shell creation failed before attachment"))
+    }
 }
 
 pub(crate) fn open_exact_run(
@@ -201,7 +305,11 @@ fn launch(
     arguments: &[OsString],
 ) -> Result<(), Box<dyn Error>> {
     let preference = desktop_entry.map(TemporaryPreference::new).transpose()?;
-    let selected = selected_with_preference(desktop_entry, preference.as_ref())?;
+    let selected = if desktop_entry.is_some() {
+        selected_with_preference(desktop_entry, preference.as_ref())?
+    } else {
+        "configured terminal".to_owned()
+    };
     let mut resolver = configured_command(preference.as_ref());
     resolver
         .arg(r"--print-cmd=\0")
@@ -260,6 +368,23 @@ fn attachment_arguments(
         arguments.extend(["--expected-run-id".into(), expected_run_id.into()]);
     } else {
         arguments.push("--restart-exited".into());
+    }
+    arguments
+}
+
+fn waiting_attachment_arguments(
+    gate: &Path,
+    shell_id: &str,
+    node_id: Option<&str>,
+) -> Vec<OsString> {
+    let mut arguments = vec![
+        "__await-attach".into(),
+        shell_id.into(),
+        "--gate".into(),
+        gate.as_os_str().to_owned(),
+    ];
+    if let Some(node_id) = node_id {
+        arguments.extend(["--node".into(), node_id.into()]);
     }
     arguments
 }
@@ -431,6 +556,79 @@ mod tests {
             .map(OsStr::new)
             .map(OsStr::to_owned)
         );
+    }
+
+    #[test]
+    fn waiting_attachment_is_exact_and_node_qualified() {
+        assert_eq!(
+            waiting_attachment_arguments(Path::new("/run/user/1/gate"), "shell-1", Some("node-1")),
+            [
+                "__await-attach",
+                "shell-1",
+                "--gate",
+                "/run/user/1/gate",
+                "--node",
+                "node-1",
+            ]
+            .map(OsStr::new)
+            .map(OsStr::to_owned)
+        );
+    }
+
+    #[test]
+    fn open_gate_releases_only_after_success() {
+        let path = env::temp_dir().join(format!("boomux-open-gate-{}", process::id()));
+        let listener = UnixListener::bind(&path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let gate = OpenGate {
+            listener,
+            path: path.clone(),
+            released: false,
+        };
+        let waiter = thread::spawn(move || await_open_gate(&path));
+
+        gate.release().unwrap();
+        waiter.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn bound_open_gate_is_owner_only_and_removed_on_drop() {
+        use std::os::unix::fs::MetadataExt;
+
+        let path = env::temp_dir().join(format!("boomux-owned-open-gate-{}", process::id()));
+        let gate = OpenGate::bind(path.clone()).unwrap();
+        let metadata = fs::symlink_metadata(&path).unwrap();
+        assert_eq!(metadata.mode() & 0o777, 0o600);
+
+        drop(gate);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn dropped_open_gate_rejects_attachment() {
+        use std::io::Read;
+        use std::sync::mpsc;
+
+        let path = env::temp_dir().join(format!("boomux-failed-open-gate-{}", process::id()));
+        let listener = UnixListener::bind(&path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let gate = OpenGate {
+            listener,
+            path: path.clone(),
+            released: false,
+        };
+        let (connected_tx, connected_rx) = mpsc::channel();
+        let waiter = thread::spawn(move || {
+            let mut stream = UnixStream::connect(path).unwrap();
+            connected_tx.send(()).unwrap();
+            let mut status = [1];
+            stream.read_exact(&mut status).unwrap();
+            status
+        });
+        connected_rx.recv().unwrap();
+
+        drop(gate);
+        assert_eq!(waiter.join().unwrap(), [0]);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3854,8 +3854,7 @@ impl App {
                         })
                     })
                     .or_else(|| {
-                        (!self.schedules.is_empty())
-                            .then_some(previous.min(self.schedules.len() - 1))
+                        (!self.schedules.is_empty()).then(|| previous.min(self.schedules.len() - 1))
                     }),
             );
             self.sync_selected_execution();
@@ -12029,6 +12028,16 @@ mod tests {
             app.pending_close,
             Some(PendingClose { target: CloseTarget::Execution(ref id), .. }) if id == "execution-2"
         ));
+    }
+
+    #[test]
+    fn schedule_refresh_clears_selection_when_the_last_schedule_disappears() {
+        let mut app = schedule_app();
+
+        app.replace_schedules(Vec::new());
+
+        assert_eq!(app.global_state.selected(), None);
+        assert_eq!(app.selected_execution(), None);
     }
 
     #[test]

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -945,11 +945,8 @@ fn native_daemon_lifecycle() {
     loop {
         match AttachFrame::read_from(&mut second) {
             Ok(AttachFrame::Output(_)) => continue,
-            Ok(AttachFrame::Reconnect) => {
-                let _ = AttachFrame::ReconnectAck.write_to(&mut second);
-                break;
-            }
-            Err(_) => break,
+            Ok(AttachFrame::Detached) => break,
+            Err(error) => panic!("old controller closed before detach: {error}"),
             Ok(frame) => panic!("old controller received unexpected frame: {frame:?}"),
         }
     }

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -9,12 +9,13 @@ use std::time::Duration;
 use boomux::client::{ClientError, RemoteError};
 use boomux::protocol::{
     AgentScheduleOverlapPolicy, AgentScheduleSession, AgentScheduleSpec, AgentScheduleState,
-    AgentScheduleTrigger, ErrorCode, Request, Response, ShellSpec, WorkspaceLauncherSpec,
+    AgentScheduleTrigger, ErrorCode, Request, Response, ShellRunExitReason, ShellSpec,
+    WorkspaceLauncherSpec,
 };
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::support::{CONTROL_MASTER_PREFIX, TestDaemon};
+use crate::support::{CONTROL_MASTER_PREFIX, TestDaemon, profile};
 
 fn node_id(value: u128) -> String {
     Uuid::from_u128(value).to_string()
@@ -299,6 +300,234 @@ fn first_resources_atomically_establish_one_exact_owner_placement() {
 }
 
 #[test]
+fn committed_local_shell_journal_replays_before_cold_start_serves_requests() {
+    let mut daemon = TestDaemon::start_with(|command, _| {
+        command.env(
+            "BOOMUX_NATIVE_TEST_LOCAL_SHELL_CHECKPOINT_DELAY_MS",
+            "60000",
+        );
+    });
+    let global = daemon
+        .client
+        .create_global_workspace("journal-recovery")
+        .unwrap();
+    let node_id = daemon.client.node_identity().unwrap();
+    let operation_id = Uuid::new_v4().to_string();
+    let owner_workspace_id = Uuid::new_v4().to_string();
+    let shell_id = Uuid::new_v4().to_string();
+    let shell = ShellSpec {
+        name: "recovered".into(),
+        command: vec!["/bin/sh".into()],
+        cwd: std::env::temp_dir(),
+    };
+    let created = daemon
+        .client
+        .create_global_workspace_shell(
+            &operation_id,
+            &global.id,
+            global.revision,
+            &node_id,
+            &owner_workspace_id,
+            Some(std::env::temp_dir()),
+            &shell_id,
+            shell.clone(),
+        )
+        .unwrap();
+    let journal = daemon
+        .runtime_dir
+        .join("state/boomux/local_shell_transactions.log");
+    assert!(fs::metadata(&journal).unwrap().len() > 0);
+
+    daemon.crash();
+    daemon.restart_with(|command| {
+        command.env(
+            "BOOMUX_NATIVE_TEST_LOCAL_SHELL_CHECKPOINT_DELAY_MS",
+            "60000",
+        );
+    });
+    assert_eq!(fs::metadata(&journal).unwrap().len(), 0);
+    let snapshot = daemon.client.snapshot().unwrap();
+    let owner = snapshot
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == owner_workspace_id)
+        .unwrap();
+    assert_eq!(owner.shells.len(), 1);
+    assert_eq!(owner.shells[0].id, shell_id);
+    let replayed = daemon
+        .client
+        .create_global_workspace_shell(
+            operation_id,
+            &global.id,
+            global.revision,
+            node_id,
+            owner_workspace_id,
+            Some(std::env::temp_dir()),
+            shell_id,
+            shell,
+        )
+        .unwrap();
+    assert_eq!(replayed, created);
+}
+
+#[test]
+fn journaled_initial_shell_run_recovers_as_interrupted_after_cold_crash() {
+    let mut daemon = TestDaemon::start_with(|command, _| {
+        command.env(
+            "BOOMUX_NATIVE_TEST_LOCAL_SHELL_CHECKPOINT_DELAY_MS",
+            "60000",
+        );
+    });
+    let global = daemon
+        .client
+        .create_global_workspace("journaled-start")
+        .unwrap();
+    let node_id = daemon.client.node_identity().unwrap();
+    let owner_workspace_id = Uuid::new_v4().to_string();
+    let shell_id = Uuid::new_v4().to_string();
+    daemon
+        .client
+        .create_global_workspace_shell(
+            Uuid::new_v4().to_string(),
+            &global.id,
+            global.revision,
+            node_id,
+            &owner_workspace_id,
+            Some(std::env::temp_dir()),
+            &shell_id,
+            ShellSpec {
+                name: "journaled-start".into(),
+                command: vec!["/bin/sh".into(), "-c".into(), "sleep 30".into()],
+                cwd: std::env::temp_dir(),
+            },
+        )
+        .unwrap();
+    let journal = daemon
+        .runtime_dir
+        .join("state/boomux/local_shell_transactions.log");
+    let create_bytes = fs::metadata(&journal).unwrap().len();
+    let fresh_client =
+        boomux::client::Client::from_socket_path(daemon.client.socket_path().to_path_buf());
+    fresh_client.snapshot().unwrap();
+    fresh_client.combined_node_snapshot(None).unwrap();
+    assert_eq!(fs::metadata(&journal).unwrap().len(), create_bytes);
+    let attachment = fresh_client.attach(&shell_id, false, profile()).unwrap();
+    assert!(fs::metadata(&journal).unwrap().len() > create_bytes);
+    drop(attachment);
+
+    daemon.crash();
+    daemon.restart_with(|command| {
+        command.env(
+            "BOOMUX_NATIVE_TEST_LOCAL_SHELL_CHECKPOINT_DELAY_MS",
+            "60000",
+        );
+    });
+    assert_eq!(fs::metadata(&journal).unwrap().len(), 0);
+    let recovered = daemon.client.get_shell(&shell_id).unwrap();
+    assert!(recovered.run.is_none());
+    let state: serde_json::Value = serde_json::from_slice(
+        &fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap(),
+    )
+    .unwrap();
+    let recovered_run = state["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|workspace| workspace["shells"].as_array().unwrap())
+        .find(|shell| shell["id"] == shell_id)
+        .unwrap()["last_run"]
+        .clone();
+    assert_eq!(recovered_run["generation"], 1);
+    assert_eq!(
+        serde_json::from_value::<Option<ShellRunExitReason>>(recovered_run["exit_reason"].clone())
+            .unwrap(),
+        Some(ShellRunExitReason::Interrupted)
+    );
+}
+
+#[test]
+fn later_shell_mutations_checkpoint_creation_before_changing_recovery_semantics() {
+    let mut daemon = TestDaemon::start_with(|command, _| {
+        command.env(
+            "BOOMUX_NATIVE_TEST_LOCAL_SHELL_CHECKPOINT_DELAY_MS",
+            "60000",
+        );
+    });
+    let mut global = daemon
+        .client
+        .create_global_workspace("journal-frontier")
+        .unwrap();
+    let node_id = daemon.client.node_identity().unwrap();
+    let owner_workspace_id = Uuid::new_v4().to_string();
+    let journal = daemon
+        .runtime_dir
+        .join("state/boomux/local_shell_transactions.log");
+    for (operation_id, shell_id, name) in [
+        (Uuid::new_v4(), Uuid::new_v4(), "rename-me"),
+        (Uuid::new_v4(), Uuid::new_v4(), "close-me"),
+    ] {
+        global = daemon
+            .client
+            .create_global_workspace_shell(
+                operation_id.to_string(),
+                &global.id,
+                global.revision,
+                &node_id,
+                &owner_workspace_id,
+                Some(std::env::temp_dir()),
+                shell_id.to_string(),
+                ShellSpec::login(name, std::env::temp_dir()),
+            )
+            .unwrap()
+            .0;
+    }
+    assert!(fs::metadata(&journal).unwrap().len() > 0);
+
+    let output = daemon
+        .command()
+        .args([
+            "shell",
+            "rename",
+            "rename-me",
+            "renamed",
+            "--workspace",
+            "journal-frontier",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(fs::metadata(&journal).unwrap().len(), 0);
+    let output = daemon
+        .command()
+        .args([
+            "shell",
+            "close",
+            "close-me",
+            "--workspace",
+            "journal-frontier",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    daemon.crash();
+    daemon.restart_with(|command| {
+        command.env(
+            "BOOMUX_NATIVE_TEST_LOCAL_SHELL_CHECKPOINT_DELAY_MS",
+            "60000",
+        );
+    });
+    let snapshot = daemon.client.snapshot().unwrap();
+    let owner = snapshot
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == owner_workspace_id)
+        .unwrap();
+    assert!(owner.shells.iter().any(|shell| shell.name == "renamed"));
+    assert!(owner.shells.iter().all(|shell| shell.name != "close-me"));
+}
+
+#[test]
 fn concurrent_first_resources_with_distinct_requested_owners_replay_canonical_successes() {
     let daemon = TestDaemon::start();
     let global = daemon
@@ -313,6 +542,11 @@ fn concurrent_first_resources_with_distinct_requested_owners_replay_canonical_su
         let operation_id = Uuid::from_u128(100 + offset).to_string();
         let requested_owner_id = Uuid::from_u128(200 + offset).to_string();
         let shell_id = Uuid::from_u128(300 + offset).to_string();
+        let requested_default_cwd = if offset == 0 {
+            std::env::temp_dir()
+        } else {
+            std::env::current_dir().unwrap()
+        };
         let shell = ShellSpec {
             name: format!("shell-{offset}"),
             command: Vec::new(),
@@ -323,6 +557,7 @@ fn concurrent_first_resources_with_distinct_requested_owners_replay_canonical_su
             requested_owner_id.clone(),
             shell_id.clone(),
             shell.clone(),
+            requested_default_cwd.clone(),
         ));
         let client = daemon.client.clone();
         let barrier = Arc::clone(&barrier);
@@ -337,7 +572,7 @@ fn concurrent_first_resources_with_distinct_requested_owners_replay_canonical_su
                     global.revision,
                     node_id,
                     requested_owner_id,
-                    Some(std::env::temp_dir()),
+                    Some(requested_default_cwd),
                     shell_id,
                     shell,
                 )
@@ -361,7 +596,7 @@ fn concurrent_first_resources_with_distinct_requested_owners_replay_canonical_su
             .any(|request| request.1 == first.1.workspace_id)
     );
 
-    for (index, (operation_id, requested_owner_id, shell_id, shell)) in
+    for (index, (operation_id, requested_owner_id, shell_id, shell, default_cwd)) in
         requests.into_iter().enumerate()
     {
         let replay = daemon
@@ -372,7 +607,7 @@ fn concurrent_first_resources_with_distinct_requested_owners_replay_canonical_su
                 global.revision,
                 &node_id,
                 requested_owner_id,
-                Some(std::env::temp_dir()),
+                Some(default_cwd),
                 shell_id,
                 shell,
             )

--- a/tests/native_backend/shell_name_suggestion.rs
+++ b/tests/native_backend/shell_name_suggestion.rs
@@ -1,8 +1,98 @@
 use std::collections::BTreeSet;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
 
 use boomux::protocol::ShellSpec;
 
-use crate::support::{TestDaemon, assert_generated_name};
+use crate::support::{TestDaemon, assert_generated_name, wait_until};
+
+#[test]
+fn create_and_open_releases_terminal_only_after_durable_creation() {
+    let daemon = TestDaemon::start();
+    daemon.client.create_global_workspace("gated-open").unwrap();
+    let bin = daemon.runtime_dir.join("bin");
+    fs::create_dir(&bin).unwrap();
+    let resolver = bin.join("xdg-terminal-exec");
+    fs::write(
+        &resolver,
+        "#!/bin/sh\nwhile [ \"$#\" -gt 0 ] && [ \"$1\" != -- ]; do shift; done\nshift\ngate=\nwhile [ \"$#\" -gt 0 ]; do\n  if [ \"$1\" = --gate ]; then shift; gate=$1; break; fi\n  shift\ndone\nprintf '%s\\0' python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); s.connect(sys.argv[1]); status=s.recv(1); open(sys.argv[2], \"wb\").write(status)' \"$gate\" \"$BOOMUX_GATE_MARKER\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&resolver, fs::Permissions::from_mode(0o700)).unwrap();
+    let marker = daemon.runtime_dir.join("gate-status");
+    let output = daemon
+        .command()
+        .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+        .env("BOOMUX_GATE_MARKER", &marker)
+        .args([
+            "shell",
+            "create",
+            "gated-open",
+            "--name",
+            "gated",
+            "--cwd",
+            "/tmp",
+            "--open",
+            "--",
+            "/bin/sh",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "create and open failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    wait_until(
+        || fs::read(&marker).is_ok_and(|status| status == [1]),
+        "terminal did not observe the successful creation gate",
+    );
+    let snapshot = daemon.client.snapshot().unwrap();
+    let shell = snapshot
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.name == "gated-open")
+        .unwrap()
+        .shells
+        .iter()
+        .find(|shell| shell.name == "gated")
+        .unwrap();
+    assert!(shell.run.is_none(), "the gate observer must not attach");
+
+    fs::write(&resolver, "#!/bin/sh\nexit 64\n").unwrap();
+    let output = daemon
+        .command()
+        .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+        .args([
+            "shell",
+            "create",
+            "gated-open",
+            "--name",
+            "terminal-failed",
+            "--open",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(
+        daemon
+            .client
+            .snapshot()
+            .unwrap()
+            .workspaces
+            .iter()
+            .flat_map(|workspace| &workspace.shells)
+            .all(|shell| shell.name != "terminal-failed"),
+        "terminal preparation failure must happen before Shell creation"
+    );
+
+    let output = daemon
+        .command()
+        .args(["workspace", "close", "gated-open"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+}
 
 #[test]
 fn shell_name_suggestion_is_stable_non_mutating_cli_data() {


### PR DESCRIPTION
## Summary
- commit local coordinated Shell creation through a bounded, checksummed owner-only journal and checkpoint the larger state files asynchronously
- prelaunch and gate native terminals, then journal the initial ShellRun before attachment success
- preserve exact cold replay, mutation frontiers, event ordering, graceful handoff, and existing remote owner preparation semantics
- allow negotiation and mutation-free projection reads to coexist with immediate attachment without forcing a slow checkpoint
- detach a displaced native controller on explicit takeover while retaining browser collaboration and graceful handoff reconnection
- avoid an empty-schedule TUI refresh underflow and clear the stale schedule selection

## Performance
- reduced a live `shell create --open` process-start probe from 2.09s to 0.50s on the normal Btrfs-backed state directory
- reduced isolated coordinated Shell creation from roughly 2.8s before this work to about 0.1s when storage sync latency is low

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`

Native coverage includes cold journal replay, journaled initial-run interruption recovery, later mutation frontiers, concurrent first-resource canonicalization, terminal creation gating, and displaced-controller detachment.