### PR TITLE
fix(release): use release token for draft publication

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.tag != '' }}
         id: dispatch-release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ inputs.tag }}
         run: |
@@ -116,7 +116,7 @@ jobs:
       - build-release
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
       GH_REPO: ${{ github.repository }}
       TAG: ${{ needs.release-please.outputs.tag-name }}
       SOURCE_REF: ${{ needs.release-please.outputs.source-ref }}


### PR DESCRIPTION
## Summary
- use the same release-capable token for draft lookup and publication that Release Please uses to create the draft
- allow workflow dispatch to recover an existing draft release

## Root cause
The default `github.token` could not resolve the v1.5.0 draft created with `RELEASE_PLEASE_TOKEN`, so asset publication failed with `could not resolve one release for v1.5.0`.

## Recovery
After merge, rerun the Release Please workflow with `tag=v1.5.0` to upload assets, append installation notes, and publish the existing draft.