### PR TITLE
feat(setup): polish first-run onboarding

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -133,17 +133,22 @@ boomux integration status codex --json
 ```
 
 When the user explicitly asks for first-run local configuration, `boomux setup`
-is the interactive end-to-end workflow. It discovers installed harnesses, offers
-their lifecycle assets individually, starts the local daemon when needed,
-optionally installs this Agent Skill, and can configure the Omarchy companion
-plugin and Boomux-owned Hyprland bindings.
+is the interactive end-to-end workflow. It inspects the machine first, shows a
+plan, discovers installed harnesses, offers their lifecycle assets individually,
+starts the local daemon during final verification, optionally installs this
+Agent Skill, and can configure the Omarchy companion plugin and Boomux-owned
+Hyprland bindings.
+Its final receipt distinguishes current, changed, skipped, warning, and failed
+steps and prints exact recovery commands for failures.
 It rejects Cargo-private desktop setup when Omarchy cannot resolve `boomux` from
 its graphical environment and restarts Omarchy Shell after changing the plugin.
 It recognizes and preserves a complete compatible user-managed binding profile.
-It requires a terminal, starts the daemon automatically, and defaults every
-configuration mutation prompt to no. Do not run it for inspection alone or
-without explicit authorization; use the JSON status and dry-run commands below
-instead.
+It requires a terminal and treats missing `xdg-terminal-exec` as a blocker. The
+recommended fixed Omarchy plugin and Workspace layer default to yes; harness
+assets, keybindings, replacements, and modified assets default to no. Current
+assets are not offered for redundant reinstall or reload. Do not run setup for
+inspection alone or without explicit authorization; use the JSON status and
+dry-run commands below instead.
 
 Mutation commands include:
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ Workspaces, Shells, Agents, and Nodes.
 - Use the project-folder button to create a same-named Workspace at a configured
   project path.
 
-`boomux setup` detects supported Agent harnesses, starts the local daemon, and
-prompts before installing or replacing integrations and the Boomux Agent Skill.
-Prompts default to no, and rerunning setup preserves modified or user-owned
-assets unless replacement is explicitly confirmed.
+`boomux setup` inspects the machine before making changes, detects supported
+Agent harnesses, starts the local daemon during verification, and prints a final
+readiness receipt with exact recovery commands for failures. The recommended
+Omarchy plugin and Workspace layer default to yes; integrations, keybindings,
+replacements, and modified assets default to no. Reruns skip current assets and
+preserve modified or user-owned content unless replacement is explicitly confirmed.
 
 Omarchy's graphical environment must be able to resolve `boomux`; official
 release installations use `~/.local/bin`. See the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -944,11 +944,16 @@ reporting, and `integration uninstall` safely removes one or all managed assets.
 
 The human-only top-level `boomux setup` command composes these existing local
 primitives without adding protocol or durable setup state. It requires terminal
-input and output, connects to or starts the local daemon during its system check,
-probes every bundled harness, and offers installation only for harness executables
-found on the current `PATH`. Each harness mutation has a separate default-no
-prompt; modified assets are identified and require explicit replacement consent.
-The optional Agent Skill remains a separate owned asset.
+input and output, prints its active configuration path, and completes read-only
+terminal, daemon, harness, and Omarchy inspection before presenting a concise
+machine-specific plan. A missing `xdg-terminal-exec` is a blocker before any
+mutation. Harness and modified-asset prompts remain default-no. Setup starts or
+confirms the local daemon only during final verification, then reinspects current
+assets and prints a readiness receipt, exact restart guidance, and one primary
+next action. The in-memory receipt retains current, changed, skipped, warning,
+and failed outcomes; failures include a step-specific recovery command, while
+reinspection reports any earlier committed desktop state. The optional Agent
+Skill remains a separate owned asset.
 
 On an Omarchy installation, setup executes only bounded exact-argument `omarchy`
 commands. Plugin inventory comes from `omarchy plugin list --json`; installation
@@ -956,14 +961,16 @@ uses the fixed `gardnmi/omarchy-boomux` HTTPS repository and Omarchy retains
 plugin lifecycle ownership. A Cargo-private executable without a corresponding
 `~/.local/bin/boomux` is rejected before desktop mutation because it may be
 absent from the graphical session's `PATH`. After installing or enabling the
-plugin, setup runs bounded `omarchy restart shell` so the running shell loads it.
-Reruns offer the same reload for an already-enabled but potentially stale plugin.
+plugin, setup runs bounded `omarchy restart shell` so the running shell loads it,
+then rechecks that the fixed plugin identity is enabled. Current enabled plugins
+and current or compatible user-managed keybindings produce no rerun prompt.
 The plugin is presented as the recommended core Omarchy experience rather than
 an incidental integration. Once it is enabled, setup separately offers to enable
 the default-off Hyprland Workspace layer by updating only
 `desktop.workspace_layer` in the active configuration layer through the same
 owner validation, baseline revalidation, and atomic commit boundary as
-`boomux config edit`. Declining either prompt preserves the current state.
+`boomux config edit`. The fixed plugin and Workspace-layer prompts are visibly
+recommended and default to yes; declining either preserves the current state.
 After a guided local Boomux update commits, the updater revalidates an installed
 companion plugin, delegates its update to the fixed exact-argument Omarchy CLI,
 and restarts Omarchy Shell when the plugin is enabled. Omarchy remains the plugin

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,8 @@ const READ_BYTES: usize = 1024 * 1024;
 #[command(
     version,
     about = "Native persistent terminal workspaces",
-    subcommand_value_name = "SUBCOMMAND"
+    subcommand_value_name = "SUBCOMMAND",
+    after_help = "First run: boomux setup"
 )]
 struct Cli {
     /// Emit the stable boomux.cli/v1 envelope for commands advertised by capabilities
@@ -10184,6 +10185,7 @@ fn install_skill(force: bool) -> Result<(), Box<dyn Error>> {
 
 fn install_skill_at(home: &Path, force: bool) -> Result<(), Box<dyn Error>> {
     require_absolute_root(home, "HOME")?;
+    preflight_legacy_skill_migration(home)?;
     let directory = ensure_safe_directory(&home.join(".agents/skills/boomux"))?;
     let path = skill_install_path(home);
     let outcome = install_asset_at(&directory, &path, BOOMUX_SKILL, force)?;
@@ -10197,7 +10199,7 @@ fn install_skill_at(home: &Path, force: bool) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn migrate_legacy_skill(home: &Path) -> Result<(), Box<dyn Error>> {
+fn preflight_legacy_skill_migration(home: &Path) -> Result<(), Box<dyn Error>> {
     let directory = home.join(".agents/skills/boomux-shells");
     match fs::symlink_metadata(&directory) {
         Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
@@ -10210,6 +10212,21 @@ fn migrate_legacy_skill(home: &Path) -> Result<(), Box<dyn Error>> {
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error.into()),
+    }
+    let path = legacy_skill_install_path(home);
+    if let Some(content_matches) = regular_file_matches(&path, LEGACY_BOOMUX_SHELLS_SKILL)? {
+        let entries = fs::read_dir(&directory)?.collect::<Result<Vec<_>, _>>()?;
+        let _untouched =
+            content_matches && entries.len() == 1 && entries[0].file_name() == "SKILL.md";
+    }
+    Ok(())
+}
+
+pub(crate) fn migrate_legacy_skill(home: &Path) -> Result<(), Box<dyn Error>> {
+    preflight_legacy_skill_migration(home)?;
+    let directory = home.join(".agents/skills/boomux-shells");
+    if !directory.exists() {
+        return Ok(());
     }
     let path = legacy_skill_install_path(home);
     if let Some(content_matches) = regular_file_matches(&path, LEGACY_BOOMUX_SHELLS_SKILL)? {
@@ -14821,6 +14838,17 @@ mod tests {
         assert_eq!(fs::read_to_string(&outside).unwrap(), "do not replace");
         fs::remove_dir_all(&home).unwrap();
         fs::remove_file(&outside).unwrap();
+
+        let home = test_skill_home("legacy-symlink");
+        let outside = test_skill_home("legacy-symlink-target");
+        fs::create_dir_all(home.join(".agents/skills")).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, home.join(".agents/skills/boomux-shells")).unwrap();
+
+        assert!(install_skill_at(&home, false).is_err());
+        assert!(!skill_install_path(&home).exists());
+        fs::remove_dir_all(home).unwrap();
+        fs::remove_dir_all(outside).unwrap();
     }
 
     fn test_skill_home(label: &str) -> PathBuf {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -131,6 +131,89 @@ struct BindingsPlan {
     compatible_unmanaged: bool,
 }
 
+struct SetupReadiness {
+    complete: bool,
+    plugin_enabled: bool,
+    keybindings_ready: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SetupOutcomeKind {
+    Current,
+    Changed,
+    Skipped,
+    Warning,
+    Failed,
+}
+
+struct SetupOutcome {
+    kind: SetupOutcomeKind,
+    label: String,
+    message: String,
+    recovery: Option<String>,
+}
+
+impl SetupOutcome {
+    fn new(kind: SetupOutcomeKind, label: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            label: label.into(),
+            message: message.into(),
+            recovery: None,
+        }
+    }
+
+    fn failed(
+        label: impl Into<String>,
+        error: impl std::fmt::Display,
+        recovery: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind: SetupOutcomeKind::Failed,
+            label: label.into(),
+            message: error.to_string(),
+            recovery: Some(recovery.into()),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ApplyOutcome {
+    Current,
+    Changed,
+    Skipped,
+}
+
+#[derive(Default)]
+struct DesktopSetupOutcomes {
+    plugin: Option<ApplyOutcome>,
+    workspace_layer: Option<ApplyOutcome>,
+    keybindings: Option<ApplyOutcome>,
+}
+
+struct DesktopSetupPlan {
+    workspace_enabled: bool,
+    bindings_ready: bool,
+    bindings_path: PathBuf,
+    conflicts: Vec<String>,
+}
+
+#[derive(Debug)]
+struct DesktopPartialFailure {
+    message: String,
+    committed_message: &'static str,
+    failure_label: &'static str,
+    recovery: &'static str,
+}
+
+impl std::fmt::Display for DesktopPartialFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for DesktopPartialFailure {}
+
 fn colors_enabled() -> bool {
     io::stdout().is_terminal()
         && env::var_os("NO_COLOR").is_none()
@@ -172,45 +255,68 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
         .into());
     }
 
-    println!("{}", paint("1;35", "BOOMUX SETUP"));
+    println!("{}", paint("1;35", "BOOMUX"));
+    println!("{}", paint("1", "Set up this machine"));
     println!(
         "{}",
         paint(
             "2",
-            "Discover harnesses, lifecycle integrations, and desktop support."
+            format!(
+                "v{}  |  config {}",
+                env!("CARGO_PKG_VERSION"),
+                crate::config::active_path()?.display()
+            )
         )
     );
     println!(
         "{}",
         paint(
             "2",
-            "Daemon readiness is automatic; configuration changes require confirmation."
+            "Inspect first, confirm every change, then verify the finished setup."
         )
     );
 
-    section("System Check");
-    if let Some(terminal_resolver) = executable_on_path("xdg-terminal-exec") {
-        status(
-            "ok",
-            "32",
-            "Terminal resolver",
-            terminal_resolver.display().to_string(),
-        );
-    } else {
-        status("!!", "33", "Terminal resolver", "not found on PATH");
-    }
-    let daemon_was_running = client::connect().is_ok();
-    client::connect_or_start()?;
+    section("Inspecting System");
+    let Some(terminal_resolver) = executable_on_path("xdg-terminal-exec") else {
+        status("xx", "31", "Terminal resolver", "not found on PATH");
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "xdg-terminal-exec is required; install it and rerun `boomux setup`",
+        )
+        .into());
+    };
     status(
         "ok",
         "32",
+        "Terminal resolver",
+        terminal_resolver.display().to_string(),
+    );
+    let daemon_was_running = client::connect().is_ok();
+    status(
+        if daemon_was_running { "ok" } else { "--" },
+        if daemon_was_running { "32" } else { "2" },
         "Daemon",
         if daemon_was_running {
             "already running"
         } else {
-            "started"
+            "will start during verification"
         },
     );
+
+    let omarchy_plan = if let Some(omarchy) = executable_on_path("omarchy") {
+        let version = run_command(&omarchy, &["version"], COMMAND_TIMEOUT)?;
+        ensure_omarchy_can_resolve_boomux()?;
+        status(
+            "ok",
+            "32",
+            "Desktop",
+            String::from_utf8_lossy(&version.stdout).trim(),
+        );
+        Some(omarchy_plugins(&omarchy)?)
+    } else {
+        status("--", "2", "Desktop", "Omarchy not detected");
+        None
+    };
 
     let environment = integration_management::Environment::from_process();
     let statuses = IntegrationId::all()
@@ -226,12 +332,179 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
         .filter(|(_, status)| status.host.state != HostState::Missing)
         .count();
 
+    for (integration, integration_status) in &statuses {
+        if integration_status.host.state != HostState::Missing
+            && matches!(
+                integration_status.asset.state,
+                AssetState::Missing | AssetState::Modified
+            )
+        {
+            integration_management::plan_install(
+                *integration,
+                &environment,
+                integration_status.asset.state == AssetState::Modified,
+            )?;
+        }
+    }
+    let skill_before = if detected > 0 {
+        let skill = required_home()?.join(".agents/skills/boomux/SKILL.md");
+        Some(integration_management::regular_file_matches(
+            &skill,
+            crate::BOOMUX_SKILL,
+        )?)
+    } else {
+        None
+    };
+    let (desktop_plan, desktop_plan_error) = if omarchy_plan.is_some() {
+        let omarchy = executable_on_path("omarchy")
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "omarchy disappeared"))?;
+        match inspect_omarchy_desktop_plan(&omarchy) {
+            Ok(plan) => (Some(plan), None),
+            Err(error) => (None, Some(error.to_string())),
+        }
+    } else {
+        (None, None)
+    };
+
+    section("Setup Plan");
+    if let Some(plugins) = omarchy_plan.as_deref() {
+        let plugin = plugins.iter().find(|plugin| plugin.id == OMARCHY_PLUGIN_ID);
+        status(
+            if plugin.is_some_and(|plugin| plugin.enabled) {
+                "ok"
+            } else {
+                "->"
+            },
+            if plugin.is_some_and(|plugin| plugin.enabled) {
+                "32"
+            } else {
+                "36"
+            },
+            "Companion pane",
+            match plugin {
+                Some(plugin) if plugin.enabled => "plugin enabled",
+                Some(_) => "enable recommended plugin",
+                None => "install and enable recommended plugin",
+            },
+        );
+        detail(format!("source: {OMARCHY_PLUGIN_URL}"));
+        let workspace_enabled = desktop_plan
+            .as_ref()
+            .is_some_and(|plan| plan.workspace_enabled);
+        status(
+            if workspace_enabled { "ok" } else { "->" },
+            if workspace_enabled { "32" } else { "36" },
+            "Workspace layer",
+            if workspace_enabled {
+                "enabled"
+            } else {
+                "enable recommended Hyprland presentation"
+            },
+        );
+        detail(format!(
+            "config: {}",
+            crate::config::active_path()?.display()
+        ));
+        let bindings_ready = desktop_plan
+            .as_ref()
+            .is_some_and(|plan| plan.bindings_ready);
+        status(
+            if bindings_ready { "ok" } else { "--" },
+            if bindings_ready { "32" } else { "2" },
+            "Keybindings",
+            if bindings_ready {
+                "current compatible profile"
+            } else {
+                "optional; install only with confirmation"
+            },
+        );
+        if let Some(desktop_plan) = desktop_plan.as_ref() {
+            detail(format!("path: {}", desktop_plan.bindings_path.display()));
+            for conflict in &desktop_plan.conflicts {
+                detail(format!("conflict: {conflict}"));
+            }
+        } else {
+            detail(format!(
+                "desktop plan unavailable: {}",
+                desktop_plan_error.as_deref().unwrap_or("unknown error")
+            ));
+        }
+    } else {
+        status("--", "2", "Companion pane", "Omarchy not detected");
+    }
+    for (integration_id, integration) in &statuses {
+        if integration.host.state == HostState::Missing {
+            continue;
+        }
+        let (marker, color, plan) = match integration.asset.state {
+            AssetState::Current => ("ok", "32", "integration current"),
+            AssetState::Missing => ("->", "36", "install integration"),
+            AssetState::Modified => ("!!", "33", "replace only with confirmation"),
+            AssetState::Unavailable => ("xx", "31", "inspection must be repaired"),
+        };
+        status(marker, color, integration.display_name, plan);
+        if let Some(path) = integration.asset.path.as_deref() {
+            detail(format!("path: {path}"));
+        } else if matches!(
+            integration.asset.state,
+            AssetState::Missing | AssetState::Modified
+        ) {
+            let force = integration.asset.state == AssetState::Modified;
+            let plan = integration_management::plan_install(*integration_id, &environment, force)?;
+            detail(format!("path: {}", plan.path));
+        }
+    }
+    if detected == 0 {
+        status(
+            "--",
+            "2",
+            "Agent lifecycle",
+            "no supported harnesses detected",
+        );
+    } else if let Some(skill) = skill_before {
+        let (marker, color, plan) = match skill {
+            Some(true) => ("ok", "32", "Agent Skill current"),
+            Some(false) => ("!!", "33", "replace Agent Skill only with confirmation"),
+            None => ("->", "36", "offer Agent Skill installation"),
+        };
+        status(marker, color, "Agent Skill", plan);
+        detail(format!(
+            "path: {}",
+            required_home()?
+                .join(".agents/skills/boomux/SKILL.md")
+                .display()
+        ));
+    }
+    status(
+        "->",
+        "36",
+        "Verification",
+        "start or confirm the local daemon",
+    );
+    detail("Recommended Omarchy choices default to yes.");
+    detail("Modified assets, replacements, and optional keybindings default to no.");
+
+    let skip_desktop = if let Some(error) = desktop_plan_error.as_deref() {
+        status("!!", "33", "Desktop blocker", error);
+        detail("No desktop change will be attempted unless inspection succeeds.");
+        if confirm_recommended("Skip unavailable optional desktop setup and continue?")? {
+            true
+        } else {
+            return Err(io::Error::other(format!(
+                "desktop setup inspection failed: {error}; fix it and rerun `boomux setup`"
+            ))
+            .into());
+        }
+    } else {
+        false
+    };
+
     section("Agent Harnesses");
     if detected == 0 {
         status("--", "2", "Harnesses", "none found on PATH");
     }
-    let mut failures = Vec::new();
-    let mut changed_harnesses = 0usize;
+    let mut outcomes = Vec::new();
+    let mut changed_harnesses = Vec::new();
     for (integration, integration_status) in statuses {
         if integration_status.host.state == HostState::Missing {
             continue;
@@ -259,17 +532,28 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
             ));
         }
         if integration_status.asset.state == AssetState::Current {
+            outcomes.push(SetupOutcome::new(
+                SetupOutcomeKind::Current,
+                integration_status.display_name,
+                "integration current",
+            ));
             continue;
         }
         if integration_status.asset.state == AssetState::Unavailable {
-            failures.push(format!(
-                "{} integration could not be inspected: {}",
+            outcomes.push(SetupOutcome::failed(
                 integration_status.display_name,
-                integration_status
-                    .asset
-                    .error
-                    .as_deref()
-                    .unwrap_or("unknown error")
+                format!(
+                    "integration could not be inspected: {}",
+                    integration_status
+                        .asset
+                        .error
+                        .as_deref()
+                        .unwrap_or("unknown error")
+                ),
+                format!(
+                    "`boomux integration status {} --json`",
+                    integration.spec().key
+                ),
             ));
             continue;
         }
@@ -277,23 +561,36 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
         let plan = match integration_management::plan_install(integration, &environment, force) {
             Ok(plan) => plan,
             Err(error) => {
-                failures.push(format!(
-                    "{} integration: {error}",
-                    integration_status.display_name
+                outcomes.push(SetupOutcome::failed(
+                    integration_status.display_name,
+                    error,
+                    format!(
+                        "`boomux integration status {} --json`",
+                        integration.spec().key
+                    ),
                 ));
                 continue;
             }
         };
-        let action = match plan.action {
-            InstallAction::Install => "Install",
-            InstallAction::Replace => "Replace modified",
+        let (action, prompt) = match plan.action {
+            InstallAction::Install => (
+                "Install",
+                format!(
+                    "Install the {} integration?",
+                    integration_status.display_name
+                ),
+            ),
+            InstallAction::Replace => (
+                "Replace modified",
+                format!(
+                    "Replace the modified {} integration?",
+                    integration_status.display_name
+                ),
+            ),
             InstallAction::Unchanged => continue,
         };
         detail(format!("Plan: {action} asset at {}", plan.path));
-        if confirm(&format!(
-            "{action} the {} integration?",
-            integration_status.display_name
-        ))? {
+        if confirm(&prompt)? {
             match integration_management::install(integration, &environment, force) {
                 Ok(result) => {
                     status(
@@ -303,60 +600,479 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
                         "integration installed",
                     );
                     detail(format!("path: {}", result.path));
+                    outcomes.push(SetupOutcome::new(
+                        SetupOutcomeKind::Changed,
+                        integration_status.display_name,
+                        "integration installed",
+                    ));
                     if result.restart_required {
-                        changed_harnesses += 1;
+                        changed_harnesses.push(integration_status.display_name);
                         detail(integration.installation().reload_message);
                     }
                 }
-                Err(error) => failures.push(format!(
-                    "{} integration: {error}",
-                    integration_status.display_name
+                Err(error) => outcomes.push(SetupOutcome::failed(
+                    integration_status.display_name,
+                    error,
+                    format!("`boomux integration install {}`", integration.spec().key),
                 )),
             }
         } else {
             status("--", "2", integration_status.display_name, "skipped");
+            outcomes.push(SetupOutcome::new(
+                SetupOutcomeKind::Skipped,
+                integration_status.display_name,
+                "integration skipped",
+            ));
         }
     }
 
-    if detected > 0
-        && let Err(error) = setup_agent_skill()
-    {
-        failures.push(format!("Agent Skill: {error}"));
+    if detected > 0 {
+        match setup_agent_skill() {
+            Ok(outcome) => outcomes.push(apply_outcome(
+                "Agent Skill",
+                outcome,
+                "current",
+                "installed",
+                "skipped",
+            )),
+            Err(error) => {
+                outcomes.push(SetupOutcome::failed("Agent Skill", error, "`boomux setup`"))
+            }
+        }
     }
 
-    if let Err(error) = setup_omarchy() {
-        failures.push(format!("Omarchy desktop setup: {error}"));
+    let desktop_result = if skip_desktop {
+        if omarchy_plan.as_deref().is_some_and(|plugins| {
+            plugins
+                .iter()
+                .any(|plugin| plugin.id == OMARCHY_PLUGIN_ID && plugin.enabled)
+        }) {
+            outcomes.push(SetupOutcome::new(
+                SetupOutcomeKind::Warning,
+                "Omarchy plugin",
+                "enabled; later desktop verification skipped",
+            ));
+        }
+        outcomes.push(SetupOutcome::new(
+            SetupOutcomeKind::Skipped,
+            "Omarchy desktop",
+            "skipped because read-only inspection failed",
+        ));
+        Ok(DesktopSetupOutcomes::default())
+    } else {
+        setup_omarchy()
+    };
+    match desktop_result {
+        Ok(desktop) => {
+            if let Some(outcome) = desktop.plugin {
+                outcomes.push(apply_outcome(
+                    "Omarchy plugin",
+                    outcome,
+                    "enabled",
+                    "installed and loaded",
+                    "skipped",
+                ));
+            }
+            if let Some(outcome) = desktop.workspace_layer {
+                outcomes.push(apply_outcome(
+                    "Workspace layer",
+                    outcome,
+                    "enabled",
+                    "enabled",
+                    "skipped",
+                ));
+            }
+            if let Some(outcome) = desktop.keybindings {
+                outcomes.push(apply_outcome(
+                    "Keybindings",
+                    outcome,
+                    "current compatible profile",
+                    "installed",
+                    "skipped",
+                ));
+            }
+        }
+        Err(error) => {
+            if let Some(partial) = error.downcast_ref::<DesktopPartialFailure>() {
+                outcomes.push(SetupOutcome::new(
+                    SetupOutcomeKind::Changed,
+                    "Omarchy plugin",
+                    partial.committed_message,
+                ));
+                outcomes.push(SetupOutcome::failed(
+                    partial.failure_label,
+                    partial,
+                    partial.recovery,
+                ));
+            } else {
+                outcomes.push(SetupOutcome::failed(
+                    "Omarchy desktop",
+                    error,
+                    "run `omarchy plugin list --json`, then `boomux setup`",
+                ));
+            }
+        }
     }
 
-    section("Summary");
-    if failures.is_empty() {
-        status("ok", "32", "Setup", "completed without errors");
-        if changed_harnesses > 0 {
-            detail("Restart changed harnesses before verifying lifecycle reporting.");
+    section("Verification");
+    let daemon_ready = match client::connect_or_start() {
+        Ok(_) => {
+            status(
+                "ok",
+                "32",
+                "Daemon",
+                if daemon_was_running {
+                    "running"
+                } else {
+                    "started"
+                },
+            );
+            outcomes.push(SetupOutcome::new(
+                if daemon_was_running {
+                    SetupOutcomeKind::Current
+                } else {
+                    SetupOutcomeKind::Changed
+                },
+                "Daemon",
+                if daemon_was_running {
+                    "running"
+                } else {
+                    "started"
+                },
+            ));
+            true
+        }
+        Err(error) => {
+            status("xx", "31", "Daemon", "could not be started");
+            outcomes.push(SetupOutcome::failed(
+                "Daemon",
+                error,
+                "run `boomux doctor`, then `boomux setup`",
+            ));
+            false
+        }
+    };
+
+    let recommended_ready = render_setup_receipt(
+        &environment,
+        detected,
+        &changed_harnesses,
+        daemon_ready,
+        skip_desktop,
+        &mut outcomes,
+    );
+
+    let failures = outcomes
+        .iter()
+        .filter(|outcome| outcome.kind == SetupOutcomeKind::Failed)
+        .count();
+    if failures == 0 {
+        section("Next");
+        if recommended_ready.plugin_enabled {
+            if recommended_ready.keybindings_ready {
+                detail("Press Super+B to open Boomux, then press + to create a Workspace.");
+            } else {
+                detail("Open Boomux from the Omarchy bar, then press + to create a Workspace.");
+            }
+            detail("If the pane is not visible yet, run `omarchy restart shell` once.");
         } else {
-            detail("No harness restart is required.");
+            detail("Run `boomux` to open the dashboard and create your first Workspace.");
+        }
+        detail("Run `boomux doctor` at any time to check system health.");
+        if !recommended_ready.complete {
+            detail("Run `boomux setup` again to finish skipped recommended steps.");
         }
         return Ok(());
     }
-    for failure in &failures {
-        eprintln!("  {} {failure}", paint("31", "[xx]"));
+    for failure in outcomes
+        .iter()
+        .filter(|outcome| outcome.kind == SetupOutcomeKind::Failed)
+    {
+        eprintln!(
+            "  {} {}: {}",
+            paint("31", "[xx]"),
+            failure.label,
+            failure.message
+        );
+        if let Some(recovery) = &failure.recovery {
+            eprintln!("       Recovery: {recovery}");
+        }
     }
     Err(io::Error::other(format!(
         "setup completed with {} failure{}",
-        failures.len(),
-        if failures.len() == 1 { "" } else { "s" }
+        failures,
+        if failures == 1 { "" } else { "s" }
     ))
     .into())
 }
 
-fn setup_agent_skill() -> Result<(), Box<dyn Error>> {
+fn apply_outcome(
+    label: impl Into<String>,
+    outcome: ApplyOutcome,
+    current: impl Into<String>,
+    changed: impl Into<String>,
+    skipped: impl Into<String>,
+) -> SetupOutcome {
+    let label = label.into();
+    match outcome {
+        ApplyOutcome::Current => SetupOutcome::new(SetupOutcomeKind::Current, label, current),
+        ApplyOutcome::Changed => SetupOutcome::new(SetupOutcomeKind::Changed, label, changed),
+        ApplyOutcome::Skipped => SetupOutcome::new(SetupOutcomeKind::Skipped, label, skipped),
+    }
+}
+
+fn render_setup_receipt(
+    environment: &integration_management::Environment,
+    detected: usize,
+    changed_harnesses: &[&str],
+    daemon_ready: bool,
+    skip_desktop: bool,
+    outcomes: &mut Vec<SetupOutcome>,
+) -> SetupReadiness {
+    let installed_integrations = IntegrationId::all()
+        .map(|integration| integration_management::inspect(integration, environment, None))
+        .filter(|integration| {
+            integration.host.state == HostState::Available
+                && integration.asset.state == AssetState::Current
+        })
+        .count();
+    let integrations_ready =
+        detected == 0 || installed_integrations == detected && changed_harnesses.is_empty();
+    if detected == 0 {
+        outcomes.push(SetupOutcome::new(
+            SetupOutcomeKind::Skipped,
+            "Agent lifecycle",
+            "no harnesses detected",
+        ));
+    } else if installed_integrations != detected
+        && changed_harnesses.is_empty()
+        && !outcomes
+            .iter()
+            .any(|outcome| outcome.kind == SetupOutcomeKind::Failed)
+    {
+        outcomes.push(SetupOutcome::new(
+            SetupOutcomeKind::Warning,
+            "Agent lifecycle",
+            format!("{installed_integrations} of {detected} integrations verified"),
+        ));
+    }
+    if !changed_harnesses.is_empty() {
+        outcomes.push(SetupOutcome::new(
+            SetupOutcomeKind::Warning,
+            "Harness restart",
+            format!("restart to load {}", changed_harnesses.join(", ")),
+        ));
+    }
+
+    let skill_ready = if detected == 0 {
+        true
+    } else {
+        match required_home()
+            .map(|home| home.join(".agents/skills/boomux/SKILL.md"))
+            .and_then(|path| {
+                integration_management::regular_file_matches(&path, crate::BOOMUX_SKILL)
+                    .map_err(|error| io::Error::other(error.to_string()))
+            }) {
+            Ok(Some(true)) => true,
+            Ok(_) => false,
+            Err(error) => {
+                outcomes.push(SetupOutcome::failed(
+                    "Agent Skill verification",
+                    error,
+                    "`boomux setup`",
+                ));
+                false
+            }
+        }
+    };
+    let mut plugin_enabled = false;
+    let mut workspace_layer_enabled = false;
+    let mut keybindings_ready = false;
+    let omarchy = executable_on_path("omarchy");
+    if skip_desktop {
+        plugin_enabled = outcomes.iter().any(|outcome| {
+            outcome.label == "Omarchy plugin"
+                && matches!(
+                    outcome.kind,
+                    SetupOutcomeKind::Current
+                        | SetupOutcomeKind::Changed
+                        | SetupOutcomeKind::Warning
+                )
+        });
+    } else if let Some(omarchy) = omarchy.as_deref() {
+        plugin_enabled = match omarchy_plugins(omarchy) {
+            Ok(plugins) => plugins
+                .iter()
+                .any(|plugin| plugin.id == OMARCHY_PLUGIN_ID && plugin.enabled),
+            Err(error) => {
+                outcomes.push(SetupOutcome::failed(
+                    "Omarchy plugin verification",
+                    error,
+                    "run `omarchy plugin list --json`, then `boomux setup`",
+                ));
+                false
+            }
+        };
+        let desktop_failed = outcomes.iter().any(|outcome| {
+            outcome.kind == SetupOutcomeKind::Failed && outcome.label == "Omarchy desktop"
+        });
+        if plugin_enabled
+            && !outcomes
+                .iter()
+                .any(|outcome| outcome.label == "Omarchy plugin")
+        {
+            outcomes.push(SetupOutcome::new(
+                if desktop_failed {
+                    SetupOutcomeKind::Warning
+                } else {
+                    SetupOutcomeKind::Current
+                },
+                "Omarchy plugin",
+                if desktop_failed {
+                    "enabled before a later desktop step failed"
+                } else {
+                    "installed and enabled"
+                },
+            ));
+        }
+        if plugin_enabled {
+            workspace_layer_enabled = match crate::config::load() {
+                Ok(config) => {
+                    config.desktop.workspace_layer
+                        == crate::config::DesktopWorkspaceLayer::HyprlandSpecial
+                }
+                Err(error) => {
+                    outcomes.push(SetupOutcome::failed(
+                        "Workspace layer verification",
+                        error,
+                        "run `boomux config validate`, then `boomux setup`",
+                    ));
+                    false
+                }
+            };
+            if workspace_layer_enabled
+                && !outcomes
+                    .iter()
+                    .any(|outcome| outcome.label == "Workspace layer")
+            {
+                outcomes.push(SetupOutcome::new(
+                    if desktop_failed {
+                        SetupOutcomeKind::Warning
+                    } else {
+                        SetupOutcomeKind::Current
+                    },
+                    "Workspace layer",
+                    if desktop_failed {
+                        "enabled before a later desktop step failed"
+                    } else {
+                        "enabled"
+                    },
+                ));
+            }
+            let keybindings = match bindings_plan() {
+                Ok(plan) => Some(plan),
+                Err(error) => {
+                    outcomes.push(SetupOutcome::failed(
+                        "Keybindings verification",
+                        error,
+                        "`boomux setup`",
+                    ));
+                    None
+                }
+            };
+            keybindings_ready = keybindings.as_ref().is_some_and(|plan| !plan.changed);
+            let compatible_unmanaged = keybindings
+                .as_ref()
+                .is_some_and(|plan| plan.compatible_unmanaged);
+            if keybindings_ready
+                && !outcomes
+                    .iter()
+                    .any(|outcome| outcome.label == "Keybindings")
+            {
+                outcomes.push(SetupOutcome::new(
+                    if desktop_failed {
+                        SetupOutcomeKind::Warning
+                    } else {
+                        SetupOutcomeKind::Current
+                    },
+                    "Keybindings",
+                    if desktop_failed {
+                        "compatible state preserved after a later failure"
+                    } else if compatible_unmanaged {
+                        "compatible user-managed profile"
+                    } else {
+                        "managed profile ready"
+                    },
+                ));
+            }
+        }
+    } else {
+        outcomes.push(SetupOutcome::new(
+            SetupOutcomeKind::Skipped,
+            "Omarchy desktop",
+            "not detected",
+        ));
+    }
+
+    let desktop_ready =
+        skip_desktop || omarchy.is_none() || plugin_enabled && workspace_layer_enabled;
+    let failed = outcomes
+        .iter()
+        .any(|outcome| outcome.kind == SetupOutcomeKind::Failed);
+    let complete = daemon_ready && !failed && integrations_ready && skill_ready && desktop_ready;
+
+    println!(
+        "\n{}",
+        paint(
+            if complete { "1;32" } else { "1;36" },
+            if complete {
+                "BOOMUX IS READY"
+            } else {
+                "BOOMUX SETUP RECEIPT"
+            }
+        )
+    );
+    for outcome in outcomes.iter() {
+        let (marker, color) = match outcome.kind {
+            SetupOutcomeKind::Current | SetupOutcomeKind::Changed => ("ok", "32"),
+            SetupOutcomeKind::Skipped => ("--", "2"),
+            SetupOutcomeKind::Warning => ("!!", "33"),
+            SetupOutcomeKind::Failed => ("xx", "31"),
+        };
+        status(marker, color, &outcome.label, &outcome.message);
+        if let Some(recovery) = &outcome.recovery {
+            detail(format!("Recovery: {recovery}"));
+        }
+    }
+    status(
+        if complete { "ok" } else { "!!" },
+        if complete { "32" } else { "33" },
+        "Setup",
+        if complete {
+            "this machine is ready"
+        } else if !failed {
+            "recommended steps remain"
+        } else {
+            "completed with failures"
+        },
+    );
+
+    SetupReadiness {
+        complete,
+        plugin_enabled,
+        keybindings_ready,
+    }
+}
+
+fn setup_agent_skill() -> Result<ApplyOutcome, Box<dyn Error>> {
     let home = required_home()?;
     let path = home.join(".agents/skills/boomux/SKILL.md");
     match integration_management::regular_file_matches(&path, crate::BOOMUX_SKILL)? {
         Some(true) => {
             status("ok", "32", "Agent Skill", "current");
             detail(path.display().to_string());
-            Ok(())
+            crate::migrate_legacy_skill(&home)?;
+            Ok(ApplyOutcome::Current)
         }
         state => {
             let modified = state == Some(false);
@@ -370,10 +1086,11 @@ fn setup_agent_skill() -> Result<(), Box<dyn Error>> {
                 "Install the Boomux Agent Skill?"
             };
             if confirm(prompt)? {
-                crate::install_skill(modified)
+                crate::install_skill(modified)?;
+                Ok(ApplyOutcome::Changed)
             } else {
                 status("--", "2", "Agent Skill", "skipped");
-                Ok(())
+                Ok(ApplyOutcome::Skipped)
             }
         }
     }
@@ -387,12 +1104,12 @@ fn required_home() -> io::Result<PathBuf> {
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "HOME must be absolute"))
 }
 
-fn setup_omarchy() -> Result<(), Box<dyn Error>> {
+fn setup_omarchy() -> Result<DesktopSetupOutcomes, Box<dyn Error>> {
     section("Desktop Integration");
     let Some(omarchy) = executable_on_path("omarchy") else {
         status("--", "2", "Omarchy", "not detected");
         detail("Desktop plugin and keybindings were skipped.");
-        return Ok(());
+        return Ok(DesktopSetupOutcomes::default());
     };
     let version = run_command(&omarchy, &["version"], COMMAND_TIMEOUT)?;
     status(
@@ -416,7 +1133,7 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
     );
 
     let plugins = omarchy_plugins(&omarchy)?;
-    let (plugin_enabled, plugin_changed) = match plugins
+    let (plugin_enabled, plugin_changed, plugin_outcome) = match plugins
         .iter()
         .find(|plugin| plugin.id == OMARCHY_PLUGIN_ID)
     {
@@ -427,11 +1144,8 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
                 "omarchy-boomux",
                 "recommended core experience installed and enabled",
             );
-            detail("Reload the shell if the plugin was installed after Omarchy Shell started.");
-            (
-                true,
-                confirm("Restart Omarchy Shell and reload omarchy-boomux?")?,
-            )
+            detail("Enabled in the Omarchy plugin inventory; no change is needed.");
+            (true, false, ApplyOutcome::Current)
         }
         Some(_) => {
             status(
@@ -441,16 +1155,17 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
                 "recommended core experience is disabled",
             );
             detail("Enabling the plugin also restarts Omarchy Shell so it is loaded.");
-            if confirm("Enable and load the recommended omarchy-boomux plugin?")? {
+            if confirm_recommended("Enable and load the recommended omarchy-boomux plugin?")? {
+                preflight_omarchy_desktop(&omarchy)?;
                 run_command(
                     &omarchy,
                     &["plugin", "enable", OMARCHY_PLUGIN_ID],
                     COMMAND_TIMEOUT,
                 )?;
                 status("ok", "32", "omarchy-boomux", "enabled");
-                (true, true)
+                (true, true, ApplyOutcome::Changed)
             } else {
-                (false, false)
+                (false, false, ApplyOutcome::Skipped)
             }
         }
         None => {
@@ -464,29 +1179,65 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
             detail("Plugins run as unsandboxed code inside the Omarchy shell.");
             detail(format!("Source: {OMARCHY_PLUGIN_URL}"));
             detail("Installation also restarts Omarchy Shell so the plugin is loaded.");
-            if confirm("Install, enable, and load the recommended omarchy-boomux plugin?")? {
+            if confirm_recommended(
+                "Install, enable, and load the recommended omarchy-boomux plugin?",
+            )? {
+                preflight_omarchy_desktop(&omarchy)?;
                 run_command(
                     &omarchy,
                     &["plugin", "add", OMARCHY_PLUGIN_URL, "--enable", "--yes"],
                     PLUGIN_INSTALL_TIMEOUT,
                 )?;
                 status("ok", "32", "omarchy-boomux", "installed and enabled");
-                (true, true)
+                (true, true, ApplyOutcome::Changed)
             } else {
-                (false, false)
+                (false, false, ApplyOutcome::Skipped)
             }
         }
     };
     if plugin_changed {
-        run_command(&omarchy, &["restart", "shell"], PLUGIN_INSTALL_TIMEOUT)?;
+        run_command(&omarchy, &["restart", "shell"], PLUGIN_INSTALL_TIMEOUT).map_err(|error| {
+            Box::new(DesktopPartialFailure {
+                message: format!("plugin is enabled, but Omarchy Shell did not restart: {error}"),
+                committed_message: "enabled before shell reload failed",
+                failure_label: "Omarchy Shell reload",
+                recovery: "`omarchy restart shell`",
+            }) as Box<dyn Error>
+        })?;
         status("ok", "32", "Omarchy Shell", "restarted with plugin loaded");
+        let plugins = omarchy_plugins(&omarchy).map_err(|error| {
+            Box::new(DesktopPartialFailure {
+                message: format!(
+                    "plugin was enabled and the shell restarted, but inventory verification failed: {error}"
+                ),
+                committed_message: "enabled and shell reloaded before verification failed",
+                failure_label: "Omarchy plugin verification",
+                recovery: "run `omarchy plugin list --json`, then `omarchy restart shell` if the plugin is not visible",
+            }) as Box<dyn Error>
+        })?;
+        if !plugins
+            .iter()
+            .any(|plugin| plugin.id == OMARCHY_PLUGIN_ID && plugin.enabled)
+        {
+            return Err(Box::new(DesktopPartialFailure {
+                message: "Omarchy did not report the companion plugin as enabled after the change"
+                    .into(),
+                committed_message: "enabled and shell reloaded before verification failed",
+                failure_label: "Omarchy plugin verification",
+                recovery: "run `omarchy plugin list --json`, then `omarchy restart shell`",
+            }));
+        }
     }
     if !plugin_enabled {
         status("--", "2", "Keybindings", "skipped; plugin is not enabled");
-        return Ok(());
+        return Ok(DesktopSetupOutcomes {
+            plugin: Some(plugin_outcome),
+            workspace_layer: None,
+            keybindings: None,
+        });
     }
 
-    setup_hyprland_workspace_layer()?;
+    let workspace_layer = setup_hyprland_workspace_layer()?;
 
     let plan = bindings_plan()?;
     if !plan.changed {
@@ -516,10 +1267,12 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
             status("ok", "32", "Keybindings", "current managed profile");
         }
 
-        if !confirm("Reinstall the standard Boomux keybinding profile?")? {
-            status("--", "2", "Keybindings", "kept unchanged");
-            return Ok(());
-        }
+        detail("No changes are needed.");
+        return Ok(DesktopSetupOutcomes {
+            plugin: Some(plugin_outcome),
+            workspace_layer: Some(workspace_layer),
+            keybindings: Some(ApplyOutcome::Current),
+        });
     } else {
         let inventory = run_command(
             &omarchy,
@@ -545,7 +1298,11 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
         };
         if !confirm(prompt)? {
             status("--", "2", "Keybindings", "skipped");
-            return Ok(());
+            return Ok(DesktopSetupOutcomes {
+                plugin: Some(plugin_outcome),
+                workspace_layer: Some(workspace_layer),
+                keybindings: Some(ApplyOutcome::Skipped),
+            });
         }
     }
     commit_bindings(&plan)?;
@@ -587,15 +1344,19 @@ fn setup_omarchy() -> Result<(), Box<dyn Error>> {
     if hyprland_active {
         status("ok", "32", "Hyprland config", "reloaded without errors");
     }
-    Ok(())
+    Ok(DesktopSetupOutcomes {
+        plugin: Some(plugin_outcome),
+        workspace_layer: Some(workspace_layer),
+        keybindings: Some(ApplyOutcome::Changed),
+    })
 }
 
-fn setup_hyprland_workspace_layer() -> Result<(), Box<dyn Error>> {
+fn setup_hyprland_workspace_layer() -> Result<ApplyOutcome, Box<dyn Error>> {
     if crate::config::load()?.desktop.workspace_layer
         == crate::config::DesktopWorkspaceLayer::HyprlandSpecial
     {
         status("ok", "32", "Workspace layer", "enabled");
-        return Ok(());
+        return Ok(ApplyOutcome::Current);
     }
 
     status(
@@ -605,15 +1366,52 @@ fn setup_hyprland_workspace_layer() -> Result<(), Box<dyn Error>> {
         "recommended for the core Omarchy experience",
     );
     detail("Present coordinated Boomux Workspaces as named Hyprland special Workspaces.");
-    if !confirm("Enable the recommended Hyprland Workspace layer?")? {
+    if !confirm_recommended("Enable the recommended Hyprland Workspace layer?")? {
         status("--", "2", "Workspace layer", "kept disabled");
-        return Ok(());
+        return Ok(ApplyOutcome::Skipped);
     }
 
     let path = crate::config::enable_hyprland_workspace_layer()?;
     status("ok", "32", "Workspace layer", "enabled");
     detail(format!("config: {}", path.display()));
-    Ok(())
+    Ok(ApplyOutcome::Changed)
+}
+
+fn preflight_omarchy_desktop(omarchy: &Path) -> Result<(), Box<dyn Error>> {
+    inspect_omarchy_desktop_plan(omarchy).map(|_| ())
+}
+
+fn inspect_omarchy_desktop_plan(omarchy: &Path) -> Result<DesktopSetupPlan, Box<dyn Error>> {
+    let workspace_enabled = crate::config::load()?.desktop.workspace_layer
+        == crate::config::DesktopWorkspaceLayer::HyprlandSpecial;
+    let bindings = bindings_plan()?;
+    let conflicts = if bindings.changed || bindings.compatible_unmanaged {
+        let inventory = run_command(
+            omarchy,
+            &["menu", "keybindings", "--print"],
+            COMMAND_TIMEOUT,
+        )?;
+        binding_conflicts(&String::from_utf8_lossy(&inventory.stdout))
+            .into_iter()
+            .map(str::to_owned)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if bindings.changed && env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some() {
+        executable_on_path("hyprctl").ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "HYPRLAND_INSTANCE_SIGNATURE is set but hyprctl is unavailable",
+            )
+        })?;
+    }
+    Ok(DesktopSetupPlan {
+        workspace_enabled,
+        bindings_ready: !bindings.changed,
+        bindings_path: bindings.path,
+        conflicts,
+    })
 }
 
 fn ensure_omarchy_can_resolve_boomux() -> io::Result<()> {
@@ -658,14 +1456,37 @@ fn validate_hyprland_config(hyprctl: &Path) -> io::Result<()> {
 }
 
 fn confirm(prompt: &str) -> io::Result<bool> {
-    print!("  {} {} ", paint("1;33", prompt), paint("2", "[y/N]"));
+    confirm_with_default(prompt, false)
+}
+
+fn confirm_recommended(prompt: &str) -> io::Result<bool> {
+    confirm_with_default(prompt, true)
+}
+
+fn confirm_with_default(prompt: &str, default_yes: bool) -> io::Result<bool> {
+    print!(
+        "  {} {} ",
+        paint("1;33", prompt),
+        paint("2", if default_yes { "[Y/n]" } else { "[y/N]" })
+    );
     io::stdout().flush()?;
+    read_confirmation(&mut io::stdin().lock(), default_yes)
+}
+
+fn read_confirmation(reader: &mut impl io::BufRead, default_yes: bool) -> io::Result<bool> {
     let mut response = String::new();
-    io::stdin().read_line(&mut response)?;
-    Ok(matches!(
-        response.trim().to_ascii_lowercase().as_str(),
-        "y" | "yes"
-    ))
+    if reader.read_line(&mut response)? == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "confirmation input closed before a choice was made",
+        ));
+    }
+    let response = response.trim().to_ascii_lowercase();
+    Ok(if response.is_empty() {
+        default_yes
+    } else {
+        matches!(response.as_str(), "y" | "yes")
+    })
 }
 
 fn executable_on_path(name: &str) -> Option<PathBuf> {
@@ -1308,6 +2129,13 @@ mod tests {
                 b"".as_slice(),
             ]
         );
+    }
+
+    #[test]
+    fn recommended_confirmation_accepts_enter_but_rejects_eof() {
+        assert!(read_confirmation(&mut io::Cursor::new(b"\n"), true).unwrap());
+        let error = read_confirmation(&mut io::Cursor::new([]), true).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
     }
 
     #[test]

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -47,6 +47,42 @@ fn guided_setup_requires_an_interactive_terminal() {
 }
 
 #[test]
+fn guided_setup_requires_a_terminal_resolver_before_starting_the_daemon() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-guided-terminal-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = root.join("bin");
+    let runtime = setup_runtime(&root);
+    fs::create_dir_all(&bin).unwrap();
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("XDG_CONFIG_HOME", root.join("config"));
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
+    command.env("PATH", &bin);
+    let mut child = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut reader = pty.master.try_clone_reader().unwrap();
+    assert!(!child.wait().unwrap().success());
+    let mut output = String::new();
+    std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
+    assert!(output.contains("xdg-terminal-exec is required"), "{output}");
+    assert!(!runtime.join("boomux/daemon.sock").exists());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn guided_setup_discovers_and_installs_one_selected_harness() {
     let root = std::env::temp_dir().join(format!(
         "boomux-guided-setup-{}-{}",
@@ -94,6 +130,32 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
     assert!(output.contains("Daemon"));
     assert!(output.contains("started"));
     assert!(output.contains("host available | integration missing"));
+    let plan = output
+        .split("-- Setup Plan --")
+        .nth(1)
+        .and_then(|output| output.split("-- Agent Harnesses --").next())
+        .unwrap();
+    assert!(plan.contains("OpenCode"), "{plan}");
+    assert!(plan.contains("install integration"), "{plan}");
+    assert!(plan.contains("Agent Skill"), "{plan}");
+    assert!(
+        plan.contains(
+            &config
+                .join("opencode/plugins/boomux.js")
+                .display()
+                .to_string()
+        ),
+        "{plan}"
+    );
+    assert!(
+        plan.contains(
+            &root
+                .join(".agents/skills/boomux/SKILL.md")
+                .display()
+                .to_string()
+        ),
+        "{plan}"
+    );
     assert!(output.contains("integration installed"));
     assert!(output.contains("Omarchy"));
     assert!(output.contains("not detected"));
@@ -160,8 +222,8 @@ fn guided_setup_rejects_cargo_private_boomux_before_desktop_mutation() {
     assert!(output.contains("graphical PATH"), "{output}");
     assert!(output.contains(".local/bin/boomux"), "{output}");
     assert_eq!(fs::read_to_string(&log).unwrap(), "version\n");
+    assert!(!runtime.join("boomux/daemon.sock").exists());
 
-    stop_setup_daemon(&installed, &root, &runtime);
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -179,13 +241,23 @@ fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
     let omarchy = bin.join("omarchy");
     fs::write(
         &omarchy,
-        "#!/bin/sh\nprintf 'omarchy %s\\n' \"$*\" >> \"$LOG\"\ncase \"$*\" in\n  version) printf 'Omarchy 4.0\\n' ;;\n  'plugin list --json') printf '[]\\n' ;;\n  'plugin add https://github.com/gardnmi/omarchy-boomux.git --enable --yes') ;;\n  'menu keybindings --print') printf 'SUPER + B  → Browser\\nSUPER CTRL + W  → Close\\n' ;;\n  *) exit 97 ;;\nesac\n",
+        "#!/bin/sh\nmarker=$0.enabled\nprintf 'omarchy %s\\n' \"$*\" >> \"$LOG\"\ncase \"$*\" in\n  version) printf 'Omarchy 4.0\\n' ;;\n  'plugin list --json')\n    if [ -e \"$marker\" ]; then printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":true}]\\n'; else printf '[]\\n'; fi ;;\n  'plugin add https://github.com/gardnmi/omarchy-boomux.git --enable --yes') : > \"$marker\" ;;\n  'menu keybindings --print') printf 'SUPER + B  → Browser\\nSUPER CTRL + W  → Close\\n' ;;\n  *) exit 97 ;;\nesac\n",
     )
     .unwrap();
-    let script = fs::read_to_string(&omarchy).unwrap().replace(
-        "  'menu keybindings --print')",
-        "  'restart shell') ;;\n  'menu keybindings --print')",
-    );
+    let script = fs::read_to_string(&omarchy)
+        .unwrap()
+        .replace(
+            "  'plugin list --json')\n    if",
+            "  'plugin list --json')\n    count_file=${COUNT_FILE:-$0.list-count}; count=0; if [ -e \"$count_file\" ]; then IFS= read -r count < \"$count_file\"; fi; count=$((count + 1)); printf '%s' \"$count\" > \"$count_file\"; [ \"${FAIL_LIST_AT:-}\" != \"$count\" ] || exit 89\n    if",
+        )
+        .replace(
+            "  'menu keybindings --print')",
+            "  'restart shell') [ -z \"${FAIL_RESTART:-}\" ] || exit 88 ;;\n  'menu keybindings --print')",
+        )
+        .replace(
+            "${COUNT_FILE:-$0.list-count}",
+            &root.join("plugin-list-count").display().to_string(),
+        );
     fs::write(&omarchy, script).unwrap();
     fs::set_permissions(&omarchy, fs::Permissions::from_mode(0o755)).unwrap();
     let hyprctl = bin.join("hyprctl");
@@ -220,12 +292,15 @@ fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
     drop(pty.slave);
     let mut reader = pty.master.try_clone_reader().unwrap();
     let mut writer = pty.master.take_writer().unwrap();
-    writer.write_all(b"yes\nyes\nyes\n").unwrap();
+    writer.write_all(b"\n\nyes\n").unwrap();
     drop(writer);
     assert!(child.wait().unwrap().success());
     let mut output = String::new();
     std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
     assert!(output.contains("recommended core Omarchy experience"));
+    assert!(output.contains("[Y/n]"));
+    assert!(output.contains("BOOMUX IS READY"));
+    assert!(output.contains("this machine is ready"));
     assert!(output.contains("conflicts require replacement"));
     assert!(output.contains("reloaded without errors"));
     let commands = fs::read_to_string(&log).unwrap();
@@ -240,6 +315,103 @@ fn guided_setup_installs_omarchy_plugin_and_managed_bindings() {
     let bindings = fs::read_to_string(root.join(".config/hypr/bindings.lua")).unwrap();
     assert!(bindings.contains("BEGIN BOOMUX MANAGED KEYBINDINGS"));
     assert!(bindings.contains("boomux desktop gather"));
+
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("XDG_CONFIG_HOME", root.join("config"));
+    command.env("PATH", &bin);
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
+    command.env("LOG", &log);
+    command.env("HYPRLAND_INSTANCE_SIGNATURE", "test-instance");
+    let mut rerun = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut rerun_reader = pty.master.try_clone_reader().unwrap();
+    drop(pty.master.take_writer().unwrap());
+    assert!(rerun.wait().unwrap().success());
+    let mut rerun_output = String::new();
+    std::io::Read::read_to_string(rerun_reader.as_mut(), &mut rerun_output).unwrap();
+    assert!(!rerun_output.contains("[Y/n]"), "{rerun_output}");
+    assert!(!rerun_output.contains("[y/N]"), "{rerun_output}");
+    assert!(rerun_output.contains("BOOMUX IS READY"));
+    assert!(rerun_output.contains("this machine is ready"));
+
+    fs::remove_file(bin.join("omarchy.enabled")).unwrap();
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("XDG_CONFIG_HOME", root.join("config"));
+    command.env("PATH", &bin);
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
+    command.env("LOG", &log);
+    command.env("FAIL_RESTART", "1");
+    let mut failed = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut failed_reader = pty.master.try_clone_reader().unwrap();
+    let mut writer = pty.master.take_writer().unwrap();
+    writer.write_all(b"\n").unwrap();
+    drop(writer);
+    assert!(!failed.wait().unwrap().success());
+    let mut failed_output = String::new();
+    std::io::Read::read_to_string(failed_reader.as_mut(), &mut failed_output).unwrap();
+    assert!(
+        failed_output.contains("Recovery: `omarchy restart shell`"),
+        "{failed_output}"
+    );
+    assert!(bin.join("omarchy.enabled").exists());
+
+    fs::remove_file(root.join("plugin-list-count")).unwrap();
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("XDG_CONFIG_HOME", root.join("config"));
+    command.env("PATH", &bin);
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
+    command.env("LOG", &log);
+    command.env("FAIL_LIST_AT", "3");
+    let mut verification_failed = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut verification_reader = pty.master.try_clone_reader().unwrap();
+    drop(pty.master.take_writer().unwrap());
+    let verification_status = verification_failed.wait().unwrap();
+    let mut verification_output = String::new();
+    std::io::Read::read_to_string(verification_reader.as_mut(), &mut verification_output).unwrap();
+    assert!(!verification_status.success(), "{verification_output}");
+    assert!(
+        verification_output.contains("Omarchy plugin verification"),
+        "{verification_output}"
+    );
+    assert!(
+        verification_output.contains("Recovery: run `omarchy plugin list --json`"),
+        "{verification_output}"
+    );
     stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();
 }
@@ -280,14 +452,82 @@ fn guided_setup_declined_bindings_do_not_create_hyprland_config() {
     command.env("PATH", &bin);
     command.env("XDG_RUNTIME_DIR", &runtime);
     command.env("XDG_STATE_HOME", root.join("state"));
+    command.env_remove("HYPRLAND_INSTANCE_SIGNATURE");
     let mut child = pty.slave.spawn_command(command).unwrap();
     drop(pty.slave);
     let mut writer = pty.master.take_writer().unwrap();
-    writer.write_all(b"no\nno\nno\n").unwrap();
+    writer.write_all(b"no\nno\n").unwrap();
     drop(writer);
     assert!(child.wait().unwrap().success());
     assert!(!root.join(".config/hypr").exists());
     assert!(!root.join("config/boomux/config.toml").exists());
+    stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn guided_setup_skips_unavailable_optional_desktop_preflight() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-guided-desktop-skip-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let bin = root.join("bin");
+    let hypr = root.join(".config/hypr");
+    let runtime = setup_runtime(&root);
+    fs::create_dir_all(&bin).unwrap();
+    fs::create_dir_all(&hypr).unwrap();
+    std::os::unix::fs::symlink("missing-user-bindings", hypr.join("bindings.lua")).unwrap();
+    let omarchy = bin.join("omarchy");
+    fs::write(
+        &omarchy,
+        "#!/bin/sh\ncase \"$*\" in\n  version) printf 'Omarchy 4.0\\n' ;;\n  'plugin list --json') printf '[{\"id\":\"io.github.gardnmi.boomux\",\"enabled\":true}]\\n' ;;\n  *) exit 97 ;;\nesac\n",
+    )
+    .unwrap();
+    fs::set_permissions(&omarchy, fs::Permissions::from_mode(0o755)).unwrap();
+    let terminal = bin.join("xdg-terminal-exec");
+    fs::write(&terminal, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&terminal, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 1200,
+            pixel_height: 800,
+        })
+        .unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_boomux"));
+    command.arg("setup");
+    command.env("HOME", &root);
+    command.env("XDG_CONFIG_HOME", root.join("config"));
+    command.env("PATH", &bin);
+    command.env("XDG_RUNTIME_DIR", &runtime);
+    command.env("XDG_STATE_HOME", root.join("state"));
+    command.env_remove("HYPRLAND_INSTANCE_SIGNATURE");
+    let mut child = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+    let mut reader = pty.master.try_clone_reader().unwrap();
+    let mut writer = pty.master.take_writer().unwrap();
+    writer.write_all(b"\n").unwrap();
+    drop(writer);
+    assert!(child.wait().unwrap().success());
+    let mut output = String::new();
+    std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
+    assert!(
+        output.contains("skipped because read-only inspection failed"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("Omarchy desktop       not detected"),
+        "{output}"
+    );
+    assert!(
+        fs::symlink_metadata(hypr.join("bindings.lua"))
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
     stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();
 }
@@ -351,7 +591,7 @@ o.bind(\"SUPER + CTRL + W\", \"Close Shell\", \"boomux close --focused\")\n";
     drop(pty.slave);
     let mut reader = pty.master.try_clone_reader().unwrap();
     let mut writer = pty.master.take_writer().unwrap();
-    writer.write_all(b"no\nno\nno\n").unwrap();
+    writer.write_all(b"no\n").unwrap();
     drop(writer);
     assert!(child.wait().unwrap().success());
     let mut output = String::new();
@@ -360,11 +600,8 @@ o.bind(\"SUPER + CTRL + W\", \"Close Shell\", \"boomux close --focused\")\n";
         output.contains("compatible user-managed profile"),
         "{output}"
     );
-    assert!(output.contains("Reinstall impact"), "{output}");
-    assert!(
-        output.contains("Reinstall the standard Boomux keybinding profile?"),
-        "{output}"
-    );
+    assert!(output.contains("No changes are needed."), "{output}");
+    assert!(!output.contains("Reinstall the standard Boomux keybinding profile?"));
     assert_eq!(fs::read(hypr.join("bindings.lua")).unwrap(), bindings);
     stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();
@@ -422,10 +659,22 @@ fn guided_setup_restores_bindings_after_hyprland_validation_failure() {
     command.env("HYPRLAND_INSTANCE_SIGNATURE", "test-instance");
     let mut child = pty.slave.spawn_command(command).unwrap();
     drop(pty.slave);
+    let mut reader = pty.master.try_clone_reader().unwrap();
     let mut writer = pty.master.take_writer().unwrap();
-    writer.write_all(b"no\nyes\nyes\n").unwrap();
+    writer.write_all(b"yes\nyes\n").unwrap();
     drop(writer);
     assert!(!child.wait().unwrap().success());
+    let mut output = String::new();
+    std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
+    assert!(output.contains("BOOMUX SETUP RECEIPT"), "{output}");
+    assert!(
+        output.contains("Recovery: run `omarchy plugin list --json`, then `boomux setup`"),
+        "{output}"
+    );
+    assert!(
+        output.contains("enabled before a later desktop step failed"),
+        "{output}"
+    );
     assert_eq!(fs::read(hypr.join("bindings.lua")).unwrap(), baseline);
     stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();


### PR DESCRIPTION
## Summary
- inspect the complete machine-specific setup plan before mutation
- apply recommended Omarchy defaults without redundant rerun prompts
- render typed current, changed, skipped, warning, and failed outcomes with exact recovery guidance
- delay daemon startup until verification and report a state-based next action

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `cargo test --test config_cli --locked -- --test-threads=1`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`