### PR TITLE
fix(update): identify handed-off daemon listener

### DIFF
--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -390,8 +390,11 @@ Command payloads are:
   bounded event array.
 - `daemon.status`: `status`, `protocol_version`, `socket_path`, nullable `pid`,
   `executable`, `socket_device`, and `socket_inode`. On Linux, these identity fields
-  are populated only after same-user `SO_PEERCRED` and bounded absolute
-  `/proc/<pid>/exe` validation; the executable has a kernel ` (deleted)` suffix
+  are populated only after the bound listener maps to one unique same-user holder
+  through bounded kernel Unix-socket and `/proc` descriptor views, followed by
+  bounded absolute `/proc/<pid>/exe` validation. This remains current after the
+  listener is transferred between daemon processes; retained `SO_PEERCRED` alone
+  is not process identity. The executable has a kernel ` (deleted)` suffix
   removed. Other platforms or failed proof return null.
 
 ## Project Data

--- a/docs/local-update.md
+++ b/docs/local-update.md
@@ -97,10 +97,14 @@ If no daemon was running before activation, none is started. The installed path
 is revalidated against the candidate and the backup is removed.
 
 If a daemon was running, it must belong to the same user and execute the exact
-install path. The existing graceful handoff transfers PTYs, process identities,
-runtime locks, event state, and reconnecting attachments. Success requires the
-replacement daemon's exact handoff argv and `/proc` executable device, inode,
-length, mode, and SHA-256 to match the pinned candidate.
+install path. On Linux, the updater resolves the unique current holder of the
+bound listener through the kernel Unix-socket table and that user's bounded
+`/proc` descriptor view; it does not treat listener credentials retained from a
+prior handoff process as current process identity. The existing graceful handoff
+transfers PTYs, process identities, runtime locks, event state, and reconnecting
+attachments. Success requires the replacement daemon's exact handoff argv and
+`/proc` executable device, inode, length, mode, and SHA-256 to match the pinned
+candidate.
 
 Before successful verification, any failure restores the backup pathname and
 attempts a reverse graceful handoff to the restored executable. Recovery runs

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -284,14 +284,16 @@ that executable and starts the rollback watchdog without replacing the discovere
 destination. The uploaded current binary then runs `daemon status --json` as a
 client of the existing daemon; status does not start a missing daemon. This lets
 an old released installed helper participate even when its own CLI predates the
-additive process-identity fields. On Linux, the provisional client obtains the
-socket peer PID with `SO_PEERCRED`, validates same-user `/proc` ownership,
-resolves the bounded absolute `/proc/<pid>/exe` path after normalizing the
-kernel's ` (deleted)` suffix, and records the socket device and inode. Automatic
-upgrade requires that proven process executable to equal the install destination
-exactly. Immediately before rename, the provisional binary opens one negotiated
-daemon connection and binds activation to the exact PID, executable, protocol,
-and socket device/inode fingerprint while that connection remains open.
+additive process-identity fields. On Linux, the provisional client maps the bound
+listener to one unique same-user holder through bounded kernel Unix-socket and
+`/proc` descriptor views, validates same-user `/proc` ownership, resolves the
+bounded absolute `/proc/<pid>/exe` path after normalizing the kernel's
+` (deleted)` suffix, and records the socket device and inode. This does not trust
+listener `SO_PEERCRED` retained from an earlier handoff process. Automatic upgrade
+requires that proven process executable to equal the install destination exactly.
+Immediately before rename, the provisional binary opens one negotiated daemon
+connection and binds activation to the exact current holder PID, executable,
+protocol, and socket device/inode fingerprint at the activation boundary.
 Candidate equality or an earlier unbound status result is not evidence. Missing,
 changed, malformed, macOS, or otherwise unprovable identity returns
 `upgrade_required` without activating the upload.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::error::Error;
-use std::fs::OpenOptions;
-use std::io;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read};
 use std::os::fd::AsRawFd;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
@@ -12,7 +12,7 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::protocol::{
     self, AgentInstanceSnapshot, AgentRegistrationSpec, AgentReport, AgentState,
@@ -28,6 +28,14 @@ use crate::protocol::{
 const CONNECT_ATTEMPTS: usize = 40;
 const CONNECT_DELAY: Duration = Duration::from_millis(25);
 const SHUTDOWN_ATTEMPTS: usize = 200;
+#[cfg(target_os = "linux")]
+const MAX_PROC_UNIX_BYTES: u64 = 4 * 1024 * 1024;
+#[cfg(target_os = "linux")]
+const MAX_PROC_ENTRIES: usize = 65_536;
+#[cfg(target_os = "linux")]
+const MAX_PROC_FD_ENTRIES: usize = 1_048_576;
+#[cfg(target_os = "linux")]
+const DAEMON_IDENTITY_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub type Result<T> = std::result::Result<T, ClientError>;
 
@@ -608,6 +616,22 @@ impl Client {
             uid: credentials.uid,
             protocol_version,
         })
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn daemon_process_credentials(&self) -> Result<DaemonPeerCredentials> {
+        let socket_before = fs::metadata(&self.socket_path).map_err(ClientError::Transport)?;
+        let peer = self.daemon_peer_credentials()?;
+        let pid =
+            daemon_listener_holder(&self.socket_path, peer.uid).map_err(ClientError::Transport)?;
+        let socket_after = fs::metadata(&self.socket_path).map_err(ClientError::Transport)?;
+        if socket_before.dev() != socket_after.dev() || socket_before.ino() != socket_after.ino() {
+            return Err(ClientError::Transport(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "daemon socket changed during process identification",
+            )));
+        }
+        Ok(DaemonPeerCredentials { pid, ..peer })
     }
 
     pub fn node_identity(&self) -> Result<String> {
@@ -2016,6 +2040,217 @@ fn unexpected<T>(response: Response) -> Result<T> {
     )))
 }
 
+#[cfg(target_os = "linux")]
+fn daemon_listener_holder(socket_path: &Path, uid: u32) -> io::Result<u32> {
+    let inode = daemon_listener_inode(socket_path)?;
+    let expected = format!("socket:[{inode}]");
+    let mut holders = Vec::new();
+    let mut processes = fs::read_dir("/proc")?;
+    let mut descriptor_count = 0usize;
+    let deadline = Instant::now() + DAEMON_IDENTITY_TIMEOUT;
+    for _ in 0..MAX_PROC_ENTRIES {
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "daemon listener holder inspection timed out",
+            ));
+        }
+        let Some(entry) = processes.next() else {
+            return unique_listener_holder(holders);
+        };
+        let entry = entry?;
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|value| value.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let process_path = entry.path();
+        match fs::metadata(&process_path) {
+            Ok(metadata) if metadata.is_dir() && metadata.uid() == uid => {}
+            Ok(_) => continue,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+                ) =>
+            {
+                continue;
+            }
+            Err(error) => return Err(error),
+        }
+        let descriptors = match fs::read_dir(process_path.join("fd")) {
+            Ok(descriptors) => descriptors,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+                ) =>
+            {
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        let mut holder = false;
+        for descriptor in descriptors {
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "daemon listener holder inspection timed out",
+                ));
+            }
+            descriptor_count = descriptor_count.checked_add(1).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "process descriptor count overflowed",
+                )
+            })?;
+            if descriptor_count > MAX_PROC_FD_ENTRIES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "process descriptor tables exceed the identification bound",
+                ));
+            }
+            let descriptor = match descriptor {
+                Ok(descriptor) => descriptor,
+                Err(_error)
+                    if fs::metadata(&process_path)
+                        .is_err_and(|current| current.kind() == io::ErrorKind::NotFound) =>
+                {
+                    break;
+                }
+                Err(error) => return Err(error),
+            };
+            match fs::read_link(descriptor.path()) {
+                Ok(target) if target.as_os_str().as_bytes() == expected.as_bytes() => {
+                    holder = true;
+                    break;
+                }
+                Ok(_) => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+                    ) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        if holder {
+            holders.push(pid);
+            if holders.len() > 1 {
+                return unique_listener_holder(holders);
+            }
+        }
+    }
+    if processes.next().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "process table exceeds the identification bound",
+        ));
+    }
+    unique_listener_holder(holders)
+}
+
+#[cfg(target_os = "linux")]
+fn unique_listener_holder(mut holders: Vec<u32>) -> io::Result<u32> {
+    if holders.len() == 1 {
+        Ok(holders.remove(0))
+    } else if holders.is_empty() {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "daemon listener holder was not found",
+        ))
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "daemon listener has multiple process holders",
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_listener_inode(socket_path: &Path) -> io::Result<u64> {
+    let mut bytes = Vec::new();
+    File::open("/proc/net/unix")?
+        .take(MAX_PROC_UNIX_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_PROC_UNIX_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Unix socket table exceeds the identification bound",
+        ));
+    }
+    let expected = socket_path.as_os_str().as_bytes();
+    let mut found = None;
+    for line in bytes.split(|byte| *byte == b'\n') {
+        let Some((inode, path)) = parse_proc_unix_entry(line) else {
+            continue;
+        };
+        if path != expected {
+            continue;
+        }
+        if found.replace(inode).is_some_and(|current| current != inode) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "daemon socket path has multiple kernel identities",
+            ));
+        }
+    }
+    found.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "daemon socket was not found in the Unix socket table",
+        )
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_unix_entry(line: &[u8]) -> Option<(u64, &[u8])> {
+    let mut position = 0;
+    let mut inode = None;
+    let mut flags = None;
+    let mut socket_type = None;
+    let mut state = None;
+    for field in 0..7 {
+        while line.get(position).is_some_and(u8::is_ascii_whitespace) {
+            position += 1;
+        }
+        let start = position;
+        while line
+            .get(position)
+            .is_some_and(|byte| !byte.is_ascii_whitespace())
+        {
+            position += 1;
+        }
+        if start == position {
+            return None;
+        }
+        let value = &line[start..position];
+        match field {
+            3 => flags = parse_proc_hex(value),
+            4 => socket_type = parse_proc_hex(value),
+            5 => state = parse_proc_hex(value),
+            6 => inode = std::str::from_utf8(value).ok()?.parse::<u64>().ok(),
+            _ => {}
+        }
+    }
+    while line.get(position).is_some_and(u8::is_ascii_whitespace) {
+        position += 1;
+    }
+    let inode = inode?;
+    (flags? & 0x0001_0000 != 0
+        && socket_type? == libc::SOCK_STREAM as u64
+        && state? == 1
+        && position < line.len())
+    .then_some((inode, &line[position..]))
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_hex(value: &[u8]) -> Option<u64> {
+    u64::from_str_radix(std::str::from_utf8(value).ok()?, 16).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2023,6 +2258,27 @@ mod tests {
     use std::os::unix::net::UnixListener;
 
     use uuid::Uuid;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_unix_entry_preserves_socket_paths_with_spaces() {
+        assert_eq!(
+            parse_proc_unix_entry(
+                b"0000000000000000: 00000002 00000000 00010000 0001 01 12345 /run/user/1000/path with spaces.sock"
+            ),
+            Some((12345, b"/run/user/1000/path with spaces.sock".as_slice()))
+        );
+        assert_eq!(
+            parse_proc_unix_entry(b"Num RefCount Protocol Flags Type St Inode Path"),
+            None
+        );
+        assert_eq!(
+            parse_proc_unix_entry(
+                b"0000000000000000: 00000003 00000000 00000000 0001 03 12346 /run/user/1000/path with spaces.sock"
+            ),
+            None
+        );
+    }
 
     #[test]
     fn optional_runtime_accepts_legacy_typed_absence_without_changing_required_callers() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -2280,6 +2280,20 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn listener_holder_identity_requires_exactly_one_process() {
+        assert_eq!(unique_listener_holder(vec![42]).unwrap(), 42);
+        assert_eq!(
+            unique_listener_holder(Vec::new()).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+        assert_eq!(
+            unique_listener_holder(vec![42, 43]).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+    }
+
     #[test]
     fn optional_runtime_accepts_legacy_typed_absence_without_changing_required_callers() {
         let directory = env::temp_dir().join(format!("boomux-client-runtime-{}", Uuid::new_v4()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2999,7 +2999,7 @@ struct DaemonProcessIdentity {
 #[cfg(target_os = "linux")]
 fn daemon_process_identity(client: &client::Client) -> Option<DaemonProcessIdentity> {
     let socket_before = fs::metadata(client.socket_path()).ok()?;
-    let credentials = match client.daemon_peer_credentials() {
+    let credentials = match client.daemon_process_credentials() {
         Ok(credentials) if credentials.uid == unsafe { libc::geteuid() } => credentials,
         _ => return None,
     };
@@ -3016,6 +3016,10 @@ fn daemon_process_identity(client: &client::Client) -> Option<DaemonProcessIdent
     let executable = fs::read_link(process_directory.join("exe"))
         .ok()
         .and_then(|executable| normalize_daemon_executable(executable.as_os_str().as_bytes()));
+    let confirmed = client.daemon_process_credentials().ok()?;
+    if confirmed != credentials {
+        return None;
+    }
     Some(DaemonProcessIdentity {
         pid: credentials.pid,
         protocol_version: credentials.protocol_version,

--- a/src/update.rs
+++ b/src/update.rs
@@ -22,7 +22,6 @@ const DISTRIBUTION: Option<&str> = option_env!("BOOMUX_DISTRIBUTION");
 const MAX_EXECUTABLE_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_SMOKE_OUTPUT_BYTES: usize = 4096;
 const SMOKE_TIMEOUT: Duration = Duration::from_secs(10);
-const MAX_PROC_ENTRIES: usize = 65_536;
 const MAX_PROC_CMDLINE_BYTES: u64 = 4096;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -814,15 +813,7 @@ fn daemon_disposition(target: &Path) -> io::Result<DaemonDisposition> {
             "running daemon uses a different Boomux executable or executable inode",
         ));
     }
-    let pid = daemon
-        .daemon_peer_credentials()
-        .map_err(|error| {
-            io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!("running daemon identity changed during inspection: {error}"),
-            )
-        })?
-        .pid;
+    let pid = executable.pid;
     Ok(DaemonDisposition::SameExecutable {
         client: daemon,
         pid,
@@ -840,13 +831,14 @@ fn reserve_daemon_absence(socket: &Path) -> io::Result<client::DaemonLockReserva
 
 #[cfg(target_os = "linux")]
 struct DaemonExecutable {
+    pid: u32,
     path: PathBuf,
     fingerprint: FileFingerprint,
 }
 
 #[cfg(target_os = "linux")]
 fn daemon_executable(daemon: &client::Client) -> Option<DaemonExecutable> {
-    let credentials = daemon.daemon_peer_credentials().ok()?;
+    let credentials = daemon.daemon_process_credentials().ok()?;
     if credentials.uid != unsafe { libc::geteuid() } {
         return None;
     }
@@ -861,11 +853,20 @@ fn daemon_executable(daemon: &client::Client) -> Option<DaemonExecutable> {
     let bytes = bytes.strip_suffix(b" (deleted)").unwrap_or(bytes);
     let path = PathBuf::from(std::ffi::OsString::from_vec(bytes.to_vec()));
     let fingerprint = fingerprint_following(&process_executable).ok()?;
-    Some(DaemonExecutable { path, fingerprint })
+    let confirmed = daemon.daemon_process_credentials().ok()?;
+    if confirmed != credentials {
+        return None;
+    }
+    Some(DaemonExecutable {
+        pid: credentials.pid,
+        path,
+        fingerprint,
+    })
 }
 
 #[cfg(not(target_os = "linux"))]
 struct DaemonExecutable {
+    pid: u32,
     path: PathBuf,
     fingerprint: FileFingerprint,
 }
@@ -895,8 +896,8 @@ fn finish_daemon_handoff(
                 .restart()
                 .map_err(|error| io::Error::other(error.to_string()))?;
             let installed = verify_installed_candidate(target, candidate)?;
-            let executable =
-                replacement_daemon_executable(target, candidate, *pid).ok_or_else(|| {
+            let executable = replacement_daemon_executable(client, target, candidate, *pid)
+                .ok_or_else(|| {
                     io::Error::other("replacement daemon executable could not be verified")
                 })?;
             if executable.path != target
@@ -937,54 +938,25 @@ fn recover_daemon_after_rollback(disposition: &DaemonDisposition) -> io::Result<
 
 #[cfg(target_os = "linux")]
 fn replacement_daemon_executable(
+    daemon: &client::Client,
     target: &Path,
     candidate: &FileFingerprint,
     old_pid: u32,
 ) -> Option<DaemonExecutable> {
     let deadline = Instant::now() + SMOKE_TIMEOUT;
     loop {
-        let mut matches = Vec::new();
-        let mut entries = fs::read_dir("/proc").ok()?;
-        for _ in 0..MAX_PROC_ENTRIES {
-            let Some(entry) = entries.next() else {
-                break;
-            };
-            let Ok(entry) = entry else {
-                continue;
-            };
-            let Some(_pid) = entry
-                .file_name()
-                .to_str()
-                .and_then(|value| value.parse::<u32>().ok())
-                .filter(|pid| *pid != old_pid)
-            else {
-                continue;
-            };
-            let process_directory = entry.path();
-            match fs::metadata(&process_directory) {
-                Ok(metadata)
-                    if metadata.is_dir() && metadata.uid() == unsafe { libc::geteuid() } => {}
-                _ => continue,
-            }
-            match read_proc_cmdline(&process_directory.join("cmdline")) {
-                Ok(cmdline) if is_replacement_daemon_cmdline(&cmdline, target) => {}
-                _ => continue,
-            }
-            let process_executable = process_directory.join("exe");
-            let path = match fs::read_link(&process_executable) {
-                Ok(path) if path == target => path,
-                _ => continue,
-            };
-            let fingerprint = match fingerprint_following(&process_executable) {
-                Ok(fingerprint) if same_candidate(&fingerprint, candidate) => fingerprint,
-                _ => continue,
-            };
-            matches.push(DaemonExecutable { path, fingerprint });
-        }
-        if entries.next().is_some() || matches.len() > 1 {
-            return None;
-        }
-        if let Some(executable) = matches.pop() {
+        if let Some(executable) = daemon_executable(daemon).filter(|executable| {
+            executable.pid != old_pid
+                && executable.path == target
+                && same_candidate(&executable.fingerprint, candidate)
+                && read_proc_cmdline(
+                    &PathBuf::from(format!("/proc/{}", executable.pid)).join("cmdline"),
+                )
+                .is_ok_and(|cmdline| is_replacement_daemon_cmdline(&cmdline, target))
+                && daemon.daemon_process_credentials().is_ok_and(|confirmed| {
+                    confirmed.pid == executable.pid && confirmed.uid == unsafe { libc::geteuid() }
+                })
+        }) {
             return Some(executable);
         }
         if Instant::now() >= deadline {
@@ -1025,6 +997,7 @@ fn is_replacement_daemon_cmdline(cmdline: &[u8], target: &Path) -> bool {
 
 #[cfg(not(target_os = "linux"))]
 fn replacement_daemon_executable(
+    _daemon: &client::Client,
     _target: &Path,
     _candidate: &FileFingerprint,
     _old_pid: u32,

--- a/tests/native_backend/update.rs
+++ b/tests/native_backend/update.rs
@@ -1,6 +1,7 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -222,6 +223,22 @@ fn graceful_restart_executes_an_atomically_replaced_installed_inode() {
     );
     let new_pid = wait_for_replacement_pid(&installed, old_pid);
     assert_ne!(new_pid, old_pid);
+    let persistent_connection =
+        UnixStream::connect(root.join("runtime/boomux/daemon.sock")).unwrap();
+    assert_eq!(client.daemon_peer_credentials().unwrap().pid, old_pid);
+    assert_eq!(client.daemon_process_credentials().unwrap().pid, new_pid);
+    let status = command_with_executable(&root, &installed)
+        .args(["daemon", "status", "--json"])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    let status: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(status["data"]["pid"], new_pid);
+    assert_eq!(
+        status["data"]["executable"],
+        installed.to_string_lossy().as_ref()
+    );
+    drop(persistent_connection);
     let installed_metadata = fs::metadata(&installed).unwrap();
     let daemon_metadata = fs::metadata(format!("/proc/{new_pid}/exe")).unwrap();
     assert_eq!(daemon_metadata.dev(), installed_metadata.dev());


### PR DESCRIPTION
## Summary
- preserve raw Linux `SO_PEERCRED` reporting while resolving daemon process identity from the unique current holder of the bound listener
- map only listening Unix stream entries from bounded `/proc/net/unix`, then scan a bounded same-user `/proc` descriptor view with an elapsed-time limit
- bind both updater preflight and final candidate verification to that current listener holder and revalidate ownership after executable inspection
- keep ambiguous, replaced, missing, oversized, or unverifiable listener identity fail-closed
- update local-update, CLI JSON, and remote Node contracts for transferred-listener identity

## Regression
The native update test now proves that after graceful handoff:
- raw `SO_PEERCRED` still reports the exited listener creator
- the listener-holder resolver reports the live replacement PID
- persistent accepted connections are not mistaken for additional listeners
- `daemon status --json` reports the replacement PID and exact installed executable

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1` (826 pass)
- `cargo test --test native_backend --locked -- --test-threads=1` (112 pass)
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js` (43 pass)
- `git diff --check`