### PR TITLE
perf: add regression benchmark harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,41 @@ jobs:
         if: env.RUN_CODE == 'true'
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
 
+  benchmarks:
+    name: Benchmark smoke
+    needs: changes
+    if: always()
+    runs-on: ubuntu-24.04
+    env:
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - name: Skip benchmark checks for Markdown-only changes
+        if: env.RUN_CODE != 'true'
+        run: printf 'Benchmark checks are not required for Markdown-only changes.\n'
+
+      - name: Check out repository
+        if: env.RUN_CODE == 'true'
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Install Rust toolchain
+        if: env.RUN_CODE == 'true'
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Validate deterministic benchmark fixtures
+        if: env.RUN_CODE == 'true'
+        run: cargo test --test benchmark_harness --features benchmark-internals --locked
+
+      - name: Compile every benchmark target
+        if: env.RUN_CODE == 'true'
+        run: cargo check --benches --all-features --locked
+
+      - name: Smoke test Criterion benchmarks
+        if: env.RUN_CODE == 'true'
+        run: |
+          cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
+          cargo bench --bench wire --locked -- --test
+
   integrations:
     name: Integrations
     needs: changes

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,176 @@
+name: Performance
+
+on:
+  schedule:
+    - cron: "37 5 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: performance-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  LC_ALL: C.UTF-8
+  RUSTUP_TOOLCHAIN: stable
+  TZ: UTC
+
+jobs:
+  criterion:
+    name: Wall-clock trends
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Record benchmark environment
+        run: |
+          rustc -Vv | tee benchmark-rustc.txt
+          uname -a | tee benchmark-uname.txt
+          lscpu | tee benchmark-cpu.txt
+          printf 'ImageOS=%s\nImageVersion=%s\n' "$ImageOS" "$ImageVersion" | tee benchmark-runner.txt
+          {
+            printf '## Benchmark environment\n\n```text\n'
+            cat benchmark-rustc.txt benchmark-uname.txt benchmark-cpu.txt benchmark-runner.txt
+            printf '```\n'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run Criterion suites
+        id: criterion
+        run: |
+          set -o pipefail
+          cargo bench --bench core_cpu --features benchmark-internals --locked 2>&1 | tee criterion-core.txt
+          cargo bench --bench wire --locked 2>&1 | tee criterion-wire.txt
+
+      - name: Upload Criterion reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: criterion-${{ github.sha }}-${{ github.run_attempt }}
+          path: |
+            target/criterion/
+            criterion-core.txt
+            criterion-wire.txt
+            benchmark-rustc.txt
+            benchmark-uname.txt
+            benchmark-cpu.txt
+            benchmark-runner.txt
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Summarize Criterion run
+        if: always()
+        env:
+          RESULT: ${{ steps.criterion.outcome }}
+        run: |
+          printf '## Wall-clock trends\n\nCriterion suites: `%s`\n' "$RESULT" >> "$GITHUB_STEP_SUMMARY"
+
+  instructions:
+    name: Deterministic instruction counts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      GUNGRAUN_HOME: target/gungraun
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Install Gungraun runner
+        run: |
+          cargo install gungraun-runner --version 0.19.4 --locked
+          gungraun-runner --version | tee gungraun-runner.txt
+
+      - name: Install Valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes valgrind
+          valgrind --version | tee gungraun-valgrind.txt
+
+      - name: Record instruction benchmark environment
+        run: |
+          rustc -Vv | tee gungraun-rustc.txt
+          uname -a | tee gungraun-uname.txt
+          lscpu | tee gungraun-cpu.txt
+          printf 'ImageOS=%s\nImageVersion=%s\n' "$ImageOS" "$ImageVersion" | tee gungraun-runner-image.txt
+
+      - name: Resolve comparison base
+        id: comparison
+        env:
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          git fetch --no-tags origin main
+          if [[ "$HEAD_SHA" == "$(git rev-parse origin/main)" ]]; then
+            base_sha=$(git rev-parse "$HEAD_SHA^")
+          else
+            base_sha=$(git merge-base "$HEAD_SHA" origin/main)
+          fi
+          printf 'base_sha=%s\n' "$base_sha" >> "$GITHUB_OUTPUT"
+          if git cat-file -e "$base_sha:benches/core_instructions.rs" 2>/dev/null; then
+            printf 'available=true\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'available=false\n' >> "$GITHUB_OUTPUT"
+            printf 'The comparison commit predates the instruction benchmark; this run establishes the first result.\n' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Measure comparison base
+        id: base
+        if: steps.comparison.outputs.available == 'true'
+        env:
+          BASE_SHA: ${{ steps.comparison.outputs.base_sha }}
+        run: |
+          set -o pipefail
+          git checkout --detach "$BASE_SHA"
+          cargo bench --bench core_instructions --features benchmark-internals --locked -- --save-baseline=base 2>&1 | tee gungraun-base.txt
+
+      - name: Measure current revision
+        id: head
+        env:
+          HAS_BASELINE: ${{ steps.comparison.outputs.available }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -o pipefail
+          git checkout --detach "$HEAD_SHA"
+          if [[ "$HAS_BASELINE" == true ]]; then
+            cargo bench --bench core_instructions --features benchmark-internals --locked -- --baseline=base 2>&1 | tee gungraun-head.txt
+          else
+            cargo bench --bench core_instructions --features benchmark-internals --locked 2>&1 | tee gungraun-head.txt
+          fi
+
+      - name: Upload instruction-count reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: gungraun-${{ github.sha }}-${{ github.run_attempt }}
+          path: |
+            target/gungraun/
+            gungraun-base.txt
+            gungraun-head.txt
+            gungraun-runner.txt
+            gungraun-valgrind.txt
+            gungraun-rustc.txt
+            gungraun-uname.txt
+            gungraun-cpu.txt
+            gungraun-runner-image.txt
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Summarize instruction-count run
+        if: always()
+        env:
+          BASE_RESULT: ${{ steps.base.outcome }}
+          HEAD_RESULT: ${{ steps.head.outcome }}
+        run: |
+          printf '## Deterministic instruction counts\n\nBase measurement: `%s`  \nCurrent measurement: `%s`\n' \
+            "$BASE_RESULT" "$HEAD_RESULT" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ cargo clippy --all-targets --all-features --locked -- -D warnings
 cargo test --lib --bins --locked -- --test-threads=1
 cargo test --test config_cli --locked -- --test-threads=1
 cargo test --test native_backend --locked -- --test-threads=1
+cargo test --test benchmark_harness --features benchmark-internals --locked
+cargo check --benches --all-features --locked
+cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
+cargo bench --bench wire --locked -- --test
 cargo deny check
 bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
 ```
@@ -50,6 +54,7 @@ exercise process, socket, PTY, and daemon lifecycle behavior.
 | PTY, attachment, or process lifecycle | Colocated unit tests plus serial `native_backend` scenarios |
 | Graceful handoff | Serial native tests covering rollback, reconnect, PID preservation, and later cleanup |
 | TUI state or rendering | Focused `tui.rs` model, input, and rendering tests |
+| Performance hot path or benchmark | Semantic tests, deterministic benchmark fixtures, benchmark smoke, and before/after evidence from the same machine |
 | OpenCode, Pi, Claude, Codex, or Kiro reducer | The corresponding focused reducer tests, including `boomux-tui.test.js` for OpenCode TUI claims |
 | Host compatibility claim | Focused fixtures plus an update to `docs/lifecycle-validation.md` when validated live |
 

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -1,0 +1,126 @@
+# Benchmarking Boomux
+
+Boomux uses separate mechanisms for deterministic regression gates and elapsed-time
+trend analysis. Benchmarks complement semantic tests; they do not replace protocol,
+persistence, lifecycle, or native compatibility coverage.
+
+## Benchmark Tiers
+
+| Tier | Tool | Purpose | Merge policy |
+| --- | --- | --- | --- |
+| Bounded-work fixtures | Rust tests | Stable cardinality, digest, and limit checks | Required |
+| CPU instruction counts | Gungraun and Callgrind | Deterministic algorithmic regressions | Ten-percent soft limit in same-run base/head comparisons |
+| Wall-clock trends | Criterion | Latency and throughput investigation | Report-only on shared runners |
+| Local kernel | Future local tools | PTY, process, filesystem, and handoff behavior | Report-only |
+
+GitHub-hosted elapsed time is too noisy to reject a change reliably. A controlled
+runner is required before Criterion results can become a hard gate.
+
+## Prerequisites
+
+The smoke suite needs the normal stable Rust toolchain. Gungraun execution also
+requires Valgrind and the runner version paired with the locked library:
+
+```console
+sudo pacman -S valgrind
+cargo install gungraun-runner --version 0.19.4 --locked
+```
+
+Benchmark dependencies are locked and covered by the repository dependency policy.
+The bench profile retains debug information so Callgrind can identify benchmarked
+functions.
+
+## Smoke Validation
+
+Run the deterministic fixtures and compile every target:
+
+```console
+cargo test --test benchmark_harness --features benchmark-internals --locked
+cargo check --benches --all-features --locked
+cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
+cargo bench --bench wire --locked -- --test
+```
+
+Smoke mode executes each Criterion case once. It verifies fixtures and benchmark
+wiring, but does not produce meaningful timing measurements.
+
+## Wall-Clock Measurements
+
+Run the complete Criterion suites with optimized code:
+
+```console
+cargo bench --bench core_cpu --features benchmark-internals --locked
+cargo bench --bench wire --locked
+```
+
+Criterion writes reports under `target/criterion/`. Compare changes on the same
+machine, with the same toolchain and minimal competing load. Save a baseline before
+changing code, then compare the candidate against that named baseline:
+
+```console
+cargo bench --bench core_cpu --features benchmark-internals --locked -- --save-baseline main
+cargo bench --bench core_cpu --features benchmark-internals --locked -- --baseline main
+```
+
+Treat small differences as investigation signals, not proof. Confirm important
+results with repeated runs and inspect the affected benchmark's throughput and
+input cardinality.
+
+## Instruction Counts
+
+Run deterministic CPU cases through Callgrind:
+
+```console
+cargo bench --bench core_instructions --features benchmark-internals --locked
+```
+
+The suite monitors Callgrind's simulated executed-instruction count with a ten-percent
+soft regression limit.
+Gungraun exits unsuccessfully when a named baseline exists and a limit is exceeded.
+Keep `target/gungraun/` when comparing local revisions. The scheduled workflow saves
+a baseline from the merge base (or the previous `main` commit) and measures the current
+revision against it in the same job; its first run is report-only when the comparison
+commit predates the benchmark. Instruction count is not wall-clock latency and does
+not model waiting, kernel scheduling, or I/O.
+
+## Current Workloads
+
+`core_cpu` covers:
+
+- retained daemon event pages at the head, middle, and tail of the 8,192-event bound;
+- 256/257-event reduced projection cuts;
+- blocked Node/focus invalidation coalescing;
+- durable and host-catalog Session projection, including shared-directory output
+  amplification;
+- terminal ingestion, structured preview, and reconstruction with full scrollback.
+
+`wire` covers 16-KiB attachment frames and one-MiB JSON control messages.
+
+`core_instructions` gates a small stable subset: both sides of the 256/257 projection
+cutoff, shared catalog projection, and structured terminal preview.
+
+## Adding A Benchmark
+
+1. Start in the module that owns the behavior and read its semantic tests and contract.
+2. Expose only an opaque operation through the `benchmark-internals` feature.
+3. Use fixed IDs, timestamps, absolute synthetic paths, ordering, and payloads.
+4. Construct fixtures outside the measured region unless construction is the operation.
+5. Validate an exact cardinality or repeatable summary before registering measurements.
+6. Add or identify a semantic test that protects the benchmarked result.
+7. Include common and boundary-sized inputs; avoid a single convenient fixture.
+8. Document intentional workload or benchmark-name changes in the pull request.
+
+Do not duplicate production modules with path inclusion, expose ordinary public APIs
+only for benchmarking, or add benchmark-only branches to production hot paths.
+
+## Safety And Privacy
+
+Benchmarks and uploaded artifacts must use synthetic data. Never include real terminal
+contents, user paths, environment variables, configuration, credentials, Node routes,
+or external Session IDs.
+
+Hard-gated CPU benchmarks must not use network access, subprocesses, sleep, PTYs,
+filesystem scans, or daemon lifecycle operations. Those measurements belong in a
+separate report-only local-kernel suite with isolated XDG state.
+
+Benchmark reports are CI artifacts, not product release assets.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,34 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -153,6 +177,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode-next"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6626829353ae29293be5c86f42de5f0468bc758af074b0c7d08f07e538ccbc"
+dependencies = [
+ "pastey",
+ "rapidhash",
+ "serde",
+ "unty-next",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,8 +215,10 @@ version = "1.7.1"
 dependencies = [
  "axum",
  "clap",
+ "criterion",
  "crossterm",
  "futures-util",
+ "gungraun",
  "libc",
  "nix",
  "portable-pty",
@@ -218,12 +256,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -237,6 +291,33 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -317,10 +398,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -348,6 +489,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -459,6 +606,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
+name = "either-or-both"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717164c227120ba9ddf3e2b32305fc0122741d3ee41a54968eae7573ee01933"
+dependencies = [
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +647,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "foldhash"
@@ -589,6 +752,55 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+]
+
+[[package]]
+name = "gungraun"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9300d38d30facf6870c15bc9e243edcc47e5ddc270c9d2c1ae824a00b1faea79"
+dependencies = [
+ "bincode-next",
+ "derive_more",
+ "gungraun-macros",
+ "gungraun-runner",
+]
+
+[[package]]
+name = "gungraun-macros"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f3214bae6cfd6739f4f29edb262bae439c6393a7b7b12c4eeb96417c2e50df"
+dependencies = [
+ "derive_more",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "gungraun-runner"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c68c92812da579a2510a2cc702d5aa3251992b9662d4a98502ca46e0cbe16e"
+dependencies = [
+ "either-or-both",
+ "serde",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -742,6 +954,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -932,6 +1153,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1232,34 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1030,6 +1301,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-error-attr3"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1092,6 +1385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,7 +1416,7 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -1148,7 +1450,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -1159,6 +1461,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1488,35 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc_version"
@@ -1200,6 +1551,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1342,6 +1702,12 @@ name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1517,6 +1883,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "tokio"
@@ -1706,7 +2082,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1716,6 +2092,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unty-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e"
 
 [[package]]
 name = "utf8parse"
@@ -1760,6 +2142,16 @@ checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
  "memchr",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1823,6 +2215,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +2239,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "1.7.1"
 edition = "2024"
 license = "MIT"
 
+[features]
+benchmark-internals = []
+
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4", features = ["derive"] }
@@ -26,4 +29,28 @@ unicode-width = "0.2"
 vt100 = "=0.16.2"
 
 [dev-dependencies]
+criterion = "0.8.2"
+gungraun = "0.19.4"
 tungstenite = "0.29"
+
+[profile.bench]
+debug = true
+
+[[bench]]
+name = "core_cpu"
+harness = false
+required-features = ["benchmark-internals"]
+
+[[bench]]
+name = "core_instructions"
+harness = false
+required-features = ["benchmark-internals"]
+
+[[bench]]
+name = "wire"
+harness = false
+
+[[test]]
+name = "benchmark_harness"
+path = "tests/benchmark_harness.rs"
+required-features = ["benchmark-internals"]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -171,6 +171,23 @@ bun test integrations/opencode/boomux.test.js \
   integrations/pi/boomux.test.js
 ```
 
+## Performance Benchmarks
+
+Use [`BENCHMARKING.md`](BENCHMARKING.md) for the benchmark tiers, fixture policy,
+local commands, and interpretation rules. Before changing a benchmarked hot path,
+save a local Criterion baseline on the same machine. Before opening a code PR, run
+the deterministic benchmark fixtures and smoke suite:
+
+```console
+cargo test --test benchmark_harness --features benchmark-internals --locked
+cargo check --benches --all-features --locked
+cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
+cargo bench --bench wire --locked -- --test
+```
+
+Criterion timing on shared runners is evidence, not a merge gate. Gungraun provides
+the deterministic instruction-count tier and requires Valgrind for execution.
+
 ## Complete Validation
 
 Before opening a pull request that changes code, configuration, packaging, or
@@ -182,6 +199,10 @@ cargo clippy --all-targets --all-features --locked -- -D warnings
 cargo test --lib --bins --locked -- --test-threads=1
 cargo test --test config_cli --locked -- --test-threads=1
 cargo test --test native_backend --locked -- --test-threads=1
+cargo test --test benchmark_harness --features benchmark-internals --locked
+cargo check --benches --all-features --locked
+cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
+cargo bench --bench wire --locked -- --test
 cargo deny check
 bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
 ```

--- a/benches/core_cpu.rs
+++ b/benches/core_cpu.rs
@@ -1,0 +1,165 @@
+use std::hint::black_box;
+
+use boomux::benchmark_support::{
+    EventAppendFixture, EventFixture, RuntimeEventFixture, SessionFixture, TerminalFixture,
+    terminal_transcript,
+};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+fn event_benchmarks(criterion: &mut Criterion) {
+    let events = EventFixture::retained(8_192);
+    for distance in [8_192, 4_096, 256] {
+        for limit in [1, 64, 256] {
+            assert_eq!(events.read_page(distance, limit).summary().count, limit);
+        }
+    }
+    assert_eq!(
+        events.read_page(256, 256).summary().checksum,
+        14_253_501_652_687_160_347
+    );
+    assert_eq!(
+        events.projection_cut(256).summary().checksum,
+        14_253_501_652_687_160_347
+    );
+    assert!(events.projection_cut(257).summary().baseline);
+    assert_eq!(events.projection_cut(64).summary().count, 64);
+    assert!(events.projection_cut(8_192).summary().baseline);
+
+    let append = EventAppendFixture::retained_with_batch(8_192, 256);
+    let appended = append.clone().append().summary();
+    assert_eq!(
+        (appended.count, appended.first_id, appended.last_id),
+        (8_192, 257, 8_448)
+    );
+    assert_eq!(appended.checksum, 8_051_509_862_202_861_121);
+    criterion.bench_function("events/append_256_at_retention_limit", |benchmark| {
+        benchmark.iter_batched(
+            || append.clone(),
+            |fixture| black_box(fixture.append()),
+            BatchSize::LargeInput,
+        );
+    });
+
+    let mut reads = criterion.benchmark_group("events/read_page");
+    for (position, distance) in [("head", 8_192), ("middle", 4_096), ("tail", 256)] {
+        for limit in [1, 64, 256] {
+            reads.throughput(Throughput::Elements(limit));
+            reads.bench_with_input(
+                BenchmarkId::new(position, limit),
+                &(distance, limit as usize),
+                |benchmark, &(distance, limit)| {
+                    benchmark.iter(|| black_box(events.read_page(distance, limit)));
+                },
+            );
+        }
+    }
+    reads.finish();
+
+    let mut cuts = criterion.benchmark_group("events/projection_cut");
+    for distance in [64, 256, 257, 8_192] {
+        cuts.bench_with_input(
+            BenchmarkId::from_parameter(distance),
+            &distance,
+            |benchmark, &distance| {
+                benchmark.iter(|| black_box(events.projection_cut(distance)));
+            },
+        );
+    }
+    cuts.finish();
+
+    let invalidations = RuntimeEventFixture::invalidations(128, 64);
+    let summary = invalidations.clone().coalesce().summary();
+    assert_eq!(summary.count, 129);
+    assert_eq!(summary.checksum, 9_953_927_640_701_513_843);
+    criterion.bench_function("events/coalesce_128_nodes_64_revisions", |benchmark| {
+        benchmark.iter_batched(
+            || invalidations.clone(),
+            |fixture| black_box(fixture.coalesce()),
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+fn session_benchmarks(criterion: &mut Criterion) {
+    let durable = SessionFixture::durable(64, 8, 2);
+    let durable_summary = durable.project().summary();
+    assert_eq!(durable_summary.sessions, 1_024);
+    assert_eq!(durable_summary.occurrences, 1_024);
+    assert_eq!(durable_summary.current, 1_024);
+    assert_eq!(durable_summary.checksum, 1_011_118_191_847_967_550);
+
+    let unique_catalog = SessionFixture::catalog(64, 400, false);
+    let unique_summary = unique_catalog.project().summary();
+    assert_eq!(unique_summary.sessions, 400);
+    assert_eq!(unique_summary.checksum, 8_601_524_830_593_867_508);
+    let shared_catalog = SessionFixture::catalog(32, 400, true);
+    let shared_summary = shared_catalog.project().summary();
+    assert_eq!(shared_summary.sessions, 12_800);
+    assert_eq!(shared_summary.checksum, 6_725_822_761_224_353_157);
+
+    let mut sessions = criterion.benchmark_group("sessions");
+    sessions.throughput(Throughput::Elements(1_024));
+    sessions.bench_function("durable_64w_512s_1024a", |benchmark| {
+        benchmark.iter(|| black_box(durable.project()));
+    });
+    sessions.throughput(Throughput::Elements(400));
+    sessions.bench_function("catalog_400_unique", |benchmark| {
+        benchmark.iter(|| black_box(unique_catalog.project()));
+    });
+    sessions.throughput(Throughput::Elements(12_800));
+    sessions.bench_function("catalog_400_shared_32w", |benchmark| {
+        benchmark.iter(|| black_box(shared_catalog.project()));
+    });
+    sessions.finish();
+}
+
+fn terminal_benchmarks(criterion: &mut Criterion) {
+    let transcript = terminal_transcript(2_048, 128);
+    let terminal = TerminalFixture::from_transcript(24, 80, &transcript);
+    let summary = terminal.summary();
+    assert_eq!(summary.preview_checksum, 10_375_648_925_095_483_392);
+    assert_eq!(summary.reconstruction_checksum, 12_069_107_278_816_405_535);
+    let chunked = TerminalFixture::from_chunked_transcript(24, 80, &transcript, 16 * 1024);
+    assert_eq!(chunked.summary(), summary);
+    let preview = terminal.preview(1024 * 1024, 16, 20_000);
+    assert_eq!(preview.lines.len(), 16);
+    let reconstruction = terminal.reconstruction();
+    assert!(!reconstruction.is_empty());
+    assert!(reconstruction.len() <= 1024 * 1024);
+
+    let mut process = criterion.benchmark_group("terminal/process");
+    process.throughput(Throughput::Bytes(transcript.len() as u64));
+    process.bench_function("2048_styled_lines", |benchmark| {
+        benchmark.iter_batched(
+            || transcript.as_slice(),
+            |transcript| {
+                black_box(TerminalFixture::from_chunked_transcript(
+                    24,
+                    80,
+                    black_box(transcript),
+                    16 * 1024,
+                ))
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    process.finish();
+
+    criterion.bench_function("terminal/preview_2000_scrollback_rows", |benchmark| {
+        benchmark.iter(|| black_box(terminal.preview(1024 * 1024, 16, 20_000)));
+    });
+    criterion.bench_function(
+        "terminal/reconstruction_2000_scrollback_rows",
+        |benchmark| {
+            benchmark.iter(|| black_box(terminal.reconstruction()));
+        },
+    );
+}
+
+criterion_group!(
+    benches,
+    event_benchmarks,
+    session_benchmarks,
+    terminal_benchmarks
+);
+criterion_main!(benches);

--- a/benches/core_instructions.rs
+++ b/benches/core_instructions.rs
@@ -1,0 +1,81 @@
+extern crate gungraun;
+
+use std::hint::black_box;
+
+use boomux::benchmark_support::{
+    EventFixture, SessionFixture, SessionProjectionResult, TerminalFixture, TransitionResult,
+    terminal_transcript,
+};
+use boomux::protocol::TerminalPreview;
+use gungraun::{
+    Callgrind, EventKind, LibraryBenchmarkConfig, library_benchmark, library_benchmark_group, main,
+};
+
+fn setup_events(count: usize) -> EventFixture {
+    let fixture = EventFixture::retained(count);
+    assert_eq!(
+        fixture.projection_cut(256).summary().checksum,
+        14_253_501_652_687_160_347
+    );
+    let baseline = fixture.projection_cut(257).summary();
+    assert!(baseline.baseline);
+    assert_eq!((baseline.count, baseline.checksum), (0, 0));
+    fixture
+}
+
+#[library_benchmark]
+#[bench::cut_256(args = (8_192), setup = setup_events)]
+fn event_projection_cut_256(fixture: EventFixture) -> TransitionResult {
+    black_box(fixture.projection_cut(256))
+}
+
+#[library_benchmark]
+#[bench::cut_257(args = (8_192), setup = setup_events)]
+fn event_projection_cut_257(fixture: EventFixture) -> TransitionResult {
+    black_box(fixture.projection_cut(257))
+}
+
+fn setup_shared_catalog(workspaces: usize, records: usize) -> SessionFixture {
+    let fixture = SessionFixture::catalog(workspaces, records, true);
+    let summary = fixture.project().summary();
+    assert_eq!(summary.sessions, workspaces * records);
+    assert_eq!(summary.checksum, 6_725_822_761_224_353_157);
+    fixture
+}
+
+#[library_benchmark]
+#[bench::shared_32w_400(args = (32, 400), setup = setup_shared_catalog)]
+fn shared_catalog_projection(fixture: SessionFixture) -> SessionProjectionResult {
+    black_box(fixture.project())
+}
+
+fn setup_terminal(lines: usize, line_bytes: usize) -> TerminalFixture {
+    let transcript = terminal_transcript(lines, line_bytes);
+    let fixture = TerminalFixture::from_transcript(24, 80, &transcript);
+    let summary = fixture.summary();
+    assert_eq!(summary.preview_lines, 16);
+    assert_eq!(summary.preview_checksum, 10_375_648_925_095_483_392);
+    assert_eq!(summary.reconstruction_checksum, 12_069_107_278_816_405_535);
+    fixture
+}
+
+#[library_benchmark]
+#[bench::styled_2000(args = (2_048, 128), setup = setup_terminal)]
+fn terminal_preview(fixture: TerminalFixture) -> TerminalPreview {
+    black_box(fixture.preview(1024 * 1024, 16, 20_000))
+}
+
+library_benchmark_group!(
+    name = core_instructions;
+    benchmarks = event_projection_cut_256,
+                 event_projection_cut_257,
+                 shared_catalog_projection,
+                 terminal_preview
+);
+
+main!(
+    config = LibraryBenchmarkConfig::default().tool(
+        Callgrind::default().soft_limits([(EventKind::Ir, 10.0)])
+    );
+    library_benchmark_groups = core_instructions
+);

--- a/benches/wire.rs
+++ b/benches/wire.rs
@@ -1,0 +1,76 @@
+use std::hint::black_box;
+use std::io::Cursor;
+
+use boomux::protocol::{AttachFrame, read_message, write_message};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ControlFixture {
+    sequence: u64,
+    payload: String,
+}
+
+fn wire_benchmarks(criterion: &mut Criterion) {
+    let attach = AttachFrame::Output(vec![b'x'; 16 * 1024]);
+    let mut encoded_attach = Vec::new();
+    attach.write_to(&mut encoded_attach).unwrap();
+    assert_eq!(
+        AttachFrame::read_from(&mut Cursor::new(&encoded_attach)).unwrap(),
+        attach
+    );
+
+    let control = ControlFixture {
+        sequence: 42,
+        payload: "x".repeat(1024 * 1024),
+    };
+    let mut encoded_control = Vec::new();
+    write_message(&mut encoded_control, &control).unwrap();
+    let decoded: ControlFixture = read_message(&mut Cursor::new(&encoded_control)).unwrap();
+    assert_eq!(decoded, control);
+    assert_eq!(encoded_attach.len(), 16_389);
+    assert_eq!(encoded_control.len(), 1_048_608);
+
+    let mut attach_group = criterion.benchmark_group("wire/attach");
+    attach_group.throughput(Throughput::Bytes(16 * 1024));
+    attach_group.bench_function("encode_16k", |benchmark| {
+        benchmark.iter_batched(
+            || Vec::with_capacity(encoded_attach.len()),
+            |mut output| {
+                attach.write_to(&mut output).unwrap();
+                black_box(output)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    attach_group.bench_function("decode_16k", |benchmark| {
+        benchmark.iter(|| {
+            let mut input = Cursor::new(encoded_attach.as_slice());
+            black_box(AttachFrame::read_from(&mut input).unwrap())
+        });
+    });
+    attach_group.finish();
+
+    let mut control_group = criterion.benchmark_group("wire/control");
+    control_group.throughput(Throughput::Bytes(control.payload.len() as u64));
+    control_group.bench_function("encode_1m", |benchmark| {
+        benchmark.iter_batched(
+            || Vec::with_capacity(encoded_control.len()),
+            |mut output| {
+                write_message(&mut output, &control).unwrap();
+                black_box(output)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    control_group.bench_function("decode_1m", |benchmark| {
+        benchmark.iter(|| {
+            let mut input = Cursor::new(encoded_control.as_slice());
+            black_box(read_message::<ControlFixture>(&mut input).unwrap())
+        });
+    });
+    control_group.finish();
+}
+
+criterion_group!(benches, wire_benchmarks);
+criterion_main!(benches);

--- a/src/benchmark_support.rs
+++ b/src/benchmark_support.rs
@@ -1,0 +1,10 @@
+pub use crate::daemon::benchmark_support::{
+    EventAppendFixture, EventAppendResult, EventFixture, EventPageResult, EventPageSummary,
+    RuntimeEventFixture, RuntimeEventResult, TransitionResult, TransitionSummary,
+};
+pub use crate::session_projection::benchmark_support::{
+    SessionFixture, SessionProjectionResult, SessionSummary,
+};
+pub use crate::terminal_state::benchmark_support::{
+    TerminalFixture, TerminalSummary, terminal_transcript,
+};

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4224,6 +4224,326 @@ fn projection_transitions(
     (NodeProjectionSyncMode::Resumed, transitions)
 }
 
+#[cfg(any(test, feature = "benchmark-internals"))]
+#[doc(hidden)]
+pub mod benchmark_support {
+    use super::*;
+
+    const STREAM_ID: &str = "00000000-0000-0000-0000-000000000001";
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct EventPageSummary {
+        pub count: usize,
+        pub first_id: u64,
+        pub last_id: u64,
+        pub checksum: u64,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct TransitionSummary {
+        pub baseline: bool,
+        pub count: usize,
+        pub checksum: u64,
+    }
+
+    pub struct EventFixture {
+        stream: EventStream,
+        retained: usize,
+    }
+
+    pub struct EventPageResult(Response);
+
+    impl EventPageResult {
+        pub fn summary(&self) -> EventPageSummary {
+            let Response::Events { events, .. } = &self.0 else {
+                panic!("benchmark event read returned a non-event response");
+            };
+            EventPageSummary {
+                count: events.len(),
+                first_id: events.first().map_or(0, |event| event.id),
+                last_id: events.last().map_or(0, |event| event.id),
+                checksum: events.iter().fold(0, checksum_event),
+            }
+        }
+    }
+
+    pub struct TransitionResult {
+        mode: NodeProjectionSyncMode,
+        transitions: Vec<NodeProjectionTransition>,
+    }
+
+    impl TransitionResult {
+        pub fn summary(&self) -> TransitionSummary {
+            TransitionSummary {
+                baseline: self.mode == NodeProjectionSyncMode::Baseline,
+                count: self.transitions.len(),
+                checksum: self.transitions.iter().fold(0, checksum_transition),
+            }
+        }
+    }
+
+    pub struct EventAppendFixture {
+        state: EventStreamState,
+        kinds: Vec<DaemonEventKind>,
+    }
+
+    pub struct EventAppendResult(EventStreamState);
+
+    impl EventAppendResult {
+        pub fn summary(&self) -> EventPageSummary {
+            summarize_events(&self.0.events)
+        }
+    }
+
+    impl Clone for EventAppendFixture {
+        fn clone(&self) -> Self {
+            Self {
+                state: EventStreamState {
+                    stream_id: self.state.stream_id.clone(),
+                    latest_id: self.state.latest_id,
+                    events: self.state.events.clone(),
+                },
+                kinds: self.kinds.clone(),
+            }
+        }
+    }
+
+    impl EventFixture {
+        pub fn retained(count: usize) -> Self {
+            assert!(count <= MAX_RETAINED_EVENTS);
+            let events = (1..=count)
+                .map(|index| DaemonEvent {
+                    id: index as u64,
+                    at_ms: 1_000_000 + index as u64,
+                    kind: DaemonEventKind::WorkspaceClosed {
+                        workspace_id: format!("workspace-{index}"),
+                    },
+                })
+                .collect();
+            Self {
+                stream: EventStream::from_transfer(Some(handoff::EventStreamManifest {
+                    stream_id: STREAM_ID.into(),
+                    latest_id: count as u64,
+                    events,
+                })),
+                retained: count,
+            }
+        }
+
+        pub fn read_page(&self, distance_from_tail: usize, limit: usize) -> EventPageResult {
+            assert!(distance_from_tail <= self.retained);
+            let cursor = EventCursor {
+                stream_id: STREAM_ID.into(),
+                event_id: (self.retained - distance_from_tail) as u64,
+            };
+            EventPageResult(
+                self.stream
+                    .read_after(&cursor, limit, 0, || false)
+                    .expect("benchmark event cursor remains valid"),
+            )
+        }
+
+        pub fn projection_cut(&self, distance_from_tail: usize) -> TransitionResult {
+            assert!(distance_from_tail <= self.retained);
+            let state = lock(&self.stream.state).expect("benchmark event state lock");
+            let through = EventCursor {
+                stream_id: STREAM_ID.into(),
+                event_id: self.retained as u64,
+            };
+            let after = EventCursor {
+                stream_id: STREAM_ID.into(),
+                event_id: (self.retained - distance_from_tail) as u64,
+            };
+            let (mode, transitions) = projection_transitions(&state, Some(&after), &through);
+            TransitionResult { mode, transitions }
+        }
+    }
+
+    impl EventAppendFixture {
+        pub fn retained_with_batch(retained: usize, batch: usize) -> Self {
+            let fixture = EventFixture::retained(retained);
+            let state = lock(&fixture.stream.state)
+                .expect("benchmark event state lock")
+                .to_owned_for_benchmark();
+            let kinds = (0..batch)
+                .map(|index| DaemonEventKind::WorkspaceClosed {
+                    workspace_id: format!("appended-workspace-{index}"),
+                })
+                .collect();
+            Self { state, kinds }
+        }
+
+        pub fn append(mut self) -> EventAppendResult {
+            EventStream::append_batch_locked(&mut self.state, self.kinds);
+            EventAppendResult(self.state)
+        }
+    }
+
+    impl EventStreamState {
+        fn to_owned_for_benchmark(&self) -> Self {
+            Self {
+                stream_id: self.stream_id.clone(),
+                latest_id: self.latest_id,
+                events: self.events.clone(),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct RuntimeEventFixture {
+        events: Vec<DaemonEventKind>,
+    }
+
+    pub struct RuntimeEventResult(TransitionState);
+
+    impl RuntimeEventResult {
+        pub fn summary(&self) -> EventPageSummary {
+            let checksum = self
+                .0
+                .pending_runtime_events
+                .iter()
+                .fold(0_u64, |checksum, event| match event {
+                    DaemonEventKind::NodeProjectionChanged {
+                        node_id,
+                        cache_generation,
+                    } => checksum_bytes(
+                        mix_checksum(checksum, *cache_generation),
+                        node_id.as_bytes(),
+                    ),
+                    DaemonEventKind::FocusedTerminalPresentationChanged => {
+                        mix_checksum(checksum, u64::MAX)
+                    }
+                    _ => checksum,
+                });
+            EventPageSummary {
+                count: self.0.pending_runtime_events.len(),
+                first_id: 0,
+                last_id: 0,
+                checksum,
+            }
+        }
+    }
+
+    impl RuntimeEventFixture {
+        pub fn invalidations(nodes: usize, revisions: usize) -> Self {
+            let mut events =
+                Vec::with_capacity(nodes.saturating_mul(revisions).saturating_add(revisions));
+            for revision in 1..=revisions {
+                for node in 0..nodes {
+                    events.push(DaemonEventKind::NodeProjectionChanged {
+                        node_id: format!("node-{node}"),
+                        cache_generation: revision as u64,
+                    });
+                }
+                events.push(DaemonEventKind::FocusedTerminalPresentationChanged);
+            }
+            Self { events }
+        }
+
+        pub fn coalesce(self) -> RuntimeEventResult {
+            let mut transition = TransitionState {
+                persistence_in_flight: true,
+                ..TransitionState::default()
+            };
+            for event in self.events {
+                transition.queue_runtime_event(event);
+            }
+            RuntimeEventResult(transition)
+        }
+    }
+
+    fn summarize_events(events: &VecDeque<DaemonEvent>) -> EventPageSummary {
+        EventPageSummary {
+            count: events.len(),
+            first_id: events.front().map_or(0, |event| event.id),
+            last_id: events.back().map_or(0, |event| event.id),
+            checksum: events.iter().fold(0, checksum_event_without_time),
+        }
+    }
+
+    fn checksum_event(checksum: u64, event: &DaemonEvent) -> u64 {
+        checksum_workspace_event(
+            mix_checksum(mix_checksum(checksum, event.id), event.at_ms),
+            &event.kind,
+        )
+    }
+
+    fn checksum_event_without_time(checksum: u64, event: &DaemonEvent) -> u64 {
+        checksum_workspace_event(mix_checksum(checksum, event.id), &event.kind)
+    }
+
+    fn checksum_workspace_event(checksum: u64, kind: &DaemonEventKind) -> u64 {
+        let DaemonEventKind::WorkspaceClosed { workspace_id } = kind else {
+            panic!("benchmark event fixture contains an unexpected event kind");
+        };
+        checksum_bytes(checksum, workspace_id.as_bytes())
+    }
+
+    fn checksum_transition(checksum: u64, transition: &NodeProjectionTransition) -> u64 {
+        let checksum = mix_checksum(
+            mix_checksum(checksum, transition.event_id),
+            transition.at_ms,
+        );
+        let NodeProjectionTransitionKind::Workspace { workspace_id } = &transition.kind else {
+            panic!("benchmark transition fixture contains an unexpected transition kind");
+        };
+        checksum_bytes(checksum, workspace_id.as_bytes())
+    }
+
+    fn checksum_bytes(mut checksum: u64, bytes: &[u8]) -> u64 {
+        for byte in bytes {
+            checksum = mix_checksum(checksum, u64::from(*byte));
+        }
+        checksum
+    }
+
+    fn mix_checksum(checksum: u64, value: u64) -> u64 {
+        checksum.wrapping_mul(0x100_0000_01b3).wrapping_add(value)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn benchmark_event_fixtures_have_stable_bounded_results() {
+            let events = EventFixture::retained(MAX_RETAINED_EVENTS);
+            let page = events.read_page(256, 256).summary();
+            assert_eq!(
+                (page.count, page.first_id, page.last_id),
+                (256, 7_937, 8_192)
+            );
+            assert_ne!(page.checksum, 0);
+            assert_eq!(page.checksum, 14_253_501_652_687_160_347);
+            assert_eq!(events.read_page(256, 256).summary(), page);
+
+            let resumed = events.projection_cut(256).summary();
+            assert!(!resumed.baseline);
+            assert_eq!(resumed.count, 256);
+            assert_ne!(resumed.checksum, 0);
+            assert_eq!(resumed.checksum, 14_253_501_652_687_160_347);
+            assert_eq!(events.projection_cut(256).summary(), resumed);
+            assert!(events.projection_cut(257).summary().baseline);
+
+            let appended = EventAppendFixture::retained_with_batch(MAX_RETAINED_EVENTS, 256)
+                .append()
+                .summary();
+            assert_eq!(
+                (appended.count, appended.first_id, appended.last_id),
+                (MAX_RETAINED_EVENTS, 257, 8_448)
+            );
+            assert_ne!(appended.checksum, 0);
+            assert_eq!(appended.checksum, 8_051_509_862_202_861_121);
+
+            let coalesced = RuntimeEventFixture::invalidations(128, 64)
+                .coalesce()
+                .summary();
+            assert_eq!(coalesced.count, 129);
+            assert_eq!(coalesced.checksum, 9_953_927_640_701_513_843);
+        }
+    }
+}
+
 fn reduce_projection_transition(event: &DaemonEvent) -> Option<NodeProjectionTransition> {
     let kind = match &event.kind {
         DaemonEventKind::WorkspaceCreated { workspace_id, .. }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 extern crate self as boomux;
 
 pub mod attach;
+#[cfg(feature = "benchmark-internals")]
+#[doc(hidden)]
+pub mod benchmark_support;
 pub mod client;
 pub mod daemon;
 mod desktop_notifications;

--- a/src/session_projection.rs
+++ b/src/session_projection.rs
@@ -350,6 +350,332 @@ fn stable_session_id(workspace_id: &str, integration: &str, identity: &str) -> S
     Uuid::new_v5(&SESSION_ID_NAMESPACE, &name).to_string()
 }
 
+#[cfg(any(test, feature = "benchmark-internals"))]
+pub mod benchmark_support {
+    use super::*;
+    use boomux::protocol::{AgentAuthority, ShellRunSnapshot, ShellSnapshot};
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct SessionSummary {
+        pub sessions: usize,
+        pub occurrences: usize,
+        pub current: usize,
+        pub checksum: u64,
+    }
+
+    pub struct SessionFixture {
+        workspaces: Vec<WorkspaceSnapshot>,
+        catalog: Vec<HostSession>,
+    }
+
+    pub struct SessionProjectionResult(Vec<SessionProjection>);
+
+    impl SessionProjectionResult {
+        pub fn summary(&self) -> SessionSummary {
+            SessionSummary {
+                sessions: self.0.len(),
+                occurrences: self.0.iter().map(|session| session.occurrences.len()).sum(),
+                current: self
+                    .0
+                    .iter()
+                    .filter(|session| session.state_is_current)
+                    .count(),
+                checksum: self.0.iter().fold(0, checksum_session),
+            }
+        }
+    }
+
+    impl SessionFixture {
+        pub fn durable(
+            workspace_count: usize,
+            shells_per_workspace: usize,
+            agents_per_shell: usize,
+        ) -> Self {
+            let workspaces = (0..workspace_count)
+                .map(|workspace_index| {
+                    let workspace_id = format!("workspace-{workspace_index}");
+                    let directory = PathBuf::from(format!("/benchmark/{workspace_id}"));
+                    let shells = (0..shells_per_workspace)
+                        .map(|shell_index| {
+                            shell(
+                                &workspace_id,
+                                shell_index,
+                                directory.clone(),
+                                agents_per_shell,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    let agents = shells
+                        .iter()
+                        .flat_map(|shell| {
+                            (0..agents_per_shell).map(|agent_index| {
+                                agent(&workspace_id, shell, agent_index, directory.clone())
+                            })
+                        })
+                        .collect();
+                    WorkspaceSnapshot {
+                        id: workspace_id.clone(),
+                        revision: 1,
+                        name: workspace_id,
+                        default_cwd: Some(directory),
+                        shells,
+                        launchers: Vec::new(),
+                        agents,
+                    }
+                })
+                .collect();
+            Self {
+                workspaces,
+                catalog: Vec::new(),
+            }
+        }
+
+        pub fn catalog(workspace_count: usize, record_count: usize, shared: bool) -> Self {
+            let shared_directory = PathBuf::from("/benchmark/shared");
+            let workspaces = (0..workspace_count)
+                .map(|workspace_index| {
+                    let workspace_id = format!("workspace-{workspace_index}");
+                    let directory = if shared {
+                        shared_directory.clone()
+                    } else {
+                        PathBuf::from(format!("/benchmark/{workspace_id}"))
+                    };
+                    WorkspaceSnapshot {
+                        id: workspace_id.clone(),
+                        revision: 1,
+                        name: workspace_id.clone(),
+                        default_cwd: Some(directory.clone()),
+                        shells: vec![shell(&workspace_id, 0, directory, 0)],
+                        launchers: Vec::new(),
+                        agents: Vec::new(),
+                    }
+                })
+                .collect::<Vec<_>>();
+            let catalog = (0..record_count)
+                .map(|record_index| HostSession {
+                    integration: "opencode".into(),
+                    root_id: format!("catalog-{record_index}"),
+                    title: format!("Catalog session {record_index}"),
+                    directory: if shared {
+                        shared_directory.clone()
+                    } else {
+                        PathBuf::from(format!(
+                            "/benchmark/workspace-{}",
+                            record_index % workspace_count
+                        ))
+                    },
+                    created_at_ms: record_index as u64,
+                    updated_at_ms: record_index as u64 + 1,
+                })
+                .collect();
+            Self {
+                workspaces,
+                catalog,
+            }
+        }
+
+        pub fn project(&self) -> SessionProjectionResult {
+            SessionProjectionResult(project_workspaces_with_catalog(
+                &self.workspaces,
+                (!self.catalog.is_empty()).then_some(self.catalog.as_slice()),
+            ))
+        }
+    }
+
+    fn shell(
+        workspace_id: &str,
+        shell_index: usize,
+        directory: PathBuf,
+        agents_per_shell: usize,
+    ) -> ShellSnapshot {
+        let shell_id = format!("{workspace_id}-shell-{shell_index}");
+        ShellSnapshot {
+            id: shell_id.clone(),
+            revision: 1,
+            workspace_id: workspace_id.into(),
+            name: format!("shell-{shell_index}"),
+            cwd: directory,
+            command: Vec::new(),
+            status: ShellStatus::Running,
+            run: Some(ShellRunSnapshot {
+                id: format!("{shell_id}-run"),
+                generation: 1,
+                started_at_ms: 1,
+                ended_at_ms: None,
+                exit_reason: None,
+                output_revision: agents_per_shell as u64,
+                environment_has_run_id: true,
+            }),
+            recovered_agent_id: None,
+            foreground_process: None,
+        }
+    }
+
+    fn agent(
+        workspace_id: &str,
+        shell: &ShellSnapshot,
+        agent_index: usize,
+        directory: PathBuf,
+    ) -> AgentInstanceSnapshot {
+        let run_id = shell
+            .run
+            .as_ref()
+            .expect("benchmark shell has a run")
+            .id
+            .clone();
+        let id = format!("{}-agent-{agent_index}", shell.id);
+        AgentInstanceSnapshot {
+            id: id.clone(),
+            workspace_id: workspace_id.into(),
+            shell_id: shell.id.clone(),
+            run_id,
+            name: id.clone(),
+            integration: "opencode".into(),
+            external_session_id: Some(id),
+            cwd: Some(directory),
+            started_at_ms: agent_index as u64 + 1,
+            ended_at_ms: None,
+            observation: AgentObservationSnapshot {
+                revision: 1,
+                state: if agent_index.is_multiple_of(2) {
+                    AgentState::Working
+                } else {
+                    AgentState::Idle
+                },
+                authority: AgentAuthority::LifecycleIntegration,
+                evidence: "benchmark fixture".into(),
+                confidence: 100,
+                observed_at_ms: agent_index as u64 + 2,
+            },
+            attention: None,
+        }
+    }
+
+    fn checksum_session(mut checksum: u64, session: &SessionProjection) -> u64 {
+        checksum = checksum_string(checksum, &session.id);
+        checksum = checksum_string(checksum, &session.workspace_id);
+        checksum = checksum_string(checksum, &session.workspace_name);
+        checksum = checksum_string(checksum, &session.integration);
+        checksum = checksum_optional_string(checksum, session.external_session_id.as_deref());
+        checksum = checksum_string(checksum, &session.description);
+        checksum = checksum_agent_state(checksum, session.state);
+        checksum = checksum_value(checksum, u64::from(session.state_is_current));
+        checksum = checksum_value(checksum, session.started_at_ms);
+        checksum = checksum_value(checksum, session.last_at_ms);
+        checksum = checksum_optional_path(checksum, session.source_cwd.as_deref());
+        checksum = checksum_value(checksum, session.occurrences.len() as u64);
+        for occurrence in &session.occurrences {
+            checksum = checksum_string(checksum, &occurrence.agent_id);
+            checksum = checksum_string(checksum, &occurrence.shell_id);
+            checksum = checksum_string(checksum, &occurrence.run_id);
+            checksum = checksum_value(checksum, occurrence.started_at_ms);
+            checksum = checksum_optional_u64(checksum, occurrence.ended_at_ms);
+            checksum = checksum_value(checksum, occurrence.observation.revision);
+            checksum = checksum_agent_state(checksum, occurrence.observation.state);
+            checksum = checksum_authority(checksum, occurrence.observation.authority);
+            checksum = checksum_string(checksum, &occurrence.observation.evidence);
+            checksum = checksum_value(checksum, u64::from(occurrence.observation.confidence));
+            checksum = checksum_value(checksum, occurrence.observation.observed_at_ms);
+            checksum = checksum_value(checksum, u64::from(occurrence.is_current));
+            checksum =
+                checksum_optional_string(checksum, occurrence.retained_shell_name.as_deref());
+            checksum = checksum_optional_path(checksum, occurrence.retained_shell_cwd.as_deref());
+            checksum = checksum_optional_path(checksum, occurrence.source_cwd.as_deref());
+        }
+        checksum
+    }
+
+    fn checksum_string(checksum: u64, value: &str) -> u64 {
+        let mut checksum = checksum_value(checksum, value.len() as u64);
+        for byte in value.bytes() {
+            checksum = checksum_value(checksum, u64::from(byte));
+        }
+        checksum
+    }
+
+    fn checksum_optional_string(checksum: u64, value: Option<&str>) -> u64 {
+        match value {
+            Some(value) => checksum_string(checksum_value(checksum, 1), value),
+            None => checksum_value(checksum, 0),
+        }
+    }
+
+    fn checksum_optional_path(checksum: u64, value: Option<&Path>) -> u64 {
+        match value {
+            Some(value) => checksum_string(
+                checksum_value(checksum, 1),
+                value.to_string_lossy().as_ref(),
+            ),
+            None => checksum_value(checksum, 0),
+        }
+    }
+
+    fn checksum_optional_u64(checksum: u64, value: Option<u64>) -> u64 {
+        match value {
+            Some(value) => checksum_value(checksum_value(checksum, 1), value),
+            None => checksum_value(checksum, 0),
+        }
+    }
+
+    fn checksum_agent_state(checksum: u64, state: AgentState) -> u64 {
+        checksum_value(
+            checksum,
+            match state {
+                AgentState::Unknown => 0,
+                AgentState::Working => 1,
+                AgentState::Blocked => 2,
+                AgentState::Idle => 3,
+                AgentState::Inactive => 4,
+                AgentState::Done => 5,
+            },
+        )
+    }
+
+    fn checksum_authority(checksum: u64, authority: AgentAuthority) -> u64 {
+        checksum_value(
+            checksum,
+            match authority {
+                AgentAuthority::LifecycleIntegration => 0,
+                AgentAuthority::ProcessAdapter => 1,
+                AgentAuthority::TerminalHeuristic => 2,
+                AgentAuthority::DaemonLifecycle => 3,
+            },
+        )
+    }
+
+    fn checksum_value(checksum: u64, value: u64) -> u64 {
+        checksum.wrapping_mul(0x100_0000_01b3).wrapping_add(value)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn benchmark_session_fixtures_have_stable_complete_summaries() {
+            let durable = SessionFixture::durable(64, 8, 2);
+            let summary = durable.project().summary();
+            assert_eq!(
+                (summary.sessions, summary.occurrences, summary.current),
+                (1_024, 1_024, 1_024)
+            );
+            assert_ne!(summary.checksum, 0);
+            assert_eq!(summary.checksum, 1_011_118_191_847_967_550);
+            assert_eq!(durable.project().summary(), summary);
+
+            let unique = SessionFixture::catalog(64, 400, false).project().summary();
+            assert_eq!(unique.sessions, 400);
+            assert_ne!(unique.checksum, 0);
+            assert_eq!(unique.checksum, 8_601_524_830_593_867_508);
+
+            let shared = SessionFixture::catalog(32, 400, true).project().summary();
+            assert_eq!((shared.sessions, shared.occurrences), (12_800, 0));
+            assert_ne!(shared.checksum, 0);
+            assert_eq!(shared.checksum, 6_725_822_761_224_353_157);
+        }
+    }
+}
+
 fn state_priority(state: AgentState) -> u8 {
     match state {
         AgentState::Blocked => 0,

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -283,6 +283,176 @@ impl TerminalSnapshot {
     }
 }
 
+#[cfg(any(test, feature = "benchmark-internals"))]
+pub mod benchmark_support {
+    use super::*;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct TerminalSummary {
+        pub preview_lines: usize,
+        pub preview_spans: usize,
+        pub preview_bytes: usize,
+        pub preview_checksum: u64,
+        pub reconstruction_bytes: usize,
+        pub reconstruction_checksum: u64,
+    }
+
+    pub struct TerminalFixture {
+        state: TerminalState,
+    }
+
+    impl TerminalFixture {
+        pub fn empty(rows: u16, cols: u16) -> Self {
+            Self {
+                state: TerminalState::new(rows, cols),
+            }
+        }
+
+        pub fn from_transcript(rows: u16, cols: u16, transcript: &[u8]) -> Self {
+            let mut fixture = Self::empty(rows, cols);
+            fixture.process(transcript);
+            fixture
+        }
+
+        pub fn from_chunked_transcript(
+            rows: u16,
+            cols: u16,
+            transcript: &[u8],
+            chunk_bytes: usize,
+        ) -> Self {
+            assert!(chunk_bytes > 0);
+            let mut fixture = Self::empty(rows, cols);
+            for chunk in transcript.chunks(chunk_bytes) {
+                fixture.process(chunk);
+            }
+            fixture
+        }
+
+        pub fn process(&mut self, bytes: &[u8]) {
+            self.state.process(bytes);
+        }
+
+        pub fn preview(
+            &self,
+            max_bytes: usize,
+            max_lines: usize,
+            max_spans: usize,
+        ) -> TerminalPreview {
+            self.state
+                .snapshot()
+                .preview(max_bytes, max_lines, max_spans)
+        }
+
+        pub fn reconstruction(&self) -> Vec<u8> {
+            self.state.reconstruction()
+        }
+
+        pub fn summary(&self) -> TerminalSummary {
+            let preview = self.preview(1024 * 1024, 16, 20_000);
+            let reconstruction = self.reconstruction();
+            TerminalSummary {
+                preview_lines: preview.lines.len(),
+                preview_spans: preview.lines.iter().map(|line| line.spans.len()).sum(),
+                preview_bytes: preview
+                    .lines
+                    .iter()
+                    .flat_map(|line| &line.spans)
+                    .map(|span| span.text.len())
+                    .sum(),
+                preview_checksum: checksum_preview(&preview),
+                reconstruction_bytes: reconstruction.len(),
+                reconstruction_checksum: checksum_bytes(&reconstruction),
+            }
+        }
+    }
+
+    pub fn terminal_transcript(lines: usize, line_bytes: usize) -> Vec<u8> {
+        let mut transcript =
+            Vec::with_capacity(lines.saturating_mul(line_bytes.saturating_add(24)));
+        for line in 0..lines {
+            transcript.extend_from_slice(format!("\x1b[3{}mline-{line:05} ", line % 8).as_bytes());
+            let payload = line_bytes.saturating_sub(12);
+            transcript.extend(std::iter::repeat_n(b'a' + (line % 26) as u8, payload));
+            transcript.extend_from_slice(b"\x1b[0m\r\n");
+        }
+        transcript
+    }
+
+    fn checksum_bytes(bytes: &[u8]) -> u64 {
+        bytes.iter().fold(0, |checksum, byte| {
+            checksum_value(checksum, u64::from(*byte))
+        })
+    }
+
+    fn checksum_preview(preview: &TerminalPreview) -> u64 {
+        let mut checksum = checksum_value(0, preview.lines.len() as u64);
+        for line in &preview.lines {
+            checksum = checksum_value(checksum, line.spans.len() as u64);
+            for span in &line.spans {
+                checksum = checksum_value(checksum, span.text.len() as u64);
+                for byte in span.text.bytes() {
+                    checksum = checksum_value(checksum, u64::from(byte));
+                }
+                checksum = checksum_color(checksum, span.style.foreground);
+                checksum = checksum_color(checksum, span.style.background);
+                for value in [
+                    span.style.bold,
+                    span.style.dim,
+                    span.style.italic,
+                    span.style.underline,
+                    span.style.inverse,
+                ] {
+                    checksum = checksum_value(checksum, u64::from(value));
+                }
+            }
+        }
+        checksum
+    }
+
+    fn checksum_color(checksum: u64, color: TerminalColor) -> u64 {
+        match color {
+            TerminalColor::Default => checksum_value(checksum, 0),
+            TerminalColor::Indexed(index) => {
+                checksum_value(checksum_value(checksum, 1), u64::from(index))
+            }
+            TerminalColor::Rgb { red, green, blue } => {
+                let checksum = checksum_value(checksum, 2);
+                let checksum = checksum_value(checksum, u64::from(red));
+                let checksum = checksum_value(checksum, u64::from(green));
+                checksum_value(checksum, u64::from(blue))
+            }
+        }
+    }
+
+    fn checksum_value(checksum: u64, value: u64) -> u64 {
+        checksum.wrapping_mul(0x100_0000_01b3).wrapping_add(value)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn benchmark_terminal_fixture_has_a_stable_bounded_summary() {
+            let transcript = terminal_transcript(2_048, 128);
+            let terminal = TerminalFixture::from_transcript(24, 80, &transcript);
+            let summary = terminal.summary();
+            assert_eq!(summary.preview_lines, 16);
+            assert!(summary.preview_spans >= summary.preview_lines);
+            assert!(summary.preview_bytes > 0);
+            assert_ne!(summary.preview_checksum, 0);
+            assert_eq!(summary.preview_checksum, 10_375_648_925_095_483_392);
+            assert!(summary.reconstruction_bytes <= 1024 * 1024);
+            assert_ne!(summary.reconstruction_checksum, 0);
+            assert_eq!(summary.reconstruction_checksum, 12_069_107_278_816_405_535);
+            assert_eq!(terminal.summary(), summary);
+
+            let chunked = TerminalFixture::from_chunked_transcript(24, 80, &transcript, 16 * 1024);
+            assert_eq!(chunked.summary(), summary);
+        }
+    }
+}
+
 fn plain_row(screen: &vt100::Screen, row: u16, cols: u16, wrapping: bool) -> String {
     let mut text = String::new();
     let mut next_col = 0;

--- a/tests/benchmark_harness.rs
+++ b/tests/benchmark_harness.rs
@@ -1,0 +1,92 @@
+use boomux::benchmark_support::{
+    EventAppendFixture, EventFixture, RuntimeEventFixture, SessionFixture, TerminalFixture,
+    terminal_transcript,
+};
+
+#[test]
+fn event_fixtures_preserve_bounds_and_deterministic_summaries() {
+    let events = EventFixture::retained(8_192);
+    let page = events.read_page(256, 256).summary();
+    assert_eq!(page.count, 256);
+    assert_eq!(page.first_id, 7_937);
+    assert_eq!(page.last_id, 8_192);
+    assert_ne!(page.checksum, 0);
+    assert_eq!(page.checksum, 14_253_501_652_687_160_347);
+    assert_eq!(events.read_page(256, 256).summary(), page);
+
+    let resumed = events.projection_cut(256).summary();
+    assert!(!resumed.baseline);
+    assert_eq!(resumed.count, 256);
+    assert_ne!(resumed.checksum, 0);
+    assert_eq!(resumed.checksum, 14_253_501_652_687_160_347);
+    assert_eq!(events.projection_cut(256).summary(), resumed);
+    let reseeded = events.projection_cut(257).summary();
+    assert!(reseeded.baseline);
+    assert_eq!(reseeded.count, 0);
+
+    let invalidations = RuntimeEventFixture::invalidations(128, 64);
+    let coalesced = invalidations.clone().coalesce().summary();
+    assert_eq!(coalesced.count, 129);
+    assert_eq!(coalesced.checksum, 9_953_927_640_701_513_843);
+    assert_eq!(invalidations.coalesce().summary(), coalesced);
+    assert_ne!(coalesced.checksum, 0);
+
+    let append = EventAppendFixture::retained_with_batch(8_192, 256);
+    let appended = append.clone().append().summary();
+    assert_eq!(
+        (appended.count, appended.first_id, appended.last_id),
+        (8_192, 257, 8_448)
+    );
+    assert_ne!(appended.checksum, 0);
+    assert_eq!(appended.checksum, 8_051_509_862_202_861_121);
+    assert_eq!(append.append().summary(), appended);
+}
+
+#[test]
+fn session_fixtures_preserve_expected_cardinality_and_digest() {
+    let durable = SessionFixture::durable(64, 8, 2);
+    let summary = durable.project().summary();
+    assert_eq!(summary.sessions, 1_024);
+    assert_eq!(summary.occurrences, 1_024);
+    assert_eq!(summary.current, 1_024);
+    assert_ne!(summary.checksum, 0);
+    assert_eq!(summary.checksum, 1_011_118_191_847_967_550);
+    assert_eq!(durable.project().summary(), summary);
+
+    let unique = SessionFixture::catalog(64, 400, false);
+    let unique_summary = unique.project().summary();
+    assert_eq!(unique_summary.sessions, 400);
+    assert_ne!(unique_summary.checksum, 0);
+    assert_eq!(unique_summary.checksum, 8_601_524_830_593_867_508);
+    assert_eq!(unique.project().summary(), unique_summary);
+
+    let shared = SessionFixture::catalog(32, 400, true);
+    let shared_summary = shared.project().summary();
+    assert_eq!(shared_summary.sessions, 12_800);
+    assert_ne!(shared_summary.checksum, 0);
+    assert_eq!(shared_summary.checksum, 6_725_822_761_224_353_157);
+    assert_eq!(shared.project().summary(), shared_summary);
+}
+
+#[test]
+fn terminal_fixtures_are_synthetic_bounded_and_repeatable() {
+    let transcript = terminal_transcript(2_048, 128);
+    let terminal = TerminalFixture::from_transcript(24, 80, &transcript);
+    let summary = terminal.summary();
+    assert_eq!(summary.preview_lines, 16);
+    assert_ne!(summary.preview_checksum, 0);
+    assert_eq!(summary.preview_checksum, 10_375_648_925_095_483_392);
+    assert_ne!(summary.reconstruction_checksum, 0);
+    assert_eq!(summary.reconstruction_checksum, 12_069_107_278_816_405_535);
+    assert_eq!(terminal.summary(), summary);
+    let chunked = TerminalFixture::from_chunked_transcript(24, 80, &transcript, 16 * 1024);
+    assert_eq!(chunked.summary(), summary);
+    let preview = terminal.preview(1024 * 1024, 16, 20_000);
+    assert_eq!(preview.lines.len(), 16);
+    assert_eq!(terminal.preview(1024 * 1024, 16, 20_000), preview);
+
+    let reconstruction = terminal.reconstruction();
+    assert!(!reconstruction.is_empty());
+    assert!(reconstruction.len() <= 1024 * 1024);
+    assert_eq!(terminal.reconstruction(), reconstruction);
+}


### PR DESCRIPTION
## Summary
- add deterministic bounded-work fixtures and Criterion suites for event, Session, terminal, and wire paths
- add clock-free Gungraun/Callgrind instruction gates with same-run base/head comparison
- add required benchmark smoke CI, scheduled performance artifacts, and contributor documentation

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --lib --bins --locked -- --test-threads=1
- cargo test --test config_cli --locked -- --test-threads=1
- cargo test --test native_backend --locked -- --test-threads=1
- cargo test --test benchmark_harness --features benchmark-internals --locked
- cargo check --benches --all-features --locked
- cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
- cargo bench --bench wire --locked -- --test
- cargo deny check
- bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
- full Criterion core baseline
- containerized Gungraun/Callgrind run with a deliberate unoptimized comparison confirming the 10% limit fails regressions

## Dependency
Stacked on #324. Retarget to main after #324 merges.

Closes #325