### PR TITLE
fix(node): unblock upgrade maintenance during projection reads

### DIFF
--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -441,14 +441,19 @@ Framed executable candidates and install destinations that are relative,
 oversized, or contain control characters are malformed helper output and return
 `bootstrap_malformed_helper`; they are not transport evidence.
 
-Every registration carries a monotonic local registration revision.
-Synchronization and routed requests reserve admission and copy that revision
-before network I/O, then revalidate it before committing any registration or
-cache change. Setup and a candidate retarget probe copy the revision without
-joining ordinary request admission, perform network work, and revalidate at their
-mutation commit. The registry retains a monotonic tombstone epoch so deleting and
-re-adding a registration cannot make an old reservation current. Duplicate
-checks are repeated at commit while the Node mutation gate is held.
+Every registration carries a monotonic local registration revision. Routed
+requests reserve admission and copy that revision before network I/O, then
+revalidate it before returning or committing a mutation. Background projection
+synchronization is read-only on the owner: it copies the revision without
+reserving mutation admission, and cache commit requires that exact registration
+and admission epoch to remain current and open. Maintenance advances that epoch
+as it closes the commit gate, so it need not wait for an in-flight SSH projection
+read and that stale result is discarded. Setup and a candidate retarget probe
+likewise copy the revision without joining ordinary request admission, perform
+network work, and revalidate at their mutation commit. The registry retains a
+monotonic tombstone epoch so deleting and re-adding a registration cannot make
+an old observation current. Duplicate checks are repeated at commit while the
+Node mutation gate is held.
 
 Forget and retarget use prepare, drain, and commit phases. Prepare closes
 admission without changing the revision, then releases the mutation gate.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6810,20 +6810,21 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
                 return;
             }
         };
-        let admitted = service
+        let Some(admission_epoch) = service
             .node_registrations()
             .and_then(|registrations| {
                 registrations
-                    .admit(&registration)
+                    .observe(&registration)
                     .map_err(node_registration_error)
             })
-            .unwrap_or(false);
-        if !admitted {
+            .ok()
+            .flatten()
+        else {
             if interruptible_node_sleep(&service, &node_id, Duration::from_millis(100)) {
                 return;
             }
             continue;
-        }
+        };
         let attempt_at_ms = unix_time_ms();
         let result = fetch_node_projection(&registration, after);
         let mut published_generation = None;
@@ -6832,7 +6833,7 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
             Ok((sync, capabilities, observed_helper_version)) => {
                 let commit = service.node_registrations().and_then(|registrations| {
                     registrations
-                        .with_current(&registration, || {
+                        .with_observation(&registration, admission_epoch, || {
                             service
                                 .node_projection_cache
                                 .as_ref()
@@ -6869,7 +6870,7 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
                             .collect::<Vec<_>>();
                         let claimed = service.node_registrations().and_then(|registrations| {
                             registrations
-                                .with_current(&registration, || {
+                                .with_observation(&registration, admission_epoch, || {
                                     service
                                         .node_projection_cache
                                         .as_ref()
@@ -6915,7 +6916,7 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
                     .saturating_add(u64::try_from(delay.as_millis()).unwrap_or(u64::MAX));
                 let commit = service.node_registrations().and_then(|registrations| {
                     registrations
-                        .with_current(&registration, || {
+                        .with_observation(&registration, admission_epoch, || {
                             service
                                 .node_projection_cache
                                 .as_ref()
@@ -6945,10 +6946,6 @@ fn node_projection_worker(service: Weak<DaemonService>, node_id: String) {
                 }
             }
         }
-        service
-            .node_registrations()
-            .map(|registrations| registrations.release(&registration))
-            .ok();
         if let Some(cache_generation) = published_generation {
             let _ = service.events.publish_runtime_batch(vec![
                 DaemonEventKind::NodeProjectionChanged {

--- a/src/node_registration.rs
+++ b/src/node_registration.rs
@@ -42,6 +42,7 @@ struct RegistrationState {
 struct Registration {
     snapshot: NodeRegistrationSnapshot,
     admission_open: bool,
+    admission_epoch: u64,
     admitted: usize,
     maintenance: Option<MaintenanceLease>,
 }
@@ -152,6 +153,54 @@ impl NodeRegistrationManager {
         operation().map(Some)
     }
 
+    pub(crate) fn observe(&self, expected: &NodeRegistrationSnapshot) -> io::Result<Option<u64>> {
+        let mut state = self.lock_state()?;
+        let state = available_mut(&mut state)?;
+        expire_maintenance(state);
+        let Some(registration) = state
+            .registrations
+            .iter()
+            .find(|registration| registration.snapshot.node_id == expected.node_id)
+        else {
+            return Ok(None);
+        };
+        if registration.snapshot.revision != expected.revision
+            || registration.snapshot.tombstone_epoch != expected.tombstone_epoch
+            || registration.snapshot.target != expected.target
+            || !registration.admission_open
+        {
+            return Ok(None);
+        }
+        Ok(Some(registration.admission_epoch))
+    }
+
+    pub(crate) fn with_observation<T>(
+        &self,
+        expected: &NodeRegistrationSnapshot,
+        admission_epoch: u64,
+        operation: impl FnOnce() -> io::Result<T>,
+    ) -> io::Result<Option<T>> {
+        let mut state = self.lock_state()?;
+        let state = available_mut(&mut state)?;
+        expire_maintenance(state);
+        let Some(registration) = state
+            .registrations
+            .iter()
+            .find(|registration| registration.snapshot.node_id == expected.node_id)
+        else {
+            return Ok(None);
+        };
+        if registration.snapshot.revision != expected.revision
+            || registration.snapshot.tombstone_epoch != expected.tombstone_epoch
+            || registration.snapshot.target != expected.target
+            || !registration.admission_open
+            || registration.admission_epoch != admission_epoch
+        {
+            return Ok(None);
+        }
+        operation().map(Some)
+    }
+
     pub(crate) fn admit(&self, expected: &NodeRegistrationSnapshot) -> io::Result<bool> {
         let mut state = self.lock_state()?;
         let state = available_mut(&mut state)?;
@@ -243,6 +292,7 @@ impl NodeRegistrationManager {
         replacement.registrations.push(Registration {
             snapshot: snapshot.clone(),
             admission_open: true,
+            admission_epoch: 0,
             admitted: 0,
             maintenance: None,
         });
@@ -375,6 +425,10 @@ impl NodeRegistrationManager {
                 "Node registration change is already in progress",
             ));
         }
+        current.registrations[index].admission_epoch = next(
+            current.registrations[index].admission_epoch,
+            "registration admission epoch",
+        )?;
         current.registrations[index].admission_open = false;
         let token = Uuid::new_v4().to_string();
         current.registrations[index].maintenance = Some(MaintenanceLease {
@@ -506,6 +560,10 @@ impl NodeRegistrationManager {
                 "Node registration change is already in progress",
             ));
         }
+        current.registrations[index].admission_epoch = next(
+            current.registrations[index].admission_epoch,
+            "registration admission epoch",
+        )?;
         current.registrations[index].admission_open = false;
         let deadline = Instant::now() + timeout;
         loop {
@@ -789,6 +847,7 @@ fn validate_persisted(persisted: PersistedRegistrations) -> io::Result<Registrat
         registrations.push(Registration {
             snapshot,
             admission_open: true,
+            admission_epoch: 0,
             admitted: 0,
             maintenance: None,
         });
@@ -1048,6 +1107,43 @@ mod tests {
         manager
             .finish_upgrade_maintenance(&registration.node_id, &token)
             .unwrap();
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn maintenance_invalidates_observations_after_admission_reopens() {
+        let path = path();
+        let manager = NodeRegistrationManager::load_at(path.clone());
+        let registration = manager
+            .add("work".into(), "old".into(), node_id(2), &node_id(1))
+            .unwrap();
+        let stale_epoch = manager.observe(&registration).unwrap().unwrap();
+        let (_, token) = manager
+            .begin_upgrade_maintenance_if(
+                "work",
+                registration.revision,
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+                || true,
+            )
+            .unwrap();
+        manager
+            .finish_upgrade_maintenance(&registration.node_id, &token)
+            .unwrap();
+
+        assert!(
+            manager
+                .with_observation(&registration, stale_epoch, || Ok(()))
+                .unwrap()
+                .is_none()
+        );
+        let current_epoch = manager.observe(&registration).unwrap().unwrap();
+        assert!(
+            manager
+                .with_observation(&registration, current_epoch, || Ok(()))
+                .unwrap()
+                .is_some()
+        );
         fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
     }
 

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -915,6 +915,43 @@ fn node_upgrade_maintenance_blocks_registration_changes_until_release() {
 }
 
 #[test]
+fn node_upgrade_maintenance_does_not_wait_for_projection_reads() {
+    let daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let marker = runtime_dir.join("projection-started");
+        let ssh = runtime_dir.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\n{CONTROL_MASTER_PREFIX}\n: > '{}'\nsleep 1\nexit 64\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        command.env("PATH", format!("{}:/usr/bin:/bin", runtime_dir.display()));
+    });
+    let registration = daemon
+        .client
+        .add_node_registration("work", "work.example", node_id(2))
+        .unwrap();
+    let marker = daemon.runtime_dir.join("projection-started");
+    wait_until(
+        || marker.exists(),
+        "projection worker did not begin its SSH read",
+    );
+
+    let (leased, token) = daemon
+        .client
+        .begin_node_upgrade_maintenance(&registration.node_id, registration.revision)
+        .unwrap();
+    assert_eq!(leased, registration);
+    daemon
+        .client
+        .finish_node_upgrade_maintenance(&registration.node_id, token)
+        .unwrap();
+}
+
+#[test]
 fn guarded_resource_revisions_survive_cold_recovery() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon


### PR DESCRIPTION
## Summary
- keep read-only background projection SSH cycles out of mutation admission drains
- invalidate in-flight projection observations with a per-registration admission epoch
- cover prompt maintenance acquisition and stale observation rejection

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`