### PR TITLE
feat(update): update installed Omarchy plugin

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -787,12 +787,15 @@ versions, target, release URL, and recommended action. It is passive but perform
 a bounded network request to the fixed Boomux GitHub release endpoint.
 
 Use `boomux update` only after the user explicitly authorizes local executable
-replacement and graceful daemon restart. It is interactive and human-only. It
-can replace only an official release binary at `~/.local/bin/boomux`; AUR/pacman,
-source, development, root-owned, custom, and unknown installations must be
-updated through their owning installation method. It never downgrades, never
-updates remote Nodes, and leaves a stopped daemon stopped. Remote helpers remain
-under `boomux node upgrade`.
+replacement, graceful daemon restart, and the named companion-plugin update when
+the Omarchy plugin is installed. It is interactive and human-only. It can replace
+only an official release binary at `~/.local/bin/boomux`; AUR/pacman, source,
+development, root-owned, custom, and unknown installations must be updated
+through their owning installation method. After the executable update commits,
+it delegates an installed `io.github.gardnmi.boomux` update to Omarchy and reloads
+the shell when that plugin is enabled. It never downgrades, never updates remote
+Nodes, and leaves a stopped daemon stopped. Remote helpers remain under
+`boomux node upgrade`.
 
 Remove an official canonical local release installation with:
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ boomux doctor
 
 The updater verifies the selected GitHub release asset and checksum before
 replacing an eligible official installation. Compatible running daemons use
-graceful handoff so managed processes and PTYs survive. Other installation types
-must be updated through their original installer. Boomux never silently
-downgrades or enables automatic updates.
+graceful handoff so managed processes and PTYs survive. If the Omarchy companion
+plugin is installed, the same confirmation authorizes updating it after Boomux
+and reloading it when enabled. Other installation types must be updated through
+their original installer. Boomux never silently downgrades or enables automatic
+updates.
 
 > [!CAUTION]
 > Upgrading from v0.32 to v1.x crosses an incompatible protocol and state

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@
 | `src/host_session_titles.rs` and children | Shared title/catalog policy and host-specific discovery adapters |
 | `src/host_session_source.rs` and children | Canonical host source paths, normalization, and secure source lookup |
 | `src/integration_management.rs` | Integration inventory, status, setup, verification, install, and uninstall workflows |
-| `src/setup.rs` | Interactive local setup orchestration, Omarchy plugin discovery, and ownership-bounded Hyprland binding installation |
+| `src/setup.rs` | Interactive local setup orchestration, Omarchy plugin discovery and lifecycle operations, and ownership-bounded Hyprland binding installation |
 | `src/update.rs` | Local release discovery, installation classification, interactive self-update authorization, atomic executable replacement, and daemon handoff verification |
 | `src/uninstall.rs` | Interactive release uninstall orchestration, owned-asset cleanup, bounded purge validation, and process shutdown ordering |
 | `src/claude_hooks.rs`, `src/codex_hooks.rs`, `src/kiro_hooks.rs` | Bounded Claude Code, Codex, and Kiro hook decoding and lifecycle reduction |
@@ -956,6 +956,10 @@ plugin lifecycle ownership. A Cargo-private executable without a corresponding
 absent from the graphical session's `PATH`. After installing or enabling the
 plugin, setup runs bounded `omarchy restart shell` so the running shell loads it.
 Reruns offer the same reload for an already-enabled but potentially stale plugin.
+After a guided local Boomux update commits, the updater revalidates an installed
+companion plugin, delegates its update to the fixed exact-argument Omarchy CLI,
+and restarts Omarchy Shell when the plugin is enabled. Omarchy remains the plugin
+lifecycle owner, and plugin failure cannot roll back the committed executable.
 Boomux never edits `/usr/share/omarchy`. The full
 desktop binding profile is one marked block in the current user's
 `~/.config/hypr/bindings.lua`. Setup reports conflicts before consent, preserves

--- a/docs/local-update.md
+++ b/docs/local-update.md
@@ -12,8 +12,10 @@ or contact the daemon. `--json` uses the stable `boomux.cli/v1` command
 
 `boomux update` is human-only. It requires an interactive terminal, prints the
 current and latest versions and exact install path, and requires explicit `yes`
-confirmation. It has no `--yes`, `--force`, automatic, scheduled, JSON mutation,
-or remote mode. Integrations may inspect `update.status` and open the same guided
+confirmation. When the fixed `io.github.gardnmi.boomux` Omarchy plugin is
+installed, that confirmation also names and authorizes its post-install update.
+The command has no `--yes`, `--force`, automatic, scheduled, JSON mutation, or
+remote mode. Integrations may inspect `update.status` and open the same guided
 command in a native terminal; they must not download, authorize, or replace
 Boomux themselves.
 
@@ -112,6 +114,19 @@ even when directory synchronization also fails, and combined failures are
 reported. Once candidate activation and daemon verification succeed, cleanup
 failure cannot truthfully roll back the committed update; Boomux reports a
 bounded warning and may leave the hidden backup for manual inspection.
+
+After the executable update commits, an installed companion Omarchy plugin is
+revalidated through `omarchy plugin list --json` and updated only by the fixed
+exact-argument command `omarchy plugin update io.github.gardnmi.boomux --yes`.
+Omarchy retains plugin lifecycle ownership. If the plugin is enabled, Boomux
+then runs `omarchy restart shell` so the new plugin code is loaded. A plugin or
+shell-restart failure is reported as a partial failure after clearly stating
+that the Boomux executable update committed; it cannot roll back the committed
+executable. A failed or timed-out Omarchy update command is reported as an
+unknown plugin outcome because it may have mutated the plugin checkout before
+failing. Missing Omarchy or an uninstalled plugin causes no plugin mutation.
+An uninspectable optional plugin inventory is warned about and skipped rather
+than blocking the Boomux executable update.
 
 ## Release And Package Channels
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -112,6 +112,15 @@ struct CommandOutput {
     stderr: Vec<u8>,
 }
 
+pub(crate) enum OmarchyPluginUpdateOutcome {
+    NotInstalled,
+    Updated,
+    UpdatedAndReloaded,
+    UpdateOutcomeUnknown(io::Error),
+    UpdatedButReloadStateUnknown(io::Error),
+    UpdatedButReloadFailed(io::Error),
+}
+
 struct BindingsPlan {
     path: PathBuf,
     baseline: Option<Vec<u8>>,
@@ -653,6 +662,39 @@ pub(crate) fn remove_omarchy_plugin(executable: &Path) -> io::Result<bool> {
         COMMAND_TIMEOUT,
     )?;
     Ok(true)
+}
+
+pub(crate) fn update_omarchy_plugin(executable: &Path) -> io::Result<OmarchyPluginUpdateOutcome> {
+    let Some(_) = omarchy_plugins(executable)?
+        .into_iter()
+        .find(|plugin| plugin.id == OMARCHY_PLUGIN_ID)
+    else {
+        return Ok(OmarchyPluginUpdateOutcome::NotInstalled);
+    };
+    if let Err(error) = run_command(
+        executable,
+        &["plugin", "update", OMARCHY_PLUGIN_ID, "--yes"],
+        PLUGIN_INSTALL_TIMEOUT,
+    ) {
+        return Ok(OmarchyPluginUpdateOutcome::UpdateOutcomeUnknown(error));
+    }
+    let plugin = match omarchy_plugins(executable) {
+        Ok(plugins) => plugins
+            .into_iter()
+            .find(|plugin| plugin.id == OMARCHY_PLUGIN_ID),
+        Err(error) => {
+            return Ok(OmarchyPluginUpdateOutcome::UpdatedButReloadStateUnknown(
+                error,
+            ));
+        }
+    };
+    if plugin.is_some_and(|plugin| plugin.enabled) {
+        return match run_command(executable, &["restart", "shell"], PLUGIN_INSTALL_TIMEOUT) {
+            Ok(_) => Ok(OmarchyPluginUpdateOutcome::UpdatedAndReloaded),
+            Err(error) => Ok(OmarchyPluginUpdateOutcome::UpdatedButReloadFailed(error)),
+        };
+    }
+    Ok(OmarchyPluginUpdateOutcome::Updated)
 }
 
 fn run_command(
@@ -1236,5 +1278,115 @@ mod tests {
         assert!(remove_omarchy_plugin(&executable).unwrap());
         assert!(executable.with_extension("removed").exists());
         assert!(!remove_omarchy_plugin(&executable).unwrap());
+    }
+
+    #[test]
+    fn omarchy_plugin_update_rechecks_inventory_and_restarts_an_enabled_plugin() {
+        let directory = TestDirectory::new();
+        let executable = directory.0.join("omarchy");
+        fs::write(
+            &executable,
+            b"#!/bin/sh\nlog=$0.log\nfor argument do printf '<%s>\\n' \"$argument\" >> \"$log\"; done\nprintf '%s\\n' -- >> \"$log\"\ncase \"$*\" in\n  'plugin list --json') printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":true}]\\n' ;;\n  'plugin update io.github.gardnmi.boomux --yes') ;;\n  'restart shell') ;;\n  *) exit 97 ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(matches!(
+            update_omarchy_plugin(&executable).unwrap(),
+            OmarchyPluginUpdateOutcome::UpdatedAndReloaded
+        ));
+        assert_eq!(
+            fs::read_to_string(executable.with_extension("log")).unwrap(),
+            "<plugin>\n<list>\n<--json>\n--\n<plugin>\n<update>\n<io.github.gardnmi.boomux>\n<--yes>\n--\n<plugin>\n<list>\n<--json>\n--\n<restart>\n<shell>\n--\n"
+        );
+    }
+
+    #[test]
+    fn omarchy_plugin_update_skips_absent_plugin() {
+        let directory = TestDirectory::new();
+        let executable = directory.0.join("omarchy");
+        fs::write(
+            &executable,
+            b"#!/bin/sh\ncase \"$*\" in\n  'plugin list --json') printf '[]\\n' ;;\n  *) exit 97 ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(matches!(
+            update_omarchy_plugin(&executable).unwrap(),
+            OmarchyPluginUpdateOutcome::NotInstalled
+        ));
+    }
+
+    #[test]
+    fn omarchy_plugin_update_does_not_restart_a_disabled_plugin() {
+        let directory = TestDirectory::new();
+        let executable = directory.0.join("omarchy");
+        fs::write(
+            &executable,
+            b"#!/bin/sh\nlog=$0.log\nprintf '%s\\n' \"$*\" >> \"$log\"\ncase \"$*\" in\n  'plugin list --json') printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":false}]\\n' ;;\n  'plugin update io.github.gardnmi.boomux --yes') ;;\n  *) exit 97 ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(matches!(
+            update_omarchy_plugin(&executable).unwrap(),
+            OmarchyPluginUpdateOutcome::Updated
+        ));
+        assert_eq!(
+            fs::read_to_string(executable.with_extension("log")).unwrap(),
+            "plugin list --json\nplugin update io.github.gardnmi.boomux --yes\nplugin list --json\n"
+        );
+    }
+
+    #[test]
+    fn omarchy_plugin_update_rechecks_enabled_state_after_update() {
+        let directory = TestDirectory::new();
+        let executable = directory.0.join("omarchy");
+        fs::write(
+            &executable,
+            b"#!/bin/sh\nmarker=$0.updated\ncase \"$*\" in\n  'plugin list --json')\n    if [ -e \"$marker\" ]; then enabled=true; else enabled=false; fi\n    printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":%s}]\\n' \"$enabled\" ;;\n  'plugin update io.github.gardnmi.boomux --yes') : > \"$marker\" ;;\n  'restart shell') ;;\n  *) exit 97 ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(matches!(
+            update_omarchy_plugin(&executable).unwrap(),
+            OmarchyPluginUpdateOutcome::UpdatedAndReloaded
+        ));
+    }
+
+    #[test]
+    fn omarchy_plugin_update_distinguishes_a_reload_failure() {
+        let directory = TestDirectory::new();
+        let executable = directory.0.join("omarchy");
+        fs::write(
+            &executable,
+            b"#!/bin/sh\ncase \"$*\" in\n  'plugin list --json') printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":true}]\\n' ;;\n  'plugin update io.github.gardnmi.boomux --yes') ;;\n  'restart shell') exit 42 ;;\n  *) exit 97 ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(matches!(
+            update_omarchy_plugin(&executable).unwrap(),
+            OmarchyPluginUpdateOutcome::UpdatedButReloadFailed(_)
+        ));
+    }
+
+    #[test]
+    fn omarchy_plugin_update_preserves_an_unknown_command_outcome() {
+        let directory = TestDirectory::new();
+        let executable = directory.0.join("omarchy");
+        fs::write(
+            &executable,
+            b"#!/bin/sh\ncase \"$*\" in\n  'plugin list --json') printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":true}]\\n' ;;\n  'plugin update io.github.gardnmi.boomux --yes') exit 42 ;;\n  *) exit 97 ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(matches!(
+            update_omarchy_plugin(&executable).unwrap(),
+            OmarchyPluginUpdateOutcome::UpdateOutcomeUnknown(_)
+        ));
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -19,6 +19,8 @@ use uuid::Uuid;
 
 use boomux::{client, ssh_bootstrap};
 
+use crate::setup;
+
 const DISTRIBUTION: Option<&str> = option_env!("BOOMUX_DISTRIBUTION");
 const MAX_EXECUTABLE_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_SMOKE_OUTPUT_BYTES: usize = 4096;
@@ -142,7 +144,21 @@ pub(crate) fn guided_update() -> Result<(), Box<dyn std::error::Error>> {
             io::Error::new(io::ErrorKind::PermissionDenied, refusal_message(status)).into(),
         );
     }
-    print!("Download, verify, and install this release? [y/N] ");
+    let omarchy_plugin = match setup::installed_omarchy_plugin() {
+        Ok(plugin) => plugin,
+        Err(error) => {
+            eprintln!(
+                "Warning: omarchy-boomux could not be inspected and will not be updated: {error}"
+            );
+            None
+        }
+    };
+    let prompt = if omarchy_plugin.is_some() {
+        "Download, verify, and install this release, then update the installed omarchy-boomux plugin? [y/N] "
+    } else {
+        "Download, verify, and install this release? [y/N] "
+    };
+    print!("{prompt}");
     io::stdout().flush()?;
     let mut answer = String::new();
     io::stdin().read_line(&mut answer)?;
@@ -188,6 +204,43 @@ pub(crate) fn guided_update() -> Result<(), Box<dyn std::error::Error>> {
             || recover_daemon_after_rollback(&daemon),
         )?;
         println!("Updated Boomux to {latest}");
+        if let Some(omarchy) = omarchy_plugin.as_deref() {
+            match setup::update_omarchy_plugin(omarchy) {
+                Ok(setup::OmarchyPluginUpdateOutcome::NotInstalled) => {
+                    println!(
+                        "Skipped omarchy-boomux plugin update because it is no longer installed"
+                    )
+                }
+                Ok(setup::OmarchyPluginUpdateOutcome::Updated) => {
+                    println!("Updated omarchy-boomux plugin")
+                }
+                Ok(setup::OmarchyPluginUpdateOutcome::UpdatedAndReloaded) => {
+                    println!("Updated omarchy-boomux plugin and restarted Omarchy Shell")
+                }
+                Ok(setup::OmarchyPluginUpdateOutcome::UpdateOutcomeUnknown(error)) => {
+                    return Err(io::Error::other(format!(
+                        "Boomux was updated to {latest}, but the omarchy-boomux update outcome is unknown and Omarchy Shell was not restarted: {error}"
+                    )));
+                }
+                Ok(setup::OmarchyPluginUpdateOutcome::UpdatedButReloadStateUnknown(error)) => {
+                    println!("Updated omarchy-boomux plugin");
+                    return Err(io::Error::other(format!(
+                        "Boomux and omarchy-boomux were updated, but the plugin's enabled state could not be rechecked and Omarchy Shell was not restarted: {error}"
+                    )));
+                }
+                Ok(setup::OmarchyPluginUpdateOutcome::UpdatedButReloadFailed(error)) => {
+                    println!("Updated omarchy-boomux plugin");
+                    return Err(io::Error::other(format!(
+                        "Boomux and omarchy-boomux were updated, but Omarchy Shell could not be restarted: {error}"
+                    )));
+                }
+                Err(error) => {
+                    return Err(io::Error::other(format!(
+                        "Boomux was updated to {latest}, but omarchy-boomux could not be inspected before its update: {error}"
+                    )));
+                }
+            }
+        }
         Ok(())
     })();
     if result.is_err() {


### PR DESCRIPTION
## Summary
- include an installed `io.github.gardnmi.boomux` plugin in guided update consent
- delegate the post-commit plugin update to Omarchy and reload enabled plugin code
- preserve exact argument boundaries and distinguish update, reload, partial, and unknown outcomes
- document the expanded local update contract and Agent Skill behavior

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`
- `omarchy plugin update --help`