### PR TITLE
feat(node): add interactive reauthentication

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -78,6 +78,7 @@ boomux node inspect "<node-alias-or-id>" --json
 boomux node snapshot --json
 boomux node add "<alias>" "<user@host>"
 boomux node upgrade "<node>"
+boomux node reauthenticate "<node>"
 boomux node rename "<node>" "<new-alias>" --revision <revision> --json
 boomux node retarget "<node>" "<user@host>" --revision <revision> --json
 boomux node forget "<node>" --json
@@ -98,6 +99,10 @@ authorized upgrade for the selected remote Node in a native terminal.
 `node upgrade` is human-only and requires an interactive terminal. It verifies
 the registered Node identity before replacing the helper transactionally and
 gracefully restarting its daemon, including when the old helper remains protocol-compatible.
+`node reauthenticate` is human-only and uses the registration's exact stored
+route for interactive SSH authentication. It requires the pinned Node identity
+and an existing compatible helper, performs no install, upgrade, retarget, or
+registration mutation, and wakes the existing background projection observer.
 `node rekey` changes this Node's durable identity and is local, interactive, and
 human-only; use it only after the command's exact confirmation requirements are
 explicitly authorized.
@@ -615,7 +620,8 @@ terminal and refreshes for when focus returns. Enter on an Agent or Shell shows
 that same owning layer and opens only the selected terminal. Unavailable
 placement operations are reported as a warning when at least one item restored.
 
-The Nodes view inspects and refreshes registrations, starts guided setup,
+The Nodes view inspects and refreshes registrations, starts guided setup, opens
+`R` reauthentication for a selected authentication-required Node,
 revision-safely renames or retargets routes, and forgets a registration after
 confirmation. It is not a resource filter. Coordinated Workspace rows aggregate
 persisted placements while every item retains its owner Node; external owner

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Add or upgrade a Node through the interactive workflow:
 boomux node add
 boomux node list
 boomux node upgrade <node>
+boomux node reauthenticate <node>
 ```
 
 Setup verifies remote identity and requires confirmation before installation or

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1192,8 +1192,12 @@ global Workspace row aggregates qualified resources from all placements while
 each item retains its exact owner Node and owner Workspace ID. Unlinked owner
 Workspaces remain external singleton rows even when names match. External rows
 offer explicit revision-guarded adopt-as-new and link-to-existing actions. The
-Nodes tab is not a filter: it exposes inspection plus revision-pinned alias
-rename and verified retarget, confirmed route forget, and projection refresh.
+Nodes tab is not a filter: it exposes inspection plus interactive pinned-route
+reauthentication, revision-pinned alias rename and verified retarget, confirmed
+route forget, and projection refresh. Reauthentication accepts prompts only in
+its native terminal, requires an existing compatible helper and exact pinned
+identity, mutates no registration or remote installation, and then wakes the
+existing prompt-free projection observer.
 Refresh wakes that Node's existing projection worker; it never starts an
 overlapping observer.
 Resource tables place `NODE` after task identity columns rather than making Node

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -53,9 +53,10 @@ human-only. They orchestrate the default local Hyprland
 presentation and do not appear in `json_commands`, add a wire request, or expose
 compositor window identities through `boomux.cli/v1`.
 The static `hyprland_special_workspaces`, `contextual_desktop_terminal`,
-`coordinated_shell_desktop_placement`, and `desktop_workspace_show`
-features advertise that the installed CLI contains these human-facing paths;
-they do not claim that Hyprland is running or that the adapter is enabled.
+`coordinated_shell_desktop_placement`, `desktop_workspace_show`, and
+`node_reauthentication` features advertise that the installed CLI contains
+these human-facing paths; they do not claim that Hyprland is running, that the
+adapter is enabled, or that a registered Node currently needs authentication.
 
 ### Accepted Remote Node Compatibility
 
@@ -195,6 +196,13 @@ forwarded. Post-install status, restart, helper verification, handshake, and pin
 failures identify that fixed stage without exposing remote stderr.
 An already-active remote bootstrap transaction returns the existing stable
 `busy` code before changing the destination.
+`boomux node reauthenticate NODE` is human-only and absent from `json_commands`.
+It opens the registration's exact stored SSH route for normal interactive
+authentication, requires an already-compatible helper with the pinned Node
+identity, requires a subsequent prompt-free verification, revalidates unchanged
+registration state, and requests a prompt-free projection retry. It requires
+daemon protocol 38 or newer and never installs, upgrades, retargets, or mutates
+the registration.
 `boomux node upgrade NODE` is a human-only operation and rejects `--json` before
 SSH discovery or mutation. It requires a currently compatible helper to verify
 the registration's pinned Node ID, asks once after showing source, destination,

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -70,11 +70,16 @@ distinct placements atomically enlarge all related pending reservations for the
 additional future placement before either new owner dispatch proceeds.
 
 The dashboard has a dedicated Nodes tab rather than a Node filter. Inspection is
-read-only; alias rename and route retarget use registration revisions, retarget
-verifies the pinned identity before mutation, and forget requires confirmation
-and removes only the local route. Projection refresh wakes the selected Node's
-existing observer without starting an overlapping worker or changing remote
-authority.
+read-only; `R` opens interactive reauthentication for a selected
+`authentication_required` Node, alias rename and route retarget use registration
+revisions, retarget verifies the pinned identity before mutation, and forget
+requires confirmation and removes only the local route. Reauthentication uses
+the exact stored route and pinned Node identity, requires an already-compatible
+helper and a subsequent prompt-free connection, and never installs, upgrades,
+retargets, or changes registration state. Success wakes the selected Node's
+existing batch observer without starting an overlapping worker or changing
+remote authority. Daemon protocol 38 or newer is required for that explicit
+observer wake.
 Prepared operations are isolated and serialized by operation UUID, so concurrent
 identical handlers return one durable result and cancellation cannot consume an
 in-flight or completed success. Distinct first-placement requests retain their
@@ -190,8 +195,12 @@ never scans SSH configuration and automatically connects to every alias.
 The implemented registration CLI is `boomux node add ALIAS TARGET`, or guided
 interactive `boomux node add` from the dashboard command palette or Omarchy
 panel. Registration management continues with `node list`,
-`node inspect`, revision-conditional `node rename` and `node retarget`, and `node
-forget`. Human-only `node upgrade NODE` verifies the pinned identity and, after
+`node inspect`, human-only `node reauthenticate`, revision-conditional `node
+rename` and `node retarget`, and `node forget`. Reauthentication presents normal
+OpenSSH authentication in a terminal, verifies the exact stored route against
+the pinned identity and an existing compatible helper, then requests a fresh
+background observation without mutating either Node. Human-only `node upgrade
+NODE` verifies the pinned identity and, after
 confirmation, transactionally replaces a compatible registered helper without
 changing the registration. Immediately before activation it acquires a bounded
 local maintenance lease, drains admitted operations, and prevents rename,

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,6 +298,7 @@ const NON_PROTOCOL_FEATURES: &[&str] = &[
     "contextual_desktop_terminal",
     "coordinated_shell_desktop_placement",
     "desktop_workspace_show",
+    "node_reauthentication",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -603,6 +604,8 @@ enum Commands {
     GuidedNodeAdd,
     #[command(name = "__guided-node-upgrade", hide = true)]
     GuidedNodeUpgrade { selector: String },
+    #[command(name = "__guided-node-reauthenticate", hide = true)]
+    GuidedNodeReauthenticate { selector: String },
     #[command(name = "__bootstrap-activate", hide = true)]
     BootstrapActivate {
         transaction: String,
@@ -679,6 +682,8 @@ enum NodeCommands {
     List,
     /// Upgrade a registered remote Node after interactive authorization
     Upgrade { selector: String },
+    /// Reauthenticate the stored route to a registered remote Node
+    Reauthenticate { selector: String },
     /// Inspect a registered remote Node by alias or exact Node ID
     Inspect { selector: String },
     /// Show the combined Node-qualified local and cached remote projection
@@ -1532,6 +1537,7 @@ command_keys! {
     Desktop => ("desktop", HumanOnly),
     NodeAdd => ("node.add", Json),
     NodeUpgrade => ("node.upgrade", HumanOnly),
+    NodeReauthenticate => ("node.reauthenticate", HumanOnly),
     NodeList => ("node.list", Json),
     NodeInspect => ("node.inspect", Json),
     NodeSnapshot => ("node.snapshot", Json),
@@ -1647,6 +1653,9 @@ impl Cli {
             Some(Commands::Node {
                 command: NodeCommands::Upgrade { .. },
             }) => CommandKey::NodeUpgrade,
+            Some(Commands::Node {
+                command: NodeCommands::Reauthenticate { .. },
+            }) => CommandKey::NodeReauthenticate,
             Some(Commands::Node {
                 command: NodeCommands::Inspect { .. },
             }) => CommandKey::NodeInspect,
@@ -1858,6 +1867,7 @@ impl Cli {
             Some(Commands::FederationStdio) => CommandKey::Attach,
             Some(Commands::GuidedNodeAdd) => CommandKey::NodeAdd,
             Some(Commands::GuidedNodeUpgrade { .. }) => CommandKey::NodeUpgrade,
+            Some(Commands::GuidedNodeReauthenticate { .. }) => CommandKey::NodeReauthenticate,
             Some(Commands::BootstrapActivate { .. }) => CommandKey::Daemon,
         }
     }
@@ -2098,6 +2108,9 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::GuidedNodeUpgrade { selector }) => {
             return guided_node_upgrade(selector).map(CliExit::Child);
         }
+        Some(Commands::GuidedNodeReauthenticate { selector }) => {
+            return guided_node_reauthenticate(selector).map(CliExit::Child);
+        }
         Some(Commands::BootstrapActivate {
             transaction,
             expected_pid,
@@ -2268,6 +2281,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::FederationStdio) => unreachable!(),
         Some(Commands::GuidedNodeAdd) => unreachable!(),
         Some(Commands::GuidedNodeUpgrade { .. }) => unreachable!(),
+        Some(Commands::GuidedNodeReauthenticate { .. }) => unreachable!(),
         Some(Commands::BootstrapActivate { .. }) => unreachable!(),
         None => dashboard(cli.terminal.as_deref()),
     };
@@ -2473,6 +2487,77 @@ fn upgrade_node(selector: &str) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn reauthenticate_node(selector: &str) -> Result<(), Box<dyn Error>> {
+    const TIMEOUT: Duration = Duration::from_secs(120);
+
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Node reauthentication requires an interactive terminal",
+        )
+        .into());
+    }
+    let local = client::connect_or_start()?;
+    let registration = local.node_registration(selector)?;
+    if !protocol::ProtocolFeature::GlobalWorkspaces.is_supported_by(local.protocol_version()?) {
+        return Err(cli_output::failure(
+            "unsupported_version",
+            "Node reauthentication requires daemon protocol 38 or newer",
+        ));
+    }
+    println!("Node: {} ({})", registration.alias, registration.node_id);
+    println!("Stored SSH route: {}", registration.target);
+    println!(
+        "Complete any SSH authentication prompt or login URL shown in this terminal. Boomux will not install, upgrade, retarget, or modify the registration."
+    );
+    io::Write::flush(&mut io::stdout())?;
+
+    let target = ssh_bootstrap::SshTarget::parse(&registration.target)?;
+    let session = ssh_bootstrap::BootstrapSession::open(
+        target.clone(),
+        ssh_bootstrap::SshAuthenticationMode::Interactive,
+        TIMEOUT,
+    )
+    .map_err(bootstrap_cli_failure)?;
+    let connection = session
+        .connect_existing_verified(&registration.node_id, TIMEOUT)
+        .map_err(bootstrap_cli_failure)?;
+    drop(connection);
+
+    println!("Verifying that background observation can reconnect without prompts...");
+    io::Write::flush(&mut io::stdout())?;
+    let session = ssh_bootstrap::BootstrapSession::open(
+        target,
+        ssh_bootstrap::SshAuthenticationMode::Batch,
+        TIMEOUT,
+    )
+    .map_err(bootstrap_cli_failure)?;
+    let connection = session
+        .connect_existing_verified(&registration.node_id, TIMEOUT)
+        .map_err(bootstrap_cli_failure)?;
+
+    let current = local.node_registration(&registration.node_id)?;
+    if current != registration {
+        return Err(cli_output::failure(
+            "revision_changed",
+            "Node registration changed during reauthentication; refresh and retry",
+        ));
+    }
+    local.force_node_projection_refresh(&registration.node_id)?;
+    if local.node_registration(&registration.node_id)? != registration {
+        return Err(cli_output::failure(
+            "revision_changed",
+            "Node registration changed while requesting a fresh observation; refresh and retry",
+        ));
+    }
+    drop(connection);
+    println!(
+        "Authenticated {} and requested a fresh background observation",
+        registration.alias
+    );
+    Ok(())
+}
+
 fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>> {
     match command {
         NodeCommands::Add { alias, target } => {
@@ -2529,6 +2614,7 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
             }
         }
         NodeCommands::Upgrade { selector } => upgrade_node(&selector),
+        NodeCommands::Reauthenticate { selector } => reauthenticate_node(&selector),
         NodeCommands::Inspect { selector } => {
             let client = client::connect_or_start()?;
             let registration = client.node_registration(selector)?;
@@ -2724,6 +2810,25 @@ fn guided_node_upgrade(selector: &str) -> Result<process_adapter::ProcessExit, B
         &executable,
         &["node", "upgrade", selector],
         "Node upgrade",
+        &mut input,
+        &mut output,
+        interactive,
+        interactive.then(|| stdin.as_raw_fd()),
+    )
+}
+
+fn guided_node_reauthenticate(
+    selector: &str,
+) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
+    let executable = env::current_exe()?;
+    let stdin = io::stdin();
+    let interactive = stdin.is_terminal() && io::stdout().is_terminal();
+    let mut input = stdin.lock();
+    let mut output = io::stdout().lock();
+    guided_node_command_with(
+        &executable,
+        &["node", "reauthenticate", selector],
+        "Node reauthentication",
         &mut input,
         &mut output,
         interactive,
@@ -3572,6 +3677,13 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                     .map(|()| "Opened Node upgrade".into())
                     .map_err(|error| error.to_string()),
             ),
+            tui::DashboardEffect::ReauthenticateNode(node_id) => {
+                tui::DashboardEvent::OperationCompleted(
+                    terminal::open_node_reauthenticate(terminal.as_deref(), &node_id)
+                        .map(|()| "Opened Node reauthentication".into())
+                        .map_err(|error| error.to_string()),
+                )
+            }
             tui::DashboardEffect::CheckForUpdates => {
                 let result = refresh.check(&client).map_err(|error| error.to_string());
                 match result {
@@ -4508,6 +4620,8 @@ fn dashboard_state(
         schedule_editing: protocol::ProtocolFeature::AgentScheduleEditing
             .is_supported_by(refresh.negotiated_protocol),
         cached_projection_dismissal: protocol::ProtocolFeature::CachedProjectionDismissal
+            .is_supported_by(refresh.negotiated_protocol),
+        node_reauthentication: protocol::ProtocolFeature::GlobalWorkspaces
             .is_supported_by(refresh.negotiated_protocol),
         focused_terminal: dashboard_focused_terminal_view(
             refresh.negotiated_protocol,
@@ -14515,7 +14629,7 @@ mod tests {
     }
 
     #[test]
-    fn node_upgrade_and_hidden_wrapper_are_human_only() {
+    fn node_upgrade_and_reauthentication_wrappers_are_human_only() {
         let cli = Cli::try_parse_from(["boomux", "node", "upgrade", "work"]).unwrap();
         assert!(matches!(
             cli.command.as_ref(),
@@ -14524,6 +14638,24 @@ mod tests {
             }) if selector == "work"
         ));
         assert_eq!(cli.command_descriptor().key, "node.upgrade");
+
+        let cli = Cli::try_parse_from(["boomux", "node", "reauthenticate", "work"]).unwrap();
+        assert!(matches!(
+            cli.command.as_ref(),
+            Some(Commands::Node {
+                command: NodeCommands::Reauthenticate { selector }
+            }) if selector == "work"
+        ));
+        assert_eq!(cli.command_descriptor().key, "node.reauthenticate");
+        assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+
+        let cli =
+            Cli::try_parse_from(["boomux", "__guided-node-reauthenticate", "node-id"]).unwrap();
+        assert!(matches!(
+            cli.command.as_ref(),
+            Some(Commands::GuidedNodeReauthenticate { selector }) if selector == "node-id"
+        ));
+        assert_eq!(cli.command_descriptor().key, "node.reauthenticate");
         assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
 
         let cli = Cli::try_parse_from(["boomux", "__guided-node-upgrade", "node-id"]).unwrap();
@@ -17653,6 +17785,7 @@ mod tests {
             "sound_notifications",
             "integration_management",
             "desktop_workspace_show",
+            "node_reauthentication",
             "protocol_31",
             "node_registration_management",
             "pinned_node_identity",

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -1597,6 +1597,39 @@ impl BootstrapSession {
         })
     }
 
+    pub fn connect_existing_verified(
+        self,
+        expected_node_id: &str,
+        timeout: Duration,
+    ) -> io::Result<RemoteConnection> {
+        let discovery = discover_remote_in_session(&self, timeout)?;
+        let selection = inspect_remote_helpers_in_session(&self, &discovery.executables, timeout)?;
+        let helper = selection.compatible.ok_or_else(|| {
+            if let Some(error) = remote_recovery_error(discovery.recovery) {
+                return error;
+            }
+            let (code, message) = if discovery.executables.is_empty() {
+                (
+                    "install_required",
+                    "registered Node reauthentication requires an existing compatible remote helper",
+                )
+            } else {
+                (
+                    "upgrade_required",
+                    "registered Node reauthentication found no compatible remote helper",
+                )
+            };
+            classified_error(io::ErrorKind::Unsupported, code, message)
+        })?;
+        RemoteInstallIntent::ExplicitRegisteredUpgrade {
+            expected_node_id: expected_node_id.to_owned(),
+        }
+        .verify_helper_identity(&helper)?;
+        let mut connection = self.connect(helper, timeout)?;
+        connection.ping_with_timeout(timeout)?;
+        Ok(connection)
+    }
+
     pub fn connect(
         self,
         helper: CompatibleRemoteHelper,
@@ -6077,6 +6110,92 @@ mod tests {
         assert_eq!(ready.executable.as_str(), "/good/boomux");
         assert_eq!(ready.handshake.node_id, node_id);
         drop(session);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn registered_reauthentication_connects_only_the_pinned_existing_helper() {
+        let runtime = runtime_directory();
+        let node_id = Uuid::new_v4().to_string();
+        let helper = compatible_helper_script(&node_id);
+        let mutated = runtime.join("mutated");
+        let ssh = write_session_bootstrap_ssh(
+            &runtime,
+            &format!(
+                "  \"'/good/boomux' __federation-stdio\") {helper} ;;\n  *'boomux-install-transaction-v1'*|*'__bootstrap-activate'*|*'daemon restart'*) : > {}; exit 99 ;;",
+                quote_posix_shell(mutated.to_str().unwrap())
+            ),
+            "/good/boomux\\0",
+        );
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let connection = session
+            .connect_existing_verified(&node_id, Duration::from_secs(1))
+            .unwrap();
+        assert_eq!(connection.handshake.node_id, node_id);
+        drop(connection);
+        assert!(!mutated.exists());
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn registered_reauthentication_rejects_missing_and_changed_helpers_without_mutation() {
+        let runtime = runtime_directory();
+        let ssh = write_session_bootstrap_ssh(&runtime, "", "");
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let error = match session
+            .connect_existing_verified(&Uuid::new_v4().to_string(), Duration::from_secs(1))
+        {
+            Ok(_) => panic!("missing helper unexpectedly authenticated"),
+            Err(error) => error,
+        };
+        assert_eq!(error_code(&error), "install_required");
+        fs::remove_dir_all(&runtime).unwrap();
+
+        let runtime = runtime_directory();
+        let actual_node_id = Uuid::new_v4().to_string();
+        let helper = compatible_helper_script(&actual_node_id);
+        let mutated = runtime.join("mutated");
+        let ssh = write_session_bootstrap_ssh(
+            &runtime,
+            &format!(
+                "  \"'/good/boomux' __federation-stdio\") {helper} ;;\n  *'boomux-install-transaction-v1'*|*'__bootstrap-activate'*|*'daemon restart'*) : > {}; exit 99 ;;",
+                quote_posix_shell(mutated.to_str().unwrap())
+            ),
+            "/good/boomux\\0",
+        );
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let error = match session
+            .connect_existing_verified(&Uuid::new_v4().to_string(), Duration::from_secs(1))
+        {
+            Ok(_) => panic!("changed Node identity unexpectedly authenticated"),
+            Err(error) => error,
+        };
+        assert_eq!(error_code(&error), "node_identity_changed");
+        assert!(!mutated.exists());
         fs::remove_dir_all(runtime).unwrap();
     }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -396,12 +396,32 @@ pub fn open_node_upgrade(desktop_entry: Option<&str>, node_id: &str) -> Result<(
     )
 }
 
+pub fn open_node_reauthenticate(
+    desktop_entry: Option<&str>,
+    node_id: &str,
+) -> Result<(), Box<dyn Error>> {
+    let arguments = node_reauthenticate_arguments(node_id);
+    launch(
+        desktop_entry,
+        "Reauthenticate Boomux Node",
+        None,
+        attachment_executable()?.as_os_str(),
+        &arguments,
+        None,
+        false,
+    )
+}
+
 fn node_add_arguments() -> [OsString; 1] {
     ["__guided-node-add".into()]
 }
 
 fn node_upgrade_arguments(node_id: &str) -> [OsString; 2] {
     ["__guided-node-upgrade".into(), node_id.into()]
+}
+
+fn node_reauthenticate_arguments(node_id: &str) -> [OsString; 2] {
+    ["__guided-node-reauthenticate".into(), node_id.into()]
 }
 
 pub(crate) fn open_plain(desktop_entry: Option<&str>) -> Result<(), Box<dyn Error>> {
@@ -848,6 +868,17 @@ mod tests {
             node_upgrade_arguments("node;still-one-argument"),
             [
                 OsString::from("__guided-node-upgrade"),
+                OsString::from("node;still-one-argument"),
+            ]
+        );
+    }
+
+    #[test]
+    fn guided_node_reauthentication_preserves_the_exact_node_id_argument() {
+        assert_eq!(
+            node_reauthenticate_arguments("node;still-one-argument"),
+            [
+                OsString::from("__guided-node-reauthenticate"),
                 OsString::from("node;still-one-argument"),
             ]
         );

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -219,6 +219,7 @@ pub(crate) struct DashboardState {
     pub(crate) exact_run_attachment: bool,
     pub(crate) schedule_editing: bool,
     pub(crate) cached_projection_dismissal: bool,
+    pub(crate) node_reauthentication: bool,
     pub(crate) focused_terminal: Option<FocusedTerminalView>,
     pub(crate) reset_focus_revision: bool,
 }
@@ -851,6 +852,7 @@ pub(crate) enum DashboardEffect {
     Quit,
     AddNode,
     UpgradeNode(String),
+    ReauthenticateNode(String),
     SelectWorkspace {
         workspace_id: String,
     },
@@ -1105,6 +1107,7 @@ struct App {
     exact_run_attachment: bool,
     schedule_editing: bool,
     cached_projection_dismissal: bool,
+    node_reauthentication: bool,
     selected_execution_id: Option<String>,
     execution_state: TableState,
     workspace_state: TableState,
@@ -2357,6 +2360,7 @@ impl App {
             exact_run_attachment: false,
             schedule_editing: false,
             cached_projection_dismissal: false,
+            node_reauthentication: false,
             selected_execution_id: None,
             execution_state: TableState::default(),
             workspace_state,
@@ -3625,6 +3629,18 @@ impl App {
                     .filter(|node| !node.local)
                     .map(|node| DashboardEffect::UpgradeNode(node.id.clone()));
             }
+            KeyCode::Char('R') if self.primary_tab == PrimaryTab::Nodes => {
+                return self
+                    .node_state
+                    .selected()
+                    .and_then(|index| self.nodes.get(index))
+                    .filter(|node| {
+                        self.node_reauthentication
+                            && !node.local
+                            && node.health == NodeProjectionHealthCode::AuthenticationRequired
+                    })
+                    .map(|node| DashboardEffect::ReauthenticateNode(node.id.clone()));
+            }
             KeyCode::Char('p') if self.primary_tab == PrimaryTab::Schedules => {
                 return self
                     .selected_schedule()
@@ -3709,6 +3725,7 @@ impl App {
                 self.scheduling = state.scheduling;
                 self.exact_run_attachment = state.exact_run_attachment;
                 self.schedule_editing = state.schedule_editing;
+                self.node_reauthentication = state.node_reauthentication;
                 if state.reset_focus_revision {
                     self.observed_focus_revision = None;
                 }
@@ -4145,6 +4162,7 @@ pub(crate) fn run<B: DashboardBackend + Send + 'static>(
     app.exact_run_attachment = state.exact_run_attachment;
     app.schedule_editing = state.schedule_editing;
     app.cached_projection_dismissal = state.cached_projection_dismissal;
+    app.node_reauthentication = state.node_reauthentication;
     if follow_focused_terminal {
         app.enable_focus_following(state.focused_terminal.as_ref());
     }
@@ -5747,7 +5765,23 @@ fn help_lines(app: &App) -> Vec<Line<'static>> {
             }),
         );
     }
-    if app.primary_tab == PrimaryTab::Schedules {
+    if app.primary_tab == PrimaryTab::Nodes {
+        if let Some(node) = app
+            .node_state
+            .selected()
+            .and_then(|index| app.nodes.get(index))
+        {
+            lines.extend([
+                Line::from(format!("  Node: {} ({})", node.alias, short_id(&node.id))),
+                Line::from("  r wakes the prompt-free background observer."),
+                Line::from("  R opens interactive SSH reauthentication when authentication is required."),
+                Line::from("  Reauthentication uses the stored route and pinned identity; it does not retarget, install, upgrade, or change registration state."),
+                Line::from("  U opens the separately authorized helper upgrade workflow."),
+            ]);
+        } else {
+            lines.push(Line::from("  No Node selected."));
+        }
+    } else if app.primary_tab == PrimaryTab::Schedules {
         if let Some(schedule) = app.selected_schedule() {
             lines.extend([
                 Line::from(format!("  schedule: {} / {}", schedule.workspace, schedule.name)),
@@ -7641,6 +7675,21 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                     Span::styled(" restore dismissed  ", Style::new().fg(SUBTEXT)),
                 ]);
             }
+            let reauthentication_available = app.node_reauthentication
+                && app
+                    .node_state
+                    .selected()
+                    .and_then(|index| app.nodes.get(index))
+                    .is_some_and(|node| {
+                        !node.local
+                            && node.health == NodeProjectionHealthCode::AuthenticationRequired
+                    });
+            if reauthentication_available {
+                spans.extend([
+                    Span::styled("R", Style::new().fg(YELLOW)),
+                    Span::styled(" reauthenticate  ", Style::new().fg(SUBTEXT)),
+                ]);
+            }
             spans.extend([
                 Span::styled("U", Style::new().fg(GREEN)),
                 Span::styled(" upgrade  ", Style::new().fg(SUBTEXT)),
@@ -8526,6 +8575,7 @@ mod tests {
                 "missing {expected}: {rendered}"
             );
         }
+        assert!(!rendered.contains("reauthenticate"));
     }
 
     #[test]
@@ -8622,8 +8672,15 @@ mod tests {
         remote.node.local = false;
         remote.node.route = Some("user@work".into());
         remote.node.registration_revision = Some(7);
+        remote.node.health = NodeProjectionHealthCode::AuthenticationRequired;
         let mut app = App::new(vec![remote], project_context());
         app.select_tab(PrimaryTab::Nodes);
+        assert!(!rendered_text(&mut app, 180, 24).contains("reauthenticate"));
+        app.node_reauthentication = true;
+        assert!(rendered_text(&mut app, 180, 24).contains("reauthenticate"));
+        app.nodes[0].health = NodeProjectionHealthCode::Reconnecting;
+        assert_eq!(app.update_key(KeyCode::Char('R'), KeyModifiers::NONE), None);
+        app.nodes[0].health = NodeProjectionHealthCode::AuthenticationRequired;
         assert_eq!(app.update_key(KeyCode::Char('u'), KeyModifiers::NONE), None);
         assert!(!rendered_text(&mut app, 180, 24).contains("restore dismissed"));
         app.cached_projection_dismissal = true;
@@ -8641,6 +8698,11 @@ mod tests {
         assert!(matches!(
             app.update_key(KeyCode::Char('U'), KeyModifiers::NONE),
             Some(DashboardEffect::UpgradeNode(node_id))
+                if node_id == "00000000-0000-0000-0000-000000000002"
+        ));
+        assert!(matches!(
+            app.update_key(KeyCode::Char('R'), KeyModifiers::NONE),
+            Some(DashboardEffect::ReauthenticateNode(node_id))
                 if node_id == "00000000-0000-0000-0000-000000000002"
         ));
 

--- a/tests/native_backend/remote_bootstrap.rs
+++ b/tests/native_backend/remote_bootstrap.rs
@@ -950,6 +950,63 @@ fn upgraded_node_add_registers_after_the_precommit_ping_channel_closes() {
 }
 
 #[test]
+fn registered_node_reauthentication_is_interactive_read_only_and_requests_projection_retry() {
+    let directory = test_directory();
+    fs::create_dir_all(directory.join("home/.ssh")).unwrap();
+    fs::create_dir_all(directory.join("runtime")).unwrap();
+    fake_ssh(&directory, "/remote/boomux\\0", false);
+
+    let add = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["node", "add", "work", "workbox", "--json"])
+        .env("PATH", format!("{}:/usr/bin:/bin", directory.display()))
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "Node registration failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let registration_path = directory.join("state/boomux/node_registrations.json");
+    let registration_before = fs::read(&registration_path).unwrap();
+
+    let (status, output) = run_interactive(&directory, &["node", "reauthenticate", "work"], b"");
+    assert!(
+        status.success(),
+        "Node reauthentication failed with {status}: {}",
+        String::from_utf8_lossy(&output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output)
+            .contains("Authenticated work and requested a fresh background observation")
+    );
+    assert_eq!(fs::read(&registration_path).unwrap(), registration_before);
+    let ssh_log = fs::read_to_string(directory.join("ssh.log")).unwrap();
+    for forbidden in [
+        "boomux-install-transaction-v1",
+        "boomux-install-activation-v1",
+        "daemon restart",
+    ] {
+        assert!(
+            !ssh_log.contains(forbidden),
+            "unexpected {forbidden} command"
+        );
+    }
+
+    let _ = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .args(["daemon", "stop"])
+        .env("HOME", directory.join("home"))
+        .env("XDG_RUNTIME_DIR", directory.join("runtime"))
+        .env("XDG_STATE_HOME", directory.join("state"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
 fn guided_node_add_mirrors_master_challenge_and_waits_after_failure() {
     let directory = test_directory();
     fs::create_dir_all(directory.join("home/.ssh")).unwrap();


### PR DESCRIPTION
## Summary
- add a human-only Node reauthentication command and guided terminal wrapper
- verify the stored route, pinned identity, compatible helper, and prompt-free reconnect without remote or registration mutation
- expose eligibility-gated reauthentication in the native Nodes TUI and advertise the capability

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --bins --locked (436 passed)
- cargo test --lib --locked (465 passed; one concurrent bootstrap timing test passed on isolated rerun)
- cargo test --test native_backend --locked -- --test-threads=1 (150 passed)
- bun integration suite previously passed before the final capability-only changes
- git diff --check