### PR TITLE
test: tolerate queued output before reconnect

### DIFF
--- a/tests/native_backend/remote_attachment.rs
+++ b/tests/native_backend/remote_attachment.rs
@@ -479,10 +479,13 @@ fn two_daemon_remote_attachment_keeps_environment_and_runtime_on_owner() {
         .stderr(Stdio::piped())
         .spawn()
         .unwrap();
-    assert_eq!(
-        AttachFrame::read_from(&mut after_handoff.stream).unwrap(),
-        AttachFrame::Reconnect
-    );
+    loop {
+        match AttachFrame::read_from(&mut after_handoff.stream).unwrap() {
+            AttachFrame::Reconnect => break,
+            AttachFrame::Output(_) => {}
+            frame => panic!("expected reconnect after queued output, got {frame:?}"),
+        }
+    }
     AttachFrame::ReconnectAck
         .write_to(&mut after_handoff.stream)
         .unwrap();


### PR DESCRIPTION
## Summary
- allow PTY output frames queued before a graceful handoff reconnect frame
- keep rejecting unexpected attachment control frames
- remove the native backend ordering assumption exposed by post-merge CI

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`