### PR TITLE
feat: add explicit daemon startup

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -770,6 +770,7 @@ it does not invoke launchers or open sibling Shells.
 
 ```console
 boomux daemon status
+boomux daemon start
 boomux daemon restart
 boomux daemon stop
 ```

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Prefer `daemon restart` over `daemon stop`: stopping the daemon terminates every
 managed process. Upgrade registered remote Nodes separately with
 `boomux node upgrade NODE`.
 
+Use `boomux daemon status` to inspect the daemon without starting it and
+`boomux daemon start` to start it explicitly in the background. Starting an
+already-running daemon succeeds without replacing it.
+
 To remove an official release installation, use `boomux uninstall`. Add
 `--purge` only when you also intend to remove user data. Use
 `boomux node uninstall NODE` for an identity-verified remote uninstall. See

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -444,7 +444,9 @@ Command payloads are:
   bounded absolute `/proc/<pid>/exe` validation. This remains current after the
   listener is transferred between daemon processes; retained `SO_PEERCRED` alone
   is not process identity. The executable has a kernel ` (deleted)` suffix
-  removed. Other platforms or failed proof return null.
+  removed. Other platforms or failed proof return null. A stopped daemon is a
+  successful status result with `status: "stopped"`; all identity fields and
+  `protocol_version` are null. Status inspection never starts the daemon.
 
 ## Project Data
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -392,6 +392,15 @@ pub fn connect_or_start() -> Result<Client> {
     )))
 }
 
+pub fn connect_if_running() -> Result<Option<Client>> {
+    let client = connect_client()?;
+    match client.ping() {
+        Ok(()) => Ok(Some(client)),
+        Err(error) if daemon_unreachable(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
 fn daemon_unreachable(error: &ClientError) -> bool {
     matches!(
         error,

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,7 @@ const NON_PROTOCOL_FEATURES: &[&str] = &[
     "guided_local_update",
     "guided_local_uninstall",
     "guided_setup",
+    "explicit_daemon_start",
 ];
 const LEGACY_BOOMUX_SHELLS_SKILL: &str = r#"---
 name: boomux-shells
@@ -1168,6 +1169,8 @@ enum DaemonCommands {
         #[arg(long)]
         channel: i32,
     },
+    /// Start the daemon in the background
+    Start,
     /// Report whether the daemon is accepting requests
     Status,
     /// Replace the daemon without changing pending workspace state
@@ -1489,6 +1492,7 @@ impl Cli {
                 command:
                     DaemonCommands::Run
                     | DaemonCommands::ReceiveHandoff { .. }
+                    | DaemonCommands::Start
                     | DaemonCommands::Restart
                     | DaemonCommands::Stop,
             }) => CommandKey::Daemon,
@@ -3141,10 +3145,34 @@ fn print_web_start(
 }
 
 fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Error>> {
-    let client = client::connect()?;
+    let running_client = client::connect_if_running()?;
     match command {
+        DaemonCommands::Start => {
+            if running_client.is_some() {
+                println!("Boomux daemon is already running");
+            } else {
+                client::connect_or_start()?;
+                println!("Started Boomux daemon");
+            }
+        }
+        DaemonCommands::Status if running_client.is_none() && json => print_json(
+            CommandKey::DaemonStatus,
+            serde_json::json!({
+                "status": "stopped",
+                "protocol_version": null,
+                "socket_path": client::socket_path()?.display().to_string(),
+                "pid": null,
+                "executable": null,
+                "socket_device": null,
+                "socket_inode": null,
+            }),
+        )?,
+        DaemonCommands::Status if running_client.is_none() => {
+            println!("stopped ({})", client::socket_path()?.display());
+        }
         DaemonCommands::Status if json => {
-            let identity = daemon_process_identity(&client);
+            let client = running_client.as_ref().expect("running client checked");
+            let identity = daemon_process_identity(client);
             let protocol_version = identity.as_ref().map_or_else(
                 || client.protocol_version(),
                 |identity| Ok(identity.protocol_version),
@@ -3163,6 +3191,7 @@ fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Err
             )?
         }
         DaemonCommands::Status => {
+            let client = running_client.as_ref().expect("running client checked");
             println!(
                 "running (protocol {}, {})",
                 client.protocol_version()?,
@@ -3170,11 +3199,17 @@ fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Err
             );
         }
         DaemonCommands::Restart => {
+            let client = running_client.as_ref().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotConnected, "Boomux daemon is stopped")
+            })?;
             client
                 .restart_with_notification_config(config::load_notification_settings()?.into())?;
             println!("Restarted Boomux daemon");
         }
         DaemonCommands::Stop => {
+            let client = running_client.as_ref().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotConnected, "Boomux daemon is stopped")
+            })?;
             client.shutdown()?;
             println!("Stopped Boomux daemon");
         }

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -2734,6 +2734,13 @@ fn parse_remote_daemon_status(stdout: &[u8]) -> io::Result<RemoteDaemonStatus> {
             "remote daemon status returned an invalid envelope",
         ));
     }
+    if value
+        .pointer("/data/status")
+        .and_then(serde_json::Value::as_str)
+        == Some("stopped")
+    {
+        return Ok(RemoteDaemonStatus::Absent);
+    }
     let version = value
         .pointer("/data/protocol_version")
         .and_then(serde_json::Value::as_u64)
@@ -5454,6 +5461,13 @@ mod tests {
     fn daemon_status_distinguishes_absent_compatible_and_incompatible() {
         assert_eq!(
             parse_remote_daemon_status(b"boomux-daemon-status-v1\0absent\0").unwrap(),
+            RemoteDaemonStatus::Absent
+        );
+        assert_eq!(
+            parse_remote_daemon_status(
+                br#"{"schema":"boomux.cli/v1","command":"daemon.status","data":{"status":"stopped","protocol_version":null}}"#,
+            )
+            .unwrap(),
             RemoteDaemonStatus::Absent
         );
         for (version, expected) in [

--- a/tests/native_backend/project_discovery.rs
+++ b/tests/native_backend/project_discovery.rs
@@ -4,6 +4,71 @@ use std::process::Command;
 use uuid::Uuid;
 
 #[test]
+fn daemon_status_and_start_are_explicit_and_idempotent() {
+    let root = std::env::temp_dir().join(format!(
+        "boomux-explicit-start-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    let runtime = root.join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    let command = || {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_boomux"));
+        command
+            .env("HOME", &root)
+            .env("XDG_RUNTIME_DIR", &runtime)
+            .env("XDG_CONFIG_HOME", root.join("config"))
+            .env("XDG_STATE_HOME", root.join("state"));
+        command
+    };
+
+    let stopped = command()
+        .args(["daemon", "status", "--json"])
+        .output()
+        .unwrap();
+    assert!(stopped.status.success());
+    let status: serde_json::Value = serde_json::from_slice(&stopped.stdout).unwrap();
+    assert_eq!(status["command"], "daemon.status");
+    assert_eq!(status["data"]["status"], "stopped");
+    assert!(status["data"]["protocol_version"].is_null());
+    assert!(!runtime.join("boomux/daemon.sock").exists());
+
+    let started = command().args(["daemon", "start"]).output().unwrap();
+    assert!(
+        started.status.success(),
+        "daemon start failed: {}",
+        String::from_utf8_lossy(&started.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(started.stdout).unwrap().trim(),
+        "Started Boomux daemon"
+    );
+
+    let repeated = command().args(["daemon", "start"]).output().unwrap();
+    assert!(repeated.status.success());
+    assert_eq!(
+        String::from_utf8(repeated.stdout).unwrap().trim(),
+        "Boomux daemon is already running"
+    );
+
+    let running = command()
+        .args(["daemon", "status", "--json"])
+        .output()
+        .unwrap();
+    assert!(running.status.success());
+    let status: serde_json::Value = serde_json::from_slice(&running.stdout).unwrap();
+    assert_eq!(status["data"]["status"], "running");
+    assert_eq!(
+        status["data"]["protocol_version"],
+        boomux::protocol::PROTOCOL_VERSION
+    );
+
+    let stopped = command().args(["daemon", "stop"]).output().unwrap();
+    assert!(stopped.status.success());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn workspace_create_starts_the_daemon_when_absent() {
     let root = std::env::temp_dir().join(format!(
         "bmux-create-start-{}-{}",


### PR DESCRIPTION
## Summary
- add an idempotent `boomux daemon start` command
- make `daemon status` report a stable stopped state without starting the daemon
- advertise explicit startup support and preserve remote absence detection

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test native_backend daemon_status_and_start_are_explicit_and_idempotent --locked -- --test-threads=1`
- focused remote daemon status parser test