### PR TITLE
ci: serialize rust tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
       - name: Run Rust unit tests
-        run: cargo test --lib --bins --locked
+        run: cargo test --lib --bins --locked -- --test-threads=1
 
       - name: Run native backend tests
         run: cargo test --test native_backend --locked -- --test-threads=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Run the same checks as CI:
 ```console
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features --locked -- -D warnings
-cargo test --lib --bins --locked
+cargo test --lib --bins --locked -- --test-threads=1
 cargo test --test native_backend --locked -- --test-threads=1
 bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
 ```


### PR DESCRIPTION
## Summary
- run Rust unit and binary tests with one test thread
- keep the documented local validation command aligned with CI
- prevent executable-fixture races between parallel process and PTY tests

## Root cause
The failed release CI run returned exit `1` instead of the fixture child's intended exit `7`. Stress runs reproduced explicit `ETXTBSY` (`Text file busy`) failures in multiple executable fixtures. A parallel test can fork while another test is writing an executable fixture, briefly inheriting the writable descriptor until `exec`; immediate execution of that fixture then fails nondeterministically.

Failed run: https://github.com/gardnmi/boomux/actions/runs/32681732024

## Validation
- 50 repeated parallel runs reproduced the race
- 30 repeated serial runs passed
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`