### PR TITLE
docs: add development guide and streamline docs ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,66 +14,137 @@ permissions:
   contents: read
 
 jobs:
-  rust:
-    name: Rust
+  changes:
+    name: Classify changes
     runs-on: ubuntu-latest
-    env:
-      RUSTUP_TOOLCHAIN: stable
+    outputs:
+      run_code: ${{ steps.classify.outputs.run_code }}
     steps:
       - name: Check out repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-Markdown changes
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          run_code=false
+          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ || "$BASE_SHA" == 0000000000000000000000000000000000000000 ]]; then
+            run_code=true
+          else
+            while IFS= read -r -d '' path; do
+              case "$path" in
+                *.md) ;;
+                *) run_code=true; break ;;
+              esac
+            done < <(git diff --name-only --no-renames -z "$BASE_SHA" "$HEAD_SHA")
+          fi
+          printf 'run_code=%s\n' "$run_code" >> "$GITHUB_OUTPUT"
+          if [[ "$run_code" == false ]]; then
+            printf 'Only Markdown files changed; code and packaging steps will be skipped.\n' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  rust:
+    name: Rust
+    needs: changes
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - name: Skip code checks for Markdown-only changes
+        if: env.RUN_CODE != 'true'
+        run: printf 'Rust checks are not required for Markdown-only changes.\n'
+
+      - name: Check out repository
+        if: env.RUN_CODE == 'true'
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install Rust toolchain
+        if: env.RUN_CODE == 'true'
         run: rustup toolchain install stable --profile minimal --component rustfmt,clippy
 
       - name: Check formatting
+        if: env.RUN_CODE == 'true'
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
+        if: env.RUN_CODE == 'true'
         run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
       - name: Run Rust unit tests
+        if: env.RUN_CODE == 'true'
         run: cargo test --lib --bins --locked -- --test-threads=1
 
       - name: Run configuration CLI tests
+        if: env.RUN_CODE == 'true'
         run: cargo test --test config_cli --locked -- --test-threads=1
 
       - name: Run native backend tests
+        if: env.RUN_CODE == 'true'
         run: cargo test --test native_backend --locked -- --test-threads=1
 
   dependency-policy:
     name: Dependency policy
+    needs: changes
+    if: always()
     runs-on: ubuntu-latest
+    env:
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
     steps:
+      - name: Skip dependency checks for Markdown-only changes
+        if: env.RUN_CODE != 'true'
+        run: printf 'Dependency checks are not required for Markdown-only changes.\n'
+
       - name: Check out repository
+        if: env.RUN_CODE == 'true'
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Audit advisories, licenses, and dependency sources
+        if: env.RUN_CODE == 'true'
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
 
   integrations:
     name: Integrations
+    needs: changes
+    if: always()
     runs-on: ubuntu-latest
+    env:
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
     steps:
+      - name: Skip integration checks for Markdown-only changes
+        if: env.RUN_CODE != 'true'
+        run: printf 'Integration checks are not required for Markdown-only changes.\n'
+
       - name: Check out repository
+        if: env.RUN_CODE == 'true'
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Bun
+        if: env.RUN_CODE == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
       - name: Verify embedded web terminal assets
+        if: env.RUN_CODE == 'true'
         run: |
           bun install --frozen-lockfile
           bun run build:web-terminal
           git diff --exit-code -- assets/mobile-web/terminal.js assets/mobile-web/terminal.css assets/mobile-web/ghostty-vt.wasm
 
       - name: Run integration tests
+        if: env.RUN_CODE == 'true'
         run: bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
 
   release-packaging:
     name: Release packaging (${{ matrix.arch }})
+    needs: changes
+    if: always()
     strategy:
       fail-fast: false
       matrix:
@@ -87,28 +158,38 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       BOOMUX_DISTRIBUTION: github-release
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
       RUSTUP_TOOLCHAIN: stable
       TARGET: ${{ matrix.target }}
     steps:
+      - name: Skip release packaging for Markdown-only changes
+        if: env.RUN_CODE != 'true'
+        run: printf 'Release packaging is not required for Markdown-only changes.\n'
+
       - name: Check out repository
+        if: env.RUN_CODE == 'true'
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install Rust toolchain
+        if: env.RUN_CODE == 'true'
         run: rustup toolchain install stable --profile minimal
 
       - name: Read package version
+        if: env.RUN_CODE == 'true'
         run: |
           version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "boomux") | .version')
           printf 'TAG=v%s\n' "$version" >> "$GITHUB_ENV"
 
       - name: Build native release binary
+        if: env.RUN_CODE == 'true'
         run: cargo build --release --locked --target "$TARGET"
 
       - name: Package and smoke test native release
+        if: env.RUN_CODE == 'true'
         run: bash .github/scripts/package-release.sh "$TAG" "$TARGET"
 
       - name: Retain package for compatibility testing
-        if: ${{ matrix.arch == 'x86_64' }}
+        if: ${{ env.RUN_CODE == 'true' && matrix.arch == 'x86_64' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: compatibility-${{ matrix.target }}
@@ -116,7 +197,7 @@ jobs:
           if-no-files-found: error
 
       - name: Validate release scripts
-        if: ${{ matrix.arch == 'x86_64' }}
+        if: ${{ env.RUN_CODE == 'true' && matrix.arch == 'x86_64' }}
         run: |
           bash -n .github/scripts/package-release.sh .github/scripts/upload-release-assets.sh .github/scripts/update-release-notes.sh .github/scripts/test-update-release-notes.sh packaging/render-installer.sh packaging/test-installer.sh
           sh -n packaging/install-release.sh.in
@@ -125,16 +206,27 @@ jobs:
 
   aur-package:
     name: AUR package metadata
+    needs: changes
+    if: always()
     runs-on: ubuntu-24.04
     container: archlinux:base-devel@sha256:68bfc3b0d277b08a99101dc9b94aaa03e5ae70cf1b4fb965c03b2b87b915760d
+    env:
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
     steps:
+      - name: Skip AUR validation for Markdown-only changes
+        if: env.RUN_CODE != 'true'
+        run: printf 'AUR validation is not required for Markdown-only changes.\n'
+
       - name: Prepare Arch build user
+        if: env.RUN_CODE == 'true'
         run: useradd --create-home builder
 
       - name: Check out repository
+        if: env.RUN_CODE == 'true'
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Render and validate AUR metadata as an unprivileged user
+        if: env.RUN_CODE == 'true'
         run: |
           chown -R builder:builder "$GITHUB_WORKSPACE"
           runuser -u builder -- bash -c '
@@ -156,17 +248,28 @@ jobs:
 
   arch-compatibility:
     name: Pinned Arch compatibility
-    needs: release-packaging
+    needs:
+      - changes
+      - release-packaging
+    if: always()
     runs-on: ubuntu-24.04
     container: archlinux:base-devel@sha256:68bfc3b0d277b08a99101dc9b94aaa03e5ae70cf1b4fb965c03b2b87b915760d
+    env:
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
     steps:
+      - name: Skip compatibility testing for Markdown-only changes
+        if: env.RUN_CODE != 'true'
+        run: printf 'Pinned Arch compatibility is not required for Markdown-only changes.\n'
+
       - name: Download x86_64 release package
+        if: env.RUN_CODE == 'true'
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: compatibility-x86_64-unknown-linux-gnu
           path: dist
 
       - name: Smoke test Ubuntu-built binary on pinned Arch
+        if: env.RUN_CODE == 'true'
         run: |
           archive=$(printf '%s\n' dist/boomux-v*-x86_64-unknown-linux-gnu.tar.gz)
           package=${archive%.tar.gz}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 ## Start Here
 
-Use repository documentation in this order:
+Use `DEVELOPMENT.md` for the human development lifecycle and local build loop.
+Use product documentation in this order:
 
 1. `CONTEXT.md` defines canonical product terms and distinctions. Preserve those
    semantics when names in code are less precise.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,256 @@
+# Development Guide
+
+This guide describes the supported local development loop from repository setup
+through release. Product terminology and implementation contracts remain
+authoritative in the documents listed under [Repository Orientation](#repository-orientation).
+
+## Prerequisites
+
+Boomux development requires Linux and the stable Rust toolchain with `rustfmt`
+and Clippy. Install the toolchain with:
+
+```console
+rustup toolchain install stable --profile minimal --component rustfmt,clippy
+```
+
+The complete validation suite also requires:
+
+- `cargo-deny` for dependency policy checks.
+- Bun `1.3.14` for integration tests and embedded web-terminal assets.
+- Standard Unix development tools used by the packaging tests.
+- A current Omarchy/Hyprland environment only for live desktop validation.
+
+## Repository Orientation
+
+Read repository documentation in this order before changing behavior:
+
+1. [`CONTEXT.md`](CONTEXT.md) defines canonical product terminology.
+2. [`docs/architecture.md`](docs/architecture.md) maps modules and invariants.
+3. Contract documents govern their named interfaces and guarantees.
+4. [`docs/adr/`](docs/adr/) records accepted decisions and rationale.
+5. [`docs/lifecycle-validation.md`](docs/lifecycle-validation.md) records
+   version-specific live compatibility evidence.
+6. [`docs/roadmap.md`](docs/roadmap.md) is non-authoritative future intent.
+
+For exact protocol and persistence versions, source and compatibility tests are
+authoritative. Start in the owning module from the architecture module map, then
+read its colocated tests and relevant contracts.
+
+## Branches And Worktrees
+
+Create changes on a focused branch. Keeping linked worktrees under one root
+makes them easy to find; this guide uses:
+
+```text
+$HOME/Worktrees/<repository>/<branch-slug>
+```
+
+Create and remove linked worktrees through Git so tools such as Lazygit can
+discover them:
+
+```console
+git worktree add -b <branch> "$HOME/Worktrees/boomux/<branch-slug>" main
+git worktree list
+git worktree remove "$HOME/Worktrees/boomux/<branch-slug>"
+```
+
+Never delete a registered worktree directory directly.
+
+## Build Locally
+
+Build the development binary without modifying the installed release:
+
+```console
+cargo build --locked
+./target/debug/boomux --version
+./target/debug/boomux capabilities --json
+```
+
+The binary is `target/debug/boomux`. Use it directly after the first build to
+avoid repeated Cargo startup. Use an optimized build only when validating
+release behavior or performance:
+
+```console
+cargo build --release --locked
+./target/release/boomux --version
+```
+
+Do not replace `~/.local/bin/boomux` during ordinary development. Development
+builds are intentionally ineligible for self-update.
+
+## Use An Isolated Daemon
+
+By default, a development binary uses the same XDG socket, state, and
+configuration locations as the installed release. Isolate manual testing so a
+development daemon cannot adopt or terminate ordinary Boomux processes:
+
+```console
+export BOOMUX_DEV_ROOT="$(mktemp -d /tmp/boomux-dev.XXXXXX)"
+
+install -d -m 700 \
+  "$BOOMUX_DEV_ROOT/runtime" \
+  "$BOOMUX_DEV_ROOT/state" \
+  "$BOOMUX_DEV_ROOT/config"
+
+export XDG_RUNTIME_DIR="$BOOMUX_DEV_ROOT/runtime"
+export XDG_STATE_HOME="$BOOMUX_DEV_ROOT/state"
+export XDG_CONFIG_HOME="$BOOMUX_DEV_ROOT/config"
+```
+
+Every development command in that shell now uses an isolated daemon socket,
+Node identity, durable state, and configuration:
+
+```console
+./target/debug/boomux workspace create development
+./target/debug/boomux shell create development --cwd "$PWD"
+./target/debug/boomux daemon status
+```
+
+Run the dashboard from a fresh terminal carrying the same XDG variables:
+
+```console
+./target/debug/boomux ui
+```
+
+## Edit, Build, And Run
+
+Use this loop for ordinary Rust changes:
+
+```console
+cargo fmt --all
+cargo build --locked
+./target/debug/boomux daemon restart
+```
+
+`daemon restart` performs a graceful handoff from the isolated old daemon to the
+newly built executable and preserves compatible Shell processes and PTYs. It is
+the preferred way to test daemon changes.
+
+If an intentionally incompatible protocol or persistence change prevents
+handoff, stop only the isolated development daemon:
+
+```console
+./target/debug/boomux daemon stop
+```
+
+Stopping a daemon terminates every process it manages. Verify the isolated XDG
+variables before running that command.
+
+## Focused Tests
+
+Run the narrowest relevant test while iterating:
+
+```console
+cargo test --lib <test-name> --locked -- --test-threads=1
+cargo test --test config_cli <test-name> --locked -- --test-threads=1
+cargo test --test native_backend <test-name> --locked -- --test-threads=1
+```
+
+Native backend tests must remain serial because they exercise process, socket,
+PTY, and daemon lifecycle behavior. Use the change-type coverage table in
+[`AGENTS.md`](AGENTS.md) to select additional compatibility tests.
+
+## Web And Integration Changes
+
+Install the pinned JavaScript dependencies and rebuild embedded terminal assets:
+
+```console
+bun install --frozen-lockfile
+bun run build:web-terminal
+git diff --exit-code -- \
+  assets/mobile-web/terminal.js \
+  assets/mobile-web/terminal.css \
+  assets/mobile-web/ghostty-vt.wasm
+```
+
+Run the integration reducers with:
+
+```console
+bun test integrations/opencode/boomux.test.js \
+  integrations/opencode/boomux-tui.test.js \
+  integrations/pi/boomux.test.js
+```
+
+## Complete Validation
+
+Before opening a pull request that changes code, configuration, packaging, or
+generated assets, run the same checks as CI:
+
+```console
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features --locked -- -D warnings
+cargo test --lib --bins --locked -- --test-threads=1
+cargo test --test config_cli --locked -- --test-threads=1
+cargo test --test native_backend --locked -- --test-threads=1
+cargo deny check
+bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
+```
+
+Pull requests that modify only Markdown skip code, dependency, integration, and
+packaging jobs after a lightweight CI path check. Any non-Markdown change runs
+the complete CI matrix.
+
+## Compatibility Checklist
+
+Protocol changes require version negotiation, additive defaults or downgrade
+behavior, capability updates, mixed-version tests, and protocol-history
+documentation when wire behavior changes.
+
+Persisted state changes require a state-version bump, retention of the previous
+schema, an explicit migration, invalid-state coverage, and cold-recovery tests.
+
+Process and PTY changes require colocated unit tests plus serial native scenarios.
+Host compatibility claims require focused fixtures and live evidence in
+`docs/lifecycle-validation.md`.
+
+Across all changes, preserve exact argument vectors, ephemeral attachment
+environments, persistence-before-event publication, daemon lock ordering, and
+run-scoped Agent lifecycle authority.
+
+## Commits And Pull Requests
+
+Use Conventional Commits for commits and pull request titles:
+
+```text
+feat(scope): add capability
+fix(scope): correct behavior
+docs: explain development workflow
+ci: skip builds for documentation-only changes
+```
+
+Use `feat` for a user-visible minor release and `fix`, `perf`, or `refactor` for
+a patch release. Use `docs`, `test`, `build`, `ci`, or `chore` only when there is
+no release-visible product change. Mark breaking changes with `!` and a
+`BREAKING CHANGE:` footer.
+
+CI must pass before squash-merging into `main`. The Conventional pull request
+title becomes the squash commit consumed by Release Please.
+
+## Release Lifecycle
+
+After CI succeeds for the exact current `main` commit, Release Please creates or
+updates the release pull request. Merging that pull request updates the package
+version and changelog. CI validates the release commit before the release
+workflow builds x86_64 and aarch64 Linux artifacts, renders the installer,
+uploads checksums, and publishes the completed GitHub release. Manual tag
+dispatch is reserved for explicit release recovery.
+
+## Clean Up
+
+Stop the isolated daemon before deleting its temporary state:
+
+```console
+./target/debug/boomux daemon stop
+rm -rf -- "${BOOMUX_DEV_ROOT:?}"
+unset BOOMUX_DEV_ROOT XDG_RUNTIME_DIR XDG_STATE_HOME XDG_CONFIG_HOME
+```
+
+Do not use this cleanup sequence unless `BOOMUX_DEV_ROOT` identifies the
+temporary development directory created above.
+
+## Security Reports
+
+Report suspected vulnerabilities through GitHub Private Vulnerability Reporting
+as described in [`SECURITY.md`](SECURITY.md). Do not include terminal contents,
+credentials, private paths, external session IDs, or configuration contents
+unless essential and redacted.

--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ versions, downgrade behavior, and protocol history.
 
 ## Further Documentation
 
+- [Development Guide](DEVELOPMENT.md)
 - [Architecture](docs/architecture.md)
 - [Security Policy](SECURITY.md)
 - [CLI JSON contract](docs/cli-json.md)
@@ -450,17 +451,9 @@ versions, downgrade behavior, and protocol history.
 
 ## Development
 
-Run the core repository checks:
-
-```console
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features --locked -- -D warnings
-cargo test --lib --bins --locked -- --test-threads=1
-cargo test --test config_cli --locked -- --test-threads=1
-cargo test --test native_backend --locked -- --test-threads=1
-cargo deny check
-bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
-```
+See the [Development Guide](DEVELOPMENT.md) for prerequisites, isolated local
+builds, the edit-build-run loop, testing requirements, pull requests, and the
+release lifecycle.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add a complete development guide covering prerequisites, local debug/release builds, isolated daemon testing, focused and full validation, compatibility checks, pull requests, and releases
- link the guide from the README and repository agent workflow
- classify pull request and main-branch changes before CI, preserving all seven required check names while skipping their expensive steps for Markdown-only changes
- fail closed to the full CI suite if change classification cannot complete

## CI behavior
The workflow still runs for documentation-only changes so required status checks do not remain pending. Each required job reports success through a lightweight skip step when every changed path ends in `.md`. Any non-Markdown path, rename from a non-Markdown path, invalid base SHA, or classifier failure runs the complete suite.

## Validation
- workflow YAML parse
- classifier regression cases using README-only and source-plus-docs commits
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test config_cli --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- `cargo deny check`
- `bun install --frozen-lockfile` with Bun 1.3.14 and a clean cache
- `bun run build:web-terminal` with no generated diff
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js`
- development binary `--version` and `capabilities --json` smoke tests