### PR TITLE
feat: add guided setup and atomic workspace creation

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -132,6 +132,15 @@ boomux integration status opencode --json
 boomux integration status codex --json
 ```
 
+When the user explicitly asks for first-run local configuration, `boomux setup`
+is the interactive end-to-end workflow. It discovers installed harnesses, offers
+their lifecycle assets individually, optionally installs this Agent Skill, and
+can configure the Omarchy companion plugin and Boomux-owned Hyprland bindings.
+It recognizes and preserves a complete compatible user-managed binding profile.
+It requires a terminal and every mutation prompt defaults to no. Do not run it
+for inspection alone or without explicit authorization; use the JSON status and
+dry-run commands below instead.
+
 Mutation commands include:
 
 ```console

--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -485,14 +485,14 @@ path opening. Selection otherwise follows Boomux configuration and then normal
 Open the dashboard or run diagnostics with:
 
 ```console
-boomux
 boomux ui
 boomux web
 boomux doctor
 ```
 
-`boomux` and `boomux ui` must run from a fresh host terminal; they are rejected
-when `BOOMUX_SHELL_ID` is set. `boomux doctor` can run in either context.
+`boomux ui` must run from a fresh host terminal; it is rejected when
+`BOOMUX_SHELL_ID` is set. Bare `boomux` prints command help. `boomux doctor` can
+run in either context.
 
 `boomux web` serves an experimental read-only Agent PWA on
 `127.0.0.1:3737`. Use `--port` to change the loopback port. `--tailscale` is an

--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -136,6 +136,8 @@ When the user explicitly asks for first-run local configuration, `boomux setup`
 is the interactive end-to-end workflow. It discovers installed harnesses, offers
 their lifecycle assets individually, optionally installs this Agent Skill, and
 can configure the Omarchy companion plugin and Boomux-owned Hyprland bindings.
+It rejects Cargo-private desktop setup when Omarchy cannot resolve `boomux` from
+its graphical environment and restarts Omarchy Shell after changing the plugin.
 It recognizes and preserves a complete compatible user-managed binding profile.
 It requires a terminal and every mutation prompt defaults to no. Do not run it
 for inspection alone or without explicit authorization; use the JSON status and

--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -134,14 +134,16 @@ boomux integration status codex --json
 
 When the user explicitly asks for first-run local configuration, `boomux setup`
 is the interactive end-to-end workflow. It discovers installed harnesses, offers
-their lifecycle assets individually, optionally installs this Agent Skill, and
-can configure the Omarchy companion plugin and Boomux-owned Hyprland bindings.
+their lifecycle assets individually, starts the local daemon when needed,
+optionally installs this Agent Skill, and can configure the Omarchy companion
+plugin and Boomux-owned Hyprland bindings.
 It rejects Cargo-private desktop setup when Omarchy cannot resolve `boomux` from
 its graphical environment and restarts Omarchy Shell after changing the plugin.
 It recognizes and preserves a complete compatible user-managed binding profile.
-It requires a terminal and every mutation prompt defaults to no. Do not run it
-for inspection alone or without explicit authorization; use the JSON status and
-dry-run commands below instead.
+It requires a terminal, starts the daemon automatically, and defaults every
+configuration mutation prompt to no. Do not run it for inspection alone or
+without explicit authorization; use the JSON status and dry-run commands below
+instead.
 
 Mutation commands include:
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ existing Boomux Shell.
 Open the native dashboard at any time:
 
 ```console
-boomux
+boomux ui
 ```
 
 ## Core Concepts
@@ -236,7 +236,7 @@ Use `boomux --help` and `boomux <command> --help` for the complete current CLI.
 
 ## Native Dashboard
 
-Run `boomux` in a terminal. The dashboard provides four primary views:
+Run `boomux ui` in a terminal. The dashboard provides four primary views:
 
 - **Workspaces**: coordinated tasks, placement state, attention, and ownership.
 - **Agents**: current Agent lifecycle and canonical Sessions.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ boomux setup
 This is the recommended way to configure Boomux. The wizard discovers supported
 Agent harnesses on `PATH`, offers each missing or modified lifecycle integration
 separately, and can install the Boomux Agent Skill when it finds a harness. On
-Omarchy it can install and enable `omarchy-boomux`, analyze existing keybindings,
-warn which bindings would be overridden, and install the full desktop profile.
+Omarchy it can install, enable, and load `omarchy-boomux`, analyze existing
+keybindings, warn which bindings would be overridden, and install the full
+desktop profile. Desktop setup requires `boomux` to be available to Omarchy's
+graphical environment; the official release installation uses `~/.local/bin`.
 
 Every prompt defaults to no and modified assets require explicit replacement.
 Rerunning setup is safe: compatible user-managed bindings are recognized, their

--- a/README.md
+++ b/README.md
@@ -18,9 +18,32 @@ terminal as ordinary native windows.
 </p>
 
 > [!WARNING]
-> Boomux is pre-1.0. Human-facing commands and presentation may evolve. Durable
-> state uses explicit versioned migrations, and supported automation output uses
-> the stable `boomux.cli/v1` contract.
+> Human-facing commands and presentation may evolve. Supported automation output
+> uses the stable `boomux.cli/v1` contract.
+
+## Get Started
+
+After installing the Boomux binary using one of the methods below, run the
+guided setup:
+
+```console
+boomux setup
+```
+
+This is the recommended way to configure Boomux. The wizard discovers supported
+Agent harnesses on `PATH`, offers each missing or modified lifecycle integration
+separately, and can install the Boomux Agent Skill when it finds a harness. On
+Omarchy it can install and enable `omarchy-boomux`, analyze existing keybindings,
+warn which bindings would be overridden, and install the full desktop profile.
+
+Every prompt defaults to no and modified assets require explicit replacement.
+Rerunning setup is safe: compatible user-managed bindings are recognized, their
+reinstall impact is shown, and they remain unchanged unless you confirm the
+managed profile installation.
+
+For automation, use the individual `integration status`, `integration install`,
+and `skill install` commands instead. `boomux setup` intentionally requires an
+interactive terminal and does not support `--json`.
 
 ## Install And Update
 
@@ -29,12 +52,14 @@ terminal as ordinary native windows.
 - Unix or Linux with an absolute `XDG_RUNTIME_DIR`.
 - `xdg-terminal-exec` and an available terminal desktop entry.
 
-Git is optional; without it, repository metadata is empty. The default desktop
-Workspace layer additionally requires an active Hyprland session and compatible
-`hyprctl`. Outside Hyprland, ordinary Boomux terminal opens remain native windows.
+Git is optional at runtime; without it, repository metadata is empty. The default
+desktop Workspace layer additionally requires an active Hyprland session and
+compatible `hyprctl`. Outside Hyprland, ordinary Boomux terminal opens remain
+native windows.
 
 The release recipe below requires GitHub CLI (`gh`), `sha256sum`, `tar`, and
-`install`. Building from source requires Git and a Rust toolchain.
+`install`. Installing from Git requires Git and a Rust toolchain; compiling an
+existing source tree requires only the Rust toolchain.
 
 ### Latest Release
 
@@ -81,25 +106,20 @@ self-replaced, and Boomux never silently downgrades. Automatic updates are not
 enabled.
 
 > [!CAUTION]
-> v0.32 uses protocol 46, state schema 13, and handoff H7. It cannot gracefully
-> self-update into the schedule-free protocol-47 release. Before installing this
-> release, use the v0.32 binary to run `boomux daemon stop`; this terminates every
-> managed process. Back up and remove
-> `$XDG_STATE_HOME/boomux/state.json`, `global_workspaces.json`,
-> `local_shell_transactions.log`, `node-cache.json`, and
-> `selected-workspace.json` (using `~/.local/state` when `XDG_STATE_HOME` is
-> unset). Remove the `[scheduling]` table and the
-> `scheduled_dispatch_failed` and `scheduled_interrupted` keys from both
-> `[notifications]` and `[notifications.sound]` in every active config layer,
-> including `BOOMUX_CONFIG`. Then install the new binary and start it with an
-> ordinary command such as `boomux`. `node.json` and `node_registrations.json`
-> are not part of this reset.
+> Upgrading from v0.32 to v1.x crosses an incompatible protocol and state
+> boundary. It requires a cold upgrade that terminates managed processes. Follow
+> the exact [local update procedure](docs/local-update.md#protocol-47-alpha-break).
 
 Prefer `daemon restart` over `daemon stop`: stopping the daemon terminates every
 managed process. Upgrade registered remote Nodes separately with
 `boomux node upgrade NODE`.
 
-## Quick Start
+To remove an official release installation, use `boomux uninstall`. Add
+`--purge` only when you also intend to remove user data. Use
+`boomux node uninstall NODE` for an identity-verified remote uninstall. See
+[Uninstall](docs/uninstall.md) for ownership and preservation guarantees.
+
+## Create Your First Workspace
 
 Create a coordinated Workspace and its first Shell from a project directory:
 
@@ -135,13 +155,13 @@ boomux
 
 | Term | Meaning |
 | --- | --- |
-| **Node** | One independently authoritative Boomux daemon and its local resources. |
+| **Node** | A durable host-local authority with stable identity, implemented by a replaceable Boomux daemon. |
 | **Workspace** | A durable task grouping. A coordinated Workspace explicitly links owner-Node placements. |
 | **Desktop Workspace Layer** | Local presentation of a coordinated Workspace as a Hyprland special Workspace derived from its immutable coordinator ID. It owns no durable resources. |
 | **Shell** | A durable Workspace slot with at most one current process run. Each live run owns its PTY; closing its terminal attachment does not close the Shell. |
 | **Command** | A Shell with stored exact arguments instead of an interactive login command. |
 | **Launcher** | A detached exact-argument command invoked by an explicit Workspace open or restore. Desktop navigation alone never invokes it. |
-| **Agent Instance** | Run-scoped lifecycle state reported by an integration; not a permanent process-completion record. |
+| **Agent Instance** | A durable identity for one external Agent session associated with one Shell run; process exit alone never establishes completion. |
 
 Boomux preserves exact argument vectors and does not add shell interpolation to
 launchers or adapters.
@@ -188,37 +208,15 @@ boomux desktop return
 boomux desktop gather
 ```
 
-- `toggle` shows or hides the selected Workspace. If the layer has no terminal
-  windows, Boomux opens or reuses available user-Shell attachments without
-  invoking launchers. It does not fill missing siblings once one window exists.
-- `show` targets one exact coordinated Workspace with the same behavior.
-- `next` and `previous` cycle active, non-closing coordinated Workspaces. Outside
-  a Boomux layer they retain ordinary Hyprland Workspace navigation.
-- `terminal` creates a Shell in the visible layer or opens a normal terminal
-  outside one.
-- `close` permanently closes the focused Boomux Shell inside its layer; outside
-  one it closes the ordinary active window.
-- `pop` floats the active window contextually. `return` moves one exactly
-  identified Boomux terminal back to its owner layer.
-- `gather` returns the target Workspace's existing Shell windows and opens
-  missing user-Shell attachments. It does not invoke launchers.
-
-`desktop show` is navigation, not a full restore. Use the following to reveal a
-layer and perform normal Workspace restore semantics, including launchers and
-all available placements:
+`desktop toggle` and `desktop show` navigate without invoking launchers. Use the
+following to reveal a layer and perform normal Workspace restore semantics:
 
 ```console
 boomux workspace open <workspace-name-or-id> --show
 ```
 
-With the layer enabled, TUI Workspace restore and individual Agent/Shell opens
-use the same presentation. The TUI stays active in its original terminal and
-refreshes when you return.
-
-Boomux correlates adapter-opened windows using exact Node and Shell IDs encoded
-in immutable initial terminal titles. Those IDs are visible to local compositor
-inspection but are not credentials. Hyprland window addresses are ephemeral and
-never persisted or treated as Boomux identity.
+See [Architecture](docs/architecture.md) for exact navigation, placement, and
+restore semantics.
 
 ## Common Workflows
 
@@ -250,8 +248,8 @@ Use `boomux --help` and `boomux <command> --help` for the complete current CLI.
 Run `boomux` in a terminal. The dashboard provides four primary views:
 
 - **Workspaces**: coordinated tasks, placement state, attention, and ownership.
-- **Shells**: durable Shell slots, commands, launchers, and exact run state.
 - **Agents**: current Agent lifecycle and canonical Sessions.
+- **Shells**: durable Shell slots, commands, and exact run state.
 - **Nodes**: registration, route health, compatibility, and upgrade actions.
 
 Core keys:
@@ -292,22 +290,13 @@ boomux web --tailscale
 boomux web start --tailscale
 ```
 
-Boomux reuses compatible Serve routes, rejects conflicts, and removes only routes
-it created. It does not configure Tailscale grants or ACLs.
-
-`boomux web` also attempts to start a shared OpenCode runtime. When active,
-`--tailscale` publishes that separate full-control origin alongside the dashboard.
-Set a nonempty `OPENCODE_SERVER_PASSWORD` before its first start unless tailnet
-policy is intentionally the authentication boundary.
-
-The dashboard can dismiss exact local attention and authorize a short-lived
-**writable** web terminal for an exact current local Agent Shell run. Web-terminal
-control is equivalent to remote shell access. Restrict access to trusted tailnet
-users. OpenCode Web is a separate full-control origin and needs its own access
-boundary. Remote-Node terminal control is not exposed.
+> [!WARNING]
+> Web-terminal access is equivalent to shell access. OpenCode Web is a separate
+> full-control origin. Restrict both to trusted users and configure their access
+> boundaries deliberately.
 
 See [Mobile Web](docs/mobile-web.md) for complete security, lifecycle, and
-experimental HTTP behavior documentation.
+Tailscale behavior.
 
 ## Coding-Agent Integrations
 
@@ -326,7 +315,7 @@ report lifecycle events; they do not infer completion from quiet terminal output
 or parse conversations as transcripts. Modified or ineligible host invocations
 remain untracked rather than receiving fabricated authority.
 
-Install the vendor-neutral Agent skill separately when desired:
+Install the vendor-neutral Agent Skill manually when desired:
 
 ```console
 boomux skill install
@@ -437,6 +426,8 @@ versions, downgrade behavior, and protocol history.
 
 - [Architecture](docs/architecture.md)
 - [CLI JSON contract](docs/cli-json.md)
+- [Local Update](docs/local-update.md)
+- [Uninstall](docs/uninstall.md)
 - [Remote Nodes](docs/remote-nodes.md)
 - [Mobile Web](docs/mobile-web.md)
 - [Event Stream](docs/event-stream.md)

--- a/README.md
+++ b/README.md
@@ -32,16 +32,17 @@ boomux setup
 
 This is the recommended way to configure Boomux. The wizard discovers supported
 Agent harnesses on `PATH`, offers each missing or modified lifecycle integration
-separately, and can install the Boomux Agent Skill when it finds a harness. On
-Omarchy it can install, enable, and load `omarchy-boomux`, analyze existing
-keybindings, warn which bindings would be overridden, and install the full
-desktop profile. Desktop setup requires `boomux` to be available to Omarchy's
-graphical environment; the official release installation uses `~/.local/bin`.
+separately, starts the local Boomux daemon when needed, and can install the
+Boomux Agent Skill when it finds a harness. On Omarchy it can install, enable,
+and load `omarchy-boomux`, analyze existing keybindings, warn which bindings
+would be overridden, and install the full desktop profile. Desktop setup requires
+`boomux` to be available to Omarchy's graphical environment; the official release
+installation uses `~/.local/bin`.
 
-Every prompt defaults to no and modified assets require explicit replacement.
-Rerunning setup is safe: compatible user-managed bindings are recognized, their
-reinstall impact is shown, and they remain unchanged unless you confirm the
-managed profile installation.
+Every configuration prompt defaults to no and modified assets require explicit
+replacement. Daemon startup is automatic. Rerunning setup is safe: compatible
+user-managed bindings are recognized, their reinstall impact is shown, and they
+remain unchanged unless you confirm the managed profile installation.
 
 For automation, use the individual `integration status`, `integration install`,
 and `skill install` commands instead. `boomux setup` intentionally requires an

--- a/README.md
+++ b/README.md
@@ -78,17 +78,6 @@ install -Dm755 "boomux-$version-$target/boomux" ~/.local/bin/boomux
 boomux doctor
 ```
 
-To install the current development branch instead of a published release:
-
-```console
-cargo install --git https://github.com/gardnmi/boomux --locked --root "$HOME/.local"
-```
-
-This installs `boomux` at `~/.local/bin/boomux`, matching the release recipe.
-Ensure `~/.local/bin` is in `PATH`, then run `boomux setup`. Source installations
-may include unreleased changes; use `boomux --version` and
-`boomux capabilities --json` to inspect the installed build.
-
 ### Update
 
 Official release binaries installed at `~/.local/bin/boomux` have an explicit

--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ boomux doctor
 To install the current development branch instead of a published release:
 
 ```console
-cargo install --git https://github.com/gardnmi/boomux --locked
+cargo install --git https://github.com/gardnmi/boomux --locked --root "$HOME/.local"
 ```
 
-Source installations may include unreleased changes. Run `boomux --version` and
+This installs `boomux` at `~/.local/bin/boomux`, matching the release recipe.
+Ensure `~/.local/bin` is in `PATH`, then run `boomux setup`. Source installations
+may include unreleased changes; use `boomux --version` and
 `boomux capabilities --json` to inspect the installed build.
 
 ### Update

--- a/README.md
+++ b/README.md
@@ -118,14 +118,17 @@ To remove an official release installation, use `boomux uninstall`. Add
 Create a coordinated Workspace and its first Shell from a project directory:
 
 ```console
-boomux workspace create my-project
-boomux shell create my-project --cwd . --open
+boomux workspace create my-project --node LOCAL_NODE_ID --cwd . --open
 ```
 
-With only the local Node eligible, the Shell establishes its placement and opens
-in a native terminal. If multiple Nodes are eligible, add `--node NODE`. In
-Hyprland, the default desktop adapter places the terminal in the Workspace's
-named Boomux special Workspace.
+This atomically creates the coordinated Workspace, its exact local placement,
+and its first Shell before opening the native terminal. Obtain the stable local
+Node ID from `boomux node snapshot --json`. Omit `my-project` to let Boomux
+generate both Workspace and Shell names. In Hyprland, the default desktop
+adapter places the terminal in the Workspace's named Boomux special Workspace.
+
+`boomux workspace create my-project` remains the empty-Workspace form. Add its
+first Shell later with `boomux shell create my-project --cwd . --open`.
 
 For a simpler current-terminal workflow:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -940,8 +940,9 @@ reloaded and checked with `hyprctl configerrors`; otherwise the bindings take
 effect at the next session. The complete historical user-managed Boomux profile
 is recognized by its exact panel, focus-release, desktop, Shell-create, and
 focused-close actions and remains user-owned without adding a managed block.
-Local uninstall removes only an unchanged managed binding block and leaves the
-independently managed Omarchy plugin installed.
+Local uninstall removes an unchanged managed binding block and, when detected in
+a bounded rechecked inventory, removes the exact Omarchy plugin through the
+Omarchy CLI after the overall uninstall confirmation.
 
 Observed host compatibility and provider-dependent gaps are recorded in
 [`lifecycle-validation.md`](lifecycle-validation.md). Focused unit fixtures

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -922,10 +922,11 @@ reporting, and `integration uninstall` safely removes one or all managed assets.
 
 The human-only top-level `boomux setup` command composes these existing local
 primitives without adding protocol or durable setup state. It requires terminal
-input and output, probes every bundled harness, and offers installation only for
-harness executables found on the current `PATH`. Each harness mutation has a
-separate default-no prompt; modified assets are identified and require explicit
-replacement consent. The optional Agent Skill remains a separate owned asset.
+input and output, connects to or starts the local daemon during its system check,
+probes every bundled harness, and offers installation only for harness executables
+found on the current `PATH`. Each harness mutation has a separate default-no
+prompt; modified assets are identified and require explicit replacement consent.
+The optional Agent Skill remains a separate owned asset.
 
 On an Omarchy installation, setup executes only bounded exact-argument `omarchy`
 commands. Plugin inventory comes from `omarchy plugin list --json`; installation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,7 @@
 | `src/host_session_titles.rs` and children | Shared title/catalog policy and host-specific discovery adapters |
 | `src/host_session_source.rs` and children | Canonical host source paths, normalization, and secure source lookup |
 | `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
+| `src/setup.rs` | Interactive local setup orchestration, Omarchy plugin discovery, and ownership-bounded Hyprland binding installation |
 | `src/update.rs` | Local release discovery, installation classification, interactive self-update authorization, atomic executable replacement, and daemon handoff verification |
 | `src/uninstall.rs` | Interactive release uninstall orchestration, owned-asset cleanup, bounded purge validation, and process shutdown ordering |
 | `src/claude_hooks.rs`, `src/codex_hooks.rs`, `src/kiro_hooks.rs` | Bounded Claude Code, Codex, and Kiro hook decoding and lifecycle reduction |
@@ -918,6 +919,29 @@ Individual host installers remain equivalent shortcuts over the same registry
 and safe primitives. `integration setup` provides guided consent and reload
 guidance, `integration verify` checks current-run authoritative lifecycle
 reporting, and `integration uninstall` safely removes one or all managed assets.
+
+The human-only top-level `boomux setup` command composes these existing local
+primitives without adding protocol or durable setup state. It requires terminal
+input and output, probes every bundled harness, and offers installation only for
+harness executables found on the current `PATH`. Each harness mutation has a
+separate default-no prompt; modified assets are identified and require explicit
+replacement consent. The optional Agent Skill remains a separate owned asset.
+
+On an Omarchy installation, setup executes only bounded exact-argument `omarchy`
+commands. Plugin inventory comes from `omarchy plugin list --json`; installation
+uses the fixed `gardnmi/omarchy-boomux` HTTPS repository and Omarchy retains
+plugin lifecycle ownership. Boomux never edits `/usr/share/omarchy`. The full
+desktop binding profile is one marked block in the current user's
+`~/.config/hypr/bindings.lua`. Setup reports conflicts before consent, preserves
+all bytes outside that block, rejects symlinked, special, non-owned, oversized,
+or malformed targets, revalidates the inspected baseline, preserves mode, and
+atomically replaces and synchronizes the file. An active Hyprland session is
+reloaded and checked with `hyprctl configerrors`; otherwise the bindings take
+effect at the next session. The complete historical user-managed Boomux profile
+is recognized by its exact panel, focus-release, desktop, Shell-create, and
+focused-close actions and remains user-owned without adding a managed block.
+Local uninstall removes only an unchanged managed binding block and leaves the
+independently managed Omarchy plugin installed.
 
 Observed host compatibility and provider-dependent gaps are recorded in
 [`lifecycle-validation.md`](lifecycle-validation.md). Focused unit fixtures

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -930,7 +930,12 @@ replacement consent. The optional Agent Skill remains a separate owned asset.
 On an Omarchy installation, setup executes only bounded exact-argument `omarchy`
 commands. Plugin inventory comes from `omarchy plugin list --json`; installation
 uses the fixed `gardnmi/omarchy-boomux` HTTPS repository and Omarchy retains
-plugin lifecycle ownership. Boomux never edits `/usr/share/omarchy`. The full
+plugin lifecycle ownership. A Cargo-private executable without a corresponding
+`~/.local/bin/boomux` is rejected before desktop mutation because it may be
+absent from the graphical session's `PATH`. After installing or enabling the
+plugin, setup runs bounded `omarchy restart shell` so the running shell loads it.
+Reruns offer the same reload for an already-enabled but potentially stale plugin.
+Boomux never edits `/usr/share/omarchy`. The full
 desktop binding profile is one marked block in the current user's
 `~/.config/hypr/bindings.lua`. Setup reports conflicts before consent, preserves
 all bytes outside that block, rejects symlinked, special, non-owned, oversized,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@
 | `src/client.rs` | Daemon discovery/startup, protocol negotiation, typed management requests, and attachment setup |
 | `src/daemon.rs` | `DaemonService` coordination over durable registry, event-stream, shell-runtime, persistence, and handoff owners |
 | `src/state_store.rs` | Versioned durable schemas, validation, atomic state storage, and migrations |
-| `src/global_workspace_store.rs` | Independently versioned coordinator Workspace metadata, placement membership, initialization and schema migration, prepared resource recovery, and resumable close progress |
+| `src/global_workspace_store.rs` | Independently versioned coordinator Workspace metadata, placement membership, initialization and schema migration, prepared resource and placement-default recovery, and resumable close progress |
 | `src/local_shell_journal.rs` | Checksummed owner-only commit journal for local coordinated Shell creation and initial run start across owner and coordinator checkpoints |
 | `src/node_identity.rs` | Stable Node identity persistence, federation admission leases, and bounded rekey drain |
 | `src/node_registration.rs` | Independently versioned remote Node registrations, identity pinning, admission drain, validation, and atomic storage |
@@ -221,6 +221,22 @@ now-inaccessible disposable projection. The remote mutation remains a fixed SSH
 bootstrap operation rather than an arbitrary routed daemon request. Protocol-47
 peers retain every prior Node operation but cannot use this atomic completion
 primitive.
+Protocol 49 adds `workspace_placement_default_cwd`. One exact coordinated
+Workspace placement can change its owner-resolved default cwd under the current
+global Workspace and owner Workspace revisions. The coordinator persists a
+recoverable operation before owner mutation, proves ambiguous completion by an
+exact owner Workspace read, then publishes the updated placement mirror. The
+coordinator live-verifies protocol-49 owner support before preparing a remote
+operation and again on the dispatch helper handshake before durably marking the
+owner attempted. Definitive unsupported owners and cold-recovered preparations
+that never crossed that attempted boundary leave no recovery state. The
+coordinator also cancels the exact preparation after a definitive owner
+rejection while retaining transport-ambiguous outcomes for readback recovery.
+The owner persists before emitting `workspace_default_cwd_changed`; protocol-48
+event readers filter that event while retaining cursor progress. Coordinator
+Workspace schema 8 explicitly migrates schema 7 with empty pending and completed
+default-cwd operation ledgers. Owner state schema 14 and handoff generation 8 are
+unchanged because owner Workspaces already persist `default_cwd`.
 Remote notification presentation reuses protocol-32 atomic reduced transitions,
 so it does not require a later protocol. Node-cache schema 2 adds bounded local
 at-most-once individual and reconnect-digest claims with an explicit schema-1
@@ -237,8 +253,10 @@ name resolution, and dashboard backend orchestration. `src/dashboard_projection.
 converts daemon snapshots and projected sessions into typed TUI view models.
 `src/session_projection.rs` is the shared binary projection used by the CLI and
 dashboard to combine one daemon snapshot with bounded host session catalogs.
-Omitted Shell and Agent Instance names are resolved here to random lowercase
-`adjective-noun` values before requests are sent. Generated shell names are
+Omitted Workspace names in atomic create, and omitted Shell and Agent Instance
+names, are resolved here to random lowercase `adjective-noun` values before
+requests are sent. Generated names are collision-excluded from the relevant
+snapshot. Generated shell names in existing Workspaces are
 checked against the workspace snapshot and retried on a typed daemon collision;
 the resulting concrete names use the ordinary protocol and durable state fields.
 
@@ -385,6 +403,7 @@ The daemon supports:
 
 - Empty or explicitly populated workspace creation with an optional shell cwd
   default
+- Guarded owner-resolved placement default-cwd changes for future Shell creation
 - Atomic shell creation with an implicit `workspace-N` container when no
   workspace is selected
 - Additional shell creation
@@ -499,8 +518,9 @@ satisfied, so retained history does not extend PTY-writer lock hold time.
 boomux __attach <shell-id> --takeover --restart-exited
 ```
 
-`shell create --open` prepares and spawns the terminal before the coordinated
-creation request so window presentation overlaps durable coordinator work. The
+`shell create --open` and atomic `workspace create --node NODE --cwd DIRECTORY
+--open` prepare and spawn the exact terminal before the coordinated creation
+request so window presentation overlaps durable coordinator work. The
 hidden attachment waits on an owner-only runtime socket and receives success
 only after the parent has received the completed creation response. Creation
 failure closes the gate without attaching, so a ShellRun cannot start before

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -47,6 +47,13 @@ not appear in `json_commands`, and do not provide remote configuration mutation.
 `config validate` covers the complete global plus optional `BOOMUX_CONFIG`
 layered result without starting the daemon.
 
+`boomux setup` is a human-only local discovery and mutation workflow. It requires
+an interactive terminal, does not support `--json`, and is absent from
+`json_commands`. Automation must compose the advertised integration status,
+install, and uninstall commands instead. The static `guided_setup` feature means
+the binary contains this workflow; it does not claim that a supported harness,
+Omarchy, Hyprland, `hyprctl`, or the companion plugin is currently available.
+
 `boomux desktop toggle`, `desktop show TARGET`, `desktop next`, `desktop previous`, `desktop terminal`,
 `desktop close`, `desktop pop`, `desktop return`, and `desktop gather` are also
 human-only. They orchestrate the default local Hyprland

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -68,6 +68,10 @@ The static `local_update_status`, `guided_local_update`, and
 `guided_local_uninstall` features advertise the local release-management
 surfaces. They do not claim that the current executable is an eligible official
 release installation or that a newer release exists.
+The static `atomic_workspace_shell_creation` feature advertises the
+`workspace.create` JSON command and its optional durable terminal gate. Runtime
+use additionally requires the advertised protocol-38 `global_workspaces`
+feature from the daemon.
 
 ### Accepted Remote Node Compatibility
 
@@ -248,6 +252,8 @@ The following commands support `--json`:
 - `boomux project list`
 - `boomux workspace list`
 - `boomux workspace inspect`
+- `boomux workspace create [NAME] --node NODE --cwd DIRECTORY`
+- `boomux workspace set-default-cwd GLOBAL_WORKSPACE --node NODE --cwd DIRECTORY`
 - `boomux node add`
 - `boomux node list`
 - `boomux node inspect`
@@ -323,6 +329,19 @@ Command payloads are:
 - `workspace.inspect`: on protocol 38, a global target returns coordinator
   `id`, `revision`, `name`, `closing`, and explicit placements. External or
   older local targets retain the owner Workspace inspection shape.
+- `workspace.create`: available only for the atomic `--node`/`--cwd` form. It
+  returns `workspace` with exact `id`, `name`, and `revision`; `placement` with
+  exact `node_id`, `owner_workspace_id`, and owner-resolved `default_cwd`; and
+  `shell` with exact `id`, generated `name`, `node_id`, and owner-resolved
+  `cwd`. Nullable `presentation_warning` is normally null. With `--open`, a
+  terminal gate failure after durable commit returns success with a bounded
+  warning string instead of misreporting the committed mutation as failed. The
+  positional name may be omitted, in which case Boomux returns the concrete
+  generated Workspace name.
+- `workspace.set-default-cwd`: exact `workspace_id`, `node_id`,
+  `owner_workspace_id`, owner-resolved `default_cwd`, resulting
+  `global_revision`, resulting `owner_revision`, and `result`, which is
+  `updated` or `unchanged`.
 - `node.list`: an alias-then-Node-ID ordered array of registration objects.
 - `node.add`, `node.inspect`, `node.rename`, `node.retarget`, and `node.forget`:
   one registration object with `alias`, exact `target`, pinned `node_id`,
@@ -469,8 +488,8 @@ Protocol 45 adds `protocol_45` and `kiro_exact_launch_holders`. Holder acquire,
 hook report, and release are private local protocol messages and add no public
 CLI JSON field, snapshot field, event, or remote Node projection field.
 Protocol 46 added `protocol_46` and `kiro_stop_idle`; its Kiro hook report wire
-shape was unchanged. Protocol 47 advertises `protocol_47` and is both the current
-and minimum supported protocol, so the historical protocol-45/46 downgrade path
+shape was unchanged. Protocol 47 advertises `protocol_47` and is the minimum
+supported protocol, so the historical protocol-45/46 downgrade path
 is no longer negotiated.
 Protocol 47 also removes Agent Schedule and Scheduled Execution commands, JSON
 payloads, capabilities, snapshot fields, and event types. Historical schedule
@@ -478,9 +497,22 @@ request shapes are not part of the protocol-47 wire contract.
 Protocol 48 adds `protocol_48` and `node_uninstall_coordination`. The completion
 request is local coordinator state and adds no JSON mutation command, remote
 projection field, or arbitrary routed operation.
+Protocol 49 adds `protocol_49` and `workspace_placement_default_cwd` plus the
+`workspace.set-default-cwd` JSON command. The operation requires one exact
+coordinated Workspace, exact existing Node placement, fresh global and owner
+Workspace revisions, and an owner-resolved existing directory. Repeating the
+same path returns `unchanged` without incrementing either revision.
 
-Protocol-38 `workspace create` creates empty coordinator metadata without a
-default Node or cwd. First global `shell create` or `launcher create` resolves
+Protocol-38 `workspace create NAME` without placement flags creates empty
+coordinator metadata without a default Node or cwd and remains human-only.
+`workspace create [NAME] --node NODE --cwd DIRECTORY [--open] [--json]`
+instead uses the existing protocol-38 atomic Workspace-with-Shell operation.
+Both placement flags are required together, `--node` is always explicit, and
+the path is resolved by that exact eligible owner. Boomux collision-excludes
+generated Workspace and Shell names; omission of `NAME` generates the
+Workspace name. `--open` prepares the exact Shell terminal but releases its
+attachment gate only after the owner and coordinator commit succeeds.
+First global `shell create` or `launcher create` resolves
 `--node` against eligible owners. If exactly one
 owner is eligible it may be used without `--node`; zero or multiple eligible
 owners return a typed selection error listing disabled health reasons. The
@@ -492,9 +524,8 @@ local records.
 and `workspace retry GLOBAL` expose guarded adoption, linking, and unresolved
 close retry without requiring the TUI. Repeating `workspace close` for a closing
 global Workspace also uses the retry operation. Dashboard project suggestions
-contribute only the Workspace name; they create the same empty coordinator
-metadata as by-name creation. Node and path selection begins with first-resource
-creation.
+use the same atomic Workspace-with-Shell primitive with an explicit local Node
+and project path. Arbitrary by-name creation remains empty.
 An explicit `--node` on `shell create` or `launcher create` never falls back to
 local mutation. It fails with `unsupported_version` when global Workspaces are
 unavailable and with `invalid_argument` when the target is not coordinated.
@@ -512,6 +543,14 @@ Adoption and linking fetch a fresh
 protocol-38 combined local snapshot over the admitted identity-pinned route and
 require its runtime `global_workspaces` capability before using the owner revision;
 cached eligibility cannot authorize them.
+Placement default-cwd mutation likewise durably prepares its operation UUID
+before owner mutation and retains it across ambiguous transport or coordinator
+persistence outcomes. Recovery accepts only an exact owner Workspace ID, target
+cwd, and either the guarded owner revision for a no-op or its single successor
+for an update. Existing Shell and launcher cwd values never change. Future Shell
+creation with omitted `--cwd` inherits the new placement default; launcher
+creation retains its existing explicit/default `--cwd .` behavior because that
+CLI currently has no distinct cwd-omission representation.
 
 Node snapshot health is `unobserved`, `online`, `reconnecting`, `stale`,
 `unreachable`, `authentication_required`, `identity_changed`,

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -46,6 +46,9 @@ Protocol 47 removes Agent Schedules and Scheduled Executions. Current snapshots
 and event streams contain no schedule definitions, execution records, scheduler
 health, or schedule events. Historical schedule request and event shapes are not
 part of the protocol-47 wire contract.
+Protocol 49 adds `workspace_default_cwd_changed` after the owner Workspace and
+its revision are durably persisted. Protocol-48 clients do not receive the new
+event, but their returned cursor still advances across it.
 
 `boomux agent wait <id> --after-revision <revision>` is the preferred way to
 await one Agent. It returns on a newer accepted durable observation, returns
@@ -107,7 +110,8 @@ The resulting local `node_projection_changed` remains the only journal event.
 
 The event vocabulary is:
 
-- `workspace_created`, `workspace_renamed`, `workspace_closed`
+- `workspace_created`, `workspace_renamed`, `workspace_default_cwd_changed`,
+  `workspace_closed`
 - `shell_created`, `shell_renamed`, `shell_closed`
 - `launcher_created`, `launcher_renamed`, `launcher_removed`
 - `run_started`, `output_changed`, `run_exited`
@@ -137,6 +141,9 @@ successful no-ops with no event. Equal-authority reports with changed content
 are updates and emit the normal state-change or completion event. Retrying the
 exact accepted `done` report is idempotent and emits no second completion event;
 other reports against a completed instance are rejected.
+
+`workspace_default_cwd_changed` carries the owner Workspace ID and resolved
+absolute default cwd. It does not rewrite existing Shell or launcher cwd values.
 
 Accepted blocked and completed observations also carry an outstanding attention
 item in their Agent snapshot. `agent_attention_acknowledged` contains the full

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -35,6 +35,9 @@
 > the helper over one authenticated SSH endpoint. Confirmed remote removal
 > atomically consumes local maintenance into registration deletion; uncertain
 > outcomes retain the route.
+> Protocol 49 adds exact routed Workspace placement default-cwd mutation with
+> coordinator prepare/attempt/complete recovery. Coordinator Workspace schema 8
+> explicitly migrates schema 7 with empty default-cwd operation ledgers.
 
 ## Purpose
 
@@ -72,6 +75,22 @@ bound of the completed response, evicting oldest outcomes if necessary. A reques
 that cannot reserve within 1 MiB fails before any owner mutation. Concurrent
 distinct placements atomically enlarge all related pending reservations for the
 additional future placement before either new owner dispatch proceeds.
+Changing a placement default cwd uses the same authority boundary but a distinct
+prepared operation. The request fixes the global Workspace ID and revision,
+Node ID, owner Workspace ID and fresh revision, and owner-resolved directory.
+Before preparing anything, the coordinator live-verifies that a remote owner
+advertises protocol 49 and `workspace_placement_default_cwd`. The dispatch
+helper repeats that check on the connection used for mutation before durably
+marking the owner attempted. Definitive protocol-48 rejection and cold recovery
+of a preparation that never crossed that attempted boundary remove the pending
+record.
+The owner persists first. Coordinator completion accepts only the unchanged
+guarded owner revision or its single updated successor with the exact cwd, then
+updates the placement mirror and, for an update, the global revision. Exact
+replay returns the bounded durable result; a conflicting operation UUID fails.
+Definitive owner rejection cancels the exact preparation; timeout, persistence,
+and outcome-unknown responses retain it for exact owner readback.
+Existing resources are unchanged, and no offline write is queued.
 
 The dashboard has a dedicated Nodes tab rather than a Node filter. Inspection is
 read-only; `R` opens interactive reauthentication for a selected
@@ -859,19 +878,22 @@ new event kind; protocol-31 filtering of `node_projection_changed` remains the
 event compatibility boundary. Protocol 39 adds the local-only
 `focused_terminal_presentation_changed` invalidation; older clients do not
 receive it, but their cursors advance across the filtered event.
+Protocol 49 adds owner-routed default-cwd mutation and the owner-local
+`workspace_default_cwd_changed` event. Protocol-48 event readers filter it while
+advancing their cursor. A protocol-48 owner cannot receive the guarded request.
 
 Federation has three independent compatibility boundaries:
 
-- The local CLI and local daemon negotiate the ordinary core protocol. Clients
-  and daemons must both use protocol 47; protocol 46 is rejected.
+- The local CLI and local daemon negotiate the ordinary core protocol. The
+  supported range is protocol 47 through 49; protocol 46 is rejected.
 - The local coordinator and remote helper negotiate the federation handshake
   before an inner request. An absent helper triggers explicit bootstrap; an
   unsupported handshake fails with a typed pre-protocol error and sends no inner
   bytes. Unknown additive handshake fields are ignored only within a negotiated
   compatible federation version.
 - The helper and remote daemon negotiate the ordinary core protocol for every
-  channel. Protocol 47 is the current floor, so a protocol-46 helper or daemon is
-  never admitted as a Node.
+  channel. Protocol 47 is the floor and protocol 49 is current, so a protocol-46
+  helper or daemon is never admitted as a Node.
 
 A compatible running remote daemon is not restarted solely because release
 versions differ. Automatic and ad hoc bootstrap reject an all-incompatible
@@ -900,6 +922,10 @@ require no state or Node-cache schema change. If a
 later implementation places any Node field in that durable representation, it
 must bump `STATE_VERSION` and provide the ordinary explicit migration and cold
 recovery evidence.
+Coordinator Workspace schema 8 adds bounded pending and completed placement
+default-cwd operation ledgers. Schema 7 migrates explicitly with both ledgers
+empty. Owner `STATE_VERSION` and handoff remain unchanged because `default_cwd`
+already belongs to the persisted Workspace shape.
 
 Registration schema 1 is stored in owner-only `node_registrations.json` beside,
 but independently from, `state.json` and `node.json`. It stores only alias,

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -46,10 +46,11 @@ are never removed.
 An unchanged keybinding block installed by `boomux setup` is also a Boomux-owned
 asset and is removed while preserving every other byte in
 `~/.config/hypr/bindings.lua`. A modified, malformed, symlinked, special, or
-uninspectable binding target is preserved and reported. The external
-`io.github.gardnmi.boomux` Omarchy plugin remains owned by Omarchy and is not
-removed implicitly; uninstall prints its explicit `omarchy plugin remove`
-command.
+uninspectable binding target is preserved and reported. When Omarchy is
+available, uninstall checks its bounded JSON inventory for the exact
+`io.github.gardnmi.boomux` plugin ID. A detected plugin is included in the
+uninstall plan and removed through `omarchy plugin remove ... --yes` after the
+overall confirmation. An absent or uninspectable plugin is not mutated.
 
 ## Process And Data Safety
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -43,6 +43,14 @@ never uses integration force-removal implicitly. Host configuration and session
 catalogs owned by OpenCode, Pi, Claude, Codex, or Kiro are not Boomux assets and
 are never removed.
 
+An unchanged keybinding block installed by `boomux setup` is also a Boomux-owned
+asset and is removed while preserving every other byte in
+`~/.config/hypr/bindings.lua`. A modified, malformed, symlinked, special, or
+uninspectable binding target is preserved and reported. The external
+`io.github.gardnmi.boomux` Omarchy plugin remains owned by Omarchy and is not
+removed implicitly; uninstall prints its explicit `omarchy plugin remove`
+command.
+
 ## Process And Data Safety
 
 Before filesystem removal, uninstall discovers and stops bounded Boomux web

--- a/src/client.rs
+++ b/src/client.rs
@@ -939,6 +939,31 @@ impl Client {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_global_workspace_default_cwd(
+        &self,
+        operation_id: impl Into<String>,
+        global_workspace_id: impl Into<String>,
+        expected_global_revision: u64,
+        node_id: impl Into<String>,
+        owner_workspace_id: impl Into<String>,
+        expected_owner_revision: u64,
+        default_cwd: PathBuf,
+    ) -> Result<crate::protocol::WorkspaceDefaultCwdResult> {
+        match self.workspace_resource_request(Request::SetGlobalWorkspaceDefaultCwd {
+            operation_id: operation_id.into(),
+            global_workspace_id: global_workspace_id.into(),
+            expected_global_revision,
+            node_id: node_id.into(),
+            owner_workspace_id: owner_workspace_id.into(),
+            expected_owner_revision,
+            default_cwd,
+        })? {
+            Response::WorkspaceDefaultCwd { result } => Ok(result),
+            response => unexpected(response),
+        }
+    }
+
     pub fn route_node_operation(
         &self,
         node_id: impl Into<String>,
@@ -2370,7 +2395,7 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            for expected in [48, 47] {
+            for expected in [49, 48, 47] {
                 let (mut stream, _) = listener.accept().unwrap();
                 let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
                 assert_eq!(request.version, expected);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -62,6 +62,8 @@ use crate::protocol::{
     WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::ssh_bootstrap::{self, RemoteBootstrapPlan, SshAuthenticationMode, SshTarget};
+#[cfg(debug_assertions)]
+use crate::state_store::state_directory_from_environment;
 use crate::state_store::{
     PersistedAgentInstance, PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
     PersistedWorkspaceLauncher, StateStore,
@@ -459,6 +461,13 @@ fn run_daemon(
         .import_handoff(transferred.opencode_runtime)?;
     registry.import_claude_remote_control_bindings(transferred.claude_remote_control_bindings)?;
     registry.import_kiro_launch_holders(transferred.kiro_launch_holders)?;
+    #[cfg(debug_assertions)]
+    if live_handoff
+        && registry.native_test_hooks_enabled()
+        && consume_native_test_handoff_import_failure()?
+    {
+        return Err(io::Error::other("native test rejected handoff import"));
+    }
     if let Some(channel) = committed {
         {
             registry.events.transaction()?.reserve(1)?;
@@ -604,6 +613,16 @@ fn run_daemon(
     drop(socket_cleanup);
     drop(daemon_lock);
     result
+}
+
+#[cfg(debug_assertions)]
+fn consume_native_test_handoff_import_failure() -> io::Result<bool> {
+    let marker = state_directory_from_environment()?.join(".native-test-fail-handoff-import");
+    match fs::remove_file(marker) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
 }
 
 struct RestartRequest {
@@ -8779,6 +8798,8 @@ impl DaemonService {
                 expected_global_revision,
                 "global Workspace",
             )?;
+            #[cfg(debug_assertions)]
+            self.wait_for_native_first_resource_barrier(operation_id)?;
             if global.closing {
                 return Err(DaemonError::lifecycle(
                     ErrorCode::Busy,
@@ -9973,6 +9994,30 @@ impl DaemonService {
             .variables
             .iter()
             .any(|variable| variable.name == b"BOOMUX_NATIVE_TEST_HOOKS" && variable.value == b"1")
+    }
+
+    #[cfg(debug_assertions)]
+    fn wait_for_native_first_resource_barrier(&self, operation_id: &str) -> DaemonResult<()> {
+        if !self.native_test_hooks_enabled() {
+            return Ok(());
+        }
+        let barrier =
+            state_directory_from_environment()?.join(".native-test-first-resource-barrier");
+        if !barrier.is_dir() {
+            return Ok(());
+        }
+        fs::write(barrier.join(operation_id), b"")?;
+        let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+        while Instant::now() < deadline {
+            if fs::read_dir(&barrier)?.count() >= 2 {
+                return Ok(());
+            }
+            thread::sleep(IO_RETRY_DELAY);
+        }
+        Err(DaemonError::lifecycle(
+            ErrorCode::Timeout,
+            "native first-resource barrier timed out",
+        ))
     }
 
     fn resumable_agent(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -32,8 +32,8 @@ use crate::desktop_notifications::{
 };
 use crate::fd_transfer::send_descriptor;
 use crate::global_workspace_store::{
-    GlobalWorkspaceStore, PendingResourceKind, PendingWorkspaceResource, PreparedWorkspaceResource,
-    PreparedWorkspaceShell,
+    GlobalWorkspaceStore, PendingResourceKind, PendingWorkspaceResource,
+    PreparedDefaultCwdOperation, PreparedWorkspaceResource, PreparedWorkspaceShell,
 };
 use crate::handoff;
 use crate::host_services::{self, PreparedIntegrationMutation};
@@ -2302,6 +2302,16 @@ fn response_for_version(response: Response, version: u32) -> Response {
             _ => {}
         }
     }
+    if !protocol::ProtocolFeature::WorkspacePlacementDefaultCwd.is_supported_by(version)
+        && let Response::Events { events, .. } = &mut response
+    {
+        events.retain(|event| {
+            !matches!(
+                event.kind,
+                DaemonEventKind::WorkspaceDefaultCwdChanged { .. }
+            )
+        });
+    }
     if !protocol::ProtocolFeature::NodeProjectionSync.is_supported_by(version)
         && let Response::Events { events, .. } = &mut response
     {
@@ -2603,6 +2613,17 @@ fn routed_result(response: Response) -> Result<RoutedOperationResult, Box<Respon
 fn routed_postcondition(operation: &RoutedOperation, response: &Response) -> bool {
     match (operation, response) {
         (
+            RoutedOperation::SetWorkspaceDefaultCwd {
+                default_cwd,
+                expected_revision,
+                ..
+            },
+            Response::Workspace { workspace },
+        ) => {
+            workspace.default_cwd.as_ref() == Some(default_cwd)
+                && workspace.revision >= *expected_revision
+        }
+        (
             RoutedOperation::RenameWorkspace {
                 name,
                 expected_revision,
@@ -2685,6 +2706,22 @@ fn send_registered_node_request_with_timeout(
     response_timeout: Duration,
     route_feature: Option<protocol::ProtocolFeature>,
 ) -> io::Result<Response> {
+    send_registered_node_request_with_timeout_after_handshake(
+        registration,
+        request,
+        response_timeout,
+        route_feature,
+        &mut || Ok(()),
+    )
+}
+
+fn send_registered_node_request_with_timeout_after_handshake(
+    registration: &crate::protocol::NodeRegistrationSnapshot,
+    request: Request,
+    response_timeout: Duration,
+    route_feature: Option<protocol::ProtocolFeature>,
+    before_request: &mut dyn FnMut() -> io::Result<()>,
+) -> io::Result<Response> {
     let target = SshTarget::parse(registration.target.clone())?;
     let mut bootstrap = ssh_bootstrap::BootstrapSession::open(
         target,
@@ -2706,16 +2743,29 @@ fn send_registered_node_request_with_timeout(
             "remote Node identity changed",
         ));
     }
-    if let Some(feature) = route_feature.or_else(|| request.required_feature())
-        && !feature.is_supported_by(helper.handshake.core_protocol_version)
+    prepare_supported_owner_request(
+        helper.handshake.core_protocol_version,
+        route_feature.or_else(|| request.required_feature()),
+        before_request,
+    )?;
+    let mut remote = bootstrap.connect(helper, Duration::from_secs(2))?;
+    remote.request(request, response_timeout)
+}
+
+fn prepare_supported_owner_request(
+    protocol_version: u32,
+    feature: Option<protocol::ProtocolFeature>,
+    before_request: &mut dyn FnMut() -> io::Result<()>,
+) -> io::Result<()> {
+    if let Some(feature) = feature
+        && !feature.is_supported_by(protocol_version)
     {
         return Err(io::Error::new(
             io::ErrorKind::Unsupported,
             format!("remote Node does not support {}", feature.requirement()),
         ));
     }
-    let mut remote = bootstrap.connect(helper, Duration::from_secs(2))?;
-    remote.request(request, response_timeout)
+    before_request()
 }
 
 fn routed_response_timeout(operation: &RoutedOperation) -> Duration {
@@ -2724,6 +2774,9 @@ fn routed_response_timeout(operation: &RoutedOperation) -> Duration {
 }
 
 fn routed_owner_feature(operation: &RoutedOperation) -> Option<protocol::ProtocolFeature> {
+    if matches!(operation, RoutedOperation::SetWorkspaceDefaultCwd { .. }) {
+        return Some(protocol::ProtocolFeature::WorkspacePlacementDefaultCwd);
+    }
     if matches!(
         operation,
         RoutedOperation::CreateWorkspaceShell { .. }
@@ -2743,6 +2796,13 @@ fn require_guard(actual: u64, expected: u64, resource: &str) -> DaemonResult<()>
             format!("{resource} revision is {actual}; guarded operation supplied {expected}"),
         ))
     }
+}
+
+fn default_cwd_owner_error_is_ambiguous(code: Option<ErrorCode>) -> bool {
+    matches!(
+        code,
+        Some(ErrorCode::OutcomeUnknown | ErrorCode::PersistenceFailed | ErrorCode::Timeout)
+    )
 }
 
 fn request_fingerprint(value: &impl Serialize) -> DaemonResult<String> {
@@ -3494,6 +3554,11 @@ enum DurableUndo {
         previous: String,
         previous_revision: u64,
     },
+    SetWorkspaceDefaultCwd {
+        workspace: Arc<Workspace>,
+        previous: Option<PathBuf>,
+        previous_revision: u64,
+    },
     RenamedShell {
         shell: Arc<Shell>,
         previous: String,
@@ -4074,6 +4139,7 @@ fn reduce_projection_transition(event: &DaemonEvent) -> Option<NodeProjectionTra
     let kind = match &event.kind {
         DaemonEventKind::WorkspaceCreated { workspace_id, .. }
         | DaemonEventKind::WorkspaceRenamed { workspace_id, .. }
+        | DaemonEventKind::WorkspaceDefaultCwdChanged { workspace_id, .. }
         | DaemonEventKind::WorkspaceClosed { workspace_id } => {
             NodeProjectionTransitionKind::Workspace {
                 workspace_id: workspace_id.clone(),
@@ -4314,7 +4380,7 @@ impl DurableRegistry {
             id: workspace_id.clone(),
             revision: Mutex::new(1),
             name: Mutex::new(name.clone()),
-            default_cwd,
+            default_cwd: Mutex::new(default_cwd),
             shell_ids: Mutex::new(shells.iter().map(|shell| shell.id.clone()).collect()),
             launcher_ids: Mutex::new(Vec::new()),
             agent_ids: Mutex::new(Vec::new()),
@@ -4323,7 +4389,7 @@ impl DurableRegistry {
             id: workspace_id.clone(),
             revision: 1,
             name: name.clone(),
-            default_cwd: workspace.default_cwd.clone(),
+            default_cwd: lock(&workspace.default_cwd)?.clone(),
             shells: shells
                 .iter()
                 .map(|shell| shell.snapshot())
@@ -4379,7 +4445,7 @@ impl DurableRegistry {
             id: workspace_id.to_owned(),
             revision: Mutex::new(1),
             name: Mutex::new(name.clone()),
-            default_cwd: default_cwd.clone(),
+            default_cwd: Mutex::new(default_cwd.clone()),
             shell_ids: Mutex::new(Vec::new()),
             launcher_ids: Mutex::new(Vec::new()),
             agent_ids: Mutex::new(Vec::new()),
@@ -4839,6 +4905,32 @@ impl DurableRegistry {
         }))
     }
 
+    fn set_workspace_default_cwd(
+        &self,
+        workspace_id: &str,
+        default_cwd: PathBuf,
+    ) -> io::Result<Option<DurableUndo>> {
+        validate_cwd(&default_cwd)?;
+        let workspace = self.workspace(workspace_id)?;
+        let mut revision = lock(&workspace.revision)?;
+        let mut current = lock(&workspace.default_cwd)?;
+        if current.as_ref() == Some(&default_cwd) {
+            return Ok(None);
+        }
+        let previous_revision = *revision;
+        *revision = revision
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("workspace revision exhausted"))?;
+        let previous = current.replace(default_cwd);
+        drop(current);
+        drop(revision);
+        Ok(Some(DurableUndo::SetWorkspaceDefaultCwd {
+            workspace,
+            previous,
+            previous_revision,
+        }))
+    }
+
     fn register_agent(
         &self,
         shell_id: &str,
@@ -5152,6 +5244,14 @@ impl DurableRegistry {
                 *lock(&workspace.name)? = previous;
                 *lock(&workspace.revision)? = previous_revision;
             }
+            DurableUndo::SetWorkspaceDefaultCwd {
+                workspace,
+                previous,
+                previous_revision,
+            } => {
+                *lock(&workspace.default_cwd)? = previous;
+                *lock(&workspace.revision)? = previous_revision;
+            }
             DurableUndo::RenamedShell {
                 shell,
                 previous,
@@ -5309,6 +5409,8 @@ impl DurableRegistry {
         workspaces.sort_by(|left, right| left.id.cmp(&right.id));
         let mut saved = PersistedState::default();
         for workspace in workspaces {
+            let (workspace_revision, workspace_default_cwd) =
+                workspace.revision_and_default_cwd()?;
             let ids = lock(&workspace.shell_ids)?.clone();
             let mut shells = Vec::with_capacity(ids.len());
             for id in ids {
@@ -5348,9 +5450,9 @@ impl DurableRegistry {
             }
             saved.workspaces.push(PersistedWorkspace {
                 id: workspace.id.clone(),
-                revision: *lock(&workspace.revision)?,
+                revision: workspace_revision,
                 name: lock(&workspace.name)?.clone(),
-                default_cwd: workspace.default_cwd.clone(),
+                default_cwd: workspace_default_cwd,
                 shells,
                 launchers,
                 agents,
@@ -6227,7 +6329,7 @@ struct Workspace {
     id: String,
     revision: Mutex<u64>,
     name: Mutex<String>,
-    default_cwd: Option<PathBuf>,
+    default_cwd: Mutex<Option<PathBuf>>,
     shell_ids: Mutex<Vec<String>>,
     launcher_ids: Mutex<Vec<String>>,
     agent_ids: Mutex<Vec<String>>,
@@ -8076,6 +8178,15 @@ impl DaemonService {
     }
 
     fn route_node_operation(&self, node_id: &str, operation: RoutedOperation) -> Response {
+        self.route_node_operation_after_handshake(node_id, operation, &mut || Ok(()))
+    }
+
+    fn route_node_operation_after_handshake(
+        &self,
+        node_id: &str,
+        operation: RoutedOperation,
+        before_request: &mut dyn FnMut() -> io::Result<()>,
+    ) -> Response {
         let registrations = match self.node_registrations() {
             Ok(registrations) => registrations,
             Err(error) => return error.into_response(),
@@ -8099,18 +8210,20 @@ impl DaemonService {
         }
         let response_timeout = routed_response_timeout(&operation);
         let owner_feature = routed_owner_feature(&operation);
-        let mut result = send_registered_node_request_with_timeout(
+        let mut result = send_registered_node_request_with_timeout_after_handshake(
             &registration,
             operation.owner_request(),
             response_timeout,
             owner_feature,
+            before_request,
         );
         if result.is_err() && operation.is_retryable() {
-            result = send_registered_node_request_with_timeout(
+            result = send_registered_node_request_with_timeout_after_handshake(
                 &registration,
                 operation.owner_request(),
                 response_timeout,
                 owner_feature,
+                before_request,
             );
         }
         let proven = if result.is_err() && !operation.is_retryable() {
@@ -8537,6 +8650,20 @@ impl DaemonService {
     fn preflight_workspace_owner(&self, node_id: &str) -> DaemonResult<()> {
         self.require_cached_workspace_owner_eligible(node_id)?;
         self.with_live_workspace_node(node_id, |_| Ok(()))
+    }
+
+    fn preflight_remote_workspace_feature(
+        &self,
+        node_id: &str,
+        feature: protocol::ProtocolFeature,
+    ) -> DaemonResult<()> {
+        let local_node_id = self.node_identity()?.id()?;
+        if node_id == local_node_id {
+            return Ok(());
+        }
+        self.with_live_workspace_node(node_id, |node| {
+            require_capabilities_support_feature(&node.observed_capabilities, feature)
+        })
     }
 
     fn require_cached_workspace_owner_eligible(&self, node_id: &str) -> DaemonResult<()> {
@@ -9127,6 +9254,202 @@ impl DaemonService {
                 eprintln!(
                     "boomux: prepared Workspace resource {} remains unresolved: {error}",
                     pending.operation_id
+                );
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_global_workspace_default_cwd(
+        &self,
+        operation_id: &str,
+        global_workspace_id: &str,
+        expected_global_revision: u64,
+        node_id: &str,
+        owner_workspace_id: &str,
+        expected_owner_revision: u64,
+        default_cwd: PathBuf,
+    ) -> DaemonResult<protocol::WorkspaceDefaultCwdResult> {
+        self.with_workspace_operation_lock(operation_id, || {
+            let requested_default_cwd = default_cwd.clone();
+            if let Some(result) = self
+                .global_workspaces()?
+                .completed_default_cwd(
+                    operation_id,
+                    global_workspace_id,
+                    expected_global_revision,
+                    node_id,
+                    owner_workspace_id,
+                    expected_owner_revision,
+                    &requested_default_cwd,
+                )
+                .map_err(global_workspace_error)?
+            {
+                return Ok(result);
+            }
+            let local_node_id = self.node_identity()?.id()?;
+            self.preflight_remote_workspace_feature(
+                node_id,
+                protocol::ProtocolFeature::WorkspacePlacementDefaultCwd,
+            )?;
+            let default_cwd = if node_id == local_node_id {
+                host_services::resolve_directory(&default_cwd).map_err(DaemonError::from)?
+            } else {
+                match self.route_node_host_service(
+                    node_id,
+                    HostServiceOperation::ResolveDirectory { path: default_cwd },
+                ) {
+                    Response::HostService {
+                        result: HostServiceResult::Directory { path },
+                    } => path,
+                    Response::Error { message, code } => {
+                        return Err(DaemonError::lifecycle(
+                            code.unwrap_or(ErrorCode::Internal),
+                            message,
+                        ));
+                    }
+                    _ => {
+                        return Err(DaemonError::lifecycle(
+                            ErrorCode::Internal,
+                            "owner returned an unexpected directory response",
+                        ));
+                    }
+                }
+            };
+            let prepared = self
+                .global_workspaces()?
+                .prepare_default_cwd(
+                    operation_id,
+                    global_workspace_id,
+                    expected_global_revision,
+                    node_id,
+                    owner_workspace_id,
+                    expected_owner_revision,
+                    requested_default_cwd,
+                    default_cwd.clone(),
+                )
+                .map_err(global_workspace_error)?;
+            let mut pending = match prepared {
+                PreparedDefaultCwdOperation::Completed(result) => return Ok(result),
+                PreparedDefaultCwdOperation::Pending(pending) => pending,
+            };
+            let owner_identity = protocol::QualifiedIdentity::new(node_id, owner_workspace_id);
+            let owner = self.owner_workspace(&owner_identity)?;
+            if pending.owner_attempted
+                && owner.default_cwd.as_ref() == Some(&pending.default_cwd)
+                && matches!(
+                    owner.revision.checked_sub(pending.expected_owner_revision),
+                    Some(0 | 1)
+                )
+            {
+                return self
+                    .global_workspaces()?
+                    .complete_default_cwd(&pending, &owner)
+                    .map_err(global_workspace_error);
+            }
+            if owner.revision != expected_owner_revision {
+                self.global_workspaces()?
+                    .cancel_default_cwd(&pending)
+                    .map_err(global_workspace_error)?;
+                require_guard(owner.revision, expected_owner_revision, "owner Workspace")?;
+            }
+            let operation = RoutedOperation::SetWorkspaceDefaultCwd {
+                workspace_id: pending.owner_workspace_id.clone(),
+                expected_revision: pending.expected_owner_revision,
+                default_cwd: pending.default_cwd.clone(),
+            };
+            let response = if pending.node_id == local_node_id {
+                pending = self
+                    .global_workspaces()?
+                    .mark_default_cwd_owner_attempted(&pending)
+                    .map_err(global_workspace_error)?;
+                self.dispatch(operation.owner_request())
+                    .unwrap_or_else(DaemonError::into_response)
+            } else {
+                let store = self.global_workspaces()?;
+                let pending_node_id = pending.node_id.clone();
+                let mut mark_attempted = || {
+                    pending = store.mark_default_cwd_owner_attempted(&pending)?;
+                    Ok(())
+                };
+                self.route_node_operation_after_handshake(
+                    &pending_node_id,
+                    operation,
+                    &mut mark_attempted,
+                )
+            };
+            let owner = match response {
+                Response::Workspace { workspace } => workspace,
+                Response::RoutedNodeOperation {
+                    result: RoutedOperationResult::Workspace { workspace },
+                } => workspace,
+                Response::Error { message, code } => {
+                    if !default_cwd_owner_error_is_ambiguous(code) {
+                        self.global_workspaces()?
+                            .cancel_default_cwd(&pending)
+                            .map_err(global_workspace_error)?;
+                    } else if !pending.owner_attempted {
+                        self.global_workspaces()?
+                            .cancel_default_cwd_if_never_attempted(&pending)
+                            .map_err(global_workspace_error)?;
+                    }
+                    return Err(DaemonError::lifecycle(
+                        code.unwrap_or(ErrorCode::Internal),
+                        message,
+                    ));
+                }
+                _ => {
+                    return Err(DaemonError::lifecycle(
+                        ErrorCode::Internal,
+                        "owner returned an unexpected Workspace response",
+                    ));
+                }
+            };
+            self.global_workspaces()?
+                .complete_default_cwd(&pending, &owner)
+                .map_err(global_workspace_error)
+        })
+    }
+
+    fn reconcile_pending_default_cwds(&self) {
+        let pending = match self.global_workspaces().and_then(|store| {
+            store
+                .pending_default_cwd_operations()
+                .map_err(global_workspace_error)
+        }) {
+            Ok(pending) => pending,
+            Err(_) => return,
+        };
+        for operation in pending {
+            let recovered = self.with_workspace_operation_lock(&operation.operation_id, || {
+                if !operation.owner_attempted {
+                    self.global_workspaces()?
+                        .cancel_default_cwd_if_never_attempted(&operation)
+                        .map_err(global_workspace_error)?;
+                    return Ok(());
+                }
+                let owner = self.owner_workspace(&protocol::QualifiedIdentity::new(
+                    &operation.node_id,
+                    &operation.owner_workspace_id,
+                ))?;
+                if owner.default_cwd.as_ref() == Some(&operation.default_cwd)
+                    && matches!(
+                        owner
+                            .revision
+                            .checked_sub(operation.expected_owner_revision),
+                        Some(0 | 1)
+                    )
+                {
+                    self.global_workspaces()?
+                        .complete_default_cwd(&operation, &owner)
+                        .map_err(global_workspace_error)?;
+                }
+                Ok::<(), DaemonError>(())
+            });
+            if let Err(error) = recovered {
+                eprintln!(
+                    "boomux: prepared Workspace default cwd operation {} remains unresolved: {error}",
+                    operation.operation_id
                 );
             }
         }
@@ -10432,7 +10755,12 @@ impl DaemonService {
             if matches!(&request, Request::GetCombinedNodeSnapshot { .. }) {
                 self.global_workspaces
                     .as_ref()
-                    .map(|store| store.pending_resources().map(|pending| !pending.is_empty()))
+                    .map(|store| {
+                        Ok::<_, io::Error>(
+                            !store.pending_resources()?.is_empty()
+                                || !store.pending_default_cwd_operations()?.is_empty(),
+                        )
+                    })
                     .transpose()
                     .map_err(global_workspace_error)?
                     .unwrap_or(false)
@@ -10608,6 +10936,7 @@ impl DaemonService {
             Request::GetCombinedNodeSnapshot { selector } => {
                 if reconcile_combined_snapshot {
                     self.reconcile_pending_workspace_resources();
+                    self.reconcile_pending_default_cwds();
                 }
                 Ok(Response::CombinedNodeSnapshot {
                     snapshot: self.combined_node_snapshot(selector.as_deref())?,
@@ -10901,6 +11230,25 @@ impl DaemonService {
                     resource,
                 })
             }
+            Request::SetGlobalWorkspaceDefaultCwd {
+                operation_id,
+                global_workspace_id,
+                expected_global_revision,
+                node_id,
+                owner_workspace_id,
+                expected_owner_revision,
+                default_cwd,
+            } => Ok(Response::WorkspaceDefaultCwd {
+                result: self.set_global_workspace_default_cwd(
+                    &operation_id,
+                    &global_workspace_id,
+                    expected_global_revision,
+                    &node_id,
+                    &owner_workspace_id,
+                    expected_owner_revision,
+                    default_cwd,
+                )?,
+            }),
             Request::RouteNodeOperation { node_id, operation } => {
                 Ok(self.route_node_operation(&node_id, operation))
             }
@@ -11292,6 +11640,40 @@ impl DaemonService {
                 let workspace = self.workspace(&workspace_id)?.snapshot(&self.durable)?;
                 Ok(mutation.map(|()| Response::Workspace { workspace }))
             }),
+            Request::GuardedSetWorkspaceDefaultCwd {
+                workspace_id,
+                expected_revision,
+                default_cwd,
+            } => {
+                let default_cwd =
+                    host_services::resolve_directory(&default_cwd).map_err(DaemonError::from)?;
+                self.durable_mutation_outcome(|undo| {
+                    let workspace = self.workspace(&workspace_id)?;
+                    require_guard(*lock(&workspace.revision)?, expected_revision, "workspace")?;
+                    let Some(record) = self
+                        .durable
+                        .set_workspace_default_cwd(&workspace_id, default_cwd.clone())?
+                    else {
+                        return Ok(DurableMutation::Unchanged(Response::Workspace {
+                            workspace: workspace.snapshot(&self.durable)?,
+                        }));
+                    };
+                    undo.record(record);
+                    let workspace = workspace.snapshot(&self.durable)?;
+                    Ok(DurableMutation::Changed(
+                        Response::Workspace {
+                            workspace: workspace.clone(),
+                        },
+                        vec![DaemonEventKind::WorkspaceDefaultCwdChanged {
+                            workspace_id,
+                            default_cwd: workspace
+                                .default_cwd
+                                .clone()
+                                .expect("updated Workspace has a default cwd"),
+                        }],
+                    ))
+                })
+            }
             Request::RenameShell { shell_id, name } => self.durable_mutation_outcome(|undo| {
                 Ok(self
                     .rename_shell_mutation(undo, &shell_id, name)?
@@ -11563,7 +11945,7 @@ impl DaemonService {
                 id: saved_workspace.id.clone(),
                 revision: Mutex::new(saved_workspace.revision),
                 name: Mutex::new(saved_workspace.name),
-                default_cwd: saved_workspace.default_cwd,
+                default_cwd: Mutex::new(saved_workspace.default_cwd),
                 shell_ids: Mutex::new(shell_ids),
                 launcher_ids: Mutex::new(launcher_ids),
                 agent_ids: Mutex::new(workspace_agent_ids),
@@ -11609,6 +11991,30 @@ impl DaemonService {
             registry.persist()?;
         }
         Ok(registry)
+    }
+}
+
+fn capabilities_support_feature(
+    capabilities: &[String],
+    feature: protocol::ProtocolFeature,
+) -> bool {
+    feature
+        .capability_names()
+        .iter()
+        .all(|required| capabilities.iter().any(|capability| capability == required))
+}
+
+fn require_capabilities_support_feature(
+    capabilities: &[String],
+    feature: protocol::ProtocolFeature,
+) -> DaemonResult<()> {
+    if capabilities_support_feature(capabilities, feature) {
+        Ok(())
+    } else {
+        Err(DaemonError::lifecycle(
+            ErrorCode::UnsupportedVersion,
+            format!("owner Node does not support {}", feature.requirement()),
+        ))
     }
 }
 
@@ -12354,8 +12760,11 @@ impl DaemonService {
             .iter()
             .copied()
             .filter(|feature| {
-                *feature != protocol::ProtocolFeature::GlobalWorkspaces
-                    || self.global_workspaces.is_some()
+                !matches!(
+                    feature,
+                    protocol::ProtocolFeature::GlobalWorkspaces
+                        | protocol::ProtocolFeature::WorkspacePlacementDefaultCwd
+                ) || self.global_workspaces.is_some()
             })
             .flat_map(protocol::ProtocolFeature::capability_names)
             .copied()
@@ -13209,7 +13618,14 @@ impl DaemonService {
 }
 
 impl Workspace {
+    fn revision_and_default_cwd(&self) -> io::Result<(u64, Option<PathBuf>)> {
+        let revision = lock(&self.revision)?;
+        let default_cwd = lock(&self.default_cwd)?;
+        Ok((*revision, default_cwd.clone()))
+    }
+
     fn snapshot(&self, registry: &DurableRegistry) -> io::Result<WorkspaceSnapshot> {
+        let (revision, default_cwd) = self.revision_and_default_cwd()?;
         let (shells, launchers, agents) = {
             let state = lock(&registry.state)?;
             let shell_ids = lock(&self.shell_ids)?;
@@ -13243,9 +13659,9 @@ impl Workspace {
             .collect::<io::Result<_>>()?;
         Ok(WorkspaceSnapshot {
             id: self.id.clone(),
-            revision: *lock(&self.revision)?,
+            revision,
             name: lock(&self.name)?.clone(),
-            default_cwd: self.default_cwd.clone(),
+            default_cwd,
             shells,
             launchers,
             agents,
@@ -20472,6 +20888,245 @@ mod tests {
     }
 
     #[test]
+    fn protocol_forty_eight_filters_default_cwd_events_but_advances_cursor() {
+        let cursor = EventCursor {
+            stream_id: "stream".into(),
+            event_id: 4,
+        };
+        let response = Response::Events {
+            stream_id: "stream".into(),
+            cursor: cursor.clone(),
+            snapshot: None,
+            events: vec![DaemonEvent {
+                id: 4,
+                at_ms: 1,
+                kind: DaemonEventKind::WorkspaceDefaultCwdChanged {
+                    workspace_id: "workspace".into(),
+                    default_cwd: "/work".into(),
+                },
+            }],
+        };
+        let Response::Events {
+            cursor: filtered_cursor,
+            events,
+            ..
+        } = response_for_version(response, 48)
+        else {
+            panic!("expected events response");
+        };
+        assert_eq!(filtered_cursor, cursor);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn protocol_forty_eight_owner_fails_default_cwd_feature_preflight() {
+        let protocol_forty_eight = protocol::ProtocolFeature::ALL
+            .iter()
+            .copied()
+            .filter(|feature| feature.minimum_version() <= 48)
+            .flat_map(protocol::ProtocolFeature::capability_names)
+            .map(|capability| (*capability).to_owned())
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            require_capabilities_support_feature(
+                &protocol_forty_eight,
+                protocol::ProtocolFeature::WorkspacePlacementDefaultCwd,
+            ),
+            Err(DaemonError::Lifecycle {
+                code: ErrorCode::UnsupportedVersion,
+                ..
+            })
+        ));
+        let mut protocol_forty_nine = protocol_forty_eight;
+        protocol_forty_nine.extend(
+            protocol::ProtocolFeature::WorkspacePlacementDefaultCwd
+                .capability_names()
+                .iter()
+                .map(|capability| (*capability).to_owned()),
+        );
+        assert!(capabilities_support_feature(
+            &protocol_forty_nine,
+            protocol::ProtocolFeature::WorkspacePlacementDefaultCwd,
+        ));
+    }
+
+    #[test]
+    fn remote_default_cwd_attempt_is_marked_only_after_supported_handshake() {
+        let mut attempted = false;
+        let unsupported = prepare_supported_owner_request(
+            48,
+            Some(protocol::ProtocolFeature::WorkspacePlacementDefaultCwd),
+            &mut || {
+                attempted = true;
+                Ok(())
+            },
+        );
+        assert_eq!(unsupported.unwrap_err().kind(), io::ErrorKind::Unsupported);
+        assert!(!attempted);
+
+        prepare_supported_owner_request(
+            49,
+            Some(protocol::ProtocolFeature::WorkspacePlacementDefaultCwd),
+            &mut || {
+                attempted = true;
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(attempted);
+    }
+
+    #[test]
+    fn default_cwd_retains_only_ambiguous_owner_errors() {
+        for code in [
+            ErrorCode::OutcomeUnknown,
+            ErrorCode::PersistenceFailed,
+            ErrorCode::Timeout,
+        ] {
+            assert!(default_cwd_owner_error_is_ambiguous(Some(code)));
+        }
+        for code in [
+            ErrorCode::RevisionAhead,
+            ErrorCode::UnsupportedVersion,
+            ErrorCode::NotFound,
+            ErrorCode::Internal,
+        ] {
+            assert!(!default_cwd_owner_error_is_ambiguous(Some(code)));
+        }
+        assert!(!default_cwd_owner_error_is_ambiguous(None));
+    }
+
+    #[test]
+    fn guarded_workspace_default_cwd_changes_only_future_defaults() {
+        let root = env::temp_dir().join(format!("boomux-default-cwd-{}", Uuid::new_v4()));
+        let old = root.join("old");
+        let new = root.join("new");
+        fs::create_dir_all(&old).unwrap();
+        fs::create_dir_all(&new).unwrap();
+        let registry = DaemonService::default();
+        let workspace = registry
+            .create_workspace_with_default_cwd(
+                "work".into(),
+                Some(old.clone()),
+                vec![ShellSpec::login("existing", old.clone())],
+            )
+            .unwrap();
+        let response = registry
+            .dispatch(Request::GuardedSetWorkspaceDefaultCwd {
+                workspace_id: workspace.id.clone(),
+                expected_revision: workspace.revision,
+                default_cwd: new.clone(),
+            })
+            .unwrap();
+        let Response::Workspace { workspace: updated } = response else {
+            panic!("expected Workspace response");
+        };
+        assert_eq!(updated.revision, workspace.revision + 1);
+        assert_eq!(updated.default_cwd.as_deref(), Some(new.as_path()));
+        assert_eq!(updated.shells[0].cwd, old);
+
+        let Response::Events { cursor, .. } = registry
+            .dispatch(Request::Events {
+                after: None,
+                limit: 256,
+                wait_ms: 0,
+            })
+            .unwrap()
+        else {
+            panic!("expected event baseline");
+        };
+        let unchanged = registry
+            .dispatch(Request::GuardedSetWorkspaceDefaultCwd {
+                workspace_id: workspace.id.clone(),
+                expected_revision: updated.revision,
+                default_cwd: new,
+            })
+            .unwrap();
+        let Response::Workspace {
+            workspace: unchanged,
+        } = unchanged
+        else {
+            panic!("expected unchanged Workspace response");
+        };
+        assert_eq!(unchanged.revision, updated.revision);
+        let Response::Events { events, .. } = registry
+            .dispatch(Request::Events {
+                after: Some(cursor),
+                limit: 256,
+                wait_ms: 0,
+            })
+            .unwrap()
+        else {
+            panic!("expected event page");
+        };
+        assert!(events.is_empty());
+        let stale = registry.dispatch(Request::GuardedSetWorkspaceDefaultCwd {
+            workspace_id: workspace.id,
+            expected_revision: workspace.revision,
+            default_cwd: root.clone(),
+        });
+        assert!(matches!(
+            stale,
+            Err(DaemonError::Lifecycle {
+                code: ErrorCode::RevisionAhead,
+                ..
+            })
+        ));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn workspace_snapshot_never_tears_revision_from_default_cwd() {
+        let root = env::temp_dir().join(format!("boomux-cwd-snapshot-{}", Uuid::new_v4()));
+        let old = root.join("old");
+        let new = root.join("new");
+        fs::create_dir_all(&old).unwrap();
+        fs::create_dir_all(&new).unwrap();
+        let registry = Arc::new(DaemonService::default());
+        let workspace = registry
+            .create_workspace_with_default_cwd("work".into(), Some(old.clone()), Vec::new())
+            .unwrap();
+        let finished = Arc::new(AtomicBool::new(false));
+        let writer_registry = Arc::clone(&registry);
+        let writer_finished = Arc::clone(&finished);
+        let workspace_id = workspace.id.clone();
+        let writer_old = old.clone();
+        let writer_new = new.clone();
+        let writer = thread::spawn(move || {
+            for index in 0..2_000 {
+                let cwd = if index % 2 == 0 {
+                    writer_new.clone()
+                } else {
+                    writer_old.clone()
+                };
+                assert!(
+                    writer_registry
+                        .durable
+                        .set_workspace_default_cwd(&workspace_id, cwd)
+                        .unwrap()
+                        .is_some()
+                );
+            }
+            writer_finished.store(true, Ordering::Release);
+        });
+        while !finished.load(Ordering::Acquire) {
+            let snapshot = registry
+                .workspace(&workspace.id)
+                .unwrap()
+                .snapshot(&registry.durable)
+                .unwrap();
+            let expected = if snapshot.revision % 2 == 0 {
+                new.as_path()
+            } else {
+                old.as_path()
+            };
+            assert_eq!(snapshot.default_cwd.as_deref(), Some(expected));
+        }
+        writer.join().unwrap();
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn protocol_seven_event_pages_hide_launcher_events() {
         let cursor = EventCursor {
             stream_id: "stream".into(),
@@ -20896,7 +21551,7 @@ mod tests {
 
         assert_eq!(&*lock(&workspace.name).unwrap(), "workspace-2");
         assert_eq!(
-            workspace.default_cwd.as_deref(),
+            lock(&workspace.default_cwd).unwrap().as_deref(),
             Some(env::temp_dir().as_path())
         );
         registry.shutdown().unwrap();

--- a/src/global_workspace_store.rs
+++ b/src/global_workspace_store.rs
@@ -9,12 +9,12 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::protocol::{
-    GlobalWorkspaceSnapshot, RoutedOperationResult, Snapshot, WorkspacePlacementSnapshot,
-    WorkspacePlacementState, WorkspaceSnapshot,
+    GlobalWorkspaceSnapshot, RoutedOperationResult, Snapshot, WorkspaceDefaultCwdResult,
+    WorkspacePlacementSnapshot, WorkspacePlacementState, WorkspaceSnapshot,
 };
 use crate::state_store::{effective_uid, secure_state_dir, state_directory_from_environment};
 
-const COORDINATOR_WORKSPACE_VERSION: u32 = 7;
+const COORDINATOR_WORKSPACE_VERSION: u32 = 8;
 const MAX_STORE_BYTES: u64 = 1024 * 1024;
 const MAX_WORKSPACES: usize = 1_024;
 const MAX_PLACEMENTS: usize = 128;
@@ -44,6 +44,38 @@ struct PersistedGlobalWorkspaces {
     pending_resources: Vec<PendingWorkspaceResource>,
     #[serde(default)]
     completed_operations: Vec<CompletedWorkspaceOperation>,
+    #[serde(default)]
+    pending_default_cwd_operations: Vec<PendingDefaultCwdOperation>,
+    #[serde(default)]
+    completed_default_cwd_operations: Vec<CompletedDefaultCwdOperation>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PendingDefaultCwdOperation {
+    pub(crate) operation_id: String,
+    pub(crate) global_workspace_id: String,
+    pub(crate) expected_global_revision: u64,
+    pub(crate) node_id: String,
+    pub(crate) owner_workspace_id: String,
+    pub(crate) expected_owner_revision: u64,
+    pub(crate) requested_default_cwd: PathBuf,
+    pub(crate) default_cwd: PathBuf,
+    pub(crate) owner_attempted: bool,
+    completion_reservation: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompletedDefaultCwdOperation {
+    request: PendingDefaultCwdOperation,
+    result: WorkspaceDefaultCwdResult,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PreparedDefaultCwdOperation {
+    Pending(PendingDefaultCwdOperation),
+    Completed(WorkspaceDefaultCwdResult),
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -136,6 +168,10 @@ impl GlobalWorkspaceStore {
                 state.version = COORDINATOR_WORKSPACE_VERSION;
                 (state, true)
             }
+            Ok(mut state) if state.version == 7 => {
+                state.version = COORDINATOR_WORKSPACE_VERSION;
+                (state, true)
+            }
             Ok(state) => (state, false),
             Err(error) if error.kind() == io::ErrorKind::NotFound => (
                 PersistedGlobalWorkspaces {
@@ -144,6 +180,8 @@ impl GlobalWorkspaceStore {
                     workspaces: Vec::new(),
                     pending_resources: Vec::new(),
                     completed_operations: Vec::new(),
+                    pending_default_cwd_operations: Vec::new(),
+                    completed_default_cwd_operations: Vec::new(),
                 },
                 false,
             ),
@@ -223,6 +261,295 @@ impl GlobalWorkspaceStore {
 
     pub(crate) fn pending_resources(&self) -> io::Result<Vec<PendingWorkspaceResource>> {
         Ok(self.lock()?.pending_resources.clone())
+    }
+
+    pub(crate) fn pending_default_cwd_operations(
+        &self,
+    ) -> io::Result<Vec<PendingDefaultCwdOperation>> {
+        Ok(self.lock()?.pending_default_cwd_operations.clone())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn completed_default_cwd(
+        &self,
+        operation_id: &str,
+        global_workspace_id: &str,
+        expected_global_revision: u64,
+        node_id: &str,
+        owner_workspace_id: &str,
+        expected_owner_revision: u64,
+        requested_default_cwd: &Path,
+    ) -> io::Result<Option<WorkspaceDefaultCwdResult>> {
+        let state = self.lock()?;
+        let Some(completed) = state
+            .completed_default_cwd_operations
+            .iter()
+            .find(|completed| completed.request.operation_id == operation_id)
+        else {
+            return Ok(None);
+        };
+        let request = &completed.request;
+        if request.global_workspace_id != global_workspace_id
+            || request.expected_global_revision != expected_global_revision
+            || request.node_id != node_id
+            || request.owner_workspace_id != owner_workspace_id
+            || request.expected_owner_revision != expected_owner_revision
+            || request.requested_default_cwd != requested_default_cwd
+        {
+            return Err(operation_conflict());
+        }
+        Ok(Some(completed.result.clone()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn prepare_default_cwd(
+        &self,
+        operation_id: &str,
+        global_workspace_id: &str,
+        expected_global_revision: u64,
+        node_id: &str,
+        owner_workspace_id: &str,
+        expected_owner_revision: u64,
+        requested_default_cwd: PathBuf,
+        default_cwd: PathBuf,
+    ) -> io::Result<PreparedDefaultCwdOperation> {
+        let request = PendingDefaultCwdOperation {
+            operation_id: operation_id.to_owned(),
+            global_workspace_id: global_workspace_id.to_owned(),
+            expected_global_revision,
+            node_id: node_id.to_owned(),
+            owner_workspace_id: owner_workspace_id.to_owned(),
+            expected_owner_revision,
+            requested_default_cwd,
+            default_cwd,
+            owner_attempted: false,
+            completion_reservation: " ".repeat(8 * 1024),
+        };
+        self.mutate(|state| {
+            if state
+                .pending_resources
+                .iter()
+                .any(|pending| pending.operation_id == operation_id)
+                || state
+                    .completed_operations
+                    .iter()
+                    .any(|completed| completed.operation_id == operation_id)
+            {
+                return Err(operation_conflict());
+            }
+            if let Some(completed) = state
+                .completed_default_cwd_operations
+                .iter()
+                .find(|completed| completed.request.operation_id == operation_id)
+            {
+                if !same_default_cwd_request(&completed.request, &request) {
+                    return Err(operation_conflict());
+                }
+                return Ok(PreparedDefaultCwdOperation::Completed(
+                    completed.result.clone(),
+                ));
+            }
+            if let Some(pending) = state
+                .pending_default_cwd_operations
+                .iter()
+                .find(|pending| pending.operation_id == operation_id)
+            {
+                if !same_default_cwd_request(pending, &request) {
+                    return Err(operation_conflict());
+                }
+                return Ok(PreparedDefaultCwdOperation::Pending(pending.clone()));
+            }
+            ensure_no_pending_resource(state, global_workspace_id)?;
+            let workspace = state
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.id == global_workspace_id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "global Workspace not found")
+                })?;
+            require_revision(
+                workspace.revision,
+                expected_global_revision,
+                "global Workspace",
+            )?;
+            if workspace.closing {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "global Workspace close is in progress",
+                ));
+            }
+            let placement = workspace
+                .placements
+                .iter()
+                .find(|placement| placement.node_id == node_id)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "Workspace placement not found")
+                })?;
+            if placement.workspace_id != owner_workspace_id {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "exact owner Workspace placement not found",
+                ));
+            }
+            require_revision(
+                placement.owner_revision,
+                expected_owner_revision,
+                "owner Workspace",
+            )?;
+            state.pending_default_cwd_operations.push(request.clone());
+            compact_prepared_state(state)?;
+            Ok(PreparedDefaultCwdOperation::Pending(request))
+        })
+    }
+
+    pub(crate) fn mark_default_cwd_owner_attempted(
+        &self,
+        operation: &PendingDefaultCwdOperation,
+    ) -> io::Result<PendingDefaultCwdOperation> {
+        self.mutate(|state| {
+            let pending = state
+                .pending_default_cwd_operations
+                .iter_mut()
+                .find(|pending| pending.operation_id == operation.operation_id)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "prepared default cwd operation not found",
+                    )
+                })?;
+            if !same_default_cwd_request(pending, operation) {
+                return Err(operation_conflict());
+            }
+            pending.owner_attempted = true;
+            Ok(pending.clone())
+        })
+    }
+
+    pub(crate) fn cancel_default_cwd_if_never_attempted(
+        &self,
+        operation: &PendingDefaultCwdOperation,
+    ) -> io::Result<bool> {
+        self.mutate(|state| {
+            let Some(index) = state
+                .pending_default_cwd_operations
+                .iter()
+                .position(|pending| pending.operation_id == operation.operation_id)
+            else {
+                return Ok(false);
+            };
+            if !same_default_cwd_request(&state.pending_default_cwd_operations[index], operation) {
+                return Err(operation_conflict());
+            }
+            if state.pending_default_cwd_operations[index].owner_attempted {
+                return Ok(false);
+            }
+            state.pending_default_cwd_operations.remove(index);
+            Ok(true)
+        })
+    }
+
+    pub(crate) fn cancel_default_cwd(
+        &self,
+        operation: &PendingDefaultCwdOperation,
+    ) -> io::Result<bool> {
+        self.mutate(|state| {
+            let Some(index) = state
+                .pending_default_cwd_operations
+                .iter()
+                .position(|pending| pending.operation_id == operation.operation_id)
+            else {
+                return Ok(false);
+            };
+            if !same_default_cwd_request(&state.pending_default_cwd_operations[index], operation) {
+                return Err(operation_conflict());
+            }
+            state.pending_default_cwd_operations.remove(index);
+            Ok(true)
+        })
+    }
+
+    pub(crate) fn complete_default_cwd(
+        &self,
+        operation: &PendingDefaultCwdOperation,
+        owner: &WorkspaceSnapshot,
+    ) -> io::Result<WorkspaceDefaultCwdResult> {
+        self.mutate(|state| {
+            if let Some(completed) = state
+                .completed_default_cwd_operations
+                .iter()
+                .find(|completed| completed.request.operation_id == operation.operation_id)
+            {
+                if !same_default_cwd_request(&completed.request, operation) {
+                    return Err(operation_conflict());
+                }
+                return Ok(completed.result.clone());
+            }
+            let index = state
+                .pending_default_cwd_operations
+                .iter()
+                .position(|pending| pending.operation_id == operation.operation_id)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "prepared default cwd operation not found",
+                    )
+                })?;
+            let mut pending = state.pending_default_cwd_operations[index].clone();
+            if !same_default_cwd_request(&pending, operation)
+                || owner.id != pending.owner_workspace_id
+                || owner.default_cwd.as_ref() != Some(&pending.default_cwd)
+            {
+                return Err(operation_conflict());
+            }
+            let changed = match owner.revision.checked_sub(pending.expected_owner_revision) {
+                Some(0) => false,
+                Some(1) => true,
+                _ => return Err(operation_conflict()),
+            };
+            let workspace = state
+                .workspaces
+                .iter_mut()
+                .find(|workspace| workspace.id == pending.global_workspace_id)
+                .ok_or_else(|| invalid("prepared global Workspace is missing"))?;
+            let placement = workspace
+                .placements
+                .iter_mut()
+                .find(|placement| {
+                    placement.node_id == pending.node_id
+                        && placement.workspace_id == pending.owner_workspace_id
+                })
+                .ok_or_else(|| invalid("prepared Workspace placement is missing"))?;
+            if placement.owner_revision != pending.expected_owner_revision {
+                return Err(operation_conflict());
+            }
+            placement.owner_revision = owner.revision;
+            placement.default_cwd = Some(pending.default_cwd.clone());
+            if changed {
+                workspace.revision = next(workspace.revision)?;
+            }
+            let result = WorkspaceDefaultCwdResult {
+                workspace_id: workspace.id.clone(),
+                node_id: pending.node_id.clone(),
+                owner_workspace_id: pending.owner_workspace_id.clone(),
+                default_cwd: pending.default_cwd.clone(),
+                global_revision: workspace.revision,
+                owner_revision: owner.revision,
+                result: if changed { "updated" } else { "unchanged" }.into(),
+            };
+            state.pending_default_cwd_operations.remove(index);
+            pending.completion_reservation.clear();
+            state
+                .completed_default_cwd_operations
+                .push(CompletedDefaultCwdOperation {
+                    request: pending,
+                    result: result.clone(),
+                });
+            if state.completed_default_cwd_operations.len() > MAX_COMPLETED_OPERATIONS {
+                state.completed_default_cwd_operations.remove(0);
+            }
+            compact_prepared_state(state)?;
+            Ok(result)
+        })
     }
 
     pub(crate) fn completed_operation(
@@ -1255,6 +1582,10 @@ fn ensure_no_pending_resource(
         .pending_resources
         .iter()
         .any(|pending| pending.global_workspace_id == global_id)
+        || state
+            .pending_default_cwd_operations
+            .iter()
+            .any(|pending| pending.global_workspace_id == global_id)
     {
         Err(io::Error::new(
             io::ErrorKind::WouldBlock,
@@ -1428,12 +1759,15 @@ fn compact_prepared_state(state: &mut PersistedGlobalWorkspaces) -> io::Result<(
         .len() as u64
         > MAX_STORE_BYTES
     {
-        if state.completed_operations.is_empty() {
+        if !state.completed_operations.is_empty() {
+            state.completed_operations.remove(0);
+        } else if !state.completed_default_cwd_operations.is_empty() {
+            state.completed_default_cwd_operations.remove(0);
+        } else {
             return Err(invalid(
                 "coordinator store has insufficient capacity to reserve the completed Workspace operation",
             ));
         }
-        state.completed_operations.remove(0);
     }
     Ok(())
 }
@@ -1443,6 +1777,20 @@ fn operation_conflict() -> io::Error {
         io::ErrorKind::AlreadyExists,
         "prepared operation identity exists with a different request fingerprint",
     )
+}
+
+fn same_default_cwd_request(
+    left: &PendingDefaultCwdOperation,
+    right: &PendingDefaultCwdOperation,
+) -> bool {
+    left.operation_id == right.operation_id
+        && left.global_workspace_id == right.global_workspace_id
+        && left.expected_global_revision == right.expected_global_revision
+        && left.node_id == right.node_id
+        && left.owner_workspace_id == right.owner_workspace_id
+        && left.expected_owner_revision == right.expected_owner_revision
+        && left.requested_default_cwd == right.requested_default_cwd
+        && left.default_cwd == right.default_cwd
 }
 
 fn require_revision(actual: u64, expected: u64, label: &str) -> io::Result<()> {
@@ -1475,6 +1823,8 @@ fn validate(state: &PersistedGlobalWorkspaces) -> io::Result<()> {
         || state.workspaces.len() > MAX_WORKSPACES
         || state.pending_resources.len() > MAX_PENDING_RESOURCES
         || state.completed_operations.len() > MAX_COMPLETED_OPERATIONS
+        || state.pending_default_cwd_operations.len() > MAX_PENDING_RESOURCES
+        || state.completed_default_cwd_operations.len() > MAX_COMPLETED_OPERATIONS
     {
         return Err(invalid("unsupported or oversized global Workspace store"));
     }
@@ -1569,7 +1919,70 @@ fn validate(state: &PersistedGlobalWorkspaces) -> io::Result<()> {
             return Err(invalid("completed Workspace operation is invalid"));
         }
     }
+    let mut default_cwd_operations = HashSet::new();
+    for operation in &state.pending_default_cwd_operations {
+        if Uuid::parse_str(&operation.operation_id).is_err()
+            || Uuid::parse_str(&operation.global_workspace_id).is_err()
+            || Uuid::parse_str(&operation.node_id).is_err()
+            || Uuid::parse_str(&operation.owner_workspace_id).is_err()
+            || operation.expected_global_revision == 0
+            || operation.expected_owner_revision == 0
+            || !operation.default_cwd.is_absolute()
+            || operation.completion_reservation.len() != 8 * 1024
+            || operation
+                .completion_reservation
+                .bytes()
+                .any(|byte| byte != b' ')
+            || !ids.contains(&operation.global_workspace_id)
+            || pending.contains(&operation.operation_id)
+            || completed.contains(&operation.operation_id)
+            || !default_cwd_operations.insert(&operation.operation_id)
+        {
+            return Err(invalid("prepared default cwd operation is invalid"));
+        }
+    }
+    for operation in &state.completed_default_cwd_operations {
+        let request = &operation.request;
+        let result = &operation.result;
+        if Uuid::parse_str(&request.operation_id).is_err()
+            || Uuid::parse_str(&request.global_workspace_id).is_err()
+            || Uuid::parse_str(&request.node_id).is_err()
+            || Uuid::parse_str(&request.owner_workspace_id).is_err()
+            || request.expected_global_revision == 0
+            || request.expected_owner_revision == 0
+            || !request.default_cwd.is_absolute()
+            || !request.completion_reservation.is_empty()
+            || !matches!(result.result.as_str(), "updated" | "unchanged")
+            || result.workspace_id != request.global_workspace_id
+            || result.node_id != request.node_id
+            || result.owner_workspace_id != request.owner_workspace_id
+            || result.default_cwd != request.default_cwd
+            || !completed_default_cwd_revisions_are_valid(request, result)
+            || pending.contains(&request.operation_id)
+            || completed.contains(&request.operation_id)
+            || !default_cwd_operations.insert(&request.operation_id)
+        {
+            return Err(invalid("completed default cwd operation is invalid"));
+        }
+    }
     Ok(())
+}
+
+fn completed_default_cwd_revisions_are_valid(
+    request: &PendingDefaultCwdOperation,
+    result: &WorkspaceDefaultCwdResult,
+) -> bool {
+    match result.result.as_str() {
+        "unchanged" => {
+            result.global_revision == request.expected_global_revision
+                && result.owner_revision == request.expected_owner_revision
+        }
+        "updated" => {
+            request.expected_global_revision.checked_add(1) == Some(result.global_revision)
+                && request.expected_owner_revision.checked_add(1) == Some(result.owner_revision)
+        }
+        _ => false,
+    }
 }
 
 fn valid_fingerprint(fingerprint: &str) -> bool {
@@ -1733,6 +2146,328 @@ mod tests {
     }
 
     #[test]
+    fn schema_seven_migrates_with_empty_default_cwd_operation_ledgers() {
+        let root = std::env::temp_dir().join(format!("boomux-global-v7-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        store.checkpoint().unwrap();
+        drop(store);
+
+        let mut legacy: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        legacy["version"] = 7.into();
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("pending_default_cwd_operations");
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("completed_default_cwd_operations");
+        fs::write(&path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+
+        let migrated = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        assert!(
+            migrated
+                .pending_default_cwd_operations()
+                .unwrap()
+                .is_empty()
+        );
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(persisted["version"], 8);
+        assert_eq!(
+            persisted["pending_default_cwd_operations"],
+            serde_json::json!([])
+        );
+        assert_eq!(
+            persisted["completed_default_cwd_operations"],
+            serde_json::json!([])
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn default_cwd_prepare_complete_replays_exactly_and_guards_revisions() {
+        let root = std::env::temp_dir().join(format!("boomux-global-cwd-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        let node_id = Uuid::from_u128(1).to_string();
+        let owner_id = Uuid::from_u128(2).to_string();
+        let owner = snapshot(&owner_id, "work", 7);
+        store
+            .initialize_local_once(&node_id, &daemon_snapshot(vec![owner.clone()]))
+            .unwrap();
+        let global = store.list().unwrap().remove(0);
+        let operation_id = Uuid::from_u128(3).to_string();
+        let prepared = store
+            .prepare_default_cwd(
+                &operation_id,
+                &global.id,
+                global.revision,
+                &node_id,
+                &owner_id,
+                owner.revision,
+                "/owner/next".into(),
+                "/owner/next".into(),
+            )
+            .unwrap();
+        let PreparedDefaultCwdOperation::Pending(prepared) = prepared else {
+            panic!("expected prepared default cwd operation");
+        };
+        let attempted = store.mark_default_cwd_owner_attempted(&prepared).unwrap();
+        drop(store);
+
+        let restored = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        assert_eq!(
+            restored.pending_default_cwd_operations().unwrap(),
+            vec![attempted.clone()]
+        );
+        let mut updated_owner = owner.clone();
+        updated_owner.revision += 1;
+        updated_owner.default_cwd = Some("/owner/next".into());
+        let completed = restored
+            .complete_default_cwd(&attempted, &updated_owner)
+            .unwrap();
+        assert_eq!(completed.result, "updated");
+        assert_eq!(completed.global_revision, global.revision + 1);
+        assert_eq!(completed.owner_revision, owner.revision + 1);
+        assert_eq!(
+            restored
+                .prepare_default_cwd(
+                    &operation_id,
+                    &global.id,
+                    global.revision,
+                    &node_id,
+                    &owner_id,
+                    owner.revision,
+                    "/owner/next".into(),
+                    "/owner/next".into(),
+                )
+                .unwrap(),
+            PreparedDefaultCwdOperation::Completed(completed)
+        );
+        assert_eq!(
+            restored
+                .prepare_default_cwd(
+                    &operation_id,
+                    &global.id,
+                    global.revision,
+                    &node_id,
+                    &owner_id,
+                    owner.revision,
+                    "/owner/conflict".into(),
+                    "/owner/conflict".into(),
+                )
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::AlreadyExists
+        );
+        assert!(
+            restored
+                .prepare_default_cwd(
+                    &Uuid::from_u128(4).to_string(),
+                    &global.id,
+                    global.revision,
+                    &node_id,
+                    &owner_id,
+                    updated_owner.revision,
+                    "/owner/other".into(),
+                    "/owner/other".into(),
+                )
+                .is_err()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn never_attempted_default_cwd_can_be_cancelled_after_reload() {
+        let root = std::env::temp_dir().join(format!("boomux-global-cwd-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        let node_id = Uuid::from_u128(1).to_string();
+        let owner_id = Uuid::from_u128(2).to_string();
+        let owner = snapshot(&owner_id, "work", 7);
+        store
+            .initialize_local_once(&node_id, &daemon_snapshot(vec![owner.clone()]))
+            .unwrap();
+        let global = store.list().unwrap().remove(0);
+        let prepared = store
+            .prepare_default_cwd(
+                &Uuid::from_u128(3).to_string(),
+                &global.id,
+                global.revision,
+                &node_id,
+                &owner_id,
+                owner.revision,
+                "/owner/next".into(),
+                "/owner/next".into(),
+            )
+            .unwrap();
+        let PreparedDefaultCwdOperation::Pending(prepared) = prepared else {
+            panic!("expected prepared default cwd operation");
+        };
+        drop(store);
+
+        let restored = GlobalWorkspaceStore::load_at(path).unwrap();
+        assert!(
+            restored
+                .cancel_default_cwd_if_never_attempted(&prepared)
+                .unwrap()
+        );
+        assert!(
+            restored
+                .pending_default_cwd_operations()
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            !restored
+                .cancel_default_cwd_if_never_attempted(&prepared)
+                .unwrap()
+        );
+        assert!(
+            restored
+                .rename(&global.id, global.revision, "available".into())
+                .is_ok()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn attempted_default_cwd_can_be_cancelled_after_definitive_owner_rejection() {
+        let root = std::env::temp_dir().join(format!("boomux-global-cwd-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path).unwrap();
+        let node_id = Uuid::from_u128(1).to_string();
+        let owner_id = Uuid::from_u128(2).to_string();
+        let owner = snapshot(&owner_id, "work", 7);
+        store
+            .initialize_local_once(&node_id, &daemon_snapshot(vec![owner.clone()]))
+            .unwrap();
+        let global = store.list().unwrap().remove(0);
+        let prepared = store
+            .prepare_default_cwd(
+                &Uuid::from_u128(3).to_string(),
+                &global.id,
+                global.revision,
+                &node_id,
+                &owner_id,
+                owner.revision,
+                "/owner/next".into(),
+                "/owner/next".into(),
+            )
+            .unwrap();
+        let PreparedDefaultCwdOperation::Pending(prepared) = prepared else {
+            panic!("expected prepared default cwd operation");
+        };
+        let attempted = store.mark_default_cwd_owner_attempted(&prepared).unwrap();
+
+        assert!(store.cancel_default_cwd(&attempted).unwrap());
+        assert!(store.pending_default_cwd_operations().unwrap().is_empty());
+        assert!(
+            store
+                .rename(&global.id, global.revision, "available".into())
+                .is_ok()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn unchanged_default_cwd_keeps_both_revisions() {
+        let root = std::env::temp_dir().join(format!("boomux-global-cwd-noop-{}", Uuid::new_v4()));
+        let store =
+            GlobalWorkspaceStore::load_at(root.join("boomux/global_workspaces.json")).unwrap();
+        let node_id = Uuid::from_u128(1).to_string();
+        let owner = snapshot(&Uuid::from_u128(2).to_string(), "work", 7);
+        store
+            .initialize_local_once(&node_id, &daemon_snapshot(vec![owner.clone()]))
+            .unwrap();
+        let global = store.list().unwrap().remove(0);
+        let prepared = store
+            .prepare_default_cwd(
+                &Uuid::from_u128(3).to_string(),
+                &global.id,
+                global.revision,
+                &node_id,
+                &owner.id,
+                owner.revision,
+                owner.default_cwd.clone().unwrap(),
+                owner.default_cwd.clone().unwrap(),
+            )
+            .unwrap();
+        let PreparedDefaultCwdOperation::Pending(prepared) = prepared else {
+            panic!("expected pending operation");
+        };
+        let result = store.complete_default_cwd(&prepared, &owner).unwrap();
+        assert_eq!(result.result, "unchanged");
+        assert_eq!(result.global_revision, global.revision);
+        assert_eq!(result.owner_revision, owner.revision);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn schema_eight_rejects_completed_default_cwd_revision_mismatches() {
+        let root =
+            std::env::temp_dir().join(format!("boomux-global-cwd-invalid-{}", Uuid::new_v4()));
+        let path = root.join("boomux/global_workspaces.json");
+        let store = GlobalWorkspaceStore::load_at(path.clone()).unwrap();
+        let node_id = Uuid::from_u128(1).to_string();
+        let owner = snapshot(&Uuid::from_u128(2).to_string(), "work", 7);
+        store
+            .initialize_local_once(&node_id, &daemon_snapshot(vec![owner.clone()]))
+            .unwrap();
+        let global = store.list().unwrap().remove(0);
+        let prepared = store
+            .prepare_default_cwd(
+                &Uuid::from_u128(3).to_string(),
+                &global.id,
+                global.revision,
+                &node_id,
+                &owner.id,
+                owner.revision,
+                "/owner/next".into(),
+                "/owner/next".into(),
+            )
+            .unwrap();
+        let PreparedDefaultCwdOperation::Pending(prepared) = prepared else {
+            panic!("expected pending operation");
+        };
+        let mut updated_owner = owner;
+        updated_owner.revision += 1;
+        updated_owner.default_cwd = Some("/owner/next".into());
+        store
+            .complete_default_cwd(&prepared, &updated_owner)
+            .unwrap();
+        drop(store);
+        let valid = fs::read(&path).unwrap();
+
+        for (field, value) in [
+            ("result", serde_json::json!("unchanged")),
+            ("global_revision", serde_json::json!(global.revision)),
+            ("owner_revision", serde_json::json!(7)),
+        ] {
+            let mut invalid_state: serde_json::Value = serde_json::from_slice(&valid).unwrap();
+            invalid_state["completed_default_cwd_operations"][0]["result"][field] = value;
+            fs::write(&path, serde_json::to_vec_pretty(&invalid_state).unwrap()).unwrap();
+            let error = match GlobalWorkspaceStore::load_at(path.clone()) {
+                Ok(_) => panic!("schema 8 accepted invalid completed {field}"),
+                Err(error) => error,
+            };
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        }
+
+        let mut overflow: serde_json::Value = serde_json::from_slice(&valid).unwrap();
+        overflow["completed_default_cwd_operations"][0]["request"]["expected_global_revision"] =
+            u64::MAX.into();
+        overflow["completed_default_cwd_operations"][0]["result"]["global_revision"] =
+            u64::MAX.into();
+        fs::write(&path, serde_json::to_vec_pretty(&overflow).unwrap()).unwrap();
+        assert!(GlobalWorkspaceStore::load_at(path.clone()).is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn equal_names_never_merge_and_link_guards_both_authorities() {
         let root = std::env::temp_dir().join(format!("boomux-global-link-{}", Uuid::new_v4()));
         let store =
@@ -1852,7 +2587,7 @@ mod tests {
         assert_eq!(workspace.placements[0].owner_workspace_name, None);
         let persisted: serde_json::Value =
             serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        assert_eq!(persisted["version"], 7);
+        assert_eq!(persisted["version"], 8);
         assert_eq!(persisted["pending_resources"], serde_json::json!([]));
         assert_eq!(persisted["completed_operations"], serde_json::json!([]));
         fs::remove_dir_all(root).unwrap();
@@ -1901,7 +2636,7 @@ mod tests {
         assert!(!pending[0].creates_workspace);
         let persisted: serde_json::Value =
             serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        assert_eq!(persisted["version"], 7);
+        assert_eq!(persisted["version"], 8);
         assert_eq!(
             persisted["pending_resources"][0]["operation_id"],
             resource_id
@@ -1957,7 +2692,7 @@ mod tests {
         assert!(pending.owner_attempted);
         let persisted: serde_json::Value =
             serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        assert_eq!(persisted["version"], 7);
+        assert_eq!(persisted["version"], 8);
         assert_eq!(persisted["completed_operations"], serde_json::json!([]));
         fs::remove_dir_all(root).unwrap();
     }
@@ -2903,7 +3638,7 @@ mod tests {
             .unwrap();
         let persisted: serde_json::Value =
             serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        assert_eq!(persisted["version"], 7);
+        assert_eq!(persisted["version"], 8);
         assert!(
             persisted["pending_resources"][0]["completion_reservation"]
                 .as_str()
@@ -2953,7 +3688,7 @@ mod tests {
         assert!(migrated.pending_resources().unwrap()[0].owner_attempted);
         let persisted: serde_json::Value =
             serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        assert_eq!(persisted["version"], 7);
+        assert_eq!(persisted["version"], 8);
         assert_eq!(persisted["pending_resources"][0]["owner_attempted"], true);
         fs::remove_dir_all(root).unwrap();
     }
@@ -3183,6 +3918,8 @@ mod tests {
             workspaces: vec![workspace.clone()],
             pending_resources: Vec::new(),
             completed_operations: Vec::new(),
+            pending_default_cwd_operations: Vec::new(),
+            completed_default_cwd_operations: Vec::new(),
         };
         for offset in 0..=MAX_COMPLETED_OPERATIONS {
             push_completed(

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use clap::error::ErrorKind as ClapErrorKind;
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use uuid::Uuid;
 
 use boomux::protocol::{
@@ -1948,10 +1948,16 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             Ok(())
         }
         Some(Commands::BootstrapActivate { .. }) => unreachable!(),
-        None => dashboard(cli.terminal.as_deref()),
+        None => print_cli_help(),
     };
     result?;
     Ok(CliExit::Success)
+}
+
+fn print_cli_help() -> Result<(), Box<dyn Error>> {
+    Cli::command().print_help()?;
+    println!();
+    Ok(())
 }
 
 fn remote_connect(target: &str, terminal: Option<&str>) -> Result<(), Box<dyn Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ mod mobile_web;
 mod process_adapter;
 mod projects;
 mod session_projection;
+mod setup;
 mod tailscale_serve;
 mod terminal;
 mod tui;
@@ -154,6 +155,7 @@ const NON_PROTOCOL_FEATURES: &[&str] = &[
     "local_update_status",
     "guided_local_update",
     "guided_local_uninstall",
+    "guided_setup",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -265,6 +267,8 @@ enum Commands {
     },
     /// Check that Boomux's dependencies and daemon are available
     Doctor,
+    /// Discover and configure local Agent harnesses and desktop integration
+    Setup,
     /// Report stable integration capabilities without starting the daemon
     Capabilities,
     /// List all managed shells
@@ -1178,6 +1182,7 @@ command_keys! {
     WebStatus => ("web.status", Json),
     WebStop => ("web.stop", Json),
     Doctor => ("doctor", HumanOnly),
+    Setup => ("setup", HumanOnly),
     Capabilities => ("capabilities", Json),
     List => ("list", Json),
     Shells => ("shells", Json),
@@ -1441,6 +1446,7 @@ impl Cli {
             }) => CommandKey::Daemon,
             Some(Commands::Ui) | None => CommandKey::Ui,
             Some(Commands::Doctor) => CommandKey::Doctor,
+            Some(Commands::Setup) => CommandKey::Setup,
             Some(Commands::Close { .. }) => CommandKey::Close,
             Some(Commands::Skill {
                 command: SkillCommands::Install { .. },
@@ -1776,6 +1782,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Ui) => dashboard(cli.terminal.as_deref()),
         Some(Commands::Web { .. }) => unreachable!(),
         Some(Commands::Doctor) => doctor(cli.terminal.as_deref()),
+        Some(Commands::Setup) => setup::guided_setup(),
         Some(Commands::Capabilities) => capabilities(cli.json),
         Some(Commands::List) => list_shells(cli.json),
         Some(Commands::Shells) => list_workspace_shells(cli.json),
@@ -11292,6 +11299,14 @@ mod tests {
             cli.command.as_ref(),
             Some(Commands::UninstallFingerprint)
         ));
+    }
+
+    #[test]
+    fn guided_setup_is_human_only() {
+        let cli = Cli::try_parse_from(["boomux", "setup"]).unwrap();
+        assert!(matches!(cli.command.as_ref(), Some(Commands::Setup)));
+        assert_eq!(cli.command_descriptor().key, "setup");
+        assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,7 @@ const NON_PROTOCOL_FEATURES: &[&str] = &[
     "integration_management",
     "persistent_workspace_selection",
     "create_and_open_shell",
+    "atomic_workspace_shell_creation",
     "hyprland_special_workspaces",
     "contextual_desktop_terminal",
     "coordinated_shell_desktop_placement",
@@ -591,8 +592,20 @@ enum WorkspaceCommands {
     Current,
     /// Clear the persistently selected CLI workspace
     Clear,
-    /// Create an empty workspace
-    Create { name: String },
+    /// Create an empty workspace, or atomically create its first Shell with --node and --cwd
+    Create {
+        #[arg(required_unless_present = "node")]
+        name: Option<String>,
+        /// Exact eligible Node alias or Node ID for the first Shell
+        #[arg(long, requires = "cwd")]
+        node: Option<String>,
+        /// Owner-resolved directory for the placement default and first Shell
+        #[arg(long, requires = "node")]
+        cwd: Option<PathBuf>,
+        /// Open the created Shell after the atomic creation commits
+        #[arg(long, requires = "node")]
+        open: bool,
+    },
     /// Open terminal windows and invoke launchers
     Open {
         /// Coordinated Workspace name/ID, or exact owner Workspace ID with --node
@@ -609,6 +622,17 @@ enum WorkspaceCommands {
     Inspect { target: String },
     /// Rename a workspace
     Rename { target: String, name: String },
+    /// Change one placement's default working directory for future resources
+    SetDefaultCwd {
+        #[arg(value_name = "GLOBAL_WORKSPACE")]
+        target: String,
+        /// Exact Node alias or Node ID for an existing placement
+        #[arg(long)]
+        node: String,
+        /// Owner-resolved default directory
+        #[arg(long)]
+        cwd: PathBuf,
+    },
     /// Adopt an unlinked Node-local Workspace as a new coordinated Workspace
     Adopt {
         #[arg(value_name = "EXTERNAL_WORKSPACE")]
@@ -1198,6 +1222,8 @@ command_keys! {
     ProjectList => ("project.list", Json),
     WorkspaceList => ("workspace.list", Json),
     WorkspaceInspect => ("workspace.inspect", Json),
+    WorkspaceCreate => ("workspace.create", Json),
+    WorkspaceSetDefaultCwd => ("workspace.set-default-cwd", Json),
     Workspace => ("workspace", HumanOnly),
     Desktop => ("desktop", HumanOnly),
     NodeAdd => ("node.add", Json),
@@ -1305,6 +1331,12 @@ impl Cli {
             Some(Commands::Workspace {
                 command: WorkspaceCommands::Inspect { .. },
             }) => CommandKey::WorkspaceInspect,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::Create { node: Some(_), .. },
+            }) => CommandKey::WorkspaceCreate,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::SetDefaultCwd { .. },
+            }) => CommandKey::WorkspaceSetDefaultCwd,
             Some(Commands::Node {
                 command: NodeCommands::Add { .. },
             }) => CommandKey::NodeAdd,
@@ -5310,6 +5342,17 @@ fn generated_shell_name<'a>(
     })
 }
 
+fn generated_workspace_name<'a>(
+    unavailable: impl IntoIterator<Item = &'a str>,
+) -> Result<String, Box<dyn Error>> {
+    generated_names::random_excluding(unavailable).ok_or_else(|| {
+        cli_output::failure(
+            "already_exists",
+            "all generated Workspace names are already in use",
+        )
+    })
+}
+
 fn integration_command(command: IntegrationCommands, json: bool) -> Result<(), Box<dyn Error>> {
     let node = match &command {
         IntegrationCommands::List => None,
@@ -7068,8 +7111,135 @@ fn workspace_command(
             println!("Selected workspace {} ({})", workspace.name, workspace.id);
         }
         WorkspaceCommands::Clear => unreachable!(),
-        WorkspaceCommands::Create { name } => {
-            let name = cli_name(name, "workspace")?;
+        WorkspaceCommands::Create {
+            name,
+            node,
+            cwd,
+            open,
+        } => {
+            if let (Some(node), Some(cwd)) = (node, cwd) {
+                require_protocol_feature(&client, protocol::ProtocolFeature::GlobalWorkspaces)?;
+                let combined = client.combined_node_snapshot(None)?;
+                let selected_node = select_eligible_workspace_owner(&combined.nodes, Some(&node))?;
+                let cwd = resolve_owner_directory(&client, &selected_node, cwd)?;
+                let explicit_name = name.map(|name| cli_name(name, "workspace")).transpose()?;
+                let mut rejected_names = BTreeSet::new();
+                let (workspace, shell, gate) = loop {
+                    let workspace_name = match &explicit_name {
+                        Some(name) => name.clone(),
+                        None => generated_workspace_name(
+                            combined
+                                .workspaces
+                                .iter()
+                                .map(|workspace| workspace.name.as_str())
+                                .chain(rejected_names.iter().map(String::as_str)),
+                        )?,
+                    };
+                    let shell_name = generated_shell_name(std::iter::empty())?;
+                    let shell_id = Uuid::new_v4().to_string();
+                    let global_workspace_id = Uuid::new_v4().to_string();
+                    let title = if selected_node.local {
+                        format!("{workspace_name} - {shell_name}")
+                    } else {
+                        format!("[{}] {workspace_name} - {shell_name}", selected_node.alias)
+                    };
+                    let gate = if open {
+                        if hyprland_special_workspaces_enabled()? {
+                            Some(terminal::open_waiting_placed(
+                                terminal_override,
+                                (!selected_node.local).then_some(selected_node.node_id.as_str()),
+                                &selected_node.node_id,
+                                &global_workspace_id,
+                                &shell_id,
+                                &title,
+                            )?)
+                        } else {
+                            Some(terminal::open_waiting(
+                                terminal_override,
+                                (!selected_node.local).then_some(selected_node.node_id.as_str()),
+                                &shell_id,
+                                &title,
+                            )?)
+                        }
+                    } else {
+                        None
+                    };
+                    match client.create_global_workspace_with_shell(
+                        Uuid::new_v4().to_string(),
+                        &global_workspace_id,
+                        &workspace_name,
+                        &selected_node.node_id,
+                        Uuid::new_v4().to_string(),
+                        cwd.clone(),
+                        shell_id,
+                        shell_spec(shell_name, &cwd, &[]),
+                    ) {
+                        Ok((workspace, shell)) => break (workspace, shell, gate),
+                        Err(client::ClientError::Remote(error))
+                            if explicit_name.is_none()
+                                && error.code == Some(protocol::ErrorCode::AlreadyExists) =>
+                        {
+                            rejected_names.insert(workspace_name);
+                        }
+                        Err(error) => return Err(error.into()),
+                    }
+                };
+                let placement = workspace
+                    .placements
+                    .iter()
+                    .find(|placement| placement.node_id == selected_node.node_id)
+                    .ok_or_else(|| {
+                        cli_output::failure(
+                            "internal",
+                            "created Workspace response omitted the requested placement",
+                        )
+                    })?;
+                let presentation_warning = gate.and_then(|gate| {
+                    gate.release().err().map(|error| {
+                        format!(
+                            "Shell {} was created but its terminal could not attach: {error}",
+                            shell.id
+                        )
+                    })
+                });
+                if json {
+                    return print_json(
+                        CommandKey::WorkspaceCreate,
+                        serde_json::json!({
+                            "workspace": {
+                                "id": workspace.id,
+                                "name": workspace.name,
+                                "revision": workspace.revision,
+                            },
+                            "placement": {
+                                "node_id": placement.node_id,
+                                "owner_workspace_id": placement.workspace_id,
+                                "default_cwd": placement.default_cwd,
+                            },
+                            "shell": {
+                                "id": shell.id,
+                                "name": shell.name,
+                                "node_id": selected_node.node_id,
+                                "cwd": shell.cwd,
+                            },
+                            "presentation_warning": presentation_warning,
+                        }),
+                    );
+                }
+                println!(
+                    "Created workspace {} ({}) with shell {} ({}) on Node {}",
+                    workspace.name, workspace.id, shell.name, shell.id, selected_node.alias
+                );
+                if let Some(warning) = presentation_warning {
+                    eprintln!("boomux: warning: {warning}");
+                }
+                return Ok(());
+            }
+
+            let name = cli_name(
+                name.expect("clap requires a name without --node"),
+                "workspace",
+            )?;
             if client.supports(protocol::ProtocolFeature::GlobalWorkspaces)? {
                 let workspace = client.create_global_workspace(name)?;
                 println!("Created workspace {} ({})", workspace.name, workspace.id);
@@ -7334,6 +7504,81 @@ fn workspace_command(
             let workspace = resolve_workspace_target(&snapshot.workspaces, &target)?;
             client.rename_workspace(&workspace.id, &name)?;
             println!("Renamed workspace {} to {name}", workspace.name);
+        }
+        WorkspaceCommands::SetDefaultCwd { target, node, cwd } => {
+            require_protocol_feature(
+                &client,
+                protocol::ProtocolFeature::WorkspacePlacementDefaultCwd,
+            )?;
+            let combined = client.combined_node_snapshot(None)?;
+            let workspace = resolve_global_workspace_target(&combined.workspaces, &target)
+                .ok_or_else(|| {
+                    cli_output::failure("not_found", format!("Workspace not found: {target}"))
+                })?;
+            let selected_node = resolve_combined_node(&combined.nodes, &node)?;
+            let placement = workspace
+                .placements
+                .iter()
+                .find(|placement| placement.node_id == selected_node.node_id)
+                .ok_or_else(|| {
+                    cli_output::failure(
+                        "not_found",
+                        "Workspace has no placement on the selected Node",
+                    )
+                })?;
+            let local_node_id = combined
+                .nodes
+                .iter()
+                .find(|candidate| candidate.local)
+                .map(|candidate| candidate.node_id.as_str())
+                .unwrap_or_default();
+            let owner = routed_dashboard_workspace(
+                &client,
+                &protocol::QualifiedIdentity::new(&placement.node_id, &placement.workspace_id),
+                local_node_id,
+            )
+            .map_err(io::Error::other)?;
+            if owner.revision != placement.owner_revision {
+                return Err(cli_output::failure(
+                    "revision_changed",
+                    "owner Workspace changed since the coordinator placement was published",
+                ));
+            }
+            let cwd = resolve_owner_directory(&client, selected_node, cwd)?;
+            let result = client.set_global_workspace_default_cwd(
+                Uuid::new_v4().to_string(),
+                &workspace.id,
+                workspace.revision,
+                &placement.node_id,
+                &placement.workspace_id,
+                owner.revision,
+                cwd,
+            )?;
+            if json {
+                return print_json(
+                    CommandKey::WorkspaceSetDefaultCwd,
+                    serde_json::json!({
+                        "workspace_id": result.workspace_id,
+                        "node_id": result.node_id,
+                        "owner_workspace_id": result.owner_workspace_id,
+                        "default_cwd": result.default_cwd,
+                        "global_revision": result.global_revision,
+                        "owner_revision": result.owner_revision,
+                        "result": result.result,
+                    }),
+                );
+            }
+            println!(
+                "{} default cwd for workspace {} on Node {} to {}",
+                if result.result == "updated" {
+                    "Updated"
+                } else {
+                    "Kept"
+                },
+                workspace.name,
+                selected_node.alias,
+                result.default_cwd.display()
+            );
         }
         WorkspaceCommands::Adopt { target, node } => {
             require_protocol_feature(&client, protocol::ProtocolFeature::GlobalWorkspaces)?;
@@ -11680,6 +11925,25 @@ mod tests {
 
     #[test]
     fn parses_public_workspace_adopt_link_and_retry_commands() {
+        let set = Cli::try_parse_from([
+            "boomux",
+            "--json",
+            "workspace",
+            "set-default-cwd",
+            "global",
+            "--node",
+            "work",
+            "--cwd",
+            "/project",
+        ])
+        .unwrap();
+        assert_eq!(set.command_descriptor().key, "workspace.set-default-cwd");
+        assert!(matches!(
+            set.command,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::SetDefaultCwd { target, node, cwd }
+            }) if target == "global" && node == "work" && cwd == Path::new("/project")
+        ));
         assert!(matches!(
             Cli::try_parse_from(["boomux", "workspace", "adopt", "owner", "--node", "work"])
                 .unwrap()
@@ -11848,6 +12112,19 @@ mod tests {
         }
         let cli = Cli::try_parse_from(["boomux", "workspace", "create", "test", "--json"]).unwrap();
         assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "workspace",
+            "create",
+            "--node",
+            "local-node",
+            "--cwd",
+            "/tmp",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(cli.command_descriptor().key, "workspace.create");
+        assert_eq!(cli.command_descriptor().output, OutputMode::Json);
         let cli = Cli::try_parse_from(["boomux", "opencode", "install", "--json"]).unwrap();
         assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
         assert!(
@@ -11917,13 +12194,51 @@ mod tests {
                 .unwrap()
                 .command,
             Some(Commands::Workspace {
-                command: WorkspaceCommands::Create { name }
+                command: WorkspaceCommands::Create { name: Some(name), node: None, .. }
             }) if name == "project"
         ));
+        assert!(Cli::try_parse_from(["boomux", "workspace", "create"]).is_err());
         assert!(
             Cli::try_parse_from(["boomux", "workspace", "create", "project", "--cwd", "/tmp"])
                 .is_err()
         );
+        assert!(
+            Cli::try_parse_from([
+                "boomux",
+                "workspace",
+                "create",
+                "project",
+                "--node",
+                "local-node"
+            ])
+            .is_err()
+        );
+        assert!(
+            Cli::try_parse_from(["boomux", "workspace", "create", "project", "--open"]).is_err()
+        );
+        assert!(matches!(
+            Cli::try_parse_from([
+                "boomux",
+                "workspace",
+                "create",
+                "--node",
+                "local-node",
+                "--cwd",
+                "/tmp",
+                "--open",
+                "--json",
+            ])
+            .unwrap()
+            .command,
+            Some(Commands::Workspace {
+                command: WorkspaceCommands::Create {
+                    name: None,
+                    node: Some(node),
+                    cwd: Some(cwd),
+                    open: true,
+                }
+            }) if node == "local-node" && cwd == Path::new("/tmp")
+        ));
         let cli = Cli::try_parse_from([
             "boomux",
             "launcher",
@@ -14008,6 +14323,8 @@ mod tests {
     fn capabilities_advertise_phase_two_agent_integration_surface() {
         let json_commands = json_commands().collect::<Vec<_>>();
         assert!(json_commands.contains(&"shell.suggest-name"));
+        assert!(json_commands.contains(&"workspace.create"));
+        assert!(NON_PROTOCOL_FEATURES.contains(&"atomic_workspace_shell_creation"));
         for command in [
             "agent.register",
             "agent.ensure",
@@ -14081,7 +14398,7 @@ mod tests {
                 .validated_version,
             "2.1.236"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 48);
+        assert_eq!(protocol::PROTOCOL_VERSION, 49);
     }
 
     #[test]
@@ -14140,6 +14457,8 @@ mod tests {
                 "project.list",
                 "workspace.list",
                 "workspace.inspect",
+                "workspace.create",
+                "workspace.set-default-cwd",
                 "node.add",
                 "node.list",
                 "node.inspect",

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 48;
+pub const PROTOCOL_VERSION: u32 = 49;
 pub const MIN_PROTOCOL_VERSION: u32 = 47;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -178,6 +178,10 @@ define_protocol_features! {
     NodeUninstallCoordination => (48, "Node uninstall coordination", [
         "protocol_48",
         "node_uninstall_coordination",
+    ]),
+    WorkspacePlacementDefaultCwd => (49, "Workspace placement default cwd mutation", [
+        "protocol_49",
+        "workspace_placement_default_cwd",
     ]),
 }
 
@@ -749,6 +753,18 @@ pub struct GlobalWorkspaceOperationResult {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct WorkspaceDefaultCwdResult {
+    pub workspace_id: String,
+    pub node_id: String,
+    pub owner_workspace_id: String,
+    pub default_cwd: PathBuf,
+    pub global_revision: u64,
+    pub owner_revision: u64,
+    pub result: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CombinedNode {
     pub node_id: String,
     pub alias: String,
@@ -1014,6 +1030,11 @@ pub enum RoutedOperation {
     GetWorkspace {
         workspace_id: String,
     },
+    SetWorkspaceDefaultCwd {
+        workspace_id: String,
+        expected_revision: u64,
+        default_cwd: PathBuf,
+    },
     GetShell {
         shell_id: String,
     },
@@ -1102,7 +1123,8 @@ impl RoutedOperation {
                 guard: ExactId,
                 ambiguity: RetrySameRequest,
             },
-            Self::RenameWorkspace { .. }
+            Self::SetWorkspaceDefaultCwd { .. }
+            | Self::RenameWorkspace { .. }
             | Self::RenameShell { .. }
             | Self::RenameLauncher { .. }
             | Self::CloseWorkspace { .. }
@@ -1132,7 +1154,8 @@ impl RoutedOperation {
     pub fn ambiguity_probe(&self) -> Option<Request> {
         match self {
             Self::CreateWorkspaceShell { .. } | Self::CreateWorkspaceLauncher { .. } => None,
-            Self::RenameWorkspace { workspace_id, .. }
+            Self::SetWorkspaceDefaultCwd { workspace_id, .. }
+            | Self::RenameWorkspace { workspace_id, .. }
             | Self::CloseWorkspace { workspace_id, .. } => Some(Request::GetWorkspace {
                 workspace_id: workspace_id.clone(),
             }),
@@ -1179,6 +1202,15 @@ impl RoutedOperation {
                 spec,
             },
             Self::GetWorkspace { workspace_id } => Request::GetWorkspace { workspace_id },
+            Self::SetWorkspaceDefaultCwd {
+                workspace_id,
+                expected_revision,
+                default_cwd,
+            } => Request::GuardedSetWorkspaceDefaultCwd {
+                workspace_id,
+                expected_revision,
+                default_cwd,
+            },
             Self::GetShell { shell_id } => Request::GetShell { shell_id },
             Self::GetLauncher { launcher_id } => Request::GetLauncher { launcher_id },
             Self::GetAgent { agent_id } => Request::GetAgent { agent_id },
@@ -1274,6 +1306,10 @@ pub enum DaemonEventKind {
     WorkspaceRenamed {
         workspace_id: String,
         name: String,
+    },
+    WorkspaceDefaultCwdChanged {
+        workspace_id: String,
+        default_cwd: PathBuf,
     },
     WorkspaceClosed {
         workspace_id: String,
@@ -1574,6 +1610,15 @@ pub enum Request {
         launcher_id: String,
         spec: WorkspaceLauncherSpec,
     },
+    SetGlobalWorkspaceDefaultCwd {
+        operation_id: String,
+        global_workspace_id: String,
+        expected_global_revision: u64,
+        node_id: String,
+        owner_workspace_id: String,
+        expected_owner_revision: u64,
+        default_cwd: PathBuf,
+    },
     RouteNodeOperation {
         node_id: String,
         operation: RoutedOperation,
@@ -1754,6 +1799,11 @@ pub enum Request {
         name: String,
         expected_revision: u64,
     },
+    GuardedSetWorkspaceDefaultCwd {
+        workspace_id: String,
+        expected_revision: u64,
+        default_cwd: PathBuf,
+    },
     RenameShell {
         shell_id: String,
         name: String,
@@ -1886,6 +1936,12 @@ impl Request {
             | Self::CreateGlobalWorkspaceShell { .. }
             | Self::CreateGlobalWorkspaceWithShell { .. }
             | Self::CreateGlobalWorkspaceLauncher { .. } => Some(ProtocolFeature::GlobalWorkspaces),
+            Self::SetGlobalWorkspaceDefaultCwd { .. }
+            | Self::GuardedSetWorkspaceDefaultCwd { .. }
+            | Self::RouteNodeOperation {
+                operation: RoutedOperation::SetWorkspaceDefaultCwd { .. },
+                ..
+            } => Some(ProtocolFeature::WorkspacePlacementDefaultCwd),
             Self::CreateWorkspaceShell { .. }
             | Self::CreateWorkspaceLauncher { .. }
             | Self::RouteNodeOperation {
@@ -2036,6 +2092,9 @@ pub enum Response {
     GlobalWorkspaceResource {
         workspace: GlobalWorkspaceSnapshot,
         resource: RoutedOperationResult,
+    },
+    WorkspaceDefaultCwd {
+        result: WorkspaceDefaultCwdResult,
     },
     RoutedNodeOperation {
         result: RoutedOperationResult,
@@ -2514,8 +2573,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_forty_eight_with_forty_seven_floor() {
-        assert_eq!(PROTOCOL_VERSION, 48);
+    fn protocol_version_is_forty_nine_with_forty_seven_floor() {
+        assert_eq!(PROTOCOL_VERSION, 49);
         assert_eq!(MIN_PROTOCOL_VERSION, 47);
     }
 
@@ -3241,6 +3300,61 @@ mod tests {
     }
 
     #[test]
+    fn protocol_forty_nine_guards_workspace_placement_default_cwd() {
+        let operation = RoutedOperation::SetWorkspaceDefaultCwd {
+            workspace_id: "owner-1".into(),
+            expected_revision: 7,
+            default_cwd: "/owner/next".into(),
+        };
+        assert_eq!(
+            operation.classification().guard,
+            RoutedGuard::ResourceRevision
+        );
+        assert!(!operation.is_retryable());
+        assert_eq!(
+            operation.ambiguity_probe(),
+            Some(Request::GetWorkspace {
+                workspace_id: "owner-1".into(),
+            })
+        );
+        assert_eq!(
+            operation.owner_request(),
+            Request::GuardedSetWorkspaceDefaultCwd {
+                workspace_id: "owner-1".into(),
+                expected_revision: 7,
+                default_cwd: "/owner/next".into(),
+            }
+        );
+        let request = Request::SetGlobalWorkspaceDefaultCwd {
+            operation_id: "operation-1".into(),
+            global_workspace_id: "global-1".into(),
+            expected_global_revision: 3,
+            node_id: "node-1".into(),
+            owner_workspace_id: "owner-1".into(),
+            expected_owner_revision: 7,
+            default_cwd: "/owner/next".into(),
+        };
+        assert_eq!(
+            request.required_feature(),
+            Some(ProtocolFeature::WorkspacePlacementDefaultCwd)
+        );
+        assert_eq!(request.minimum_protocol_version(), 49);
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(&request).unwrap()).unwrap(),
+            request
+        );
+        let routed = Request::RouteNodeOperation {
+            node_id: "node-1".into(),
+            operation,
+        };
+        assert_eq!(routed.minimum_protocol_version(), 49);
+        assert_eq!(
+            serde_json::from_value::<Request>(serde_json::to_value(&routed).unwrap()).unwrap(),
+            routed
+        );
+    }
+
+    #[test]
     fn terminal_preview_styles_round_trip() {
         let preview = TerminalPreview {
             lines: vec![TerminalPreviewLine {
@@ -3667,6 +3781,18 @@ mod tests {
                     },
                 ],
             ),
+            (
+                49,
+                vec![Request::SetGlobalWorkspaceDefaultCwd {
+                    operation_id: "operation-1".into(),
+                    global_workspace_id: "global-1".into(),
+                    expected_global_revision: 1,
+                    node_id: "node-1".into(),
+                    owner_workspace_id: "owner-1".into(),
+                    expected_owner_revision: 1,
+                    default_cwd: "/owner/work".into(),
+                }],
+            ),
         ];
 
         for (expected, requests) in groups {
@@ -3809,6 +3935,7 @@ mod tests {
             (46, &["protocol_46", "kiro_stop_idle"][..]),
             (47, &["protocol_47"][..]),
             (48, &["protocol_48", "node_uninstall_coordination"][..]),
+            (49, &["protocol_49", "workspace_placement_default_cwd"][..]),
         ];
 
         let actual = ProtocolFeature::ALL

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -372,6 +372,7 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
         "Omarchy",
         String::from_utf8_lossy(&version.stdout).trim(),
     );
+    ensure_omarchy_can_resolve_boomux()?;
     let hyprland_active =
         env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some_and(|value| !value.is_empty());
     status(
@@ -386,42 +387,53 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
     );
 
     let plugins = omarchy_plugins(&omarchy)?;
-    let plugin_enabled = match plugins.iter().find(|plugin| plugin.id == OMARCHY_PLUGIN_ID) {
-        Some(plugin) if plugin.enabled => {
-            status("ok", "32", "omarchy-boomux", "installed and enabled");
-            true
-        }
-        Some(_) => {
-            status("!!", "33", "omarchy-boomux", "installed but disabled");
-            if confirm("Enable omarchy-boomux?")? {
-                run_command(
-                    &omarchy,
-                    &["plugin", "enable", OMARCHY_PLUGIN_ID],
-                    COMMAND_TIMEOUT,
-                )?;
-                status("ok", "32", "omarchy-boomux", "enabled");
-                true
-            } else {
-                false
-            }
-        }
-        None => {
-            status("->", "36", "omarchy-boomux", "not installed");
-            detail("Plugins run as unsandboxed code inside the Omarchy shell.");
-            detail(format!("Source: {OMARCHY_PLUGIN_URL}"));
-            if confirm("Install and enable omarchy-boomux?")? {
-                run_command(
-                    &omarchy,
-                    &["plugin", "add", OMARCHY_PLUGIN_URL, "--enable", "--yes"],
-                    PLUGIN_INSTALL_TIMEOUT,
-                )?;
+    let (plugin_enabled, plugin_changed) =
+        match plugins.iter().find(|plugin| plugin.id == OMARCHY_PLUGIN_ID) {
+            Some(plugin) if plugin.enabled => {
                 status("ok", "32", "omarchy-boomux", "installed and enabled");
-                true
-            } else {
-                false
+                detail("Reload the shell if the plugin was installed after Omarchy Shell started.");
+                (
+                    true,
+                    confirm("Restart Omarchy Shell and reload omarchy-boomux?")?,
+                )
             }
-        }
-    };
+            Some(_) => {
+                status("!!", "33", "omarchy-boomux", "installed but disabled");
+                detail("Enabling the plugin also restarts Omarchy Shell so it is loaded.");
+                if confirm("Enable and load omarchy-boomux?")? {
+                    run_command(
+                        &omarchy,
+                        &["plugin", "enable", OMARCHY_PLUGIN_ID],
+                        COMMAND_TIMEOUT,
+                    )?;
+                    status("ok", "32", "omarchy-boomux", "enabled");
+                    (true, true)
+                } else {
+                    (false, false)
+                }
+            }
+            None => {
+                status("->", "36", "omarchy-boomux", "not installed");
+                detail("Plugins run as unsandboxed code inside the Omarchy shell.");
+                detail(format!("Source: {OMARCHY_PLUGIN_URL}"));
+                detail("Installation also restarts Omarchy Shell so the plugin is loaded.");
+                if confirm("Install, enable, and load omarchy-boomux?")? {
+                    run_command(
+                        &omarchy,
+                        &["plugin", "add", OMARCHY_PLUGIN_URL, "--enable", "--yes"],
+                        PLUGIN_INSTALL_TIMEOUT,
+                    )?;
+                    status("ok", "32", "omarchy-boomux", "installed and enabled");
+                    (true, true)
+                } else {
+                    (false, false)
+                }
+            }
+        };
+    if plugin_changed {
+        run_command(&omarchy, &["restart", "shell"], PLUGIN_INSTALL_TIMEOUT)?;
+        status("ok", "32", "Omarchy Shell", "restarted with plugin loaded");
+    }
     if !plugin_enabled {
         status("--", "2", "Keybindings", "skipped; plugin is not enabled");
         return Ok(());
@@ -529,6 +541,33 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn ensure_omarchy_can_resolve_boomux() -> io::Result<()> {
+    let home = required_home()?;
+    let cargo_home = env::var_os("CARGO_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".cargo"));
+    let executable = env::current_exe()?;
+    let desktop_executable = home.join(".local/bin/boomux");
+    if executable.starts_with(cargo_home.join("bin")) && !is_executable_file(&desktop_executable) {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "{} is available to this shell but Omarchy may not include {} in its graphical PATH; install the official Boomux release at {} before configuring desktop integration",
+                executable.display(),
+                cargo_home.join("bin").display(),
+                desktop_executable.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    fs::metadata(path)
+        .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+}
+
 fn validate_hyprland_config(hyprctl: &Path) -> io::Result<()> {
     run_command(hyprctl, &["reload"], COMMAND_TIMEOUT)?;
     let errors = run_command(hyprctl, &["configerrors"], COMMAND_TIMEOUT)?;
@@ -557,9 +596,7 @@ fn confirm(prompt: &str) -> io::Result<bool> {
 fn executable_on_path(name: &str) -> Option<PathBuf> {
     env::split_paths(&env::var_os("PATH")?).find_map(|directory| {
         let candidate = directory.join(name);
-        fs::metadata(&candidate)
-            .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
-            .then_some(candidate)
+        is_executable_file(&candidate).then_some(candidate)
     })
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -385,13 +385,7 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
         },
     );
 
-    let plugins = run_command(&omarchy, &["plugin", "list", "--json"], COMMAND_TIMEOUT)?;
-    let plugins: Vec<OmarchyPlugin> = serde_json::from_slice(&plugins.stdout).map_err(|error| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("Omarchy returned invalid plugin inventory: {error}"),
-        )
-    })?;
+    let plugins = omarchy_plugins(&omarchy)?;
     let plugin_enabled = match plugins.iter().find(|plugin| plugin.id == OMARCHY_PLUGIN_ID) {
         Some(plugin) if plugin.enabled => {
             status("ok", "32", "omarchy-boomux", "installed and enabled");
@@ -567,6 +561,41 @@ fn executable_on_path(name: &str) -> Option<PathBuf> {
             .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
             .then_some(candidate)
     })
+}
+
+fn omarchy_plugins(executable: &Path) -> io::Result<Vec<OmarchyPlugin>> {
+    let output = run_command(executable, &["plugin", "list", "--json"], COMMAND_TIMEOUT)?;
+    serde_json::from_slice(&output.stdout).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Omarchy returned invalid plugin inventory: {error}"),
+        )
+    })
+}
+
+pub(crate) fn installed_omarchy_plugin() -> io::Result<Option<PathBuf>> {
+    let Some(executable) = executable_on_path("omarchy") else {
+        return Ok(None);
+    };
+    Ok(omarchy_plugins(&executable)?
+        .iter()
+        .any(|plugin| plugin.id == OMARCHY_PLUGIN_ID)
+        .then_some(executable))
+}
+
+pub(crate) fn remove_omarchy_plugin(executable: &Path) -> io::Result<bool> {
+    if !omarchy_plugins(executable)?
+        .iter()
+        .any(|plugin| plugin.id == OMARCHY_PLUGIN_ID)
+    {
+        return Ok(false);
+    }
+    run_command(
+        executable,
+        &["plugin", "remove", OMARCHY_PLUGIN_ID, "--yes"],
+        COMMAND_TIMEOUT,
+    )?;
+    Ok(true)
 }
 
 fn run_command(
@@ -1134,5 +1163,21 @@ mod tests {
                 b"".as_slice(),
             ]
         );
+    }
+
+    #[test]
+    fn omarchy_plugin_removal_rechecks_inventory_and_uses_the_exact_id() {
+        let directory = TestDirectory::new();
+        let executable = directory.0.join("omarchy");
+        fs::write(
+            &executable,
+            b"#!/bin/sh\nmarker=$0.removed\ncase \"$*\" in\n  'plugin list --json')\n    if [ -e \"$marker\" ]; then printf '[]\\n'; else printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":true}]\\n'; fi ;;\n  'plugin remove io.github.gardnmi.boomux --yes') : > \"$marker\" ;;\n  *) exit 97 ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(remove_omarchy_plugin(&executable).unwrap());
+        assert!(executable.with_extension("removed").exists());
+        assert!(!remove_omarchy_plugin(&executable).unwrap());
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,0 +1,1138 @@
+use std::env;
+use std::error::Error;
+use std::fs::{self, OpenOptions};
+use std::io::{self, IsTerminal, Read, Write};
+use std::ops::Range;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::integration_management::{self, AssetState, HostState, InstallAction, IntegrationId};
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const PLUGIN_INSTALL_TIMEOUT: Duration = Duration::from_secs(120);
+const MAX_COMMAND_OUTPUT: u64 = 1024 * 1024;
+const MAX_BINDINGS_BYTES: u64 = 1024 * 1024;
+const OMARCHY_PLUGIN_ID: &str = "io.github.gardnmi.boomux";
+const OMARCHY_PLUGIN_URL: &str = "https://github.com/gardnmi/omarchy-boomux.git";
+const BINDINGS_BEGIN: &str = "-- BEGIN BOOMUX MANAGED KEYBINDINGS";
+const BINDINGS_END: &str = "-- END BOOMUX MANAGED KEYBINDINGS";
+const BINDING_KEYS: &[&str] = &[
+    "SUPER + B",
+    "SUPER + A",
+    "SUPER + LEFT",
+    "SUPER + RIGHT",
+    "SUPER + UP",
+    "SUPER + DOWN",
+    "SUPER + TAB",
+    "SUPER + SHIFT + TAB",
+    "SUPER + RETURN",
+    "SUPER + O",
+    "SUPER + ALT + B",
+    "SUPER + ALT + R",
+    "SUPER + CTRL + RETURN",
+    "SUPER + CTRL + W",
+];
+const COMPATIBLE_BINDING_SNIPPETS: &[&[u8]] = &[
+    b"omarchy-shell io.github.gardnmi.boomux toggle",
+    b"omarchy-shell io.github.gardnmi.boomux focus",
+    b"omarchy-shell io.github.gardnmi.boomux releaseFocus",
+    b"o.bind(\"SUPER + LEFT\", \"Focus on left window\"",
+    b"o.bind(\"SUPER + RIGHT\", \"Focus on right window\"",
+    b"o.bind(\"SUPER + UP\", \"Focus on above window\"",
+    b"o.bind(\"SUPER + DOWN\", \"Focus on below window\"",
+    b"\"boomux desktop next\"",
+    b"\"boomux desktop previous\"",
+    b"\"boomux desktop terminal\"",
+    b"\"boomux desktop pop\"",
+    b"\"boomux desktop return\"",
+    b"\"boomux desktop gather\"",
+    b"\"boomux shell create --open\"",
+    b"\"boomux close --focused\"",
+];
+
+const MANAGED_BINDINGS: &str = r#"-- BEGIN BOOMUX MANAGED KEYBINDINGS
+hl.unbind("SUPER + B")
+hl.unbind("SUPER + A")
+hl.unbind("SUPER + LEFT")
+hl.unbind("SUPER + RIGHT")
+hl.unbind("SUPER + UP")
+hl.unbind("SUPER + DOWN")
+hl.unbind("SUPER + TAB")
+hl.unbind("SUPER + SHIFT + TAB")
+hl.unbind("SUPER + RETURN")
+hl.unbind("SUPER + O")
+hl.unbind("SUPER + ALT + B")
+hl.unbind("SUPER + ALT + R")
+hl.unbind("SUPER + CTRL + RETURN")
+hl.unbind("SUPER + CTRL + W")
+
+o.bind("SUPER + B", "Toggle Boomux panel", "omarchy-shell io.github.gardnmi.boomux toggle", { release = true })
+o.bind("SUPER + A", "Focus Boomux panel", "omarchy-shell io.github.gardnmi.boomux focus", { release = true })
+
+local function boomux_focus_away(direction)
+  return function()
+    hl.exec_cmd("omarchy-shell io.github.gardnmi.boomux releaseFocus")
+    hl.dispatch(hl.dsp.focus({ direction = direction }))
+  end
+end
+
+o.bind("SUPER + LEFT", "Focus on left window", boomux_focus_away("l"))
+o.bind("SUPER + RIGHT", "Focus on right window", boomux_focus_away("r"))
+o.bind("SUPER + UP", "Focus on above window", boomux_focus_away("u"))
+o.bind("SUPER + DOWN", "Focus on below window", boomux_focus_away("d"))
+o.bind("SUPER + TAB", "Next Boomux workspace", "boomux desktop next")
+o.bind("SUPER + SHIFT + TAB", "Previous Boomux workspace", "boomux desktop previous")
+o.bind("SUPER + RETURN", "Contextual terminal", "boomux desktop terminal")
+o.bind("SUPER + O", "Pop window contextually", "boomux desktop pop")
+o.bind("SUPER + ALT + B", "Return terminal to Boomux workspace", "boomux desktop return")
+o.bind("SUPER + ALT + R", "Gather Boomux workspace terminals", "boomux desktop gather")
+o.bind("SUPER + CTRL + RETURN", "New Boomux Shell", "boomux shell create --open")
+o.bind("SUPER + CTRL + W", "Permanently close focused Boomux terminal", "boomux close --focused")
+-- END BOOMUX MANAGED KEYBINDINGS
+"#;
+
+#[derive(Debug, Deserialize)]
+struct OmarchyPlugin {
+    id: String,
+    enabled: bool,
+}
+
+struct CommandOutput {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+struct BindingsPlan {
+    path: PathBuf,
+    baseline: Option<Vec<u8>>,
+    content: Vec<u8>,
+    mode: u32,
+    changed: bool,
+    modified: bool,
+    compatible_unmanaged: bool,
+}
+
+fn colors_enabled() -> bool {
+    io::stdout().is_terminal()
+        && env::var_os("NO_COLOR").is_none()
+        && env::var("TERM").is_ok_and(|term| term != "dumb")
+}
+
+fn paint(code: &str, text: impl AsRef<str>) -> String {
+    let text = text.as_ref();
+    if colors_enabled() {
+        format!("\x1b[{code}m{text}\x1b[0m")
+    } else {
+        text.to_owned()
+    }
+}
+
+fn section(title: &str) {
+    println!("\n{}", paint("1;36", format!("-- {title} --")));
+}
+
+fn status(marker: &str, color: &str, label: &str, value: impl AsRef<str>) {
+    println!(
+        "  {} {:<20} {}",
+        paint(color, format!("[{marker}]")),
+        label,
+        value.as_ref()
+    );
+}
+
+fn detail(value: impl AsRef<str>) {
+    println!("       {}", paint("2", value));
+}
+
+pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Boomux setup requires an interactive terminal; use integration status and integration install for automation",
+        )
+        .into());
+    }
+
+    println!("{}", paint("1;35", "BOOMUX SETUP"));
+    println!(
+        "{}",
+        paint(
+            "2",
+            "Discover harnesses, lifecycle integrations, and desktop support."
+        )
+    );
+    println!("{}", paint("2", "Every change requires confirmation."));
+
+    section("System Check");
+    if let Some(terminal_resolver) = executable_on_path("xdg-terminal-exec") {
+        status(
+            "ok",
+            "32",
+            "Terminal resolver",
+            terminal_resolver.display().to_string(),
+        );
+    } else {
+        status("!!", "33", "Terminal resolver", "not found on PATH");
+    }
+
+    let environment = integration_management::Environment::from_process();
+    let statuses = IntegrationId::all()
+        .map(|integration| {
+            (
+                integration,
+                integration_management::inspect(integration, &environment, None),
+            )
+        })
+        .collect::<Vec<_>>();
+    let detected = statuses
+        .iter()
+        .filter(|(_, status)| status.host.state != HostState::Missing)
+        .count();
+
+    section("Agent Harnesses");
+    if detected == 0 {
+        status("--", "2", "Harnesses", "none found on PATH");
+    }
+    let mut failures = Vec::new();
+    let mut changed_harnesses = 0usize;
+    for (integration, integration_status) in statuses {
+        if integration_status.host.state == HostState::Missing {
+            continue;
+        }
+        let (marker, color) = match integration_status.asset.state {
+            AssetState::Current => ("ok", "32"),
+            AssetState::Missing => ("->", "36"),
+            AssetState::Modified => ("!!", "33"),
+            AssetState::Unavailable => ("xx", "31"),
+        };
+        status(
+            marker,
+            color,
+            integration_status.display_name,
+            format!(
+                "host {} | integration {}",
+                integration_status.host.state.as_str().replace('_', " "),
+                integration_status.asset.state.as_str()
+            ),
+        );
+        if let Some(version) = integration_status.host.version.as_deref() {
+            detail(format!(
+                "version {version} ({})",
+                integration_status.host.compatibility
+            ));
+        }
+        if integration_status.asset.state == AssetState::Current {
+            continue;
+        }
+        if integration_status.asset.state == AssetState::Unavailable {
+            failures.push(format!(
+                "{} integration could not be inspected: {}",
+                integration_status.display_name,
+                integration_status
+                    .asset
+                    .error
+                    .as_deref()
+                    .unwrap_or("unknown error")
+            ));
+            continue;
+        }
+        let force = integration_status.asset.state == AssetState::Modified;
+        let plan = match integration_management::plan_install(integration, &environment, force) {
+            Ok(plan) => plan,
+            Err(error) => {
+                failures.push(format!(
+                    "{} integration: {error}",
+                    integration_status.display_name
+                ));
+                continue;
+            }
+        };
+        let action = match plan.action {
+            InstallAction::Install => "Install",
+            InstallAction::Replace => "Replace modified",
+            InstallAction::Unchanged => continue,
+        };
+        detail(format!("Plan: {action} asset at {}", plan.path));
+        if confirm(&format!(
+            "{action} the {} integration?",
+            integration_status.display_name
+        ))? {
+            match integration_management::install(integration, &environment, force) {
+                Ok(result) => {
+                    status(
+                        "ok",
+                        "32",
+                        integration_status.display_name,
+                        "integration installed",
+                    );
+                    detail(format!("path: {}", result.path));
+                    if result.restart_required {
+                        changed_harnesses += 1;
+                        detail(integration.installation().reload_message);
+                    }
+                }
+                Err(error) => failures.push(format!(
+                    "{} integration: {error}",
+                    integration_status.display_name
+                )),
+            }
+        } else {
+            status("--", "2", integration_status.display_name, "skipped");
+        }
+    }
+
+    if detected > 0
+        && let Err(error) = setup_agent_skill()
+    {
+        failures.push(format!("Agent Skill: {error}"));
+    }
+
+    if let Err(error) = setup_omarchy() {
+        failures.push(format!("Omarchy desktop setup: {error}"));
+    }
+
+    section("Summary");
+    if failures.is_empty() {
+        status("ok", "32", "Setup", "completed without errors");
+        if changed_harnesses > 0 {
+            detail("Restart changed harnesses before verifying lifecycle reporting.");
+        } else {
+            detail("No harness restart is required.");
+        }
+        return Ok(());
+    }
+    for failure in &failures {
+        eprintln!("  {} {failure}", paint("31", "[xx]"));
+    }
+    Err(io::Error::other(format!(
+        "setup completed with {} failure{}",
+        failures.len(),
+        if failures.len() == 1 { "" } else { "s" }
+    ))
+    .into())
+}
+
+fn setup_agent_skill() -> Result<(), Box<dyn Error>> {
+    let home = required_home()?;
+    let path = home.join(".agents/skills/boomux/SKILL.md");
+    match integration_management::regular_file_matches(&path, crate::BOOMUX_SKILL)? {
+        Some(true) => {
+            status("ok", "32", "Agent Skill", "current");
+            detail(path.display().to_string());
+            Ok(())
+        }
+        state => {
+            let modified = state == Some(false);
+            let prompt = if modified {
+                status("!!", "33", "Agent Skill", "modified");
+                detail(format!("Plan: replace {}", path.display()));
+                "Replace the modified Boomux Agent Skill?"
+            } else {
+                status("->", "36", "Agent Skill", "not installed");
+                detail(format!("Plan: install {}", path.display()));
+                "Install the Boomux Agent Skill?"
+            };
+            if confirm(prompt)? {
+                crate::install_skill(modified)
+            } else {
+                status("--", "2", "Agent Skill", "skipped");
+                Ok(())
+            }
+        }
+    }
+}
+
+fn required_home() -> io::Result<PathBuf> {
+    env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "HOME must be absolute"))
+}
+
+fn setup_omarchy() -> Result<(), Box<dyn Error>> {
+    section("Desktop Integration");
+    let Some(omarchy) = executable_on_path("omarchy") else {
+        status("--", "2", "Omarchy", "not detected");
+        detail("Desktop plugin and keybindings were skipped.");
+        return Ok(());
+    };
+    let version = run_command(&omarchy, &["version"], COMMAND_TIMEOUT)?;
+    status(
+        "ok",
+        "32",
+        "Omarchy",
+        String::from_utf8_lossy(&version.stdout).trim(),
+    );
+    let hyprland_active =
+        env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some_and(|value| !value.is_empty());
+    status(
+        if hyprland_active { "ok" } else { "--" },
+        if hyprland_active { "32" } else { "2" },
+        "Hyprland session",
+        if hyprland_active {
+            "active"
+        } else {
+            "not active"
+        },
+    );
+
+    let plugins = run_command(&omarchy, &["plugin", "list", "--json"], COMMAND_TIMEOUT)?;
+    let plugins: Vec<OmarchyPlugin> = serde_json::from_slice(&plugins.stdout).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Omarchy returned invalid plugin inventory: {error}"),
+        )
+    })?;
+    let plugin_enabled = match plugins.iter().find(|plugin| plugin.id == OMARCHY_PLUGIN_ID) {
+        Some(plugin) if plugin.enabled => {
+            status("ok", "32", "omarchy-boomux", "installed and enabled");
+            true
+        }
+        Some(_) => {
+            status("!!", "33", "omarchy-boomux", "installed but disabled");
+            if confirm("Enable omarchy-boomux?")? {
+                run_command(
+                    &omarchy,
+                    &["plugin", "enable", OMARCHY_PLUGIN_ID],
+                    COMMAND_TIMEOUT,
+                )?;
+                status("ok", "32", "omarchy-boomux", "enabled");
+                true
+            } else {
+                false
+            }
+        }
+        None => {
+            status("->", "36", "omarchy-boomux", "not installed");
+            detail("Plugins run as unsandboxed code inside the Omarchy shell.");
+            detail(format!("Source: {OMARCHY_PLUGIN_URL}"));
+            if confirm("Install and enable omarchy-boomux?")? {
+                run_command(
+                    &omarchy,
+                    &["plugin", "add", OMARCHY_PLUGIN_URL, "--enable", "--yes"],
+                    PLUGIN_INSTALL_TIMEOUT,
+                )?;
+                status("ok", "32", "omarchy-boomux", "installed and enabled");
+                true
+            } else {
+                false
+            }
+        }
+    };
+    if !plugin_enabled {
+        status("--", "2", "Keybindings", "skipped; plugin is not enabled");
+        return Ok(());
+    }
+
+    let plan = bindings_plan()?;
+    if !plan.changed {
+        if plan.compatible_unmanaged {
+            status("ok", "32", "Keybindings", "compatible user-managed profile");
+            detail("Existing bindings work and remain user-owned unless you reinstall them.");
+
+            let inventory = run_command(
+                &omarchy,
+                &["menu", "keybindings", "--print"],
+                COMMAND_TIMEOUT,
+            )?;
+            let inventory = String::from_utf8_lossy(&inventory.stdout);
+            let conflicts = binding_conflicts(&inventory);
+            if !conflicts.is_empty() {
+                status(
+                    "!!",
+                    "33",
+                    "Reinstall impact",
+                    "these existing bindings would be overridden",
+                );
+                for conflict in conflicts {
+                    detail(conflict);
+                }
+            }
+        } else {
+            status("ok", "32", "Keybindings", "current managed profile");
+        }
+
+        if !confirm("Reinstall the standard Boomux keybinding profile?")? {
+            status("--", "2", "Keybindings", "kept unchanged");
+            return Ok(());
+        }
+    } else {
+        let inventory = run_command(
+            &omarchy,
+            &["menu", "keybindings", "--print"],
+            COMMAND_TIMEOUT,
+        )?;
+        let inventory = String::from_utf8_lossy(&inventory.stdout);
+        let conflicts = binding_conflicts(&inventory);
+        if plan.modified {
+            status("!!", "33", "Keybindings", "managed profile modified");
+        } else if conflicts.is_empty() {
+            status("->", "36", "Keybindings", "full profile not installed");
+        } else {
+            status("!!", "33", "Keybindings", "conflicts require replacement");
+            for conflict in conflicts {
+                detail(conflict);
+            }
+        }
+        let prompt = if plan.modified {
+            "Replace the modified Boomux keybinding profile?"
+        } else {
+            "Install the full Boomux keybinding profile?"
+        };
+        if !confirm(prompt)? {
+            status("--", "2", "Keybindings", "skipped");
+            return Ok(());
+        }
+    }
+    commit_bindings(&plan)?;
+    status("ok", "32", "Keybindings", "installed");
+    detail(plan.path.display().to_string());
+
+    let hyprctl = hyprland_active
+        .then(|| executable_on_path("hyprctl"))
+        .flatten();
+    let validation = if hyprland_active {
+        hyprctl.as_deref().map_or_else(
+            || {
+                Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "HYPRLAND_INSTANCE_SIGNATURE is set but hyprctl is unavailable",
+                ))
+            },
+            validate_hyprland_config,
+        )
+    } else {
+        detail("Hyprland is not active; bindings will load at the next session.");
+        Ok(())
+    };
+    if let Err(error) = validation {
+        rollback_bindings(&plan).map_err(|rollback| {
+            io::Error::other(format!(
+                "{error}; additionally failed to restore prior keybindings: {rollback}"
+            ))
+        })?;
+        if let Some(hyprctl) = hyprctl.as_deref() {
+            validate_hyprland_config(hyprctl).map_err(|rollback| {
+                io::Error::other(format!(
+                    "{error}; prior keybindings were restored but Hyprland failed to reload them: {rollback}"
+                ))
+            })?;
+        }
+        return Err(error.into());
+    }
+    if hyprland_active {
+        status("ok", "32", "Hyprland config", "reloaded without errors");
+    }
+    Ok(())
+}
+
+fn validate_hyprland_config(hyprctl: &Path) -> io::Result<()> {
+    run_command(hyprctl, &["reload"], COMMAND_TIMEOUT)?;
+    let errors = run_command(hyprctl, &["configerrors"], COMMAND_TIMEOUT)?;
+    let errors = String::from_utf8_lossy(&errors.stdout);
+    if errors.trim().is_empty() {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Hyprland reported configuration errors:\n{}", errors.trim()),
+        ))
+    }
+}
+
+fn confirm(prompt: &str) -> io::Result<bool> {
+    print!("  {} {} ", paint("1;33", prompt), paint("2", "[y/N]"));
+    io::stdout().flush()?;
+    let mut response = String::new();
+    io::stdin().read_line(&mut response)?;
+    Ok(matches!(
+        response.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn executable_on_path(name: &str) -> Option<PathBuf> {
+    env::split_paths(&env::var_os("PATH")?).find_map(|directory| {
+        let candidate = directory.join(name);
+        fs::metadata(&candidate)
+            .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+            .then_some(candidate)
+    })
+}
+
+fn run_command(
+    executable: &Path,
+    arguments: &[&str],
+    timeout: Duration,
+) -> io::Result<CommandOutput> {
+    let mut child = Command::new(executable)
+        .args(arguments)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0)
+        .spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("command stdout was unavailable"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("command stderr was unavailable"))?;
+    let stdout = spawn_reader(stdout);
+    let stderr = spawn_reader(stderr);
+    let process_group = i32::try_from(child.id())
+        .map_err(|_| io::Error::other("command process ID exceeded i32"))?;
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            terminate_process_group(&mut child, process_group);
+            return Err(io::Error::new(io::ErrorKind::TimedOut, "command timed out"));
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    terminate_process_group(&mut child, process_group);
+    let stdout = receive_output(stdout)?;
+    let stderr = receive_output(stderr)?;
+    if !status.success() {
+        let detail = String::from_utf8_lossy(&stderr);
+        return Err(io::Error::other(format!(
+            "{} exited with {status}: {}",
+            executable.display(),
+            detail.trim()
+        )));
+    }
+    Ok(CommandOutput { stdout, stderr })
+}
+
+fn spawn_reader(reader: impl Read + Send + 'static) -> mpsc::Receiver<io::Result<Vec<u8>>> {
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        let result = reader
+            .take(MAX_COMMAND_OUTPUT + 1)
+            .read_to_end(&mut output)
+            .map(|_| output);
+        let _ = sender.send(result);
+    });
+    receiver
+}
+
+fn receive_output(receiver: mpsc::Receiver<io::Result<Vec<u8>>>) -> io::Result<Vec<u8>> {
+    let output = receiver
+        .recv_timeout(Duration::from_secs(1))
+        .map_err(|_| io::Error::other("command output reader stopped"))??;
+    if output.len() > MAX_COMMAND_OUTPUT as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "command output exceeded 1 MiB",
+        ));
+    }
+    Ok(output)
+}
+
+fn terminate_process_group(child: &mut std::process::Child, process_group: i32) {
+    unsafe {
+        libc::kill(-process_group, libc::SIGKILL);
+    }
+    let _ = child.wait();
+}
+
+fn bindings_plan() -> Result<BindingsPlan, Box<dyn Error>> {
+    let path = bindings_directory()?.join("bindings.lua");
+    let (baseline, mode) = read_owned_bindings(&path)?;
+    let source = baseline.as_deref().unwrap_or_default();
+    let range = managed_block_range(source)?;
+    let compatible_unmanaged = range.is_none() && compatible_unmanaged_profile(source);
+    let modified = range
+        .as_ref()
+        .is_some_and(|range| &source[range.clone()] != MANAGED_BINDINGS.as_bytes());
+    let content = render_bindings(source)?;
+    if content.len() > MAX_BINDINGS_BYTES as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "bindings file would exceed 1 MiB after setup",
+        )
+        .into());
+    }
+    let changed = !compatible_unmanaged && baseline.as_deref() != Some(content.as_slice());
+    Ok(BindingsPlan {
+        path,
+        baseline,
+        content,
+        mode,
+        changed,
+        modified,
+        compatible_unmanaged,
+    })
+}
+
+pub(crate) fn managed_bindings_status() -> io::Result<(PathBuf, Option<bool>)> {
+    let path = bindings_directory()?.join("bindings.lua");
+    let (baseline, _) = read_owned_bindings(&path)?;
+    let Some(baseline) = baseline else {
+        return Ok((path, None));
+    };
+    let range = match managed_block_range(&baseline) {
+        Ok(Some(range)) => range,
+        Ok(None) => return Ok((path, None)),
+        Err(_) => return Ok((path, Some(false))),
+    };
+    Ok((path, Some(&baseline[range] == MANAGED_BINDINGS.as_bytes())))
+}
+
+pub(crate) fn remove_managed_bindings() -> io::Result<bool> {
+    let directory = integration_management::ensure_safe_directory(&bindings_directory()?)
+        .map_err(|error| io::Error::other(error.to_string()))?;
+    let path = directory.join("bindings.lua");
+    let (baseline, mode) = read_owned_bindings(&path)?;
+    let Some(baseline) = baseline else {
+        return Ok(false);
+    };
+    let Some(range) = managed_block_range(&baseline)? else {
+        return Ok(false);
+    };
+    if &baseline[range.clone()] != MANAGED_BINDINGS.as_bytes() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "Boomux managed keybindings were modified",
+        ));
+    }
+    let mut content = baseline.clone();
+    content.drain(range);
+    let plan = BindingsPlan {
+        path,
+        baseline: Some(baseline),
+        content,
+        mode,
+        changed: true,
+        modified: false,
+        compatible_unmanaged: false,
+    };
+    commit_bindings(&plan)?;
+    Ok(true)
+}
+
+fn bindings_directory() -> io::Result<PathBuf> {
+    Ok(required_home()?.join(".config/hypr"))
+}
+
+fn read_owned_bindings(path: &Path) -> io::Result<(Option<Vec<u8>>, u32)> {
+    let file = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok((None, 0o600)),
+        Err(error) if error.raw_os_error() == Some(libc::ELOOP) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("bindings path is a symbolic link: {}", path.display()),
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("bindings path is not a regular file: {}", path.display()),
+        ));
+    }
+    if metadata.uid() != unsafe { libc::geteuid() } {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "bindings file is not owned by the current user: {}",
+                path.display()
+            ),
+        ));
+    }
+    if metadata.len() > MAX_BINDINGS_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "bindings file exceeds 1 MiB",
+        ));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_BINDINGS_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_BINDINGS_BYTES as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "bindings file exceeds 1 MiB",
+        ));
+    }
+    Ok((Some(bytes), metadata.permissions().mode() & 0o7777))
+}
+
+fn render_bindings(source: &[u8]) -> io::Result<Vec<u8>> {
+    match managed_block_range(source)? {
+        None => {
+            let mut content = source.to_vec();
+            if !content.is_empty() && !content.ends_with(b"\n") {
+                content.push(b'\n');
+            }
+            if !content.is_empty() {
+                content.push(b'\n');
+            }
+            content.extend_from_slice(MANAGED_BINDINGS.as_bytes());
+            Ok(content)
+        }
+        Some(range) => {
+            let mut content = Vec::with_capacity(source.len() + MANAGED_BINDINGS.len());
+            content.extend_from_slice(&source[..range.start]);
+            content.extend_from_slice(MANAGED_BINDINGS.as_bytes());
+            content.extend_from_slice(&source[range.end..]);
+            Ok(content)
+        }
+    }
+}
+
+fn managed_block_range(source: &[u8]) -> io::Result<Option<Range<usize>>> {
+    let begins = find_all(source, BINDINGS_BEGIN.as_bytes());
+    let ends = find_all(source, BINDINGS_END.as_bytes());
+    match (begins.as_slice(), ends.as_slice()) {
+        ([], []) => Ok(None),
+        ([begin], [end]) if begin < end => {
+            let block_end = end + BINDINGS_END.len();
+            let block_end = block_end + usize::from(source[block_end..].starts_with(b"\n"));
+            Ok(Some(*begin..block_end))
+        }
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "bindings file contains incomplete or duplicate Boomux managed markers",
+        )),
+    }
+}
+
+fn find_all(haystack: &[u8], needle: &[u8]) -> Vec<usize> {
+    haystack
+        .windows(needle.len())
+        .enumerate()
+        .filter_map(|(index, window)| (window == needle).then_some(index))
+        .collect()
+}
+
+fn compatible_unmanaged_profile(source: &[u8]) -> bool {
+    COMPATIBLE_BINDING_SNIPPETS.iter().all(|snippet| {
+        source
+            .windows(snippet.len())
+            .any(|window| window == *snippet)
+    })
+}
+
+fn binding_conflicts(inventory: &str) -> Vec<&str> {
+    inventory
+        .lines()
+        .filter(|line| {
+            let binding = line.split('→').next().unwrap_or(line).trim();
+            let binding = normalized_binding(binding);
+            BINDING_KEYS
+                .iter()
+                .any(|key| normalized_binding(key) == binding)
+        })
+        .collect()
+}
+
+fn normalized_binding(binding: &str) -> String {
+    binding
+        .chars()
+        .filter(|character| !character.is_ascii_whitespace() && *character != '+')
+        .collect()
+}
+
+fn commit_bindings(plan: &BindingsPlan) -> io::Result<()> {
+    let expected_directory = plan
+        .path
+        .parent()
+        .ok_or_else(|| io::Error::other("bindings path has no parent"))?;
+    let directory = integration_management::ensure_safe_directory(expected_directory)
+        .map_err(|error| io::Error::other(error.to_string()))?;
+    let (current, _) = read_owned_bindings(&plan.path)?;
+    require_bindings_baseline(plan, &current)?;
+    let temporary = directory.join(format!(".boomux-bindings-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(plan.mode)
+            .open(&temporary)?;
+        file.set_permissions(fs::Permissions::from_mode(plan.mode))?;
+        file.write_all(&plan.content)?;
+        file.sync_all()?;
+        let (current, _) = read_owned_bindings(&plan.path)?;
+        require_bindings_baseline(plan, &current)?;
+        fs::rename(&temporary, &plan.path)?;
+        fs::File::open(directory)?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn require_bindings_baseline(plan: &BindingsPlan, current: &Option<Vec<u8>>) -> io::Result<()> {
+    if current == &plan.baseline {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("{} changed after setup inspection", plan.path.display()),
+        ))
+    }
+}
+
+fn rollback_bindings(plan: &BindingsPlan) -> io::Result<()> {
+    let (current, _) = read_owned_bindings(&plan.path)?;
+    if current.as_deref() != Some(plan.content.as_slice()) {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("{} changed before rollback", plan.path.display()),
+        ));
+    }
+    match &plan.baseline {
+        Some(baseline) => {
+            let rollback = BindingsPlan {
+                path: plan.path.clone(),
+                baseline: current,
+                content: baseline.clone(),
+                mode: plan.mode,
+                changed: true,
+                modified: false,
+                compatible_unmanaged: false,
+            };
+            commit_bindings(&rollback)
+        }
+        None => {
+            fs::remove_file(&plan.path)?;
+            fs::File::open(
+                plan.path
+                    .parent()
+                    .ok_or_else(|| io::Error::other("bindings path has no parent"))?,
+            )?
+            .sync_all()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::symlink;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = env::temp_dir().join(format!("boomux-setup-{}-{nonce}", std::process::id()));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn managed_bindings_append_replace_and_reject_bad_markers() {
+        let original = b"-- user binding\no.bind(\"SUPER + Q\", \"User\", \"true\")\n";
+        let installed = render_bindings(original).unwrap();
+        assert!(installed.starts_with(original));
+        assert!(
+            installed
+                .windows(b"boomux desktop gather".len())
+                .any(|window| window == b"boomux desktop gather")
+        );
+        assert_eq!(render_bindings(&installed).unwrap(), installed);
+
+        let modified = String::from_utf8(installed.clone())
+            .unwrap()
+            .replace("Toggle Boomux panel", "Custom panel")
+            .into_bytes();
+        let repaired = render_bindings(&modified).unwrap();
+        assert_eq!(repaired, installed);
+        assert!(render_bindings(BINDINGS_BEGIN.as_bytes()).is_err());
+        assert!(
+            render_bindings(format!("{BINDINGS_BEGIN}\n{BINDINGS_END}\n{BINDINGS_END}").as_bytes())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn managed_bindings_preserve_non_utf8_user_bytes() {
+        let original = b"-- user\n\xff\xfe\n";
+        let installed = render_bindings(original).unwrap();
+        assert!(installed.starts_with(original));
+        let range = managed_block_range(&installed).unwrap().unwrap();
+        let mut removed = installed;
+        removed.drain(range);
+        assert_eq!(removed, b"-- user\n\xff\xfe\n\n");
+    }
+
+    #[test]
+    fn conflict_inventory_selects_only_managed_keys() {
+        let inventory =
+            "SUPER + B        → Browser\nSUPER + Q        → User\nSUPER CTRL + W   → Close\n";
+        assert_eq!(
+            binding_conflicts(inventory),
+            vec!["SUPER + B        → Browser", "SUPER CTRL + W   → Close"]
+        );
+    }
+
+    #[test]
+    fn complete_unmanaged_profile_is_compatible_but_partial_profile_is_not() {
+        let complete = COMPATIBLE_BINDING_SNIPPETS
+            .iter()
+            .flat_map(|snippet| snippet.iter().copied().chain(*b"\n"))
+            .collect::<Vec<_>>();
+        assert!(compatible_unmanaged_profile(&complete));
+
+        let partial =
+            &complete[..complete.len() - COMPATIBLE_BINDING_SNIPPETS.last().unwrap().len()];
+        assert!(!compatible_unmanaged_profile(partial));
+    }
+
+    #[test]
+    fn bindings_commit_preserves_mode_and_rejects_concurrent_changes() {
+        let directory = TestDirectory::new();
+        let path = directory.0.join("bindings.lua");
+        let baseline = b"-- user\n".to_vec();
+        fs::write(&path, &baseline).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
+        let content = render_bindings(b"-- user\n").unwrap();
+        let plan = BindingsPlan {
+            path: path.clone(),
+            baseline: Some(baseline),
+            content: content.clone(),
+            mode: 0o640,
+            changed: true,
+            modified: false,
+            compatible_unmanaged: false,
+        };
+        commit_bindings(&plan).unwrap();
+        assert_eq!(fs::read(&path).unwrap(), content);
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+
+        let stale = BindingsPlan {
+            baseline: Some(content),
+            content: b"replacement".to_vec(),
+            ..plan
+        };
+        fs::write(&path, b"user changed it").unwrap();
+        assert_eq!(
+            commit_bindings(&stale).unwrap_err().kind(),
+            io::ErrorKind::AlreadyExists
+        );
+        assert_eq!(fs::read(&path).unwrap(), b"user changed it");
+    }
+
+    #[test]
+    fn bindings_rollback_restores_existing_and_missing_baselines() {
+        let directory = TestDirectory::new();
+        let existing = directory.0.join("existing.lua");
+        fs::write(&existing, b"before").unwrap();
+        let existing_plan = BindingsPlan {
+            path: existing.clone(),
+            baseline: Some(b"before".to_vec()),
+            content: b"after".to_vec(),
+            mode: 0o640,
+            changed: true,
+            modified: false,
+            compatible_unmanaged: false,
+        };
+        commit_bindings(&existing_plan).unwrap();
+        rollback_bindings(&existing_plan).unwrap();
+        assert_eq!(fs::read(&existing).unwrap(), b"before");
+
+        let missing = directory.0.join("missing.lua");
+        let missing_plan = BindingsPlan {
+            path: missing.clone(),
+            baseline: None,
+            content: b"created".to_vec(),
+            mode: 0o600,
+            changed: true,
+            modified: false,
+            compatible_unmanaged: false,
+        };
+        commit_bindings(&missing_plan).unwrap();
+        rollback_bindings(&missing_plan).unwrap();
+        assert!(!missing.exists());
+    }
+
+    #[test]
+    fn bindings_inspection_rejects_symlinks() {
+        let directory = TestDirectory::new();
+        let target = directory.0.join("target");
+        let path = directory.0.join("bindings.lua");
+        fs::write(&target, b"user").unwrap();
+        symlink(&target, &path).unwrap();
+        assert_eq!(
+            read_owned_bindings(&path).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn bindings_inspection_rejects_fifos_without_blocking() {
+        let directory = TestDirectory::new();
+        let path = directory.0.join("bindings.lua");
+        let path_bytes = CString::new(path.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(path_bytes.as_ptr(), 0o600) }, 0);
+        assert_eq!(
+            read_owned_bindings(&path).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn bounded_command_preserves_exact_arguments() {
+        let directory = TestDirectory::new();
+        let executable = directory.0.join("probe");
+        fs::write(&executable, b"#!/bin/sh\nprintf '%s\\0' \"$@\"\n").unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        let output = run_command(
+            &executable,
+            &["value with spaces", "$(not-executed)", "semi;colon"],
+            Duration::from_secs(1),
+        )
+        .unwrap();
+        assert_eq!(
+            output.stdout.split(|byte| *byte == 0).collect::<Vec<_>>(),
+            [
+                b"value with spaces".as_slice(),
+                b"$(not-executed)".as_slice(),
+                b"semi;colon".as_slice(),
+                b"".as_slice(),
+            ]
+        );
+    }
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -14,6 +14,8 @@ use std::time::{Duration, Instant};
 use serde::Deserialize;
 use uuid::Uuid;
 
+use boomux::client;
+
 use crate::integration_management::{self, AssetState, HostState, InstallAction, IntegrationId};
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
@@ -169,7 +171,13 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
             "Discover harnesses, lifecycle integrations, and desktop support."
         )
     );
-    println!("{}", paint("2", "Every change requires confirmation."));
+    println!(
+        "{}",
+        paint(
+            "2",
+            "Daemon readiness is automatic; configuration changes require confirmation."
+        )
+    );
 
     section("System Check");
     if let Some(terminal_resolver) = executable_on_path("xdg-terminal-exec") {
@@ -182,6 +190,18 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
     } else {
         status("!!", "33", "Terminal resolver", "not found on PATH");
     }
+    let daemon_was_running = client::connect().is_ok();
+    client::connect_or_start()?;
+    status(
+        "ok",
+        "32",
+        "Daemon",
+        if daemon_was_running {
+            "already running"
+        } else {
+            "started"
+        },
+    );
 
     let environment = integration_management::Environment::from_process();
     let statuses = IntegrationId::all()

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -50,6 +50,10 @@ pub(crate) fn guided_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Er
             Some(error.to_string()),
         ),
     };
+    let (omarchy_plugin, omarchy_plugin_error) = match setup::installed_omarchy_plugin() {
+        Ok(plugin) => (plugin, None),
+        Err(error) => (None, Some(error.to_string())),
+    };
     let purge_directories = purge
         .then(|| Ok::<_, io::Error>((state_directory(&home)?, config_directory(&home)?)))
         .transpose()?;
@@ -95,9 +99,13 @@ pub(crate) fn guided_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Er
         ),
         None => {}
     }
-    println!(
-        "The Omarchy plugin remains independently managed; remove it with: omarchy plugin remove io.github.gardnmi.boomux"
-    );
+    if omarchy_plugin.is_some() {
+        println!(
+            "Desktop integration: the installed io.github.gardnmi.boomux Omarchy plugin will be removed"
+        );
+    } else if let Some(error) = &omarchy_plugin_error {
+        println!("Preserving uninspectable omarchy-boomux plugin: {error}");
+    }
     if purge {
         let (state_directory, config_directory) = purge_directories
             .as_ref()
@@ -176,6 +184,11 @@ pub(crate) fn guided_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Er
                 bindings_path.display()
             ),
         }
+    }
+    if let Some(omarchy) = &omarchy_plugin
+        && setup::remove_omarchy_plugin(omarchy)?
+    {
+        println!("Removed io.github.gardnmi.boomux Omarchy plugin");
     }
     if purge {
         let (state_directory, config_directory) = purge_directories

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Component, Path, PathBuf};
 
 use crate::integration_management::{self, AssetState};
-use crate::{BOOMUX_SKILL, client, mobile_web, tailscale_serve, update};
+use crate::{BOOMUX_SKILL, client, mobile_web, setup, tailscale_serve, update};
 
 const MAX_PURGE_ENTRIES: usize = 16_384;
 const MAX_WEB_GATEWAYS: usize = 256;
@@ -42,6 +42,14 @@ pub(crate) fn guided_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Er
     let home = required_home()?;
     let skill_path = home.join(".agents/skills/boomux/SKILL.md");
     let skill_state = integration_management::regular_file_matches(&skill_path, BOOMUX_SKILL)?;
+    let (bindings_path, bindings_state, bindings_error) = match setup::managed_bindings_status() {
+        Ok((path, state)) => (path, state, None),
+        Err(error) => (
+            home.join(".config/hypr/bindings.lua"),
+            Some(false),
+            Some(error.to_string()),
+        ),
+    };
     let purge_directories = purge
         .then(|| Ok::<_, io::Error>((state_directory(&home)?, config_directory(&home)?)))
         .transpose()?;
@@ -72,6 +80,24 @@ pub(crate) fn guided_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Er
             skill_path.display()
         );
     }
+    match bindings_state {
+        Some(true) => println!(
+            "Owned desktop assets: Boomux managed keybindings at {} will be removed",
+            bindings_path.display()
+        ),
+        Some(false) => println!(
+            "Preserving modified or uninspectable Boomux managed keybindings at {}{}",
+            bindings_path.display(),
+            bindings_error
+                .as_deref()
+                .map(|error| format!(": {error}"))
+                .unwrap_or_default()
+        ),
+        None => {}
+    }
+    println!(
+        "The Omarchy plugin remains independently managed; remove it with: omarchy plugin remove io.github.gardnmi.boomux"
+    );
     if purge {
         let (state_directory, config_directory) = purge_directories
             .as_ref()
@@ -132,6 +158,24 @@ pub(crate) fn guided_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Er
             "Preserving Boomux Agent Skill because it changed after authorization: {}",
             skill_path.display()
         );
+    }
+    if bindings_state == Some(true) {
+        match setup::managed_bindings_status() {
+            Ok((_, Some(true))) => match setup::remove_managed_bindings() {
+                Ok(true) => println!(
+                    "Removed Boomux managed keybindings from {}",
+                    bindings_path.display()
+                ),
+                _ => println!(
+                    "Preserving Boomux managed keybindings because they changed after authorization: {}",
+                    bindings_path.display()
+                ),
+            },
+            _ => println!(
+                "Preserving Boomux managed keybindings because they changed after authorization: {}",
+                bindings_path.display()
+            ),
+        }
     }
     if purge {
         let (state_directory, config_directory) = purge_directories

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -30,3 +30,5 @@ mod shell_lifecycle;
 mod shell_name_suggestion;
 #[path = "native_backend/update.rs"]
 mod update;
+#[path = "native_backend/workspace_creation.rs"]
+mod workspace_creation;

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -71,6 +71,7 @@ fn native_daemon_lifecycle() {
     for command in [
         "events",
         "project.list",
+        "workspace.create",
         "node.snapshot",
         "agent.register",
         "agent.ensure",
@@ -147,6 +148,7 @@ fn native_daemon_lifecycle() {
         "exact_run_attachment",
         "stable_node_identity",
         "workspace_default_cwd",
+        "atomic_workspace_shell_creation",
         "structured_terminal_previews",
         "focused_terminal_read",
         "focused_terminal_following",
@@ -192,7 +194,7 @@ fn native_daemon_lifecycle() {
     .unwrap();
     let response: protocol::Envelope<protocol::Response> =
         protocol::read_message(&mut protocol_forty_six).unwrap();
-    assert_eq!(response.version, 48);
+    assert_eq!(response.version, protocol::PROTOCOL_VERSION);
     assert!(matches!(
         response.message,
         protocol::Response::Error {

--- a/tests/native_backend/handoff.rs
+++ b/tests/native_backend/handoff.rs
@@ -581,16 +581,19 @@ fn graceful_restart_transfers_live_kiro_holder_authority_and_rolls_back_safely()
         .parse::<libc::pid_t>()
         .unwrap();
 
-    let state_path = daemon.runtime_dir.join("state/boomux/state.json");
-    let valid_state = fs::read(&state_path).unwrap();
-    fs::write(&state_path, b"invalid Kiro holder handoff state").unwrap();
+    fs::write(
+        daemon
+            .runtime_dir
+            .join("state/boomux/.native-test-fail-handoff-import"),
+        b"",
+    )
+    .unwrap();
     let failed = daemon
         .command()
         .args(["daemon", "restart"])
         .output()
         .unwrap();
     assert!(!failed.status.success());
-    fs::write(&state_path, valid_state).unwrap();
     fs::write(&phase_one, b"").unwrap();
     wait_until(
         || kiro_agent_state(&daemon, "handoff-session") == Some(AgentState::Unknown),

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use boomux::protocol::{self, WorkspaceLauncherSpec};
@@ -8,6 +9,28 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use uuid::Uuid;
 
 use crate::support::{TestDaemon, wait_until};
+
+fn setup_runtime(root: &Path) -> PathBuf {
+    let runtime = root.join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    runtime
+}
+
+fn stop_setup_daemon(executable: &Path, root: &Path, runtime: &Path) {
+    let output = Command::new(executable)
+        .args(["daemon", "stop"])
+        .env("HOME", root)
+        .env("XDG_RUNTIME_DIR", runtime)
+        .env("XDG_CONFIG_HOME", root.join("config"))
+        .env("XDG_STATE_HOME", root.join("state"))
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "daemon stop failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
 
 #[test]
 fn guided_setup_requires_an_interactive_terminal() {
@@ -32,6 +55,7 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
     ));
     let bin = root.join("bin");
     let config = root.join("config");
+    let runtime = setup_runtime(&root);
     fs::create_dir_all(&bin).unwrap();
     for (name, content) in [
         ("opencode", "#!/bin/sh\nprintf '1.18.18\\n'\n"),
@@ -54,6 +78,8 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
     command.arg("setup");
     command.env("HOME", &root);
     command.env("XDG_CONFIG_HOME", &config);
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
     command.env("PATH", &bin);
     let mut child = pty.slave.spawn_command(command).unwrap();
     drop(pty.slave);
@@ -65,6 +91,8 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
     let mut output = String::new();
     std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
     assert!(output.contains("OpenCode"));
+    assert!(output.contains("Daemon"));
+    assert!(output.contains("started"));
     assert!(output.contains("host available | integration missing"));
     assert!(output.contains("integration installed"));
     assert!(output.contains("Omarchy"));
@@ -74,19 +102,22 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
         "{output}"
     );
     assert!(!root.join(".agents/skills/boomux/SKILL.md").exists());
+    assert!(runtime.join("boomux/daemon.sock").exists());
+    stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();
 }
 
 #[test]
 fn guided_setup_rejects_cargo_private_boomux_before_desktop_mutation() {
     let root = std::env::temp_dir().join(format!(
-        "boomux-guided-desktop-cargo-path-{}-{}",
+        "bmux-setup-cargo-{}-{}",
         std::process::id(),
         Uuid::new_v4()
     ));
     let cargo_bin = root.join(".cargo/bin");
     let bin = root.join("bin");
     let log = root.join("commands.log");
+    let runtime = setup_runtime(&root);
     fs::create_dir_all(&cargo_bin).unwrap();
     fs::create_dir_all(&bin).unwrap();
     let installed = cargo_bin.join("boomux");
@@ -115,6 +146,8 @@ fn guided_setup_rejects_cargo_private_boomux_before_desktop_mutation() {
     command.arg("setup");
     command.env("HOME", &root);
     command.env("CARGO_HOME", root.join(".cargo"));
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
     command.env("PATH", &bin);
     command.env("LOG", &log);
     let mut child = pty.slave.spawn_command(command).unwrap();
@@ -127,6 +160,7 @@ fn guided_setup_rejects_cargo_private_boomux_before_desktop_mutation() {
     assert!(output.contains(".local/bin/boomux"), "{output}");
     assert_eq!(fs::read_to_string(&log).unwrap(), "version\n");
 
+    stop_setup_daemon(&installed, &root, &runtime);
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -139,6 +173,7 @@ fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
     ));
     let bin = root.join("bin");
     let log = root.join("commands.log");
+    let runtime = setup_runtime(&root);
     fs::create_dir_all(&bin).unwrap();
     let omarchy = bin.join("omarchy");
     fs::write(
@@ -175,6 +210,8 @@ fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
     command.arg("setup");
     command.env("HOME", &root);
     command.env("PATH", &bin);
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
     command.env("LOG", &log);
     command.env("HYPRLAND_INSTANCE_SIGNATURE", "test-instance");
     let mut child = pty.slave.spawn_command(command).unwrap();
@@ -198,6 +235,7 @@ fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
     let bindings = fs::read_to_string(root.join(".config/hypr/bindings.lua")).unwrap();
     assert!(bindings.contains("BEGIN BOOMUX MANAGED KEYBINDINGS"));
     assert!(bindings.contains("boomux desktop gather"));
+    stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -209,6 +247,7 @@ fn guided_setup_declined_bindings_do_not_create_hyprland_config() {
         Uuid::new_v4()
     ));
     let bin = root.join("bin");
+    let runtime = setup_runtime(&root);
     fs::create_dir_all(&bin).unwrap();
     let omarchy = bin.join("omarchy");
     fs::write(
@@ -233,6 +272,8 @@ fn guided_setup_declined_bindings_do_not_create_hyprland_config() {
     command.arg("setup");
     command.env("HOME", &root);
     command.env("PATH", &bin);
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
     let mut child = pty.slave.spawn_command(command).unwrap();
     drop(pty.slave);
     let mut writer = pty.master.take_writer().unwrap();
@@ -240,6 +281,7 @@ fn guided_setup_declined_bindings_do_not_create_hyprland_config() {
     drop(writer);
     assert!(child.wait().unwrap().success());
     assert!(!root.join(".config/hypr").exists());
+    stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -252,6 +294,7 @@ fn guided_setup_recognizes_compatible_user_managed_bindings() {
     ));
     let bin = root.join("bin");
     let hypr = root.join(".config/hypr");
+    let runtime = setup_runtime(&root);
     fs::create_dir_all(&bin).unwrap();
     fs::create_dir_all(&hypr).unwrap();
     let bindings = b"o.bind(\"SUPER + B\", \"Toggle Boomux panel\", \"omarchy-shell io.github.gardnmi.boomux toggle\")\n\
@@ -293,6 +336,8 @@ o.bind(\"SUPER + CTRL + W\", \"Close Shell\", \"boomux close --focused\")\n";
     command.arg("setup");
     command.env("HOME", &root);
     command.env("PATH", &bin);
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
     command.env("NO_COLOR", "1");
     let mut child = pty.slave.spawn_command(command).unwrap();
     drop(pty.slave);
@@ -313,6 +358,7 @@ o.bind(\"SUPER + CTRL + W\", \"Close Shell\", \"boomux close --focused\")\n";
         "{output}"
     );
     assert_eq!(fs::read(hypr.join("bindings.lua")).unwrap(), bindings);
+    stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -326,6 +372,7 @@ fn guided_setup_restores_bindings_after_hyprland_validation_failure() {
     let bin = root.join("bin");
     let hypr = root.join(".config/hypr");
     let validation_count = root.join("validation-count");
+    let runtime = setup_runtime(&root);
     fs::create_dir_all(&bin).unwrap();
     fs::create_dir_all(&hypr).unwrap();
     let baseline = b"-- exact user bindings\n\xff\n";
@@ -361,6 +408,8 @@ fn guided_setup_restores_bindings_after_hyprland_validation_failure() {
     command.env("HOME", &root);
     command.env("PATH", &bin);
     command.env("VALIDATION_COUNT", &validation_count);
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
     command.env("HYPRLAND_INSTANCE_SIGNATURE", "test-instance");
     let mut child = pty.slave.spawn_command(command).unwrap();
     drop(pty.slave);
@@ -369,6 +418,7 @@ fn guided_setup_restores_bindings_after_hyprland_validation_failure() {
     drop(writer);
     assert!(!child.wait().unwrap().success());
     assert_eq!(fs::read(hypr.join("bindings.lua")).unwrap(), baseline);
+    stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();
 }
 

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -4,9 +4,314 @@ use std::os::unix::fs::PermissionsExt;
 use std::process::{Command, Stdio};
 
 use boomux::protocol::{self, WorkspaceLauncherSpec};
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use uuid::Uuid;
 
 use crate::support::{TestDaemon, wait_until};
+
+#[test]
+fn guided_setup_requires_an_interactive_terminal() {
+    let output = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .arg("setup")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Boomux setup requires an interactive terminal")
+    );
+}
+
+#[test]
+fn guided_setup_discovers_and_installs_one_selected_harness() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-guided-setup-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = root.join("bin");
+    let config = root.join("config");
+    fs::create_dir_all(&bin).unwrap();
+    for (name, content) in [
+        ("opencode", "#!/bin/sh\nprintf '1.18.18\\n'\n"),
+        ("xdg-terminal-exec", "#!/bin/sh\nexit 0\n"),
+    ] {
+        let path = bin.join(name);
+        fs::write(&path, content).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("XDG_CONFIG_HOME", &config);
+    command.env("PATH", &bin);
+    let mut child = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut reader = pty.master.try_clone_reader().unwrap();
+    let mut writer = pty.master.take_writer().unwrap();
+    writer.write_all(b"yes\nno\n").unwrap();
+    drop(writer);
+    assert!(child.wait().unwrap().success());
+    let mut output = String::new();
+    std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
+    assert!(output.contains("OpenCode"));
+    assert!(output.contains("host available | integration missing"));
+    assert!(output.contains("integration installed"));
+    assert!(output.contains("Omarchy"));
+    assert!(output.contains("not detected"));
+    assert!(
+        config.join("opencode/plugins/boomux.js").is_file(),
+        "{output}"
+    );
+    assert!(!root.join(".agents/skills/boomux/SKILL.md").exists());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-guided-desktop-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = root.join("bin");
+    let log = root.join("commands.log");
+    fs::create_dir_all(&bin).unwrap();
+    let omarchy = bin.join("omarchy");
+    fs::write(
+        &omarchy,
+        "#!/bin/sh\nprintf 'omarchy %s\\n' \"$*\" >> \"$LOG\"\ncase \"$*\" in\n  version) printf 'Omarchy 4.0\\n' ;;\n  'plugin list --json') printf '[]\\n' ;;\n  'plugin add https://github.com/gardnmi/omarchy-boomux.git --enable --yes') ;;\n  'menu keybindings --print') printf 'SUPER + B  → Browser\\nSUPER CTRL + W  → Close\\n' ;;\n  *) exit 97 ;;\nesac\n",
+    )
+    .unwrap();
+    fs::set_permissions(&omarchy, fs::Permissions::from_mode(0o755)).unwrap();
+    let hyprctl = bin.join("hyprctl");
+    fs::write(
+        &hyprctl,
+        "#!/bin/sh\nprintf 'hyprctl %s\\n' \"$*\" >> \"$LOG\"\ncase \"$1\" in reload|configerrors) ;; *) exit 98 ;; esac\n",
+    )
+    .unwrap();
+    fs::set_permissions(&hyprctl, fs::Permissions::from_mode(0o755)).unwrap();
+    let terminal = bin.join("xdg-terminal-exec");
+    fs::write(&terminal, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&terminal, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("PATH", &bin);
+    command.env("LOG", &log);
+    command.env("HYPRLAND_INSTANCE_SIGNATURE", "test-instance");
+    let mut child = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut reader = pty.master.try_clone_reader().unwrap();
+    let mut writer = pty.master.take_writer().unwrap();
+    writer.write_all(b"yes\nyes\n").unwrap();
+    drop(writer);
+    assert!(child.wait().unwrap().success());
+    let mut output = String::new();
+    std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
+    assert!(output.contains("conflicts require replacement"));
+    assert!(output.contains("reloaded without errors"));
+    let commands = fs::read_to_string(&log).unwrap();
+    assert!(commands.contains(
+        "omarchy plugin add https://github.com/gardnmi/omarchy-boomux.git --enable --yes\n"
+    ));
+    assert!(commands.contains("hyprctl reload\n"));
+    assert!(commands.contains("hyprctl configerrors\n"));
+    let bindings = fs::read_to_string(root.join(".config/hypr/bindings.lua")).unwrap();
+    assert!(bindings.contains("BEGIN BOOMUX MANAGED KEYBINDINGS"));
+    assert!(bindings.contains("boomux desktop gather"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn guided_setup_declined_bindings_do_not_create_hyprland_config() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-guided-desktop-decline-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = root.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let omarchy = bin.join("omarchy");
+    fs::write(
+        &omarchy,
+        "#!/bin/sh\ncase \"$*\" in\n  version) printf 'Omarchy 4.0\\n' ;;\n  'plugin list --json') printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":true}]\\n' ;;\n  'menu keybindings --print') printf '' ;;\n  *) exit 97 ;;\nesac\n",
+    )
+    .unwrap();
+    fs::set_permissions(&omarchy, fs::Permissions::from_mode(0o755)).unwrap();
+    let terminal = bin.join("xdg-terminal-exec");
+    fs::write(&terminal, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&terminal, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("PATH", &bin);
+    let mut child = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut writer = pty.master.take_writer().unwrap();
+    writer.write_all(b"no\n").unwrap();
+    drop(writer);
+    assert!(child.wait().unwrap().success());
+    assert!(!root.join(".config/hypr").exists());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn guided_setup_recognizes_compatible_user_managed_bindings() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-guided-desktop-existing-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = root.join("bin");
+    let hypr = root.join(".config/hypr");
+    fs::create_dir_all(&bin).unwrap();
+    fs::create_dir_all(&hypr).unwrap();
+    let bindings = b"o.bind(\"SUPER + B\", \"Toggle Boomux panel\", \"omarchy-shell io.github.gardnmi.boomux toggle\")\n\
+o.bind(\"SUPER + A\", \"Focus Boomux panel\", \"omarchy-shell io.github.gardnmi.boomux focus\")\n\
+hl.exec_cmd(\"omarchy-shell io.github.gardnmi.boomux releaseFocus\")\n\
+o.bind(\"SUPER + LEFT\", \"Focus on left window\", focus(\"l\"))\n\
+o.bind(\"SUPER + RIGHT\", \"Focus on right window\", focus(\"r\"))\n\
+o.bind(\"SUPER + UP\", \"Focus on above window\", focus(\"u\"))\n\
+o.bind(\"SUPER + DOWN\", \"Focus on below window\", focus(\"d\"))\n\
+o.bind(\"SUPER + TAB\", \"Next workspace\", \"boomux desktop next\")\n\
+o.bind(\"SUPER + SHIFT + TAB\", \"Previous workspace\", \"boomux desktop previous\")\n\
+o.bind(\"SUPER + RETURN\", \"Contextual terminal\", \"boomux desktop terminal\")\n\
+o.bind(\"SUPER + O\", \"Pop window contextually\", \"boomux desktop pop\")\n\
+o.bind(\"SUPER + ALT + B\", \"Return terminal\", \"boomux desktop return\")\n\
+o.bind(\"SUPER + ALT + R\", \"Gather terminals\", \"boomux desktop gather\")\n\
+o.bind(\"SUPER + CTRL + RETURN\", \"New Shell\", \"boomux shell create --open\")\n\
+o.bind(\"SUPER + CTRL + W\", \"Close Shell\", \"boomux close --focused\")\n";
+    fs::write(hypr.join("bindings.lua"), bindings).unwrap();
+    let omarchy = bin.join("omarchy");
+    fs::write(
+        &omarchy,
+        "#!/bin/sh\ncase \"$*\" in\n  version) printf 'Omarchy 4.0\\n' ;;\n  'plugin list --json') printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":true}]\\n' ;;\n  'menu keybindings --print') printf 'SUPER + B  → Toggle Boomux panel\\nSUPER + RETURN  → Contextual terminal\\n' ;;\n  *) exit 97 ;;\nesac\n",
+    )
+    .unwrap();
+    fs::set_permissions(&omarchy, fs::Permissions::from_mode(0o755)).unwrap();
+    let terminal = bin.join("xdg-terminal-exec");
+    fs::write(&terminal, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&terminal, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("PATH", &bin);
+    command.env("NO_COLOR", "1");
+    let mut child = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut reader = pty.master.try_clone_reader().unwrap();
+    let mut writer = pty.master.take_writer().unwrap();
+    writer.write_all(b"no\n").unwrap();
+    drop(writer);
+    assert!(child.wait().unwrap().success());
+    let mut output = String::new();
+    std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
+    assert!(
+        output.contains("compatible user-managed profile"),
+        "{output}"
+    );
+    assert!(output.contains("Reinstall impact"), "{output}");
+    assert!(
+        output.contains("Reinstall the standard Boomux keybinding profile?"),
+        "{output}"
+    );
+    assert_eq!(fs::read(hypr.join("bindings.lua")).unwrap(), bindings);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn guided_setup_restores_bindings_after_hyprland_validation_failure() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-guided-desktop-rollback-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = root.join("bin");
+    let hypr = root.join(".config/hypr");
+    let validation_count = root.join("validation-count");
+    fs::create_dir_all(&bin).unwrap();
+    fs::create_dir_all(&hypr).unwrap();
+    let baseline = b"-- exact user bindings\n\xff\n";
+    fs::write(hypr.join("bindings.lua"), baseline).unwrap();
+    let omarchy = bin.join("omarchy");
+    fs::write(
+        &omarchy,
+        "#!/bin/sh\ncase \"$*\" in\n  version) printf 'Omarchy 4.0\\n' ;;\n  'plugin list --json') printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":true}]\\n' ;;\n  'menu keybindings --print') printf '' ;;\n  *) exit 97 ;;\nesac\n",
+    )
+    .unwrap();
+    fs::set_permissions(&omarchy, fs::Permissions::from_mode(0o755)).unwrap();
+    let hyprctl = bin.join("hyprctl");
+    fs::write(
+        &hyprctl,
+        "#!/bin/sh\ncase \"$1\" in\n  reload) ;;\n  configerrors) if [ ! -e \"$VALIDATION_COUNT\" ]; then : > \"$VALIDATION_COUNT\"; printf 'bad binding\\n'; fi ;;\n  *) exit 98 ;;\nesac\n",
+    )
+    .unwrap();
+    fs::set_permissions(&hyprctl, fs::Permissions::from_mode(0o755)).unwrap();
+    let terminal = bin.join("xdg-terminal-exec");
+    fs::write(&terminal, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&terminal, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("PATH", &bin);
+    command.env("VALIDATION_COUNT", &validation_count);
+    command.env("HYPRLAND_INSTANCE_SIGNATURE", "test-instance");
+    let mut child = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut writer = pty.master.take_writer().unwrap();
+    writer.write_all(b"yes\n").unwrap();
+    drop(writer);
+    assert!(!child.wait().unwrap().success());
+    assert_eq!(fs::read(hypr.join("bindings.lua")).unwrap(), baseline);
+    fs::remove_dir_all(root).unwrap();
+}
 
 #[test]
 fn workspace_launchers_persist_emit_events_and_open_without_shells() {

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -78,6 +78,59 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
 }
 
 #[test]
+fn guided_setup_rejects_cargo_private_boomux_before_desktop_mutation() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-guided-desktop-cargo-path-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let cargo_bin = root.join(".cargo/bin");
+    let bin = root.join("bin");
+    let log = root.join("commands.log");
+    fs::create_dir_all(&cargo_bin).unwrap();
+    fs::create_dir_all(&bin).unwrap();
+    let installed = cargo_bin.join("boomux");
+    fs::copy(env!("CARGO_BIN_EXE_boomux"), &installed).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let omarchy = bin.join("omarchy");
+    fs::write(
+        &omarchy,
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$LOG\"\ncase \"$*\" in\n  version) printf 'Omarchy 4.0\\n' ;;\n  *) exit 97 ;;\nesac\n",
+    )
+    .unwrap();
+    fs::set_permissions(&omarchy, fs::Permissions::from_mode(0o755)).unwrap();
+    let terminal = bin.join("xdg-terminal-exec");
+    fs::write(&terminal, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&terminal, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(&installed);
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("CARGO_HOME", root.join(".cargo"));
+    command.env("PATH", &bin);
+    command.env("LOG", &log);
+    let mut child = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut reader = pty.master.try_clone_reader().unwrap();
+    assert!(!child.wait().unwrap().success());
+    let mut output = String::new();
+    std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
+    assert!(output.contains("graphical PATH"), "{output}");
+    assert!(output.contains(".local/bin/boomux"), "{output}");
+    assert_eq!(fs::read_to_string(&log).unwrap(), "version\n");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
     let root = std::env::temp_dir().join(format!(
         "boomux-guided-desktop-{}-{}",
@@ -93,6 +146,11 @@ fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
         "#!/bin/sh\nprintf 'omarchy %s\\n' \"$*\" >> \"$LOG\"\ncase \"$*\" in\n  version) printf 'Omarchy 4.0\\n' ;;\n  'plugin list --json') printf '[]\\n' ;;\n  'plugin add https://github.com/gardnmi/omarchy-boomux.git --enable --yes') ;;\n  'menu keybindings --print') printf 'SUPER + B  → Browser\\nSUPER CTRL + W  → Close\\n' ;;\n  *) exit 97 ;;\nesac\n",
     )
     .unwrap();
+    let script = fs::read_to_string(&omarchy).unwrap().replace(
+        "  'menu keybindings --print')",
+        "  'restart shell') ;;\n  'menu keybindings --print')",
+    );
+    fs::write(&omarchy, script).unwrap();
     fs::set_permissions(&omarchy, fs::Permissions::from_mode(0o755)).unwrap();
     let hyprctl = bin.join("hyprctl");
     fs::write(
@@ -134,6 +192,7 @@ fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
     assert!(commands.contains(
         "omarchy plugin add https://github.com/gardnmi/omarchy-boomux.git --enable --yes\n"
     ));
+    assert!(commands.contains("omarchy restart shell\n"));
     assert!(commands.contains("hyprctl reload\n"));
     assert!(commands.contains("hyprctl configerrors\n"));
     let bindings = fs::read_to_string(root.join(".config/hypr/bindings.lua")).unwrap();
@@ -177,7 +236,7 @@ fn guided_setup_declined_bindings_do_not_create_hyprland_config() {
     let mut child = pty.slave.spawn_command(command).unwrap();
     drop(pty.slave);
     let mut writer = pty.master.take_writer().unwrap();
-    writer.write_all(b"no\n").unwrap();
+    writer.write_all(b"no\nno\n").unwrap();
     drop(writer);
     assert!(child.wait().unwrap().success());
     assert!(!root.join(".config/hypr").exists());
@@ -239,7 +298,7 @@ o.bind(\"SUPER + CTRL + W\", \"Close Shell\", \"boomux close --focused\")\n";
     drop(pty.slave);
     let mut reader = pty.master.try_clone_reader().unwrap();
     let mut writer = pty.master.take_writer().unwrap();
-    writer.write_all(b"no\n").unwrap();
+    writer.write_all(b"no\nno\n").unwrap();
     drop(writer);
     assert!(child.wait().unwrap().success());
     let mut output = String::new();
@@ -306,7 +365,7 @@ fn guided_setup_restores_bindings_after_hyprland_validation_failure() {
     let mut child = pty.slave.spawn_command(command).unwrap();
     drop(pty.slave);
     let mut writer = pty.master.take_writer().unwrap();
-    writer.write_all(b"yes\n").unwrap();
+    writer.write_all(b"no\nyes\n").unwrap();
     drop(writer);
     assert!(!child.wait().unwrap().success());
     assert_eq!(fs::read(hypr.join("bindings.lua")).unwrap(), baseline);

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -466,6 +466,12 @@ fn concurrent_first_resources_with_distinct_requested_owners_replay_canonical_su
         .create_global_workspace("concurrent-first")
         .unwrap();
     let node_id = daemon.client.node_identity().unwrap();
+    fs::create_dir(
+        daemon
+            .runtime_dir
+            .join("state/boomux/.native-test-first-resource-barrier"),
+    )
+    .unwrap();
     let barrier = Arc::new(Barrier::new(3));
     let mut requests = Vec::new();
     let mut handles = Vec::new();

--- a/tests/native_backend/project_discovery.rs
+++ b/tests/native_backend/project_discovery.rs
@@ -4,6 +4,34 @@ use std::process::Command;
 use uuid::Uuid;
 
 #[test]
+fn bare_cli_prints_command_help_without_starting_the_daemon() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-bare-help-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let runtime = root.join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_boomux"))
+        .env("HOME", &root)
+        .env("XDG_RUNTIME_DIR", &runtime)
+        .env("XDG_STATE_HOME", root.join("state"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Usage:"), "{stdout}");
+    assert!(stdout.contains("Commands:"), "{stdout}");
+    assert!(stdout.contains("ui"), "{stdout}");
+    assert!(!runtime.join("boomux/daemon.sock").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn project_list_is_local_and_has_a_stable_json_envelope() {
     let root = std::env::temp_dir().join(format!(
         "boomux-project-discovery-{}-{}",

--- a/tests/native_backend/project_discovery.rs
+++ b/tests/native_backend/project_discovery.rs
@@ -4,6 +4,42 @@ use std::process::Command;
 use uuid::Uuid;
 
 #[test]
+fn workspace_create_starts_the_daemon_when_absent() {
+    let root = std::env::temp_dir().join(format!(
+        "bmux-create-start-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let runtime = root.join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    let command = || {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+        command
+            .env("HOME", &root)
+            .env("XDG_RUNTIME_DIR", &runtime)
+            .env("XDG_CONFIG_HOME", root.join("config"))
+            .env("XDG_STATE_HOME", root.join("state"));
+        command
+    };
+
+    let created = command()
+        .args(["workspace", "create", "cold-start"])
+        .output()
+        .unwrap();
+    assert!(
+        created.status.success(),
+        "workspace create failed: {}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    assert!(String::from_utf8_lossy(&created.stdout).contains("Created workspace cold-start"));
+    assert!(runtime.join("boomux/daemon.sock").exists());
+
+    let stopped = command().args(["daemon", "stop"]).output().unwrap();
+    assert!(stopped.status.success());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn bare_cli_prints_command_help_without_starting_the_daemon() {
     let root = std::env::temp_dir().join(format!(
         "boomux-bare-help-{}-{}",

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -10,8 +10,8 @@ use boomux::protocol::{
 use uuid::Uuid;
 
 use crate::support::{
-    TestDaemon, assert_remote_code, contains, profile, read_until, wait_for_attach_with_profile,
-    wait_until,
+    TestDaemon, assert_remote_code, contains, profile, read_until, read_until_after,
+    wait_for_attach_with_profile, wait_until,
 };
 
 #[test]
@@ -727,7 +727,8 @@ fn attach_environment_is_ephemeral_and_authoritative_for_initial_and_restarted_r
         false,
         environment_for_shell(&client_shell, &first_secret),
     );
-    let first_output = read_until(&mut first.stream, b"|bytes= ff fe");
+    let first_reconstruction = std::mem::take(&mut first.reconstruction);
+    let first_output = read_until_after(&mut first.stream, b"|bytes= ff fe", first_reconstruction);
     assert!(contains(&first_output, first_secret.as_bytes()));
     assert!(contains(&first_output, b"daemon=unset"));
     assert!(contains(&first_output, b"term=attachment-term"));
@@ -753,7 +754,9 @@ fn attach_environment_is_ephemeral_and_authoritative_for_initial_and_restarted_r
         true,
         environment_for_shell(&client_shell, &second_secret),
     );
-    let second_output = read_until(&mut second.stream, b"|bytes= ff fe");
+    let second_reconstruction = std::mem::take(&mut second.reconstruction);
+    let second_output =
+        read_until_after(&mut second.stream, b"|bytes= ff fe", second_reconstruction);
     assert!(contains(&second_output, second_secret.as_bytes()));
     assert!(contains(&second_output, b"daemon=unset"));
     assert!(contains(&second_output, b"term=attachment-term"));

--- a/tests/native_backend/workspace_creation.rs
+++ b/tests/native_backend/workspace_creation.rs
@@ -1,0 +1,673 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::os::unix::fs::{PermissionsExt, symlink};
+
+use crate::support::{TestDaemon, assert_generated_name, wait_until};
+use uuid::Uuid;
+
+#[test]
+fn atomic_workspace_create_autostarts_and_returns_exact_local_identity() {
+    let mut daemon = TestDaemon::start();
+    let node_id = daemon.client.node_identity().unwrap();
+    let project = daemon.runtime_dir.join("project");
+    let project_alias = daemon.runtime_dir.join("project-alias");
+    fs::create_dir(&project).unwrap();
+    symlink(&project, &project_alias).unwrap();
+    daemon.stop_with_cli();
+
+    let output = daemon
+        .command()
+        .args(["workspace", "create", "--node", &node_id, "--cwd"])
+        .arg(&project_alias)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "atomic create failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(output["schema"], "boomux.cli/v1");
+    assert_eq!(output["command"], "workspace.create");
+    let data = output["data"].as_object().unwrap();
+    assert_eq!(
+        data.keys().map(String::as_str).collect::<BTreeSet<_>>(),
+        BTreeSet::from(["placement", "presentation_warning", "shell", "workspace"])
+    );
+    assert!(output["data"]["presentation_warning"].is_null());
+    for (field, expected) in [
+        ("workspace", ["id", "name", "revision"].as_slice()),
+        (
+            "placement",
+            ["default_cwd", "node_id", "owner_workspace_id"].as_slice(),
+        ),
+        ("shell", ["cwd", "id", "name", "node_id"].as_slice()),
+    ] {
+        let keys = data[field]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(keys, expected.iter().copied().collect());
+    }
+    assert_generated_name(output["data"]["workspace"]["name"].as_str().unwrap());
+    assert_generated_name(output["data"]["shell"]["name"].as_str().unwrap());
+    assert_eq!(output["data"]["placement"]["node_id"], node_id);
+    assert_eq!(output["data"]["shell"]["node_id"], node_id);
+    assert_eq!(
+        output["data"]["placement"]["default_cwd"],
+        project.display().to_string()
+    );
+    assert_eq!(
+        output["data"]["shell"]["cwd"],
+        project.display().to_string()
+    );
+
+    let global_id = output["data"]["workspace"]["id"].as_str().unwrap();
+    let owner_id = output["data"]["placement"]["owner_workspace_id"]
+        .as_str()
+        .unwrap();
+    let shell_id = output["data"]["shell"]["id"].as_str().unwrap();
+    let combined = daemon.client.combined_node_snapshot(None).unwrap();
+    let workspace = combined
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == global_id)
+        .unwrap();
+    assert_eq!(workspace.name, output["data"]["workspace"]["name"]);
+    assert_eq!(workspace.revision, output["data"]["workspace"]["revision"]);
+    assert_eq!(workspace.placements.len(), 1);
+    assert_eq!(workspace.placements[0].node_id, node_id);
+    assert_eq!(workspace.placements[0].workspace_id, owner_id);
+    assert_eq!(
+        workspace.placements[0].default_cwd.as_deref(),
+        Some(project.as_path())
+    );
+    let owner = daemon.client.get_workspace(owner_id).unwrap();
+    assert_eq!(owner.default_cwd.as_deref(), Some(project.as_path()));
+    assert_eq!(owner.shells.len(), 1);
+    assert_eq!(owner.shells[0].id, shell_id);
+    assert_eq!(owner.shells[0].cwd, project);
+
+    let empty = daemon
+        .command()
+        .args(["workspace", "create", "still-empty"])
+        .output()
+        .unwrap();
+    assert!(empty.status.success());
+    let combined = daemon.client.combined_node_snapshot(None).unwrap();
+    let empty = combined
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.name == "still-empty")
+        .unwrap();
+    assert!(empty.placements.is_empty());
+}
+
+#[test]
+fn atomic_workspace_create_open_releases_the_exact_shell_after_commit() {
+    let daemon = TestDaemon::start();
+    let node_id = daemon.client.node_identity().unwrap();
+    let bin = daemon.runtime_dir.join("bin");
+    fs::create_dir(&bin).unwrap();
+    let resolver = bin.join("xdg-terminal-exec");
+    fs::write(
+        &resolver,
+        "#!/bin/sh\nwhile [ \"$#\" -gt 0 ] && [ \"$1\" != -- ]; do shift; done\nshift\ngate=\nfor arg do if [ \"$previous\" = --gate ]; then gate=$arg; break; fi; previous=$arg; done\nprintf '%s\\0' python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); s.connect(sys.argv[1]); status=s.recv(1); open(sys.argv[2], \"w\").write(sys.argv[3]+\"\\n\"+str(status[0]))' \"$gate\" \"$BOOMUX_GATE_MARKER\" \"$3\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&resolver, fs::Permissions::from_mode(0o700)).unwrap();
+    let marker = daemon.runtime_dir.join("atomic-gate");
+    let output = daemon
+        .command()
+        .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+        .env("BOOMUX_GATE_MARKER", &marker)
+        .args([
+            "workspace",
+            "create",
+            "gated-atomic",
+            "--node",
+            &node_id,
+            "--cwd",
+            "/tmp",
+            "--open",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "atomic create and open failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    wait_until(
+        || fs::read_to_string(&marker).is_ok_and(|value| value.ends_with("\n1")),
+        "terminal did not observe the committed creation gate",
+    );
+    let marker = fs::read_to_string(marker).unwrap();
+    let (opened_shell, status) = marker.split_once('\n').unwrap();
+    assert_eq!(status, "1");
+    assert_eq!(opened_shell, output["data"]["shell"]["id"]);
+    assert!(output["data"]["presentation_warning"].is_null());
+    let owner_id = output["data"]["placement"]["owner_workspace_id"]
+        .as_str()
+        .unwrap();
+    assert!(
+        daemon
+            .client
+            .get_workspace(owner_id)
+            .unwrap()
+            .shells
+            .iter()
+            .any(|shell| shell.id == opened_shell),
+        "the gate opened before the exact Shell was committed"
+    );
+}
+
+#[test]
+fn atomic_workspace_create_reports_post_commit_gate_failure_as_a_warning() {
+    let daemon = TestDaemon::start();
+    let node_id = daemon.client.node_identity().unwrap();
+    let bin = daemon.runtime_dir.join("warning-bin");
+    fs::create_dir(&bin).unwrap();
+    let resolver = bin.join("xdg-terminal-exec");
+    fs::write(
+        &resolver,
+        "#!/bin/sh\nwhile [ \"$#\" -gt 0 ] && [ \"$1\" != -- ]; do shift; done\nshift\ngate=\nfor arg do if [ \"$previous\" = --gate ]; then gate=$arg; break; fi; previous=$arg; done\nprintf '%s\\0' python3 -c 'import socket,struct,sys; s=socket.socket(socket.AF_UNIX); s.connect(sys.argv[1]); s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack(\"ii\", 1, 0)); s.close()' \"$gate\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&resolver, fs::Permissions::from_mode(0o700)).unwrap();
+    let output = daemon
+        .command()
+        .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+        .args([
+            "workspace",
+            "create",
+            "warning-atomic",
+            "--node",
+            &node_id,
+            "--cwd",
+            "/tmp",
+            "--open",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "post-commit gate failure was reported as mutation failure: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(output["command"], "workspace.create");
+    assert!(
+        output["data"]["presentation_warning"].as_str().is_some_and(
+            |warning| warning.contains("was created but its terminal could not attach")
+        )
+    );
+    let owner_id = output["data"]["placement"]["owner_workspace_id"]
+        .as_str()
+        .unwrap();
+    let shell_id = output["data"]["shell"]["id"].as_str().unwrap();
+    assert!(
+        daemon
+            .client
+            .get_workspace(owner_id)
+            .unwrap()
+            .shells
+            .iter()
+            .any(|shell| shell.id == shell_id)
+    );
+}
+
+#[test]
+fn workspace_default_cwd_mutation_changes_only_future_omitted_shells() {
+    let mut daemon = TestDaemon::start();
+    let node_id = daemon.client.node_identity().unwrap();
+    let initial = daemon.runtime_dir.join("initial");
+    let updated = daemon.runtime_dir.join("updated");
+    let updated_alias = daemon.runtime_dir.join("updated-alias");
+    let explicit = daemon.runtime_dir.join("explicit");
+    fs::create_dir(&initial).unwrap();
+    fs::create_dir(&updated).unwrap();
+    fs::create_dir(&explicit).unwrap();
+    symlink(&updated, &updated_alias).unwrap();
+    let created = daemon
+        .command()
+        .args([
+            "workspace",
+            "create",
+            "cwd-work",
+            "--node",
+            &node_id,
+            "--cwd",
+        ])
+        .arg(&initial)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(
+        created.status.success(),
+        "{}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    let created: serde_json::Value = serde_json::from_slice(&created.stdout).unwrap();
+    let global_id = created["data"]["workspace"]["id"].as_str().unwrap();
+    let owner_id = created["data"]["placement"]["owner_workspace_id"]
+        .as_str()
+        .unwrap();
+    let existing_shell_id = created["data"]["shell"]["id"].as_str().unwrap();
+    let before = daemon.client.combined_node_snapshot(None).unwrap();
+    let before = before
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == global_id)
+        .unwrap();
+    let before_global_revision = before.revision;
+    let before_owner_revision = before.placements[0].owner_revision;
+
+    let changed = daemon
+        .command()
+        .args([
+            "workspace",
+            "set-default-cwd",
+            global_id,
+            "--node",
+            &node_id,
+            "--cwd",
+        ])
+        .arg(&updated_alias)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(
+        changed.status.success(),
+        "{}",
+        String::from_utf8_lossy(&changed.stderr)
+    );
+    let changed: serde_json::Value = serde_json::from_slice(&changed.stdout).unwrap();
+    assert_eq!(changed["schema"], "boomux.cli/v1");
+    assert_eq!(changed["command"], "workspace.set-default-cwd");
+    assert_eq!(
+        changed["data"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            "default_cwd",
+            "global_revision",
+            "node_id",
+            "owner_revision",
+            "owner_workspace_id",
+            "result",
+            "workspace_id",
+        ])
+    );
+    assert_eq!(changed["data"]["workspace_id"], global_id);
+    assert_eq!(changed["data"]["node_id"], node_id);
+    assert_eq!(changed["data"]["owner_workspace_id"], owner_id);
+    assert_eq!(
+        changed["data"]["default_cwd"],
+        updated.display().to_string()
+    );
+    assert_eq!(
+        changed["data"]["global_revision"],
+        before_global_revision + 1
+    );
+    assert_eq!(changed["data"]["owner_revision"], before_owner_revision + 1);
+    assert_eq!(changed["data"]["result"], "updated");
+    let owner = daemon.client.get_workspace(owner_id).unwrap();
+    assert_eq!(owner.default_cwd.as_deref(), Some(updated.as_path()));
+    assert_eq!(
+        owner
+            .shells
+            .iter()
+            .find(|shell| shell.id == existing_shell_id)
+            .unwrap()
+            .cwd,
+        initial
+    );
+
+    let unchanged = daemon
+        .command()
+        .args([
+            "workspace",
+            "set-default-cwd",
+            global_id,
+            "--node",
+            &node_id,
+            "--cwd",
+        ])
+        .arg(&updated)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(unchanged.status.success());
+    let unchanged: serde_json::Value = serde_json::from_slice(&unchanged.stdout).unwrap();
+    assert_eq!(unchanged["data"]["result"], "unchanged");
+    assert_eq!(
+        unchanged["data"]["global_revision"],
+        before_global_revision + 1
+    );
+    assert_eq!(
+        unchanged["data"]["owner_revision"],
+        before_owner_revision + 1
+    );
+
+    let inherited = daemon
+        .command()
+        .args([
+            "shell",
+            "create",
+            global_id,
+            "--node",
+            &node_id,
+            "--name",
+            "inherited",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        inherited.status.success(),
+        "{}",
+        String::from_utf8_lossy(&inherited.stderr)
+    );
+    let explicit_shell = daemon
+        .command()
+        .args([
+            "shell", "create", global_id, "--node", &node_id, "--name", "explicit", "--cwd",
+        ])
+        .arg(&explicit)
+        .output()
+        .unwrap();
+    assert!(
+        explicit_shell.status.success(),
+        "{}",
+        String::from_utf8_lossy(&explicit_shell.stderr)
+    );
+    let owner = daemon.client.get_workspace(owner_id).unwrap();
+    assert_eq!(
+        owner
+            .shells
+            .iter()
+            .find(|shell| shell.name == "inherited")
+            .unwrap()
+            .cwd,
+        updated
+    );
+    assert_eq!(
+        owner
+            .shells
+            .iter()
+            .find(|shell| shell.name == "explicit")
+            .unwrap()
+            .cwd,
+        explicit
+    );
+
+    daemon.stop_with_cli();
+    daemon.restart();
+    let owner = daemon.client.get_workspace(owner_id).unwrap();
+    assert_eq!(owner.default_cwd.as_deref(), Some(updated.as_path()));
+}
+
+#[test]
+fn prepared_default_cwd_operation_completes_from_owner_state_after_cold_restart() {
+    let mut daemon = TestDaemon::start();
+    let node_id = daemon.client.node_identity().unwrap();
+    let initial = daemon.runtime_dir.join("cold-initial");
+    let updated = daemon.runtime_dir.join("cold-updated");
+    fs::create_dir(&initial).unwrap();
+    fs::create_dir(&updated).unwrap();
+    let created = daemon
+        .command()
+        .args([
+            "workspace",
+            "create",
+            "cold-cwd",
+            "--node",
+            &node_id,
+            "--cwd",
+        ])
+        .arg(&initial)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(created.status.success());
+    let created: serde_json::Value = serde_json::from_slice(&created.stdout).unwrap();
+    let global_id = created["data"]["workspace"]["id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let owner_id = created["data"]["placement"]["owner_workspace_id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let combined = daemon.client.combined_node_snapshot(None).unwrap();
+    let workspace = combined
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == global_id)
+        .unwrap();
+    let global_revision = workspace.revision;
+    let owner_revision = workspace.placements[0].owner_revision;
+    daemon.stop_with_cli();
+
+    let owner_path = daemon.runtime_dir.join("state/boomux/state.json");
+    let mut owner_state: serde_json::Value =
+        serde_json::from_slice(&fs::read(&owner_path).unwrap()).unwrap();
+    let owner = owner_state["workspaces"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|workspace| workspace["id"] == owner_id)
+        .unwrap();
+    owner["revision"] = (owner_revision + 1).into();
+    owner["default_cwd"] = updated.display().to_string().into();
+    fs::write(
+        &owner_path,
+        serde_json::to_vec_pretty(&owner_state).unwrap(),
+    )
+    .unwrap();
+
+    let coordinator_path = daemon
+        .runtime_dir
+        .join("state/boomux/global_workspaces.json");
+    let mut coordinator: serde_json::Value =
+        serde_json::from_slice(&fs::read(&coordinator_path).unwrap()).unwrap();
+    coordinator["pending_default_cwd_operations"] = serde_json::json!([{
+        "operation_id": Uuid::new_v4().to_string(),
+        "global_workspace_id": global_id,
+        "expected_global_revision": global_revision,
+        "node_id": node_id,
+        "owner_workspace_id": owner_id,
+        "expected_owner_revision": owner_revision,
+        "requested_default_cwd": updated,
+        "default_cwd": updated,
+        "owner_attempted": true,
+        "completion_reservation": " ".repeat(8 * 1024),
+    }]);
+    fs::write(
+        &coordinator_path,
+        serde_json::to_vec_pretty(&coordinator).unwrap(),
+    )
+    .unwrap();
+
+    daemon.restart();
+    let combined = daemon.client.combined_node_snapshot(None).unwrap();
+    let workspace = combined
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == global_id)
+        .unwrap();
+    assert_eq!(workspace.revision, global_revision + 1);
+    assert_eq!(workspace.placements[0].owner_revision, owner_revision + 1);
+    assert_eq!(
+        workspace.placements[0].default_cwd.as_deref(),
+        Some(updated.as_path())
+    );
+    let persisted: serde_json::Value =
+        serde_json::from_slice(&fs::read(coordinator_path).unwrap()).unwrap();
+    assert!(
+        persisted["pending_default_cwd_operations"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        persisted["completed_default_cwd_operations"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn never_attempted_default_cwd_operation_is_cancelled_after_cold_restart() {
+    let mut daemon = TestDaemon::start();
+    let node_id = daemon.client.node_identity().unwrap();
+    let created = daemon
+        .command()
+        .args([
+            "workspace",
+            "create",
+            "cold-unattempted-cwd",
+            "--node",
+            &node_id,
+            "--cwd",
+            "/tmp",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(created.status.success());
+    let created: serde_json::Value = serde_json::from_slice(&created.stdout).unwrap();
+    let global_id = created["data"]["workspace"]["id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let owner_id = created["data"]["placement"]["owner_workspace_id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let combined = daemon.client.combined_node_snapshot(None).unwrap();
+    let workspace = combined
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == global_id)
+        .unwrap();
+    let global_revision = workspace.revision;
+    let owner_revision = workspace.placements[0].owner_revision;
+    daemon.stop_with_cli();
+
+    let coordinator_path = daemon
+        .runtime_dir
+        .join("state/boomux/global_workspaces.json");
+    let mut coordinator: serde_json::Value =
+        serde_json::from_slice(&fs::read(&coordinator_path).unwrap()).unwrap();
+    coordinator["pending_default_cwd_operations"] = serde_json::json!([{
+        "operation_id": Uuid::new_v4().to_string(),
+        "global_workspace_id": global_id,
+        "expected_global_revision": global_revision,
+        "node_id": node_id,
+        "owner_workspace_id": owner_id,
+        "expected_owner_revision": owner_revision,
+        "requested_default_cwd": "/tmp",
+        "default_cwd": "/tmp",
+        "owner_attempted": false,
+        "completion_reservation": " ".repeat(8 * 1024),
+    }]);
+    fs::write(
+        &coordinator_path,
+        serde_json::to_vec_pretty(&coordinator).unwrap(),
+    )
+    .unwrap();
+
+    daemon.restart();
+    daemon.client.combined_node_snapshot(None).unwrap();
+    let persisted: serde_json::Value =
+        serde_json::from_slice(&fs::read(coordinator_path).unwrap()).unwrap();
+    assert!(
+        persisted["pending_default_cwd_operations"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    let renamed = daemon
+        .command()
+        .args(["workspace", "rename", &global_id, "after-recovery"])
+        .output()
+        .unwrap();
+    assert!(
+        renamed.status.success(),
+        "cancelled prepare blocked later Workspace mutation: {}",
+        String::from_utf8_lossy(&renamed.stderr)
+    );
+}
+
+#[test]
+fn definitive_default_cwd_preflight_failure_leaves_no_pending_operation() {
+    let daemon = TestDaemon::start();
+    let node_id = daemon.client.node_identity().unwrap();
+    let created = daemon
+        .command()
+        .args([
+            "workspace",
+            "create",
+            "preflight-cwd",
+            "--node",
+            &node_id,
+            "--cwd",
+            "/tmp",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(created.status.success());
+    let created: serde_json::Value = serde_json::from_slice(&created.stdout).unwrap();
+    let global_id = created["data"]["workspace"]["id"].as_str().unwrap();
+    let missing = daemon.runtime_dir.join("does-not-exist");
+    let failed = daemon
+        .command()
+        .args([
+            "workspace",
+            "set-default-cwd",
+            global_id,
+            "--node",
+            &node_id,
+            "--cwd",
+        ])
+        .arg(missing)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(!failed.status.success());
+
+    let coordinator_path = daemon
+        .runtime_dir
+        .join("state/boomux/global_workspaces.json");
+    let persisted: serde_json::Value =
+        serde_json::from_slice(&fs::read(coordinator_path).unwrap()).unwrap();
+    assert!(
+        persisted["pending_default_cwd_operations"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    let renamed = daemon
+        .command()
+        .args(["workspace", "rename", global_id, "after-preflight"])
+        .output()
+        .unwrap();
+    assert!(
+        renamed.status.success(),
+        "definitive preflight blocked later Workspace mutation: {}",
+        String::from_utf8_lossy(&renamed.stderr)
+    );
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -263,11 +263,21 @@ pub(crate) fn ensure_test_opencode_runtime(
 }
 
 pub(crate) fn read_until(stream: &mut UnixStream, needle: &[u8]) -> Vec<u8> {
+    read_until_after(stream, needle, Vec::new())
+}
+
+pub(crate) fn read_until_after(
+    stream: &mut UnixStream,
+    needle: &[u8],
+    mut output: Vec<u8>,
+) -> Vec<u8> {
+    if contains(&output, needle) {
+        return output;
+    }
     stream
         .set_read_timeout(Some(Duration::from_millis(200)))
         .unwrap();
     let deadline = Instant::now() + TIMEOUT;
-    let mut output = Vec::new();
     while Instant::now() < deadline {
         match AttachFrame::read_from(stream) {
             Ok(AttachFrame::Output(bytes)) => {


### PR DESCRIPTION
## Summary
- add guided local setup for integrations, Omarchy bindings, plugin installation, and daemon startup
- make bare `boomux` print help and extend uninstall to remove the Omarchy plugin
- add atomic coordinated Workspace and first-Shell creation plus placement Shell start-folder updates
- preserve protocol negotiation, durable recovery, exact identities, and mixed-version behavior

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`