### PR TITLE
fix(tui): preserve project workspace cwd

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -577,11 +577,13 @@ refresh and preview reads are single-flight to keep stale work from accumulating
 Rendering remains a function of typed model state. One
 daemon snapshot contains each workspace, its launchers, and its shells, avoiding
 races between separate list operations. Configured project roots provide
-Workspace-name suggestions; when global Workspaces are negotiated, selecting one
-creates empty coordinator metadata without retaining its path. Older peers
-retain empty local Workspace creation. Git information is still collected
-independently from item directories and cached. Paths do not create
-Workspace-level Git identity, and mixed-directory Workspaces remain valid.
+Workspace-name suggestions. Selecting one validates its discovered path on the
+local Node and atomically creates the coordinated Workspace, its local placement,
+and a first pending Shell with that path as both Shell cwd and placement default.
+Arbitrary by-name creation still creates empty coordinator metadata, and older
+peers retain the path as the empty local Workspace default. Git information is
+still collected independently from item directories and cached. Paths do not
+create Workspace-level Git identity, and mixed-directory Workspaces remain valid.
 
 The dashboard establishes an atomic event-stream baseline and treats later
 events as invalidation signals for authoritative snapshot reprojection. It also

--- a/src/generated_names.rs
+++ b/src/generated_names.rs
@@ -28,6 +28,13 @@ pub(crate) fn random_excluding<'a>(
     from_seed(random_seed(), unavailable)
 }
 
+pub(crate) fn stable(value: &str) -> String {
+    let seed = value.bytes().fold(0xcbf2_9ce4_8422_2325, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(0x0000_0100_0000_01b3)
+    });
+    from_seed(seed, []).expect("the generated name catalog is nonempty")
+}
+
 fn random_seed() -> u64 {
     let bytes = Uuid::new_v4();
     u64::from_le_bytes(
@@ -77,6 +84,16 @@ mod tests {
             from_seed((ADJECTIVES.len() * NOUNS.len() - 1) as u64, [last.as_str()]),
             Some("agile-badger".into())
         );
+    }
+
+    #[test]
+    fn stable_names_repeat_for_the_same_value() {
+        assert_eq!(stable("edge-datapipe-support"), "noble-koala");
+        assert_eq!(
+            stable("edge-datapipe-support"),
+            stable("edge-datapipe-support")
+        );
+        assert_ne!(stable("edge-datapipe-support"), stable("boomux"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3824,6 +3824,17 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     create_dashboard_workspace(&client, &name).map_err(|error| error.to_string()),
                 )
             }
+            tui::DashboardEffect::CreateProjectWorkspace { name, default_cwd } => {
+                tui::DashboardEvent::OperationCompleted(
+                    create_dashboard_project_workspace(
+                        &client,
+                        &local_node_id,
+                        &name,
+                        &default_cwd,
+                    )
+                    .map_err(|error| error.to_string()),
+                )
+            }
             tui::DashboardEffect::CreateShell(workspace_id) => {
                 tui::DashboardEvent::ShellCreationCompleted(
                     local_dashboard_inner(&workspace_id, &local_node_id).and_then(|workspace_id| {
@@ -6023,6 +6034,46 @@ fn create_dashboard_workspace(
     }
     client.create_workspace_with_default_cwd(name, None, Vec::new())?;
     Ok(format!("Created empty workspace {name}"))
+}
+
+fn create_dashboard_project_workspace(
+    client: &client::Client,
+    local_node_id: &str,
+    name: &str,
+    project_cwd: &Path,
+) -> Result<String, Box<dyn Error>> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err("workspace name cannot be empty".into());
+    }
+    let cwd = resolve_directory(project_cwd)?;
+    if !client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
+        client.create_workspace_with_default_cwd(name, Some(cwd), Vec::new())?;
+        return Ok(format!("Created empty workspace {name}"));
+    }
+
+    let combined = client.combined_node_snapshot(Some(local_node_id.to_owned()))?;
+    let local = combined
+        .nodes
+        .iter()
+        .find(|node| node.local && node.node_id == local_node_id)
+        .filter(|node| node.workspace_owner_eligible)
+        .ok_or("local Node is not available for Workspace resources")?;
+    let shell_name = generated_names::stable(name);
+    let (workspace, shell) = client.create_global_workspace_with_shell(
+        Uuid::new_v4().to_string(),
+        Uuid::new_v4().to_string(),
+        name,
+        local.node_id.clone(),
+        Uuid::new_v4().to_string(),
+        cwd.clone(),
+        Uuid::new_v4().to_string(),
+        shell_spec(shell_name, &cwd, &[]),
+    )?;
+    Ok(format!(
+        "Created {} in {} on Node {}",
+        shell.name, workspace.name, local.alias
+    ))
 }
 
 fn create_dashboard_shell(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -860,6 +860,10 @@ pub(crate) enum DashboardEffect {
     CreateWorkspace {
         name: String,
     },
+    CreateProjectWorkspace {
+        name: String,
+        default_cwd: PathBuf,
+    },
     CreateShell(QualifiedIdentity),
     CreateGlobalShell {
         workspace_id: String,
@@ -4442,7 +4446,11 @@ fn handle_mode_key(
             }
             KeyCode::Enter if picker.selected().is_some() => {
                 let project = picker.selected().expect("selected project").clone();
-                app.create_workspace(&project.name)
+                app.mode = Mode::Normal;
+                Some(DashboardEffect::CreateProjectWorkspace {
+                    name: project.name,
+                    default_cwd: project.path,
+                })
             }
             KeyCode::Enter => {
                 app.mode = Mode::PickProject(picker);
@@ -9650,7 +9658,7 @@ mod tests {
     }
 
     #[test]
-    fn project_suggestion_creates_an_empty_workspace_regardless_of_nodes() {
+    fn project_suggestion_preserves_its_local_path_regardless_of_remote_nodes() {
         let mut app = app();
         let mut remote = app.nodes[0].clone();
         remote.id = "remote-node".into();
@@ -9663,8 +9671,9 @@ mod tests {
         }
         assert_eq!(
             handle_mode_key(&mut app, KeyCode::Enter, KeyModifiers::NONE),
-            Some(DashboardEffect::CreateWorkspace {
+            Some(DashboardEffect::CreateProjectWorkspace {
                 name: "alpha".into(),
+                default_cwd: "/tmp/alpha".into(),
             })
         );
         assert!(matches!(app.mode, Mode::Normal));

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -727,7 +727,39 @@ fn project_workspace_preflight_failure_does_not_reserve_the_name() {
         )
         .unwrap();
     assert_eq!(recovered.placements.len(), 1);
+    assert_eq!(
+        recovered.placements[0].default_cwd.as_deref(),
+        Some(Path::new("/tmp"))
+    );
+    assert_eq!(recovered_shell.cwd, PathBuf::from("/tmp"));
     assert_eq!(recovered_shell.name, "valid-different-semantics");
+    assert_eq!(
+        daemon
+            .client
+            .get_workspace(&recovered.placements[0].workspace_id)
+            .unwrap()
+            .default_cwd,
+        Some(PathBuf::from("/tmp"))
+    );
+    let (replayed, replayed_shell) = daemon
+        .client
+        .create_global_workspace_with_shell(
+            Uuid::new_v4().to_string(),
+            Uuid::new_v4().to_string(),
+            "missing-owner-project",
+            &local.node_id,
+            Uuid::new_v4().to_string(),
+            "/tmp".into(),
+            Uuid::new_v4().to_string(),
+            ShellSpec {
+                name: "valid-different-semantics".into(),
+                cwd: "/tmp".into(),
+                command: Vec::new(),
+            },
+        )
+        .unwrap();
+    assert_eq!(replayed, recovered);
+    assert_eq!(replayed_shell, recovered_shell);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve the canonical local path when selecting a configured project in the dashboard
- atomically create the coordinated Workspace, local placement, and first pending Shell with that path as the placement default
- keep arbitrary by-name creation empty and prevent local paths from being interpreted by remote Nodes
- make fresh dashboard retries semantically replayable with a stable generated-style initial Shell name

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`

Independent review found no remaining high- or medium-severity issues.