### PR TITLE
fix: preserve interactive node setup and workspace layout

### DIFF
--- a/src/hyprland.rs
+++ b/src/hyprland.rs
@@ -117,7 +117,6 @@ pub(crate) fn active_boomux_workspace() -> Result<Option<String>, HyprlandError>
 }
 
 pub(crate) fn toggle_special(workspace_id: &str) -> Result<(), HyprlandError> {
-    apply_workspace_layout(workspace_id)?;
     dispatch(toggle_expression(workspace_id)?)
 }
 
@@ -452,7 +451,7 @@ fn move_window(address: &str, workspace_id: &str) -> Result<(), HyprlandError> {
     dispatch(move_expression(address, workspace_id)?)
 }
 
-fn apply_workspace_layout(workspace_id: &str) -> Result<(), HyprlandError> {
+pub(crate) fn apply_workspace_layout(workspace_id: &str) -> Result<(), HyprlandError> {
     evaluate(layout_expression(workspace_id)?)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2315,6 +2315,13 @@ fn verified_remote_connection(
     } else {
         ssh_bootstrap::SshAuthenticationMode::Batch
     };
+    if interactive {
+        println!(
+            "Connecting to {}. Complete any SSH authentication prompt or login URL shown in this terminal.",
+            target.as_str()
+        );
+        std::io::Write::flush(&mut io::stdout())?;
+    }
     let mut session = ssh_bootstrap::BootstrapSession::open(target, authentication, TIMEOUT)
         .map_err(bootstrap_cli_failure)?;
     // Both branches return a channel verified by exactly one protocol ping. An
@@ -7627,6 +7634,7 @@ fn ensure_desktop_workspace(
     workspace: &protocol::GlobalWorkspaceSnapshot,
     terminal_override: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
+    hyprland::apply_workspace_layout(&workspace.id)?;
     if hyprland::workspace_has_windows(&workspace.id)? {
         return Ok(());
     }

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -1113,6 +1113,44 @@ pub struct BootstrapSession {
     stderr_reader: Option<MasterStderrReader>,
 }
 
+struct TerminalForegroundGuard {
+    terminal: fs::File,
+    original_group: i32,
+}
+
+impl TerminalForegroundGuard {
+    fn acquire(terminal: fs::File, group: i32) -> io::Result<Self> {
+        let original_group = unsafe { libc::tcgetpgrp(terminal.as_raw_fd()) };
+        if original_group == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        set_terminal_foreground(terminal.as_raw_fd(), group)?;
+        Ok(Self {
+            terminal,
+            original_group,
+        })
+    }
+}
+
+impl Drop for TerminalForegroundGuard {
+    fn drop(&mut self) {
+        let _ = set_terminal_foreground(self.terminal.as_raw_fd(), self.original_group);
+    }
+}
+
+fn set_terminal_foreground(fd: i32, group: i32) -> io::Result<()> {
+    unsafe {
+        let previous = libc::signal(libc::SIGTTOU, libc::SIG_IGN);
+        let result = libc::tcsetpgrp(fd, group);
+        libc::signal(libc::SIGTTOU, previous);
+        if result == -1 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SshProbeOutput {
     pub stdout: Vec<u8>,
@@ -1124,6 +1162,8 @@ type BoundedReader = thread::JoinHandle<io::Result<(Vec<u8>, bool)>>;
 trait StderrMirror: Write + AsRawFd + Send {}
 
 impl<T: Write + AsRawFd + Send> StderrMirror for T {}
+
+type InteractiveTerminal = (Option<Box<dyn StderrMirror>>, Option<fs::File>);
 
 #[derive(Debug, Clone, Copy)]
 enum MasterStderrEvent {
@@ -1161,14 +1201,23 @@ impl BootstrapSession {
             .filter(|home| !home.is_empty())
             .map(PathBuf::from)
             .map(|home| home.join(".ssh/config"));
-        let stderr_mirror = match authentication {
-            SshAuthenticationMode::Interactive => Some(Box::new(
-                OpenOptions::new()
-                    .write(true)
-                    .custom_flags(libc::O_CLOEXEC | libc::O_NONBLOCK)
-                    .open("/dev/tty")?,
-            ) as Box<dyn StderrMirror>),
-            SshAuthenticationMode::Batch => None,
+        let (stderr_mirror, foreground_terminal) = match authentication {
+            SshAuthenticationMode::Interactive => (
+                Some(Box::new(
+                    OpenOptions::new()
+                        .write(true)
+                        .custom_flags(libc::O_CLOEXEC | libc::O_NONBLOCK)
+                        .open("/dev/tty")?,
+                ) as Box<dyn StderrMirror>),
+                Some(
+                    OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .custom_flags(libc::O_CLOEXEC)
+                        .open("/dev/tty")?,
+                ),
+            ),
+            SshAuthenticationMode::Batch => (None, None),
         };
         Self::open_at_with_mirror(
             runtime_directory,
@@ -1177,7 +1226,7 @@ impl BootstrapSession {
             authentication,
             timeout,
             OsStr::new("ssh"),
-            stderr_mirror,
+            (stderr_mirror, foreground_terminal),
         )
     }
 
@@ -1197,7 +1246,7 @@ impl BootstrapSession {
             authentication,
             timeout,
             program,
-            None,
+            (None, None),
         )
     }
 
@@ -1208,8 +1257,9 @@ impl BootstrapSession {
         authentication: SshAuthenticationMode,
         timeout: Duration,
         program: &OsStr,
-        stderr_mirror: Option<Box<dyn StderrMirror>>,
+        interactive_terminal: InteractiveTerminal,
     ) -> io::Result<Self> {
+        let (stderr_mirror, foreground_terminal) = interactive_terminal;
         if timeout.is_zero() || timeout > MAX_PROBE_TIMEOUT {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -1229,8 +1279,12 @@ impl BootstrapSession {
             .stdout(Stdio::null())
             .stderr(Stdio::piped());
         unsafe {
-            command.pre_exec(|| {
-                if libc::setsid() == -1 {
+            command.pre_exec(move || {
+                let result = match authentication {
+                    SshAuthenticationMode::Interactive => libc::setpgid(0, 0),
+                    SshAuthenticationMode::Batch => libc::setsid(),
+                };
+                if result == -1 {
                     Err(io::Error::last_os_error())
                 } else {
                     Ok(())
@@ -1250,6 +1304,17 @@ impl BootstrapSession {
             let _ = fs::remove_dir_all(&directory);
             io::Error::other(format!("child PID overflow: {error}"))
         })?;
+        let _foreground = match foreground_terminal {
+            Some(terminal) => match TerminalForegroundGuard::acquire(terminal, master_pid) {
+                Ok(foreground) => Some(foreground),
+                Err(error) => {
+                    let _ = kill_process_group(master_pid, &mut master);
+                    let _ = fs::remove_dir_all(&directory);
+                    return Err(error);
+                }
+            },
+            None => None,
+        };
         let stderr = match master.stderr.take() {
             Some(stderr) => stderr,
             None => {
@@ -4896,7 +4961,7 @@ mod tests {
                 authentication,
                 Duration::from_secs(2),
                 ssh.as_os_str(),
-                Some(Box::new(mirror)),
+                (Some(Box::new(mirror)), None),
             )
             .unwrap();
 
@@ -4932,7 +4997,7 @@ mod tests {
             SshAuthenticationMode::Batch,
             Duration::from_secs(2),
             ssh.as_os_str(),
-            Some(Box::new(mirror)),
+            (Some(Box::new(mirror)), None),
         )
         .err()
         .expect("the fake master must fail authentication");
@@ -4962,7 +5027,7 @@ mod tests {
             SshAuthenticationMode::Interactive,
             Duration::from_secs(10),
             ssh.as_os_str(),
-            Some(Box::new(mirror)),
+            (Some(Box::new(mirror)), None),
         )
         .err()
         .expect("oversized master stderr must fail");

--- a/tests/native_backend/remote_bootstrap.rs
+++ b/tests/native_backend/remote_bootstrap.rs
@@ -199,6 +199,20 @@ fn fake_challenge_ssh(directory: &Path) {
     fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
 }
 
+fn fake_terminal_prompt_ssh(directory: &Path) {
+    let ssh = directory.join("ssh");
+    let authentication = directory.join("authentication");
+    fs::write(
+        &ssh,
+        format!(
+            "#!/bin/sh\ncontrol=; previous=; master=false; check=false\nfor arg do\n  case \"$previous\" in -S) control=$arg ;; -O) [ \"$arg\" = check ] && check=true ;; esac\n  case \"$arg\" in ControlPath=*) control=${{arg#ControlPath=}} ;; -N) master=true ;; esac\n  previous=$arg\ndone\nif $master; then\n  printf 'SSH password: ' > /dev/tty\n  IFS= read -r password < /dev/tty || exit 70\n  printf '%s' \"$password\" > '{}'\n  : > \"$control.ready\"\n  trap 'rm -f \"$control.ready\"' EXIT HUP INT TERM\n  while :; do sleep 60; done\nfi\nif $check; then [ -e \"$control.ready\" ]; exit; fi\nexit 64\n",
+            authentication.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
 fn command(directory: &Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
     command
@@ -1017,6 +1031,33 @@ fn guided_node_add_mirrors_master_challenge_and_waits_after_failure() {
     assert!(child.try_wait().unwrap().is_none());
     master.write_all(b"\n").unwrap();
     assert_eq!(child.wait().unwrap().code(), Some(1));
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn guided_node_add_allows_ssh_to_read_authentication_from_the_terminal() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_terminal_prompt_ssh(&directory);
+
+    let (status, output) = run_interactive(
+        &directory,
+        &["__guided-node-add"],
+        b"workbox\nwork\nsecret\n\n",
+    );
+    let output = String::from_utf8_lossy(&output);
+    assert_eq!(status.code(), Some(1), "{output}");
+    assert!(
+        output.contains("Complete any SSH authentication prompt or login URL"),
+        "{output}"
+    );
+    assert!(output.contains("SSH password:"), "{output}");
+    assert_eq!(
+        fs::read(directory.join("authentication")).unwrap(),
+        b"secret"
+    );
+    assert!(output.contains("Node setup failed (exit 1)."), "{output}");
     fs::remove_dir_all(directory).unwrap();
 }
 


### PR DESCRIPTION
## Summary
- keep interactive SSH bootstrap in the foreground terminal so passwords, host-key prompts, and login URLs can be completed during guided Node setup
- explain the authentication step before connecting and retain existing bounded stderr mirroring and batch isolation
- reapply the dwindle rule whenever a Boomux desktop Workspace is presented, including an already-active layer after Hyprland reload

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- focused guided Node authentication and Hyprland Workspace layer tests