### PR TITLE
ci(release): validate omarchy-boomux compatibility

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -225,3 +225,15 @@ jobs:
             printf 'release publication verification failed for %s\n' "$TAG" >&2
             exit 1
           fi
+
+  validate-omarchy-boomux:
+    name: Validate omarchy-boomux compatibility
+    needs:
+      - release-please
+      - publish-release
+    permissions:
+      contents: read
+    uses: gardnmi/omarchy-boomux/.github/workflows/boomux-compatibility.yml@6c26ce52c5dbfad6185037b374d98d0933f4b8fe
+    with:
+      boomux_tag: ${{ needs.release-please.outputs.tag-name }}
+      plugin_ref: 6c26ce52c5dbfad6185037b374d98d0933f4b8fe


### PR DESCRIPTION
## Summary

- call the credential-free omarchy-boomux compatibility workflow after publishing each Boomux release
- validate the exact published tag against the plugin minimum/current release matrix
- pin both the reusable workflow and tested plugin source to immutable omarchy-boomux commit `6c26ce52c5dbfad6185037b374d98d0933f4b8fe`

## Validation

- `actionlint .github/workflows/release-please.yml`
- `git diff --check`
- manually dispatched the pinned reusable workflow against Boomux `v1.7.2`: https://github.com/gardnmi/omarchy-boomux/actions/runs/33275912758

Follow-up to gardnmi/omarchy-boomux#57.