### PR TITLE
fix(kiro): stage shim before host installation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1400,8 +1400,10 @@ Boomux does not share that file with unrelated Kiro configuration.
 Eligible managed Kiro invocations pass through the common Shell-scoped shim and
 hidden launcher. A bare `kiro-cli` becomes `kiro-cli --v3`, while an explicit
 leading `--v3` is preserved. Both receive `BOOMUX_KIRO_RUN_SCOPED=1` only while
-the installed asset is current. Kiro v2 and service invocations, absolute paths
-typed in a login Shell,
+the installed asset is current. Eligible login ShellRuns stage the delegating
+shim even when Kiro is not yet installed, so a later installation into their
+existing executable search path does not bypass lifecycle integration. Kiro v2
+and service invocations, absolute paths typed in a login Shell,
 modified PATHs, absent or modified assets, and use outside Boomux execute stock
 Kiro unchanged and untracked. Exact configured executable paths are retained
 through `BOOMUX_REAL_KIRO`; private launcher provenance is removed from unrelated

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1222,16 +1222,6 @@ fn inject_opencode_shim_environment(
     let real_claude = resolve_executable(environment, Some(&shim_dir), "claude");
     let real_codex = resolve_codex_executable(environment, Some(&shim_dir));
     let real_kiro = resolve_kiro_executable(environment, Some(&shim_dir));
-    if real_opencode.is_none()
-        && real_claude.is_none()
-        && real_codex.is_none()
-        && real_kiro.is_none()
-    {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "supported Agent executables are unavailable",
-        ));
-    }
     let boomux = env::current_exe()?.canonicalize()?;
     let boomux_metadata = fs::metadata(&boomux)?;
     if !boomux.is_absolute()
@@ -1272,9 +1262,7 @@ fn inject_opencode_shim_environment(
     if real_codex.is_some() {
         atomic_runtime_asset(&shim_dir.join("codex"), CODEX_SHIM, 0o700)?;
     }
-    if real_kiro.is_some() {
-        atomic_runtime_asset(&shim_dir.join("kiro-cli"), KIRO_SHIM, 0o700)?;
-    }
+    atomic_runtime_asset(&shim_dir.join("kiro-cli"), KIRO_SHIM, 0o700)?;
 
     let original_path = environment_value(environment, b"PATH").unwrap_or_default();
     let mut paths = vec![shim_dir.clone()];
@@ -20160,7 +20148,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_real_opencode_leaves_the_sanitized_environment_usable() {
+    fn missing_agent_hosts_still_prepare_the_late_install_kiro_shim() {
         let directory = env::temp_dir().join(format!("boomux-opencode-missing-{}", Uuid::new_v4()));
         let runtime = directory.join("runtime");
         let empty_bin = directory.join("bin");
@@ -20168,8 +20156,17 @@ mod tests {
         fs::create_dir_all(&empty_bin).unwrap();
         let environment = test_environment(&[("XDG_RUNTIME_DIR", &runtime), ("PATH", &empty_bin)]);
         let sanitized = sanitize_opencode_shim_environment(&environment);
-        assert!(inject_opencode_shim_environment(&sanitized, true).is_err());
-        assert_eq!(sanitized, environment);
+        let injected = inject_opencode_shim_environment(&sanitized, true).unwrap();
+        let shim_dir =
+            PathBuf::from(environment_value(&injected, b"BOOMUX_OPENCODE_SHIM_DIR").unwrap());
+        assert!(shim_dir.join("kiro-cli").is_file());
+        assert_eq!(environment_value(&injected, b"BOOMUX_REAL_KIRO"), None);
+        assert_eq!(
+            env::split_paths(&environment_value(&injected, b"PATH").unwrap())
+                .next()
+                .as_deref(),
+            Some(shim_dir.as_path())
+        );
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -306,7 +306,7 @@ pub const KIRO: IntegrationDescriptor = IntegrationDescriptor {
         asset_name: "hooks",
         content: include_str!("../integrations/kiro/boomux.json"),
         executable: "kiro-cli",
-        reload_message: "Restart Kiro CLI in v3 mode to activate the hooks",
+        reload_message: "Reopen its managed ShellRun, then start Kiro CLI in v3 mode to activate the hooks",
         target: InstallTargetKind::Kiro,
     }),
     titles: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6684,7 +6684,7 @@ fn format_integration_statuses(statuses: &[integration_management::IntegrationSt
             output,
             "  {:<14}{}",
             "Action",
-            format_recommended_action(status.recommended_action)
+            format_recommended_action(status.name, status.recommended_action)
         )
         .expect("writing to a string cannot fail");
         writeln!(
@@ -6711,11 +6711,17 @@ fn format_runtime_status(status: &integration_management::RuntimeStatus) -> Stri
     )
 }
 
-fn format_recommended_action(action: integration_management::RecommendedAction) -> &'static str {
+fn format_recommended_action(
+    integration: &str,
+    action: integration_management::RecommendedAction,
+) -> &'static str {
     match action {
         integration_management::RecommendedAction::None => "none",
         integration_management::RecommendedAction::Install => "install integration",
         integration_management::RecommendedAction::Replace => "replace with --force",
+        integration_management::RecommendedAction::RestartHost if integration == "kiro" => {
+            "reopen managed ShellRun, then launch bare kiro-cli"
+        }
         integration_management::RecommendedAction::RestartHost => "restart host",
         integration_management::RecommendedAction::InspectError => "inspect reported error",
     }
@@ -13155,10 +13161,17 @@ fn print_integration_diagnostic(
         );
         true
     } else {
-        eprintln!(
-            "err {} integration: {} foreground process(es) are untracked; restart {} and verify it loads {path}",
-            spec.key, status.runtime.untracked_processes, spec.display_name
-        );
+        if integration == integration_management::IntegrationId::KIRO {
+            eprintln!(
+                "err {} integration: {} foreground process(es) are untracked; reopen the owning managed ShellRun, then launch bare kiro-cli and verify it loads {path}",
+                spec.key, status.runtime.untracked_processes
+            );
+        } else {
+            eprintln!(
+                "err {} integration: {} foreground process(es) are untracked; restart {} and verify it loads {path}",
+                spec.key, status.runtime.untracked_processes, spec.display_name
+            );
+        }
         false
     }
 }
@@ -17145,6 +17158,13 @@ mod tests {
             output.contains("  Runtime       untracked (3 running, 2 reporting, 1 untracked)\n")
         );
         assert!(output.contains("  Action        restart host\n"));
+        assert_eq!(
+            format_recommended_action(
+                "kiro",
+                integration_management::RecommendedAction::RestartHost
+            ),
+            "reopen managed ShellRun, then launch bare kiro-cli"
+        );
     }
 
     #[test]

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -338,7 +338,7 @@ fn bare_codex_typed_in_managed_login_shell_uses_run_scoped_hooks() {
 }
 
 #[test]
-fn bare_kiro_typed_in_managed_login_shell_selects_v3() {
+fn kiro_installed_after_managed_login_shell_start_selects_v3() {
     let mut daemon = TestDaemon::start();
     let bin = daemon.runtime_dir.join("kiro-login-bin");
     let home = daemon.runtime_dir.join("kiro-login-home");
@@ -352,18 +352,6 @@ fn bare_kiro_typed_in_managed_login_shell_selects_v3() {
         include_str!("../../integrations/kiro/boomux.json"),
     )
     .unwrap();
-    let kiro = bin.join("kiro-cli");
-    fs::write(
-        &kiro,
-        format!(
-            "#!/bin/sh\n: > '{}'\nfor arg do printf '%s\\0' \"$arg\" >> '{}'; done\nprintf '%s' \"${{BOOMUX_KIRO_RUN_SCOPED-unset}}\" > '{}'\n",
-            argv_output.display(),
-            argv_output.display(),
-            marker_output.display(),
-        ),
-    )
-    .unwrap();
-    fs::set_permissions(&kiro, fs::Permissions::from_mode(0o700)).unwrap();
     let workspace = daemon
         .client
         .create_workspace(
@@ -391,6 +379,18 @@ fn bare_kiro_typed_in_managed_login_shell_selects_v3() {
     };
     let mut attachment =
         attach_with_environment(&daemon.client, &workspace.shells[0].id, false, environment);
+    let kiro = bin.join("kiro-cli");
+    fs::write(
+        &kiro,
+        format!(
+            "#!/bin/sh\n: > '{}'\nfor arg do printf '%s\\0' \"$arg\" >> '{}'; done\nprintf '%s' \"${{BOOMUX_KIRO_RUN_SCOPED-unset}}\" > '{}'\n",
+            argv_output.display(),
+            argv_output.display(),
+            marker_output.display(),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&kiro, fs::Permissions::from_mode(0o700)).unwrap();
     AttachFrame::Input(b"kiro-cli\n".to_vec())
         .write_to(&mut attachment.stream)
         .unwrap();


### PR DESCRIPTION
## Summary
- stage the scoped Kiro delegator for every eligible managed login ShellRun, even before Kiro is installed
- guide users with pre-upgrade ShellRuns to reopen the ShellRun instead of repeating an ineffective host restart
- cover late Kiro installation through the native PTY boundary and document the behavior

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`