### PR TITLE
feat: add safe local and remote uninstall

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -77,6 +77,7 @@ boomux node inspect "<node-alias-or-id>" --json
 boomux node snapshot --json
 boomux node add "<alias>" "<user@host>"
 boomux node upgrade "<node>"
+boomux node uninstall "<node>"
 boomux node reauthenticate "<node>"
 boomux node rename "<node>" "<new-alias>" --revision <revision> --json
 boomux node retarget "<node>" "<user@host>" --revision <revision> --json
@@ -98,6 +99,12 @@ authorized upgrade for the selected remote Node in a native terminal.
 `node upgrade` is human-only and requires an interactive terminal. It verifies
 the registered Node identity before replacing the helper transactionally and
 gracefully restarting its daemon, including when the old helper remains protocol-compatible.
+`node uninstall` is human-only and interactive. It verifies the registered Node
+identity and canonical owner-controlled user installation, removes current
+Boomux integration assets while preserving modified assets and durable data,
+stops every remote managed process, removes the remote executable, and forgets
+the local registration only after confirmed removal. It is distinct from
+`node forget`, which never contacts the owner.
 `node reauthenticate` is human-only and uses the registration's exact stored
 route for interactive SSH authentication. It requires the pinned Node identity
 and an existing compatible helper, performs no install, upgrade, retarget, or
@@ -773,6 +780,21 @@ source, development, root-owned, custom, and unknown installations must be
 updated through their owning installation method. It never downgrades, never
 updates remote Nodes, and leaves a stopped daemon stopped. Remote helpers remain
 under `boomux node upgrade`.
+
+Remove an official canonical local release installation with:
+
+```console
+boomux uninstall
+boomux uninstall --purge
+```
+
+Uninstall stops every local Boomux web gateway and managed process and removes
+unchanged Boomux-owned integrations and this Skill. It preserves modified
+assets, configuration, and durable state by default. `--purge` explicitly
+removes the standard Boomux state and configuration directories.
+Package-managed, source, custom, or otherwise unproven executable paths are
+refused. Use only with explicit authorization because process shutdown is
+destructive.
 
 ## Install Or Update This Skill
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@
 | `src/host_session_source.rs` and children | Canonical host source paths, normalization, and secure source lookup |
 | `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
 | `src/update.rs` | Local release discovery, installation classification, interactive self-update authorization, atomic executable replacement, and daemon handoff verification |
+| `src/uninstall.rs` | Interactive release uninstall orchestration, owned-asset cleanup, bounded purge validation, and process shutdown ordering |
 | `src/claude_hooks.rs`, `src/codex_hooks.rs`, `src/kiro_hooks.rs` | Bounded Claude Code, Codex, and Kiro hook decoding and lifecycle reduction |
 | `src/process_adapter.rs` | Exact-argv child supervision and fail-open process-bound Agent observation |
 | `src/config.rs` | Layered configuration resolution, bounded validation, and transactional active-layer editing |
@@ -64,6 +65,9 @@
 - **Local update ownership:** [`local-update.md`](local-update.md) defines the
   official-release eligibility, package-manager refusal, no-downgrade rule,
   atomic replacement, and graceful daemon handoff boundary.
+- **Local uninstall ownership:** [`uninstall.md`](uninstall.md) reuses the
+  official-release ownership boundary, preserves modified assets and user data
+  by default, and removes the executable only after process cleanup.
 - **Remote Node authority:** [`remote-nodes.md`](remote-nodes.md) defines the
   accepted federation boundary: one owning Node remains authoritative, SSH is a
   route, and local cached projections never authorize mutation or lifecycle
@@ -209,6 +213,13 @@ incompatible runtime, coordinator, journal, selection, and projection state,
 remove the old scheduling and scheduled-notification config keys, then install
 and start the new binary. [`local-update.md`](local-update.md) defines the exact
 operator sequence.
+Protocol 48 adds `node_uninstall_coordination`. It atomically consumes an exact
+Node maintenance lease into registration removal only after the interactive
+client confirms identity-pinned remote uninstall, then best-effort removes the
+now-inaccessible disposable projection. The remote mutation remains a fixed SSH
+bootstrap operation rather than an arbitrary routed daemon request. Protocol-47
+peers retain every prior Node operation but cannot use this atomic completion
+primitive.
 Remote notification presentation reuses protocol-32 atomic reduced transitions,
 so it does not require a later protocol. Node-cache schema 2 adds bounded local
 at-most-once individual and reconnect-digest claims with an explicit schema-1

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -57,9 +57,10 @@ The static `hyprland_special_workspaces`, `contextual_desktop_terminal`,
 `node_reauthentication` features advertise that the installed CLI contains
 these human-facing paths; they do not claim that Hyprland is running, that the
 adapter is enabled, or that a registered Node currently needs authentication.
-The static `local_update_status` and `guided_local_update` features advertise
-the local update surfaces. They do not claim that the current executable is an
-eligible official release installation or that a newer release exists.
+The static `local_update_status`, `guided_local_update`, and
+`guided_local_uninstall` features advertise the local release-management
+surfaces. They do not claim that the current executable is an eligible official
+release installation or that a newer release exists.
 
 ### Accepted Remote Node Compatibility
 
@@ -212,6 +213,10 @@ successful commit or lease expiry. The CLI renews the lease while active, and
 local daemon restart or stop returns `busy` until release or expiry.
 Successful commit releases it immediately; a failed or ambiguous upgrade keeps
 it closed through bounded expiry so remote watchdog rollback cannot race routing.
+`boomux node uninstall NODE` is likewise human-only and rejects `--json` before
+SSH discovery. Protocol 48 atomically consumes its exact maintenance lease into
+registration removal only after the identity-pinned remote executable has been
+removed. Failures retain the registration.
 Per-Node observed capabilities must distinguish passive combined projection from
 process-starting, destructive, integration-management, and exact-attachment
 support. The full compatibility and privacy rules are defined
@@ -463,6 +468,9 @@ is no longer negotiated.
 Protocol 47 also removes Agent Schedule and Scheduled Execution commands, JSON
 payloads, capabilities, snapshot fields, and event types. Historical schedule
 request shapes are not part of the protocol-47 wire contract.
+Protocol 48 adds `protocol_48` and `node_uninstall_coordination`. The completion
+request is local coordinator state and adds no JSON mutation command, remote
+projection field, or arbitrary routed operation.
 
 Protocol-38 `workspace create` creates empty coordinator metadata without a
 default Node or cwd. First global `shell create` or `launcher create` resolves

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -29,6 +29,12 @@
 > from an authenticated projection connection for Nodes-view presentation.
 > Public `boomux --remote TARGET`
 > remains ad hoc.
+> Protocol 48 adds explicit registered-Node uninstall coordination. The
+> interactive client verifies the pinned owner and canonical user install,
+> removes current owner integration assets, stops the proven daemon, and removes
+> the helper over one authenticated SSH endpoint. Confirmed remote removal
+> atomically consumes local maintenance into registration deletion; uncertain
+> outcomes retain the route.
 
 ## Purpose
 
@@ -210,6 +216,17 @@ Successful remote commit, failure before remote mutation, and a synchronously
 confirmed rollback release it immediately. Only an ambiguous upgrade or a
 rollback whose completion cannot be confirmed leaves it closed until bounded
 expiry so the remote watchdog settles before local routing resumes.
+Human-only `node uninstall NODE` uses the same admission-closing maintenance
+lease after explicit process and data-impact confirmation. It requires an
+existing protocol-48 helper at the canonical user install destination, proves a
+present daemon executes that exact destination, performs Node-ID-conditional
+normal daemon stop, and owner-validates the regular single-link executable
+against its pre-confirmation fingerprint before removal. Remote state, config, modified
+integrations, and the Agent Skill remain. Confirmed removal atomically deletes
+the local registration while admission is still closed, then best-effort removes
+its now-inaccessible disposable projection. Any failure retains the registration
+and releases maintenance; Boomux never interprets `node forget` as remote
+uninstall authority.
 Add and retarget complete verified bootstrap before submitting a registration
 mutation to the local daemon. The selected helper path is
 connection-local and is rediscovered on every later connection; it is not a

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,0 +1,65 @@
+# Uninstall Contract
+
+> **Status: Current contract.** This document governs removal of Boomux-owned
+> local release assets and preserved user data.
+
+## Surface
+
+`boomux uninstall` is human-only and requires an interactive terminal. It shows
+the exact executable, process impact, owned assets, modified assets that will be
+preserved, and data policy before requiring explicit confirmation. It has no
+`--yes`, JSON mutation, scheduled, or ad hoc remote mode. The non-protocol
+capability is `guided_local_uninstall`.
+
+`boomux uninstall --purge` additionally removes the standard Boomux state and
+configuration directories after validating their complete bounded trees. It
+does not remove a `BOOMUX_CONFIG` file outside the standard Boomux configuration
+directory.
+
+`boomux node uninstall NODE` is a separate human-only operation for an exact
+registered Node. It authenticates the stored route, verifies the pinned Node ID,
+requires a protocol-48 helper at the canonical owner-controlled user installation,
+removes current integration assets while preserving modified assets, stops the
+remote daemon, proves the socket absent, and removes the remote executable. It
+preserves remote durable state, configuration, and Agent Skill. The local
+registration is removed atomically only after confirmed remote removal; failure
+or an ambiguous outcome retains the identity-pinned route. Shutdown is
+conditional on the unchanged Node ID, and executable removal is bound to the
+exact fingerprint authorized before confirmation. Disposable projection cleanup
+follows best-effort and any retained cache is inaccessible without its registration.
+
+## Ownership
+
+Self-uninstall uses the same installation ownership boundary as self-update. It
+is available only to an official GitHub release at the canonical
+`$HOME/.local/bin/boomux` path through an owner-controlled directory chain.
+Package-managed, root-owned, source, development, custom, symlinked, multiply
+linked, changed, and otherwise unprovable executables are refused. Package
+installations must be removed with their owning package manager.
+
+Unchanged bundled integration assets and the unchanged Boomux Agent Skill are
+removed. Modified or uninspectable assets are preserved and reported; uninstall
+never uses integration force-removal implicitly. Host configuration and session
+catalogs owned by OpenCode, Pi, Claude, Codex, or Kiro are not Boomux assets and
+are never removed.
+
+## Process And Data Safety
+
+Before filesystem removal, uninstall discovers and stops bounded Boomux web
+gateways, reconciles only Tailscale routes owned by those gateways, and requests
+normal daemon shutdown. Daemon shutdown terminates managed Shell process groups,
+PTYs, projection workers, and the Shared Harness Runtime. Uninstall then holds
+the daemon ownership lock until cleanup is complete so another client cannot
+start a daemon against partially removed state.
+
+Without `--purge`, durable state, Node identity and registrations, Workspace and
+Agent history, and Boomux configuration remain available to a later reinstall.
+With `--purge`, the standard state and configuration trees must contain only
+current-user-owned regular files and directories, no symbolic links or special
+files, and no more than 16,384 entries. Validation completes before either tree
+is recursively removed.
+
+The executable fingerprint captured before authorization is revalidated after
+process and asset cleanup. The executable is removed last and its parent
+directory is synchronized. A changed executable fails closed instead of
+removing the new or externally replaced file.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1045,6 +1045,17 @@ impl Client {
         )
     }
 
+    pub fn finish_node_uninstall_maintenance(
+        &self,
+        node_id: impl Into<String>,
+        token: impl Into<String>,
+    ) -> Result<NodeRegistrationSnapshot> {
+        self.node_registration_response(Request::FinishNodeUninstallMaintenance {
+            node_id: node_id.into(),
+            token: token.into(),
+        })
+    }
+
     pub fn renew_node_upgrade_maintenance(
         &self,
         node_id: impl Into<String>,
@@ -1068,6 +1079,20 @@ impl Client {
 
     pub fn shutdown(&self) -> Result<()> {
         expect_ok(self.request(Request::Shutdown)?, Response::Ok)?;
+        self.wait_for_shutdown()
+    }
+
+    pub fn shutdown_if_node_identity(&self, expected_node_id: impl Into<String>) -> Result<()> {
+        expect_ok(
+            self.request(Request::ShutdownIfNodeIdentity {
+                expected_node_id: expected_node_id.into(),
+            })?,
+            Response::Ok,
+        )?;
+        self.wait_for_shutdown()
+    }
+
+    fn wait_for_shutdown(&self) -> Result<()> {
         for _ in 0..SHUTDOWN_ATTEMPTS {
             if !self.socket_path.exists() && daemon_lock_available(&self.socket_path)? {
                 return Ok(());
@@ -2345,21 +2370,23 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
-            assert_eq!(request.version, 47);
-            assert_eq!(request.message, Request::Ping);
-            protocol::write_message(
-                &mut stream,
-                &Envelope::with_version(
-                    46,
-                    Response::Error {
-                        message: "protocol 47 unsupported".into(),
-                        code: Some(ErrorCode::UnsupportedVersion),
-                    },
-                ),
-            )
-            .unwrap();
+            for expected in [48, 47] {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                assert_eq!(request.version, expected);
+                assert_eq!(request.message, Request::Ping);
+                protocol::write_message(
+                    &mut stream,
+                    &Envelope::with_version(
+                        46,
+                        Response::Error {
+                            message: format!("protocol {expected} unsupported"),
+                            code: Some(ErrorCode::UnsupportedVersion),
+                        },
+                    ),
+                )
+                .unwrap();
+            }
         });
         let client = Client::from_socket_path(socket);
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1949,7 +1949,14 @@ fn handle_connection_inner(
             },
         );
     }
-    if matches!(request.message, Request::Shutdown) {
+    let shutdown_identity = match &request.message {
+        Request::Shutdown => Some(None),
+        Request::ShutdownIfNodeIdentity { expected_node_id } => {
+            Some(Some(expected_node_id.as_str()))
+        }
+        _ => None,
+    };
+    if let Some(expected_node_id) = shutdown_identity {
         if transition
             .compare_exchange(
                 TRANSITION_IDLE,
@@ -1968,6 +1975,30 @@ fn handle_connection_inner(
                 )
                 .into_response(),
             );
+        }
+        if let Some(expected_node_id) = expected_node_id {
+            match registry
+                .node_identity()
+                .and_then(|identity| identity.id().map_err(DaemonError::from))
+            {
+                Ok(node_id) if node_id == expected_node_id => {}
+                Ok(_) => {
+                    transition.store(TRANSITION_IDLE, Ordering::Release);
+                    return send_response(
+                        &mut stream,
+                        response_version,
+                        DaemonError::lifecycle(
+                            ErrorCode::NodeIdentityChanged,
+                            "daemon Node identity changed from the authorized uninstall target",
+                        )
+                        .into_response(),
+                    );
+                }
+                Err(error) => {
+                    transition.store(TRANSITION_IDLE, Ordering::Release);
+                    return send_response(&mut stream, response_version, error.into_response());
+                }
+            }
         }
         match node_upgrade_maintenance_active(&registry) {
             Ok(true) => {
@@ -10506,6 +10537,16 @@ impl DaemonService {
                 .finish_upgrade_maintenance(&node_id, &token)
                 .map(|()| Response::Ok)
                 .map_err(node_registration_error),
+            Request::FinishNodeUninstallMaintenance { node_id, token } => {
+                let registration = self
+                    .node_registrations()?
+                    .finish_uninstall_maintenance(&node_id, &token)
+                    .map_err(node_registration_error)?;
+                if let Err(error) = self.node_projection_cache()?.remove(&registration.node_id) {
+                    eprintln!("boomux: could not remove disposable Node projection: {error}");
+                }
+                Ok(Response::NodeRegistration { registration })
+            }
             Request::RenewNodeUpgradeMaintenance { node_id, token } => self
                 .node_registrations()?
                 .renew_upgrade_maintenance(&node_id, &token, NODE_UPGRADE_MAINTENANCE_LEASE)
@@ -10872,7 +10913,9 @@ impl DaemonService {
             Request::Restart | Request::RestartWithNotificationConfig { .. } => {
                 unreachable!("restart is handled before dispatch")
             }
-            Request::Shutdown => unreachable!("shutdown is handled before dispatch"),
+            Request::Shutdown | Request::ShutdownIfNodeIdentity { .. } => {
+                unreachable!("shutdown is handled before dispatch")
+            }
             Request::Snapshot => Ok(Response::Snapshot {
                 snapshot: self.snapshot()?,
             }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ mod session_projection;
 mod tailscale_serve;
 mod terminal;
 mod tui;
+mod uninstall;
 mod update;
 mod web_terminal;
 mod workspace_selection;
@@ -152,6 +153,7 @@ const NON_PROTOCOL_FEATURES: &[&str] = &[
     "node_reauthentication",
     "local_update_status",
     "guided_local_update",
+    "guided_local_uninstall",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -308,6 +310,12 @@ enum Commands {
         #[command(subcommand)]
         command: Option<UpdateCommands>,
     },
+    /// Remove this official Boomux release installation
+    Uninstall {
+        /// Also remove standard Boomux durable state and configuration
+        #[arg(long)]
+        purge: bool,
+    },
     /// Discover configured projects
     Project {
         #[command(subcommand)]
@@ -461,6 +469,13 @@ enum Commands {
         expected_socket_device: u64,
         expected_socket_inode: u64,
     },
+    #[command(name = "__uninstall-remote", hide = true)]
+    UninstallRemote {
+        expected_node_id: String,
+        expected_executable: String,
+    },
+    #[command(name = "__uninstall-fingerprint", hide = true)]
+    UninstallFingerprint,
 }
 
 #[derive(Subcommand)]
@@ -534,6 +549,8 @@ enum NodeCommands {
     List,
     /// Upgrade a registered remote Node after interactive authorization
     Upgrade { selector: String },
+    /// Uninstall Boomux from a registered remote Node
+    Uninstall { selector: String },
     /// Reauthenticate the stored route to a registered remote Node
     Reauthenticate { selector: String },
     /// Inspect a registered remote Node by alias or exact Node ID
@@ -1172,6 +1189,7 @@ command_keys! {
     ConfigEdit => ("config.edit", HumanOnly),
     UpdateStatus => ("update.status", Json),
     Update => ("update", HumanOnly),
+    Uninstall => ("uninstall", HumanOnly),
     ProjectList => ("project.list", Json),
     WorkspaceList => ("workspace.list", Json),
     WorkspaceInspect => ("workspace.inspect", Json),
@@ -1179,6 +1197,7 @@ command_keys! {
     Desktop => ("desktop", HumanOnly),
     NodeAdd => ("node.add", Json),
     NodeUpgrade => ("node.upgrade", HumanOnly),
+    NodeUninstall => ("node.uninstall", HumanOnly),
     NodeReauthenticate => ("node.reauthenticate", HumanOnly),
     NodeList => ("node.list", Json),
     NodeInspect => ("node.inspect", Json),
@@ -1229,6 +1248,8 @@ command_keys! {
     Daemon => ("daemon", HumanOnly),
     Attach => ("attach", HumanOnly),
     ResumeSessionInternal => ("resume-session-internal", HumanOnly),
+    UninstallRemote => ("uninstall-remote", HumanOnly),
+    UninstallFingerprint => ("uninstall-fingerprint", HumanOnly),
 }
 
 impl Cli {
@@ -1269,6 +1290,7 @@ impl Cli {
                 command: Some(UpdateCommands::Status),
             }) => CommandKey::UpdateStatus,
             Some(Commands::Update { command: None }) => CommandKey::Update,
+            Some(Commands::Uninstall { .. }) => CommandKey::Uninstall,
             Some(Commands::Project {
                 command: ProjectCommands::List { .. },
             }) => CommandKey::ProjectList,
@@ -1287,6 +1309,9 @@ impl Cli {
             Some(Commands::Node {
                 command: NodeCommands::Upgrade { .. },
             }) => CommandKey::NodeUpgrade,
+            Some(Commands::Node {
+                command: NodeCommands::Uninstall { .. },
+            }) => CommandKey::NodeUninstall,
             Some(Commands::Node {
                 command: NodeCommands::Reauthenticate { .. },
             }) => CommandKey::NodeReauthenticate,
@@ -1465,6 +1490,8 @@ impl Cli {
             Some(Commands::GuidedNodeAdd) => CommandKey::NodeAdd,
             Some(Commands::GuidedNodeUpgrade { .. }) => CommandKey::NodeUpgrade,
             Some(Commands::GuidedNodeReauthenticate { .. }) => CommandKey::NodeReauthenticate,
+            Some(Commands::UninstallRemote { .. }) => CommandKey::UninstallRemote,
+            Some(Commands::UninstallFingerprint) => CommandKey::UninstallFingerprint,
             Some(Commands::BootstrapActivate { .. }) => CommandKey::Daemon,
         }
     }
@@ -1808,6 +1835,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             }
         }
         Some(Commands::Update { command: None }) => update::guided_update(),
+        Some(Commands::Uninstall { purge }) => uninstall::guided_uninstall(purge),
         Some(Commands::Project {
             command: ProjectCommands::List { node },
         }) => list_projects(cli.json, node.as_deref()),
@@ -1900,6 +1928,18 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::GuidedNodeAdd) => unreachable!(),
         Some(Commands::GuidedNodeUpgrade { .. }) => unreachable!(),
         Some(Commands::GuidedNodeReauthenticate { .. }) => unreachable!(),
+        Some(Commands::UninstallRemote {
+            expected_node_id,
+            expected_executable,
+        }) => uninstall::remote_uninstall(&expected_node_id, &expected_executable),
+        Some(Commands::UninstallFingerprint) => {
+            let target = update::uninstall_target()?;
+            println!(
+                "boomux-uninstall-fingerprint-v1 {}",
+                target.authorization_token()
+            );
+            Ok(())
+        }
         Some(Commands::BootstrapActivate { .. }) => unreachable!(),
         None => dashboard(cli.terminal.as_deref()),
     };
@@ -2100,6 +2140,97 @@ fn upgrade_node(selector: &str) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn uninstall_node(selector: &str) -> Result<(), Box<dyn Error>> {
+    const TIMEOUT: Duration = Duration::from_secs(120);
+
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Node uninstall requires an interactive terminal",
+        )
+        .into());
+    }
+    let local = client::connect_or_start()?;
+    if !local.supports(protocol::ProtocolFeature::NodeUninstallCoordination)? {
+        return Err(cli_output::failure(
+            "unsupported_version",
+            "Node uninstall requires daemon protocol 48 or newer",
+        ));
+    }
+    let registration = local.node_registration(selector)?;
+    let target = ssh_bootstrap::SshTarget::parse(&registration.target)?;
+    let mut session = ssh_bootstrap::BootstrapSession::open(
+        target,
+        ssh_bootstrap::SshAuthenticationMode::Interactive,
+        TIMEOUT,
+    )
+    .map_err(bootstrap_cli_failure)?;
+    let plan = session
+        .plan_explicit_uninstall(&registration.node_id, TIMEOUT)
+        .map_err(bootstrap_cli_failure)?;
+
+    println!("Node: {} ({})", registration.alias, registration.node_id);
+    println!("Remote target: {}", registration.target);
+    println!("Install path: {}", plan.destination.as_str());
+    println!("Remote helper version: {}", plan.helper_version);
+    println!(
+        "Process impact: every managed Shell process, PTY, projection worker, and shared runtime on this remote Node will be stopped"
+    );
+    println!(
+        "Data impact: durable remote state and configuration are preserved; current Boomux integration assets are removed and modified assets are preserved"
+    );
+    for (display_name, path) in &plan.preserved_integrations {
+        println!(
+            "Preserving modified or uninspectable {display_name} integration asset{}",
+            path.as_deref()
+                .map(|path| format!(" at {path}"))
+                .unwrap_or_default()
+        );
+    }
+    println!(
+        "Registration impact: the local registration is removed atomically only after remote executable removal is confirmed"
+    );
+    if !confirm_setup("Uninstall Boomux from this registered Node?")? {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "remote Boomux uninstall was not authorized",
+        )
+        .into());
+    }
+
+    let current = local.node_registration(&registration.node_id)?;
+    if current != registration {
+        return Err(cli_output::failure(
+            "revision_changed",
+            "Node registration changed during uninstall preparation; refresh and retry",
+        ));
+    }
+    let (current, maintenance_token) =
+        local.begin_node_upgrade_maintenance(&registration.node_id, registration.revision)?;
+    if current != registration {
+        let _ = local.finish_node_upgrade_maintenance(&registration.node_id, &maintenance_token);
+        return Err(cli_output::failure(
+            "revision_changed",
+            "Node registration changed while uninstall authorization was pending; refresh and retry",
+        ));
+    }
+    let uninstall = session.uninstall_registered(&plan, TIMEOUT, || {
+        local
+            .renew_node_upgrade_maintenance(&registration.node_id, &maintenance_token)
+            .map_err(|error| io::Error::other(error.to_string()))
+    });
+    if let Err(error) = uninstall {
+        let _ = local.finish_node_upgrade_maintenance(&registration.node_id, &maintenance_token);
+        return Err(bootstrap_cli_failure(error));
+    }
+    local.finish_node_uninstall_maintenance(&registration.node_id, maintenance_token)?;
+    println!(
+        "Uninstalled Boomux from {} and forgot registration {}",
+        registration.target, registration.alias
+    );
+    Ok(())
+}
+
 fn reauthenticate_node(selector: &str) -> Result<(), Box<dyn Error>> {
     const TIMEOUT: Duration = Duration::from_secs(120);
 
@@ -2227,6 +2358,7 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
             }
         }
         NodeCommands::Upgrade { selector } => upgrade_node(&selector),
+        NodeCommands::Uninstall { selector } => uninstall_node(&selector),
         NodeCommands::Reauthenticate { selector } => reauthenticate_node(&selector),
         NodeCommands::Inspect { selector } => {
             let client = client::connect_or_start()?;
@@ -11072,7 +11204,7 @@ mod tests {
     }
 
     #[test]
-    fn node_upgrade_and_reauthentication_wrappers_are_human_only() {
+    fn node_upgrade_uninstall_and_reauthentication_wrappers_are_human_only() {
         let cli = Cli::try_parse_from(["boomux", "node", "upgrade", "work"]).unwrap();
         assert!(matches!(
             cli.command.as_ref(),
@@ -11081,6 +11213,16 @@ mod tests {
             }) if selector == "work"
         ));
         assert_eq!(cli.command_descriptor().key, "node.upgrade");
+
+        let cli = Cli::try_parse_from(["boomux", "node", "uninstall", "work"]).unwrap();
+        assert!(matches!(
+            cli.command.as_ref(),
+            Some(Commands::Node {
+                command: NodeCommands::Uninstall { selector }
+            }) if selector == "work"
+        ));
+        assert_eq!(cli.command_descriptor().key, "node.uninstall");
+        assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
 
         let cli = Cli::try_parse_from(["boomux", "node", "reauthenticate", "work"]).unwrap();
         assert!(matches!(
@@ -11115,6 +11257,40 @@ mod tests {
         ));
         assert!(!should_release_node_upgrade_maintenance(
             ssh_bootstrap::BootstrapRecoveryDisposition::OutcomeUnknown
+        ));
+    }
+
+    #[test]
+    fn local_uninstall_is_human_only_and_purge_is_explicit() {
+        let cli = Cli::try_parse_from(["boomux", "uninstall"]).unwrap();
+        assert!(matches!(
+            cli.command.as_ref(),
+            Some(Commands::Uninstall { purge: false })
+        ));
+        assert_eq!(cli.command_descriptor().key, "uninstall");
+        assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+
+        let cli = Cli::try_parse_from(["boomux", "uninstall", "--purge"]).unwrap();
+        assert!(matches!(
+            cli.command.as_ref(),
+            Some(Commands::Uninstall { purge: true })
+        ));
+
+        let node_id = "550e8400-e29b-41d4-a716-446655440000";
+        let cli =
+            Cli::try_parse_from(["boomux", "__uninstall-remote", node_id, "fingerprint"]).unwrap();
+        assert!(matches!(
+            cli.command.as_ref(),
+            Some(Commands::UninstallRemote { expected_node_id, expected_executable })
+                if expected_node_id == node_id && expected_executable == "fingerprint"
+        ));
+        assert_eq!(cli.command_descriptor().key, "uninstall-remote");
+        assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+
+        let cli = Cli::try_parse_from(["boomux", "__uninstall-fingerprint"]).unwrap();
+        assert!(matches!(
+            cli.command.as_ref(),
+            Some(Commands::UninstallFingerprint)
         ));
     }
 
@@ -13884,7 +14060,7 @@ mod tests {
                 .validated_version,
             "2.1.236"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 47);
+        assert_eq!(protocol::PROTOCOL_VERSION, 48);
     }
 
     #[test]

--- a/src/node_registration.rs
+++ b/src/node_registration.rs
@@ -498,6 +498,48 @@ impl NodeRegistrationManager {
         Ok(())
     }
 
+    pub(crate) fn finish_uninstall_maintenance(
+        &self,
+        node_id: &str,
+        token: &str,
+    ) -> io::Result<NodeRegistrationSnapshot> {
+        let mut state = self.lock_state()?;
+        let current = available_mut(&mut state)?;
+        expire_maintenance(current);
+        let index = current
+            .registrations
+            .iter()
+            .position(|registration| registration.snapshot.node_id == node_id)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "Node registration not found")
+            })?;
+        if current.registrations[index]
+            .maintenance
+            .as_ref()
+            .is_none_or(|maintenance| maintenance.token != token)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "Node uninstall maintenance lease is not current",
+            ));
+        }
+        if current.registrations[index].admitted != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::ResourceBusy,
+                "Node uninstall maintenance still has admitted operations",
+            ));
+        }
+        let mut replacement = current.clone();
+        let tombstone_epoch = next(replacement.tombstone_epoch, "registration tombstone epoch")?;
+        replacement.tombstone_epoch = tombstone_epoch;
+        let mut removed = replacement.registrations.remove(index).snapshot;
+        removed.tombstone_epoch = tombstone_epoch;
+        save(&self.path, &replacement)?;
+        *current = replacement;
+        self.changed.notify_all();
+        Ok(removed)
+    }
+
     pub(crate) fn renew_upgrade_maintenance(
         &self,
         node_id: &str,
@@ -1207,6 +1249,35 @@ mod tests {
         thread::sleep(Duration::from_millis(2));
         assert!(manager.admit(&registration).unwrap());
         manager.release(&registration);
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn uninstall_maintenance_atomically_persists_registration_removal() {
+        let path = path();
+        let manager = NodeRegistrationManager::load_at(path.clone());
+        let registration = manager
+            .add("work".into(), "old".into(), node_id(2), &node_id(1))
+            .unwrap();
+        let (_, token) = manager
+            .begin_upgrade_maintenance_if(
+                "work",
+                registration.revision,
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+                || true,
+            )
+            .unwrap();
+
+        let removed = manager
+            .finish_uninstall_maintenance(&registration.node_id, &token)
+            .unwrap();
+        assert_eq!(removed.node_id, registration.node_id);
+        assert!(removed.tombstone_epoch > registration.tombstone_epoch);
+        assert!(manager.list().unwrap().is_empty());
+
+        let restored = NodeRegistrationManager::load_at(path.clone());
+        assert!(restored.list().unwrap().is_empty());
         fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 47;
+pub const PROTOCOL_VERSION: u32 = 48;
 pub const MIN_PROTOCOL_VERSION: u32 = 47;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -175,6 +175,10 @@ define_protocol_features! {
         "kiro_stop_idle",
     ]),
     ScheduleFreeProtocol => (47, "schedule-free protocol", ["protocol_47"]),
+    NodeUninstallCoordination => (48, "Node uninstall coordination", [
+        "protocol_48",
+        "node_uninstall_coordination",
+    ]),
 }
 
 pub const MAX_NODE_PROJECTION_TRANSITIONS: u16 = 256;
@@ -1478,6 +1482,10 @@ pub enum Request {
         node_id: String,
         token: String,
     },
+    FinishNodeUninstallMaintenance {
+        node_id: String,
+        token: String,
+    },
     RenewNodeUpgradeMaintenance {
         node_id: String,
         token: String,
@@ -1584,6 +1592,9 @@ pub enum Request {
         environment: Option<UnixEnvironment>,
     },
     Shutdown,
+    ShutdownIfNodeIdentity {
+        expected_node_id: String,
+    },
     Snapshot,
     GetFocusedTerminal,
     GetWorkspace {
@@ -1852,6 +1863,10 @@ impl Request {
             | Self::RenewNodeUpgradeMaintenance { .. } => {
                 Some(ProtocolFeature::NodeUpgradeCoordination)
             }
+            Self::FinishNodeUninstallMaintenance { .. } => {
+                Some(ProtocolFeature::NodeUninstallCoordination)
+            }
+            Self::ShutdownIfNodeIdentity { .. } => Some(ProtocolFeature::NodeUninstallCoordination),
             Self::SyncNodeProjection { .. } | Self::GetNodeProjectionHealth { .. } => {
                 Some(ProtocolFeature::NodeProjectionSync)
             }
@@ -2499,8 +2514,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_forty_seven_only() {
-        assert_eq!(PROTOCOL_VERSION, 47);
+    fn protocol_version_is_forty_eight_with_forty_seven_floor() {
+        assert_eq!(PROTOCOL_VERSION, 48);
         assert_eq!(MIN_PROTOCOL_VERSION, 47);
     }
 
@@ -2661,6 +2676,27 @@ mod tests {
             serde_json::from_value::<Response>(encoded).unwrap(),
             response
         );
+    }
+
+    #[test]
+    fn node_uninstall_completion_requires_protocol_forty_eight() {
+        for request in [
+            Request::FinishNodeUninstallMaintenance {
+                node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+                token: "token".into(),
+            },
+            Request::ShutdownIfNodeIdentity {
+                expected_node_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            },
+        ] {
+            let encoded = serde_json::to_value(&request).unwrap();
+            assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
+            assert_eq!(
+                request.required_feature(),
+                Some(ProtocolFeature::NodeUninstallCoordination)
+            );
+            assert_eq!(request.minimum_protocol_version(), 48);
+        }
     }
 
     #[test]
@@ -3772,6 +3808,7 @@ mod tests {
             (45, &["protocol_45", "kiro_exact_launch_holders"][..]),
             (46, &["protocol_46", "kiro_stop_idle"][..]),
             (47, &["protocol_47"][..]),
+            (48, &["protocol_48", "node_uninstall_coordination"][..]),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -28,6 +28,7 @@ const MAX_DISCOVERED_EXECUTABLES: usize = 32;
 const MAX_PROBE_STDERR_BYTES: usize = 16 * 1024;
 const MAX_PROBE_TIMEOUT: Duration = Duration::from_secs(120);
 const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(10);
+type RemoteIntegrationCleanupPlan = (Vec<String>, Vec<(String, Option<String>)>);
 const PLATFORM_PROBE_PREFIX: &[u8] = b"boomux-platform-v1";
 const EXECUTABLE_PROBE_PREFIX: &[u8] = b"boomux-executables-v1";
 const INSTALL_DESTINATION_PROBE_PREFIX: &[u8] = b"boomux-install-destination-v1";
@@ -38,6 +39,7 @@ const INSTALL_STAGE_PREFIX: &str = "boomux-install-stage-v1";
 const RUNTIME_STAGE_PREFIX: &str = "boomux-runtime-v1";
 const DAEMON_STATUS_PREFIX: &[u8] = b"boomux-daemon-status-v1";
 const DAEMON_PRESENCE_PREFIX: &[u8] = b"boomux-daemon-presence-v1";
+const UNINSTALL_FINGERPRINT_PREFIX: &str = "boomux-uninstall-fingerprint-v1 ";
 const MAX_RELEASE_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_RELEASE_METADATA_BYTES: u64 = 64 * 1024;
 const RELEASE_DOWNLOAD_TIMEOUT_SECONDS: &str = "120";
@@ -223,6 +225,66 @@ fn remote_helper_command(executable: &RemoteExecutable) -> String {
     remote_daemon_command(executable, "__federation-stdio")
 }
 
+fn remote_integration_cleanup_plan(
+    session: &BootstrapSession,
+    executable: &RemoteExecutable,
+    timeout: Duration,
+) -> io::Result<RemoteIntegrationCleanupPlan> {
+    let output = run_bounded_command(
+        session.command(&remote_daemon_command(
+            executable,
+            "integration status --json",
+        )),
+        timeout,
+    )?;
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|_| invalid_probe("remote integration status returned invalid JSON"))?;
+    if value.get("schema").and_then(serde_json::Value::as_str) != Some("boomux.cli/v1")
+        || value.get("command").and_then(serde_json::Value::as_str) != Some("integration.status")
+    {
+        return Err(invalid_probe(
+            "remote integration status returned an invalid envelope",
+        ));
+    }
+    let rows = value
+        .pointer("/data/integrations")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| invalid_probe("remote integration status omitted integrations"))?;
+    let allowed = ["opencode", "pi", "claude", "codex", "kiro"];
+    let mut current = Vec::new();
+    let mut preserved = Vec::new();
+    for row in rows {
+        let name = row
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .filter(|name| allowed.contains(name))
+            .ok_or_else(|| invalid_probe("remote integration status returned an unknown name"))?;
+        let display_name = row
+            .get("display_name")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| invalid_probe("remote integration status omitted a display name"))?;
+        let state = row
+            .pointer("/asset/state")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| invalid_probe("remote integration status omitted an asset state"))?;
+        let path = row
+            .pointer("/asset/path")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned);
+        match state {
+            "current" => current.push(name.to_owned()),
+            "modified" | "unavailable" => preserved.push((display_name.to_owned(), path)),
+            "missing" => {}
+            _ => {
+                return Err(invalid_probe(
+                    "remote integration status returned an invalid state",
+                ));
+            }
+        }
+    }
+    Ok((current, preserved))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SshAuthenticationMode {
     Interactive,
@@ -339,6 +401,19 @@ pub struct RemoteInstallPlan {
     bootstrap_id: Option<Uuid>,
     upgrade_helper: Option<RemoteExecutable>,
     intent: RemoteInstallIntent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteUninstallPlan {
+    pub target: SshTarget,
+    pub destination: RemoteExecutable,
+    pub helper_version: String,
+    pub preserved_integrations: Vec<(String, Option<String>)>,
+    helper: RemoteExecutable,
+    bootstrap_id: Uuid,
+    current_integrations: Vec<String>,
+    expected_node_id: String,
+    expected_executable: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1602,6 +1677,133 @@ impl BootstrapSession {
             upgrade_helper: Some(helper.executable),
             intent,
         })
+    }
+
+    pub fn plan_explicit_uninstall(
+        &mut self,
+        expected_node_id: &str,
+        timeout: Duration,
+    ) -> io::Result<RemoteUninstallPlan> {
+        let discovery = discover_remote_in_session(self, timeout)?;
+        if let Some(error) = remote_recovery_error(discovery.recovery) {
+            return Err(error);
+        }
+        let selection = inspect_remote_helpers_in_session(self, &discovery.executables, timeout)?;
+        let helper = selection.compatible.ok_or_else(|| {
+            classified_error(
+                io::ErrorKind::Unsupported,
+                "upgrade_required",
+                "registered Node uninstall requires an existing compatible remote helper",
+            )
+        })?;
+        RemoteInstallIntent::ExplicitRegisteredUpgrade {
+            expected_node_id: expected_node_id.to_owned(),
+        }
+        .verify_helper_identity(&helper)?;
+        if helper.handshake.core_protocol_version < 48 {
+            return Err(classified_error(
+                io::ErrorKind::Unsupported,
+                "upgrade_required",
+                "registered Node uninstall requires a protocol-48 helper; upgrade this Node first",
+            ));
+        }
+        let fingerprint = run_bounded_command(
+            self.command(&remote_daemon_command(
+                &helper.executable,
+                "__uninstall-fingerprint",
+            )),
+            timeout,
+        )?;
+        let expected_executable = std::str::from_utf8(&fingerprint.stdout)
+            .ok()
+            .and_then(|value| value.strip_suffix('\n'))
+            .and_then(|value| value.strip_prefix(UNINSTALL_FINGERPRINT_PREFIX))
+            .filter(|value| {
+                !value.is_empty()
+                    && value.len() <= 512
+                    && value.bytes().all(|byte| byte.is_ascii_graphic())
+            })
+            .ok_or_else(|| invalid_probe("remote uninstall fingerprint is invalid"))?
+            .to_owned();
+        if helper.executable != discovery.install_destination {
+            return Err(classified_error(
+                io::ErrorKind::PermissionDenied,
+                "package_managed",
+                "the registered Node helper is not the canonical user installation; uninstall it with its owning package or installation workflow",
+            ));
+        }
+        let (current_integrations, preserved_integrations) =
+            remote_integration_cleanup_plan(self, &helper.executable, timeout)?;
+        Ok(RemoteUninstallPlan {
+            target: self.target.clone(),
+            destination: discovery.install_destination,
+            helper_version: helper.handshake.helper_version,
+            preserved_integrations,
+            helper: helper.executable,
+            bootstrap_id: self.id,
+            current_integrations,
+            expected_node_id: expected_node_id.to_owned(),
+            expected_executable,
+        })
+    }
+
+    pub fn uninstall_registered(
+        self,
+        plan: &RemoteUninstallPlan,
+        timeout: Duration,
+        mut maintenance: impl FnMut() -> io::Result<()>,
+    ) -> io::Result<()> {
+        if plan.bootstrap_id != self.id
+            || plan.target != self.target
+            || plan.helper != plan.destination
+        {
+            return Err(classified_error(
+                io::ErrorKind::PermissionDenied,
+                "bootstrap_authentication_failed",
+                "remote uninstall authorization belongs to a different bootstrap endpoint",
+            ));
+        }
+        maintenance()?;
+        for integration in &plan.current_integrations {
+            let arguments = match integration.as_str() {
+                "opencode" => "integration uninstall opencode --json",
+                "pi" => "integration uninstall pi --json",
+                "claude" => "integration uninstall claude --json",
+                "codex" => "integration uninstall codex --json",
+                "kiro" => "integration uninstall kiro --json",
+                _ => {
+                    return Err(invalid_probe(
+                        "remote uninstall plan contains an unknown integration",
+                    ));
+                }
+            };
+            let output = run_bounded_command(
+                self.command(&remote_daemon_command(&plan.helper, arguments)),
+                timeout,
+            )?;
+            let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+                .map_err(|_| invalid_probe("remote integration uninstall returned invalid JSON"))?;
+            if value.get("schema").and_then(serde_json::Value::as_str) != Some("boomux.cli/v1")
+                || value.get("command").and_then(serde_json::Value::as_str)
+                    != Some("integration.uninstall")
+            {
+                return Err(invalid_probe(
+                    "remote integration uninstall returned an invalid envelope",
+                ));
+            }
+            maintenance()?;
+        }
+        maintenance()?;
+        let arguments = format!(
+            "__uninstall-remote {} {}",
+            quote_posix_shell(&plan.expected_node_id),
+            quote_posix_shell(&plan.expected_executable)
+        );
+        run_bounded_command(
+            self.command(&remote_daemon_command(&plan.helper, &arguments)),
+            timeout,
+        )?;
+        Ok(())
     }
 
     pub fn connect_existing_verified(
@@ -4953,13 +5155,13 @@ mod tests {
         let mut request_bytes = Vec::new();
         protocol::write_message(
             &mut request_bytes,
-            &Envelope::with_version(protocol::PROTOCOL_VERSION, Request::Ping),
+            &Envelope::with_version(core_protocol_version, Request::Ping),
         )
         .unwrap();
         let mut response_bytes = Vec::new();
         protocol::write_message(
             &mut response_bytes,
-            &Envelope::with_version(protocol::PROTOCOL_VERSION, Response::Pong),
+            &Envelope::with_version(core_protocol_version, Response::Pong),
         )
         .unwrap();
         format!(
@@ -6418,6 +6620,81 @@ mod tests {
             }
         );
         drop(session);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn explicit_uninstall_requires_protocol_forty_eight_helper() {
+        let runtime = runtime_directory();
+        let node_id = Uuid::new_v4().to_string();
+        let helper = helper_script(&node_id, 47);
+        let executable = "/home/person/.local/bin/boomux";
+        let ssh = write_session_bootstrap_ssh(
+            &runtime,
+            &format!(
+                "  \"'{executable}' __federation-stdio\") {helper} ;;\n  \"'{executable}' --version\") printf 'boomux 1.0.0\\n' ;;"
+            ),
+            "/home/person/.local/bin/boomux\\0",
+        );
+        let mut session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+
+        let error = session
+            .plan_explicit_uninstall(&node_id, Duration::from_secs(1))
+            .unwrap_err();
+        assert_eq!(error_code(&error), "upgrade_required");
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn explicit_uninstall_uses_one_session_and_preserves_modified_integrations() {
+        let runtime = runtime_directory();
+        let marker = runtime.join("uninstalled");
+        let node_id = Uuid::new_v4().to_string();
+        let helper = compatible_helper_script(&node_id);
+        let executable = "/home/person/.local/bin/boomux";
+        let status = r#"{"schema":"boomux.cli/v1","command":"integration.status","data":{"integrations":[{"name":"opencode","display_name":"OpenCode","asset":{"state":"current","path":"/current"}},{"name":"pi","display_name":"Pi","asset":{"state":"modified","path":"/modified"}}]}}"#;
+        let removed = r#"{"schema":"boomux.cli/v1","command":"integration.uninstall","data":{"integrations":[]}}"#;
+        let ssh = write_session_bootstrap_ssh(
+            &runtime,
+            &format!(
+                "  \"'{executable}' __federation-stdio\") {helper} ;;\n  \"'{executable}' --version\") printf 'boomux 1.0.1\\n' ;;\n  *'__uninstall-fingerprint'*) printf 'boomux-uninstall-fingerprint-v1 token\\n' ;;\n  *'integration status --json'*) printf '%s' '{status}' ;;\n  *'integration uninstall opencode --json'*) printf '%s' '{removed}' ;;\n  *'__uninstall-remote'*) : > {} ;;",
+                quote_posix_shell(marker.to_str().unwrap())
+            ),
+            "/home/person/.local/bin/boomux\\0",
+        );
+        let mut session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let plan = session
+            .plan_explicit_uninstall(&node_id, Duration::from_secs(1))
+            .unwrap();
+        assert_eq!(
+            plan.preserved_integrations,
+            vec![("Pi".into(), Some("/modified".into()))]
+        );
+        let mut renewals = 0;
+        session
+            .uninstall_registered(&plan, Duration::from_secs(1), || {
+                renewals += 1;
+                Ok(())
+            })
+            .unwrap();
+        assert!(renewals >= 3);
+        assert!(marker.exists());
         fs::remove_dir_all(runtime).unwrap();
     }
 

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -1,0 +1,591 @@
+use std::env;
+use std::fs;
+use std::io::{self, IsTerminal, Write};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Component, Path, PathBuf};
+
+use crate::integration_management::{self, AssetState};
+use crate::{BOOMUX_SKILL, client, mobile_web, tailscale_serve, update};
+
+const MAX_PURGE_ENTRIES: usize = 16_384;
+const MAX_WEB_GATEWAYS: usize = 256;
+
+pub(crate) fn guided_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Error>> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Boomux uninstall requires an interactive terminal",
+        )
+        .into());
+    }
+
+    let target = update::uninstall_target()?;
+    let environment = integration_management::Environment::from_process();
+    let mut removable_integrations = Vec::new();
+    let mut preserved_integrations = Vec::new();
+    for integration in integration_management::IntegrationId::all() {
+        let status = integration_management::inspect(integration, &environment, None);
+        match status.asset.state {
+            AssetState::Current => removable_integrations.push(integration),
+            AssetState::Modified | AssetState::Unavailable => {
+                preserved_integrations.push((integration, status.asset.path))
+            }
+            AssetState::Missing => {}
+        }
+    }
+    for integration in &removable_integrations {
+        integration_management::preflight_uninstall(*integration, &environment, false)?;
+    }
+
+    let home = required_home()?;
+    let skill_path = home.join(".agents/skills/boomux/SKILL.md");
+    let skill_state = integration_management::regular_file_matches(&skill_path, BOOMUX_SKILL)?;
+    let purge_directories = purge
+        .then(|| Ok::<_, io::Error>((state_directory(&home)?, config_directory(&home)?)))
+        .transpose()?;
+    if let Some((state_directory, config_directory)) = &purge_directories {
+        validate_owned_tree_if_present(state_directory)?;
+        validate_owned_tree_if_present(config_directory)?;
+    }
+
+    println!("Install path: {}", target.path().display());
+    println!(
+        "Process impact: every Boomux web gateway, managed Shell process, PTY, and shared runtime on this Node will be stopped"
+    );
+    println!(
+        "Owned assets: current Boomux integration files and the unchanged Boomux Agent Skill will be removed"
+    );
+    for (integration, path) in &preserved_integrations {
+        println!(
+            "Preserving modified or uninspectable {} integration asset{}",
+            integration.spec().display_name,
+            path.as_deref()
+                .map(|path| format!(" at {path}"))
+                .unwrap_or_default()
+        );
+    }
+    if skill_state == Some(false) {
+        println!(
+            "Preserving modified Boomux Agent Skill at {}",
+            skill_path.display()
+        );
+    }
+    if purge {
+        let (state_directory, config_directory) = purge_directories
+            .as_ref()
+            .expect("purge directories were resolved");
+        println!(
+            "Data impact: --purge removes {} and {}",
+            state_directory.display(),
+            config_directory.display()
+        );
+        println!(
+            "The optional BOOMUX_CONFIG file is not removed when it is outside the standard Boomux config directory"
+        );
+    } else {
+        println!(
+            "Data impact: durable state and configuration are preserved for a later reinstall"
+        );
+    }
+    print!("Uninstall Boomux? [y/N] ");
+    io::stdout().flush()?;
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer)?;
+    if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "uninstall was not authorized",
+        )
+        .into());
+    }
+
+    update::revalidate_uninstall_target(&target)?;
+    for integration in &removable_integrations {
+        integration_management::preflight_uninstall(*integration, &environment, false)?;
+    }
+    if let Some((state_directory, config_directory)) = &purge_directories {
+        validate_owned_tree_if_present(state_directory)?;
+        validate_owned_tree_if_present(config_directory)?;
+    }
+
+    stop_web_gateways()?;
+    let _daemon_reservation = update::stop_daemon_for_uninstall(&target)?;
+    for integration in removable_integrations {
+        let result = integration_management::uninstall(integration, &environment, false)?;
+        if result.result == integration_management::UninstallOutcome::Removed {
+            println!(
+                "Removed {} integration asset from {}",
+                integration.spec().display_name,
+                result.path
+            );
+        }
+    }
+    if skill_state == Some(true)
+        && integration_management::regular_file_matches(&skill_path, BOOMUX_SKILL)? == Some(true)
+    {
+        fs::remove_file(&skill_path)?;
+        println!("Removed Boomux Agent Skill from {}", skill_path.display());
+    } else if skill_state == Some(true) {
+        println!(
+            "Preserving Boomux Agent Skill because it changed after authorization: {}",
+            skill_path.display()
+        );
+    }
+    if purge {
+        let (state_directory, config_directory) = purge_directories
+            .as_ref()
+            .expect("purge directories were resolved");
+        validate_owned_tree_if_present(state_directory)?;
+        validate_owned_tree_if_present(config_directory)?;
+        remove_owned_tree_if_present(&home, state_directory)?;
+        remove_owned_tree_if_present(&home, config_directory)?;
+    }
+    update::remove_uninstall_target(&target)?;
+    println!("Uninstalled Boomux from {}", target.path().display());
+    Ok(())
+}
+
+pub(crate) fn remote_uninstall(
+    expected_node_id: &str,
+    expected_executable: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    uuid::Uuid::parse_str(expected_node_id)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "expected Node ID is invalid"))?;
+    let target = update::uninstall_target()?;
+    if target.authorization_token() != expected_executable {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "installed Boomux executable changed after remote uninstall authorization",
+        )
+        .into());
+    }
+    stop_web_gateways()?;
+    update::revalidate_uninstall_target(&target)?;
+    let _daemon_reservation = update::stop_daemon_for_remote_uninstall(&target, expected_node_id)?;
+    update::remove_uninstall_target(&target)?;
+    println!("Uninstalled Boomux from {}", target.path().display());
+    Ok(())
+}
+
+fn stop_web_gateways() -> Result<(), Box<dyn std::error::Error>> {
+    let runtime = client::socket_path()?
+        .parent()
+        .ok_or_else(|| io::Error::other("Boomux runtime socket has no parent"))?
+        .to_path_buf();
+    let entries = match fs::read_dir(&runtime) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut ports = Vec::new();
+    let mut entry_count = 0;
+    for entry in entries {
+        entry_count += 1;
+        if entry_count > MAX_WEB_GATEWAYS {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Boomux runtime directory exceeds the uninstall entry bound",
+            )
+            .into());
+        }
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(port) = name
+            .strip_prefix("web-")
+            .and_then(|name| name.strip_suffix(".sock"))
+        else {
+            continue;
+        };
+        if let Ok(port) = port.parse::<u16>() {
+            ports.push(port);
+        }
+    }
+    ports.sort_unstable();
+    ports.dedup();
+    for port in ports {
+        mobile_web::stop(port)?;
+        tailscale_serve::cleanup_stale(port)?;
+    }
+    Ok(())
+}
+
+fn required_home() -> io::Result<PathBuf> {
+    env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "HOME must be an absolute path"))
+}
+
+fn state_directory(home: &Path) -> io::Result<PathBuf> {
+    xdg_directory("XDG_STATE_HOME", home.join(".local/state"), home).map(|root| root.join("boomux"))
+}
+
+fn config_directory(home: &Path) -> io::Result<PathBuf> {
+    xdg_directory("XDG_CONFIG_HOME", home.join(".config"), home).map(|root| root.join("boomux"))
+}
+
+fn xdg_directory(variable: &str, fallback: PathBuf, home: &Path) -> io::Result<PathBuf> {
+    let root = env::var_os(variable)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or(fallback);
+    if !root.is_absolute()
+        || root
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+        || !root.starts_with(home)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("{variable} must be an absolute path beneath HOME for purge"),
+        ));
+    }
+    validate_owned_directory_chain(home, &root)?;
+    Ok(root)
+}
+
+fn validate_owned_directory_chain(home: &Path, target: &Path) -> io::Result<()> {
+    let uid = unsafe { libc::geteuid() };
+    let relative = target.strip_prefix(home).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "purge directory is outside HOME",
+        )
+    })?;
+    let mut current = home.to_path_buf();
+    for component in std::iter::once(Component::RootDir).chain(relative.components()) {
+        if component == Component::RootDir {
+            current = home.to_path_buf();
+        } else if let Component::Normal(component) = component {
+            current.push(component);
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "purge directory contains an unsafe path component",
+            ));
+        }
+        match fs::symlink_metadata(&current) {
+            Ok(metadata)
+                if metadata.is_dir()
+                    && !metadata.file_type().is_symlink()
+                    && metadata.uid() == uid => {}
+            Ok(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("unsafe purge directory chain at {}", current.display()),
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => break,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn remove_owned_tree_if_present(home: &Path, path: &Path) -> io::Result<()> {
+    let Some((parent, name, directory)) = open_owned_tree(home, path)? else {
+        return Ok(());
+    };
+    let staged = format!(".boomux.uninstall.{}", uuid::Uuid::new_v4());
+    renameat_noreplace(parent.as_raw_fd(), &name, &staged)?;
+    let mut count = 0;
+    remove_directory_contents(&directory, &mut count)?;
+    unlinkat(parent.as_raw_fd(), &staged, libc::AT_REMOVEDIR)
+}
+
+fn open_owned_tree(home: &Path, path: &Path) -> io::Result<Option<(OwnedFd, String, OwnedFd)>> {
+    let relative = path.strip_prefix(home).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "purge path is outside HOME",
+        )
+    })?;
+    let mut components = relative.components().peekable();
+    let home_fd = open_directory(home)?;
+    validate_directory_fd(&home_fd)?;
+    let mut parent = home_fd;
+    let mut name = None;
+    while let Some(component) = components.next() {
+        let Component::Normal(component) = component else {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "purge path contains an unsafe component",
+            ));
+        };
+        let component = component.to_str().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "purge path is not UTF-8")
+        })?;
+        if components.peek().is_none() {
+            name = Some(component.to_owned());
+            break;
+        }
+        parent = match openat_directory(parent.as_raw_fd(), component) {
+            Ok(directory) => directory,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        validate_directory_fd(&parent)?;
+    }
+    let name = name
+        .ok_or_else(|| io::Error::new(io::ErrorKind::PermissionDenied, "refusing to purge HOME"))?;
+    let directory = match openat_directory(parent.as_raw_fd(), &name) {
+        Ok(directory) => directory,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let mut count = 0;
+    validate_owned_directory_contents(&directory, &mut count)?;
+    Ok(Some((parent, name, directory)))
+}
+
+fn open_directory(path: &Path) -> io::Result<OwnedFd> {
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+    let fd = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
+}
+
+fn openat_directory(parent: i32, name: &str) -> io::Result<OwnedFd> {
+    let name = std::ffi::CString::new(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+    let fd = unsafe {
+        libc::openat(
+            parent,
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
+}
+
+fn validate_directory_fd(directory: &OwnedFd) -> io::Result<()> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(directory.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_uid != unsafe { libc::geteuid() }
+        || stat.st_mode & libc::S_IFMT != libc::S_IFDIR
+        || stat.st_mode & 0o022 != 0
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "purge directory is not owner-controlled",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_owned_directory_contents(directory: &OwnedFd, count: &mut usize) -> io::Result<()> {
+    validate_directory_fd(directory)?;
+    for entry in fs::read_dir(format!("/proc/self/fd/{}", directory.as_raw_fd()))? {
+        *count += 1;
+        if *count > MAX_PURGE_ENTRIES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Boomux data tree exceeds the purge entry bound",
+            ));
+        }
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "purge entry is not UTF-8")
+        })?;
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if metadata.uid() != unsafe { libc::geteuid() }
+            || metadata.file_type().is_symlink()
+            || (!metadata.is_dir() && !metadata.is_file())
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "purge tree contains an unsafe entry",
+            ));
+        }
+        if metadata.is_dir() {
+            let child = openat_directory(directory.as_raw_fd(), name)?;
+            validate_owned_directory_contents(&child, count)?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_directory_contents(directory: &OwnedFd, count: &mut usize) -> io::Result<()> {
+    validate_directory_fd(directory)?;
+    for entry in fs::read_dir(format!("/proc/self/fd/{}", directory.as_raw_fd()))? {
+        *count += 1;
+        if *count > MAX_PURGE_ENTRIES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Boomux data tree exceeded the purge entry bound during removal",
+            ));
+        }
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "purge entry is not UTF-8")
+        })?;
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if metadata.uid() != unsafe { libc::geteuid() } {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "purge tree changed to an entry owned by another user",
+            ));
+        }
+        if metadata.is_dir() && !metadata.file_type().is_symlink() {
+            let child = openat_directory(directory.as_raw_fd(), name)?;
+            remove_directory_contents(&child, count)?;
+            unlinkat(directory.as_raw_fd(), name, libc::AT_REMOVEDIR)?;
+        } else if metadata.is_file() && !metadata.file_type().is_symlink() {
+            unlinkat(directory.as_raw_fd(), name, 0)?;
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "purge tree changed to an unsafe entry",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn renameat_noreplace(parent: i32, from: &str, to: &str) -> io::Result<()> {
+    let from = std::ffi::CString::new(from).unwrap();
+    let to = std::ffi::CString::new(to).unwrap();
+    if unsafe {
+        libc::renameat2(
+            parent,
+            from.as_ptr(),
+            parent,
+            to.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    } == 0
+    {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+fn unlinkat(parent: i32, name: &str, flags: i32) -> io::Result<()> {
+    let name = std::ffi::CString::new(name).unwrap();
+    if unsafe { libc::unlinkat(parent, name.as_ptr(), flags) } == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+fn validate_owned_tree_if_present(path: &Path) -> io::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if !metadata.is_dir()
+        || metadata.file_type().is_symlink()
+        || metadata.uid() != unsafe { libc::geteuid() }
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("refusing to purge unsafe directory {}", path.display()),
+        ));
+    }
+    let mut count = 0;
+    validate_owned_tree(path, unsafe { libc::geteuid() }, &mut count)?;
+    Ok(())
+}
+
+fn validate_owned_tree(path: &Path, uid: u32, count: &mut usize) -> io::Result<()> {
+    for entry in fs::read_dir(path)? {
+        *count += 1;
+        if *count > MAX_PURGE_ENTRIES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Boomux data tree exceeds the purge entry bound",
+            ));
+        }
+        let entry = entry?;
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if metadata.uid() != uid
+            || metadata.file_type().is_symlink()
+            || (!metadata.is_dir() && !metadata.is_file())
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("refusing to purge unsafe entry {}", entry.path().display()),
+            ));
+        }
+        if metadata.is_dir() {
+            validate_owned_tree(&entry.path(), uid, count)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn purge_validation_rejects_symlinks_before_removing_the_tree() {
+        let root = env::temp_dir().join(format!("boomux-uninstall-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(root.join("nested")).unwrap();
+        fs::write(root.join("state.json"), b"state").unwrap();
+        std::os::unix::fs::symlink("state.json", root.join("nested/link")).unwrap();
+
+        assert_eq!(
+            validate_owned_tree_if_present(&root).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert!(root.join("state.json").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn purge_removes_only_a_valid_owner_tree() {
+        let home = env::temp_dir().join(format!("boomux-uninstall-{}", uuid::Uuid::new_v4()));
+        let root = home.join("state/boomux");
+        fs::create_dir_all(root.join("nested")).unwrap();
+        fs::write(root.join("nested/state.json"), b"state").unwrap();
+
+        remove_owned_tree_if_present(&home, &root).unwrap();
+        assert!(!root.exists());
+        remove_owned_tree_if_present(&home, &root).unwrap();
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn purge_directory_chain_rejects_symlinked_ancestors() {
+        let home = env::temp_dir().join(format!("boomux-uninstall-{}", uuid::Uuid::new_v4()));
+        let outside = env::temp_dir().join(format!("boomux-outside-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, home.join("state-link")).unwrap();
+
+        assert_eq!(
+            validate_owned_directory_chain(&home, &home.join("state-link"))
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        fs::remove_dir_all(home).unwrap();
+        fs::remove_dir_all(outside).unwrap();
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,8 +1,9 @@
 use std::cmp::Ordering;
 use std::env;
+use std::fmt::Write as _;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, IsTerminal, Read, Write};
-use std::os::unix::ffi::OsStringExt;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -99,6 +100,21 @@ struct Inspection {
     tag: Option<String>,
 }
 
+pub(crate) struct UninstallTarget {
+    path: PathBuf,
+    baseline: FileFingerprint,
+}
+
+impl UninstallTarget {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn authorization_token(&self) -> String {
+        fingerprint_token(&self.baseline)
+    }
+}
+
 pub(crate) fn status() -> UpdateStatus {
     inspect().status
 }
@@ -178,6 +194,159 @@ pub(crate) fn guided_update() -> Result<(), Box<dyn std::error::Error>> {
         let _ = fs::remove_file(&candidate);
     }
     result.map_err(Into::into)
+}
+
+pub(crate) fn uninstall_target() -> io::Result<UninstallTarget> {
+    let path = env::current_exe()?;
+    let home = env::var_os("HOME").map(PathBuf::from);
+    let (kind, baseline) = classify_installation(&path, home.as_deref(), DISTRIBUTION);
+    if kind != InstallKind::GithubRelease {
+        let message = match kind {
+            InstallKind::PackageManaged | InstallKind::RootOwned => {
+                "this Boomux executable is package-managed; uninstall it with the package manager that installed it"
+            }
+            InstallKind::SourceBuild | InstallKind::DevelopmentBuild => {
+                "this Boomux executable is a source or development build; remove it through its build or installation workflow"
+            }
+            InstallKind::Custom | InstallKind::Unknown | InstallKind::GithubRelease => {
+                "this Boomux executable is not an ownership-proven official release installation"
+            }
+        };
+        return Err(io::Error::new(io::ErrorKind::PermissionDenied, message));
+    }
+    Ok(UninstallTarget {
+        path,
+        baseline: baseline.expect("eligible uninstall has a baseline"),
+    })
+}
+
+pub(crate) fn stop_daemon_for_uninstall(
+    target: &UninstallTarget,
+) -> io::Result<client::DaemonLockReservation> {
+    match daemon_disposition(&target.path)? {
+        DaemonDisposition::Absent { _reservation, .. } => Ok(_reservation),
+        DaemonDisposition::SameExecutable { client, .. } => {
+            client
+                .shutdown()
+                .map_err(|error| io::Error::other(error.to_string()))?;
+            reserve_daemon_absence(&client::socket_path()?)
+        }
+    }
+}
+
+pub(crate) fn stop_daemon_for_remote_uninstall(
+    target: &UninstallTarget,
+    expected_node_id: &str,
+) -> io::Result<client::DaemonLockReservation> {
+    match daemon_disposition(&target.path)? {
+        DaemonDisposition::Absent { .. } => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "remote uninstall requires the identity-verified daemon to remain running",
+        )),
+        DaemonDisposition::SameExecutable { client, .. } => {
+            client
+                .shutdown_if_node_identity(expected_node_id)
+                .map_err(|error| io::Error::other(error.to_string()))?;
+            reserve_daemon_absence(&client::socket_path()?)
+        }
+    }
+}
+
+fn fingerprint_token(fingerprint: &FileFingerprint) -> String {
+    let mut digest = String::with_capacity(64);
+    for byte in fingerprint.digest {
+        write!(digest, "{byte:02x}").expect("writing to a string cannot fail");
+    }
+    format!(
+        "{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}",
+        fingerprint.device,
+        fingerprint.inode,
+        fingerprint.length,
+        fingerprint.modified_seconds,
+        fingerprint.modified_nanoseconds,
+        fingerprint.changed_seconds,
+        fingerprint.changed_nanoseconds,
+        fingerprint.owner,
+        fingerprint.mode,
+        fingerprint.links,
+        digest
+    )
+}
+
+pub(crate) fn remove_uninstall_target(target: &UninstallTarget) -> io::Result<()> {
+    let parent = target
+        .path
+        .parent()
+        .ok_or_else(|| io::Error::other("install path has no parent directory"))?;
+    let staged = parent.join(format!(".boomux.uninstall.{}", Uuid::new_v4()));
+    rename_noreplace(&target.path, &staged)?;
+    let moved = match fingerprint(&staged) {
+        Ok(moved) => moved,
+        Err(error) => {
+            return match rename_noreplace(&staged, &target.path) {
+                Ok(()) => Err(error),
+                Err(restore) => Err(io::Error::other(format!(
+                    "could not inspect the staged Boomux executable: {error}; restoring it failed: {restore}; preserved at {}",
+                    staged.display()
+                ))),
+            };
+        }
+    };
+    if !same_candidate(&moved, &target.baseline) {
+        return match rename_noreplace(&staged, &target.path) {
+            Ok(()) => Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "installed Boomux executable changed after uninstall authorization",
+            )),
+            Err(restore) => Err(io::Error::other(format!(
+                "installed Boomux executable changed after uninstall authorization; restoring the moved file failed: {restore}; preserved at {}",
+                staged.display()
+            ))),
+        };
+    }
+    fs::remove_file(&staged)?;
+    sync_directory(parent)
+}
+
+#[cfg(target_os = "linux")]
+fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+    let from = std::ffi::CString::new(from.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+    let to = std::ffi::CString::new(to.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+    if unsafe {
+        libc::renameat2(
+            libc::AT_FDCWD,
+            from.as_ptr(),
+            libc::AT_FDCWD,
+            to.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    } == 0
+    {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn rename_noreplace(_from: &Path, _to: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "self-uninstall requires Linux atomic rename support",
+    ))
+}
+
+pub(crate) fn revalidate_uninstall_target(target: &UninstallTarget) -> io::Result<()> {
+    let current = fingerprint(&target.path)?;
+    if current != target.baseline {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "installed Boomux executable changed after uninstall authorization",
+        ));
+    }
+    Ok(())
 }
 
 fn inspect() -> Inspection {
@@ -1080,6 +1249,46 @@ mod tests {
             classify_installation(&executable, Some(&home), Some("github-release")).0,
             InstallKind::GithubRelease
         );
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn uninstall_removes_the_unchanged_pinned_executable_and_syncs_parent() {
+        let home = temporary_directory();
+        let bin = home.join(".local/bin");
+        fs::create_dir_all(&bin).unwrap();
+        let path = bin.join("boomux");
+        fs::write(&path, b"binary").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        let target = UninstallTarget {
+            baseline: fingerprint(&path).unwrap(),
+            path: path.clone(),
+        };
+
+        remove_uninstall_target(&target).unwrap();
+        assert!(!path.exists());
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn uninstall_refuses_an_executable_changed_after_authorization() {
+        let home = temporary_directory();
+        let bin = home.join(".local/bin");
+        fs::create_dir_all(&bin).unwrap();
+        let path = bin.join("boomux");
+        fs::write(&path, b"binary").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        let target = UninstallTarget {
+            baseline: fingerprint(&path).unwrap(),
+            path: path.clone(),
+        };
+        fs::write(&path, b"changed").unwrap();
+
+        assert_eq!(
+            remove_uninstall_target(&target).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(fs::read(&path).unwrap(), b"changed");
         fs::remove_dir_all(home).unwrap();
     }
 

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -192,7 +192,7 @@ fn native_daemon_lifecycle() {
     .unwrap();
     let response: protocol::Envelope<protocol::Response> =
         protocol::read_message(&mut protocol_forty_six).unwrap();
-    assert_eq!(response.version, 47);
+    assert_eq!(response.version, 48);
     assert!(matches!(
         response.message,
         protocol::Response::Error {
@@ -200,6 +200,12 @@ fn native_daemon_lifecycle() {
             ..
         }
     ));
+    let error = daemon
+        .client
+        .shutdown_if_node_identity(Uuid::new_v4().to_string())
+        .unwrap_err();
+    assert_remote_code(&error, ErrorCode::NodeIdentityChanged);
+    daemon.client.ping().unwrap();
 
     let missing_id = Uuid::new_v4().to_string();
     let error = daemon.client.get_shell(&missing_id).unwrap_err();

--- a/tests/native_backend/update.rs
+++ b/tests/native_backend/update.rs
@@ -147,7 +147,7 @@ fn update_status_has_stable_json_and_does_not_start_daemon() {
 }
 
 #[test]
-fn capabilities_advertise_update_surfaces() {
+fn capabilities_advertise_release_management_surfaces() {
     let root = fixture();
     let output = command(&root)
         .args(["--json", "capabilities"])
@@ -160,6 +160,11 @@ fn capabilities_advertise_update_surfaces() {
     let features = value["data"]["features"].as_array().unwrap();
     assert!(features.iter().any(|value| value == "local_update_status"));
     assert!(features.iter().any(|value| value == "guided_local_update"));
+    assert!(
+        features
+            .iter()
+            .any(|value| value == "guided_local_uninstall")
+    );
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -170,6 +175,21 @@ fn json_guided_update_is_rejected_before_any_mutation() {
     assert!(!output.status.success());
     let value: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
     assert_eq!(value["command"], "update");
+    assert_eq!(value["error"]["code"], "invalid_argument");
+    assert!(!root.join("runtime").exists());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn json_guided_uninstall_is_rejected_before_any_mutation() {
+    let root = fixture();
+    let output = command(&root)
+        .args(["--json", "uninstall"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(value["command"], "uninstall");
     assert_eq!(value["error"]["code"], "invalid_argument");
     assert!(!root.join("runtime").exists());
     fs::remove_dir_all(root).unwrap();


### PR DESCRIPTION
## Summary
- add `boomux uninstall` with durable state preservation by default and explicit `--purge`
- add identity-pinned `boomux node uninstall NODE` with protocol-48 completion coordination
- protect modified integration assets, package-managed/custom installs, changed executables, and unsafe purge paths
- document uninstall ownership, recovery, CLI, and remote Node guarantees

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1` (838 passed)
- `cargo test --test native_backend --locked -- --test-threads=1` (114 passed)
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js` (43 passed)