### PR TITLE
test(ssh): relax local transaction deadline

### DIFF
--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -5135,7 +5135,7 @@ mod tests {
     fn run_local_transaction(home: &Path, command: &str, transaction: &InstallTransactionId) {
         let mut child = local_shell_command("sh", home);
         child.args(["-c", command]);
-        run_streaming_command(child, transaction.input(), Duration::from_secs(1)).unwrap();
+        run_streaming_command(child, transaction.input(), Duration::from_secs(5)).unwrap();
     }
 
     fn compatible_helper_script(node_id: &str) -> String {


### PR DESCRIPTION
## Summary

- allow successful local SSH transaction fixtures up to five seconds to complete
- retain explicit short deadlines in tests that exercise timeout behavior
- stabilize the release CI failure in `rollback_does_not_signal_reused_watchdog_pid`

## Validation

- failing test passed 20 consecutive runs
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`

Failed run: https://github.com/gardnmi/boomux/actions/runs/33006888465/job/98303059729