### PR TITLE
feat(cli): close focused shell

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -392,8 +392,10 @@ timed work even when the daemon still answers other requests.
 
 Exact shell IDs are global only within one Node. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.
-`boomux read` and top-level `boomux close` require an exact shell ID outside a
-managed shell. If a name remains ambiguous, ask the user to select a target.
+`boomux read` and targeted top-level `boomux close` require an exact shell ID
+outside a managed shell. `boomux close --focused` instead resolves the most
+recently focused Boomux terminal, which can remain selected while a non-Boomux
+window is active. If a name remains ambiguous, ask the user to select a target.
 
 Shell status meanings:
 
@@ -780,7 +782,13 @@ The contextual close shorthand is:
 
 ```console
 boomux close "<shell-name-or-shell-id>"
+boomux close --focused
 ```
+
+Focused close revalidates the exact Shell and routes a remote focused Shell to
+its owning Node. It requires daemon protocol 39, fails when no Boomux terminal
+has reported focus, and never allows a managed Shell to close itself from inside
+that Shell.
 
 ## Open Shells
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ boomux . --name my-project --new -- sh -lc 'cargo test | tee test.log'
 | Suggest an unused shell name | `boomux shell suggest-name feature-x` |
 | Add a randomly named shell | `boomux shell create feature-x` |
 | Add and open a randomly named shell | `boomux shell create feature-x --open` |
+| Close the most recently focused Boomux terminal | `boomux close --focused` |
 | Open the new shell in another terminal | `boomux . --name feature-x --new` |
 | Run one command | `boomux . --name feature-x --new -- lazygit` |
 | Choose a terminal | `boomux . --terminal Alacritty.desktop` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -563,6 +563,13 @@ frontier. A replaced event stream or a handoff that changes the negotiated
 protocol resets it once. Same-version handoff retains the exact presentation
 frontier, while 39-to-38 and 38-to-39 transitions deliberately start the active
 protocol's revision domain without suppressing later physical focus gains.
+`boomux close --focused` resolves this latest reported Boomux focus, revalidates
+the authoritative Shell, and performs a local close or revision-guarded remote
+close on its owning Node. It requires protocol 39 so resolution always uses a
+Node-qualified identity. It is not an operating-system active-window query: if
+a non-Boomux window is active, the latest retained Boomux focus remains the
+target. The command fails when no focus has been reported and retains the normal
+prohibition against closing the invoking managed Shell from inside itself.
 
 Selected-kind previews remain read-only. Workspace, launcher, and run metadata
 come from the polled snapshot. Shell output uses a bounded plain-text read only

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,8 +431,14 @@ enum Commands {
         #[arg(long, default_value_t = 0)]
         wait_ms: u32,
     },
-    /// Close a shell by name or shell ID
-    Close { target: String },
+    /// Close a shell by name, shell ID, or latest focused Boomux terminal
+    Close {
+        #[arg(required_unless_present = "focused", conflicts_with = "focused")]
+        target: Option<String>,
+        /// Close the most recently focused Boomux terminal
+        #[arg(long)]
+        focused: bool,
+    },
     /// Inspect and edit layered Boomux configuration
     Config {
         #[command(subcommand)]
@@ -2115,7 +2121,13 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             limit,
             wait_ms,
         }) => read_events(after.as_deref(), limit, wait_ms, cli.json),
-        Some(Commands::Close { target }) => close_shell(&target),
+        Some(Commands::Close { target, focused }) => {
+            if focused {
+                close_focused_shell()
+            } else {
+                close_shell(target.as_deref().expect("clap requires a close target"))
+            }
+        }
         Some(Commands::Config { command }) => config_command(command),
         Some(Commands::Project {
             command: ProjectCommands::List { node },
@@ -11231,6 +11243,70 @@ fn close_shell(target: &str) -> Result<(), Box<dyn Error>> {
     close_shell_with_workspace(&client, target, None)
 }
 
+fn close_focused_shell() -> Result<(), Box<dyn Error>> {
+    let client = client::connect_or_start()?;
+    let message = close_focused_shell_with_client(&client).map_err(io::Error::other)?;
+    println!("{message}");
+    Ok(())
+}
+
+fn close_focused_shell_with_client(client: &client::Client) -> Result<String, String> {
+    if !client
+        .supports(protocol::ProtocolFeature::QualifiedFocusedTerminal)
+        .map_err(|error| error.to_string())?
+    {
+        return Err("focused Shell close requires daemon protocol 39 or newer".into());
+    }
+    let combined = client
+        .combined_node_snapshot(None)
+        .map_err(|error| error.to_string())?;
+    let local_node_id = combined
+        .nodes
+        .iter()
+        .find(|node| node.local)
+        .map(|node| node.node_id.clone())
+        .ok_or_else(|| "local Node identity is unavailable".to_owned())?;
+    let identity = combined
+        .focused_terminal
+        .ok_or_else(|| "no Boomux terminal has reported focus; focus one and retry".to_owned())?
+        .shell;
+    let local = identity.node_id == local_node_id;
+    let shell = routed_dashboard_shell(client, &identity, &local_node_id)?;
+    if local && env::var("BOOMUX_SHELL_ID").ok().as_deref() == Some(shell.id.as_str()) {
+        return Err(
+            "cannot close the current shell from inside it; use the dashboard or another shell"
+                .into(),
+        );
+    }
+    let workspace = routed_dashboard_workspace(
+        client,
+        &protocol::QualifiedIdentity::new(&identity.node_id, &shell.workspace_id),
+        &local_node_id,
+    )?;
+    if local {
+        client
+            .close_shell(&shell.id)
+            .map_err(|error| error.to_string())?;
+    } else {
+        match routed_dashboard_operation(
+            client,
+            &identity,
+            &local_node_id,
+            protocol::RoutedOperation::CloseShell {
+                shell_id: shell.id.clone(),
+                expected_revision: shell.revision,
+            },
+        )? {
+            protocol::RoutedOperationResult::Ok => {}
+            _ => return Err("remote Node returned an unexpected shell close response".into()),
+        }
+    }
+    Ok(format!(
+        "Closed focused shell {} from {}",
+        shell.name, workspace.name
+    ))
+}
+
 fn close_shell_with_workspace(
     client: &client::Client,
     target: &str,
@@ -13695,8 +13771,19 @@ mod tests {
             Cli::try_parse_from(["boomux", "close", "tests"])
                 .unwrap()
                 .command,
-            Some(Commands::Close { target }) if target == "tests"
+            Some(Commands::Close { target: Some(target), focused: false }) if target == "tests"
         ));
+        assert!(matches!(
+            Cli::try_parse_from(["boomux", "close", "--focused"])
+                .unwrap()
+                .command,
+            Some(Commands::Close {
+                target: None,
+                focused: true
+            })
+        ));
+        assert!(Cli::try_parse_from(["boomux", "close"]).is_err());
+        assert!(Cli::try_parse_from(["boomux", "close", "tests", "--focused"]).is_err());
     }
 
     #[test]

--- a/tests/native_backend/handoff.rs
+++ b/tests/native_backend/handoff.rs
@@ -236,6 +236,75 @@ fn focused_attachment_is_exposed_in_daemon_snapshots() {
 }
 
 #[test]
+fn focused_shell_can_be_closed_from_the_cli() {
+    let mut daemon = TestDaemon::start();
+    let no_focus = daemon
+        .command()
+        .args(["close", "--focused"])
+        .env_remove("BOOMUX_SHELL_ID")
+        .env_remove("BOOMUX_WORKSPACE_ID")
+        .output()
+        .unwrap();
+    assert!(!no_focus.status.success());
+    assert!(String::from_utf8_lossy(&no_focus.stderr).contains("has reported focus"));
+
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "focused-close",
+            vec![ShellSpec::login("shell", std::env::temp_dir())],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let mut attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    AttachFrame::FocusGained
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    wait_until(
+        || {
+            daemon
+                .client
+                .focused_terminal()
+                .ok()
+                .flatten()
+                .is_some_and(|focused| focused.shell_id == shell_id)
+        },
+        "daemon did not expose the focused Shell before close",
+    );
+
+    let self_close = daemon
+        .command()
+        .args(["close", "--focused"])
+        .env("BOOMUX_SHELL_ID", &shell_id)
+        .env("BOOMUX_WORKSPACE_ID", &workspace.id)
+        .output()
+        .unwrap();
+    assert!(!self_close.status.success());
+    assert!(String::from_utf8_lossy(&self_close.stderr).contains("cannot close the current shell"));
+    assert!(daemon.client.get_shell(&shell_id).is_ok());
+
+    let close = daemon
+        .command()
+        .args(["close", "--focused"])
+        .env_remove("BOOMUX_SHELL_ID")
+        .env_remove("BOOMUX_WORKSPACE_ID")
+        .output()
+        .unwrap();
+    assert!(
+        close.status.success(),
+        "focused close failed: {}",
+        String::from_utf8_lossy(&close.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&close.stdout)
+            .contains("Closed focused shell shell from focused-close")
+    );
+    assert!(daemon.client.get_shell(&shell_id).is_err());
+    drop(attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn graceful_restart_preserves_exited_run_and_terminal_state() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon

--- a/tests/native_backend/remote_attachment.rs
+++ b/tests/native_backend/remote_attachment.rs
@@ -515,5 +515,43 @@ fn two_daemon_remote_attachment_keeps_environment_and_runtime_on_owner() {
     );
     assert!(crate::support::process_exists(pid));
 
+    AttachFrame::FocusGained
+        .write_to(&mut after_remote_handoff.stream)
+        .unwrap();
+    wait_until(
+        || {
+            local
+                .client
+                .combined_node_snapshot(None)
+                .ok()
+                .and_then(|snapshot| snapshot.focused_terminal)
+                .is_some_and(|focused| {
+                    focused.shell == QualifiedIdentity::new(&remote_node, &shell.id)
+                })
+        },
+        "remote Shell did not regain presented focus before close",
+    );
+    let focused_close = local
+        .command()
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", local.runtime_dir.display()),
+        )
+        .env_remove("BOOMUX_SHELL_ID")
+        .env_remove("BOOMUX_WORKSPACE_ID")
+        .args(["close", "--focused"])
+        .output()
+        .unwrap();
+    assert!(
+        focused_close.status.success(),
+        "focused remote close failed: {}",
+        String::from_utf8_lossy(&focused_close.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&focused_close.stdout)
+            .contains("Closed focused shell remote-shell from remote-workspace")
+    );
+    assert!(remote.client.get_shell(&shell.id).is_err());
+
     remote.stop_with_cli();
 }


### PR DESCRIPTION
## Summary
- add `boomux close --focused` as an exclusive alternative to a shell name or ID
- resolve the most recently reported Boomux focus through protocol 39 Node-qualified identity
- revalidate the authoritative Shell before closing locally or through revision-guarded remote routing
- preserve the self-close prohibition and fail when focus is absent or the daemon is too old
- document that focused means the latest Boomux focus, not the operating system active window

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`

Native coverage includes missing focus, local focused close, self-close rejection, qualified remote focus, graceful handoff, and revision-guarded owner-routed close.