### PR TITLE
fix(release): preserve draft tag during publication

### DIFF
--- a/.github/scripts/test-update-release-notes.sh
+++ b/.github/scripts/test-update-release-notes.sh
@@ -14,11 +14,17 @@ cat > "$root/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ " $* " == *' --method PATCH '* ]]; then
+  preserved_tag=false
   for argument in "$@"; do
     case $argument in
       body=*) printf '%s' "${argument#body=}" > "$RELEASE_BODY" ;;
+      tag_name=v1.2.3) preserved_tag=true ;;
     esac
   done
+  if [[ $preserved_tag != true ]]; then
+    printf 'release update did not preserve its tag name\n' >&2
+    exit 1
+  fi
   updates=$(<"$RELEASE_UPDATES")
   printf '%s' "$((updates + 1))" > "$RELEASE_UPDATES"
 elif [[ " $* " == *' --jq .id '* ]]; then

--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -18,7 +18,7 @@ release_id=$(gh api "repos/${repo}/releases/tags/${tag}" --jq .id 2>/dev/null \
   | sed -n '/^[0-9][0-9]*$/p' || true)
 if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
   release_id=$(gh api --paginate "repos/${repo}/releases?per_page=100" \
-    --jq ".[] | select(.tag_name == \"$tag\") | .id" \
+    --jq ".[] | select((.tag_name == \"$tag\") or (.draft == true and .name == \"$tag\")) | .id" \
     | sed -n '/^[0-9][0-9]*$/p')
 fi
 if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
@@ -73,7 +73,7 @@ for attempt in 1 2 3; do
     updated+=$'\n\n'
   fi
   updated+=$handoff
-  if gh api --method PATCH "$endpoint" -f body="$updated" >/dev/null; then
+  if gh api --method PATCH "$endpoint" -f tag_name="$tag" -f body="$updated" >/dev/null; then
     verified=$(gh api "$endpoint" --jq '.body // ""')
     marker_count=$(count_occurrences "$verified" "$marker")
     end_marker_count=$(count_occurrences "$verified" "$end_marker")

--- a/.github/scripts/upload-release-assets.sh
+++ b/.github/scripts/upload-release-assets.sh
@@ -81,7 +81,7 @@ release_id=$(gh api "repos/${repo}/releases/tags/${tag}" --jq .id 2>/dev/null \
   | sed -n '/^[0-9][0-9]*$/p' || true)
 if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
   release_id=$(gh api --paginate "repos/${repo}/releases?per_page=100" \
-    --jq ".[] | select(.tag_name == \"$tag\") | .id" \
+    --jq ".[] | select((.tag_name == \"$tag\") or (.draft == true and .name == \"$tag\")) | .id" \
     | sed -n '/^[0-9][0-9]*$/p')
 fi
 if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           release_id=$(gh api "repos/$GH_REPO/releases/tags/$TAG" --jq .id 2>/dev/null | sed -n '/^[0-9][0-9]*$/p' || true)
           if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
-            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select(.tag_name == \"$TAG\") | .id" | sed -n '/^[0-9][0-9]*$/p')
+            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select((.tag_name == \"$TAG\") or (.draft == true and .name == \"$TAG\")) | .id" | sed -n '/^[0-9][0-9]*$/p')
           fi
           if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
             printf 'could not resolve one release for %s\n' "$TAG" >&2
@@ -163,9 +163,17 @@ jobs:
         run: |
           release_id=$(gh api "repos/$GH_REPO/releases/tags/$TAG" --jq .id 2>/dev/null | sed -n '/^[0-9][0-9]*$/p' || true)
           if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
-            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select(.tag_name == \"$TAG\") | .id" | sed -n '/^[0-9][0-9]*$/p')
+            release_id=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" --jq ".[] | select((.tag_name == \"$TAG\") or (.draft == true and .name == \"$TAG\")) | .id" | sed -n '/^[0-9][0-9]*$/p')
           fi
-          if [[ $(gh api "repos/$GH_REPO/releases/$release_id" --jq .draft) == true ]]; then
-            gh api --method PATCH "repos/$GH_REPO/releases/$release_id" \
-              -f tag_name="$TAG" -F draft=false >/dev/null
+          if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+            printf 'could not resolve one release for %s\n' "$TAG" >&2
+            exit 1
+          fi
+          gh api --method PATCH "repos/$GH_REPO/releases/$release_id" \
+            -f tag_name="$TAG" -F draft=false >/dev/null
+          published=$(gh api "repos/$GH_REPO/releases/$release_id" \
+            --jq '[.tag_name, (.draft | tostring)] | join("\t")')
+          if [[ "$published" != "$TAG"$'\tfalse' ]]; then
+            printf 'release publication verification failed for %s\n' "$TAG" >&2
+            exit 1
           fi


### PR DESCRIPTION
## Summary
- preserve the intended tag when updating draft release notes
- recover drafts by release name if GitHub has rewritten their internal tag
- fail publication unless the release ID resolves and the final tag/draft state verifies

## Testing
- `bash .github/scripts/test-update-release-notes.sh`
- `bash -n .github/scripts/update-release-notes.sh .github/scripts/upload-release-assets.sh .github/scripts/test-update-release-notes.sh`
- YAML parse with Ruby `Psych`
- repaired and verified the live v1.5.1 release, all five assets, the latest installer URL, checksum, and tag

This addresses the silent publication failure observed after merging #302.