### PR TITLE
feat(install): add verified guided installer

### DIFF
--- a/.github/scripts/package-release.sh
+++ b/.github/scripts/package-release.sh
@@ -49,6 +49,13 @@ for file in LICENSE README.md THIRD_PARTY_NOTICES.md; do
     exit 1
   fi
 done
+packaged_readme="${smoke_dir}/${package}/README.md"
+if ! grep -Fq 'releases/latest/download/boomux-installer.sh' "$packaged_readme" \
+  || ! grep -Fq 'offers to run `boomux setup` immediately' "$packaged_readme" \
+  || ! grep -Fq '~/.local/bin/boomux setup' "$packaged_readme"; then
+  printf 'packaged README is missing the installer or setup handoff\n' >&2
+  exit 1
+fi
 
 smoke_home="${smoke_dir}/home"
 smoke_bin="${smoke_dir}/bin"

--- a/.github/scripts/test-update-release-notes.sh
+++ b/.github/scripts/test-update-release-notes.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(mktemp -d)
+cleanup() {
+  rm -rf "$root"
+}
+trap cleanup EXIT
+
+mkdir "$root/bin"
+printf 'Generated release notes' > "$root/body"
+printf '0' > "$root/updates"
+cat > "$root/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ " $* " == *' --method PATCH '* ]]; then
+  for argument in "$@"; do
+    case $argument in
+      body=*) printf '%s' "${argument#body=}" > "$RELEASE_BODY" ;;
+    esac
+  done
+  updates=$(<"$RELEASE_UPDATES")
+  printf '%s' "$((updates + 1))" > "$RELEASE_UPDATES"
+elif [[ " $* " == *' --jq .id '* ]]; then
+  printf '42\n'
+elif [[ " $* " == *' --include '* ]]; then
+  printf 'HTTP/2 200\netag: "fixture-%s"\n\n' "$(<"$RELEASE_UPDATES")"
+  cat "$RELEASE_BODY"
+else
+  cat "$RELEASE_BODY"
+fi
+EOF
+chmod 755 "$root/bin/gh"
+
+for _ in first second; do
+  GH_REPO=gardnmi/boomux \
+    RELEASE_BODY="$root/body" \
+    RELEASE_UPDATES="$root/updates" \
+    PATH="$root/bin:/usr/bin:/bin" \
+    bash .github/scripts/update-release-notes.sh v1.2.3 >/dev/null
+done
+
+[[ $(<"$root/updates") == 1 ]]
+grep -F 'Generated release notes' "$root/body" >/dev/null
+grep -F 'releases/latest/download/boomux-installer.sh' "$root/body" >/dev/null
+grep -F '`~/.local/bin/boomux setup`' "$root/body" >/dev/null
+grep -F '<!-- /boomux-install-handoff -->' "$root/body" >/dev/null
+
+for malformed in \
+  '<!-- /boomux-install-handoff -->' \
+  '<!-- boomux-install-handoff --><!-- boomux-install-handoff -->'; do
+  printf '%s\n' 'Generated release notes' "$malformed" > "$root/body"
+  if GH_REPO=gardnmi/boomux RELEASE_BODY="$root/body" \
+    RELEASE_UPDATES="$root/updates" PATH="$root/bin:/usr/bin:/bin" \
+    bash .github/scripts/update-release-notes.sh v1.2.3 >/dev/null 2>&1; then
+    printf 'release-note updater accepted malformed marker structure\n' >&2
+    exit 1
+  fi
+  [[ $(<"$root/updates") == 1 ]]
+done
+
+printf '%s\n' 'Generated release notes' '<!-- boomux-install-handoff -->' 'broken' > "$root/body"
+if GH_REPO=gardnmi/boomux RELEASE_BODY="$root/body" \
+  RELEASE_UPDATES="$root/updates" PATH="$root/bin:/usr/bin:/bin" \
+  bash .github/scripts/update-release-notes.sh v1.2.3 >/dev/null 2>&1; then
+  printf 'release-note updater accepted a malformed managed block\n' >&2
+  exit 1
+fi
+[[ $(<"$root/updates") == 1 ]]

--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag=${1:?usage: update-release-notes.sh TAG}
+if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  printf 'release tag must be strict vMAJOR.MINOR.PATCH: %s\n' "$tag" >&2
+  exit 1
+fi
+repo=${GH_REPO:-${GITHUB_REPOSITORY:-}}
+if [[ -z "$repo" ]]; then
+  printf 'GH_REPO or GITHUB_REPOSITORY must be set\n' >&2
+  exit 1
+fi
+
+marker='<!-- boomux-install-handoff -->'
+end_marker='<!-- /boomux-install-handoff -->'
+release_id=$(gh api "repos/${repo}/releases/tags/${tag}" --jq .id 2>/dev/null || true)
+if [[ -z "$release_id" ]]; then
+  release_id=$(gh api --paginate "repos/${repo}/releases?per_page=100" \
+    --jq ".[] | select(.tag_name == \"$tag\") | .id")
+fi
+if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+  printf 'could not resolve one release for %s\n' "$tag" >&2
+  exit 1
+fi
+read -r -d '' handoff <<'EOF' || true
+<!-- boomux-install-handoff -->
+## Install Boomux
+
+```console
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/gardnmi/boomux/releases/latest/download/boomux-installer.sh | sh
+```
+
+The verified installer offers to run `boomux setup` immediately. If setup is
+deferred or interrupted, run `~/.local/bin/boomux setup` to continue.
+<!-- /boomux-install-handoff -->
+EOF
+
+endpoint="repos/${repo}/releases/${release_id}"
+count_occurrences() {
+  local remaining=$1
+  local needle=$2
+  local count=0
+  while [[ "$remaining" == *"$needle"* ]]; do
+    remaining=${remaining#*"$needle"}
+    count=$((count + 1))
+  done
+  printf '%s\n' "$count"
+}
+
+for attempt in 1 2 3; do
+  body=$(gh api "$endpoint" --jq '.body // ""')
+  marker_count=$(count_occurrences "$body" "$marker")
+  end_marker_count=$(count_occurrences "$body" "$end_marker")
+  if [[ "$marker_count" != 0 || "$end_marker_count" != 0 ]]; then
+    if [[ "$marker_count" != 1 || "$end_marker_count" != 1 || "$body" != *"$handoff" ]]; then
+      printf 'release notes contain a malformed installation handoff\n' >&2
+      exit 1
+    fi
+    printf 'release notes already contain installation handoff\n'
+    exit 0
+  fi
+
+  response=$(gh api --include "$endpoint")
+  etag=$(printf '%s\n' "$response" | sed -n 's/^[Ee][Tt][Aa][Gg]:[[:space:]]*//p' | tr -d '\r' | sed -n '1p')
+  if [[ -z "$etag" ]]; then
+    printf 'release response did not include an ETag\n' >&2
+    exit 1
+  fi
+  if [[ $(gh api "$endpoint" --jq '.body // ""') != "$body" ]]; then
+    continue
+  fi
+
+  updated=$body
+  if [[ -n "$updated" ]]; then
+    updated+=$'\n\n'
+  fi
+  updated+=$handoff
+  if gh api --method PATCH "$endpoint" -H "If-Match: $etag" -f body="$updated" >/dev/null; then
+    verified=$(gh api "$endpoint" --jq '.body // ""')
+    marker_count=$(count_occurrences "$verified" "$marker")
+    end_marker_count=$(count_occurrences "$verified" "$end_marker")
+    if [[ "$marker_count" == 1 && "$end_marker_count" == 1 && "$verified" == *"$handoff" ]]; then
+      exit 0
+    fi
+  fi
+done
+
+printf 'release notes changed concurrently; handoff was not applied\n' >&2
+exit 1

--- a/.github/scripts/upload-release-assets.sh
+++ b/.github/scripts/upload-release-assets.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 tag=${1:?usage: upload-release-assets.sh TAG ASSET...}
 shift
+if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  printf 'release tag must be strict vMAJOR.MINOR.PATCH: %s\n' "$tag" >&2
+  exit 1
+fi
 
 if (($# == 0)); then
   printf 'no release assets supplied\n' >&2
@@ -16,6 +20,7 @@ if [[ -z "$repo" ]]; then
 fi
 
 declare -A expected_assets=()
+expected_assets[boomux-installer.sh]=1
 for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
   archive="boomux-${tag}-${target}.tar.gz"
   expected_assets["$archive"]=1
@@ -59,8 +64,28 @@ for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
     sha256sum --check "$(basename "${local_assets[${archive}.sha256]}")"
   )
 done
+installer=${local_assets[boomux-installer.sh]}
+sh -n "$installer"
+if ! grep -Fq "tag='$tag'" "$installer"; then
+  printf 'release installer does not target %s\n' "$tag" >&2
+  exit 1
+fi
+if ! grep -Fq "repository='https://github.com/gardnmi/boomux'" "$installer" \
+  || grep -Fq 'BOOMUX_INSTALL_BASE_URL' "$installer" \
+  || ! grep -Fq 'Run the guided setup now? [Y/n]' "$installer"; then
+  printf 'release installer does not preserve the reviewed origin and setup handoff\n' >&2
+  exit 1
+fi
 
-release_id=$(gh api "repos/${repo}/releases/tags/${tag}" --jq .id)
+release_id=$(gh api "repos/${repo}/releases/tags/${tag}" --jq .id 2>/dev/null || true)
+if [[ -z "$release_id" ]]; then
+  release_id=$(gh api --paginate "repos/${repo}/releases?per_page=100" \
+    --jq ".[] | select(.tag_name == \"$tag\") | .id")
+fi
+if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+  printf 'could not resolve one release for %s\n' "$tag" >&2
+  exit 1
+fi
 declare -A remote_digests=()
 declare -A remote_ids=()
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,11 @@ jobs:
 
       - name: Validate release scripts
         if: ${{ matrix.arch == 'x86_64' }}
-        run: bash -n .github/scripts/package-release.sh .github/scripts/upload-release-assets.sh
+        run: |
+          bash -n .github/scripts/package-release.sh .github/scripts/upload-release-assets.sh .github/scripts/update-release-notes.sh .github/scripts/test-update-release-notes.sh packaging/render-installer.sh packaging/test-installer.sh
+          sh -n packaging/install-release.sh.in
+          bash packaging/test-installer.sh
+          bash .github/scripts/test-update-release-notes.sh
 
   aur-package:
     name: AUR package metadata
@@ -124,6 +128,7 @@ jobs:
             packaging/aur/render-pkgbuild.sh 1.2.3 "$tmp/boomux-v1.2.3-x86_64-unknown-linux-gnu.tar.gz" "$tmp/boomux-v1.2.3-aarch64-unknown-linux-gnu.tar.gz" "$tmp/second"
             cmp "$tmp/first/PKGBUILD" "$tmp/second/PKGBUILD"
             cmp "$tmp/first/.SRCINFO" "$tmp/second/.SRCINFO"
+            cmp "$tmp/first/boomux-bin.install" "$tmp/second/boomux-bin.install"
             packaging/aur/validate-pkgbuild.sh "$tmp/first"
             rm -rf "$tmp"
           ' _ "$GITHUB_WORKSPACE"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,8 @@ jobs:
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
       tag-name: ${{ inputs.tag || steps.release.outputs.tag_name }}
+      release-sha: ${{ steps.release.outputs.sha }}
+      source-ref: ${{ steps.dispatch-release.outputs.source-ref || steps.release.outputs.sha }}
     steps:
       - name: Run Release Please
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.tag == '' }}
@@ -35,6 +37,34 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Resolve dispatched release source
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.tag != '' }}
+        id: dispatch-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            printf 'release tag must be strict vMAJOR.MINOR.PATCH: %s\n' "$TAG" >&2
+            exit 1
+          fi
+          release_id=$(gh api "repos/$GH_REPO/releases/tags/$TAG" --jq .id 2>/dev/null || true)
+          if [[ -z "$release_id" ]]; then
+            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select(.tag_name == \"$TAG\") | .id")
+          fi
+          if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+            printf 'could not resolve one release for %s\n' "$TAG" >&2
+            exit 1
+          fi
+          draft=$(gh api "repos/$GH_REPO/releases/$release_id" --jq .draft)
+          if [[ "$draft" == true ]]; then
+            source_ref=$(gh api "repos/$GH_REPO/releases/$release_id" --jq .target_commitish)
+          else
+            source_ref=$TAG
+          fi
+          printf 'source-ref=%s\n' "$source_ref" >> "$GITHUB_OUTPUT"
 
   build-release:
     name: Build Linux ${{ matrix.arch }} release
@@ -56,11 +86,12 @@ jobs:
       RUSTUP_TOOLCHAIN: stable
       TARGET: ${{ matrix.target }}
       TAG: ${{ needs.release-please.outputs.tag-name }}
+      SOURCE_REF: ${{ needs.release-please.outputs.source-ref }}
     steps:
       - name: Check out release tag
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
-          ref: ${{ env.TAG }}
+          ref: ${{ env.SOURCE_REF }}
 
       - name: Install Rust toolchain
         run: rustup toolchain install stable --profile minimal
@@ -88,11 +119,12 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
       TAG: ${{ needs.release-please.outputs.tag-name }}
+      SOURCE_REF: ${{ needs.release-please.outputs.source-ref }}
     steps:
       - name: Check out release tag
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
-          ref: ${{ env.TAG }}
+          ref: ${{ env.SOURCE_REF }}
 
       - name: Download release artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
@@ -101,5 +133,21 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Render release installer
+        run: packaging/render-installer.sh "$TAG" dist/boomux-installer.sh
+
       - name: Upload assets to GitHub Release
         run: bash .github/scripts/upload-release-assets.sh "$TAG" dist/*
+
+      - name: Add installation handoff to release notes
+        run: bash .github/scripts/update-release-notes.sh "$TAG"
+
+      - name: Publish completed release
+        run: |
+          release_id=$(gh api "repos/$GH_REPO/releases/tags/$TAG" --jq .id 2>/dev/null || true)
+          if [[ -z "$release_id" ]]; then
+            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select(.tag_name == \"$TAG\") | .id")
+          fi
+          if [[ $(gh api "repos/$GH_REPO/releases/$release_id" --jq .draft) == true ]]; then
+            gh release edit "$TAG" --draft=false --repo "$GH_REPO"
+          fi

--- a/README.md
+++ b/README.md
@@ -61,20 +61,33 @@ controls and safety behavior. For CLI-only creation, continue to
 
 ### Requirements
 
-- A Unix-like system with an absolute `XDG_RUNTIME_DIR`. Official v1.2.0 binaries
-  are available only for x86_64 and aarch64 GNU/Linux.
+- A Unix-like system with an absolute `XDG_RUNTIME_DIR`. Official binaries are
+  available only for x86_64 and aarch64 GNU/Linux.
 - `xdg-terminal-exec` and an available terminal desktop entry.
 
 Git is optional for core session persistence; without it, repository metadata is
 empty. `boomux doctor` currently reports missing Git as a failed dependency
-check. The default desktop Workspace layer additionally requires an active
+check. The optional desktop Workspace layer additionally requires an active
 Hyprland session and compatible `hyprctl`. Outside Hyprland, ordinary Boomux
 terminal opens remain native windows.
 
-The release recipe below requires GitHub CLI (`gh`), `sha256sum`, `tar`, and
-`install`.
+The guided installer requires `curl`, `sha256sum`, `tar`, and `install`.
 
 ### Latest Release
+
+```console
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/gardnmi/boomux/releases/latest/download/boomux-installer.sh | sh
+```
+
+The release-pinned installer verifies the published archive checksum, installs
+to `~/.local/bin/boomux`, and offers to run `boomux setup` immediately. It
+refuses to replace an existing installation; use that installation's update
+mechanism instead. Pass `--no-setup` with `sh -s -- --no-setup` when a
+noninteractive installation should print the next command without opening the
+wizard. See the [installation contract](docs/install.md) for exact guarantees.
+
+To inspect and install the release manually, use GitHub CLI (`gh`):
 
 ```console
 case "$(uname -s):$(uname -m)" in
@@ -88,7 +101,7 @@ gh release download "$version" --repo gardnmi/boomux \
 sha256sum --check "boomux-$version-$target.tar.gz.sha256"
 tar -xzf "boomux-$version-$target.tar.gz"
 install -Dm755 "boomux-$version-$target/boomux" ~/.local/bin/boomux
-~/.local/bin/boomux doctor
+~/.local/bin/boomux setup
 ```
 
 ### Update
@@ -109,11 +122,6 @@ plugin is installed, the same confirmation authorizes updating it after Boomux
 and reloading it when enabled. Other installation types must be updated through
 their original installer. Boomux never silently downgrades or enables automatic
 updates.
-
-> [!CAUTION]
-> Upgrading from v0.32 to v1.x crosses an incompatible protocol and state
-> boundary. It requires a cold upgrade that terminates managed processes. Follow
-> the exact [local update procedure](docs/local-update.md#protocol-47-alpha-break).
 
 Prefer `daemon restart` over `daemon stop`: stopping the daemon terminates every
 managed process. Upgrade registered remote Nodes separately with

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,9 @@
 - **Local update ownership:** [`local-update.md`](local-update.md) defines the
   official-release eligibility, package-manager refusal, no-downgrade rule,
   atomic replacement, and graceful daemon handoff boundary.
+- **Official first installation:** [`install.md`](install.md) defines the
+  release-pinned installer, checksum verification, existing-target refusal, and
+  interactive setup handoff.
 - **Local uninstall ownership:** [`uninstall.md`](uninstall.md) reuses the
   official-release ownership boundary, preserves modified assets and user data
   by default, and removes the executable only after process cleanup.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,63 @@
+# Official Installation Contract
+
+> **Status: Current contract.** This document governs the release-pinned
+> `boomux-installer.sh` asset. Package managers and source builds retain their
+> own installation ownership.
+
+## Surface
+
+Each stable GitHub release publishes `boomux-installer.sh` alongside the native
+GNU/Linux archives. The stable entry point is:
+
+```console
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/gardnmi/boomux/releases/latest/download/boomux-installer.sh | sh
+```
+
+The installer supports only `--no-setup`. Unknown arguments fail before network
+or filesystem mutation. It never invokes privilege escalation or a package
+manager.
+
+## Platform And Destination
+
+The installer accepts only x86_64 and aarch64 GNU/Linux release targets. `HOME`
+must be absolute. `HOME`, `~/.local`, and `~/.local/bin` must be real,
+current-user-owned directories that are not group/world-writable; missing local
+directories are created owner-only. The sole destination is
+`~/.local/bin/boomux`.
+
+An existing file or symbolic link at that destination is never replaced, even
+if it appears while the installer is running. The operator must use `boomux
+update`, the owning package manager, or the workflow that owns a source or
+custom installation. This keeps first installation separate from the local
+update ownership and graceful daemon handoff contract.
+
+## Integrity
+
+The installer is rendered for one strict `vMAJOR.MINOR.PATCH` release tag. It
+downloads only that tag's exact architecture archive and checksum sidecar from
+the fixed `gardnmi/boomux` HTTPS repository. Curl is restricted to HTTPS with
+TLS 1.2 or newer. The sidecar must validate through `sha256sum`, extraction must
+produce the exact expected executable path, and the candidate must print the
+embedded release version before installation.
+
+Temporary files are removed on success, failure, or interruption. The verified
+candidate is installed executable at the fixed destination only after all
+checks pass.
+
+## Setup Handoff
+
+After installation, an available controlling terminal receives:
+
+```text
+Run the guided setup now? [Y/n]
+```
+
+The default runs the installed binary's human-only `setup` command with terminal
+input and output attached directly to that controlling terminal. Declining,
+passing `--no-setup`, or running without a controlling terminal prints the exact
+absolute setup command instead.
+
+Setup failure does not remove the verified Boomux installation. The installer
+reports that installation succeeded, reports setup as incomplete, prints the
+exact retry command, and exits nonzero.

--- a/docs/local-update.md
+++ b/docs/local-update.md
@@ -130,15 +130,19 @@ than blocking the Boomux executable update.
 
 ## Release And Package Channels
 
-Release Please remains the version and tag authority. Its release build matrix
+Release Please remains the version and tag authority. It creates a draft release
+without exposing a tag, then its release build matrix
 produces native `x86_64-unknown-linux-gnu` and
 `aarch64-unknown-linux-gnu` archives, smoke-tests each on a native GitHub-hosted
 runner, and publishes assets idempotently. Existing same-digest assets are left
 unchanged; a same-name digest conflict fails instead of clobbering a release.
+Before atomically publishing the completed draft and tag, the workflow
+idempotently appends the reviewed installer and `boomux setup` handoff to the
+generated GitHub release notes without replacing Release Please's content.
 
 The AUR package is `boomux-bin` because it consumes prebuilt release artifacts.
 Its architecture-specific sources pin both archive checksums. The AUR Git
-repository contains generated `PKGBUILD` and `.SRCINFO`; this source repository
-retains the reviewed template and deterministic renderer. AUR publication is a
-separate maintainer action and never grants the local updater ownership of
-pacman-managed files.
+repository contains generated `PKGBUILD`, `.SRCINFO`, and the post-install setup
+reminder; this source repository retains the reviewed templates and deterministic
+renderer. AUR publication is a separate maintainer action and never grants the
+local updater ownership of pacman-managed files.

--- a/packaging/aur/PKGBUILD.in
+++ b/packaging/aur/PKGBUILD.in
@@ -16,6 +16,7 @@ optdepends=(
 provides=("boomux=${pkgver}")
 conflicts=('boomux')
 options=('!strip')
+install=boomux-bin.install
 source_x86_64=("boomux-${pkgver}-x86_64.tar.gz::${url}/releases/download/v${pkgver}/boomux-v${pkgver}-x86_64-unknown-linux-gnu.tar.gz")
 source_aarch64=("boomux-${pkgver}-aarch64.tar.gz::${url}/releases/download/v${pkgver}/boomux-v${pkgver}-aarch64-unknown-linux-gnu.tar.gz")
 sha256sums_x86_64=('@X86_64_SHA256@')

--- a/packaging/aur/boomux-bin.install
+++ b/packaging/aur/boomux-bin.install
@@ -1,0 +1,3 @@
+post_install() {
+  printf '%s\n' 'Boomux is installed. Run `boomux setup` to configure this machine.'
+}

--- a/packaging/aur/render-pkgbuild.sh
+++ b/packaging/aur/render-pkgbuild.sh
@@ -58,6 +58,7 @@ srcinfo_tmp="${output_dir}/.SRCINFO.tmp.$$"
 trap 'rm -f "$pkgbuild_tmp" "$srcinfo_tmp"' EXIT
 printf '%s\n' "$rendered" > "$pkgbuild_tmp"
 mv "$pkgbuild_tmp" "${output_dir}/PKGBUILD"
+cp "${script_dir}/boomux-bin.install" "${output_dir}/boomux-bin.install"
 (
   cd "$output_dir"
   makepkg --printsrcinfo > "$srcinfo_tmp"

--- a/packaging/aur/validate-pkgbuild.sh
+++ b/packaging/aur/validate-pkgbuild.sh
@@ -6,8 +6,9 @@ set -euo pipefail
 directory=${1:?usage: validate-pkgbuild.sh DIRECTORY}
 pkgbuild="${directory}/PKGBUILD"
 srcinfo="${directory}/.SRCINFO"
+install_script="${directory}/boomux-bin.install"
 
-for file in "$pkgbuild" "$srcinfo"; do
+for file in "$pkgbuild" "$srcinfo" "$install_script"; do
   if [[ ! -f "$file" ]]; then
     printf 'AUR metadata not found: %s\n' "$file" >&2
     exit 1
@@ -23,6 +24,12 @@ if grep -Eq '@(VERSION|X86_64_SHA256|AARCH64_SHA256)@' "$pkgbuild" "$srcinfo"; t
 fi
 
 bash -n "$pkgbuild"
+bash -n "$install_script"
+hook_output=$(bash -c 'source "$1"; post_install' _ "$install_script")
+if [[ "$hook_output" != 'Boomux is installed. Run `boomux setup` to configure this machine.' ]]; then
+  printf 'AUR install hook must print only the reviewed setup reminder\n' >&2
+  exit 1
+fi
 bash -c '
   set -euo pipefail
   source "$1"
@@ -31,6 +38,7 @@ bash -c '
   [[ "${depends[*]}" == "curl gcc-libs git glibc xdg-terminal-exec" ]]
   [[ "${provides[*]}" == "boomux=${pkgver}" ]]
   [[ "${conflicts[*]}" == boomux ]]
+  [[ "$install" == boomux-bin.install ]]
   [[ ${#source_x86_64[@]} -eq 1 && ${#source_aarch64[@]} -eq 1 ]]
   [[ ${sha256sums_x86_64[0]} =~ ^[0-9a-f]{64}$ ]]
   [[ ${sha256sums_aarch64[0]} =~ ^[0-9a-f]{64}$ ]]
@@ -40,6 +48,7 @@ bash -c '
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 cp "$pkgbuild" "${tmp_dir}/PKGBUILD"
+cp "$install_script" "${tmp_dir}/boomux-bin.install"
 (
   cd "$tmp_dir"
   makepkg --printsrcinfo > .SRCINFO

--- a/packaging/install-release.sh.in
+++ b/packaging/install-release.sh.in
@@ -1,0 +1,169 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Mike Gardner
+# SPDX-License-Identifier: 0BSD
+set -eu
+
+tag='@TAG@'
+repository='https://github.com/gardnmi/boomux'
+run_setup=true
+
+usage() {
+  printf 'Usage: boomux-installer.sh [--no-setup]\n'
+}
+
+if [ "$#" -gt 1 ]; then
+  usage >&2
+  exit 64
+fi
+case ${1-} in
+  '') ;;
+  --no-setup) run_setup=false ;;
+  -h|--help) usage; exit 0 ;;
+  *) usage >&2; exit 64 ;;
+esac
+
+case "$(uname -s):$(uname -m)" in
+  Linux:x86_64) target=x86_64-unknown-linux-gnu ;;
+  Linux:aarch64) target=aarch64-unknown-linux-gnu ;;
+  *)
+    printf 'Boomux has no official release for %s.\n' "$(uname -s):$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+for command in curl id install ln mkdir mktemp rm sha256sum stat tar uname; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    printf '%s is required to install Boomux.\n' "$command" >&2
+    exit 1
+  fi
+done
+
+case ${HOME-} in
+  /*) ;;
+  *) printf 'HOME must be an absolute path.\n' >&2; exit 1 ;;
+esac
+
+validate_directory() {
+  directory=$1
+  label=$2
+  if [ ! -d "$directory" ] || [ -L "$directory" ]; then
+    printf '%s must be a real directory: %s\n' "$label" "$directory" >&2
+    exit 1
+  fi
+  owner=$(stat -c '%u' -- "$directory")
+  mode=$(stat -c '%a' -- "$directory")
+  if [ "$owner" != "$(id -u)" ] || [ $(((mode / 10) % 10 & 2)) -ne 0 ] \
+    || [ $((mode % 10 & 2)) -ne 0 ]; then
+    printf '%s must be owned by the current user and not group/world-writable: %s\n' \
+      "$label" "$directory" >&2
+    exit 1
+  fi
+}
+
+validate_directory "$HOME" HOME
+local_directory=$HOME/.local
+bin_directory=$local_directory/bin
+if [ ! -e "$local_directory" ] && [ ! -L "$local_directory" ]; then
+  (umask 077 && mkdir "$local_directory")
+fi
+validate_directory "$local_directory" '~/.local'
+if [ ! -e "$bin_directory" ] && [ ! -L "$bin_directory" ]; then
+  (umask 077 && mkdir "$bin_directory")
+fi
+validate_directory "$bin_directory" '~/.local/bin'
+
+destination=$bin_directory/boomux
+if [ -e "$destination" ] || [ -L "$destination" ]; then
+  printf 'Boomux is already installed at %s.\n' "$destination" >&2
+  printf 'Use `boomux update` or the installation method that owns that file.\n' >&2
+  exit 1
+fi
+
+package=boomux-${tag}-${target}
+archive=${package}.tar.gz
+checksum=${archive}.sha256
+base_url=${repository}/releases/download/${tag}
+temporary=$(mktemp -d "${TMPDIR:-/tmp}/boomux-install.XXXXXX")
+staged=
+cleanup() {
+  if [ -n "$staged" ]; then rm -f "$staged"; fi
+  rm -rf "$temporary"
+}
+trap cleanup EXIT HUP INT TERM
+
+printf 'Downloading Boomux %s for %s...\n' "${tag#v}" "$target"
+curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+  --output "$temporary/$archive" "$base_url/$archive"
+curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+  --output "$temporary/$checksum" "$base_url/$checksum"
+(
+  cd "$temporary"
+  {
+    IFS=' ' read -r expected expected_archive trailing \
+      || { printf 'The release checksum is malformed.\n' >&2; exit 1; }
+    if IFS= read -r unexpected; then
+      printf 'The release checksum contains unexpected entries.\n' >&2
+      exit 1
+    fi
+    case $expected in
+      *[!0-9a-f]*) valid=false ;;
+      *) valid=true ;;
+    esac
+    if [ "$valid" != true ] || [ "${#expected}" -ne 64 ] \
+      || [ "$expected_archive" != "$archive" ] || [ -n "$trailing" ]; then
+      printf 'The release checksum does not name the expected archive.\n' >&2
+      exit 1
+    fi
+    printf '%s  %s\n' "$expected" "$archive" | sha256sum --check -
+  } < "$checksum"
+)
+tar -C "$temporary" -xzf "$temporary/$archive"
+
+candidate=$temporary/$package/boomux
+if [ ! -f "$candidate" ] || [ -L "$candidate" ] || [ ! -x "$candidate" ]; then
+  printf 'The verified release archive did not contain the expected Boomux binary.\n' >&2
+  exit 1
+fi
+actual=$("$candidate" --version)
+if [ "$actual" != "boomux ${tag#v}" ]; then
+  printf 'Expected boomux %s, got %s.\n' "${tag#v}" "$actual" >&2
+  exit 1
+fi
+
+staged=$(mktemp "$bin_directory/.boomux-install.XXXXXX")
+install -m755 "$candidate" "$staged"
+if ! ln -T "$staged" "$destination"; then
+  printf 'Boomux was not installed because the destination now exists: %s\n' \
+    "$destination" >&2
+  exit 1
+fi
+rm -f "$staged"
+staged=
+printf '\nBoomux %s installed at %s\n' "${tag#v}" "$destination"
+
+next_step() {
+  printf 'Next: %s setup\n' "$destination"
+}
+
+if [ "$run_setup" != true ]; then
+  next_step
+  exit 0
+fi
+
+if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+  printf '\nRun the guided setup now? [Y/n] ' >/dev/tty
+  response=
+  IFS= read -r response </dev/tty || response=n
+  case $response in
+    ''|y|Y|yes|YES|Yes)
+      if ! "$destination" setup </dev/tty >/dev/tty 2>/dev/tty; then
+        printf '\nBoomux is installed, but setup did not complete.\n' >&2
+        next_step >&2
+        exit 1
+      fi
+      ;;
+    *) next_step ;;
+  esac
+else
+  next_step
+fi

--- a/packaging/render-installer.sh
+++ b/packaging/render-installer.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Mike Gardner
+# SPDX-License-Identifier: 0BSD
+set -euo pipefail
+
+tag=${1:?usage: render-installer.sh TAG OUTPUT}
+output=${2:?usage: render-installer.sh TAG OUTPUT}
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+template="${script_dir}/install-release.sh.in"
+
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  printf 'tag must have the form vX.Y.Z: %s\n' "$tag" >&2
+  exit 1
+fi
+
+rendered=$(<"$template")
+rendered=${rendered//@TAG@/$tag}
+temporary="${output}.tmp.$$"
+trap 'rm -f "$temporary"' EXIT
+printf '%s\n' "$rendered" > "$temporary"
+chmod 755 "$temporary"
+mv "$temporary" "$output"

--- a/packaging/test-installer.sh
+++ b/packaging/test-installer.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Mike Gardner
+# SPDX-License-Identifier: 0BSD
+set -euo pipefail
+
+root=$(mktemp -d)
+cleanup() {
+  rm -rf "$root"
+}
+trap cleanup EXIT
+
+tag=v1.2.3
+target=x86_64-unknown-linux-gnu
+package="boomux-${tag}-${target}"
+archive="${package}.tar.gz"
+mkdir -p "$root/release/$package" "$root/bin" "$root/home"
+cat > "$root/release/$package/boomux" <<'EOF'
+#!/bin/sh
+if [ "${1-}" = --version ]; then printf 'boomux 1.2.3\n'; exit 0; fi
+exit 97
+EOF
+chmod 755 "$root/release/$package/boomux"
+tar -C "$root/release" -czf "$root/release/$archive" "$package"
+(
+  cd "$root/release"
+  sha256sum "$archive" > "${archive}.sha256"
+)
+
+cat > "$root/bin/curl" <<'EOF'
+#!/bin/sh
+output=
+url=
+previous=
+for argument do
+  if [ "$previous" = --output ]; then output=$argument; fi
+  previous=$argument
+  url=$argument
+done
+[ -n "$output" ] || exit 64
+cp "${BOOMUX_INSTALL_FIXTURES}/${url##*/}" "$output"
+EOF
+chmod 755 "$root/bin/curl"
+
+packaging/render-installer.sh "$tag" "$root/installer"
+if grep -Fq 'BOOMUX_INSTALL_BASE_URL' "$root/installer" \
+  || ! grep -Fq 'https://github.com/gardnmi/boomux' "$root/installer"; then
+  printf 'installer download origin is not fixed to the official repository\n' >&2
+  exit 1
+fi
+output=$(
+  BOOMUX_INSTALL_FIXTURES="$root/release" \
+  HOME="$root/home" \
+  PATH="$root/bin:/usr/bin:/bin" \
+  "$root/installer" --no-setup
+)
+[[ "$output" == *"Boomux 1.2.3 installed"* ]]
+[[ "$output" == *"Next: $root/home/.local/bin/boomux setup"* ]]
+[[ $("$root/home/.local/bin/boomux" --version) == 'boomux 1.2.3' ]]
+
+if BOOMUX_INSTALL_FIXTURES="$root/release" \
+  HOME="$root/home" \
+  PATH="$root/bin:/usr/bin:/bin" \
+  "$root/installer" --no-setup >"$root/reinstall.out" 2>"$root/reinstall.err"; then
+  printf 'installer replaced an existing Boomux installation\n' >&2
+  exit 1
+fi
+grep -F 'Boomux is already installed' "$root/reinstall.err" >/dev/null
+
+if HOME="$root/home" PATH="$root/bin:/usr/bin:/bin" \
+  "$root/installer" --no-setup unexpected >/dev/null 2>&1; then
+  printf 'installer accepted an extra argument\n' >&2
+  exit 1
+fi
+
+unsafe_home="$root/unsafe-home"
+mkdir "$unsafe_home"
+chmod 0777 "$unsafe_home"
+if BOOMUX_INSTALL_FIXTURES="$root/release" HOME="$unsafe_home" \
+  PATH="$root/bin:/usr/bin:/bin" "$root/installer" --no-setup >/dev/null 2>&1; then
+  printf 'installer accepted an unsafe HOME directory\n' >&2
+  exit 1
+fi
+
+checksum_home="$root/checksum-home"
+mkdir "$checksum_home"
+printf '%064d  %s\n' 0 "$archive" > "$root/release/${archive}.sha256"
+if BOOMUX_INSTALL_FIXTURES="$root/release" HOME="$checksum_home" \
+  PATH="$root/bin:/usr/bin:/bin" "$root/installer" --no-setup >/dev/null 2>&1; then
+  printf 'installer accepted a checksum mismatch\n' >&2
+  exit 1
+fi
+[[ ! -e "$checksum_home/.local/bin/boomux" ]]
+archive_digest=$(sha256sum "$root/release/$archive")
+archive_digest=${archive_digest%% *}
+printf '%s  other-archive.tar.gz\n' "$archive_digest" > "$root/release/${archive}.sha256"
+if BOOMUX_INSTALL_FIXTURES="$root/release" HOME="$checksum_home" \
+  PATH="$root/bin:/usr/bin:/bin" "$root/installer" --no-setup >/dev/null 2>&1; then
+  printf 'installer accepted a checksum for the wrong archive\n' >&2
+  exit 1
+fi
+[[ ! -e "$checksum_home/.local/bin/boomux" ]]
+(
+  cd "$root/release"
+  sha256sum "$archive" > "${archive}.sha256"
+)
+
+race_home="$root/race-home"
+mkdir "$race_home"
+cat > "$root/bin/ln" <<'EOF'
+#!/bin/sh
+case ${BOOMUX_RACE_KIND:-file} in
+  file) : > "$BOOMUX_RACE_DESTINATION" ;;
+  directory) mkdir "$BOOMUX_RACE_DESTINATION" ;;
+esac
+exec /usr/bin/ln "$@"
+EOF
+chmod 755 "$root/bin/ln"
+if BOOMUX_INSTALL_FIXTURES="$root/release" \
+  BOOMUX_RACE_DESTINATION="$race_home/.local/bin/boomux" \
+  HOME="$race_home" PATH="$root/bin:/usr/bin:/bin" \
+  "$root/installer" --no-setup >/dev/null 2>&1; then
+  printf 'installer replaced a destination created during installation\n' >&2
+  exit 1
+fi
+[[ -f "$race_home/.local/bin/boomux" ]]
+[[ ! -s "$race_home/.local/bin/boomux" ]]
+
+race_directory_home="$root/race-directory-home"
+mkdir "$race_directory_home"
+if BOOMUX_INSTALL_FIXTURES="$root/release" \
+  BOOMUX_RACE_DESTINATION="$race_directory_home/.local/bin/boomux" \
+  BOOMUX_RACE_KIND=directory HOME="$race_directory_home" \
+  PATH="$root/bin:/usr/bin:/bin" \
+  "$root/installer" --no-setup >/dev/null 2>&1; then
+  printf 'installer accepted a directory created at the destination\n' >&2
+  exit 1
+fi
+[[ -d "$race_directory_home/.local/bin/boomux" ]]
+[[ ! -e "$race_directory_home/.local/bin/boomux/.boomux-install."* ]]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,7 +18,8 @@
     ".": {
       "release-type": "rust",
       "package-name": "boomux",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "draft": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- reapplies the installer and distribution changes from #295 directly onto `main`
- #295 was accidentally merged into its feature-branch base after #294 merged
- this branch is tree-identical to the previously reviewed and validated installer branch

## Included
- verified release-pinned installer and setup handoff
- AUR, README, CLI help, packaged README, and release-note guidance
- draft release assembly followed by complete publication

## Validation
- #295 passed Rust, integrations, x86_64/aarch64 packaging, and AUR CI
- the recovered branch has no tree differences from `feat/verified-installer`