### PR TITLE
fix(kiro): report stop as idle

### DIFF
--- a/docs/adr/0007-bind-kiro-v3-hooks-to-managed-runs.md
+++ b/docs/adr/0007-bind-kiro-v3-hooks-to-managed-runs.md
@@ -1,6 +1,6 @@
 # Bind Kiro V3 Hooks To Managed Runs
 
-Status: Accepted
+Status: Accepted; Stop lifecycle semantics superseded by ADR 0009
 
 Kiro CLI v3 supports global standalone hooks whose payload contains the
 canonical `session_id`, but a global hook alone does not establish which Boomux

--- a/docs/adr/0009-treat-kiro-v3-stop-as-idle.md
+++ b/docs/adr/0009-treat-kiro-v3-stop-as-idle.md
@@ -1,0 +1,23 @@
+# Treat Kiro V3 Stop As Idle
+
+Status: Accepted
+
+Kiro CLI v3 documents the standalone `Stop` hook as firing after the agent has
+completed its turn and finished responding to the user. A live authenticated
+Kiro CLI `2.18.0` turn produced `UserPromptSubmit`, then `Stop` after the final
+assistant response and return to the input prompt. Boomux therefore reports
+Working for prompt and tool activity and Idle for Stop on the exact Session
+bound through the live Launch Holder.
+
+Idle means that the observed turn finished and the Session can accept another
+prompt. It does not mean the Session is permanently complete. Kiro still exposes
+no standalone hook for permission waits, durable Session completion, or process
+inactivity, so Boomux does not infer Blocked or Done. Final holder release remains
+the authority for Inactive.
+
+This supersedes only the Stop-to-Unknown decision in ADR 0007. Its managed-run
+binding, holder authority, exact Session identity, and process-exit semantics
+remain unchanged. Protocol 46 advertises the changed admission semantics; a new
+client downgrades Stop to Unknown for a protocol-45 daemon. The wire shape and
+durable representation are unchanged, so no persistence version change is
+required.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,6 +189,10 @@ generation 6 and transfers live holders and their exact Session/Agent
 associations; cold recovery starts with none. Capacity is 256 holders with 16
 Sessions per holder, whose maximal handoff encoding remains below the control
 frame bound.
+Protocol 46 adds `kiro_stop_idle`. Kiro v3 Stop hooks report Idle turn
+completion. Protocol-46 clients downgrade Stop to Unknown when connected to a
+protocol-45 daemon, preserving the original holder-report admission contract.
+The wire shape, durable state, events, and handoff generation are unchanged.
 Remote notification presentation reuses protocol-32 atomic reduced transitions,
 so it does not require a later protocol. Node-cache schema 2 adds bounded local
 at-most-once individual and reconnect-digest claims with an explicit schema-1
@@ -1434,20 +1438,18 @@ children.
 
 Kiro hook `session_id` is the canonical Session identity and ensures the exact
 `(kiro, session, shell, run)` Agent key through its live Launch Holder. Prompt and
-tool events report Working.
-Kiro runs hooks in isolated sub-agent executions, but the standalone SessionStart
-and Stop payloads do not identify whether the event belongs to the root execution.
-Those boundaries therefore report Unknown rather than Idle and cannot produce a
-completion notification. The documented hooks expose no authoritative
-permission-wait, session-inactivity, error, or permanent-completion event, so
-Boomux never derives Blocked, Idle, or Done for Kiro. Exact supervised process
-exit releases its holder; if no other live holder owns that canonical Session,
-Boomux reports Inactive at lifecycle integration authority. Concurrent holders
-for one Session keep it active until the final release. Late hooks from dead
-holders fail closed inside Boomux and remain fail-open to Kiro. If one Kiro
-process switches canonical Sessions without ending the old one, both histories
-remain truthful and cold recovery refuses the resulting ambiguity rather than
-guessing.
+tool events report Working. Kiro v3 documents Stop as the boundary where the
+agent completed its turn and finished responding, so Stop reports Idle for that
+exact Session. Idle is resumable turn completion, not permanent Session
+completion. The documented hooks expose no authoritative permission-wait,
+session-inactivity, error, or permanent-completion event, so Boomux never derives
+Blocked or Done for Kiro. Exact supervised process exit releases its holder; if
+no other live holder owns that canonical Session, Boomux reports Inactive at
+lifecycle integration authority. Concurrent holders for one Session keep it
+active until the final release. Late hooks from dead holders fail closed inside
+Boomux and remain fail-open to Kiro. If one Kiro process switches canonical
+Sessions without ending the old one, both histories remain truthful and cold
+recovery refuses the resulting ambiguity rather than guessing.
 
 Exact resume uses `kiro-cli --v3 chat --resume-id <session-id>`. Scheduled work
 uses `kiro-cli --v3 chat --no-interactive --` with the exact prompt as one argv

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -502,6 +502,9 @@ projection field.
 Protocol 45 adds `protocol_45` and `kiro_exact_launch_holders`. Holder acquire,
 hook report, and release are private local protocol messages and add no public
 CLI JSON field, snapshot field, event, or remote Node projection field.
+Protocol 46 adds `protocol_46` and `kiro_stop_idle`. The Kiro hook report wire
+shape is unchanged; new clients report Stop as Unknown to protocol-45 daemons
+and Idle to protocol-46 daemons. No public CLI JSON shape changes.
 
 Protocol-38 `workspace create` creates empty coordinator metadata without a
 default Node or cwd. First global `shell create`, `launcher create`, or

--- a/docs/lifecycle-validation.md
+++ b/docs/lifecycle-validation.md
@@ -7,6 +7,17 @@ This record separates observed host behavior from reducer fixtures and intended
 semantics. Host compatibility is not inferred from process names, terminal
 output, or database recency.
 
+## 2026-08-25
+
+Kiro CLI `2.18.0` was live-validated in a Boomux-managed ShellRun with the
+installed standalone v3 hook asset. Submitting `hi` produced authoritative
+`UserPromptSubmit` Working evidence for one canonical Session; after Kiro
+rendered its final assistant response and returned to the input prompt, the same
+Session produced a `Stop` event. Current Kiro v3 documentation defines Stop as
+firing when the agent has completed its turn and finished responding. Boomux
+therefore treats Stop as Idle turn completion while retaining final holder
+release as Inactive and making no Blocked or Done claim.
+
 ## 2026-08-24
 
 Hyprland `0.56.2` was live-validated with the special-Workspace desktop adapter,
@@ -78,7 +89,8 @@ permission wait, cloud Session, or Kiro Web handoff was exercised. No Blocked,
 Idle, Inactive, Done, cloud lifecycle, catalog, or native web capability is
 claimed. Kiro documents isolated sub-agent hook execution but no root-execution
 field in standalone SessionStart or Stop payloads, so fixtures reduce those
-ambiguous boundaries to Unknown.
+ambiguous boundaries to Unknown. The Stop mapping was superseded by the
+2026-08-25 live validation and current v3 hook contract above.
 
 Codex CLI `0.147.0` was inspected against the documented hooks and experimental
 app-server interfaces. Repository tests validate bounded hook decoding,

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentScheduleInspection,
-    AgentScheduleSnapshot, AgentScheduleSpec, AgentScheduleUpdate,
+    AgentScheduleSnapshot, AgentScheduleSpec, AgentScheduleUpdate, AgentState,
     ClaudeRemoteControlBindingSnapshot, CombinedNodeSnapshot, DaemonEvent, Envelope, ErrorCode,
     EventCursor, FocusedTerminalSnapshot, NodeProjectionHealth, NodeRegistrationSnapshot,
     NotificationDeliveryConfig, OpenCodeSessionClaimSnapshot, OpenCodeSharedRuntimeSnapshot,
@@ -1567,13 +1567,27 @@ impl Client {
         &self,
         holder_id: impl Into<String>,
         session_id: impl Into<String>,
-        report: AgentReport,
+        mut report: AgentReport,
     ) -> Result<AgentInstanceSnapshot> {
-        match self.request(Request::ReportKiroHook {
-            holder_id: holder_id.into(),
-            session_id: session_id.into(),
-            report,
-        })? {
+        let holder_id = holder_id.into();
+        let session_id = session_id.into();
+        let response = match self.request(Request::ReportKiroHook {
+            holder_id: holder_id.clone(),
+            session_id: session_id.clone(),
+            report: report.clone(),
+        }) {
+            Err(ClientError::Protocol(ProtocolError::UnsupportedVersion(_)))
+                if downgrade_kiro_stop_report(&mut report) =>
+            {
+                self.request(Request::ReportKiroHook {
+                    holder_id,
+                    session_id,
+                    report,
+                })?
+            }
+            result => result?,
+        };
+        match response {
             Response::Agent { agent } => Ok(agent),
             other => unexpected(other),
         }
@@ -2283,6 +2297,15 @@ fn daemon_lock_available(socket_path: &Path) -> io::Result<bool> {
     }
 }
 
+fn downgrade_kiro_stop_report(report: &mut AgentReport) -> bool {
+    if report.state != AgentState::Idle {
+        return false;
+    }
+    report.state = AgentState::Unknown;
+    report.evidence = "Kiro hook execution stopped".into();
+    true
+}
+
 fn expect_ok(actual: Response, expected: Response) -> Result<()> {
     if actual == expected {
         Ok(())
@@ -2309,6 +2332,7 @@ mod tests {
     fn reject_protocol(listener: &UnixListener, attempted: u32, supported: u32) {
         reject_protocol_once(listener, attempted, supported);
         if attempted == protocol::PROTOCOL_VERSION && supported == 41 {
+            reject_protocol_once(listener, 45, supported);
             reject_protocol_once(listener, 44, supported);
             reject_protocol_once(listener, 43, supported);
             reject_protocol_once(listener, 42, supported);
@@ -2428,6 +2452,7 @@ mod tests {
         let (client_done_sender, client_done_receiver) = mpsc::channel();
         let server = thread::spawn(move || {
             for _ in 0..3 {
+                reject_protocol_once(&listener, 46, 42);
                 reject_protocol_once(&listener, 45, 42);
                 reject_protocol_once(&listener, 44, 42);
                 reject_protocol_once(&listener, 43, 42);
@@ -2463,6 +2488,96 @@ mod tests {
             ));
         }
         client_done_sender.send(()).unwrap();
+
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn kiro_stop_idle_downgrades_when_daemon_is_replaced_by_protocol_forty_five() {
+        let directory = env::temp_dir().join(format!("boomux-client-kiro-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 46);
+            assert!(matches!(
+                request.message,
+                Request::ReportKiroHook {
+                    report: AgentReport {
+                        state: AgentState::Idle,
+                        ..
+                    },
+                    ..
+                }
+            ));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    45,
+                    Response::Error {
+                        message: "protocol 46 unsupported".into(),
+                        code: Some(ErrorCode::UnsupportedVersion),
+                    },
+                ),
+            )
+            .unwrap();
+            reject_protocol_once(&listener, 46, 45);
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 45);
+            assert!(matches!(request.message, Request::Ping));
+            protocol::write_message(&mut stream, &Envelope::with_version(45, Response::Pong))
+                .unwrap();
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 45);
+            assert!(matches!(
+                request.message,
+                Request::ReportKiroHook {
+                    report: AgentReport {
+                        state: AgentState::Unknown,
+                        ..
+                    },
+                    ..
+                }
+            ));
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    45,
+                    Response::Error {
+                        message: "test complete".into(),
+                        code: Some(ErrorCode::NotFound),
+                    },
+                ),
+            )
+            .unwrap();
+        });
+        let client = Client::from_socket_path(socket);
+
+        let error = client
+            .report_kiro_hook(
+                "holder-1",
+                "session-1",
+                AgentReport {
+                    state: AgentState::Idle,
+                    authority: protocol::AgentAuthority::LifecycleIntegration,
+                    evidence: "Kiro session idle".into(),
+                    confidence: 100,
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ClientError::Remote(RemoteError {
+                code: Some(ErrorCode::NotFound),
+                ..
+            })
+        ));
 
         server.join().unwrap();
         fs::remove_dir_all(directory).unwrap();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12833,10 +12833,13 @@ impl DaemonService {
             .map_err(|error| DaemonError::validation(error.to_string()))?;
         validate_agent_report(&report)?;
         if report.authority != AgentAuthority::LifecycleIntegration
-            || !matches!(report.state, AgentState::Unknown | AgentState::Working)
+            || !matches!(
+                report.state,
+                AgentState::Unknown | AgentState::Working | AgentState::Idle
+            )
         {
             return Err(DaemonError::validation(
-                "Kiro hooks may report only Unknown or Working at lifecycle integration authority",
+                "Kiro hooks may report only Unknown, Working, or Idle at lifecycle integration authority",
             ));
         }
         let (response, holders) = self.durable_mutation_outcome(|undo| {
@@ -21034,6 +21037,43 @@ mod tests {
             panic!("expected Kiro Agent");
         };
         agent
+    }
+
+    #[test]
+    fn kiro_hooks_accept_only_documented_lifecycle_states() {
+        let registry = DaemonService::default();
+        let (_, shell, _) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let (holder_id, mut process) = test_kiro_holder(&registry, &shell.id, &run_id);
+
+        for state in [AgentState::Unknown, AgentState::Working, AgentState::Idle] {
+            let Response::Agent { agent } = registry
+                .dispatch(Request::ReportKiroHook {
+                    holder_id: holder_id.clone(),
+                    session_id: "session-a".into(),
+                    report: kiro_report(state),
+                })
+                .unwrap()
+            else {
+                panic!("expected Kiro Agent");
+            };
+            assert_eq!(agent.observation.state, state);
+        }
+        for state in [AgentState::Blocked, AgentState::Inactive, AgentState::Done] {
+            assert!(
+                registry
+                    .dispatch(Request::ReportKiroHook {
+                        holder_id: holder_id.clone(),
+                        session_id: "session-a".into(),
+                        report: kiro_report(state),
+                    })
+                    .is_err(),
+                "accepted unsupported Kiro state {state:?}"
+            );
+        }
+
+        process.kill().unwrap();
+        process.wait().unwrap();
     }
 
     #[test]

--- a/src/kiro_hooks.rs
+++ b/src/kiro_hooks.rs
@@ -65,7 +65,7 @@ fn reduce(event: HookEvent) -> LifecycleObservation {
         HookEvent::UserPromptSubmit => (AgentState::Working, "Kiro processing prompt"),
         HookEvent::PreToolUse => (AgentState::Working, "Kiro using tool"),
         HookEvent::PostToolUse => (AgentState::Working, "Kiro tool completed"),
-        HookEvent::Stop => (AgentState::Unknown, "Kiro hook execution stopped"),
+        HookEvent::Stop => (AgentState::Idle, "Kiro session idle"),
     };
     LifecycleObservation { state, evidence }
 }
@@ -83,13 +83,13 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_events_reduce_without_inventing_unsupported_states() {
+    fn lifecycle_events_reduce_to_documented_states() {
         let cases = [
             ("SessionStart", AgentState::Unknown),
             ("UserPromptSubmit", AgentState::Working),
             ("PreToolUse", AgentState::Working),
             ("PostToolUse", AgentState::Working),
-            ("Stop", AgentState::Unknown),
+            ("Stop", AgentState::Idle),
         ];
         for (event, state) in cases {
             let update = update(event);
@@ -97,7 +97,7 @@ mod tests {
             assert_eq!(update.observation.state, state, "{event}");
             assert!(!matches!(
                 update.observation.state,
-                AgentState::Blocked | AgentState::Idle | AgentState::Inactive | AgentState::Done
+                AgentState::Blocked | AgentState::Inactive | AgentState::Done
             ));
         }
     }
@@ -109,7 +109,7 @@ mod tests {
             ("userPromptSubmit", AgentState::Working),
             ("preToolUse", AgentState::Working),
             ("postToolUse", AgentState::Working),
-            ("stop", AgentState::Unknown),
+            ("stop", AgentState::Idle),
         ] {
             assert_eq!(update(event).observation.state, state, "{event}");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11649,6 +11649,7 @@ fn kiro_hook_command() -> Result<(), Box<dyn Error>> {
         _ => return Ok(()),
     };
     let update = kiro_hooks::read_update(io::stdin().lock())?;
+    let client = client::connect_or_start()?;
     let observation = update.observation;
     let report = AgentReport {
         state: observation.state,
@@ -11656,7 +11657,6 @@ fn kiro_hook_command() -> Result<(), Box<dyn Error>> {
         evidence: observation.evidence.into(),
         confidence: 100,
     };
-    let client = client::connect_or_start()?;
     client.report_kiro_hook(holder_id, update.session_id, report)?;
     Ok(())
 }
@@ -17821,7 +17821,7 @@ mod tests {
                 .validated_version,
             "2.1.236"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 45);
+        assert_eq!(protocol::PROTOCOL_VERSION, 46);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 45;
+pub const PROTOCOL_VERSION: u32 = 46;
 pub const MIN_PROTOCOL_VERSION: u32 = 6;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -201,6 +201,10 @@ define_protocol_features! {
     KiroLaunchHolders => (45, "Kiro exact launch holders", [
         "protocol_45",
         "kiro_exact_launch_holders",
+    ]),
+    KiroStopIdle => (46, "Kiro Stop idle reporting", [
+        "protocol_46",
+        "kiro_stop_idle",
     ]),
 }
 
@@ -2716,6 +2720,9 @@ impl Request {
             | Self::GetClaudeRemoteControlBinding { .. } => {
                 Some(ProtocolFeature::ClaudeRemoteControlBindings)
             }
+            Self::ReportKiroHook { report, .. } if report.state == AgentState::Idle => {
+                Some(ProtocolFeature::KiroStopIdle)
+            }
             Self::AcquireKiroLaunchHolder { .. }
             | Self::ReportKiroHook { .. }
             | Self::ReleaseKiroLaunchHolder { .. } => Some(ProtocolFeature::KiroLaunchHolders),
@@ -3439,8 +3446,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_forty_five_with_minimum_six() {
-        assert_eq!(PROTOCOL_VERSION, 45);
+    fn protocol_version_is_forty_six_with_minimum_six() {
+        assert_eq!(PROTOCOL_VERSION, 46);
         assert_eq!(MIN_PROTOCOL_VERSION, 6);
     }
 
@@ -3853,6 +3860,27 @@ mod tests {
         assert_eq!(MAX_KIRO_LAUNCH_HOLDERS, 256);
         assert_eq!(MAX_KIRO_HOLDER_SESSIONS, 16);
         assert_eq!(MAX_KIRO_SESSION_ID_BYTES, 256);
+    }
+
+    #[test]
+    fn kiro_stop_idle_requires_protocol_forty_six() {
+        let request = Request::ReportKiroHook {
+            holder_id: "holder-1".into(),
+            session_id: "session-1".into(),
+            report: AgentReport {
+                state: AgentState::Idle,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "Kiro session idle".into(),
+                confidence: 100,
+            },
+        };
+        assert_eq!(
+            request.required_feature(),
+            Some(ProtocolFeature::KiroStopIdle)
+        );
+        assert_eq!(request.minimum_protocol_version(), 46);
+        let encoded = serde_json::to_value(&request).unwrap();
+        assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
     }
 
     #[test]
@@ -5170,6 +5198,7 @@ mod tests {
                 &["protocol_44", "collaborative_exact_run_attachment"][..],
             ),
             (45, &["protocol_45", "kiro_exact_launch_holders"][..]),
+            (46, &["protocol_46", "kiro_stop_idle"][..]),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -230,7 +230,7 @@ fn sequential_kiro_process_holders_inactivate_only_the_exited_session() {
     let kiro = daemon.runtime_dir.join("kiro-holder-cli");
     fs::write(
         &kiro,
-        "#!/bin/sh\nprintf '%s' \"$$\" > \"$KIRO_TEST_PID\"\nprintf '{\"session_id\":\"%s\",\"hook_event_name\":\"UserPromptSubmit\"}' \"$KIRO_TEST_SESSION\" | \"$KIRO_TEST_BOOMUX\" kiro hook\n/bin/sleep 300 &\nprintf '%s' \"$!\" > \"$KIRO_TEST_DESCENDANT_PID\"\nwait\n",
+        "#!/bin/sh\nprintf '%s' \"$$\" > \"$KIRO_TEST_PID\"\nprintf '{\"session_id\":\"%s\",\"hook_event_name\":\"UserPromptSubmit\"}' \"$KIRO_TEST_SESSION\" | \"$KIRO_TEST_BOOMUX\" kiro hook\nwhile [ ! -e \"$KIRO_TEST_STOP\" ]; do sleep 0.01; done\nprintf '{\"session_id\":\"%s\",\"hook_event_name\":\"Stop\"}' \"$KIRO_TEST_SESSION\" | \"$KIRO_TEST_BOOMUX\" kiro hook\n/bin/sleep 300 &\nprintf '%s' \"$!\" > \"$KIRO_TEST_DESCENDANT_PID\"\nwait\n",
     )
     .unwrap();
     fs::set_permissions(&kiro, fs::Permissions::from_mode(0o755)).unwrap();
@@ -263,6 +263,7 @@ fn sequential_kiro_process_holders_inactivate_only_the_exited_session() {
         let descendant_pid_file = daemon
             .runtime_dir
             .join(format!("kiro-{case}-descendant-pid"));
+        let stop_file = daemon.runtime_dir.join(format!("kiro-{case}-stop"));
         let mut command = daemon.command();
         command
             .args(["kiro", "launch", "--"])
@@ -273,6 +274,7 @@ fn sequential_kiro_process_holders_inactivate_only_the_exited_session() {
             .env("KIRO_TEST_SESSION", session)
             .env("KIRO_TEST_PID", &pid_file)
             .env("KIRO_TEST_DESCENDANT_PID", &descendant_pid_file)
+            .env("KIRO_TEST_STOP", &stop_file)
             .env("KIRO_TEST_BOOMUX", env!("CARGO_BIN_EXE_boomux"));
         command.process_group(0);
         let mut child = command.spawn().unwrap();
@@ -286,6 +288,18 @@ fn sequential_kiro_process_holders_inactivate_only_the_exited_session() {
                 })
             },
             "Kiro holder hook did not report Working",
+        );
+        fs::write(&stop_file, "").unwrap();
+        wait_until(
+            || {
+                daemon.client.snapshot().is_ok_and(|snapshot| {
+                    snapshot.workspaces[0].agents.iter().any(|agent| {
+                        agent.external_session_id.as_deref() == Some(session)
+                            && agent.observation.state == AgentState::Idle
+                    })
+                })
+            },
+            "Kiro Stop hook did not report Idle",
         );
         let pid = fs::read_to_string(pid_file)
             .unwrap()


### PR DESCRIPTION
## Summary
- map Kiro v3 Stop hooks to resumable Idle lifecycle observations
- gate Idle reports behind protocol 46 and downgrade safely for protocol-45 daemons, including daemon replacement races
- document the lifecycle decision and cover Working to Idle to Inactive behavior

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --lib --bins --locked -- --test-threads=1
- cargo test --test native_backend --locked -- --test-threads=1
- bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js