### PR TITLE
fix(release): create tags for draft releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,8 @@
       "release-type": "rust",
       "package-name": "boomux",
       "include-component-in-tag": false,
-      "draft": true
+      "draft": true,
+      "force-tag-creation": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- enable Release Please `force-tag-creation` for draft releases
- ensure the release tag exists before Release Please calculates the next proposal
- prevent historical commits from being regenerated as a bogus major release

## Testing
- parsed `release-please-config.json` with Ruby JSON
- `git diff --check`
- verified v1.5.2 is published, tagged, latest, and has no remaining draft

This is the documented Release Please setting for draft releases that need immediate tag visibility.