### PR TITLE
fix(release): harden draft publication

### DIFF
--- a/.github/scripts/test-update-release-notes.sh
+++ b/.github/scripts/test-update-release-notes.sh
@@ -22,6 +22,12 @@ if [[ " $* " == *' --method PATCH '* ]]; then
   updates=$(<"$RELEASE_UPDATES")
   printf '%s' "$((updates + 1))" > "$RELEASE_UPDATES"
 elif [[ " $* " == *' --jq .id '* ]]; then
+  if [[ ${RELEASE_TAG_LOOKUP_FAIL:-0} == 1 ]]; then
+    printf '{"message":"Not Found"}\n'
+    exit 1
+  fi
+  printf '42\n'
+elif [[ "$*" == *'releases?per_page=100'* ]]; then
   printf '42\n'
 elif [[ " $* " == *' --include '* ]]; then
   printf 'HTTP/2 200\netag: "fixture-%s"\n\n' "$(<"$RELEASE_UPDATES")"
@@ -32,10 +38,15 @@ fi
 EOF
 chmod 755 "$root/bin/gh"
 
-for _ in first second; do
+for pass in first second; do
+  tag_lookup_fail=0
+  if [[ $pass == first ]]; then
+    tag_lookup_fail=1
+  fi
   GH_REPO=gardnmi/boomux \
     RELEASE_BODY="$root/body" \
     RELEASE_UPDATES="$root/updates" \
+    RELEASE_TAG_LOOKUP_FAIL="$tag_lookup_fail" \
     PATH="$root/bin:/usr/bin:/bin" \
     bash .github/scripts/update-release-notes.sh v1.2.3 >/dev/null
 done

--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -14,10 +14,12 @@ fi
 
 marker='<!-- boomux-install-handoff -->'
 end_marker='<!-- /boomux-install-handoff -->'
-release_id=$(gh api "repos/${repo}/releases/tags/${tag}" --jq .id 2>/dev/null || true)
-if [[ -z "$release_id" ]]; then
+release_id=$(gh api "repos/${repo}/releases/tags/${tag}" --jq .id 2>/dev/null \
+  | sed -n '/^[0-9][0-9]*$/p' || true)
+if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
   release_id=$(gh api --paginate "repos/${repo}/releases?per_page=100" \
-    --jq ".[] | select(.tag_name == \"$tag\") | .id")
+    --jq ".[] | select(.tag_name == \"$tag\") | .id" \
+    | sed -n '/^[0-9][0-9]*$/p')
 fi
 if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
   printf 'could not resolve one release for %s\n' "$tag" >&2
@@ -62,12 +64,6 @@ for attempt in 1 2 3; do
     exit 0
   fi
 
-  response=$(gh api --include "$endpoint")
-  etag=$(printf '%s\n' "$response" | sed -n 's/^[Ee][Tt][Aa][Gg]:[[:space:]]*//p' | tr -d '\r' | sed -n '1p')
-  if [[ -z "$etag" ]]; then
-    printf 'release response did not include an ETag\n' >&2
-    exit 1
-  fi
   if [[ $(gh api "$endpoint" --jq '.body // ""') != "$body" ]]; then
     continue
   fi
@@ -77,7 +73,7 @@ for attempt in 1 2 3; do
     updated+=$'\n\n'
   fi
   updated+=$handoff
-  if gh api --method PATCH "$endpoint" -H "If-Match: $etag" -f body="$updated" >/dev/null; then
+  if gh api --method PATCH "$endpoint" -f body="$updated" >/dev/null; then
     verified=$(gh api "$endpoint" --jq '.body // ""')
     marker_count=$(count_occurrences "$verified" "$marker")
     end_marker_count=$(count_occurrences "$verified" "$end_marker")
@@ -87,5 +83,5 @@ for attempt in 1 2 3; do
   fi
 done
 
-printf 'release notes changed concurrently; handoff was not applied\n' >&2
+printf 'release notes changed concurrently or update verification failed; handoff was not applied\n' >&2
 exit 1

--- a/.github/scripts/upload-release-assets.sh
+++ b/.github/scripts/upload-release-assets.sh
@@ -77,10 +77,12 @@ if ! grep -Fq "repository='https://github.com/gardnmi/boomux'" "$installer" \
   exit 1
 fi
 
-release_id=$(gh api "repos/${repo}/releases/tags/${tag}" --jq .id 2>/dev/null || true)
-if [[ -z "$release_id" ]]; then
+release_id=$(gh api "repos/${repo}/releases/tags/${tag}" --jq .id 2>/dev/null \
+  | sed -n '/^[0-9][0-9]*$/p' || true)
+if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
   release_id=$(gh api --paginate "repos/${repo}/releases?per_page=100" \
-    --jq ".[] | select(.tag_name == \"$tag\") | .id")
+    --jq ".[] | select(.tag_name == \"$tag\") | .id" \
+    | sed -n '/^[0-9][0-9]*$/p')
 fi
 if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
   printf 'could not resolve one release for %s\n' "$tag" >&2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,8 +29,25 @@ jobs:
       release-sha: ${{ steps.release.outputs.sha }}
       source-ref: ${{ steps.dispatch-release.outputs.source-ref || steps.release.outputs.sha }}
     steps:
-      - name: Run Release Please
+      - name: Check for pending draft release
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.tag == '' }}
+        id: pending-draft
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          draft_ids=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" \
+            --jq '.[] | select(.draft == true) | .id' \
+            | sed -n '/^[0-9][0-9]*$/p')
+          if [[ -n "$draft_ids" ]]; then
+            printf 'exists=true\n' >> "$GITHUB_OUTPUT"
+            printf 'An unpublished draft release exists; deferring the next release proposal.\n' >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf 'exists=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Release Please
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.tag == '') && steps.pending-draft.outputs.exists != 'true' }}
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
@@ -50,9 +67,9 @@ jobs:
             printf 'release tag must be strict vMAJOR.MINOR.PATCH: %s\n' "$TAG" >&2
             exit 1
           fi
-          release_id=$(gh api "repos/$GH_REPO/releases/tags/$TAG" --jq .id 2>/dev/null || true)
-          if [[ -z "$release_id" ]]; then
-            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select(.tag_name == \"$TAG\") | .id")
+          release_id=$(gh api "repos/$GH_REPO/releases/tags/$TAG" --jq .id 2>/dev/null | sed -n '/^[0-9][0-9]*$/p' || true)
+          if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select(.tag_name == \"$TAG\") | .id" | sed -n '/^[0-9][0-9]*$/p')
           fi
           if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
             printf 'could not resolve one release for %s\n' "$TAG" >&2
@@ -144,10 +161,11 @@ jobs:
 
       - name: Publish completed release
         run: |
-          release_id=$(gh api "repos/$GH_REPO/releases/tags/$TAG" --jq .id 2>/dev/null || true)
-          if [[ -z "$release_id" ]]; then
-            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select(.tag_name == \"$TAG\") | .id")
+          release_id=$(gh api "repos/$GH_REPO/releases/tags/$TAG" --jq .id 2>/dev/null | sed -n '/^[0-9][0-9]*$/p' || true)
+          if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select(.tag_name == \"$TAG\") | .id" | sed -n '/^[0-9][0-9]*$/p')
           fi
           if [[ $(gh api "repos/$GH_REPO/releases/$release_id" --jq .draft) == true ]]; then
-            gh release edit "$TAG" --draft=false --repo "$GH_REPO"
+            gh api --method PATCH "repos/$GH_REPO/releases/$release_id" \
+              -f tag_name="$TAG" -F draft=false >/dev/null
           fi


### PR DESCRIPTION
## Summary
- defer new Release Please proposals while an unpublished draft release exists
- resolve draft releases by numeric ID even when tag lookup emits a 404 payload
- update notes without unsupported `If-Match` PATCH headers and publish by release ID while preserving the intended tag

## Testing
- `bash .github/scripts/test-update-release-notes.sh`
- `bash -n .github/scripts/update-release-notes.sh .github/scripts/upload-release-assets.sh .github/scripts/test-update-release-notes.sh`
- YAML parse with Ruby `Psych`
- verified v1.5.0 latest installer download and SHA-256 (`9cfeaf9cde9f9ea0654514e663a6037cd6d2d20459aa4eae10bb3e3dba231919`)

Closes the workflow gap that generated #300 while v1.5.0 was still a draft.