### PR TITLE
feat(session): add cross-harness session navigation

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -315,9 +315,11 @@ Discover projected session metadata with:
 boomux session list --json
 boomux session list --workspace "<workspace-name-or-id>" --json
 boomux session inspect "<exact-session-id>" --json
+boomux session open "<exact-session-id>"
 boomux session resume "<exact-session-id>"
 boomux session list --node "<node>" --json
 boomux session inspect "<exact-session-id>" --node "<same-node>" --json
+boomux session open "<exact-session-id>" --node "<same-node>"
 boomux session resume "<exact-session-id>" --node "<same-node>"
 ```
 
@@ -328,9 +330,12 @@ run of a running retained shell; otherwise it is last-known. Catalog-only
 OpenCode or Codex history has state `unknown`, no fabricated occurrence, and a
 sanitized host title. Registered-session descriptions remain durable Agent names.
 Protocol-13 sessions retain a `source_cwd` after shell removal so an exact
-canonical session can be resumed in its original context. Resume launches a
-native host process and requires authorization. A remote Session ID is exact
-only within its owning Node; keep the same `--node` used for discovery.
+canonical session can be resumed in its original context. Open attaches the exact
+current ShellRun with takeover or resumes an exact historical Session, and fails
+closed if that target is done, missing, ambiguous, unavailable, or changed.
+Resume always launches a native host process and requires authorization. A
+remote Session ID is exact only within its owning Node; keep the same `--node`
+used for discovery.
 
 Exact shell IDs are global only within one Node. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.

--- a/README.md
+++ b/README.md
@@ -372,6 +372,17 @@ delete the remote Node.
 Cached remote projections are presentation-only. Mutations require a live,
 identity-verified owner connection and are never queued for later.
 
+Open an exact projected Agent Session in a native terminal with:
+
+```console
+boomux session open <session-id>
+boomux session open <session-id> --node <node>
+```
+
+Current Sessions open their exact current ShellRun with takeover. Historical
+Sessions resume on their exact owning Node. Invalid or changed targets fail
+closed rather than substituting another Shell, run, Session, path, or Node.
+
 See [Remote Nodes](docs/remote-nodes.md) for routing, bootstrap, upgrade, and
 failure semantics.
 

--- a/README.md
+++ b/README.md
@@ -254,19 +254,37 @@ Use `boomux --help` and `boomux <command> --help` for the complete current CLI.
 
 ## Native Dashboard
 
-Run `boomux ui` in a terminal. The dashboard provides four primary views:
+Run `boomux ui` in a terminal. The dashboard provides five primary views:
 
 - **Workspaces**: coordinated tasks, placement state, attention, and ownership.
-- **Agents**: current Agent lifecycle and canonical Sessions.
+- **Agents**: current ShellRun-bound Agent lifecycle.
+- **Sessions**: canonical Agent Sessions across harnesses and live Nodes.
 - **Shells**: durable Shell slots, commands, and exact run state.
 - **Nodes**: registration, route health, compatibility, and upgrade actions.
+
+The Sessions view is a projection of existing Agent Instances and host history,
+not a renamed Agent view or a new durable identity. It combines local Sessions
+with live catalogs from online registered Nodes, keeps identity qualified by
+owning Node, and reports per-Node failures without giving stale remote
+projections authority. Rows are ordered by last activity for presentation only;
+timestamps do not establish causal order across Nodes. Every row names its
+harness, and columns adapt from the compact age, harness, and title view to add
+state, Node, Workspace, and occurrence information as space permits.
+
+`Enter` opens the selected Session. A current Session opens its exact managed
+Shell; historical resume runs the exact owner-side harness. An unavailable,
+missing-cwd, done, or otherwise invalid Session reports an error and never opens
+a substitute. OpenCode and Codex may contribute catalog-only history; Pi,
+Claude, and Kiro appear only after Boomux has durably observed an Agent Instance.
+Press `i` for Session details and `Esc` to return. With the mouse, the first click
+selects a Session row and a second click on that selected row opens it.
 
 Core keys:
 
 | Keys | Action |
 | --- | --- |
 | Arrow keys or `h/j/k/l` | Navigate |
-| `Tab`, `Shift-Tab`, `1`-`4` | Change view |
+| `Tab`, `Shift-Tab`, `1`-`5` | Change view |
 | `Enter` | Open or activate the selected item |
 | `a`, `e`, `x` | Add, rename/edit, or close/remove where available |
 | `/` or `:` | Open the command palette |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -854,13 +854,23 @@ resume service. Done, unavailable, missing-cwd, or otherwise invalid selections
 fail visibly and never substitute another Shell, Node, path, harness, or Session.
 This presentation reuses existing protocol-36 host services and existing durable
 Agent state; it changes neither protocol nor persistence versions.
-The public human-only `boomux session open SESSION_ID [--node NODE]` command
+The public human-only `boomux session open SESSION_ID [--node NODE]
+[--workspace WORKSPACE]` command
 uses that same core activation path. Current Sessions revalidate one exact
 current owner ShellRun and launch a terminal with expected-run attachment and
 takeover; historical Sessions validate owner cwd and launch the existing exact
 owner-routed resume. Done, missing, ambiguous, unavailable, and concurrently
 changed targets fail closed. Command success reports terminal launch; a later
 owner-side rejection remains visible in that terminal without substitution. The
+optional Workspace validates a non-closing coordinated presentation target and
+uses the desktop presentation path; it does not change Shell membership or owner
+authority for a current Session. Historical opening with a Workspace creates a
+managed command-backed Shell on the Session owner Node in that coordinated
+Workspace and starts the exact harness resume argv through `agent supervise` and
+normal attachment. The process adapter creates an immediate unknown Agent for
+the exact canonical Session, then lifecycle integration supersedes it with
+authoritative state. `BOOMUX_*` run identity is available throughout. Historical
+opening without a Workspace retains the legacy unmanaged resume path. The
 static CLI capability is `exact_session_open`; no JSON command, wire request,
 protocol bump, or persistence change is added.
 The integration descriptor registry is the authority for integration keys,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -854,6 +854,15 @@ resume service. Done, unavailable, missing-cwd, or otherwise invalid selections
 fail visibly and never substitute another Shell, Node, path, harness, or Session.
 This presentation reuses existing protocol-36 host services and existing durable
 Agent state; it changes neither protocol nor persistence versions.
+The public human-only `boomux session open SESSION_ID [--node NODE]` command
+uses that same core activation path. Current Sessions revalidate one exact
+current owner ShellRun and launch a terminal with expected-run attachment and
+takeover; historical Sessions validate owner cwd and launch the existing exact
+owner-routed resume. Done, missing, ambiguous, unavailable, and concurrently
+changed targets fail closed. Command success reports terminal launch; a later
+owner-side rejection remains visible in that terminal without substitution. The
+static CLI capability is `exact_session_open`; no JSON command, wire request,
+protocol bump, or persistence change is added.
 The integration descriptor registry is the authority for integration keys,
 display names, and optional typed capabilities. A title capability selects its
 host adapter and independently declares catalog support. The shared title layer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -817,7 +817,7 @@ bounded to the attachment limit, browser backgrounding releases control, and all
 terminal API responses remain outside service-worker and HTTP caches. The
 external private access layer must restrict the dashboard to trusted users.
 
-Agent sessions are a client-side projection, not a sixth durable daemon
+Agent sessions are a client-side projection, not another durable daemon
 identity. The projection groups stored Agent instances by workspace,
 integration, and external session ID, while isolating instances without an
 external ID. It retains original shell/run identity and observations even when a
@@ -830,7 +830,30 @@ registration under the same stable ID. Catalog records associate to each
 workspace that references their exact normalized directory. The dashboard maps
 the active or latest exact match into a durable Agent's contextual preview and
 discovers catalogs asynchronously; session CLI listing performs the same bounded
-discovery synchronously. Sessions are not a dashboard kind.
+discovery synchronously. Pi, Claude, and Kiro have no complete catalog adapter,
+so their Sessions enter the projection only through durably observed Agent
+Instances.
+
+The dashboard primary kinds are Workspaces, Agents, Sessions, Shells, and Nodes.
+Sessions is this canonical projection, not a rename of ShellRun-bound Agent
+Instances or a new identity layer. Its bounded asynchronous loader combines the
+local projection with live protocol-36 Session catalogs from every online
+registered Node. Each row retains `(node_id, session_id)` identity; owner failures
+are reported independently so successful Nodes remain usable. Cached stale
+remote projections never supply Session catalog authority. Last-activity order
+uses deterministic Node, Workspace, and Session tie-breakers only for
+presentation and establishes no cross-Node causal order.
+
+Session rows always show textual harness identity. Rendering preserves age,
+harness, and title at narrow widths and progressively adds state, Node,
+Workspace, and occurrence columns. `i` opens the detail overlay; `Enter` opens
+the selected row, while a first mouse click selects it and a second click on the
+selected row opens it. A current Session opens its exact Node-qualified managed
+Shell. A historical resumable Session uses the existing exact owner-side harness
+resume service. Done, unavailable, missing-cwd, or otherwise invalid selections
+fail visibly and never substitute another Shell, Node, path, harness, or Session.
+This presentation reuses existing protocol-36 host services and existing durable
+Agent state; it changes neither protocol nor persistence versions.
 The integration descriptor registry is the authority for integration keys,
 display names, and optional typed capabilities. A title capability selects its
 host adapter and independently declares catalog support. The shared title layer

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -47,6 +47,15 @@ not appear in `json_commands`, and do not provide remote configuration mutation.
 `config validate` covers the complete global plus optional `BOOMUX_CONFIG`
 layered result without starting the daemon.
 
+`boomux session open SESSION_ID [--node NODE]` is also human-only and absent
+from `json_commands`. The static `exact_session_open` feature advertises this
+CLI orchestration surface, not a new daemon request. It launches a terminal that
+opens an exact current ShellRun with expected-run attachment and takeover, or
+uses exact owner-routed resume for a historical Session; done, missing,
+ambiguous, unavailable, and changed targets fail closed. A successful command
+exit confirms terminal launch, while owner-side attachment or resume errors
+remain visible in that terminal and never fall back to another target.
+
 `boomux setup` is a human-only local discovery and mutation workflow. It requires
 an interactive terminal, does not support `--json`, and is absent from
 `json_commands`. Automation must compose the advertised integration status,
@@ -780,8 +789,8 @@ exact ID returned by `session.list` resolves; external IDs, descriptions, shell
 IDs, and Agent IDs never resolve through `session.inspect`.
 All session commands require a negotiated daemon protocol of at least 12 and return
 `unsupported_version` before projection against an older daemon.
-`session list`, `session inspect`, and human-only `session resume` accept
-`--node SELECTOR` under protocol 36. Remote JSON responses add the exact
+`session list`, `session inspect`, and human-only `session open` and `session
+resume` accept `--node SELECTOR` under protocol 36. Remote JSON responses add the exact
 `node_id`. Resume opens a local native terminal but resolves the opaque ID and
 executes the integration argv only on the owner; it creates no ordinary
 Workspace or Shell.

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -47,7 +47,7 @@ not appear in `json_commands`, and do not provide remote configuration mutation.
 `config validate` covers the complete global plus optional `BOOMUX_CONFIG`
 layered result without starting the daemon.
 
-`boomux session open SESSION_ID [--node NODE]` is also human-only and absent
+`boomux session open SESSION_ID [--node NODE] [--workspace WORKSPACE]` is also human-only and absent
 from `json_commands`. The static `exact_session_open` feature advertises this
 CLI orchestration surface, not a new daemon request. It launches a terminal that
 opens an exact current ShellRun with expected-run attachment and takeover, or
@@ -55,6 +55,14 @@ uses exact owner-routed resume for a historical Session; done, missing,
 ambiguous, unavailable, and changed targets fail closed. A successful command
 exit confirms terminal launch, while owner-side attachment or resume errors
 remain visible in that terminal and never fall back to another target.
+When `--workspace` names a non-closing coordinated Workspace, Boomux presents that
+desktop Workspace and places an exact current ShellRun terminal there without
+changing durable Shell membership. For a historical Session, it creates a
+managed command-backed Shell on the Session's owning Node in the selected
+Workspace and runs the exact harness resume argv through `agent supervise`.
+The supervisor immediately registers the exact Session as an unknown Agent;
+lifecycle integration then supersedes it with authoritative state. Without `--workspace`, the legacy
+unmanaged historical resume remains available.
 
 `boomux setup` is a human-only local discovery and mutation workflow. It requires
 an interactive terminal, does not support `--json`, and is absent from

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -89,6 +89,7 @@ const MAX_NAME_BYTES: usize = 256;
 const MAX_AGENT_EVIDENCE_BYTES: usize = 4 * 1024;
 const MAX_HOST_SERVICE_PREVIEWS: usize = 64;
 const HOST_SERVICE_PREVIEW_TTL: Duration = Duration::from_secs(300);
+const HOST_SESSION_CATALOG_TTL: Duration = Duration::from_secs(30);
 const MAX_TERMINAL_ROWS: u16 = 1_000;
 const MAX_TERMINAL_COLS: u16 = 1_000;
 const MAX_TERMINAL_PREVIEW_LINES: usize = 500;
@@ -1260,6 +1261,42 @@ fn resolve_executable(
 
 fn opencode_shim_eligible(shell: &Shell, effective_command: &[String]) -> bool {
     shell.command.is_empty() && effective_command.is_empty()
+}
+
+fn supervised_opencode_session(effective_command: &[String]) -> Option<&str> {
+    if effective_command.len() != 12 {
+        return None;
+    }
+    let external_session_id = &effective_command[7];
+    let session_id = &effective_command[11];
+    (Path::new(&effective_command[0]).file_name()?.to_str()? == "boomux"
+        && effective_command[1] == "agent"
+        && effective_command[2] == "supervise"
+        && effective_command[4] == "--integration"
+        && effective_command[5] == "opencode"
+        && effective_command[6] == "--external-session-id"
+        && effective_command[8] == "--"
+        && Path::new(&effective_command[9]).file_name()?.to_str()? == "opencode"
+        && effective_command[10] == "--session"
+        && !session_id.is_empty()
+        && session_id == external_session_id)
+        .then_some(session_id.as_str())
+}
+
+fn supervised_shared_opencode_command(
+    effective_command: &[String],
+    boomux: &str,
+) -> Option<Vec<String>> {
+    let session_id = supervised_opencode_session(effective_command)?;
+    let mut command = effective_command[..9].to_vec();
+    command.extend([
+        boomux.into(),
+        "opencode".into(),
+        "shared".into(),
+        "--session".into(),
+        session_id.into(),
+    ]);
+    Some(command)
 }
 
 fn codex_launch_eligible(_shell: &Shell, effective_command: &[String]) -> bool {
@@ -2913,6 +2950,7 @@ struct DaemonService {
     claude_remote_control: ClaudeRemoteControlBindings,
     remote_attachments: RemoteAttachmentManager,
     host_service_previews: Mutex<HashMap<String, HostServicePreview>>,
+    host_session_catalog: Mutex<Option<HostSessionCatalog>>,
     workspace_operation_locks: Mutex<HashMap<String, Weak<Mutex<()>>>>,
     mutation_lock: Mutex<()>,
     notification_settings: NotificationDeliverySettings,
@@ -2926,6 +2964,12 @@ struct DaemonService {
 struct HostServicePreview {
     created_at: Instant,
     prepared: PreparedIntegrationMutation,
+}
+
+struct HostSessionCatalog {
+    directories: Vec<PathBuf>,
+    sessions: Vec<crate::host_session_titles::HostSession>,
+    inspected_at: Instant,
 }
 
 #[derive(Default)]
@@ -6332,6 +6376,7 @@ impl Default for DaemonService {
             claude_remote_control: ClaudeRemoteControlBindings::default(),
             remote_attachments: RemoteAttachmentManager::default(),
             host_service_previews: Mutex::new(HashMap::new()),
+            host_session_catalog: Mutex::new(None),
             workspace_operation_locks: Mutex::new(HashMap::new()),
             mutation_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
@@ -8299,6 +8344,31 @@ impl DaemonService {
         }
     }
 
+    fn host_sessions(
+        &self,
+        snapshot: &Snapshot,
+    ) -> DaemonResult<Vec<crate::session_projection::SessionProjection>> {
+        let directories = host_services::session_catalog_directories(snapshot);
+        let mut cached = lock(&self.host_session_catalog)?;
+        if cached.as_ref().is_none_or(|catalog| {
+            catalog.directories != directories
+                || catalog.inspected_at.elapsed() >= HOST_SESSION_CATALOG_TTL
+        }) {
+            *cached = Some(HostSessionCatalog {
+                sessions: host_services::session_catalog(&directories),
+                directories,
+                inspected_at: Instant::now(),
+            });
+        }
+        Ok(host_services::sessions_with_catalog(
+            snapshot,
+            &cached
+                .as_ref()
+                .expect("Session catalog was inserted")
+                .sessions,
+        ))
+    }
+
     fn host_service(&self, operation: HostServiceOperation) -> DaemonResult<HostServiceResult> {
         match operation {
             HostServiceOperation::DiscoverProjects => Ok(HostServiceResult::Projects {
@@ -8404,7 +8474,9 @@ impl DaemonService {
                 run_id,
             }),
             HostServiceOperation::ListAgentSessions { workspace_id } => {
-                let sessions = host_services::sessions(&self.snapshot()?)
+                let snapshot = self.snapshot()?;
+                let sessions = self
+                    .host_sessions(&snapshot)?
                     .into_iter()
                     .filter(|session| {
                         workspace_id
@@ -8416,9 +8488,15 @@ impl DaemonService {
                 Ok(HostServiceResult::AgentSessions { sessions })
             }
             HostServiceOperation::InspectAgentSession { session_id } => {
+                let snapshot = self.snapshot()?;
+                let sessions = self.host_sessions(&snapshot)?;
                 Ok(HostServiceResult::AgentSession {
-                    session: host_services::inspect_session(&self.snapshot()?, &session_id)
-                        .map_err(DaemonError::from)?,
+                    session: host_services::inspect_projected_session(
+                        &snapshot,
+                        &sessions,
+                        &session_id,
+                    )
+                    .map_err(DaemonError::from)?,
                 })
             }
             HostServiceOperation::ResolveAgentSession {
@@ -12071,6 +12149,7 @@ impl DaemonService {
             claude_remote_control: ClaudeRemoteControlBindings::default(),
             remote_attachments: RemoteAttachmentManager::default(),
             host_service_previews: Mutex::new(HashMap::new()),
+            host_session_catalog: Mutex::new(None),
             workspace_operation_locks: Mutex::new(HashMap::new()),
             mutation_lock: Mutex::new(()),
             notification_settings: NotificationDeliverySettings::default(),
@@ -14045,6 +14124,7 @@ impl ShellRuntimeManager {
             .unwrap_or_else(capture_current_environment);
         let mut child_environment = sanitize_opencode_shim_environment(&original_environment);
         let mut shared_recovery_command = None;
+        let mut supervised_shared_command = None;
         let mut codex_launch_command = None;
         let mut kiro_launch_command = None;
         if let Some(session_id) = recovery.opencode_session_id
@@ -14077,6 +14157,19 @@ impl ShellRuntimeManager {
                     "--session".into(),
                     session_id.into(),
                 ]);
+            }
+        } else if supervised_opencode_session(selected_command).is_some()
+            && let Ok(injected) =
+                inject_opencode_shim_environment(&child_environment, claude_remote_control)
+        {
+            child_environment = injected;
+            if let Some(executable) =
+                environment_value(&child_environment, b"BOOMUX_SHIM_EXECUTABLE")
+            {
+                supervised_shared_command = supervised_shared_opencode_command(
+                    selected_command,
+                    &executable.to_string_lossy(),
+                );
             }
         } else if codex_launch
             && let Ok(injected) =
@@ -14150,6 +14243,7 @@ impl ShellRuntimeManager {
         }
         let selected_command = shared_recovery_command
             .as_deref()
+            .or(supervised_shared_command.as_deref())
             .or(codex_launch_command.as_deref())
             .or(kiro_launch_command.as_deref())
             .unwrap_or(selected_command);
@@ -16058,6 +16152,52 @@ mod tests {
         )
         .unwrap();
         assert!(!opencode_shim_eligible(&command, &command.command));
+    }
+
+    #[test]
+    fn supervised_opencode_resume_is_exactly_recognized_for_shared_launch() {
+        let command = vec![
+            "/opt/boomux".into(),
+            "agent".into(),
+            "supervise".into(),
+            "OpenCode".into(),
+            "--integration".into(),
+            "opencode".into(),
+            "--external-session-id".into(),
+            "session-exact".into(),
+            "--".into(),
+            "/opt/opencode".into(),
+            "--session".into(),
+            "session-exact".into(),
+        ];
+        assert_eq!(supervised_opencode_session(&command), Some("session-exact"));
+        assert_eq!(
+            supervised_shared_opencode_command(&command, "/new/boomux").unwrap(),
+            [
+                "/opt/boomux",
+                "agent",
+                "supervise",
+                "OpenCode",
+                "--integration",
+                "opencode",
+                "--external-session-id",
+                "session-exact",
+                "--",
+                "/new/boomux",
+                "opencode",
+                "shared",
+                "--session",
+                "session-exact",
+            ]
+        );
+
+        let mut mismatched = command.clone();
+        mismatched[11] = "different-session".into();
+        assert_eq!(supervised_opencode_session(&mismatched), None);
+
+        let mut argument_bearing = command;
+        argument_bearing.push("--fork".into());
+        assert_eq!(supervised_opencode_session(&argument_bearing), None);
     }
 
     #[test]

--- a/src/host_services.rs
+++ b/src/host_services.rs
@@ -551,13 +551,25 @@ pub(crate) fn verify_integration(
 }
 
 pub(crate) fn sessions(snapshot: &Snapshot) -> Vec<SessionProjection> {
-    let directories = workspace_directories(&snapshot.workspaces)
+    let directories = session_catalog_directories(snapshot);
+    let catalog = session_catalog(&directories);
+    sessions_with_catalog(snapshot, &catalog)
+}
+
+pub(crate) fn session_catalog_directories(snapshot: &Snapshot) -> Vec<PathBuf> {
+    workspace_directories(&snapshot.workspaces)
         .into_iter()
         .take(MAX_CATALOG_DIRECTORIES)
-        .collect::<Vec<_>>();
-    let catalog = thread::scope(|scope| {
+        .collect()
+}
+
+pub(crate) fn session_catalog(
+    directories: &[PathBuf],
+) -> Vec<crate::host_session_titles::HostSession> {
+    thread::scope(|scope| {
         directories
-            .into_iter()
+            .iter()
+            .cloned()
             .flat_map(|directory| {
                 crate::host_session_titles::catalog_integrations()
                     .map(move |integration| (integration, directory.clone()))
@@ -570,8 +582,14 @@ pub(crate) fn sessions(snapshot: &Snapshot) -> Vec<SessionProjection> {
             .filter_map(|handle| handle.join().ok().flatten())
             .flatten()
             .collect::<Vec<_>>()
-    });
-    let mut sessions = session_projection::project_snapshot_with_catalog(snapshot, Some(&catalog));
+    })
+}
+
+pub(crate) fn sessions_with_catalog(
+    snapshot: &Snapshot,
+    catalog: &[crate::host_session_titles::HostSession],
+) -> Vec<SessionProjection> {
+    let mut sessions = session_projection::project_snapshot_with_catalog(snapshot, Some(catalog));
     sessions.truncate(MAX_HOST_SERVICE_SESSIONS);
     sessions
 }
@@ -617,12 +635,12 @@ pub(crate) fn session_summary(session: &SessionProjection) -> HostAgentSessionSu
     }
 }
 
-pub(crate) fn inspect_session(
+pub(crate) fn inspect_projected_session(
     snapshot: &Snapshot,
+    sessions: &[SessionProjection],
     session_id: &str,
 ) -> io::Result<HostAgentSessionInspection> {
-    let sessions = sessions(snapshot);
-    let session = session_projection::resolve_exact(&sessions, session_id).map_err(|error| {
+    let session = session_projection::resolve_exact(sessions, session_id).map_err(|error| {
         io::Error::new(
             match error {
                 session_projection::ResolveError::NotFound => io::ErrorKind::NotFound,

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,7 @@ const NON_PROTOCOL_FEATURES: &[&str] = &[
     "persistent_workspace_selection",
     "create_and_open_shell",
     "atomic_workspace_shell_creation",
+    "exact_session_open",
     "hyprland_special_workspaces",
     "contextual_desktop_terminal",
     "coordinated_shell_desktop_placement",
@@ -888,6 +889,13 @@ enum SessionCommands {
         #[arg(long)]
         node: Option<String>,
     },
+    /// Open one exact current or historical Session in a native terminal
+    Open {
+        session_id: String,
+        /// Exact registered Node alias or Node ID
+        #[arg(long)]
+        node: Option<String>,
+    },
     /// Resume one exact projected session in a native terminal
     Resume {
         session_id: String,
@@ -1262,6 +1270,7 @@ command_keys! {
     IntegrationVerify => ("integration.verify", Json),
     SessionList => ("session.list", Json),
     SessionInspect => ("session.inspect", Json),
+    SessionOpen => ("session.open", HumanOnly),
     SessionResume => ("session.resume", HumanOnly),
     Skill => ("skill", HumanOnly),
     Opencode => ("opencode", HumanOnly),
@@ -1419,6 +1428,9 @@ impl Cli {
             Some(Commands::Session {
                 command: SessionCommands::Inspect { .. },
             }) => CommandKey::SessionInspect,
+            Some(Commands::Session {
+                command: SessionCommands::Open { .. },
+            }) => CommandKey::SessionOpen,
             Some(Commands::Session {
                 command: SessionCommands::Resume { .. },
             }) => CommandKey::SessionResume,
@@ -1896,7 +1908,9 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Notification {
             command: NotificationCommands::Test { reason },
         }) => test_notification(reason),
-        Some(Commands::Session { command }) => session_command(command, cli.json),
+        Some(Commands::Session { command }) => {
+            session_command(command, cli.json, cli.terminal.as_deref())
+        }
         Some(Commands::Integration { command }) => integration_command(command, cli.json),
         Some(Commands::Skill {
             command: SkillCommands::Install { force },
@@ -4045,13 +4059,12 @@ fn dashboard_session_effect(
             tui::DashboardEvent::SessionsLoaded(load_dashboard_sessions(&nodes))
         }
         tui::DashboardEffect::InspectSession(identity) => {
-            let result = inspect_dashboard_session(&identity, local_node_id).map(|inspection| {
-                let action = dashboard_session_action(&inspection).and_then(|action| {
+            let result = inspect_session_on_node(&identity, local_node_id).map(|inspection| {
+                let action = session_open_action(&inspection).and_then(|action| {
                     if inspection.summary.state_is_current {
                         Ok(action)
                     } else {
-                        validate_dashboard_session_cwd(&identity, local_node_id, &inspection)
-                            .map(|_| action)
+                        validate_session_cwd(&identity, local_node_id, &inspection).map(|_| action)
                     }
                 });
                 dashboard_session_details(&identity, inspection, action)
@@ -4059,7 +4072,7 @@ fn dashboard_session_effect(
             tui::DashboardEvent::SessionInspected { identity, result }
         }
         tui::DashboardEffect::ActivateSession(identity) => tui::DashboardEvent::OperationCompleted(
-            activate_dashboard_session(&identity, local_node_id, terminal_entry),
+            open_exact_session(&identity, local_node_id, terminal_entry),
         ),
         effect => panic!("unexpected effect on Session worker: {effect:?}"),
     }
@@ -4145,7 +4158,7 @@ fn dashboard_session_summary(
     }
 }
 
-fn inspect_dashboard_session(
+fn inspect_session_on_node(
     identity: &protocol::QualifiedIdentity,
     local_node_id: &str,
 ) -> Result<protocol::HostAgentSessionInspection, String> {
@@ -4183,7 +4196,7 @@ fn dashboard_session_details(
     }
 }
 
-fn dashboard_session_action(
+fn session_open_action(
     inspection: &protocol::HostAgentSessionInspection,
 ) -> Result<String, String> {
     if inspection.summary.state == AgentState::Done {
@@ -4207,7 +4220,7 @@ fn dashboard_session_action(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum DashboardSessionOpenPlan {
+enum SessionOpenPlan {
     Current {
         node_id: Option<String>,
         shell_id: String,
@@ -4223,13 +4236,13 @@ enum DashboardSessionOpenPlan {
     },
 }
 
-fn dashboard_session_open_plan(
+fn session_open_plan(
     identity: &protocol::QualifiedIdentity,
     local_node_id: &str,
     inspection: &protocol::HostAgentSessionInspection,
     workspace: Option<&WorkspaceSnapshot>,
-) -> Result<DashboardSessionOpenPlan, String> {
-    dashboard_session_action(inspection)?;
+) -> Result<SessionOpenPlan, String> {
+    session_open_action(inspection)?;
     let summary = &inspection.summary;
     let node_id = (identity.node_id != local_node_id && !identity.node_id.is_empty())
         .then(|| identity.node_id.clone());
@@ -4238,7 +4251,7 @@ fn dashboard_session_open_plan(
         summary.workspace_name, summary.integration
     );
     if !summary.state_is_current {
-        return Ok(DashboardSessionOpenPlan::Historical {
+        return Ok(SessionOpenPlan::Historical {
             node_id,
             session_id: identity.inner_id.clone(),
             title,
@@ -4252,6 +4265,14 @@ fn dashboard_session_open_plan(
         return Err("Session owner Workspace identity changed; refusing ambiguity".into());
     }
     let mut current = inspection.occurrences.iter().filter_map(|occurrence| {
+        if occurrence.ended_at_ms.is_some()
+            || matches!(
+                occurrence.observation.state,
+                AgentState::Inactive | AgentState::Done
+            )
+        {
+            return None;
+        }
         workspace
             .shells
             .iter()
@@ -4271,7 +4292,7 @@ fn dashboard_session_open_plan(
     if current.next().is_some() {
         return Err("Session has multiple current managed Shells; refusing ambiguity".into());
     }
-    Ok(DashboardSessionOpenPlan::Current {
+    Ok(SessionOpenPlan::Current {
         node_id,
         shell_id,
         run_id,
@@ -4280,8 +4301,8 @@ fn dashboard_session_open_plan(
     })
 }
 
-fn dispatch_dashboard_session_open<L, R, H>(
-    plan: &DashboardSessionOpenPlan,
+fn dispatch_session_open<L, R, H>(
+    plan: &SessionOpenPlan,
     mut open_local: L,
     mut open_remote: R,
     mut resume: H,
@@ -4292,7 +4313,7 @@ where
     H: FnMut(Option<&str>, &str, &str) -> Result<(), String>,
 {
     match plan {
-        DashboardSessionOpenPlan::Current {
+        SessionOpenPlan::Current {
             node_id,
             shell_id,
             run_id,
@@ -4304,21 +4325,23 @@ where
             } else {
                 open_local(shell_id, run_id, title)?;
             }
-            Ok(format!("Opened current Session {description}"))
+            Ok(format!("Opened terminal for current Session {description}"))
         }
-        DashboardSessionOpenPlan::Historical {
+        SessionOpenPlan::Historical {
             node_id,
             session_id,
             title,
             description,
         } => {
             resume(node_id.as_deref(), session_id, title)?;
-            Ok(format!("Opened historical Session {description}"))
+            Ok(format!(
+                "Opened terminal for historical Session {description}"
+            ))
         }
     }
 }
 
-fn validate_dashboard_session_cwd(
+fn validate_session_cwd(
     identity: &protocol::QualifiedIdentity,
     local_node_id: &str,
     inspection: &protocol::HostAgentSessionInspection,
@@ -4341,12 +4364,12 @@ fn validate_dashboard_session_cwd(
     }
 }
 
-fn activate_dashboard_session(
+fn open_exact_session(
     identity: &protocol::QualifiedIdentity,
     local_node_id: &str,
     terminal_entry: Option<&str>,
 ) -> Result<String, String> {
-    let inspection = inspect_dashboard_session(identity, local_node_id)?;
+    let inspection = inspect_session_on_node(identity, local_node_id)?;
     let summary = &inspection.summary;
     let remote = identity.node_id != local_node_id && !identity.node_id.is_empty();
     let workspace = if summary.state_is_current {
@@ -4370,12 +4393,11 @@ fn activate_dashboard_session(
                 .map_err(|error| error.to_string())?
         })
     } else {
-        validate_dashboard_session_cwd(identity, local_node_id, &inspection)?;
+        validate_session_cwd(identity, local_node_id, &inspection)?;
         None
     };
-    let plan =
-        dashboard_session_open_plan(identity, local_node_id, &inspection, workspace.as_ref())?;
-    dispatch_dashboard_session_open(
+    let plan = session_open_plan(identity, local_node_id, &inspection, workspace.as_ref())?;
+    dispatch_session_open(
         &plan,
         |shell_id, run_id, title| {
             terminal::open_exact_run(terminal_entry, shell_id, run_id, title, true)
@@ -8813,12 +8835,33 @@ fn attention_command(command: AttentionCommands, json: bool) -> Result<(), Box<d
     Ok(())
 }
 
-fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn Error>> {
+fn session_command(
+    command: SessionCommands,
+    json: bool,
+    terminal_override: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     validate_session_protocol(client.protocol_version()?)?;
+    if let SessionCommands::Open { session_id, node } = &command {
+        let local_node_id = client.node_identity()?;
+        let owner_node_id = match node {
+            Some(node) => client.node_registration(node)?.node_id,
+            None => local_node_id.clone(),
+        };
+        let terminal = effective_terminal(terminal_override)?;
+        let message = open_exact_session(
+            &protocol::QualifiedIdentity::new(owner_node_id, session_id),
+            &local_node_id,
+            terminal.as_deref(),
+        )
+        .map_err(io::Error::other)?;
+        println!("{message}");
+        return Ok(());
+    }
     let selected_node = match &command {
         SessionCommands::List { node, .. }
         | SessionCommands::Inspect { node, .. }
+        | SessionCommands::Open { node, .. }
         | SessionCommands::Resume { node, .. } => node.as_deref(),
     };
     if let Some(node) = selected_node {
@@ -8903,6 +8946,7 @@ fn session_command(command: SessionCommands, json: bool) -> Result<(), Box<dyn E
             }
             print_session(session);
         }
+        SessionCommands::Open { .. } => unreachable!("Session open returns before projection"),
         SessionCommands::Resume { session_id, .. } => {
             let catalog = discover_host_catalog(&snapshot.workspaces);
             let sessions =
@@ -9006,6 +9050,7 @@ fn remote_session_command(
             println!("INTEGRATION\t{}", session.summary.integration);
             println!("OCCURRENCES\t{}", session.summary.occurrence_count);
         }
+        SessionCommands::Open { .. } => unreachable!("Session open uses shared exact-open logic"),
         SessionCommands::Resume { session_id, .. } => {
             let result = client.route_node_host_service(
                 &registration.node_id,
@@ -13141,7 +13186,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_session_discovery_commands_and_json_support() {
+    fn parses_session_discovery_and_human_only_open_commands() {
         let list = Cli::try_parse_from([
             "boomux",
             "session",
@@ -13168,7 +13213,43 @@ mod tests {
         assert_eq!(inspect.command_descriptor().key, "session.inspect");
         assert_eq!(inspect.command_descriptor().output, OutputMode::Json);
 
+        let open =
+            Cli::try_parse_from(["boomux", "session", "open", "opaque", "--node", "workbox"])
+                .unwrap();
+        assert_eq!(open.command_descriptor().key, "session.open");
+        assert_eq!(open.command_descriptor().output, OutputMode::HumanOnly);
+        assert!(matches!(
+            open.command,
+            Some(Commands::Session {
+                command: SessionCommands::Open { session_id, node }
+            }) if session_id == "opaque" && node.as_deref() == Some("workbox")
+        ));
+
+        let json_open =
+            Cli::try_parse_from(["boomux", "--json", "session", "open", "opaque"]).unwrap();
+        assert!(
+            run(json_open)
+                .unwrap_err()
+                .to_string()
+                .contains("--json is not supported for session.open")
+        );
+
         assert!(Cli::try_parse_from(["boomux", "session", "read", "opaque"]).is_err());
+    }
+
+    #[test]
+    fn session_open_help_is_public_and_documents_exact_identity_and_node() {
+        let session_help = match Cli::try_parse_from(["boomux", "session", "--help"]) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("Session help must exit before command dispatch"),
+        };
+        assert!(session_help.contains("open"));
+        let open_help = match Cli::try_parse_from(["boomux", "session", "open", "--help"]) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("Session open help must exit before command dispatch"),
+        };
+        assert!(open_help.contains("SESSION_ID"));
+        assert!(open_help.contains("--node <NODE>"));
     }
 
     #[test]
@@ -14709,6 +14790,8 @@ mod tests {
         assert!(json_commands.contains(&"shell.suggest-name"));
         assert!(json_commands.contains(&"workspace.create"));
         assert!(NON_PROTOCOL_FEATURES.contains(&"atomic_workspace_shell_creation"));
+        assert!(NON_PROTOCOL_FEATURES.contains(&"exact_session_open"));
+        assert!(!json_commands.contains(&"session.open"));
         for command in [
             "agent.register",
             "agent.ensure",
@@ -15274,13 +15357,13 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_session_actions_distinguish_current_historical_and_invalid_sessions() {
+    fn session_open_actions_distinguish_current_historical_and_invalid_sessions() {
         assert_eq!(
-            dashboard_session_action(&inspected_session(AgentState::Working, true, None)),
+            session_open_action(&inspected_session(AgentState::Working, true, None)),
             Ok("open exact current managed Shell".into())
         );
         assert_eq!(
-            dashboard_session_action(&inspected_session(
+            session_open_action(&inspected_session(
                 AgentState::Inactive,
                 false,
                 Some("/tmp/project")
@@ -15288,17 +15371,17 @@ mod tests {
             Ok("resume exact historical Session".into())
         );
         assert!(
-            dashboard_session_action(&inspected_session(AgentState::Done, false, Some("/tmp")))
+            session_open_action(&inspected_session(AgentState::Done, false, Some("/tmp")))
                 .unwrap_err()
                 .contains("permanently done")
         );
         assert!(
-            dashboard_session_action(&inspected_session(AgentState::Done, true, Some("/tmp")))
+            session_open_action(&inspected_session(AgentState::Done, true, Some("/tmp")))
                 .unwrap_err()
                 .contains("permanently done")
         );
         assert!(
-            dashboard_session_action(&inspected_session(AgentState::Inactive, false, None))
+            session_open_action(&inspected_session(AgentState::Inactive, false, None))
                 .unwrap_err()
                 .contains("source cwd")
         );
@@ -15377,14 +15460,14 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_current_session_plan_routes_exact_local_shell_and_run() {
+    fn session_open_plan_routes_exact_local_current_shell_and_run() {
         let inspection = current_inspected_session("local-shell", "r1");
         let workspace = workspace(
             "workspace-id",
             "workspace",
             vec![shell("local-shell", "workspace-id", "agent")],
         );
-        let plan = dashboard_session_open_plan(
+        let plan = session_open_plan(
             &protocol::QualifiedIdentity::new("local-node", "session-id"),
             "local-node",
             &inspection,
@@ -15393,7 +15476,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             plan,
-            DashboardSessionOpenPlan::Current {
+            SessionOpenPlan::Current {
                 node_id: None,
                 shell_id: "local-shell".into(),
                 run_id: "r1".into(),
@@ -15402,7 +15485,7 @@ mod tests {
             }
         );
         let opened = std::cell::RefCell::new(Vec::new());
-        let message = dispatch_dashboard_session_open(
+        let message = dispatch_session_open(
             &plan,
             |shell, run, _| {
                 opened
@@ -15418,26 +15501,25 @@ mod tests {
             opened.into_inner(),
             vec![("local", "local-shell".into(), "r1".into())]
         );
-        assert_eq!(message, "Opened current Session review");
+        assert_eq!(message, "Opened terminal for current Session review");
     }
 
     #[test]
-    fn dashboard_remote_current_session_plan_preserves_owner_and_ignores_colliding_local_identity()
-    {
+    fn session_open_plan_routes_exact_remote_current_owner_and_ignores_local_collision() {
         let inspection = current_inspected_session("same-shell", "r1");
         let owner_workspace = workspace(
             "workspace-id",
             "owner",
             vec![shell("same-shell", "workspace-id", "owner-agent")],
         );
-        let remote = dashboard_session_open_plan(
+        let remote = session_open_plan(
             &protocol::QualifiedIdentity::new("remote-owner", "same-session"),
             "local-node",
             &inspection,
             Some(&owner_workspace),
         )
         .unwrap();
-        let local = dashboard_session_open_plan(
+        let local = session_open_plan(
             &protocol::QualifiedIdentity::new("local-node", "same-session"),
             "local-node",
             &inspection,
@@ -15446,15 +15528,15 @@ mod tests {
         .unwrap();
         assert!(matches!(
             &remote,
-            DashboardSessionOpenPlan::Current { node_id: Some(node), shell_id, run_id, .. }
+            SessionOpenPlan::Current { node_id: Some(node), shell_id, run_id, .. }
                 if node == "remote-owner" && shell_id == "same-shell" && run_id == "r1"
         ));
         assert!(matches!(
             local,
-            DashboardSessionOpenPlan::Current { node_id: None, .. }
+            SessionOpenPlan::Current { node_id: None, .. }
         ));
         let routed = std::cell::RefCell::new(Vec::new());
-        dispatch_dashboard_session_open(
+        dispatch_session_open(
             &remote,
             |_, _, _| panic!("remote Session must not use local attachment"),
             |node, shell, run, _| {
@@ -15473,9 +15555,9 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_remote_historical_session_plan_resumes_exact_owner_identity() {
+    fn session_open_plan_resumes_exact_remote_historical_owner_identity() {
         let inspection = inspected_session(AgentState::Inactive, false, Some("/owner/project"));
-        let plan = dashboard_session_open_plan(
+        let plan = session_open_plan(
             &protocol::QualifiedIdentity::new("remote-owner", "exact-session"),
             "local-node",
             &inspection,
@@ -15484,11 +15566,11 @@ mod tests {
         .unwrap();
         assert!(matches!(
             &plan,
-            DashboardSessionOpenPlan::Historical { node_id: Some(node), session_id, .. }
+            SessionOpenPlan::Historical { node_id: Some(node), session_id, .. }
                 if node == "remote-owner" && session_id == "exact-session"
         ));
         let resumed = std::cell::RefCell::new(Vec::new());
-        dispatch_dashboard_session_open(
+        dispatch_session_open(
             &plan,
             |_, _, _| panic!("historical Session must not attach locally"),
             |_, _, _, _| panic!("historical Session must not attach remotely"),
@@ -15507,10 +15589,36 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_session_plan_rejects_done_missing_and_ambiguous_current_targets() {
+    fn session_open_plan_resumes_exact_local_historical_identity() {
+        let inspection = inspected_session(AgentState::Inactive, false, Some("/local/project"));
+        let plan = session_open_plan(
+            &protocol::QualifiedIdentity::new("local-node", "exact-session"),
+            "local-node",
+            &inspection,
+            None,
+        )
+        .unwrap();
+        let resumed = std::cell::RefCell::new(Vec::new());
+        dispatch_session_open(
+            &plan,
+            |_, _, _| panic!("historical Session must not attach locally"),
+            |_, _, _, _| panic!("historical Session must not attach remotely"),
+            |node, session, _| {
+                resumed
+                    .borrow_mut()
+                    .push((node.map(str::to_owned), session.to_owned()));
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(resumed.into_inner(), vec![(None, "exact-session".into())]);
+    }
+
+    #[test]
+    fn session_open_plan_rejects_done_missing_and_ambiguous_current_targets() {
         let identity = protocol::QualifiedIdentity::new("local-node", "session-id");
         assert!(
-            dashboard_session_open_plan(
+            session_open_plan(
                 &identity,
                 "local-node",
                 &inspected_session(AgentState::Done, false, Some("/tmp")),
@@ -15520,7 +15628,7 @@ mod tests {
             .contains("permanently done")
         );
         assert!(
-            dashboard_session_open_plan(
+            session_open_plan(
                 &identity,
                 "local-node",
                 &current_inspected_session("missing", "r1"),
@@ -15542,10 +15650,36 @@ mod tests {
             ],
         );
         assert!(
-            dashboard_session_open_plan(&identity, "local-node", &inspection, Some(&workspace),)
+            session_open_plan(&identity, "local-node", &inspection, Some(&workspace),)
                 .unwrap_err()
                 .contains("multiple current")
         );
+    }
+
+    #[test]
+    fn session_open_plan_ignores_ended_and_inactive_occurrences() {
+        let identity = protocol::QualifiedIdentity::new("local-node", "session-id");
+        let mut inspection = current_inspected_session("current", "r1");
+        let mut inactive = agent("inactive-agent", "workspace-id", "inactive");
+        inactive.observation.state = AgentState::Inactive;
+        let mut ended = agent("ended-agent", "workspace-id", "ended");
+        ended.ended_at_ms = Some(12);
+        inspection.occurrences.extend([inactive, ended]);
+        let workspace = workspace(
+            "workspace-id",
+            "workspace",
+            vec![
+                shell("current", "workspace-id", "current"),
+                shell("inactive", "workspace-id", "inactive"),
+                shell("ended", "workspace-id", "ended"),
+            ],
+        );
+
+        assert!(matches!(
+            session_open_plan(&identity, "local-node", &inspection, Some(&workspace)),
+            Ok(SessionOpenPlan::Current { shell_id, run_id, .. })
+                if shell_id == "current" && run_id == "r1"
+        ));
     }
 
     fn test_skill_home(label: &str) -> PathBuf {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3403,6 +3403,8 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
         .ok()
         .flatten()
         .map(|selection| selection.workspace_id().to_owned());
+    let session_local_node_id = local_node_id.clone();
+    let session_terminal = terminal.clone();
     tui::run(
         initial_state,
         selected_workspace_id,
@@ -3950,6 +3952,14 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                 run_id,
                 output_revision,
             },
+            tui::DashboardEffect::LoadSessions { .. }
+            | tui::DashboardEffect::InspectSession(_)
+            | tui::DashboardEffect::ActivateSession(_) => {
+                unreachable!("Session effects use the dedicated dashboard worker")
+            }
+        },
+        move |effect| {
+            dashboard_session_effect(effect, &session_local_node_id, session_terminal.as_deref())
         },
     )?;
     Ok(())
@@ -4023,6 +4033,363 @@ fn dashboard_state(
         ),
         reset_focus_revision,
     }
+}
+
+fn dashboard_session_effect(
+    effect: tui::DashboardEffect,
+    local_node_id: &str,
+    terminal_entry: Option<&str>,
+) -> tui::DashboardEvent {
+    match effect {
+        tui::DashboardEffect::LoadSessions { nodes } => {
+            tui::DashboardEvent::SessionsLoaded(load_dashboard_sessions(&nodes))
+        }
+        tui::DashboardEffect::InspectSession(identity) => {
+            let result = inspect_dashboard_session(&identity, local_node_id).map(|inspection| {
+                let action = dashboard_session_action(&inspection).and_then(|action| {
+                    if inspection.summary.state_is_current {
+                        Ok(action)
+                    } else {
+                        validate_dashboard_session_cwd(&identity, local_node_id, &inspection)
+                            .map(|_| action)
+                    }
+                });
+                dashboard_session_details(&identity, inspection, action)
+            });
+            tui::DashboardEvent::SessionInspected { identity, result }
+        }
+        tui::DashboardEffect::ActivateSession(identity) => tui::DashboardEvent::OperationCompleted(
+            activate_dashboard_session(&identity, local_node_id, terminal_entry),
+        ),
+        effect => panic!("unexpected effect on Session worker: {effect:?}"),
+    }
+}
+
+fn load_dashboard_sessions(
+    nodes: &[tui::SessionNodeView],
+) -> Result<tui::SessionLoadResult, String> {
+    let client = client::connect().map_err(|error| error.to_string())?;
+    let loads = nodes.iter().cloned().map(|node| {
+        let operation = protocol::HostServiceOperation::ListAgentSessions { workspace_id: None };
+        let result = if node.local {
+            client.host_service(operation)
+        } else {
+            client.route_node_host_service(&node.id, operation)
+        };
+        let result = match result {
+            Ok(protocol::HostServiceResult::AgentSessions {
+                sessions: node_sessions,
+            }) => Ok(node_sessions),
+            Ok(_) => Err("returned an unexpected Session-list response".into()),
+            Err(error) => Err(error.to_string()),
+        };
+        DashboardSessionNodeLoad { node, result }
+    });
+    aggregate_dashboard_session_loads(loads)
+}
+
+struct DashboardSessionNodeLoad {
+    node: tui::SessionNodeView,
+    result: Result<Vec<protocol::HostAgentSessionSummary>, String>,
+}
+
+fn aggregate_dashboard_session_loads(
+    loads: impl IntoIterator<Item = DashboardSessionNodeLoad>,
+) -> Result<tui::SessionLoadResult, String> {
+    let mut sessions = Vec::new();
+    let mut warnings = Vec::new();
+    let mut successful_nodes = 0usize;
+    for load in loads {
+        match load.result {
+            Ok(node_sessions) => {
+                successful_nodes += 1;
+                sessions.extend(node_sessions.into_iter().map(|session| {
+                    dashboard_session_summary(&load.node.id, &load.node.alias, session)
+                }));
+            }
+            Err(error) => warnings.push(format!("Node {}: {error}", load.node.alias)),
+        }
+    }
+    if successful_nodes == 0 && !warnings.is_empty() {
+        return Err(format!("Unable to load Sessions: {}", warnings.join("; ")));
+    }
+    sessions.sort_by(|left, right| {
+        right
+            .last_at_ms
+            .cmp(&left.last_at_ms)
+            .then_with(|| left.node_id.cmp(&right.node_id))
+            .then_with(|| left.workspace_id.cmp(&right.workspace_id))
+            .then_with(|| left.session_id.cmp(&right.session_id))
+    });
+    Ok(tui::SessionLoadResult { sessions, warnings })
+}
+
+fn dashboard_session_summary(
+    node_id: &str,
+    node_alias: &str,
+    session: protocol::HostAgentSessionSummary,
+) -> tui::DashboardSessionView {
+    tui::DashboardSessionView {
+        node_id: node_id.to_owned(),
+        node_alias: node_alias.to_owned(),
+        session_id: session.id,
+        workspace_id: session.workspace_id,
+        workspace_name: session.workspace_name,
+        title: session.description,
+        integration: session.integration,
+        state: session.state.into(),
+        state_is_current: session.state_is_current,
+        started_at_ms: session.started_at_ms,
+        last_at_ms: session.last_at_ms,
+        occurrence_count: session.occurrence_count,
+    }
+}
+
+fn inspect_dashboard_session(
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+) -> Result<protocol::HostAgentSessionInspection, String> {
+    let client = client::connect().map_err(|error| error.to_string())?;
+    let operation = protocol::HostServiceOperation::InspectAgentSession {
+        session_id: identity.inner_id.clone(),
+    };
+    let result = if identity.node_id == local_node_id || identity.node_id.is_empty() {
+        client.host_service(operation)
+    } else {
+        client.route_node_host_service(&identity.node_id, operation)
+    }
+    .map_err(|error| error.to_string())?;
+    match result {
+        protocol::HostServiceResult::AgentSession { session } => Ok(session),
+        _ => Err("Node returned an unexpected Session inspection response".into()),
+    }
+}
+
+fn dashboard_session_details(
+    identity: &protocol::QualifiedIdentity,
+    inspection: protocol::HostAgentSessionInspection,
+    action: Result<String, String>,
+) -> tui::DashboardSessionDetails {
+    let node_alias = if identity.node_id.is_empty() {
+        "local".into()
+    } else {
+        identity.node_id.clone()
+    };
+    tui::DashboardSessionDetails {
+        session: dashboard_session_summary(&identity.node_id, &node_alias, inspection.summary),
+        source_cwd: inspection.source_cwd,
+        occurrences: inspection.occurrences,
+        action,
+    }
+}
+
+fn dashboard_session_action(
+    inspection: &protocol::HostAgentSessionInspection,
+) -> Result<String, String> {
+    if inspection.summary.state == AgentState::Done {
+        return Err("Session is permanently done".into());
+    }
+    if inspection.summary.state_is_current {
+        return Ok("open exact current managed Shell".into());
+    }
+    if inspection.source_cwd.is_none() {
+        return Err("Session has no retained source cwd".into());
+    }
+    let integration = boomux::integrations::by_key(&inspection.summary.integration)
+        .ok_or_else(|| "Session uses an unknown integration".to_owned())?;
+    if integration.resume.is_none() || inspection.summary.external_session_id.is_none() {
+        return Err(format!(
+            "{} cannot resume this exact Session",
+            integration.display_name
+        ));
+    }
+    Ok("resume exact historical Session".into())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DashboardSessionOpenPlan {
+    Current {
+        node_id: Option<String>,
+        shell_id: String,
+        run_id: String,
+        title: String,
+        description: String,
+    },
+    Historical {
+        node_id: Option<String>,
+        session_id: String,
+        title: String,
+        description: String,
+    },
+}
+
+fn dashboard_session_open_plan(
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+    inspection: &protocol::HostAgentSessionInspection,
+    workspace: Option<&WorkspaceSnapshot>,
+) -> Result<DashboardSessionOpenPlan, String> {
+    dashboard_session_action(inspection)?;
+    let summary = &inspection.summary;
+    let node_id = (identity.node_id != local_node_id && !identity.node_id.is_empty())
+        .then(|| identity.node_id.clone());
+    let title = format!(
+        "{} - {} Session",
+        summary.workspace_name, summary.integration
+    );
+    if !summary.state_is_current {
+        return Ok(DashboardSessionOpenPlan::Historical {
+            node_id,
+            session_id: identity.inner_id.clone(),
+            title,
+            description: summary.description.clone(),
+        });
+    }
+
+    let workspace =
+        workspace.ok_or_else(|| "Session owner Workspace is no longer available".to_owned())?;
+    if workspace.id != summary.workspace_id {
+        return Err("Session owner Workspace identity changed; refusing ambiguity".into());
+    }
+    let mut current = inspection.occurrences.iter().filter_map(|occurrence| {
+        workspace
+            .shells
+            .iter()
+            .find(|shell| {
+                shell.id == occurrence.shell_id
+                    && shell.status == ShellStatus::Running
+                    && shell
+                        .run
+                        .as_ref()
+                        .is_some_and(|run| run.id == occurrence.run_id)
+            })
+            .map(|shell| (shell.id.clone(), occurrence.run_id.clone()))
+    });
+    let (shell_id, run_id) = current
+        .next()
+        .ok_or_else(|| "Session no longer has an exact current managed Shell".to_owned())?;
+    if current.next().is_some() {
+        return Err("Session has multiple current managed Shells; refusing ambiguity".into());
+    }
+    Ok(DashboardSessionOpenPlan::Current {
+        node_id,
+        shell_id,
+        run_id,
+        title,
+        description: summary.description.clone(),
+    })
+}
+
+fn dispatch_dashboard_session_open<L, R, H>(
+    plan: &DashboardSessionOpenPlan,
+    mut open_local: L,
+    mut open_remote: R,
+    mut resume: H,
+) -> Result<String, String>
+where
+    L: FnMut(&str, &str, &str) -> Result<(), String>,
+    R: FnMut(&str, &str, &str, &str) -> Result<(), String>,
+    H: FnMut(Option<&str>, &str, &str) -> Result<(), String>,
+{
+    match plan {
+        DashboardSessionOpenPlan::Current {
+            node_id,
+            shell_id,
+            run_id,
+            title,
+            description,
+        } => {
+            if let Some(node_id) = node_id {
+                open_remote(node_id, shell_id, run_id, title)?;
+            } else {
+                open_local(shell_id, run_id, title)?;
+            }
+            Ok(format!("Opened current Session {description}"))
+        }
+        DashboardSessionOpenPlan::Historical {
+            node_id,
+            session_id,
+            title,
+            description,
+        } => {
+            resume(node_id.as_deref(), session_id, title)?;
+            Ok(format!("Opened historical Session {description}"))
+        }
+    }
+}
+
+fn validate_dashboard_session_cwd(
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+    inspection: &protocol::HostAgentSessionInspection,
+) -> Result<PathBuf, String> {
+    let cwd = inspection
+        .source_cwd
+        .clone()
+        .ok_or_else(|| "Session has no retained source cwd".to_owned())?;
+    let client = client::connect().map_err(|error| error.to_string())?;
+    let operation = protocol::HostServiceOperation::ResolveDirectory { path: cwd };
+    let result = if identity.node_id == local_node_id || identity.node_id.is_empty() {
+        client.host_service(operation)
+    } else {
+        client.route_node_host_service(&identity.node_id, operation)
+    }
+    .map_err(|error| format!("Session source cwd is unavailable: {error}"))?;
+    match result {
+        protocol::HostServiceResult::Directory { path } => Ok(path),
+        _ => Err("Node returned an unexpected source cwd response".into()),
+    }
+}
+
+fn activate_dashboard_session(
+    identity: &protocol::QualifiedIdentity,
+    local_node_id: &str,
+    terminal_entry: Option<&str>,
+) -> Result<String, String> {
+    let inspection = inspect_dashboard_session(identity, local_node_id)?;
+    let summary = &inspection.summary;
+    let remote = identity.node_id != local_node_id && !identity.node_id.is_empty();
+    let workspace = if summary.state_is_current {
+        let client = client::connect().map_err(|error| error.to_string())?;
+        Some(if remote {
+            match client
+                .route_node_operation(
+                    &identity.node_id,
+                    protocol::RoutedOperation::GetWorkspace {
+                        workspace_id: summary.workspace_id.clone(),
+                    },
+                )
+                .map_err(|error| error.to_string())?
+            {
+                protocol::RoutedOperationResult::Workspace { workspace } => workspace,
+                _ => return Err("Node returned an unexpected Workspace response".into()),
+            }
+        } else {
+            client
+                .get_workspace(&summary.workspace_id)
+                .map_err(|error| error.to_string())?
+        })
+    } else {
+        validate_dashboard_session_cwd(identity, local_node_id, &inspection)?;
+        None
+    };
+    let plan =
+        dashboard_session_open_plan(identity, local_node_id, &inspection, workspace.as_ref())?;
+    dispatch_dashboard_session_open(
+        &plan,
+        |shell_id, run_id, title| {
+            terminal::open_exact_run(terminal_entry, shell_id, run_id, title, true)
+                .map_err(|error| error.to_string())
+        },
+        |node_id, shell_id, run_id, title| {
+            terminal::open_remote_exact_run(terminal_entry, node_id, shell_id, run_id, title, true)
+                .map_err(|error| error.to_string())
+        },
+        |node_id, session_id, title| {
+            terminal::open_agent_session(terminal_entry, node_id, session_id, title)
+                .map_err(|error| error.to_string())
+        },
+    )
 }
 
 fn assign_local_workspace_node(workspaces: &mut [tui::WorkspaceView], node: &tui::NodeView) {
@@ -14849,6 +15216,336 @@ mod tests {
         assert!(!skill_install_path(&home).exists());
         fs::remove_dir_all(home).unwrap();
         fs::remove_dir_all(outside).unwrap();
+    }
+
+    fn inspected_session(
+        state: AgentState,
+        current: bool,
+        cwd: Option<&str>,
+    ) -> protocol::HostAgentSessionInspection {
+        protocol::HostAgentSessionInspection {
+            summary: protocol::HostAgentSessionSummary {
+                id: "session-id".into(),
+                workspace_id: "workspace-id".into(),
+                workspace_name: "workspace".into(),
+                description: "review".into(),
+                integration: "opencode".into(),
+                external_session_id: Some("external-id".into()),
+                state,
+                state_is_current: current,
+                started_at_ms: 10,
+                last_at_ms: 20,
+                occurrence_count: 1,
+            },
+            source_cwd: cwd.map(PathBuf::from),
+            occurrences: Vec::new(),
+        }
+    }
+
+    fn host_session_summary(
+        id: &str,
+        workspace_id: &str,
+        last_at_ms: u64,
+    ) -> protocol::HostAgentSessionSummary {
+        protocol::HostAgentSessionSummary {
+            id: id.into(),
+            workspace_id: workspace_id.into(),
+            workspace_name: format!("workspace-{workspace_id}"),
+            description: format!("Session {id}"),
+            integration: "opencode".into(),
+            external_session_id: Some(format!("external-{id}")),
+            state: AgentState::Inactive,
+            state_is_current: false,
+            started_at_ms: last_at_ms.saturating_sub(10),
+            last_at_ms,
+            occurrence_count: 1,
+        }
+    }
+
+    fn current_inspected_session(
+        shell_id: &str,
+        run_id: &str,
+    ) -> protocol::HostAgentSessionInspection {
+        let mut inspection = inspected_session(AgentState::Working, true, Some("/tmp/project"));
+        let mut occurrence = agent("agent-id", "workspace-id", shell_id);
+        occurrence.run_id = run_id.into();
+        inspection.occurrences.push(occurrence);
+        inspection
+    }
+
+    #[test]
+    fn dashboard_session_actions_distinguish_current_historical_and_invalid_sessions() {
+        assert_eq!(
+            dashboard_session_action(&inspected_session(AgentState::Working, true, None)),
+            Ok("open exact current managed Shell".into())
+        );
+        assert_eq!(
+            dashboard_session_action(&inspected_session(
+                AgentState::Inactive,
+                false,
+                Some("/tmp/project")
+            )),
+            Ok("resume exact historical Session".into())
+        );
+        assert!(
+            dashboard_session_action(&inspected_session(AgentState::Done, false, Some("/tmp")))
+                .unwrap_err()
+                .contains("permanently done")
+        );
+        assert!(
+            dashboard_session_action(&inspected_session(AgentState::Done, true, Some("/tmp")))
+                .unwrap_err()
+                .contains("permanently done")
+        );
+        assert!(
+            dashboard_session_action(&inspected_session(AgentState::Inactive, false, None))
+                .unwrap_err()
+                .contains("source cwd")
+        );
+    }
+
+    #[test]
+    fn dashboard_session_aggregation_retains_partial_node_results_and_qualified_order() {
+        let loaded = aggregate_dashboard_session_loads([
+            DashboardSessionNodeLoad {
+                node: tui::SessionNodeView {
+                    id: "a-local".into(),
+                    alias: "local".into(),
+                    local: true,
+                },
+                result: Ok(vec![host_session_summary("same", "z-workspace", 100)]),
+            },
+            DashboardSessionNodeLoad {
+                node: tui::SessionNodeView {
+                    id: "b-remote".into(),
+                    alias: "work".into(),
+                    local: false,
+                },
+                result: Ok(vec![
+                    host_session_summary("newest", "remote-workspace", 200),
+                    host_session_summary("same", "a-workspace", 100),
+                ]),
+            },
+            DashboardSessionNodeLoad {
+                node: tui::SessionNodeView {
+                    id: "c-unavailable".into(),
+                    alias: "offline".into(),
+                    local: false,
+                },
+                result: Err("authentication required".into()),
+            },
+        ])
+        .unwrap();
+
+        assert_eq!(loaded.sessions.len(), 3);
+        assert_eq!(
+            loaded
+                .sessions
+                .iter()
+                .map(|session| (
+                    session.node_id.as_str(),
+                    session.workspace_id.as_str(),
+                    session.session_id.as_str(),
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("b-remote", "remote-workspace", "newest"),
+                ("a-local", "z-workspace", "same"),
+                ("b-remote", "a-workspace", "same"),
+            ]
+        );
+        assert_eq!(loaded.sessions[0].node_alias, "work");
+        assert_eq!(loaded.sessions[1].node_alias, "local");
+        assert_eq!(
+            loaded.warnings,
+            vec!["Node offline: authentication required"]
+        );
+    }
+
+    #[test]
+    fn dashboard_session_summary_preserves_node_qualified_identity_fields() {
+        let details = dashboard_session_details(
+            &protocol::QualifiedIdentity::new("owner-node", "session-id"),
+            inspected_session(AgentState::Inactive, false, Some("/owner/path")),
+            Ok("eligible".into()),
+        );
+
+        assert_eq!(details.session.node_id, "owner-node");
+        assert_eq!(details.session.session_id, "session-id");
+        assert_eq!(details.session.workspace_id, "workspace-id");
+        assert_eq!(details.source_cwd, Some(PathBuf::from("/owner/path")));
+    }
+
+    #[test]
+    fn dashboard_current_session_plan_routes_exact_local_shell_and_run() {
+        let inspection = current_inspected_session("local-shell", "r1");
+        let workspace = workspace(
+            "workspace-id",
+            "workspace",
+            vec![shell("local-shell", "workspace-id", "agent")],
+        );
+        let plan = dashboard_session_open_plan(
+            &protocol::QualifiedIdentity::new("local-node", "session-id"),
+            "local-node",
+            &inspection,
+            Some(&workspace),
+        )
+        .unwrap();
+        assert_eq!(
+            plan,
+            DashboardSessionOpenPlan::Current {
+                node_id: None,
+                shell_id: "local-shell".into(),
+                run_id: "r1".into(),
+                title: "workspace - opencode Session".into(),
+                description: "review".into(),
+            }
+        );
+        let opened = std::cell::RefCell::new(Vec::new());
+        let message = dispatch_dashboard_session_open(
+            &plan,
+            |shell, run, _| {
+                opened
+                    .borrow_mut()
+                    .push(("local", shell.to_owned(), run.to_owned()));
+                Ok(())
+            },
+            |_, _, _, _| panic!("must not route a local Session remotely"),
+            |_, _, _| panic!("must not resume a current Session"),
+        )
+        .unwrap();
+        assert_eq!(
+            opened.into_inner(),
+            vec![("local", "local-shell".into(), "r1".into())]
+        );
+        assert_eq!(message, "Opened current Session review");
+    }
+
+    #[test]
+    fn dashboard_remote_current_session_plan_preserves_owner_and_ignores_colliding_local_identity()
+    {
+        let inspection = current_inspected_session("same-shell", "r1");
+        let owner_workspace = workspace(
+            "workspace-id",
+            "owner",
+            vec![shell("same-shell", "workspace-id", "owner-agent")],
+        );
+        let remote = dashboard_session_open_plan(
+            &protocol::QualifiedIdentity::new("remote-owner", "same-session"),
+            "local-node",
+            &inspection,
+            Some(&owner_workspace),
+        )
+        .unwrap();
+        let local = dashboard_session_open_plan(
+            &protocol::QualifiedIdentity::new("local-node", "same-session"),
+            "local-node",
+            &inspection,
+            Some(&owner_workspace),
+        )
+        .unwrap();
+        assert!(matches!(
+            &remote,
+            DashboardSessionOpenPlan::Current { node_id: Some(node), shell_id, run_id, .. }
+                if node == "remote-owner" && shell_id == "same-shell" && run_id == "r1"
+        ));
+        assert!(matches!(
+            local,
+            DashboardSessionOpenPlan::Current { node_id: None, .. }
+        ));
+        let routed = std::cell::RefCell::new(Vec::new());
+        dispatch_dashboard_session_open(
+            &remote,
+            |_, _, _| panic!("remote Session must not use local attachment"),
+            |node, shell, run, _| {
+                routed
+                    .borrow_mut()
+                    .push((node.to_owned(), shell.to_owned(), run.to_owned()));
+                Ok(())
+            },
+            |_, _, _| panic!("current Session must not resume historically"),
+        )
+        .unwrap();
+        assert_eq!(
+            routed.into_inner(),
+            vec![("remote-owner".into(), "same-shell".into(), "r1".into())]
+        );
+    }
+
+    #[test]
+    fn dashboard_remote_historical_session_plan_resumes_exact_owner_identity() {
+        let inspection = inspected_session(AgentState::Inactive, false, Some("/owner/project"));
+        let plan = dashboard_session_open_plan(
+            &protocol::QualifiedIdentity::new("remote-owner", "exact-session"),
+            "local-node",
+            &inspection,
+            None,
+        )
+        .unwrap();
+        assert!(matches!(
+            &plan,
+            DashboardSessionOpenPlan::Historical { node_id: Some(node), session_id, .. }
+                if node == "remote-owner" && session_id == "exact-session"
+        ));
+        let resumed = std::cell::RefCell::new(Vec::new());
+        dispatch_dashboard_session_open(
+            &plan,
+            |_, _, _| panic!("historical Session must not attach locally"),
+            |_, _, _, _| panic!("historical Session must not attach remotely"),
+            |node, session, _| {
+                resumed
+                    .borrow_mut()
+                    .push((node.map(str::to_owned), session.to_owned()));
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            resumed.into_inner(),
+            vec![(Some("remote-owner".into()), "exact-session".into())]
+        );
+    }
+
+    #[test]
+    fn dashboard_session_plan_rejects_done_missing_and_ambiguous_current_targets() {
+        let identity = protocol::QualifiedIdentity::new("local-node", "session-id");
+        assert!(
+            dashboard_session_open_plan(
+                &identity,
+                "local-node",
+                &inspected_session(AgentState::Done, false, Some("/tmp")),
+                None,
+            )
+            .unwrap_err()
+            .contains("permanently done")
+        );
+        assert!(
+            dashboard_session_open_plan(
+                &identity,
+                "local-node",
+                &current_inspected_session("missing", "r1"),
+                None,
+            )
+            .unwrap_err()
+            .contains("Workspace is no longer available")
+        );
+        let mut inspection = current_inspected_session("first", "r1");
+        inspection
+            .occurrences
+            .push(agent("second-agent", "workspace-id", "second"));
+        let workspace = workspace(
+            "workspace-id",
+            "workspace",
+            vec![
+                shell("first", "workspace-id", "first"),
+                shell("second", "workspace-id", "second"),
+            ],
+        );
+        assert!(
+            dashboard_session_open_plan(&identity, "local-node", &inspection, Some(&workspace),)
+                .unwrap_err()
+                .contains("multiple current")
+        );
     }
 
     fn test_skill_home(label: &str) -> PathBuf {

--- a/src/main.rs
+++ b/src/main.rs
@@ -895,6 +895,9 @@ enum SessionCommands {
         /// Exact registered Node alias or Node ID
         #[arg(long)]
         node: Option<String>,
+        /// Coordinated Workspace to use for optional desktop placement
+        #[arg(long, value_name = "COORDINATED_WORKSPACE")]
+        workspace: Option<String>,
     },
     /// Resume one exact projected session in a native terminal
     Resume {
@@ -4072,7 +4075,7 @@ fn dashboard_session_effect(
             tui::DashboardEvent::SessionInspected { identity, result }
         }
         tui::DashboardEffect::ActivateSession(identity) => tui::DashboardEvent::OperationCompleted(
-            open_exact_session(&identity, local_node_id, terminal_entry),
+            open_exact_session(&identity, local_node_id, terminal_entry, None),
         ),
         effect => panic!("unexpected effect on Session worker: {effect:?}"),
     }
@@ -4368,50 +4371,237 @@ fn open_exact_session(
     identity: &protocol::QualifiedIdentity,
     local_node_id: &str,
     terminal_entry: Option<&str>,
+    coordinated_workspace: Option<&str>,
 ) -> Result<String, String> {
     let inspection = inspect_session_on_node(identity, local_node_id)?;
+    session_open_action(&inspection)?;
     let summary = &inspection.summary;
     let remote = identity.node_id != local_node_id && !identity.node_id.is_empty();
-    let workspace = if summary.state_is_current {
+    let (workspace, source_cwd) = if summary.state_is_current {
         let client = client::connect().map_err(|error| error.to_string())?;
-        Some(if remote {
-            match client
-                .route_node_operation(
-                    &identity.node_id,
-                    protocol::RoutedOperation::GetWorkspace {
-                        workspace_id: summary.workspace_id.clone(),
-                    },
-                )
-                .map_err(|error| error.to_string())?
-            {
-                protocol::RoutedOperationResult::Workspace { workspace } => workspace,
-                _ => return Err("Node returned an unexpected Workspace response".into()),
-            }
-        } else {
-            client
-                .get_workspace(&summary.workspace_id)
-                .map_err(|error| error.to_string())?
-        })
+        (
+            Some(if remote {
+                match client
+                    .route_node_operation(
+                        &identity.node_id,
+                        protocol::RoutedOperation::GetWorkspace {
+                            workspace_id: summary.workspace_id.clone(),
+                        },
+                    )
+                    .map_err(|error| error.to_string())?
+                {
+                    protocol::RoutedOperationResult::Workspace { workspace } => workspace,
+                    _ => return Err("Node returned an unexpected Workspace response".into()),
+                }
+            } else {
+                client
+                    .get_workspace(&summary.workspace_id)
+                    .map_err(|error| error.to_string())?
+            }),
+            None,
+        )
     } else {
-        validate_session_cwd(identity, local_node_id, &inspection)?;
-        None
+        (
+            None,
+            Some(validate_session_cwd(identity, local_node_id, &inspection)?),
+        )
     };
+    if !summary.state_is_current
+        && let Some(target) = coordinated_workspace
+    {
+        open_managed_historical_session(
+            identity,
+            &inspection,
+            source_cwd.as_deref().expect("historical Session cwd"),
+            target,
+            terminal_entry,
+        )
+        .map_err(|error| error.to_string())?;
+        return Ok(format!(
+            "Opened managed terminal for historical Session {}",
+            summary.description
+        ));
+    }
+    let placement = coordinated_workspace
+        .map(|target| {
+            let client = client::connect().map_err(|error| error.to_string())?;
+            prepare_session_desktop_placement(&client, target).map_err(|error| error.to_string())
+        })
+        .transpose()?
+        .flatten();
     let plan = session_open_plan(identity, local_node_id, &inspection, workspace.as_ref())?;
     dispatch_session_open(
         &plan,
         |shell_id, run_id, title| {
-            terminal::open_exact_run(terminal_entry, shell_id, run_id, title, true)
-                .map_err(|error| error.to_string())
+            if let Some(workspace_id) = placement.as_deref() {
+                terminal::open_exact_run_placed(
+                    terminal_entry,
+                    shell_id,
+                    run_id,
+                    title,
+                    true,
+                    terminal::HyprlandPlacement {
+                        workspace_id,
+                        node_id: local_node_id,
+                        shell_id,
+                    },
+                )
+            } else {
+                terminal::open_exact_run(terminal_entry, shell_id, run_id, title, true)
+            }
+            .map_err(|error| error.to_string())
         },
         |node_id, shell_id, run_id, title| {
-            terminal::open_remote_exact_run(terminal_entry, node_id, shell_id, run_id, title, true)
-                .map_err(|error| error.to_string())
+            if let Some(workspace_id) = placement.as_deref() {
+                terminal::open_remote_exact_run_placed(
+                    terminal_entry,
+                    node_id,
+                    shell_id,
+                    run_id,
+                    title,
+                    true,
+                    workspace_id,
+                )
+            } else {
+                terminal::open_remote_exact_run(
+                    terminal_entry,
+                    node_id,
+                    shell_id,
+                    run_id,
+                    title,
+                    true,
+                )
+            }
+            .map_err(|error| error.to_string())
         },
         |node_id, session_id, title| {
             terminal::open_agent_session(terminal_entry, node_id, session_id, title)
                 .map_err(|error| error.to_string())
         },
     )
+}
+
+fn open_managed_historical_session(
+    identity: &protocol::QualifiedIdentity,
+    inspection: &protocol::HostAgentSessionInspection,
+    cwd: &Path,
+    coordinated_workspace: &str,
+    terminal_entry: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    let summary = &inspection.summary;
+    let external_session_id = summary.external_session_id.as_deref().ok_or_else(|| {
+        cli_output::failure("invalid_argument", "Session has no canonical external ID")
+    })?;
+    let integration = boomux::integrations::by_key(&summary.integration)
+        .ok_or_else(|| cli_output::failure("invalid_argument", "unknown Agent integration"))?;
+    let resume = integration.resume.ok_or_else(|| {
+        cli_output::failure(
+            "invalid_argument",
+            "integration does not support exact Session resume",
+        )
+    })?;
+    let resume_command = resume.command(&[], external_session_id).ok_or_else(|| {
+        cli_output::failure(
+            "invalid_argument",
+            "could not build exact Session resume argv",
+        )
+    })?;
+    let client = client::connect()?;
+    let context = WorkspaceCreationContext::load(&client)?;
+    let selection = context
+        .coordinated_owner(coordinated_workspace, Some(&identity.node_id))?
+        .ok_or_else(|| {
+            cli_output::failure(
+                "not_found",
+                format!("coordinated Workspace not found: {coordinated_workspace}"),
+            )
+        })?;
+    let boomux_executable = if selection.node.local {
+        env::current_exe()?
+            .into_os_string()
+            .into_string()
+            .map_err(|_| "Boomux executable path is not valid UTF-8")?
+    } else {
+        "boomux".into()
+    };
+    let command = supervised_session_resume_command(
+        &boomux_executable,
+        integration.display_name,
+        integration.key,
+        external_session_id,
+        &resume_command,
+    );
+    let shell_id = Uuid::new_v4().to_string();
+    let suffix = Uuid::new_v4().simple().to_string();
+    let name = format!("{}-session-{}", summary.integration, &suffix[..8]);
+    let title = if selection.node.local {
+        format!("{} - {name}", selection.workspace.name)
+    } else {
+        format!(
+            "[{}] {} - {name}",
+            selection.node.alias, selection.workspace.name
+        )
+    };
+    let gate = if hyprland_special_workspaces_enabled()? {
+        terminal::open_waiting_placed(
+            terminal_entry,
+            (!selection.node.local).then_some(selection.node.node_id.as_str()),
+            &selection.node.node_id,
+            &selection.workspace.id,
+            &shell_id,
+            &title,
+        )?
+    } else {
+        terminal::open_waiting(
+            terminal_entry,
+            (!selection.node.local).then_some(selection.node.node_id.as_str()),
+            &shell_id,
+            &title,
+        )?
+    };
+    let owner_default_cwd = selection
+        .default_cwd
+        .clone()
+        .or_else(|| Some(cwd.to_path_buf()));
+    let (_, shell) = client.create_global_workspace_shell(
+        Uuid::new_v4().to_string(),
+        &selection.workspace.id,
+        selection.workspace.revision,
+        &selection.node.node_id,
+        selection.owner_workspace_id,
+        owner_default_cwd,
+        shell_id,
+        shell_spec(name, cwd, &command),
+    )?;
+    gate.release().map_err(|error| {
+        format!(
+            "Shell {} was created but its terminal could not attach: {error}",
+            shell.id
+        )
+    })?;
+    Ok(())
+}
+
+fn supervised_session_resume_command(
+    boomux_executable: &str,
+    agent_name: &str,
+    integration: &str,
+    external_session_id: &str,
+    resume_command: &[String],
+) -> Vec<String> {
+    let mut command = vec![
+        boomux_executable.to_owned(),
+        "agent".into(),
+        "supervise".into(),
+        agent_name.to_owned(),
+        "--integration".into(),
+        integration.to_owned(),
+        "--external-session-id".into(),
+        external_session_id.to_owned(),
+        "--".into(),
+    ];
+    command.extend_from_slice(resume_command);
+    command
 }
 
 fn assign_local_workspace_node(workspaces: &mut [tui::WorkspaceView], node: &tui::NodeView) {
@@ -8842,7 +9032,12 @@ fn session_command(
 ) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     validate_session_protocol(client.protocol_version()?)?;
-    if let SessionCommands::Open { session_id, node } = &command {
+    if let SessionCommands::Open {
+        session_id,
+        node,
+        workspace,
+    } = &command
+    {
         let local_node_id = client.node_identity()?;
         let owner_node_id = match node {
             Some(node) => client.node_registration(node)?.node_id,
@@ -8853,6 +9048,7 @@ fn session_command(
             &protocol::QualifiedIdentity::new(owner_node_id, session_id),
             &local_node_id,
             terminal.as_deref(),
+            workspace.as_deref(),
         )
         .map_err(io::Error::other)?;
         println!("{message}");
@@ -8875,24 +9071,15 @@ fn session_command(
                 .as_deref()
                 .map(|target| resolve_workspace_target(&snapshot.workspaces, target))
                 .transpose()?;
-            let catalog = selected_workspace.map_or_else(
-                || discover_host_catalog(&snapshot.workspaces),
-                |workspace| discover_host_catalog(std::slice::from_ref(workspace)),
-            );
-            let sessions =
-                session_projection::project_snapshot_with_catalog(&snapshot, Some(&catalog));
             let workspace_id = selected_workspace.map(|workspace| workspace.id.as_str());
-            let sessions = sessions
-                .iter()
-                .filter(|session| {
-                    workspace_id.is_none_or(|workspace_id| session.workspace_id == workspace_id)
-                })
-                .collect::<Vec<_>>();
+            let result =
+                client.host_service(protocol::HostServiceOperation::ListAgentSessions {
+                    workspace_id: workspace_id.map(str::to_owned),
+                })?;
+            let protocol::HostServiceResult::AgentSessions { sessions } = result else {
+                return Err("daemon returned an unexpected Session-list response".into());
+            };
             if json {
-                let sessions = sessions
-                    .iter()
-                    .map(|session| cli_output::session_summary(session))
-                    .collect::<Vec<_>>();
                 return print_json(
                     CommandKey::SessionList,
                     serde_json::json!({ "sessions": sessions }),
@@ -8915,7 +9102,7 @@ fn session_command(
                         "last-known"
                     },
                     session.last_at_ms,
-                    session.occurrences.len()
+                    session.occurrence_count
                 );
             }
         }
@@ -10516,6 +10703,34 @@ fn prepare_shell_desktop_placement(
         owner_workspace_id,
         &combined.workspaces,
     )
+}
+
+fn prepare_session_desktop_placement(
+    client: &client::Client,
+    target: &str,
+) -> Result<Option<String>, Box<dyn Error>> {
+    let combined = client.combined_node_snapshot(None)?;
+    let workspace =
+        resolve_global_workspace_target(&combined.workspaces, target).ok_or_else(|| {
+            cli_output::failure(
+                "not_found",
+                format!("coordinated Workspace not found: {target}"),
+            )
+        })?;
+    if workspace.closing {
+        return Err(cli_output::failure(
+            "invalid_argument",
+            "the selected coordinated Workspace is closing",
+        ));
+    }
+    if !hyprland_special_workspaces_enabled()? {
+        return Ok(None);
+    }
+    if hyprland::active_boomux_workspace()?.as_deref() != Some(workspace.id.as_str()) {
+        hyprland::toggle_special(&workspace.id)?;
+    }
+    select_desktop_workspace(workspace)?;
+    Ok(Some(workspace.id.clone()))
 }
 
 fn prepare_shell_desktop_placement_from_snapshot(
@@ -13213,16 +13428,25 @@ mod tests {
         assert_eq!(inspect.command_descriptor().key, "session.inspect");
         assert_eq!(inspect.command_descriptor().output, OutputMode::Json);
 
-        let open =
-            Cli::try_parse_from(["boomux", "session", "open", "opaque", "--node", "workbox"])
-                .unwrap();
+        let open = Cli::try_parse_from([
+            "boomux",
+            "session",
+            "open",
+            "opaque",
+            "--node",
+            "workbox",
+            "--workspace",
+            "active",
+        ])
+        .unwrap();
         assert_eq!(open.command_descriptor().key, "session.open");
         assert_eq!(open.command_descriptor().output, OutputMode::HumanOnly);
         assert!(matches!(
             open.command,
             Some(Commands::Session {
-                command: SessionCommands::Open { session_id, node }
+                command: SessionCommands::Open { session_id, node, workspace }
             }) if session_id == "opaque" && node.as_deref() == Some("workbox")
+                && workspace.as_deref() == Some("active")
         ));
 
         let json_open =
@@ -15612,6 +15836,54 @@ mod tests {
         )
         .unwrap();
         assert_eq!(resumed.into_inner(), vec![(None, "exact-session".into())]);
+    }
+
+    #[test]
+    fn managed_historical_session_supervision_preserves_exact_identity_and_argv() {
+        let command = supervised_session_resume_command(
+            "/opt/boomux",
+            "OpenCode",
+            "opencode",
+            "ses_exact; literal",
+            &[
+                "opencode".into(),
+                "--session".into(),
+                "ses_exact; literal".into(),
+            ],
+        );
+        assert_eq!(
+            command,
+            [
+                "/opt/boomux",
+                "agent",
+                "supervise",
+                "OpenCode",
+                "--integration",
+                "opencode",
+                "--external-session-id",
+                "ses_exact; literal",
+                "--",
+                "opencode",
+                "--session",
+                "ses_exact; literal",
+            ]
+        );
+        let parsed = Cli::try_parse_from(command).unwrap();
+        assert!(matches!(
+            parsed.command,
+            Some(Commands::Agent {
+                command: AgentCommands::Supervise(AgentSuperviseArgs {
+                    name: Some(name),
+                    integration,
+                    external_session_id,
+                    command,
+                    ..
+                })
+            }) if name == "OpenCode"
+                && integration == "opencode"
+                && external_session_id == "ses_exact; literal"
+                && command == ["opencode", "--session", "ses_exact; literal"]
+        ));
     }
 
     #[test]

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -243,6 +243,7 @@ fn merge_catalog(
                     && session.integration == record.integration
                     && session.external_session_id.as_deref() == Some(record.root_id.as_str())
             }) {
+                session.description = record.title.clone();
                 if session.source_cwd.is_none() {
                     session.source_cwd = Some(record_directory.clone());
                 }
@@ -615,7 +616,7 @@ mod tests {
     }
 
     #[test]
-    fn catalog_merges_durable_identity_and_keeps_stable_id_and_durable_source() {
+    fn catalog_merges_durable_identity_with_title_and_keeps_durable_lifecycle() {
         let durable = workspace("w1", &["a1"]);
         let durable_only = project_workspaces(std::slice::from_ref(&durable));
         let mut record = catalog_session("external", "/tmp/project");
@@ -626,7 +627,7 @@ mod tests {
 
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].id, durable_only[0].id);
-        assert_eq!(merged[0].description, durable_only[0].description);
+        assert_eq!(merged[0].description, "Catalog external");
         assert_eq!(merged[0].state, AgentState::Working);
         assert!(merged[0].state_is_current);
         assert_eq!(merged[0].occurrences.len(), 1);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -257,6 +257,25 @@ pub(crate) fn open_exact_run(
     )
 }
 
+pub(crate) fn open_exact_run_placed(
+    desktop_entry: Option<&str>,
+    shell_id: &str,
+    expected_run_id: &str,
+    title: &str,
+    takeover: bool,
+    placement: HyprlandPlacement<'_>,
+) -> Result<(), Box<dyn Error>> {
+    open_with_expected_run_and_placement(
+        desktop_entry,
+        shell_id,
+        None,
+        title,
+        takeover,
+        Some(expected_run_id),
+        Some(placement),
+    )
+}
+
 pub(crate) fn open_remote_exact_run(
     desktop_entry: Option<&str>,
     node_id: &str,
@@ -272,6 +291,30 @@ pub(crate) fn open_remote_exact_run(
         title,
         takeover,
         Some(expected_run_id),
+    )
+}
+
+pub(crate) fn open_remote_exact_run_placed(
+    desktop_entry: Option<&str>,
+    node_id: &str,
+    shell_id: &str,
+    expected_run_id: &str,
+    title: &str,
+    takeover: bool,
+    workspace_id: &str,
+) -> Result<(), Box<dyn Error>> {
+    open_with_expected_run_and_placement(
+        desktop_entry,
+        shell_id,
+        Some(node_id),
+        title,
+        takeover,
+        Some(expected_run_id),
+        Some(HyprlandPlacement {
+            workspace_id,
+            node_id,
+            shell_id,
+        }),
     )
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::io;
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
@@ -6,11 +7,12 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::agent_attention_projection::AgentStateCounts;
 use crate::protocol::{
-    NodeProjectionHealthCode, QualifiedIdentity, TerminalColor, TerminalPreview,
-    TerminalPreviewLine, TerminalStyle,
+    AgentInstanceSnapshot, NodeProjectionHealthCode, QualifiedIdentity, TerminalColor,
+    TerminalPreview, TerminalPreviewLine, TerminalStyle,
 };
 use crossterm::event::{
-    self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEventKind, KeyModifiers,
+    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+    Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
 };
 use crossterm::execute;
 use ratatui::Frame;
@@ -51,6 +53,7 @@ const BOOMUX_SMOKE: [&str; 5] = [
 const TERMINAL_PREVIEW_ROWS: usize = 16;
 const TERMINAL_PREVIEW_SCROLL_STEP: usize = 12;
 const PREVIEW_RESERVED_ITEM_HEIGHT: u16 = 6;
+const SESSION_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 const AGENT_TABLE_HEADERS: [&str; 9] = [
     "STATUS",
     "UPDATED",
@@ -215,6 +218,49 @@ pub(crate) struct DashboardState {
     pub(crate) node_reauthentication: bool,
     pub(crate) focused_terminal: Option<FocusedTerminalView>,
     pub(crate) reset_focus_revision: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SessionNodeView {
+    pub(crate) id: String,
+    pub(crate) alias: String,
+    pub(crate) local: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DashboardSessionView {
+    pub(crate) node_id: String,
+    pub(crate) node_alias: String,
+    pub(crate) session_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) workspace_name: String,
+    pub(crate) title: String,
+    pub(crate) integration: String,
+    pub(crate) state: AgentDisplayState,
+    pub(crate) state_is_current: bool,
+    pub(crate) started_at_ms: u64,
+    pub(crate) last_at_ms: u64,
+    pub(crate) occurrence_count: usize,
+}
+
+impl DashboardSessionView {
+    fn identity(&self) -> QualifiedIdentity {
+        QualifiedIdentity::new(self.node_id.clone(), self.session_id.clone())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DashboardSessionDetails {
+    pub(crate) session: DashboardSessionView,
+    pub(crate) source_cwd: Option<PathBuf>,
+    pub(crate) occurrences: Vec<AgentInstanceSnapshot>,
+    pub(crate) action: Result<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SessionLoadResult {
+    pub(crate) sessions: Vec<DashboardSessionView>,
+    pub(crate) warnings: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -701,6 +747,11 @@ pub(crate) enum DashboardEffect {
     RefreshNode(String),
     RestoreDismissedShells(String),
     Refresh,
+    LoadSessions {
+        nodes: Vec<SessionNodeView>,
+    },
+    InspectSession(QualifiedIdentity),
+    ActivateSession(QualifiedIdentity),
     ReadTerminalPreview {
         shell_id: QualifiedIdentity,
         run_id: Option<String>,
@@ -716,6 +767,8 @@ impl DashboardEffect {
                 | Self::CheckForUpdates
                 | Self::RefreshNode(_)
                 | Self::Refresh
+                | Self::LoadSessions { .. }
+                | Self::InspectSession(_)
                 | Self::ReadTerminalPreview { .. }
         )
     }
@@ -727,6 +780,10 @@ pub(crate) enum DashboardEvent {
         modifiers: KeyModifiers,
     },
     RefreshElapsed,
+    MousePressed {
+        event: MouseEvent,
+        area: Rect,
+    },
     PreviewRequested,
     UpdateCheckCompleted,
     OperationCompleted(Result<String, String>),
@@ -737,6 +794,11 @@ pub(crate) enum DashboardEvent {
     },
     ShellCreationCompleted(Result<String, String>),
     RefreshCompleted(Result<DashboardState, String>),
+    SessionsLoaded(Result<SessionLoadResult, String>),
+    SessionInspected {
+        identity: QualifiedIdentity,
+        result: Result<DashboardSessionDetails, String>,
+    },
     TextPasted(String),
     TerminalPreviewCompleted {
         shell_id: String,
@@ -761,16 +823,31 @@ where
 
 struct DashboardRuntime {
     effects: Sender<DashboardEffect>,
+    session_effects: Sender<DashboardEffect>,
     completions: Receiver<(DashboardEffect, DashboardEvent)>,
     update_check_in_flight: bool,
     preview_in_flight: bool,
+    session_load_in_flight: bool,
+    session_effects_in_flight: usize,
+    pending_session_activations: HashSet<QualifiedIdentity>,
     operations_in_flight: usize,
 }
 
 impl DashboardRuntime {
-    fn spawn(mut backend: impl DashboardBackend + Send + 'static) -> Self {
+    fn spawn(backend: impl DashboardBackend + Send + 'static) -> Self {
+        Self::spawn_with_session_backend(backend, |effect| {
+            panic!("unexpected session effect: {effect:?}")
+        })
+    }
+
+    fn spawn_with_session_backend(
+        mut backend: impl DashboardBackend + Send + 'static,
+        mut session_backend: impl DashboardBackend + Send + 'static,
+    ) -> Self {
         let (effect_sender, effect_receiver) = mpsc::channel::<DashboardEffect>();
+        let (session_effect_sender, session_effect_receiver) = mpsc::channel::<DashboardEffect>();
         let (completion_sender, completion_receiver) = mpsc::channel();
+        let session_completion_sender = completion_sender.clone();
         thread::spawn(move || {
             while let Ok(effect) = effect_receiver.recv() {
                 let completed_effect = effect.clone();
@@ -780,11 +857,27 @@ impl DashboardRuntime {
                 }
             }
         });
+        thread::spawn(move || {
+            while let Ok(effect) = session_effect_receiver.recv() {
+                let completed_effect = effect.clone();
+                let event = session_backend.execute(effect);
+                if session_completion_sender
+                    .send((completed_effect, event))
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
         Self {
             effects: effect_sender,
+            session_effects: session_effect_sender,
             completions: completion_receiver,
             update_check_in_flight: false,
             preview_in_flight: false,
+            session_load_in_flight: false,
+            session_effects_in_flight: 0,
+            pending_session_activations: HashSet::new(),
             operations_in_flight: 0,
         }
     }
@@ -800,20 +893,40 @@ impl DashboardRuntime {
             if (effect == DashboardEffect::CheckForUpdates && self.update_check_in_flight)
                 || (matches!(effect, DashboardEffect::ReadTerminalPreview { .. })
                     && self.preview_in_flight)
+                || (matches!(effect, DashboardEffect::LoadSessions { .. })
+                    && self.session_load_in_flight)
+            {
+                continue;
+            }
+            if let DashboardEffect::ActivateSession(identity) = &effect
+                && !self.pending_session_activations.insert(identity.clone())
             {
                 continue;
             }
             match &effect {
                 DashboardEffect::CheckForUpdates => self.update_check_in_flight = true,
                 DashboardEffect::ReadTerminalPreview { .. } => self.preview_in_flight = true,
+                DashboardEffect::LoadSessions { .. } => self.session_load_in_flight = true,
                 _ => {}
+            }
+            if is_session_effect(&effect) {
+                self.session_effects_in_flight += 1;
             }
             if effect.must_finish_before_quit() {
                 self.operations_in_flight += 1;
             }
-            self.effects.send(effect).map_err(|_| {
-                io::Error::new(io::ErrorKind::BrokenPipe, "dashboard backend stopped")
-            })?;
+            let sender = if is_session_effect(&effect) {
+                &self.session_effects
+            } else {
+                &self.effects
+            };
+            if let Err(error) = sender.send(effect) {
+                self.complete_effect(&error.0);
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "dashboard backend stopped",
+                ));
+            }
         }
         Ok(false)
     }
@@ -822,16 +935,7 @@ impl DashboardRuntime {
         loop {
             match self.completions.try_recv() {
                 Ok((effect, event)) => {
-                    match effect {
-                        DashboardEffect::CheckForUpdates => self.update_check_in_flight = false,
-                        DashboardEffect::ReadTerminalPreview { .. } => {
-                            self.preview_in_flight = false;
-                        }
-                        _ => {}
-                    }
-                    if effect.must_finish_before_quit() {
-                        self.operations_in_flight = self.operations_in_flight.saturating_sub(1);
-                    }
+                    self.complete_effect(&effect);
                     let effects = app.update(event);
                     if self.dispatch(effects)? {
                         return Ok(true);
@@ -839,6 +943,12 @@ impl DashboardRuntime {
                 }
                 Err(TryRecvError::Empty) => return Ok(false),
                 Err(TryRecvError::Disconnected) => {
+                    self.update_check_in_flight = false;
+                    self.preview_in_flight = false;
+                    self.session_load_in_flight = false;
+                    self.session_effects_in_flight = 0;
+                    self.pending_session_activations.clear();
+                    self.operations_in_flight = 0;
                     return Err(io::Error::new(
                         io::ErrorKind::BrokenPipe,
                         "dashboard backend stopped",
@@ -849,12 +959,46 @@ impl DashboardRuntime {
     }
 
     fn has_in_flight_effect(&self) -> bool {
-        self.update_check_in_flight || self.preview_in_flight || self.operations_in_flight > 0
+        self.update_check_in_flight
+            || self.preview_in_flight
+            || self.session_effects_in_flight > 0
+            || self.operations_in_flight > 0
     }
 
     fn can_quit(&self) -> bool {
         self.operations_in_flight == 0
     }
+
+    fn complete_effect(&mut self, effect: &DashboardEffect) {
+        match effect {
+            DashboardEffect::CheckForUpdates => self.update_check_in_flight = false,
+            DashboardEffect::ReadTerminalPreview { .. } => self.preview_in_flight = false,
+            DashboardEffect::LoadSessions { .. } => {
+                self.session_load_in_flight = false;
+                self.session_effects_in_flight = self.session_effects_in_flight.saturating_sub(1);
+            }
+            DashboardEffect::ActivateSession(identity) => {
+                self.pending_session_activations.remove(identity);
+                self.session_effects_in_flight = self.session_effects_in_flight.saturating_sub(1);
+            }
+            effect if is_session_effect(effect) => {
+                self.session_effects_in_flight = self.session_effects_in_flight.saturating_sub(1);
+            }
+            _ => {}
+        }
+        if effect.must_finish_before_quit() {
+            self.operations_in_flight = self.operations_in_flight.saturating_sub(1);
+        }
+    }
+}
+
+fn is_session_effect(effect: &DashboardEffect) -> bool {
+    matches!(
+        effect,
+        DashboardEffect::LoadSessions { .. }
+            | DashboardEffect::InspectSession(_)
+            | DashboardEffect::ActivateSession(_)
+    )
 }
 
 struct App {
@@ -867,6 +1011,10 @@ struct App {
     item_state: TableState,
     global_state: TableState,
     node_state: TableState,
+    session_state: TableState,
+    sessions: Vec<DashboardSessionView>,
+    session_load: SessionLoadState,
+    last_session_load: Option<Instant>,
     primary_tab: PrimaryTab,
     focus: Focus,
     mode: Mode,
@@ -879,6 +1027,13 @@ struct App {
     selection_pinned: bool,
     selected_workspace_id: Option<String>,
     observed_focus_revision: Option<u64>,
+}
+
+enum SessionLoadState {
+    NotLoaded,
+    Loading,
+    Loaded { warnings: Vec<String> },
+    Failed(String),
 }
 
 struct TerminalPreviewState {
@@ -899,17 +1054,25 @@ enum Focus {
 enum PrimaryTab {
     Workspaces,
     Agents,
+    Sessions,
     Shells,
     Nodes,
 }
 
 impl PrimaryTab {
-    const ALL: [Self; 4] = [Self::Workspaces, Self::Agents, Self::Shells, Self::Nodes];
+    const ALL: [Self; 5] = [
+        Self::Workspaces,
+        Self::Agents,
+        Self::Sessions,
+        Self::Shells,
+        Self::Nodes,
+    ];
 
     fn kind(self) -> Option<ItemKind> {
         match self {
             Self::Workspaces => None,
             Self::Agents => Some(ItemKind::Agent),
+            Self::Sessions => None,
             Self::Shells => Some(ItemKind::Shell),
             Self::Nodes => None,
         }
@@ -919,6 +1082,7 @@ impl PrimaryTab {
         match self {
             Self::Workspaces => "WORKSPACES",
             Self::Agents => "AGENTS",
+            Self::Sessions => "SESSIONS",
             Self::Shells => "SHELLS",
             Self::Nodes => "NODES",
         }
@@ -1004,6 +1168,8 @@ enum Mode {
     SelectWorkspaceNode(WorkspaceNodePicker),
     LinkWorkspace(LinkWorkspacePicker),
     InspectNode(NodeView),
+    InspectSessionLoading(QualifiedIdentity),
+    InspectSession(DashboardSessionDetails),
     RetargetNode {
         node_id: String,
         expected_revision: u64,
@@ -1682,6 +1848,10 @@ impl App {
             item_state,
             global_state: TableState::default(),
             node_state: TableState::default().with_selected(has_nodes.then_some(0)),
+            session_state: TableState::default(),
+            sessions: Vec::new(),
+            session_load: SessionLoadState::NotLoaded,
+            last_session_load: None,
             primary_tab: PrimaryTab::Workspaces,
             focus: Focus::Workspaces,
             mode: Mode::Normal,
@@ -1796,6 +1966,9 @@ impl App {
     }
 
     fn selected_item_location(&self) -> Option<(usize, usize)> {
+        if self.primary_tab == PrimaryTab::Sessions {
+            return None;
+        }
         if self.primary_tab == PrimaryTab::Workspaces {
             let workspace_index = self.workspace_state.selected()?;
             let ordinal = self.item_state.selected()?;
@@ -1838,6 +2011,9 @@ impl App {
         if self.primary_tab == PrimaryTab::Nodes {
             return self.nodes.len();
         }
+        if self.primary_tab == PrimaryTab::Sessions {
+            return self.sessions.len();
+        }
         let Some(kind) = self.primary_tab.kind() else {
             return 0;
         };
@@ -1861,13 +2037,26 @@ impl App {
             self.message = None;
             return;
         }
+        if tab == PrimaryTab::Sessions {
+            self.focus = Focus::Items;
+            self.session_state.select(
+                (!self.sessions.is_empty()).then_some(
+                    self.session_state
+                        .selected()
+                        .unwrap_or(0)
+                        .min(self.sessions.len().saturating_sub(1)),
+                ),
+            );
+            self.message = None;
+            return;
+        }
         self.focus = Focus::Items;
         self.global_state
             .select((self.global_item_count() > 0).then_some(0));
         self.message = None;
     }
 
-    fn cycle_tab(&mut self, backwards: bool) {
+    fn cycle_tab(&mut self, backwards: bool) -> Option<DashboardEffect> {
         let index = PrimaryTab::ALL
             .iter()
             .position(|tab| *tab == self.primary_tab)
@@ -1878,6 +2067,13 @@ impl App {
             (index + 1) % PrimaryTab::ALL.len()
         };
         self.select_tab(PrimaryTab::ALL[next]);
+        self.session_load_on_entry()
+    }
+
+    fn session_load_on_entry(&mut self) -> Option<DashboardEffect> {
+        (self.primary_tab == PrimaryTab::Sessions
+            && matches!(self.session_load, SessionLoadState::NotLoaded))
+        .then(|| self.load_sessions())
     }
 
     fn next(&mut self) {
@@ -1890,6 +2086,17 @@ impl App {
                         .map_or(0, |index| (index + 1) % self.nodes.len());
                     self.node_state.select(Some(next));
                 }
+                return;
+            }
+            if self.primary_tab == PrimaryTab::Sessions {
+                if !self.sessions.is_empty() {
+                    let next = self
+                        .session_state
+                        .selected()
+                        .map_or(0, |index| (index + 1) % self.sessions.len());
+                    self.session_state.select(Some(next));
+                }
+                self.message = None;
                 return;
             }
             let item_count = self.global_item_count();
@@ -1944,6 +2151,20 @@ impl App {
                     });
                     self.node_state.select(Some(previous));
                 }
+                return;
+            }
+            if self.primary_tab == PrimaryTab::Sessions {
+                if !self.sessions.is_empty() {
+                    let previous = self.session_state.selected().map_or(0, |index| {
+                        if index == 0 {
+                            self.sessions.len() - 1
+                        } else {
+                            index - 1
+                        }
+                    });
+                    self.session_state.select(Some(previous));
+                }
+                self.message = None;
                 return;
             }
             let item_count = self.global_item_count();
@@ -2345,6 +2566,48 @@ impl App {
         Some(DashboardEffect::Open(target))
     }
 
+    fn selected_session(&self) -> Option<&DashboardSessionView> {
+        self.session_state
+            .selected()
+            .and_then(|index| self.sessions.get(index))
+    }
+
+    fn session_nodes(&self) -> Vec<SessionNodeView> {
+        self.nodes
+            .iter()
+            .filter(|node| {
+                node.local
+                    || (node.current
+                        && !node.stale
+                        && node.health == NodeProjectionHealthCode::Online)
+            })
+            .map(|node| SessionNodeView {
+                id: node.id.clone(),
+                alias: node.alias.clone(),
+                local: node.local,
+            })
+            .collect()
+    }
+
+    fn load_sessions(&mut self) -> DashboardEffect {
+        self.session_load = SessionLoadState::Loading;
+        DashboardEffect::LoadSessions {
+            nodes: self.session_nodes(),
+        }
+    }
+
+    fn inspect_selected_session(&mut self) -> Option<DashboardEffect> {
+        let identity = self.selected_session()?.identity();
+        self.mode = Mode::InspectSessionLoading(identity.clone());
+        Some(DashboardEffect::InspectSession(identity))
+    }
+
+    fn activate_selected_session(&self) -> Option<DashboardEffect> {
+        Some(DashboardEffect::ActivateSession(
+            self.selected_session()?.identity(),
+        ))
+    }
+
     fn activate_selected_item(&mut self) -> Option<DashboardEffect> {
         self.open_selected_item()
     }
@@ -2483,7 +2746,21 @@ impl App {
             DashboardEvent::KeyPressed { code, modifiers } => {
                 return self.update_key(code, modifiers).into_iter().collect();
             }
-            DashboardEvent::RefreshElapsed => return vec![DashboardEffect::CheckForUpdates],
+            DashboardEvent::RefreshElapsed => {
+                let mut effects = vec![DashboardEffect::CheckForUpdates];
+                if self.primary_tab == PrimaryTab::Sessions
+                    && !matches!(self.session_load, SessionLoadState::Loading)
+                    && self
+                        .last_session_load
+                        .is_some_and(|loaded| loaded.elapsed() >= SESSION_REFRESH_INTERVAL)
+                {
+                    effects.push(self.load_sessions());
+                }
+                return effects;
+            }
+            DashboardEvent::MousePressed { event, area } => {
+                return self.update_mouse(event, area).into_iter().collect();
+            }
             DashboardEvent::PreviewRequested => {
                 return self.terminal_preview_effect().into_iter().collect();
             }
@@ -2512,6 +2789,27 @@ impl App {
             }
             DashboardEvent::RefreshCompleted(result) => {
                 self.apply_refresh(result);
+            }
+            DashboardEvent::SessionsLoaded(result) => self.apply_sessions(result),
+            DashboardEvent::SessionInspected { identity, result } => {
+                if matches!(&self.mode, Mode::InspectSessionLoading(expected) if *expected == identity)
+                {
+                    match result {
+                        Ok(mut details) => {
+                            if let Some(session) = self.sessions.iter().find(|session| {
+                                session.node_id == identity.node_id
+                                    && session.session_id == identity.inner_id
+                            }) {
+                                details.session.node_alias = session.node_alias.clone();
+                            }
+                            self.mode = Mode::InspectSession(details);
+                        }
+                        Err(text) => {
+                            self.mode = Mode::Normal;
+                            self.message = Some(Message { text, error: true });
+                        }
+                    }
+                }
             }
             DashboardEvent::TextPasted(_) => {}
             DashboardEvent::TerminalPreviewCompleted {
@@ -2572,6 +2870,9 @@ impl App {
                     self.inspect_selected_node();
                     return None;
                 }
+                if self.primary_tab == PrimaryTab::Sessions {
+                    return self.activate_selected_session();
+                }
                 return if self.primary_tab != PrimaryTab::Workspaces {
                     self.open_selected_item()
                 } else {
@@ -2589,6 +2890,9 @@ impl App {
                     .filter(|node| !node.local)
                     .map(|node| DashboardEffect::RefreshNode(node.id.clone()))
                     .or(Some(DashboardEffect::Refresh));
+            }
+            KeyCode::Char('r') if self.primary_tab == PrimaryTab::Sessions => {
+                return Some(self.load_sessions());
             }
             KeyCode::Char('r') => return Some(DashboardEffect::Refresh),
             KeyCode::Char('u') if self.primary_tab == PrimaryTab::Nodes => {
@@ -2632,6 +2936,9 @@ impl App {
                 self.link_selected_external();
             }
             KeyCode::Char('e') => return self.request_rename(),
+            KeyCode::Char('i') if self.primary_tab == PrimaryTab::Sessions => {
+                return self.inspect_selected_session();
+            }
             KeyCode::Char('t') if self.primary_tab == PrimaryTab::Nodes => {
                 self.retarget_selected_node();
             }
@@ -2639,18 +2946,97 @@ impl App {
             KeyCode::Char('/' | ':') => self.open_palette(),
             KeyCode::Char('?') => self.mode = Mode::Help,
             KeyCode::Tab => {
-                self.cycle_tab(false);
+                return self.cycle_tab(false);
             }
             KeyCode::BackTab => {
-                self.cycle_tab(true);
+                return self.cycle_tab(true);
             }
             KeyCode::Char(key) if shortcut_tab(key).is_some() => {
                 self.select_tab(shortcut_tab(key).expect("validated tab shortcut"));
+                return self.session_load_on_entry();
             }
             key if self.handle_focus_key(key) => {}
             _ => {}
         }
         None
+    }
+
+    fn update_mouse(&mut self, event: MouseEvent, area: Rect) -> Option<DashboardEffect> {
+        if self.primary_tab != PrimaryTab::Sessions
+            || !matches!(self.mode, Mode::Normal)
+            || event.kind != MouseEventKind::Down(MouseButton::Left)
+        {
+            return None;
+        }
+        let dashboard = Rect::new(
+            area.x,
+            area.y.saturating_add(1),
+            area.width,
+            area.height.saturating_sub(2),
+        );
+        let (table, _) = session_content_areas(dashboard, self.session_warning().is_some());
+        let data_top = table.y.saturating_add(1);
+        if event.column < table.x
+            || event.column >= table.right()
+            || event.row < data_top
+            || event.row >= table.bottom()
+        {
+            return None;
+        }
+        let index = self
+            .session_state
+            .offset()
+            .saturating_add(usize::from(event.row - data_top));
+        if index >= self.sessions.len() {
+            return None;
+        }
+        if self.session_state.selected() == Some(index) {
+            return self.activate_selected_session();
+        }
+        self.session_state.select(Some(index));
+        self.message = None;
+        None
+    }
+
+    fn session_warning(&self) -> Option<&str> {
+        match &self.session_load {
+            SessionLoadState::Loaded { warnings } => warnings.first().map(String::as_str),
+            SessionLoadState::NotLoaded
+            | SessionLoadState::Loading
+            | SessionLoadState::Failed(_) => None,
+        }
+    }
+
+    fn apply_sessions(&mut self, result: Result<SessionLoadResult, String>) {
+        self.last_session_load = Some(Instant::now());
+        match result {
+            Ok(mut loaded) => {
+                let selected = self.selected_session().map(DashboardSessionView::identity);
+                loaded.sessions.sort_by(|left, right| {
+                    right
+                        .last_at_ms
+                        .cmp(&left.last_at_ms)
+                        .then_with(|| left.node_id.cmp(&right.node_id))
+                        .then_with(|| left.workspace_id.cmp(&right.workspace_id))
+                        .then_with(|| left.session_id.cmp(&right.session_id))
+                });
+                self.sessions = loaded.sessions;
+                self.session_state.select(
+                    selected
+                        .and_then(|identity| {
+                            self.sessions.iter().position(|session| {
+                                session.node_id == identity.node_id
+                                    && session.session_id == identity.inner_id
+                            })
+                        })
+                        .or_else(|| (!self.sessions.is_empty()).then_some(0)),
+                );
+                self.session_load = SessionLoadState::Loaded {
+                    warnings: loaded.warnings,
+                };
+            }
+            Err(error) => self.session_load = SessionLoadState::Failed(error),
+        }
     }
 
     fn apply_refresh(&mut self, result: Result<DashboardState, String>) {
@@ -3024,13 +3410,14 @@ fn item_pending_removal(
     })
 }
 
-pub(crate) fn run<B: DashboardBackend + Send + 'static>(
+pub(crate) fn run<B: DashboardBackend + Send + 'static, S: DashboardBackend + Send + 'static>(
     state: DashboardState,
     selected_workspace_id: Option<String>,
     follow_focused_terminal: bool,
     project_context: ProjectContext,
     play_intro: bool,
     backend: B,
+    session_backend: S,
 ) -> io::Result<()> {
     let mut terminal = ratatui::try_init().map_err(|error| {
         io::Error::new(
@@ -3038,7 +3425,7 @@ pub(crate) fn run<B: DashboardBackend + Send + 'static>(
             format!("dashboard requires an interactive terminal: {error}"),
         )
     })?;
-    if let Err(error) = execute!(io::stdout(), EnableBracketedPaste) {
+    if let Err(error) = enable_dashboard_terminal_modes(&mut io::stdout()) {
         let _ = ratatui::try_restore();
         return Err(error);
     }
@@ -3052,15 +3439,31 @@ pub(crate) fn run<B: DashboardBackend + Send + 'static>(
         app.enable_focus_following(state.focused_terminal.as_ref());
     }
     let result = if play_intro {
-        play_bomb_animation(&mut terminal).and_then(|()| run_loop(&mut terminal, app, backend))
+        play_bomb_animation(&mut terminal)
+            .and_then(|()| run_loop(&mut terminal, app, backend, session_backend))
     } else {
-        run_loop(&mut terminal, app, backend)
+        run_loop(&mut terminal, app, backend, session_backend)
     };
-    let paste_result = execute!(io::stdout(), DisableBracketedPaste);
+    let mode_result = disable_dashboard_terminal_modes(&mut io::stdout());
     let restore_result = ratatui::try_restore();
-    paste_result?;
+    mode_result?;
     restore_result?;
     result
+}
+
+fn enable_dashboard_terminal_modes(writer: &mut impl io::Write) -> io::Result<()> {
+    execute!(writer, EnableBracketedPaste)?;
+    if let Err(error) = execute!(writer, EnableMouseCapture) {
+        let _ = execute!(writer, DisableBracketedPaste);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn disable_dashboard_terminal_modes(writer: &mut impl io::Write) -> io::Result<()> {
+    let mouse = execute!(writer, DisableMouseCapture);
+    let paste = execute!(writer, DisableBracketedPaste);
+    mouse.and(paste)
 }
 
 fn play_bomb_animation(terminal: &mut ratatui::DefaultTerminal) -> io::Result<()> {
@@ -3080,11 +3483,17 @@ fn play_bomb_animation(terminal: &mut ratatui::DefaultTerminal) -> io::Result<()
     }
 }
 
-fn run_loop<B>(terminal: &mut ratatui::DefaultTerminal, mut app: App, backend: B) -> io::Result<()>
+fn run_loop<B, S>(
+    terminal: &mut ratatui::DefaultTerminal,
+    mut app: App,
+    backend: B,
+    session_backend: S,
+) -> io::Result<()>
 where
     B: DashboardBackend + Send + 'static,
+    S: DashboardBackend + Send + 'static,
 {
-    let mut runtime = DashboardRuntime::spawn(backend);
+    let mut runtime = DashboardRuntime::spawn_with_session_backend(backend, session_backend);
     let mut last_refresh = Instant::now();
     loop {
         if runtime.drain(&mut app)? {
@@ -3119,6 +3528,10 @@ where
                 })
             }
             Event::Paste(text) => app.update(DashboardEvent::TextPasted(text)),
+            Event::Mouse(event) => app.update(DashboardEvent::MousePressed {
+                event,
+                area: terminal.size()?.into(),
+            }),
             _ => continue,
         };
         if effects.contains(&DashboardEffect::Quit) {
@@ -3423,6 +3836,20 @@ fn handle_mode_key(
                 None
             }
         },
+        Mode::InspectSessionLoading(identity) => match key {
+            KeyCode::Esc => None,
+            _ => {
+                app.mode = Mode::InspectSessionLoading(identity);
+                None
+            }
+        },
+        Mode::InspectSession(details) => match key {
+            KeyCode::Esc => None,
+            _ => {
+                app.mode = Mode::InspectSession(details);
+                None
+            }
+        },
         Mode::RetargetNode {
             node_id,
             expected_revision,
@@ -3507,6 +3934,8 @@ fn render(frame: &mut Frame, app: &mut App) {
     render_tabs(frame, tabs_area, app);
     if app.primary_tab == PrimaryTab::Nodes {
         render_nodes(frame, dashboard_area, app);
+    } else if app.primary_tab == PrimaryTab::Sessions {
+        render_sessions(frame, dashboard_area, app);
     } else if app.primary_tab != PrimaryTab::Workspaces {
         render_global_items(frame, dashboard_area, app);
     } else if dashboard_area.width >= 114 {
@@ -3529,10 +3958,114 @@ fn render(frame: &mut Frame, app: &mut App) {
         Mode::SelectWorkspaceNode(picker) => render_workspace_node_picker(frame, area, picker),
         Mode::LinkWorkspace(picker) => render_link_workspace_picker(frame, area, picker),
         Mode::InspectNode(node) => render_node_inspection(frame, area, node),
+        Mode::InspectSessionLoading(identity) => render_session_loading(frame, area, identity),
+        Mode::InspectSession(details) => render_session_inspection(frame, area, details),
         Mode::RetargetNode { input, .. } => render_node_retarget(frame, area, input),
         Mode::ConfirmForgetNode(node) => render_node_forget_confirmation(frame, area, node),
         Mode::Normal | Mode::Rename { .. } => {}
     }
+}
+
+fn session_content_areas(area: Rect, has_warning: bool) -> (Rect, Option<Rect>) {
+    let inner = Rect::new(
+        area.x.saturating_add(1),
+        area.y.saturating_add(1),
+        area.width.saturating_sub(2),
+        area.height.saturating_sub(2),
+    );
+    if !has_warning || inner.height == 0 {
+        return (inner, None);
+    }
+    let [table, warning] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(inner);
+    (table, Some(warning))
+}
+
+fn render_session_loading(frame: &mut Frame, area: Rect, identity: &QualifiedIdentity) {
+    let popup = if area.width < 90 {
+        area
+    } else {
+        centered_rect(area, 76, 70)
+    };
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Paragraph::new(format!(
+            "Inspecting exact Session {} on Node {}...\n\nesc close",
+            short_id(&identity.inner_id),
+            short_id(&identity.node_id)
+        ))
+        .block(
+            Block::bordered()
+                .title(" Session details ")
+                .border_style(Style::new().fg(TEAL)),
+        ),
+        popup,
+    );
+}
+
+fn render_session_inspection(frame: &mut Frame, area: Rect, details: &DashboardSessionDetails) {
+    let popup = if area.width < 90 {
+        area
+    } else {
+        centered_rect(area, 76, 78)
+    };
+    let session = &details.session;
+    let action = match &details.action {
+        Ok(action) => Span::styled(action.clone(), Style::new().fg(GREEN)),
+        Err(error) => Span::styled(error.clone(), Style::new().fg(RED)),
+    };
+    let lines = vec![
+        preview_field("TITLE", session.title.clone()),
+        preview_field(
+            "NODE",
+            format!("{} ({})", session.node_alias, session.node_id),
+        ),
+        preview_field(
+            "WORKSPACE",
+            format!("{} ({})", session.workspace_name, session.workspace_id),
+        ),
+        preview_field("HARNESS", integration_display_name(&session.integration)),
+        preview_field(
+            "STATE",
+            format!(
+                "{} ({})",
+                session.state.label(),
+                if session.state_is_current {
+                    "current"
+                } else {
+                    "historical"
+                }
+            ),
+        ),
+        preview_field("STARTED", timestamp_detail(session.started_at_ms)),
+        preview_field("LAST", timestamp_detail(session.last_at_ms)),
+        preview_field(
+            "SOURCE CWD",
+            details
+                .source_cwd
+                .as_deref()
+                .map_or_else(|| "-".into(), |cwd| cwd.display().to_string()),
+        ),
+        preview_field("OCCURRENCES", details.occurrences.len().to_string()),
+        Line::from(vec![preview_label("ACTION"), action]),
+        Line::from(""),
+        Line::styled("esc close", Style::new().fg(SUBTEXT)),
+    ];
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::bordered()
+                    .title(" Session details ")
+                    .border_style(Style::new().fg(TEAL)),
+            )
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+fn timestamp_detail(timestamp_ms: u64) -> String {
+    format!("{timestamp_ms} ({})", compact_recency(timestamp_ms))
 }
 
 fn render_node_inspection(frame: &mut Frame, area: Rect, node: &NodeView) {
@@ -4283,7 +4816,7 @@ fn help_lines(app: &App) -> Vec<Line<'static>> {
         Line::from("  attention filter palette results to outstanding durable attention"),
         Line::from("  Enter    restore a workspace or open an item"),
         Line::from("  a/e/x    add, rename, or request confirmed close/remove"),
-        Line::from("  Tab/1-4 change view; h/l change pane; j/k navigate"),
+        Line::from("  Tab/1-5 change view; h/l change pane; j/k navigate"),
         Line::from(""),
         Line::from(Span::styled(
             "SELECTED CONTEXT",
@@ -4506,6 +5039,7 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
                         .flat_map(|workspace| &workspace.items)
                         .filter(|item| item.kind() == ItemKind::Agent)
                         .count(),
+                    PrimaryTab::Sessions => app.sessions.len(),
                     PrimaryTab::Shells => {
                         app.workspaces.iter().map(WorkspaceView::shell_count).sum()
                     }
@@ -4524,6 +5058,124 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
             }),
     );
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn render_sessions(frame: &mut Frame, area: Rect, app: &mut App) {
+    let status = match &app.session_load {
+        SessionLoadState::NotLoaded => "not loaded; enter tab or press r",
+        SessionLoadState::Loading if app.sessions.is_empty() => "loading live Session lists...",
+        SessionLoadState::Loading => "refreshing live Session lists...",
+        SessionLoadState::Loaded { warnings } if !warnings.is_empty() => "partial results",
+        SessionLoadState::Loaded { .. } => "live",
+        SessionLoadState::Failed(_) => "load failed",
+    };
+    let block = Block::bordered()
+        .title(format!(" Sessions ({}) - {status} ", app.sessions.len()))
+        .border_style(Style::new().fg(TEAL));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if app.sessions.is_empty() {
+        let message = match &app.session_load {
+            SessionLoadState::NotLoaded => "Sessions have not been loaded.",
+            SessionLoadState::Loading => "Loading local and online Node Sessions...",
+            SessionLoadState::Loaded { warnings } if warnings.is_empty() => {
+                "No Agent Sessions were found."
+            }
+            SessionLoadState::Loaded { warnings } => warnings
+                .first()
+                .map(String::as_str)
+                .unwrap_or("No Sessions loaded."),
+            SessionLoadState::Failed(error) => error,
+        };
+        frame.render_widget(
+            Paragraph::new(message).style(Style::new().fg(match app.session_load {
+                SessionLoadState::Failed(_) => RED,
+                SessionLoadState::Loaded { ref warnings } if !warnings.is_empty() => YELLOW,
+                _ => SUBTEXT,
+            })),
+            inner,
+        );
+        return;
+    }
+
+    let (table_area, warning_area) = session_content_areas(area, app.session_warning().is_some());
+    let wide_state = table_area.width >= 75;
+    let wide_owner = table_area.width >= 105;
+    let wide_occurrences = table_area.width >= 135;
+    let mut headers = vec!["AGE", "HARNESS", "TITLE"];
+    let mut widths = vec![
+        Constraint::Length(9),
+        Constraint::Length(12),
+        Constraint::Fill(1),
+    ];
+    if wide_state {
+        headers.insert(2, "STATE");
+        widths.insert(2, Constraint::Length(17));
+    }
+    if wide_owner {
+        let title_index = headers.len() - 1;
+        headers.insert(title_index, "NODE");
+        headers.insert(title_index + 1, "WORKSPACE");
+        widths.insert(title_index, Constraint::Length(14));
+        widths.insert(title_index + 1, Constraint::Length(20));
+    }
+    if wide_occurrences {
+        let title_index = headers.len() - 1;
+        headers.insert(title_index, "OCC");
+        widths.insert(title_index, Constraint::Length(5));
+    }
+    let rows = app.sessions.iter().map(|session| {
+        let mut cells = vec![
+            Cell::from(compact_recency(session.last_at_ms)),
+            Cell::from(integration_display_name(&session.integration)),
+            Cell::from(session.title.clone()),
+        ];
+        if wide_state {
+            cells.insert(
+                2,
+                Cell::from(format!(
+                    "{} {}",
+                    session.state.label(),
+                    if session.state_is_current {
+                        "current"
+                    } else {
+                        "historical"
+                    }
+                )),
+            );
+        }
+        if wide_owner {
+            let title_index = cells.len() - 1;
+            cells.insert(title_index, Cell::from(session.node_alias.clone()));
+            cells.insert(title_index + 1, Cell::from(session.workspace_name.clone()));
+        }
+        if wide_occurrences {
+            let title_index = cells.len() - 1;
+            cells.insert(
+                title_index,
+                Cell::from(session.occurrence_count.to_string()),
+            );
+        }
+        Row::new(cells)
+    });
+    let table = Table::new(rows, widths)
+        .header(Row::new(headers).style(Style::new().fg(BLUE).add_modifier(Modifier::BOLD)))
+        .column_spacing(1)
+        .row_highlight_style(
+            Style::new()
+                .fg(TEXT)
+                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+        )
+        .highlight_symbol("> ");
+    frame.render_stateful_widget(table, table_area, &mut app.session_state);
+
+    if let (Some(warning), Some(warning_area)) = (app.session_warning(), warning_area) {
+        frame.render_widget(
+            Paragraph::new(format!("Warning: {warning}")).style(Style::new().fg(YELLOW)),
+            warning_area,
+        );
+    }
 }
 
 fn render_nodes(frame: &mut Frame, area: Rect, app: &mut App) {
@@ -5762,6 +6414,17 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
             format!(" {}", message.text),
             Style::new().fg(if message.error { RED } else { GREEN }),
         ))
+    } else if app.primary_tab == PrimaryTab::Sessions {
+        Line::from(vec![
+            Span::styled("enter", Style::new().fg(GREEN)),
+            Span::styled(" open exact  ", Style::new().fg(SUBTEXT)),
+            Span::styled("i", Style::new().fg(TEAL)),
+            Span::styled(" details  ", Style::new().fg(SUBTEXT)),
+            Span::styled("r", Style::new().fg(BLUE)),
+            Span::styled(" refresh  ", Style::new().fg(SUBTEXT)),
+            Span::styled("q", Style::new().fg(RED)),
+            Span::styled(" quit", Style::new().fg(SUBTEXT)),
+        ])
     } else {
         let launcher_selected = matches!(app.selected_item(), Some(WorkspaceItemView::Launcher(_)));
         let offline_shell_selected =
@@ -5819,7 +6482,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 Span::styled(" forget  ", Style::new().fg(SUBTEXT)),
                 Span::styled("tab/shift-tab", Style::new().fg(TEAL)),
                 Span::styled(" views  ", Style::new().fg(SUBTEXT)),
-                Span::styled("1-4", Style::new().fg(TEAL)),
+                Span::styled("1-5", Style::new().fg(TEAL)),
                 Span::styled(" select view  ", Style::new().fg(SUBTEXT)),
                 Span::styled("/", Style::new().fg(TEAL)),
                 Span::styled(" palette  ", Style::new().fg(SUBTEXT)),
@@ -5835,7 +6498,7 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect, app: &App) {
                 if app.primary_tab == PrimaryTab::Workspaces {
                     " navigate  tab/shift-tab views  h/l panes  "
                 } else {
-                    " navigate  tab/shift-tab views  1-4 select view  "
+                    " navigate  tab/shift-tab views  1-5 select view  "
                 },
                 Style::new().fg(SUBTEXT),
             ),
@@ -7384,7 +8047,11 @@ mod tests {
         app.cycle_tab(false);
         assert_eq!(app.primary_tab, PrimaryTab::Agents);
         app.cycle_tab(false);
+        assert_eq!(app.primary_tab, PrimaryTab::Sessions);
+        app.cycle_tab(false);
         assert_eq!(app.primary_tab, PrimaryTab::Shells);
+        app.cycle_tab(true);
+        assert_eq!(app.primary_tab, PrimaryTab::Sessions);
         app.cycle_tab(true);
         assert_eq!(app.primary_tab, PrimaryTab::Agents);
         app.cycle_tab(true);
@@ -7490,14 +8157,18 @@ mod tests {
 
         assert!(text.contains("WORKSPACES 1"));
         assert!(text.contains("AGENTS 1"));
-        assert!(!text.contains("SESSIONS"));
+        assert!(text.contains("SESSIONS 0"));
         assert!(!text.contains("LAUNCHERS 1"));
         assert!(text.contains("SHELLS 1"));
         assert!(!text.contains("COMMANDS 1"));
         assert!(!text.contains("active agents"));
         let workspace_tab = text.find("WORKSPACES 1").expect("workspace tab");
         let agent_tab = text.find("AGENTS 1").expect("agent tab");
+        let session_tab = text.find("SESSIONS 0").expect("Session tab");
+        let shell_tab = text.find("SHELLS 1").expect("Shell tab");
         assert!(workspace_tab < agent_tab);
+        assert!(agent_tab < session_tab);
+        assert!(session_tab < shell_tab);
         assert!(!text.contains("NODES:"));
         assert!(!text.contains("NODE:all"));
         assert!(lines.iter().any(|line| line.contains("> mixed")));
@@ -9798,5 +10469,543 @@ mod tests {
         assert!(text.contains("FROM PROJECT"));
         assert!(text.contains("Create a workspace by name"));
         assert!(text.contains("alpha"));
+    }
+
+    fn dashboard_session(node_id: &str, session_id: &str, last_at_ms: u64) -> DashboardSessionView {
+        DashboardSessionView {
+            node_id: node_id.into(),
+            node_alias: format!("node-{node_id}"),
+            session_id: session_id.into(),
+            workspace_id: format!("workspace-{session_id}"),
+            workspace_name: format!("work-{session_id}"),
+            title: format!("Session {session_id}"),
+            integration: "opencode".into(),
+            state: AgentDisplayState::Idle,
+            state_is_current: false,
+            started_at_ms: last_at_ms.saturating_sub(100),
+            last_at_ms,
+            occurrence_count: 2,
+        }
+    }
+
+    #[test]
+    fn sessions_are_the_third_tab_and_first_entry_starts_one_live_load() {
+        let mut app = app();
+        app.nodes[0].id = "local-node".into();
+
+        let effect = app.update_key(KeyCode::Char('3'), KeyModifiers::NONE);
+
+        assert_eq!(app.primary_tab, PrimaryTab::Sessions);
+        assert!(matches!(
+            effect,
+            Some(DashboardEffect::LoadSessions { nodes })
+                if nodes == vec![SessionNodeView {
+                    id: "local-node".into(),
+                    alias: "local".into(),
+                    local: true,
+                }]
+        ));
+        assert_eq!(app.update_key(KeyCode::Char('3'), KeyModifiers::NONE), None);
+    }
+
+    #[test]
+    fn session_results_sort_deterministically_and_preserve_qualified_selection() {
+        let mut app = app();
+        app.select_tab(PrimaryTab::Sessions);
+        app.apply_sessions(Ok(SessionLoadResult {
+            sessions: vec![
+                dashboard_session("b", "same", 20),
+                dashboard_session("a", "older", 10),
+                dashboard_session("a", "same", 20),
+            ],
+            warnings: Vec::new(),
+        }));
+        assert_eq!(
+            app.sessions
+                .iter()
+                .map(|session| (session.node_id.as_str(), session.session_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("a", "same"), ("b", "same"), ("a", "older")]
+        );
+        app.session_state.select(Some(1));
+
+        app.apply_sessions(Ok(SessionLoadResult {
+            sessions: vec![
+                dashboard_session("a", "same", 30),
+                dashboard_session("b", "same", 5),
+            ],
+            warnings: Vec::new(),
+        }));
+
+        assert_eq!(app.selected_session().unwrap().node_id, "b");
+        assert_eq!(app.selected_session().unwrap().session_id, "same");
+    }
+
+    #[test]
+    fn session_table_progressively_adds_owner_state_and_occurrences() {
+        let mut app = app();
+        app.select_tab(PrimaryTab::Sessions);
+        app.apply_sessions(Ok(SessionLoadResult {
+            sessions: vec![dashboard_session("alpha", "review", current_time_ms())],
+            warnings: vec!["Node beta: unavailable".into()],
+        }));
+
+        let narrow = rendered_text(&mut app, 70, 20);
+        assert!(narrow.contains("AGE"));
+        assert!(narrow.contains("HARNESS"));
+        assert!(narrow.contains("TITLE"));
+        assert!(narrow.contains("OpenCode"));
+        assert!(narrow.contains("Session review"));
+        assert!(!narrow.contains("node-alpha"));
+        assert!(!narrow.contains("work-review"));
+        assert!(!narrow.contains("historical"));
+
+        let wide = rendered_text(&mut app, 160, 24);
+        for expected in [
+            "STATE",
+            "NODE",
+            "WORKSPACE",
+            "OCC",
+            "historical",
+            "node-alpha",
+            "work-review",
+            "Warning: Node beta: unavailable",
+        ] {
+            assert!(wide.contains(expected), "missing {expected}: {wide}");
+        }
+    }
+
+    #[test]
+    fn session_empty_loading_and_failure_present_distinct_states() {
+        let mut app = app();
+        app.select_tab(PrimaryTab::Sessions);
+        assert!(rendered_text(&mut app, 80, 20).contains("not loaded"));
+        app.session_load = SessionLoadState::Loading;
+        assert!(rendered_text(&mut app, 80, 20).contains("Loading local and online"));
+        app.session_load = SessionLoadState::Failed("catalog failed".into());
+        assert!(rendered_text(&mut app, 80, 20).contains("catalog failed"));
+        app.session_load = SessionLoadState::Loaded {
+            warnings: Vec::new(),
+        };
+        assert!(rendered_text(&mut app, 80, 20).contains("No Agent Sessions"));
+    }
+
+    #[test]
+    fn session_enter_and_details_use_exact_node_qualified_identity() {
+        let mut app = app();
+        app.select_tab(PrimaryTab::Sessions);
+        app.apply_sessions(Ok(SessionLoadResult {
+            sessions: vec![dashboard_session("owner", "exact", 20)],
+            warnings: Vec::new(),
+        }));
+        assert_eq!(
+            app.update_key(KeyCode::Enter, KeyModifiers::NONE),
+            Some(DashboardEffect::ActivateSession(QualifiedIdentity::new(
+                "owner", "exact"
+            )))
+        );
+        assert_eq!(
+            app.update_key(KeyCode::Char('i'), KeyModifiers::NONE),
+            Some(DashboardEffect::InspectSession(QualifiedIdentity::new(
+                "owner", "exact"
+            )))
+        );
+        let identity = QualifiedIdentity::new("owner", "exact");
+        app.update(DashboardEvent::SessionInspected {
+            identity,
+            result: Ok(DashboardSessionDetails {
+                session: dashboard_session("owner", "exact", 20),
+                source_cwd: Some("/tmp/exact".into()),
+                occurrences: Vec::new(),
+                action: Ok("resume exact historical Session".into()),
+            }),
+        });
+        let rendered = rendered_text(&mut app, 140, 30);
+        for expected in [
+            "Session details",
+            "node-owner",
+            "work-exact",
+            "OpenCode",
+            "historical",
+            "/tmp/exact",
+            "OCCURRENCES",
+            "resume exact historical Session",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "missing {expected}: {rendered}"
+            );
+        }
+        app.update_key(KeyCode::Esc, KeyModifiers::NONE);
+        assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn session_mouse_first_selects_and_second_click_opens_same_row() {
+        let mut app = app();
+        app.select_tab(PrimaryTab::Sessions);
+        app.apply_sessions(Ok(SessionLoadResult {
+            sessions: vec![
+                dashboard_session("a", "first", 20),
+                dashboard_session("b", "second", 10),
+            ],
+            warnings: Vec::new(),
+        }));
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 4,
+            row: 4,
+            modifiers: KeyModifiers::NONE,
+        };
+        assert_eq!(app.update_mouse(event, Rect::new(0, 0, 80, 24)), None);
+        assert_eq!(app.selected_session().unwrap().session_id, "second");
+        assert_eq!(
+            app.update_mouse(event, Rect::new(0, 0, 80, 24)),
+            Some(DashboardEffect::ActivateSession(QualifiedIdentity::new(
+                "b", "second"
+            )))
+        );
+        let border = MouseEvent { row: 1, ..event };
+        assert_eq!(app.update_mouse(border, Rect::new(0, 0, 80, 24)), None);
+    }
+
+    #[test]
+    fn partial_warning_reserves_saturated_table_row_and_is_not_mouse_actionable() {
+        let mut app = app();
+        app.select_tab(PrimaryTab::Sessions);
+        app.apply_sessions(Ok(SessionLoadResult {
+            sessions: vec![
+                dashboard_session("a", "visible", 30),
+                dashboard_session("b", "hidden", 20),
+                dashboard_session("c", "also-hidden", 10),
+            ],
+            warnings: vec!["Node offline".into()],
+        }));
+        let mut terminal = Terminal::new(TestBackend::new(80, 7)).unwrap();
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let lines = (0..7)
+            .map(|row| {
+                (0..80)
+                    .map(|column| terminal.backend().buffer()[(column, row)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+
+        assert!(lines[3].contains("Session visible"), "{}", lines[3]);
+        assert!(!lines[3].contains("Session hidden"), "{}", lines[3]);
+        assert!(lines[4].contains("Warning: Node offline"), "{}", lines[4]);
+        let warning_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 4,
+            row: 4,
+            modifiers: KeyModifiers::NONE,
+        };
+        assert_eq!(
+            app.update_mouse(warning_click, Rect::new(0, 0, 80, 7)),
+            None
+        );
+        assert_eq!(app.selected_session().unwrap().session_id, "visible");
+    }
+
+    #[test]
+    fn mouse_capture_commands_are_enabled_and_cleaned_up() {
+        let mut output = Vec::new();
+        enable_dashboard_terminal_modes(&mut output).unwrap();
+        disable_dashboard_terminal_modes(&mut output).unwrap();
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("?1000h"));
+        assert!(output.contains("?1000l"));
+        assert!(output.contains("?2004h"));
+        assert!(output.contains("?2004l"));
+    }
+
+    #[test]
+    fn blocked_session_load_does_not_block_mutation_worker_and_is_single_flight() {
+        let (session_started_tx, session_started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (mutation_tx, mutation_rx) = mpsc::channel();
+        let mut runtime = DashboardRuntime::spawn_with_session_backend(
+            move |effect: DashboardEffect| {
+                mutation_tx.send(effect).unwrap();
+                DashboardEvent::OperationCompleted(Ok("mutated".into()))
+            },
+            move |effect: DashboardEffect| {
+                session_started_tx.send(effect).unwrap();
+                release_rx.recv().unwrap();
+                DashboardEvent::SessionsLoaded(Ok(SessionLoadResult {
+                    sessions: Vec::new(),
+                    warnings: Vec::new(),
+                }))
+            },
+        );
+        let load = DashboardEffect::LoadSessions { nodes: Vec::new() };
+        runtime.dispatch(vec![load.clone(), load]).unwrap();
+        session_started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        runtime
+            .dispatch(vec![DashboardEffect::Rename {
+                target: RenameTarget::Workspace("workspace".into()),
+                name: "changed".into(),
+            }])
+            .unwrap();
+        assert!(matches!(
+            mutation_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            DashboardEffect::Rename { .. }
+        ));
+        assert!(matches!(
+            session_started_rx.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+        release_tx.send(()).unwrap();
+    }
+
+    #[test]
+    fn inspection_queues_behind_session_load_instead_of_being_discarded() {
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let mut runtime = DashboardRuntime::spawn_with_session_backend(
+            |_| DashboardEvent::UpdateCheckCompleted,
+            move |effect: DashboardEffect| {
+                started_tx.send(effect.clone()).unwrap();
+                match effect {
+                    DashboardEffect::LoadSessions { .. } => {
+                        release_rx.recv().unwrap();
+                        DashboardEvent::SessionsLoaded(Ok(SessionLoadResult {
+                            sessions: Vec::new(),
+                            warnings: Vec::new(),
+                        }))
+                    }
+                    DashboardEffect::InspectSession(identity) => DashboardEvent::SessionInspected {
+                        identity,
+                        result: Err("inspection complete".into()),
+                    },
+                    effect => panic!("unexpected effect: {effect:?}"),
+                }
+            },
+        );
+        let identity = QualifiedIdentity::new("owner", "session");
+        runtime
+            .dispatch(vec![DashboardEffect::LoadSessions { nodes: Vec::new() }])
+            .unwrap();
+        assert!(matches!(
+            started_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            DashboardEffect::LoadSessions { .. }
+        ));
+        runtime
+            .dispatch(vec![DashboardEffect::InspectSession(identity.clone())])
+            .unwrap();
+        assert!(matches!(
+            started_rx.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+
+        release_tx.send(()).unwrap();
+        assert_eq!(
+            started_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            DashboardEffect::InspectSession(identity)
+        );
+    }
+
+    #[test]
+    fn activation_queues_behind_session_load_instead_of_being_discarded() {
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let mut runtime = DashboardRuntime::spawn_with_session_backend(
+            |_| DashboardEvent::UpdateCheckCompleted,
+            move |effect: DashboardEffect| {
+                started_tx.send(effect.clone()).unwrap();
+                match effect {
+                    DashboardEffect::LoadSessions { .. } => {
+                        release_rx.recv().unwrap();
+                        DashboardEvent::SessionsLoaded(Ok(SessionLoadResult {
+                            sessions: Vec::new(),
+                            warnings: Vec::new(),
+                        }))
+                    }
+                    DashboardEffect::ActivateSession(_) => {
+                        DashboardEvent::OperationCompleted(Ok("opened".into()))
+                    }
+                    effect => panic!("unexpected effect: {effect:?}"),
+                }
+            },
+        );
+        let identity = QualifiedIdentity::new("owner", "session");
+        runtime
+            .dispatch(vec![DashboardEffect::LoadSessions { nodes: Vec::new() }])
+            .unwrap();
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        runtime
+            .dispatch(vec![DashboardEffect::ActivateSession(identity.clone())])
+            .unwrap();
+        assert!(matches!(
+            started_rx.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+
+        release_tx.send(()).unwrap();
+        assert_eq!(
+            started_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            DashboardEffect::ActivateSession(identity)
+        );
+    }
+
+    #[test]
+    fn repeated_exact_activation_is_deduplicated_while_queued_and_allowed_after_completion() {
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let mut runtime = DashboardRuntime::spawn_with_session_backend(
+            |effect| match effect {
+                DashboardEffect::Refresh => DashboardEvent::RefreshCompleted(Err("ignored".into())),
+                effect => panic!("unexpected ordinary effect: {effect:?}"),
+            },
+            move |effect: DashboardEffect| {
+                started_tx.send(effect.clone()).unwrap();
+                match effect {
+                    DashboardEffect::LoadSessions { .. } => {
+                        release_rx.recv().unwrap();
+                        DashboardEvent::SessionsLoaded(Ok(SessionLoadResult {
+                            sessions: Vec::new(),
+                            warnings: Vec::new(),
+                        }))
+                    }
+                    DashboardEffect::ActivateSession(_) => {
+                        DashboardEvent::OperationCompleted(Ok("opened".into()))
+                    }
+                    effect => panic!("unexpected Session effect: {effect:?}"),
+                }
+            },
+        );
+        let identity = QualifiedIdentity::new("owner", "session");
+        let activation = DashboardEffect::ActivateSession(identity.clone());
+        runtime
+            .dispatch(vec![DashboardEffect::LoadSessions { nodes: Vec::new() }])
+            .unwrap();
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        runtime
+            .dispatch(vec![
+                activation.clone(),
+                activation.clone(),
+                activation.clone(),
+            ])
+            .unwrap();
+        assert_eq!(runtime.pending_session_activations.len(), 1);
+        assert_eq!(runtime.session_effects_in_flight, 2);
+        release_tx.send(()).unwrap();
+        assert_eq!(
+            started_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            activation
+        );
+        assert!(matches!(
+            started_rx.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+
+        let mut app = app();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !runtime.pending_session_activations.is_empty() && Instant::now() < deadline {
+            runtime.drain(&mut app).unwrap();
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert!(runtime.pending_session_activations.is_empty());
+        runtime.dispatch(vec![activation.clone()]).unwrap();
+        assert_eq!(
+            started_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            activation
+        );
+    }
+
+    #[test]
+    fn failed_session_send_and_completion_disconnect_clear_activation_admission() {
+        let (effects, _effect_receiver) = mpsc::channel();
+        let (session_effects, session_receiver) = mpsc::channel();
+        drop(session_receiver);
+        let (_completion_sender, completions) = mpsc::channel();
+        let mut runtime = DashboardRuntime {
+            effects,
+            session_effects,
+            completions,
+            update_check_in_flight: false,
+            preview_in_flight: false,
+            session_load_in_flight: false,
+            session_effects_in_flight: 0,
+            pending_session_activations: HashSet::new(),
+            operations_in_flight: 0,
+        };
+        let identity = QualifiedIdentity::new("owner", "session");
+        assert!(
+            runtime
+                .dispatch(vec![DashboardEffect::ActivateSession(identity.clone())])
+                .is_err()
+        );
+        assert!(runtime.pending_session_activations.is_empty());
+        assert_eq!(runtime.session_effects_in_flight, 0);
+        assert_eq!(runtime.operations_in_flight, 0);
+
+        runtime.pending_session_activations.insert(identity);
+        drop(_completion_sender);
+        assert!(runtime.drain(&mut app()).is_err());
+        assert!(runtime.pending_session_activations.is_empty());
+        assert_eq!(runtime.session_effects_in_flight, 0);
+        assert_eq!(runtime.operations_in_flight, 0);
+    }
+
+    #[test]
+    fn refresh_queued_during_activation_clears_session_loading_state() {
+        let (activation_tx, activation_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (load_tx, load_rx) = mpsc::channel();
+        let mut runtime = DashboardRuntime::spawn_with_session_backend(
+            |effect| match effect {
+                DashboardEffect::Refresh => {
+                    DashboardEvent::RefreshCompleted(Err("snapshot unavailable".into()))
+                }
+                effect => panic!("unexpected ordinary effect: {effect:?}"),
+            },
+            move |effect| match effect {
+                DashboardEffect::ActivateSession(_) => {
+                    activation_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    DashboardEvent::OperationCompleted(Ok("opened".into()))
+                }
+                DashboardEffect::LoadSessions { .. } => {
+                    load_tx.send(()).unwrap();
+                    DashboardEvent::SessionsLoaded(Ok(SessionLoadResult {
+                        sessions: vec![dashboard_session("owner", "session", 30)],
+                        warnings: Vec::new(),
+                    }))
+                }
+                effect => panic!("unexpected Session effect: {effect:?}"),
+            },
+        );
+        let mut app = app();
+        app.select_tab(PrimaryTab::Sessions);
+        app.apply_sessions(Ok(SessionLoadResult {
+            sessions: vec![dashboard_session("owner", "session", 20)],
+            warnings: Vec::new(),
+        }));
+        runtime
+            .dispatch(vec![app.activate_selected_session().unwrap()])
+            .unwrap();
+        activation_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        let refresh = app
+            .update_key(KeyCode::Char('r'), KeyModifiers::NONE)
+            .unwrap();
+        assert!(matches!(app.session_load, SessionLoadState::Loading));
+        runtime.dispatch(vec![refresh]).unwrap();
+        assert!(matches!(load_rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
+
+        release_tx.send(()).unwrap();
+        load_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while runtime.has_in_flight_effect() && Instant::now() < deadline {
+            runtime.drain(&mut app).unwrap();
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert!(!runtime.has_in_flight_effect());
+        assert!(matches!(
+            app.session_load,
+            SessionLoadState::Loaded { ref warnings } if warnings.is_empty()
+        ));
     }
 }

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -6,7 +6,7 @@ use std::os::unix::net::UnixStream;
 use std::os::unix::process::{CommandExt, ExitStatusExt};
 use std::process::Stdio;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use boomux::client::Client;
 use boomux::protocol::{
@@ -444,16 +444,20 @@ fn sequential_kiro_process_holders_inactivate_only_the_exited_session() {
 
 #[test]
 fn codex_app_server_catalog_projects_named_historical_threads_without_agents() {
-    let mut daemon = TestDaemon::start();
-    let bin = daemon.runtime_dir.join("codex-catalog-bin");
-    fs::create_dir(&bin).unwrap();
-    let codex = bin.join("codex");
-    fs::write(
-        &codex,
-        "#!/bin/sh\n[ \"$1\" = app-server ] || exit 64\nIFS= read -r line || exit 65\nprintf '%s\\n' '{\"id\":1,\"result\":{}}'\nIFS= read -r line || exit 66\nIFS= read -r line || exit 67\nprintf '%s\\n' '{\"id\":2,\"result\":{\"data\":[{\"id\":\"codex-history\",\"name\":\"Historical Codex thread\",\"preview\":\"fallback\",\"ephemeral\":false,\"createdAt\":10,\"updatedAt\":20}],\"nextCursor\":null}}'\n",
-    )
-    .unwrap();
-    fs::set_permissions(&codex, fs::Permissions::from_mode(0o755)).unwrap();
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let bin = runtime_dir.join("codex-catalog-bin");
+        fs::create_dir(&bin).unwrap();
+        let codex = bin.join("codex");
+        fs::write(
+            &codex,
+            "#!/bin/sh\nprintf x >> \"$CODEX_CATALOG_COUNT\"\n/bin/sleep 1\n[ \"$1\" = app-server ] || exit 64\nIFS= read -r line || exit 65\nprintf '%s\\n' '{\"id\":1,\"result\":{}}'\nIFS= read -r line || exit 66\nIFS= read -r line || exit 67\nprintf '%s\\n' '{\"id\":2,\"result\":{\"data\":[{\"id\":\"codex-history\",\"name\":\"Historical Codex thread\",\"preview\":\"fallback\",\"ephemeral\":false,\"createdAt\":10,\"updatedAt\":20}],\"nextCursor\":null}}'\n",
+        )
+        .unwrap();
+        fs::set_permissions(&codex, fs::Permissions::from_mode(0o755)).unwrap();
+        command
+            .env("PATH", &bin)
+            .env("CODEX_CATALOG_COUNT", runtime_dir.join("catalog-count"));
+    });
     let workspace = daemon
         .client
         .create_workspace(
@@ -462,12 +466,13 @@ fn codex_app_server_catalog_projects_named_historical_threads_without_agents() {
         )
         .unwrap();
 
+    let list_started = Instant::now();
     let output = daemon
         .command()
         .args(["session", "list", "--workspace", &workspace.id, "--json"])
-        .env("PATH", &bin)
         .output()
         .unwrap();
+    let list_elapsed = list_started.elapsed();
     assert!(
         output.status.success(),
         "{}",
@@ -481,6 +486,34 @@ fn codex_app_server_catalog_projects_named_historical_threads_without_agents() {
     assert_eq!(sessions[0]["description"], "Historical Codex thread");
     assert_eq!(sessions[0]["state"], "unknown");
     assert_eq!(sessions[0]["occurrence_count"], 0);
+    let session_id = sessions[0]["id"].as_str().unwrap();
+    let inspect_started = Instant::now();
+    assert!(matches!(
+        daemon
+            .client
+            .request(Request::HostService {
+                operation: protocol::HostServiceOperation::InspectAgentSession {
+                    session_id: session_id.into(),
+                },
+            })
+            .unwrap(),
+        Response::HostService {
+            result: protocol::HostServiceResult::AgentSession { .. }
+        }
+    ));
+    let inspect_elapsed = inspect_started.elapsed();
+    assert_eq!(
+        fs::read(daemon.runtime_dir.join("catalog-count")).unwrap(),
+        b"x"
+    );
+    assert!(list_elapsed >= Duration::from_millis(900));
+    assert!(
+        inspect_elapsed < Duration::from_millis(250),
+        "cached Session inspection took {inspect_elapsed:?}"
+    );
+    eprintln!(
+        "cold Session catalog took {list_elapsed:?}; cached inspection took {inspect_elapsed:?}"
+    );
 
     daemon.stop_with_cli();
 }
@@ -1031,6 +1064,90 @@ fn cold_recovery_attaches_opencode_session_to_shared_runtime_and_new_run() {
     );
 
     drop(recovered_attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn supervised_opencode_resume_attaches_to_warm_shared_runtime_without_cold_start() {
+    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
+        let runtime_bin = runtime_dir.join("bin");
+        fs::create_dir(&runtime_bin).unwrap();
+        let opencode = runtime_bin.join("opencode");
+        fs::write(
+            &opencode,
+            "#!/bin/sh\ncase \"${1-}\" in\n  serve) exec python3 -c 'import socket,sys,time; s=socket.socket(); s.bind((\"127.0.0.1\", int(sys.argv[5]))); s.listen(); time.sleep(60)' \"$@\" ;;\n  attach) { for arg do printf 'arg:%s\\n' \"$arg\"; done; printf 'generation:%s\\nshell:%s\\nrun:%s\\n' \"$BOOMUX_OPENCODE_SHARED_GENERATION\" \"$BOOMUX_SHELL_ID\" \"$BOOMUX_RUN_ID\"; } > \"$CAPTURE\"; while :; do sleep 60; done ;;\n  *) printf 'standalone:%s\\n' \"$*\" > \"$STANDALONE_CAPTURE\"; while :; do sleep 60; done ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&opencode, fs::Permissions::from_mode(0o700)).unwrap();
+        command
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    runtime_bin.display(),
+                    std::env::var("PATH").unwrap()
+                ),
+            )
+            .env("CAPTURE", runtime_dir.join("shared-resume"))
+            .env("STANDALONE_CAPTURE", runtime_dir.join("standalone-resume"));
+    });
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let runtime = ensure_test_opencode_runtime(&daemon, port).unwrap();
+    let session_id = "ses_managed_resume_exact";
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "managed-shared-opencode",
+            vec![ShellSpec {
+                name: "opencode-session".into(),
+                command: vec![
+                    daemon.executable.display().to_string(),
+                    "agent".into(),
+                    "supervise".into(),
+                    "OpenCode".into(),
+                    "--integration".into(),
+                    "opencode".into(),
+                    "--external-session-id".into(),
+                    session_id.into(),
+                    "--".into(),
+                    "opencode".into(),
+                    "--session".into(),
+                    session_id.into(),
+                ],
+                cwd: daemon.runtime_dir.clone(),
+            }],
+        )
+        .unwrap();
+    let shell_id = workspace.shells[0].id.clone();
+    let capture = daemon.runtime_dir.join("shared-resume");
+    let standalone_capture = daemon.runtime_dir.join("standalone-resume");
+
+    let started = Instant::now();
+    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
+    wait_until(
+        || capture.is_file(),
+        "supervised OpenCode resume did not attach to the shared runtime",
+    );
+    let elapsed = started.elapsed();
+    let shell = daemon.client.get_shell(&shell_id).unwrap();
+    let run = shell.run.unwrap();
+    let captured = fs::read_to_string(capture).unwrap();
+    assert!(captured.contains("arg:attach\n"));
+    assert!(captured.contains(&format!("arg:{}\n", runtime.url)));
+    assert!(captured.contains(&format!("arg:--session\narg:{session_id}\n")));
+    assert!(captured.contains(&format!("generation:{}\n", runtime.generation_id)));
+    assert!(captured.contains(&format!("shell:{shell_id}\n")));
+    assert!(captured.contains(&format!("run:{}\n", run.id)));
+    assert!(!standalone_capture.exists());
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "warm shared resume took {elapsed:?}"
+    );
+    eprintln!("warm shared OpenCode resume attached in {elapsed:?}");
+
+    drop(attachment);
     daemon.stop_with_cli();
 }
 

--- a/tests/native_backend/remote_host_services.rs
+++ b/tests/native_backend/remote_host_services.rs
@@ -176,6 +176,42 @@ fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv(
             },
         )
         .unwrap();
+    let current_sessions = local
+        .client
+        .route_node_host_service(
+            &owner_id,
+            HostServiceOperation::ListAgentSessions {
+                workspace_id: Some(session_workspace.id.clone()),
+            },
+        )
+        .unwrap();
+    let HostServiceResult::AgentSessions {
+        sessions: current_sessions,
+    } = current_sessions
+    else {
+        panic!("unexpected current Agent Session response");
+    };
+    assert_eq!(current_sessions.len(), 1);
+    assert!(current_sessions[0].state_is_current);
+    let current_inspection = local
+        .client
+        .route_node_host_service(
+            &owner_id,
+            HostServiceOperation::InspectAgentSession {
+                session_id: current_sessions[0].id.clone(),
+            },
+        )
+        .unwrap();
+    let HostServiceResult::AgentSession {
+        session: current_inspection,
+    } = current_inspection
+    else {
+        panic!("unexpected current Agent Session inspection response");
+    };
+    assert_eq!(current_inspection.occurrences.len(), 1);
+    assert_eq!(current_inspection.occurrences[0].shell_id, shell_id);
+    assert_eq!(current_inspection.occurrences[0].run_id, run_id);
+    assert!(local.client.snapshot().unwrap().workspaces.is_empty());
     owner
         .client
         .report_agent(


### PR DESCRIPTION
## Summary

- add a five-tab TUI with a cross-harness Sessions view aggregated across the local Node and online registered Nodes
- add capability-gated `boomux session open SESSION_ID [--node NODE]` for exact current-ShellRun attachment or exact historical owner resume
- preserve Node-qualified Session identity and fail closed without substituting another Node, Shell, run, path, harness, or Session
- add adaptive rendering, details, mouse selection/activation, bounded Session workers, partial-failure handling, documentation, and native owner-routing coverage

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1` (897 passed)
- `cargo test --test config_cli --locked -- --test-threads=1` (7 passed)
- `cargo test --test native_backend --locked -- --test-threads=1` (133 passed)
- `cargo deny check`
- clean-cache Bun install and embedded web-terminal build, with no generated asset diff
- `bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js` (43 passed)

Closes #318