### PR TITLE
chore: harden public release readiness

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -505,7 +505,7 @@ boomux doctor
 `BOOMUX_SHELL_ID` is set. Bare `boomux` prints command help. `boomux doctor` can
 run in either context.
 
-`boomux web` serves an experimental read-only Agent PWA on
+`boomux web` serves an installable Agent dashboard on
 `127.0.0.1:3737`. Use `--port` to change the loopback port. `--tailscale` is an
 explicit mutation that publishes the dashboard and enabled OpenCode runtime
 through a connected PATH-resolved Tailscale CLI. It reuses compatible routes,
@@ -527,7 +527,9 @@ Conflicts and failures from an installed runtime remain fatal.
 an unrelated server. `--no-opencode-web` disables web-triggered runtime startup
 and native links. Boomux does not proxy or authenticate that full-control
 service. The private access layer owns TLS, authentication, and ACLs. Remote
-Agents remain unlinked.
+Agents remain unlinked. Current local Agent cards can authorize short-lived
+collaborative access to their exact active terminal; this is writable shell
+access, while the native terminal remains resize authority.
 Stop only the default gateway with `boomux web stop`, or an alternate gateway
 with `boomux web stop --port PORT`. This leaves the daemon, managed processes,
 and Shared Harness Runtime running. The command is safe when no matching gateway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,21 @@ jobs:
       - name: Run Rust unit tests
         run: cargo test --lib --bins --locked -- --test-threads=1
 
+      - name: Run configuration CLI tests
+        run: cargo test --test config_cli --locked -- --test-threads=1
+
       - name: Run native backend tests
         run: cargo test --test native_backend --locked -- --test-threads=1
+
+  dependency-policy:
+    name: Dependency policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Audit advisories, licenses, and dependency sources
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
 
   integrations:
     name: Integrations
@@ -94,6 +107,14 @@ jobs:
       - name: Package and smoke test native release
         run: bash .github/scripts/package-release.sh "$TAG" "$TARGET"
 
+      - name: Retain package for compatibility testing
+        if: ${{ matrix.arch == 'x86_64' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: compatibility-${{ matrix.target }}
+          path: dist/boomux-${{ env.TAG }}-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+
       - name: Validate release scripts
         if: ${{ matrix.arch == 'x86_64' }}
         run: |
@@ -132,3 +153,24 @@ jobs:
             packaging/aur/validate-pkgbuild.sh "$tmp/first"
             rm -rf "$tmp"
           ' _ "$GITHUB_WORKSPACE"
+
+  arch-compatibility:
+    name: Pinned Arch compatibility
+    needs: release-packaging
+    runs-on: ubuntu-24.04
+    container: archlinux:base-devel@sha256:68bfc3b0d277b08a99101dc9b94aaa03e5ae70cf1b4fb965c03b2b87b915760d
+    steps:
+      - name: Download x86_64 release package
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: compatibility-x86_64-unknown-linux-gnu
+          path: dist
+
+      - name: Smoke test Ubuntu-built binary on pinned Arch
+        run: |
+          archive=$(printf '%s\n' dist/boomux-v*-x86_64-unknown-linux-gnu.tar.gz)
+          package=${archive%.tar.gz}
+          package=${package#dist/}
+          tar -C dist -xzf "$archive"
+          dist/"$package"/boomux --version
+          dist/"$package"/boomux capabilities --json >/dev/null

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,11 @@
 name: Release Please
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       tag:
@@ -22,6 +24,10 @@ concurrency:
 
 jobs:
   release-please:
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.workflow_run.conclusion == 'success' &&
+           github.event.workflow_run.head_branch == github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
@@ -29,6 +35,20 @@ jobs:
       release-sha: ${{ steps.release.outputs.sha }}
       source-ref: ${{ steps.dispatch-release.outputs.source-ref || steps.release.outputs.sha }}
     steps:
+      - name: Verify triggering CI commit is current
+        if: ${{ github.event_name == 'workflow_run' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          current_sha=$(gh api "repos/$GH_REPO/commits/$DEFAULT_BRANCH" --jq .sha)
+          if [[ "$current_sha" != "$VALIDATED_SHA" ]]; then
+            printf 'CI validated %s, but %s is now %s\n' "$VALIDATED_SHA" "$DEFAULT_BRANCH" "$current_sha" >&2
+            exit 1
+          fi
+
       - name: Check for pending draft release
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.tag == '' }}
         id: pending-draft
@@ -54,6 +74,17 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Verify release source passed triggering CI
+        if: ${{ github.event_name == 'workflow_run' && steps.release.outputs.release_created == 'true' }}
+        env:
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+          VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [[ "$RELEASE_SHA" != "$VALIDATED_SHA" ]]; then
+            printf 'release source %s was not the CI-validated commit %s\n' "$RELEASE_SHA" "$VALIDATED_SHA" >&2
+            exit 1
+          fi
 
       - name: Resolve dispatched release source
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.tag != '' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ Run the same checks as CI:
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features --locked -- -D warnings
 cargo test --lib --bins --locked -- --test-threads=1
+cargo test --test config_cli --locked -- --test-threads=1
 cargo test --test native_backend --locked -- --test-threads=1
+cargo deny check
 bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
 ```
 
@@ -109,6 +111,8 @@ exercise process, socket, PTY, and daemon lifecycle behavior.
   version.
 - Squash-merge PRs into `main` so the conventional PR title becomes the
   main-branch commit consumed by Release Please.
+- Normal Release Please runs are triggered only after CI succeeds for the exact
+  `main` commit. Manual tag dispatch is reserved for explicit release recovery.
 - Before merging, update the PR title if its release type or scope changed.
 - If a PR contains existing non-conventional commits, add a Release Please
   commit override to the PR body and squash-merge it:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,9 +836,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]

--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ controls and safety behavior. For CLI-only creation, continue to
 
 ### Requirements
 
-- A Unix-like system with an absolute `XDG_RUNTIME_DIR`. Official binaries are
-  available only for x86_64 and aarch64 GNU/Linux.
+- Current Omarchy is the supported desktop environment. Official x86_64 release
+  binaries are compatibility-tested on a pinned Arch Linux baseline selected for
+  Omarchy. Official binaries are also built for aarch64 GNU/Linux; other Linux
+  desktop environments are best-effort when the requirements below are present.
+- An absolute `XDG_RUNTIME_DIR`.
 - `xdg-terminal-exec` and an available terminal desktop entry.
 
 Git is optional for core session persistence; without it, repository metadata is
@@ -435,12 +438,13 @@ versions, downgrade behavior, and protocol history.
 - Boomux does not preserve a terminal emulator's tabs, panes, or window layout.
 - Shells are not containers; they retain the privileges of their owner account.
 - Browser terminal control is limited to exact current local Agent runs.
-- Official releases currently target x86_64 and aarch64 GNU/Linux desktop
-  sessions.
+- Current Omarchy is the supported desktop environment. Other GNU/Linux desktop
+  environments are best-effort; official binaries target x86_64 and aarch64.
 
 ## Further Documentation
 
 - [Architecture](docs/architecture.md)
+- [Security Policy](SECURITY.md)
 - [CLI JSON contract](docs/cli-json.md)
 - [Local Update](docs/local-update.md)
 - [Uninstall](docs/uninstall.md)
@@ -458,10 +462,14 @@ Run the core repository checks:
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features --locked -- -D warnings
 cargo test --lib --bins --locked -- --test-threads=1
+cargo test --test config_cli --locked -- --test-threads=1
 cargo test --test native_backend --locked -- --test-threads=1
+cargo deny check
 bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
 ```
 
 ## License
 
-Boomux is licensed under the [MIT License](LICENSE).
+Boomux is licensed under the [MIT License](LICENSE). Resolved Rust dependencies
+are checked against the repository's [license and advisory policy](deny.toml);
+notices for embedded web assets are in [Third-Party Notices](THIRD_PARTY_NOTICES.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest published Boomux release. Upgrade to
+the latest release before reporting an issue that may already be fixed.
+
+## Reporting A Vulnerability
+
+Report suspected vulnerabilities privately through
+[GitHub Private Vulnerability Reporting](https://github.com/gardnmi/boomux/security/advisories/new).
+Do not open a public issue for a suspected vulnerability.
+
+Include the Boomux version, operating system, affected feature, reproduction
+steps, and impact when known. Do not include terminal contents, environment
+variables, credentials, SSH output, private paths, external session IDs, or
+configuration contents unless they are essential and have been redacted.
+
+You should receive an acknowledgement within seven days. Please allow time for
+investigation and a coordinated release before publishing details.
+
+## Security Boundaries
+
+Writable web-terminal access is equivalent to shell access. Boomux's web
+services bind to loopback; operators are responsible for authentication, TLS,
+and access controls when publishing them through a private network layer.
+
+Shells and coding-host integrations run with the current user's privileges and
+are not sandboxed. See the [security and privacy notes](README.md#security-and-privacy)
+and [mobile web contract](docs/mobile-web.md#security-and-privacy) for the
+current boundaries.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,32 @@
+[graph]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+]
+all-features = true
+
+[advisories]
+unmaintained = "workspace"
+unsound = "all"
+ignore = []
+
+[licenses]
+confidence-threshold = 0.93
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MIT",
+  "Unicode-3.0",
+  "Zlib",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,8 +76,8 @@
   accepted federation boundary: one owning Node remains authoritative, SSH is a
   route, and local cached projections never authorize mutation or lifecycle
   inference. Ad hoc bootstrap and verified transport are implemented; durable
-  registration and background reduced projection synchronization are
-  implemented; routed management remains tracked by #173.
+  registration, background reduced projection synchronization, and the typed
+  routed management described by the current protocol history are implemented.
 
 ## Product Boundary
 
@@ -551,7 +551,7 @@ Baseline launching requires no emulator-specific adapter or compositor window
 ID. The local desktop layer defaults to `disabled`; an explicit
 `desktop.workspace_layer = "hyprland-special"` enables it. On Omarchy,
 `boomux setup` recommends the companion plugin and offers this configuration as
-separate default-no consent. When enabled, the local
+separate default-yes consent. When enabled, the local
 client decorates initial titles for coordinated Workspace opens, desktop-layer
 presentation, and coordinated create-and-open with exact Node and Shell
 identity. Direct Shell, dashboard Shell/item, path, and Session opens retain
@@ -1275,7 +1275,8 @@ handshake version 1 is emitted by the hidden `__federation-stdio` helper only
 after the helper's state-root identity matches the identity returned on the exact
 daemon socket subsequently used for inner protocol bytes. Protocol-28 peers keep
 stable identity queries but cannot open that channel. The SSH launcher/bootstrap,
-registration, and projection protocols remain unimplemented under #173.
+registration, and projection capabilities were introduced by the later protocol
+versions below under #173.
 
 Protocol 30 adds expected-ID-conditional Node rekey. The daemon excludes restart,
 shutdown, and concurrent rekey transitions, closes federation admission, and

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -75,10 +75,11 @@ feature from the daemon.
 
 ### Accepted Remote Node Compatibility
 
-Remote Node federation is an incremental extension tracked by #173. Protocol 31
-advertises registration management explicitly; clients must not infer support
-from a CLI or daemon version string. Registration commands manage local routes
-only and do not imply projected reads or routed resource mutation.
+Remote Node federation was delivered incrementally under #173. Protocol 31
+advertises registration management explicitly; clients must not infer individual
+capabilities from a CLI or daemon version string. Registration commands manage
+local routes only; later protocol capabilities separately advertise projected
+reads and routed resource mutation.
 
 Protocol 33 advertises the separately named `node.snapshot` combined read. It
 contacts only the local daemon and returns qualified local plus bounded cached

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,6 +26,11 @@ current-user-owned directories that are not group/world-writable; missing local
 directories are created owner-only. The sole destination is
 `~/.local/bin/boomux`.
 
+Platform acceptance is separate from desktop support. Current Omarchy is the
+supported desktop environment, and the official x86_64 binary is smoke-tested
+on the repository's pinned Arch Linux compatibility baseline. Other Linux
+desktop environments and the aarch64 binary are best-effort.
+
 An existing file or symbolic link at that destination is never replaced, even
 if it appears while the installer is running. The operator must use `boomux
 update`, the owning package manager, or the workflow that owns a source or

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -1,9 +1,9 @@
 # Remote Node Federation
 
-> **Status: Accepted design contract; implementation in progress.** This document
-> defines the authority, identity, privacy, compatibility, and failure semantics
-> delivered by [#174](https://github.com/gardnmi/boomux/issues/174) under tracking
-> epic [#173](https://github.com/gardnmi/boomux/issues/173). Current source and
+> **Status: Current contract.** This document defines the implemented authority,
+> identity, privacy, compatibility, and failure semantics delivered incrementally
+> under [#174](https://github.com/gardnmi/boomux/issues/174) and tracking epic
+> [#173](https://github.com/gardnmi/boomux/issues/173). Current source and
 > compatibility tests remain authoritative for shipped behavior. Protocol 28
 > implements stable local Node identity; protocol 29, handshake version 1, and
 > the hidden stdio helper establish the verified same-socket bridge boundary.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,7 @@
       "package-name": "boomux",
       "include-component-in-tag": false,
       "draft": true,
-      "force-tag-creation": true
+      "force-tag-creation": false
     }
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,7 +245,7 @@ struct Cli {
 enum Commands {
     /// Open the interactive workspace dashboard
     Ui,
-    /// Serve the read-only mobile Agent dashboard on loopback
+    /// Serve the mobile Agent dashboard and exact-run terminals on loopback
     Web {
         #[command(subcommand)]
         command: Option<WebCommands>,


### PR DESCRIPTION
## Summary

- add a public security policy and enable dependency license/advisory enforcement
- test the packaged x86_64 binary on a pinned Arch baseline for Omarchy support
- require exact-main CI success before normal release preparation and publication
- align current documentation with shipped setup, federation, and web terminal behavior

## GitHub settings

- enabled Private Vulnerability Reporting
- protected `main` with strict required CI checks, linear history, resolved conversations, and force-push/deletion prevention

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test config_cli --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `cargo deny check`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`
- `actionlint .github/workflows/ci.yml .github/workflows/release-please.yml`