### PR TITLE
fix(kiro): inactivate agents without live holders

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1097,11 +1097,14 @@ observation cadence. Holder operations and graceful handoff reconcile
 immediately. Reconciliation uses the ordinary durable mutation coordinator, so
 Inactive persistence precedes event publication and wakes event waiters. Failed
 release after graceful replacement is therefore eventually observed by the
-replacement daemon without another Kiro launch. Routine checks read only exact
-PID/start identity; acquire and import retain strict argv and environment checks.
-Acquire revalidates the exact current
-ShellRun and unchanged process start identity inside that same mutation gate
-immediately before insertion. Handoff import independently requires a live
+replacement daemon without another Kiro launch. Reconciliation also reports an
+active Kiro Agent without any live holder association as Inactive. This clears
+authority after cold recovery and when a pre-protocol-45 Kiro process survives a
+Boomux upgrade without weakening holder admission. Routine checks read only
+exact PID/start identity; acquire and import retain strict argv and environment
+checks. Acquire revalidates the exact current ShellRun and unchanged process
+start identity inside that same mutation gate immediately before insertion.
+Handoff import independently requires a live
 process, a current running ShellRun, and active exact Kiro Agent associations.
 
 The launcher installs Linux `PR_SET_PDEATHSIG` on the exact Kiro child before

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10697,14 +10697,13 @@ impl DaemonService {
     }
 
     fn reconcile_dead_kiro_holders(&self) -> DaemonResult<()> {
-        if lock(&self.kiro.state)?.is_empty() {
-            return Ok(());
-        }
         let holders = self.durable_mutation_outcome(|undo| {
             let state = lock(&self.kiro.state)?;
             let mut holders = KiroHoldersMutation::new(state);
             let removed = prune_dead_kiro_holders(&mut holders.state);
-            let events = self.inactivate_released_kiro_sessions(undo, &holders.state, removed)?;
+            let mut events =
+                self.inactivate_released_kiro_sessions(undo, &holders.state, removed)?;
+            events.extend(self.inactivate_unowned_kiro_agents(undo, &holders.state)?);
             if events.is_empty() {
                 Ok(DurableMutation::Unchanged(holders))
             } else {
@@ -10713,6 +10712,55 @@ impl DaemonService {
         })?;
         holders.commit();
         Ok(())
+    }
+
+    fn inactivate_unowned_kiro_agents(
+        &self,
+        undo: &mut DurableUndoLog,
+        holders: &HashMap<String, KiroLaunchHolder>,
+    ) -> DaemonResult<Vec<DaemonEventKind>> {
+        let owned = holders
+            .values()
+            .flat_map(|holder| holder.sessions.values().cloned())
+            .collect::<HashSet<_>>();
+        let candidates = lock(&self.durable.state)?
+            .agents
+            .values()
+            .filter(|agent| agent.integration == "kiro" && !owned.contains(&agent.id))
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut events = Vec::new();
+        for agent in candidates {
+            let should_inactivate = {
+                let state = lock(&agent.state)?;
+                state.ended_at_ms.is_none()
+                    && state.observation.authority == AgentAuthority::LifecycleIntegration
+                    && !matches!(
+                        state.observation.state,
+                        AgentState::Inactive | AgentState::Done
+                    )
+            };
+            if !should_inactivate {
+                continue;
+            }
+            let report = AgentReport {
+                state: AgentState::Inactive,
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "Kiro launch authority unavailable".into(),
+                confidence: 100,
+            };
+            let (agent, changed, completed) =
+                self.report_agent_mutation(undo, &agent.id, &agent.run_id, report)?;
+            debug_assert!(!completed);
+            if changed {
+                events.push(DaemonEventKind::AgentStateChanged {
+                    workspace_id: agent.workspace_id.clone(),
+                    shell_id: agent.shell_id.clone(),
+                    agent,
+                });
+            }
+        }
+        Ok(events)
     }
 
     fn export_kiro_launch_holders(&self) -> io::Result<Vec<handoff::KiroLaunchHolderManifest>> {
@@ -16740,6 +16788,71 @@ mod tests {
                 "accepted unsupported Kiro state {state:?}"
             );
         }
+
+        process.kill().unwrap();
+        process.wait().unwrap();
+    }
+
+    #[test]
+    fn kiro_reconciliation_inactivates_agents_without_live_holder_authority() {
+        let registry = DaemonService::default();
+        let (_, shell, _) = running_shell(&registry);
+        let run_id = shell.snapshot().unwrap().run.unwrap().id;
+        let Response::Agent { agent: orphan } = registry
+            .dispatch(Request::RegisterAgent {
+                shell_id: shell.id.clone(),
+                run_id: run_id.clone(),
+                spec: AgentRegistrationSpec {
+                    name: "legacy Kiro".into(),
+                    integration: "kiro".into(),
+                    external_session_id: Some("legacy-session".into()),
+                    report: kiro_report(AgentState::Idle),
+                },
+            })
+            .unwrap()
+        else {
+            panic!("expected registered Kiro Agent");
+        };
+        let (holder_id, mut process) = test_kiro_holder(&registry, &shell.id, &run_id);
+        let owned = report_test_kiro(&registry, &holder_id, "owned-session");
+
+        registry.fail_after_mutation.store(true, Ordering::Release);
+        assert!(registry.reconcile_dead_kiro_holders().is_err());
+        assert_eq!(
+            registry
+                .durable
+                .agent(&orphan.id)
+                .unwrap()
+                .snapshot()
+                .unwrap()
+                .observation
+                .state,
+            AgentState::Idle
+        );
+
+        registry.reconcile_dead_kiro_holders().unwrap();
+        let orphan = registry
+            .durable
+            .agent(&orphan.id)
+            .unwrap()
+            .snapshot()
+            .unwrap();
+        assert_eq!(orphan.observation.state, AgentState::Inactive);
+        assert_eq!(
+            orphan.observation.evidence,
+            "Kiro launch authority unavailable"
+        );
+        assert_eq!(
+            registry
+                .durable
+                .agent(&owned.id)
+                .unwrap()
+                .snapshot()
+                .unwrap()
+                .observation
+                .state,
+            AgentState::Working
+        );
 
         process.kill().unwrap();
         process.wait().unwrap();

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -203,6 +203,56 @@ fn codex_hook_requires_run_scoped_launch_and_reuses_exact_thread_agent() {
 }
 
 #[test]
+fn kiro_agent_without_live_holder_becomes_inactive() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "holderless-kiro",
+            vec![ShellSpec {
+                name: "kiro".into(),
+                command: vec!["/bin/sleep".into(), "300".into()],
+                cwd: std::env::temp_dir(),
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
+    let agent = daemon
+        .client
+        .register_agent(
+            &shell_id,
+            &run_id,
+            AgentRegistrationSpec {
+                name: "Kiro CLI".into(),
+                integration: "kiro".into(),
+                external_session_id: Some("pre-holder-session".into()),
+                report: AgentReport {
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "Kiro session idle".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+
+    wait_until(
+        || {
+            daemon.client.get_agent(&agent.id).is_ok_and(|agent| {
+                agent.observation.state == AgentState::Inactive
+                    && agent.observation.evidence == "Kiro launch authority unavailable"
+            })
+        },
+        "holderless Kiro Agent remained active",
+    );
+
+    drop(attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn sequential_kiro_process_holders_inactivate_only_the_exited_session() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon


### PR DESCRIPTION
## Summary
- reconcile active Kiro Agents that no longer have a live exact-process Launch Holder to Inactive
- preserve Agents still owned by a live holder and retain durable mutation rollback guarantees
- document and test cold-recovery and pre-protocol-45 upgrade behavior

## Root cause
A Kiro process launched by an older Boomux version can survive an upgrade without the private holder capability introduced in protocol 45. Current hook commands correctly reject that process, but its prior durable Agent observation remained misleadingly Idle.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test config_cli --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `cargo deny check`
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`