### PR TITLE
docs(opencode): describe final claim release

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -190,6 +190,8 @@ server lifecycle plugin to resolve reports; it is not an Agent Instance, Agent
 Session, process, controller, projection, event, or durable identity.
 Expiry, final-holder release, ShellRun replacement, or runtime-generation
 replacement removes authority without deleting or moving durable Agent history.
+Final-holder release also records the resumable Agent Instance as Inactive so it
+no longer decorates the ShellRun after the TUI exits.
 Claims are not persisted, projected, event-published, or transferred during
 daemon handoff; surviving TUIs reacquire them from the replacement daemon. When
 cold recovery resumes one exact OpenCode Session on a replacement ShellRun, its

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -545,9 +545,10 @@ is idempotent per runtime generation, root Session, ShellRun, and TUI holder; it
 also ensures the durable Agent Instance. Multiple holders for the same mapping
 are allowed, while a different current ShellRun for the same runtime Session is
 `busy`. Release removes one holder, expiry removes abandoned holders, and the
-last holder removes report authority. Run or runtime replacement invalidates the
-mapping. The bounded claim map is not persisted, projected, handed off, or
-event-published, so `STATE_VERSION` and all durable schemas remain unchanged.
+last holder removes report authority and records the resumable Agent as
+Inactive. Run or runtime replacement invalidates the mapping. The bounded claim
+map is not persisted, projected, handed off, or event-published, so
+`STATE_VERSION` and all durable schemas remain unchanged.
 
 The Shared Harness Runtime is neither a durable resource nor part of the Shell
 registry. The daemon starts one generation on the first eligible bare interactive

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -771,8 +771,8 @@ current mapping to another ShellRun returns `busy`.
 ```
 
 Release takes exact `--generation`, `--holder`, and `--claim-id`, addresses one
-holder, and is idempotent. The final holder removes report authority, not durable
-Agent history.
+holder, and is idempotent. The final holder removes report authority and records
+the resumable Agent as `inactive`; it does not remove durable Agent history.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- document that final OpenCode claim release records the resumable Agent as inactive
- clarify that durable Agent history remains intact
- align the domain glossary, architecture reference, and CLI JSON contract

## Stack
Depends on #338.

## Testing
- cargo fmt --all -- --check
- git diff --check

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>