### PR TITLE
fix(session): retire public session interfaces

### DIFF
--- a/.agents/skills/boomux/SKILL.md
+++ b/.agents/skills/boomux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: boomux
-description: Inspect and manage Boomux Nodes, coordinated persistent terminal Workspaces, launchers, shells, run-scoped agent instances, attention, projected sessions, local configuration, notifications, the OpenCode Shared Harness Runtime, process supervision, and integrations. Use when asked to discover Nodes, shells, agents, or sessions, read terminal output, inspect, validate, or edit local Boomux configuration, supervise an explicitly identified external session, report agent lifecycle state, configure or test notifications, install or remove an OpenCode, Pi, Claude Code, Codex, or Kiro integration, create or open Workspaces and shells, inspect status, rename or close targets, or manage the local Boomux daemon.
+description: Inspect and manage Boomux Nodes, coordinated persistent terminal Workspaces, launchers, shells, run-scoped agent instances, attention, local configuration, notifications, the OpenCode Shared Harness Runtime, process supervision, and integrations. Use when asked to discover Nodes, shells, or agents, read terminal output, inspect, validate, or edit local Boomux configuration, supervise an explicitly identified external harness run, report agent lifecycle state, configure or test notifications, install or remove an OpenCode, Pi, Claude Code, Codex, or Kiro integration, create or open Workspaces and shells, inspect status, rename or close targets, or manage the local Boomux daemon.
 compatibility: Requires boomux on PATH. Federated resource identity is the pair of owning Node ID and Node-local inner ID. Some name operations require Workspace context or an explicit --workspace/--node; agent mutation and supervision require exact shell-run context, and supervision requires caller-supplied exact canonical session identity.
 metadata:
   author: boomux
-  version: "17"
+  version: "18"
 ---
 
 # Boomux
@@ -62,7 +62,7 @@ as illustrative; `capabilities.data.json_commands` is authoritative.
 
 Most daemon-backed inspection commands automatically start Boomux when it is
 not running. This includes `list`, `shells`, `read`, `events`, workspace, shell,
-and launcher inspection, Agent, attention, and session inspection, and
+and launcher inspection, Agent and attention inspection, and
 `doctor`. Use `boomux daemon status` first when starting the daemon would be an
 unwanted side effect. `capabilities`, `project list`, `integration list`, and
 `integration status` do not start it.
@@ -118,7 +118,7 @@ temporary verified connection and does not persist registration. Registered and
 ad hoc routes do not make hostnames or addresses resource identities.
 
 Node-qualified host operations include `project list`, launcher invocation,
-integration management, Session catalogs/resume, and `open`. Preserve the same explicit `--node` on every follow-up
+integration management and `open`. Preserve the same explicit `--node` on every follow-up
 operation. Remote paths, commands, catalogs, and integration assets are resolved
 only by their owning Node. Daemon status, restart, and stop remain local and are
 not routed through registration.
@@ -303,41 +303,9 @@ startup-sampled configuration until `boomux daemon restart`. Restart applies
 the invoking client's resolved notification settings, even when the old daemon
 inherited a different config environment.
 
-Session discovery is not limited to daemon metadata. It may execute the
-PATH-resolved OpenCode, Codex, or Kiro CLI and inspect bounded Pi or Claude host
-files in workspace-derived directories, exposing sanitized but potentially
-private Session titles. Require authorization appropriate to the host-history
-metadata before listing or inspecting Sessions.
-
-Discover projected session metadata with:
-
-```console
-boomux session list --json
-boomux session list --workspace "<workspace-name-or-id>" --json
-boomux session inspect "<exact-session-id>" --json
-boomux session open "<exact-session-id>"
-boomux session resume "<exact-session-id>"
-boomux session list --node "<node>" --json
-boomux session inspect "<exact-session-id>" --node "<same-node>" --json
-boomux session open "<exact-session-id>" --node "<same-node>"
-boomux session resume "<exact-session-id>" --node "<same-node>"
-```
-
-Use the exact opaque session ID returned by `session list`. Never guess or
-resolve it from an external session ID, description, shell ID, or Agent ID.
-Session state is marked current only when an occurrence is active on the current
-run of a running retained shell; otherwise it is last-known. Catalog-only
-OpenCode or Codex history has state `unknown`, no fabricated occurrence, and a
-sanitized host title. Exact Pi, Claude, or Kiro host records may title only an
-already-observed Session and never create history. A user override still takes
-precedence over every host title.
-Protocol-13 sessions retain a `source_cwd` after shell removal so an exact
-canonical session can be resumed in its original context. Open attaches the exact
-current ShellRun with takeover or resumes an exact historical Session, and fails
-closed if that target is done, missing, ambiguous, unavailable, or changed.
-Resume always launches a native host process and requires authorization. A
-remote Session ID is exact only within its owning Node; keep the same `--node`
-used for discovery.
+Boomux no longer exposes a Session catalog, Session history, or Session resume
+command. External session IDs remain opaque integration input for exact Agent
+lifecycle correlation and supervision; never use one as a Boomux resource ID.
 
 Exact shell IDs are global only within one Node. Shell names resolve in the current workspace,
 or through `--workspace` for `shell inspect`, `shell rename`, and `shell close`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,44 +110,18 @@ external integration authority.
 Inactive means a resumable external session is not currently active. It remains durable and can
 return to idle or working, but does not decorate a dashboard shell. Done is permanent completion.
 A foreground process hint is not an Agent Instance and is presented as Untracked, never Idle.
-Catalog-only OpenCode or Codex history is a client-side projected session with Unknown state and
-no fabricated Agent occurrence.
+## External Session Identity
 
-## Agent Session
+An opaque identity assigned by an external harness and retained on an Agent
+Instance for lifecycle correlation, shared-runtime authority, and exact cold
+recovery. It is not a Boomux resource, history object, process, PTY, or lifecycle
+observation. Boomux does not list, inspect, rename, hide, open, or resume external
+history as a separate user-facing Session resource.
 
-The canonical external conversation projected into one workspace from Agent Instances or host
-history. It can span multiple shell runs and Agent Instances that share an integration and exact
-external session identity, but it owns no process, PTY, or lifecycle observation.
-
-An Agent Session remains a projection rather than a durable lifecycle entity. An owning Node may
-persist only explicit user presentation metadata inside the owning Workspace, keyed by Workspace,
-integration, and external Session identity, or by Agent Instance identity when no external identity
-exists. Display-name metadata overrides the projected description. A hidden-Session tombstone
-suppresses the semantic Session from protocol-51 list, inspect, resolve, open, and resume without
-deleting host history, Agent Instances, Shells, processes, display names, or lifecycle state.
-Metadata survives temporary host-catalog absence, new Agent occurrences, Workspace rename, and
-daemon restart, but is removed with the Workspace. Different Workspaces may name or hide the same
-external conversation independently. Remote mutation is accepted only by a live authoritative
-owner. Bounded idempotency receipts may retain the semantic key, request, and minimal accepted
-mutation result; they never retain the projected Session summary, harness title, catalog data,
-lifecycle state, or occurrences.
-
-The projected display name is the user override, then the current harness title, then the latest
-Agent Instance name or generated fallback. Presentation may separately expose that latest Agent
-name as attribution; it does not replace the effective description.
-
-A projected Session may include bounded references to outstanding Agent-owned
-attention and bounded Agent Working Contexts. Those fields are presentation
-context, not Session lifecycle. Attention remains guarded by the exact Agent
-observation revision. Working Contexts remain owned by the Agent's Node and are
-never resolved from a path on another Node. The owner may enrich a projected
-Working Context with bounded, no-fetch response-time inspection for its exact
-current branch. Existing local tracking refs produce the separate push status;
-porcelain worktree inspection produces only staged and unstaged-or-untracked
-booleans, never file names, file counts, or file contents. Neither reports behind
-count, persists derived status, publishes an event, or turns Git state into
-lifecycle authority. A catalog-only Session has neither kind of Agent-owned
-context.
+Two Agent Instances may carry the same integration and external session ID
+without becoming one durable Boomux entity. Every lifecycle mutation remains
+bound to an exact Agent Instance, Shell, and ShellRun. Compatibility decoders and
+old persisted presentation metadata do not restore a public Session model.
 
 ## Agent Working Context
 
@@ -164,11 +138,8 @@ does not replace the Agent's registration-time `cwd`, a Shell's cwd, or a
 Workspace's default cwd, and it never proves that the retained set is complete.
 Boomux does not derive it from transcripts, terminal output, command strings,
 process trees, arbitrary tool payloads, or paths resolved by another Node. A
-Session projection excludes the canonical launch root already represented by
-its launch context, deduplicates the remaining contexts from its Agent
-occurrences, exposes at most four newest roots plus the total distinct count, and
-may retain them after the originating Shell is removed. The Agent retains the
-launch-root observation in its own bounded evidence.
+Presentation may deduplicate observed roots, but the Agent retains every bounded
+observation under its own identity and authority.
 
 ## Shared Harness Runtime
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ boomux ui
 | **Command** | The dashboard presentation of a Shell whose stored startup argument vector is nonempty. |
 | **Launcher** | A durable exact-argument command invoked on every explicit Workspace open or restore. Each invocation is detached, ephemeral, and has no PTY. |
 | **Agent Instance** | A durable identity for one external Agent session associated with one Shell run; process exit alone never establishes completion. |
-| **Agent Session** | An external conversation projected from Agent Instances or host history. It owns no process, PTY, or lifecycle observation. |
+| **External session ID** | An opaque harness identity retained on an Agent Instance for lifecycle correlation and exact recovery. It is not a Boomux resource or user-facing history object. |
 
 Boomux preserves exact argument vectors and does not add shell interpolation to
 launchers or adapters.
@@ -258,48 +258,19 @@ Use `boomux --help` and `boomux <command> --help` for the complete current CLI.
 
 ## Native Dashboard
 
-Run `boomux ui` in a terminal. The dashboard provides five primary views:
+Run `boomux ui` in a terminal. The dashboard provides four primary views:
 
 - **Workspaces**: coordinated tasks, placement state, attention, and ownership.
 - **Agents**: current ShellRun-bound Agent lifecycle.
-- **Sessions**: canonical Agent Sessions across harnesses and live Nodes.
 - **Shells**: durable Shell slots, commands, and exact run state.
 - **Nodes**: registration, route health, compatibility, and upgrade actions.
-
-The Sessions view is a projection of existing Agent Instances and host history,
-not a renamed Agent view or a new durable identity. It combines local Sessions
-with live catalogs from online registered Nodes, keeps identity qualified by
-owning Node, and reports per-Node failures without giving stale remote
-projections authority. Rows are ordered by last activity for presentation only;
-timestamps do not establish causal order across Nodes. Every row names its
-harness, and columns adapt from the compact age, harness, and title view to add
-state, Node, Workspace, and occurrence information as space permits.
-Session details distinguish the registration-time source directory and launch
-branch from bounded repository/branch contexts observed by the Session's exact
-Agent occurrences. Observed contexts are owner-authoritative hints, may be
-incomplete, and are never fabricated for catalog-only history. Protocol-51
-owners may also report the latest Agent name plus separate push and worktree
-status for the context's exact current branch. The owner uses bounded no-fetch
-response-time inspection of local tracking refs and porcelain state; worktree
-status exposes only `staged` and `unstaged_or_untracked` booleans, never file
-names, file counts, or file contents. These derived fields are not persisted or
-published as events, and protocol-50 responses omit them.
-
-`Enter` opens the selected Session. A current Session opens its exact managed
-Shell; historical resume runs the exact owner-side harness. An unavailable,
-missing-cwd, done, or otherwise invalid Session reports an error and never opens
-a substitute. OpenCode and Codex may contribute catalog-only history; Pi,
-Claude, and Kiro appear only after Boomux has durably observed an Agent Instance,
-but exact bounded host records may supply their displayed titles.
-Press `i` for Session details and `Esc` to return. With the mouse, the first click
-selects a Session row and a second click on that selected row opens it.
 
 Core keys:
 
 | Keys | Action |
 | --- | --- |
 | Arrow keys or `h/j/k/l` | Navigate |
-| `Tab`, `Shift-Tab`, `1`-`5` | Change view |
+| `Tab`, `Shift-Tab`, `1`-`4` | Change view |
 | `Enter` | Open or activate the selected item |
 | `a`, `e`, `x` | Add, rename/edit, or close/remove where available |
 | `/` or `:` | Open the command palette |
@@ -386,27 +357,6 @@ delete the remote Node.
 
 Cached remote projections are presentation-only. Mutations require a live,
 identity-verified owner connection and are never queued for later.
-
-Open an exact projected Agent Session in a native terminal with:
-
-```console
-boomux session open <session-id>
-boomux session open <session-id> --node <node>
-```
-
-Current Sessions open their exact current ShellRun with takeover. Historical
-Sessions resume on their exact owning Node. Invalid or changed targets fail
-closed rather than substituting another Shell, run, Session, path, or Node.
-
-Hide a projected Session from one owning Workspace without deleting provider
-history, Agents, Shells, or processes:
-
-```console
-boomux session hide <session-id> --workspace <workspace-id>
-boomux session hide <session-id> --workspace <workspace-id> --node <node>
-```
-
-Hiding is persistent and Workspace-scoped. There is no unhide command.
 
 See [Remote Nodes](docs/remote-nodes.md) for routing, bootstrap, upgrade, and
 failure semantics.

--- a/docs/adr/0011-store-projected-session-display-names-on-workspaces.md
+++ b/docs/adr/0011-store-projected-session-display-names-on-workspaces.md
@@ -1,6 +1,6 @@
 # Store Projected Session Display Names On Workspaces
 
-Status: Accepted
+Status: Superseded by ADR 0014
 
 Agent Sessions remain projections assembled from durable Agent Instances and
 ephemeral host catalogs. Making the projected Session UUID a durable entity would

--- a/docs/adr/0013-hide-projected-sessions-with-workspace-tombstones.md
+++ b/docs/adr/0013-hide-projected-sessions-with-workspace-tombstones.md
@@ -1,6 +1,6 @@
 # Hide Projected Sessions With Workspace Tombstones
 
-Status: Accepted
+Status: Superseded by ADR 0014
 
 Agent Sessions are projections assembled from durable Agent Instances and
 ephemeral host catalogs. Removing provider history is outside Boomux authority,

--- a/docs/adr/0014-retire-public-agent-sessions.md
+++ b/docs/adr/0014-retire-public-agent-sessions.md
@@ -1,0 +1,42 @@
+# Retire public Agent Sessions without discarding external identity
+
+## Status
+
+Accepted.
+
+## Context
+
+The projected Agent Session feature combined durable Agent lifecycle records,
+provider history catalogs, presentation metadata, remote host services, and
+historical process resume behind one user-facing resource. That projection was
+not a lifecycle authority, but its breadth made it appear equivalent to an Agent
+or Shell and required private host-history discovery to populate ordinary UI.
+
+External harness session identity is still required. Lifecycle integrations use
+it to correlate reports, OpenCode shared-runtime claims bind it to exact current
+ShellRuns, and cold recovery uses it to reconstruct exact resume arguments.
+Removing that identity would weaken Agent authority and recovery guarantees.
+
+## Decision
+
+Boomux no longer advertises or exposes Agent Session list, inspect, rename,
+reset-name, hide, open, or resume operations. The native dashboard omits the
+Sessions view. Local, routed, host-service, and streaming resume requests using
+the retained protocol-51 variants fail with `unsupported_version`.
+
+Protocol variants and state-schema-17 Session presentation fields remain
+decodable during a compatibility stage. This keeps existing owner state readable
+and lets mixed-version peers receive a typed rejection rather than a malformed
+frame or failed daemon start. Those fields grant no current capability and may be
+removed by a later explicit protocol-floor and state migration.
+
+`AgentInstanceSnapshot.external_session_id`, integration claims and holders,
+working-context observations, and exact cold-recovery inputs remain. They are
+opaque lifecycle and recovery data, not a user-facing Boomux resource.
+
+## Consequences
+
+- No Session command, tab, JSON command, or Session feature is advertised.
+- Provider history catalogs are no longer reachable through supported APIs.
+- Existing Session presentation metadata remains inert until a later migration.
+- Agent lifecycle authority and exact external-session recovery remain intact.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,6 +242,18 @@ event readers filter that event while retaining cursor progress. Coordinator
 Workspace schema 8 explicitly migrates schema 7 with empty pending and completed
 default-cwd operation ledgers. Owner state schema 14 and handoff generation 8 are
 unchanged because owner Workspaces already persist `default_cwd`.
+Public Agent Session projection was retired after protocol 51. Current binaries
+do not advertise Session capabilities or JSON commands, the native dashboard has
+no Sessions view, and local or routed list, inspect, resolve, display-name, hide,
+open, and resume requests fail with `unsupported_version`. Protocol 13, 50, and
+51 wire shapes and state-schema-17 presentation metadata remain decodable during
+this compatibility stage so existing state and mixed-version peers fail closed
+instead of becoming unreadable. External session IDs remain durable only as
+opaque Agent lifecycle, integration-authority, and exact-recovery inputs.
+
+The following protocol 50 and 51 paragraphs describe retained legacy wire and
+persistence shapes, not current advertised product capabilities.
+
 Protocol 50 adds `session_display_names` and `session_presentation_context`. The
 owner resolves one exact projected Agent Session, requires its owning Workspace
 revision, and persists normalized
@@ -906,95 +918,20 @@ bounded to the attachment limit, browser backgrounding releases control, and all
 terminal API responses remain outside service-worker and HTTP caches. The
 external private access layer must restrict the dashboard to trusted users.
 
-Agent sessions are a client-side projection, not another durable daemon
-identity. The projection groups stored Agent instances by workspace,
-integration, and external session ID, while isolating instances without an
-external ID. It retains original shell/run identity and observations even when a
-shell no longer exists. UUID v5 IDs use a fixed namespace and a versioned,
-length-prefixed encoding of workspace ID, integration, and the external-or-agent
-grouping identity. IDs are globally unique and deterministic but opaque to
-consumers. Bounded OpenCode root-session and Codex thread catalogs add
-historical, `unknown` sessions without fabricating Agent occurrences and merge
-with a later durable registration under the same stable ID. Pi's bounded local
-Session store, Claude's bounded local transcript discovery, and Kiro's bounded
-local Session listing may title an already-durable Session only when their exact
-external ID and normalized Workspace directory match; unmatched title records
-never create historical Sessions. Catalog records associate to each workspace
-that references their exact normalized directory. The dashboard maps
-the active or latest exact match into a durable Agent's contextual preview and
-discovers catalogs asynchronously; session CLI listing performs the same bounded
-discovery synchronously. Exact inspection and resume resolve durable projection
-state first and may enrich it from the existing catalog cache without refreshing
-unrelated hosts; a catalog-only ID performs discovery only when no cached catalog
-can resolve it. Pi, Claude, and Kiro have no complete catalog projection: their
-Sessions enter the projection only through durably observed Agent Instances, and
-host records can change only their title.
+Agent Sessions were formerly a client-side projection over Agent instances and
+provider history catalogs. ADR 0014 retires that public resource model. The
+dashboard primary kinds are now Workspaces, Agents, Shells, and Nodes; dashboard
+startup and refresh do not inspect provider history catalogs. The `session`
+command, Session host services, resume services, and Session mutations are not
+advertised and current daemons reject their retained legacy request shapes with
+`unsupported_version`.
 
-Synchronous discovery plans normalized `(integration, directory)` requests before
-inspection. OpenCode and Codex inspect every bounded projection directory because
-they can contribute history; Pi, Claude, and Kiro inspect only directories with a
-matching durable external Session. The owner keeps at most 256 ephemeral per-key
-results, with 30-second success and five-second failure freshness, and coalesces
-concurrent misses into one demand-driven refresh. Discovery runs outside the cache
-lock with at most four concurrent tasks. One short-lived Codex app-server serves
-all missing Codex directories in a refresh batch. The cache is neither persisted
-nor transferred, and no startup, timer, or background process warms it.
-
-Session summaries can project outstanding Agent attention and Git branch context
-without changing ownership. Attention remains durable Agent state and carries
-its exact acknowledgment revision; Git context is transient, deduplicated by
-source cwd for one list, and inspected only on the owning Node. Neither field is
-stored in owner state, coordinator projection caches, or handoff manifests.
-
-The dashboard primary kinds are Workspaces, Agents, Sessions, Shells, and Nodes.
-Sessions is this canonical projection, not a rename of ShellRun-bound Agent
-Instances or a new identity layer. Its bounded asynchronous loader combines the
-local projection with live protocol-36 Session catalogs from every online
-registered Node. Each row retains `(node_id, session_id)` identity; owner failures
-are reported independently so successful Nodes remain usable. Cached stale
-remote projections never supply Session catalog authority. Last-activity order
-uses deterministic Node, Workspace, and Session tie-breakers only for
-presentation and establishes no cross-Node causal order.
-
-Session rows always show textual harness identity. Rendering preserves age,
-harness, and title at narrow widths and progressively adds state, Node,
-Workspace, and occurrence columns. `i` opens the detail overlay; `Enter` opens
-the selected row, while a first mouse click selects it and a second click on the
-selected row opens it. A current Session opens its exact Node-qualified managed
-Shell. A historical resumable Session uses the existing exact owner-side harness
-resume service. Done, unavailable, missing-cwd, or otherwise invalid selections
-fail visibly and never substitute another Shell, Node, path, harness, or Session.
-This presentation reuses existing protocol-36 host services and existing durable
-Agent state; it changes neither protocol nor persistence versions.
-The public human-only `boomux session open SESSION_ID [--node NODE]
-[--workspace WORKSPACE]` command
-uses that same core activation path. Current Sessions revalidate one exact
-current owner ShellRun and launch a terminal with expected-run attachment and
-takeover; historical Sessions validate owner cwd and launch the existing exact
-owner-routed resume. Done, missing, ambiguous, unavailable, and concurrently
-changed targets fail closed. Command success reports terminal launch; a later
-owner-side rejection remains visible in that terminal without substitution. The
-optional Workspace validates a non-closing coordinated presentation target and
-uses the desktop presentation path; it does not change Shell membership or owner
-authority for a current Session. Historical opening with a Workspace creates a
-managed command-backed Shell on the Session owner Node in that coordinated
-Workspace and starts the exact harness resume argv through `agent supervise` and
-normal attachment. The process adapter creates an immediate unknown Agent for
-the exact canonical Session, then lifecycle integration supersedes it with
-authoritative state. `BOOMUX_*` run identity is available throughout. Historical
-opening without a Workspace retains the legacy unmanaged resume path. The
-static CLI capability is `exact_session_open`; no JSON command, wire request,
-protocol bump, or persistence change is added.
-The integration descriptor registry is the authority for integration keys,
-display names, and optional typed capabilities. A title capability selects its
-host adapter and independently declares catalog support. The shared title layer
-owns asynchronous cache, refresh, deduplication, sanitization, and fallback
-policy; OpenCode, Pi, Claude, Codex, and Kiro modules own host discovery or
-command execution and title extraction.
-Neutral host source modules own shared path normalization and secure catalog
-discovery. Title and catalog support remain independent from installation,
-foreground recognition, and recovery eligibility, so a future harness can
-implement only the capabilities it provides.
+Protocol 51 and state schema 17 remain decodable during this compatibility stage.
+Legacy Session wire variants, projection helpers, and persisted presentation
+metadata are inert implementation detail, not supported APIs. Exact external
+session IDs remain on Agent instances because integrations use them as opaque
+run-scoped lifecycle authority and exact cold-recovery input. They do not define
+a browseable, resumable, nameable, or hideable Boomux resource.
 
 Session list/inspect requires a negotiated protocol-12 snapshot because the
 projection depends on that complete Agent state model. Protocol 13 adds an

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -47,27 +47,10 @@ not appear in `json_commands`, and do not provide remote configuration mutation.
 `config validate` covers the complete global plus optional `BOOMUX_CONFIG`
 layered result without starting the daemon.
 
-`boomux session open SESSION_ID [--node NODE] [--workspace WORKSPACE]` is also human-only and absent
-from `json_commands`. The static `exact_session_open` feature advertises this
-CLI orchestration surface, not a new daemon request. It launches a terminal that
-opens an exact current ShellRun with expected-run attachment and takeover, or
-uses exact owner-routed resume for a historical Session; done, missing,
-ambiguous, unavailable, and changed targets fail closed. A successful command
-exit confirms terminal launch, while owner-side attachment or resume errors
-remain visible in that terminal and never fall back to another target. After
-launch, Boomux acknowledges each outstanding Agent attention reference projected
-onto that exact Session using its original observation revision. A newer
-attention revision remains outstanding, and an acknowledgment failure is
-reported as a post-launch warning rather than misreporting the terminal launch
-as failed.
-When `--workspace` names a non-closing coordinated Workspace, Boomux presents that
-desktop Workspace and places an exact current ShellRun terminal there without
-changing durable Shell membership. For a historical Session, it creates a
-managed command-backed Shell on the Session's owning Node in the selected
-Workspace and runs the exact harness resume argv through `agent supervise`.
-The supervisor immediately registers the exact Session as an unknown Agent;
-lifecycle integration then supersedes it with authoritative state. Without `--workspace`, the legacy
-unmanaged historical resume remains available.
+Session commands and Session feature names are absent from `json_commands` and
+`features`. Protocol 51 retains legacy request and response shapes only for safe
+decoding of mixed-version peers; current daemons reject Session catalog, inspect,
+mutation, open, and resume operations with `unsupported_version`.
 
 `boomux setup` is a human-only local discovery and mutation workflow. It requires
 an interactive terminal, does not support `--json`, and is absent from
@@ -296,11 +279,6 @@ The following commands support `--json`:
 - `boomux agent report`
 - `boomux attention list`
 - `boomux attention acknowledge`
-- `boomux session list`
-- `boomux session inspect`
-- `boomux session rename SESSION_ID NAME --revision N [--node NODE]`
-- `boomux session reset-name SESSION_ID --revision N [--node NODE]`
-- `boomux session hide SESSION_ID --workspace WORKSPACE_ID [--node NODE]`
 - `boomux integration list`
 - `boomux integration status [opencode|pi|claude|codex]`
 - `boomux integration install <opencode|pi|claude|codex>`
@@ -543,28 +521,14 @@ Protocol 49 adds `protocol_49` and `workspace_placement_default_cwd` plus the
 coordinated Workspace, exact existing Node placement, fresh global and owner
 Workspace revisions, and an owner-resolved existing directory. Repeating the
 same path returns `unchanged` without incrementing either revision.
-Protocol 50 adds `protocol_50`, `session_display_names`,
-`session_presentation_context`, and `observed_agent_working_contexts` plus the stable
-`session.rename` and `session.reset-name` JSON commands. Mutation is optional for
-consumers of Session browsing and is never inferred from the package version.
-Protocol-50 inspection also carries owner-projected occurrence details so local
-and remote `session.inspect` serialize the same authoritative response without
-client-side catalog rediscovery. Session presentation context consists only of
-bounded exact Agent attention references, nullable owner-inspected launch Git
-branch context, and bounded observed repository/branch contexts. It adds no
-durable Session lifecycle or transcript state. The integration-only
-`agent observe-working-context` command is private JSON plumbing, not a stable
-automation command.
-Protocol 51 adds `protocol_51`, `session_latest_agent_attribution`,
-`session_working_context_push_status`,
-`session_working_context_worktree_status`, and `workspace_session_hiding` plus
-the stable `session.hide` JSON command. Latest Agent attribution and the two Git
-status objects are optional additive presentation fields. Hide is an
-owner-authoritative, Workspace-scoped tombstone mutation and is never inferred
-from package version. Protocol-50 list, inspect, resolve, and resume callers
-retain their previous visibility; protocol-50 responses omit
-`latest_agent_name`, `push_status`, `worktree_status`, and the hide event while
-event cursors still advance.
+Protocols 50 and 51 historically added Session presentation fields, mutations,
+and capabilities. ADR 0014 retires those public interfaces. Their wire shapes
+remain decodable for protocol-51 compatibility, but current daemons do not
+advertise Session capabilities and reject Session commands, host services,
+resume requests, and mutations with `unsupported_version`. Persisted Session
+presentation metadata is inert. The integration-only
+`agent observe-working-context` command remains private JSON plumbing for Agent
+lifecycle context, not a Session automation command.
 
 Protocol-38 `workspace create NAME` without placement flags creates empty
 coordinator metadata without a default Node or cwd and remains human-only.

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -49,6 +49,10 @@ part of the protocol-47 wire contract.
 Protocol 49 adds `workspace_default_cwd_changed` after the owner Workspace and
 its revision are durably persisted. Protocol-48 clients do not receive the new
 event, but their returned cursor still advances across it.
+Current daemons no longer accept the Session mutations that produced
+`agent_session_display_name_changed` or `agent_session_hidden`. Their event
+variants remain decodable for protocol-51 handoff and cursor compatibility but
+are not part of the advertised current surface.
 Protocol 50 adds `agent_session_display_name_changed` only after the owning
 Workspace metadata and incremented revision are durable. It also adds
 `agent_working_context_observed` after an exact Agent working-context observation

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -661,6 +661,12 @@ federation and event lock is released.
 
 ## Reads, Mutations, And Failure
 
+Agent Session host services and exact Session resume are retired. Current owners
+reject the retained legacy list, inspect, resolve, mutation, and resume wire
+variants with `unsupported_version`; external session identity remains internal
+to Agent lifecycle and recovery. The historical protocol paragraphs below
+describe compatibility shapes, not advertised current operations.
+
 Protocol 34 routes one closed `RoutedOperation` union. It is not an arbitrary
 daemon-request envelope: creation, daemon stop/restart, Node rekey, integration
 mutation, launcher execution, attachment/session resume, and every unlisted

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1947,26 +1947,34 @@ fn handle_connection_inner(
     }
 
     if let Request::ResumeNodeAgentSession {
-        node_id,
-        session_id,
-        profile,
+        node_id: _,
+        session_id: _,
+        profile: _,
     } = request.message
     {
-        return registry.handle_remote_session_resume(
-            stream,
+        return send_response(
+            &mut stream,
             response_version,
-            &node_id,
-            &session_id,
-            profile,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "Agent Session resume has been removed",
+            ),
         );
     }
 
     if let Request::ResumeAgentSession {
-        session_id,
-        profile,
+        session_id: _,
+        profile: _,
     } = request.message
     {
-        return registry.handle_session_resume(stream, response_version, &session_id, profile);
+        return send_response(
+            &mut stream,
+            response_version,
+            error_response(
+                ErrorCode::UnsupportedVersion,
+                "Agent Session resume has been removed",
+            ),
+        );
     }
 
     if let Request::Attach {
@@ -9075,6 +9083,16 @@ impl DaemonService {
         requester_version: u32,
         before_request: &mut dyn FnMut() -> io::Result<()>,
     ) -> Response {
+        if matches!(
+            operation,
+            RoutedOperation::SetAgentSessionDisplayName { .. }
+                | RoutedOperation::HideAgentSession { .. }
+        ) {
+            return error_response(
+                ErrorCode::UnsupportedVersion,
+                "Agent Session mutation has been removed",
+            );
+        }
         if let RoutedOperation::SetAgentSessionDisplayName { operation_id, .. } = &operation
             && let Err(error) = validate_uuid(operation_id, "Session display-name operation ID")
         {
@@ -9321,7 +9339,7 @@ impl DaemonService {
     fn host_service_for_version(
         &self,
         operation: HostServiceOperation,
-        requester_version: u32,
+        _requester_version: u32,
     ) -> DaemonResult<HostServiceResult> {
         match operation {
             HostServiceOperation::DiscoverProjects => Ok(HostServiceResult::Projects {
@@ -9426,78 +9444,12 @@ impl DaemonService {
                 shell_id,
                 run_id,
             }),
-            HostServiceOperation::ListAgentSessions { workspace_id } => {
-                let snapshot = self.snapshot()?;
-                let mut projected = self.host_sessions(&snapshot, workspace_id.as_deref())?;
-                let hidden = if protocol::ProtocolFeature::WorkspaceSessionHiding
-                    .is_supported_by(requester_version)
-                {
-                    self.hidden_session_metadata()?
-                } else {
-                    Vec::new()
-                };
-                apply_session_visibility_limit(&mut projected, &hidden, requester_version);
-                let sessions = host_services::session_summaries(&snapshot, &projected);
-                Ok(HostServiceResult::AgentSessions { sessions })
-            }
-            HostServiceOperation::InspectAgentSession { session_id } => {
-                let snapshot = self.snapshot()?;
-                let mut sessions = self.exact_host_sessions(&snapshot, &session_id)?;
-                if protocol::ProtocolFeature::WorkspaceSessionHiding
-                    .is_supported_by(requester_version)
-                {
-                    crate::session_projection::filter_hidden(
-                        &mut sessions,
-                        &self.hidden_session_metadata()?,
-                    );
-                }
-                Ok(HostServiceResult::AgentSession {
-                    session: host_services::inspect_projected_session(
-                        &snapshot,
-                        &sessions,
-                        &session_id,
-                    )
-                    .map_err(DaemonError::from)?,
-                })
-            }
-            HostServiceOperation::ResolveAgentSession {
-                workspace_id,
-                agent_id,
-            } => {
-                let snapshot = self.snapshot()?;
-                let mut sessions = self.durable_host_sessions(&snapshot)?;
-                if protocol::ProtocolFeature::WorkspaceSessionHiding
-                    .is_supported_by(requester_version)
-                {
-                    crate::session_projection::filter_hidden(
-                        &mut sessions,
-                        &self.hidden_session_metadata()?,
-                    );
-                }
-                let matches = sessions
-                    .into_iter()
-                    .filter(|session| {
-                        session.workspace_id == workspace_id
-                            && session
-                                .occurrences
-                                .iter()
-                                .any(|occurrence| occurrence.agent_id == agent_id)
-                    })
-                    .collect::<Vec<_>>();
-                let [session] = matches.as_slice() else {
-                    return Err(DaemonError::lifecycle(
-                        if matches.is_empty() {
-                            ErrorCode::NotFound
-                        } else {
-                            ErrorCode::AmbiguousTarget
-                        },
-                        "exact Agent occurrence did not resolve to one Agent Session",
-                    ));
-                };
-                Ok(HostServiceResult::ResolvedAgentSession {
-                    session: host_services::session_summary_with_snapshot(&snapshot, session),
-                })
-            }
+            HostServiceOperation::ListAgentSessions { .. }
+            | HostServiceOperation::InspectAgentSession { .. }
+            | HostServiceOperation::ResolveAgentSession { .. } => Err(DaemonError::lifecycle(
+                ErrorCode::UnsupportedVersion,
+                "Agent Session services have been removed",
+            )),
         }
     }
 
@@ -9831,6 +9783,17 @@ impl DaemonService {
         operation: HostServiceOperation,
         requester_version: u32,
     ) -> Response {
+        if matches!(
+            operation,
+            HostServiceOperation::ListAgentSessions { .. }
+                | HostServiceOperation::InspectAgentSession { .. }
+                | HostServiceOperation::ResolveAgentSession { .. }
+        ) {
+            return error_response(
+                ErrorCode::UnsupportedVersion,
+                "Agent Session services have been removed",
+            );
+        }
         let registrations = match self.node_registrations() {
             Ok(registrations) => registrations,
             Err(error) => return error.into_response(),
@@ -12809,28 +12772,12 @@ impl DaemonService {
                     vec![event],
                 ))
             }),
-            Request::SetAgentSessionDisplayName {
-                operation_id,
-                session_id,
-                expected_workspace_revision,
-                display_name,
-            } => self.set_agent_session_display_name(
-                operation_id,
-                session_id,
-                expected_workspace_revision,
-                display_name,
-            ),
-            Request::HideAgentSession {
-                operation_id,
-                session_id,
-                workspace_id,
-                expected_workspace_revision,
-            } => self.hide_agent_session(
-                operation_id,
-                session_id,
-                workspace_id,
-                expected_workspace_revision,
-            ),
+            Request::SetAgentSessionDisplayName { .. } | Request::HideAgentSession { .. } => {
+                Err(DaemonError::lifecycle(
+                    ErrorCode::UnsupportedVersion,
+                    "Agent Session mutation has been removed",
+                ))
+            }
             Request::CreateWorkspace {
                 name,
                 default_cwd,
@@ -18350,9 +18297,9 @@ mod tests {
         assert!(matches!(
             response,
             Response::Error {
-                code: Some(ErrorCode::InvalidArgument),
+                code: Some(ErrorCode::UnsupportedVersion),
                 ref message,
-            } if message.contains("invalid Session display-name operation ID")
+            } if message.contains("Agent Session mutation has been removed")
         ));
 
         let response = registry
@@ -18494,53 +18441,24 @@ mod tests {
             agent_id
         );
 
-        let HostServiceResult::AgentSessions { sessions } = registry
-            .host_service_for_version(
+        for version in [50, 51] {
+            for operation in [
                 HostServiceOperation::ListAgentSessions {
                     workspace_id: Some(workspace.id.clone()),
                 },
-                51,
-            )
-            .unwrap()
-        else {
-            panic!("unexpected current Session list response");
-        };
-        assert!(sessions.is_empty());
-        let HostServiceResult::AgentSessions { sessions } = registry
-            .host_service_for_version(
-                HostServiceOperation::ListAgentSessions {
-                    workspace_id: Some(workspace.id.clone()),
+                HostServiceOperation::InspectAgentSession {
+                    session_id: session_id.clone(),
                 },
-                50,
-            )
-            .unwrap()
-        else {
-            panic!("unexpected old Session list response");
-        };
-        assert_eq!(sessions.len(), 1);
-        assert_eq!(
-            registry
-                .host_service_for_version(
-                    HostServiceOperation::InspectAgentSession {
-                        session_id: session_id.clone(),
-                    },
-                    51,
-                )
-                .unwrap_err()
-                .wire_code(),
-            ErrorCode::NotFound
-        );
-        assert!(matches!(
-            registry
-                .host_service_for_version(
-                    HostServiceOperation::InspectAgentSession {
-                        session_id: session_id.clone(),
-                    },
-                    50,
-                )
-                .unwrap(),
-            HostServiceResult::AgentSession { .. }
-        ));
+            ] {
+                assert_eq!(
+                    registry
+                        .host_service_for_version(operation, version)
+                        .unwrap_err()
+                        .wire_code(),
+                    ErrorCode::UnsupportedVersion
+                );
+            }
+        }
 
         let replay = registry
             .hide_agent_session(

--- a/src/host_services.rs
+++ b/src/host_services.rs
@@ -13,15 +13,19 @@ use serde::Deserialize;
 
 use crate::generated_names;
 use crate::integration_management::{self, IntegrationId};
+#[cfg(test)]
 use crate::protocol::{
-    AgentAttentionReason, AgentInstanceSnapshot, AgentWorkingContextSnapshot,
-    HostAgentSessionAttention, HostAgentSessionInspection, HostAgentSessionResumePlan,
+    AgentAttentionReason, HostAgentSessionAttention, HostAgentSessionInspection,
     HostAgentSessionSummary, HostAgentSessionWorkingContext, HostGitPushStatus,
-    HostGitWorktreeStatus, HostIntegrationMutationResult, HostIntegrationPlan,
-    HostIntegrationStatus, HostProjectDiscovery, HostProjectSnapshot, HostServiceIntegrationAction,
-    MAX_HOST_SERVICE_PROJECTS, MAX_HOST_SERVICE_SESSIONS, MAX_HOST_SERVICE_WARNINGS,
-    MAX_SESSION_INSPECTION_WORKING_CONTEXTS, MAX_SESSION_WORKING_CONTEXTS, Snapshot,
-    WorkspaceLauncherSnapshot, WorkspaceSnapshot,
+    HostGitWorktreeStatus, MAX_HOST_SERVICE_SESSIONS, MAX_SESSION_INSPECTION_WORKING_CONTEXTS,
+    MAX_SESSION_WORKING_CONTEXTS,
+};
+use crate::protocol::{
+    AgentInstanceSnapshot, AgentWorkingContextSnapshot, HostAgentSessionResumePlan,
+    HostIntegrationMutationResult, HostIntegrationPlan, HostIntegrationStatus,
+    HostProjectDiscovery, HostProjectSnapshot, HostServiceIntegrationAction,
+    MAX_HOST_SERVICE_PROJECTS, MAX_HOST_SERVICE_WARNINGS, Snapshot, WorkspaceLauncherSnapshot,
+    WorkspaceSnapshot,
 };
 use crate::session_projection::{self, SessionProjection};
 
@@ -106,12 +110,14 @@ pub(crate) fn inspect_working_context(
     }))
 }
 
+#[cfg(test)]
 #[derive(Debug, Default, PartialEq, Eq)]
 struct WorkingContextPresentationStatus {
     push_status: Option<HostGitPushStatus>,
     worktree_status: Option<HostGitWorktreeStatus>,
 }
 
+#[cfg(test)]
 fn inspect_presentation_status(
     context: &AgentWorkingContextSnapshot,
 ) -> WorkingContextPresentationStatus {
@@ -134,6 +140,7 @@ fn inspect_presentation_status(
     }
 }
 
+#[cfg(test)]
 fn inspect_push_status(
     context: &AgentWorkingContextSnapshot,
 ) -> io::Result<Option<HostGitPushStatus>> {
@@ -164,6 +171,7 @@ fn inspect_push_status(
     Ok(git_output(&context.worktree_root, &["remote"])?.map(|_| HostGitPushStatus::Unpublished))
 }
 
+#[cfg(test)]
 fn inspect_worktree_status(
     context: &AgentWorkingContextSnapshot,
 ) -> io::Result<Option<HostGitWorktreeStatus>> {
@@ -183,6 +191,7 @@ fn inspect_worktree_status(
     parse_worktree_status(&output, &context.branch)
 }
 
+#[cfg(test)]
 fn parse_worktree_status(
     output: &str,
     expected_branch: &str,
@@ -913,6 +922,7 @@ pub(crate) fn sessions_with_catalog(
     session_projection::project_snapshot_with_catalog(snapshot, Some(catalog))
 }
 
+#[cfg(test)]
 pub(crate) fn session_summaries(
     snapshot: &Snapshot,
     sessions: &[SessionProjection],
@@ -920,6 +930,7 @@ pub(crate) fn session_summaries(
     session_summaries_with_context_limit(snapshot, sessions, MAX_SESSION_WORKING_CONTEXTS)
 }
 
+#[cfg(test)]
 fn session_summaries_with_context_limit(
     snapshot: &Snapshot,
     sessions: &[SessionProjection],
@@ -1041,6 +1052,7 @@ fn session_summaries_with_context_limit(
         .collect()
 }
 
+#[cfg(test)]
 pub(crate) fn session_summary_with_snapshot(
     snapshot: &Snapshot,
     session: &SessionProjection,
@@ -1050,6 +1062,7 @@ pub(crate) fn session_summary_with_snapshot(
         .expect("one Session produces one summary")
 }
 
+#[cfg(test)]
 fn session_inspection_summary_with_snapshot(
     snapshot: &Snapshot,
     session: &SessionProjection,
@@ -1063,6 +1076,7 @@ fn session_inspection_summary_with_snapshot(
     .expect("one Session produces one inspection summary")
 }
 
+#[cfg(test)]
 fn session_summary(
     session: &SessionProjection,
     latest_agent_name: Option<String>,
@@ -1093,6 +1107,7 @@ fn session_summary(
     }
 }
 
+#[cfg(test)]
 fn attention_rank(reason: AgentAttentionReason) -> u8 {
     match reason {
         AgentAttentionReason::Blocked => 0,
@@ -1100,6 +1115,7 @@ fn attention_rank(reason: AgentAttentionReason) -> u8 {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn inspect_projected_session(
     snapshot: &Snapshot,
     sessions: &[SessionProjection],

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,6 @@ const BOOMUX_SKILL: &str = include_str!("../.agents/skills/boomux/SKILL.md");
 const BOOMUX_OPENCODE_PLUGIN: &str = integration_management::OPENCODE_ASSET;
 #[cfg(test)]
 const BOOMUX_PI_EXTENSION: &str = integration_management::PI_ASSET;
-const MAX_HOST_CATALOG_DIRECTORIES: usize = 8;
 const NON_PROTOCOL_FEATURES: &[&str] = &[
     "opencode_lifecycle_plugin",
     "pi_lifecycle_extension",
@@ -148,7 +147,6 @@ const NON_PROTOCOL_FEATURES: &[&str] = &[
     "persistent_workspace_selection",
     "create_and_open_shell",
     "atomic_workspace_shell_creation",
-    "exact_session_open",
     "hyprland_special_workspaces",
     "contextual_desktop_terminal",
     "coordinated_shell_desktop_placement",
@@ -369,7 +367,8 @@ enum Commands {
         #[command(subcommand)]
         command: NotificationCommands,
     },
-    /// Discover projected agent sessions
+    /// Legacy Agent Session commands retained for argument compatibility
+    #[command(hide = true)]
     Session {
         #[command(subcommand)]
         command: SessionCommands,
@@ -884,7 +883,8 @@ impl From<CliNotificationReason> for daemon::NotificationTestReason {
 
 #[derive(Subcommand)]
 enum SessionCommands {
-    /// List projected agent sessions
+    /// Retired compatibility syntax
+    #[command(hide = true)]
     List {
         #[arg(long, value_name = "NAME_OR_ID")]
         workspace: Option<String>,
@@ -892,15 +892,16 @@ enum SessionCommands {
         #[arg(long)]
         node: Option<String>,
     },
-    /// Show a projected session by exact opaque ID
-    #[command(alias = "get")]
+    /// Retired compatibility syntax
+    #[command(alias = "get", hide = true)]
     Inspect {
         session_id: String,
         /// Exact registered Node alias or Node ID
         #[arg(long)]
         node: Option<String>,
     },
-    /// Open one exact current or historical Session in a native terminal
+    /// Retired compatibility syntax
+    #[command(hide = true)]
     Open {
         session_id: String,
         /// Exact registered Node alias or Node ID
@@ -910,14 +911,16 @@ enum SessionCommands {
         #[arg(long, value_name = "COORDINATED_WORKSPACE")]
         workspace: Option<String>,
     },
-    /// Resume one exact projected session in a native terminal
+    /// Retired compatibility syntax
+    #[command(hide = true)]
     Resume {
         session_id: String,
         /// Exact registered Node alias or Node ID
         #[arg(long)]
         node: Option<String>,
     },
-    /// Set a Boomux display name on one exact projected Session
+    /// Retired compatibility syntax
+    #[command(hide = true)]
     Rename {
         session_id: String,
         name: String,
@@ -929,7 +932,8 @@ enum SessionCommands {
         #[arg(long)]
         operation_id: Option<String>,
     },
-    /// Reset the Boomux display name on one exact projected Session
+    /// Retired compatibility syntax
+    #[command(hide = true)]
     ResetName {
         session_id: String,
         #[arg(long)]
@@ -940,7 +944,8 @@ enum SessionCommands {
         #[arg(long)]
         operation_id: Option<String>,
     },
-    /// Hide one exact Session from this Workspace without deleting host history
+    /// Retired compatibility syntax
+    #[command(hide = true)]
     Hide {
         session_id: String,
         #[arg(long)]
@@ -1616,7 +1621,8 @@ impl Cli {
 fn json_commands() -> impl Iterator<Item = &'static str> {
     CommandKey::ALL.iter().filter_map(|key| {
         let descriptor = key.descriptor();
-        (descriptor.output == OutputMode::Json).then_some(descriptor.key)
+        (descriptor.output == OutputMode::Json && !descriptor.key.starts_with("session."))
+            .then_some(descriptor.key)
     })
 }
 
@@ -1701,6 +1707,9 @@ fn requests_json(arguments: impl IntoIterator<Item = OsString>) -> bool {
 
 fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
     let descriptor = cli.command_descriptor();
+    if matches!(cli.command.as_ref(), Some(Commands::Session { .. })) {
+        return Err(removed_session_error());
+    }
     if cli.json && descriptor.output == OutputMode::HumanOnly {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -1832,8 +1841,8 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             return Ok(CliExit::Success);
         }
         Some(Commands::ResumeSession { session_id, node }) => {
-            attach::run_agent_session(session_id, node.as_deref())?;
-            return Ok(CliExit::Success);
+            let _ = (session_id, node);
+            return Err(removed_session_error());
         }
         Some(Commands::FederationStdio) => {
             federation::run_stdio_helper()?;
@@ -1974,7 +1983,8 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             command: NotificationCommands::Test { reason },
         }) => test_notification(reason),
         Some(Commands::Session { command }) => {
-            session_command(command, cli.json, cli.terminal.as_deref())
+            let _ = command;
+            Err(removed_session_error())
         }
         Some(Commands::Integration { command }) => integration_command(command, cli.json),
         Some(Commands::Skill {
@@ -2064,6 +2074,13 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
     };
     result?;
     Ok(CliExit::Success)
+}
+
+fn removed_session_error() -> Box<dyn Error> {
+    client::ClientError::Protocol(client::ProtocolError::UnsupportedVersion(
+        "Agent Session commands have been removed".into(),
+    ))
+    .into()
 }
 
 fn print_cli_help() -> Result<(), Box<dyn Error>> {
@@ -3475,7 +3492,6 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
     let client = client::connect_or_start()?;
     let local_node_id = client.node_identity()?;
     let mut git_cache = git::Cache::default();
-    let mut title_cache = host_session_titles::Cache::default();
     let mut refresh = DashboardRefresh::baseline(&client)?;
     let snapshot = refresh.snapshot().clone();
     let combined = combined_node_snapshot_for_dashboard(&client)?;
@@ -3501,14 +3517,7 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
         roots_configured,
     };
 
-    let initial_state = dashboard_state(
-        snapshot,
-        combined,
-        &refresh,
-        &mut git_cache,
-        &mut title_cache,
-        false,
-    );
+    let initial_state = dashboard_state(snapshot, combined, &refresh, &mut git_cache, false);
     let selected_workspace_id = workspace_selection::load_from_environment()
         .ok()
         .flatten()
@@ -3573,7 +3582,6 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                                     combined,
                                     &refresh,
                                     &mut git_cache,
-                                    &mut title_cache,
                                     reset_focus_revision,
                                 )))
                             }
@@ -4042,7 +4050,6 @@ fn dashboard(terminal_override: Option<&str>) -> Result<(), Box<dyn Error>> {
                             .map_err(|error| error.to_string())?,
                         &refresh,
                         &mut git_cache,
-                        &mut title_cache,
                         reset_focus_revision,
                     ))
                 })();
@@ -4081,14 +4088,14 @@ fn dashboard_state(
     combined: Option<protocol::CombinedNodeSnapshot>,
     refresh: &DashboardRefresh,
     git_cache: &mut git::Cache,
-    title_cache: &mut host_session_titles::Cache,
     reset_focus_revision: bool,
 ) -> tui::DashboardState {
     let qualified_focused_terminal = combined
         .as_ref()
         .and_then(|snapshot| snapshot.focused_terminal.clone());
-    let mut workspaces = dashboard_views_with_catalog(&snapshot.workspaces, git_cache, title_cache);
-    enrich_session_titles(&mut workspaces, title_cache);
+    let sessions = session_projection::project_snapshot_with_catalog(&snapshot, None);
+    let mut workspaces =
+        dashboard_projection::project_with_sessions(&snapshot.workspaces, git_cache, &sessions);
     let mut nodes = Vec::new();
     if let Some(combined) = combined {
         let global_workspaces = combined.workspaces;
@@ -5198,91 +5205,6 @@ fn dashboard_views(
     git_cache: &mut git::Cache,
 ) -> Vec<tui::WorkspaceView> {
     dashboard_projection::project(workspaces, git_cache)
-}
-
-fn dashboard_views_with_catalog(
-    workspaces: &[WorkspaceSnapshot],
-    git_cache: &mut git::Cache,
-    title_cache: &mut host_session_titles::Cache,
-) -> Vec<tui::WorkspaceView> {
-    let catalog = cached_host_catalog(workspaces, title_cache);
-    let sessions = session_projection::project_workspaces_with_catalog(workspaces, Some(&catalog));
-    dashboard_projection::project_with_sessions(workspaces, git_cache, &sessions)
-}
-
-fn workspace_source_directories(workspaces: &[WorkspaceSnapshot]) -> BTreeSet<PathBuf> {
-    workspaces
-        .iter()
-        .flat_map(|workspace| {
-            workspace
-                .default_cwd
-                .iter()
-                .cloned()
-                .chain(workspace.shells.iter().map(|shell| shell.cwd.clone()))
-                .chain(
-                    workspace
-                        .launchers
-                        .iter()
-                        .map(|launcher| launcher.cwd.clone()),
-                )
-                .chain(
-                    workspace
-                        .agents
-                        .iter()
-                        .filter_map(|agent| agent.cwd.clone()),
-                )
-        })
-        .collect()
-}
-
-fn cached_host_catalog(
-    workspaces: &[WorkspaceSnapshot],
-    cache: &mut host_session_titles::Cache,
-) -> Vec<host_session_titles::HostSession> {
-    let mut catalog = Vec::new();
-    for directory in workspace_source_directories(workspaces)
-        .into_iter()
-        .take(MAX_HOST_CATALOG_DIRECTORIES)
-    {
-        for integration in host_session_titles::projection_integrations() {
-            if let Some(sessions) = cache.projection_records(integration, &directory) {
-                catalog.extend(sessions);
-            }
-        }
-    }
-    catalog
-}
-
-fn discover_host_catalog(
-    workspaces: &[WorkspaceSnapshot],
-) -> Vec<host_session_titles::HostSession> {
-    let directories = workspace_source_directories(workspaces)
-        .into_iter()
-        .take(MAX_HOST_CATALOG_DIRECTORIES)
-        .collect::<Vec<_>>();
-    let requests = directories.into_iter().flat_map(|directory| {
-        host_session_titles::projection_integrations()
-            .map(move |integration| (integration, directory.clone()))
-    });
-    thread::scope(|scope| {
-        requests
-            .map(|(integration, directory)| {
-                scope
-                    .spawn(move || host_session_titles::projection_records(integration, &directory))
-            })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .filter_map(|handle| handle.join().ok().flatten())
-            .flatten()
-            .collect()
-    })
-}
-
-fn enrich_session_titles(
-    workspaces: &mut [tui::WorkspaceView],
-    title_cache: &mut host_session_titles::Cache,
-) {
-    dashboard_projection::enrich_session_titles(workspaces, title_cache);
 }
 
 fn open_directory(
@@ -13834,7 +13756,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_session_discovery_and_human_only_open_commands() {
+    fn parses_legacy_session_arguments_for_typed_rejection() {
         let list = Cli::try_parse_from([
             "boomux",
             "session",
@@ -13884,11 +13806,10 @@ mod tests {
 
         let json_open =
             Cli::try_parse_from(["boomux", "--json", "session", "open", "opaque"]).unwrap();
-        assert!(
-            run(json_open)
-                .unwrap_err()
-                .to_string()
-                .contains("--json is not supported for session.open")
+        let error = run(json_open).unwrap_err();
+        assert_eq!(
+            cli_output::classify_for_test("session.open", error.as_ref()),
+            "unsupported_version"
         );
 
         let rename = Cli::try_parse_from([
@@ -13960,18 +13881,18 @@ mod tests {
     }
 
     #[test]
-    fn session_open_help_is_public_and_documents_exact_identity_and_node() {
+    fn session_commands_are_not_advertised() {
         let session_help = match Cli::try_parse_from(["boomux", "session", "--help"]) {
             Err(error) => error.to_string(),
             Ok(_) => panic!("Session help must exit before command dispatch"),
         };
-        assert!(session_help.contains("open"));
-        let open_help = match Cli::try_parse_from(["boomux", "session", "open", "--help"]) {
-            Err(error) => error.to_string(),
-            Ok(_) => panic!("Session open help must exit before command dispatch"),
-        };
-        assert!(open_help.contains("SESSION_ID"));
-        assert!(open_help.contains("--node <NODE>"));
+        for command in ["open", "list", "rename"] {
+            assert!(
+                !session_help
+                    .lines()
+                    .any(|line| line.trim_start().starts_with(&format!("{command} ")))
+            );
+        }
     }
 
     #[test]
@@ -15514,7 +15435,7 @@ mod tests {
         assert!(json_commands.contains(&"shell.suggest-name"));
         assert!(json_commands.contains(&"workspace.create"));
         assert!(NON_PROTOCOL_FEATURES.contains(&"atomic_workspace_shell_creation"));
-        assert!(NON_PROTOCOL_FEATURES.contains(&"exact_session_open"));
+        assert!(!NON_PROTOCOL_FEATURES.contains(&"exact_session_open"));
         assert!(!json_commands.contains(&"session.open"));
         for command in [
             "agent.register",
@@ -15526,9 +15447,22 @@ mod tests {
         ] {
             assert!(json_commands.contains(&command));
         }
-        for command in ["session.list", "session.inspect"] {
-            assert!(json_commands.contains(&command));
+        for command in [
+            "session.list",
+            "session.inspect",
+            "session.rename",
+            "session.reset-name",
+            "session.hide",
+        ] {
+            assert!(!json_commands.contains(&command));
         }
+        assert!(!protocol::protocol_capabilities().any(|feature| {
+            feature == "projected_agent_sessions"
+                || feature == "remote_agent_session_catalog"
+                || feature == "remote_exact_session_resume"
+                || feature.starts_with("session_")
+                || feature == "workspace_session_hiding"
+        }));
         for command in [
             "integration.list",
             "integration.status",
@@ -15674,11 +15608,6 @@ mod tests {
                 "integration.install",
                 "integration.uninstall",
                 "integration.verify",
-                "session.list",
-                "session.inspect",
-                "session.rename",
-                "session.reset-name",
-                "session.hide",
                 "daemon.status",
             ]
         );
@@ -15884,9 +15813,6 @@ mod tests {
             "boomux attention list",
             "boomux attention acknowledge",
             "boomux notification test",
-            "boomux session list",
-            "boomux session inspect",
-            "boomux session resume",
             "boomux integration list",
             "boomux integration status",
             "boomux integration install",
@@ -15915,7 +15841,7 @@ mod tests {
         assert!(BOOMUX_SKILL.contains("--node"));
         assert!(BOOMUX_SKILL.contains("--revision"));
         assert!(BOOMUX_SKILL.contains("--terminal"));
-        assert!(!BOOMUX_SKILL.contains("boomux session read"));
+        assert!(!BOOMUX_SKILL.contains("boomux session "));
         assert!(!BOOMUX_SKILL.contains("workspace create \"<name>\" --cwd"));
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -494,6 +494,23 @@ pub fn protocol_capabilities() -> impl Iterator<Item = &'static str> {
         .filter(|feature| feature.is_supported_by(PROTOCOL_VERSION))
         .flat_map(ProtocolFeature::capability_names)
         .copied()
+        .filter(|capability| !is_retired_session_capability(capability))
+}
+
+fn is_retired_session_capability(capability: &str) -> bool {
+    matches!(
+        capability,
+        "projected_agent_sessions"
+            | "durable_session_source_context"
+            | "remote_agent_session_catalog"
+            | "remote_exact_session_resume"
+            | "session_display_names"
+            | "session_presentation_context"
+            | "session_working_context_push_status"
+            | "session_working_context_worktree_status"
+            | "session_latest_agent_attribution"
+            | "workspace_session_hiding"
+    )
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -4422,6 +4439,7 @@ mod tests {
             expected
                 .into_iter()
                 .flat_map(|(_, capabilities)| capabilities.iter().copied())
+                .filter(|capability| !is_retired_session_capability(capability))
                 .collect::<Vec<_>>()
         );
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1070,13 +1070,7 @@ enum PrimaryTab {
 }
 
 impl PrimaryTab {
-    const ALL: [Self; 5] = [
-        Self::Workspaces,
-        Self::Agents,
-        Self::Sessions,
-        Self::Shells,
-        Self::Nodes,
-    ];
+    const ALL: [Self; 4] = [Self::Workspaces, Self::Agents, Self::Shells, Self::Nodes];
 
     fn kind(self) -> Option<ItemKind> {
         match self {
@@ -8222,11 +8216,11 @@ mod tests {
         app.cycle_tab(false);
         assert_eq!(app.primary_tab, PrimaryTab::Agents);
         app.cycle_tab(false);
-        assert_eq!(app.primary_tab, PrimaryTab::Sessions);
-        app.cycle_tab(false);
         assert_eq!(app.primary_tab, PrimaryTab::Shells);
+        app.cycle_tab(false);
+        assert_eq!(app.primary_tab, PrimaryTab::Nodes);
         app.cycle_tab(true);
-        assert_eq!(app.primary_tab, PrimaryTab::Sessions);
+        assert_eq!(app.primary_tab, PrimaryTab::Shells);
         app.cycle_tab(true);
         assert_eq!(app.primary_tab, PrimaryTab::Agents);
         app.cycle_tab(true);
@@ -8332,18 +8326,16 @@ mod tests {
 
         assert!(text.contains("WORKSPACES 1"));
         assert!(text.contains("AGENTS 1"));
-        assert!(text.contains("SESSIONS 0"));
+        assert!(!text.contains("SESSIONS"));
         assert!(!text.contains("LAUNCHERS 1"));
         assert!(text.contains("SHELLS 1"));
         assert!(!text.contains("COMMANDS 1"));
         assert!(!text.contains("active agents"));
         let workspace_tab = text.find("WORKSPACES 1").expect("workspace tab");
         let agent_tab = text.find("AGENTS 1").expect("agent tab");
-        let session_tab = text.find("SESSIONS 0").expect("Session tab");
         let shell_tab = text.find("SHELLS 1").expect("Shell tab");
         assert!(workspace_tab < agent_tab);
-        assert!(agent_tab < session_tab);
-        assert!(session_tab < shell_tab);
+        assert!(agent_tab < shell_tab);
         assert!(!text.contains("NODES:"));
         assert!(!text.contains("NODE:all"));
         assert!(lines.iter().any(|line| line.contains("> mixed")));
@@ -10667,23 +10659,14 @@ mod tests {
     }
 
     #[test]
-    fn sessions_are_the_third_tab_and_first_entry_starts_one_live_load() {
+    fn sessions_are_absent_from_primary_navigation() {
         let mut app = app();
         app.nodes[0].id = "local-node".into();
 
         let effect = app.update_key(KeyCode::Char('3'), KeyModifiers::NONE);
 
-        assert_eq!(app.primary_tab, PrimaryTab::Sessions);
-        assert!(matches!(
-            effect,
-            Some(DashboardEffect::LoadSessions { nodes })
-                if nodes == vec![SessionNodeView {
-                    id: "local-node".into(),
-                    alias: "local".into(),
-                    local: true,
-                    session_display_names: false,
-                }]
-        ));
+        assert_eq!(app.primary_tab, PrimaryTab::Shells);
+        assert_eq!(effect, None);
         assert_eq!(app.update_key(KeyCode::Char('3'), KeyModifiers::NONE), None);
     }
 

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -443,282 +443,7 @@ fn sequential_kiro_process_holders_inactivate_only_the_exited_session() {
 }
 
 #[test]
-fn one_codex_app_server_catalogs_multiple_workspace_directories() {
-    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
-        let bin = runtime_dir.join("codex-catalog-bin");
-        fs::create_dir(&bin).unwrap();
-        fs::create_dir(runtime_dir.join("other")).unwrap();
-        let codex = bin.join("codex");
-        fs::write(
-            &codex,
-            "#!/bin/sh\nprintf x >> \"$CODEX_CATALOG_COUNT\"\n/bin/sleep 1\n[ \"$1\" = app-server ] || exit 64\nIFS= read -r line || exit 65\nprintf '%s\\n' '{\"id\":1,\"result\":{}}'\nIFS= read -r line || exit 66\nfor id in 2 3; do\n  IFS= read -r line || exit 67\n  printf '{\"id\":%s,\"result\":{\"data\":[{\"id\":\"codex-history-%s\",\"name\":\"Historical Codex thread %s\",\"preview\":\"fallback\",\"ephemeral\":false,\"createdAt\":10,\"updatedAt\":20}],\"nextCursor\":null}}\\n' \"$id\" \"$id\" \"$id\"\ndone\n",
-        )
-        .unwrap();
-        fs::set_permissions(&codex, fs::Permissions::from_mode(0o755)).unwrap();
-        command
-            .env("PATH", &bin)
-            .env("CODEX_CATALOG_COUNT", runtime_dir.join("catalog-count"));
-    });
-    let workspace = daemon
-        .client
-        .create_workspace(
-            "codex-catalog",
-            vec![
-                ShellSpec::login("shell", &daemon.runtime_dir),
-                ShellSpec::login("other", daemon.runtime_dir.join("other")),
-            ],
-        )
-        .unwrap();
-
-    let list_started = Instant::now();
-    let output = daemon
-        .command()
-        .args(["session", "list", "--workspace", &workspace.id, "--json"])
-        .output()
-        .unwrap();
-    let list_elapsed = list_started.elapsed();
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let sessions = output["data"]["sessions"].as_array().unwrap();
-    assert_eq!(sessions.len(), 2, "{sessions:#?}");
-    assert!(sessions.iter().all(|session| {
-        session["integration"] == "codex"
-            && session["state"] == "unknown"
-            && session["occurrence_count"] == 0
-    }));
-    let session_id = sessions[0]["id"].as_str().unwrap();
-    let inspect_started = Instant::now();
-    assert!(matches!(
-        daemon
-            .client
-            .request(Request::HostService {
-                operation: protocol::HostServiceOperation::InspectAgentSession {
-                    session_id: session_id.into(),
-                },
-            })
-            .unwrap(),
-        Response::HostService {
-            result: protocol::HostServiceResult::AgentSession { .. }
-        }
-    ));
-    let inspect_elapsed = inspect_started.elapsed();
-    assert_eq!(
-        fs::read(daemon.runtime_dir.join("catalog-count")).unwrap(),
-        b"x"
-    );
-    assert!(list_elapsed >= Duration::from_millis(900));
-    assert!(
-        inspect_elapsed < Duration::from_millis(250),
-        "cached Session inspection took {inspect_elapsed:?}"
-    );
-    eprintln!(
-        "cold Session catalog took {list_elapsed:?}; cached inspection took {inspect_elapsed:?}"
-    );
-
-    daemon.stop_with_cli();
-}
-
-#[test]
-fn kiro_catalog_titles_exact_observed_session_without_projecting_history() {
-    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
-        let bin = runtime_dir.join("kiro-catalog-bin");
-        fs::create_dir(&bin).unwrap();
-        let kiro = bin.join("kiro-cli");
-        fs::write(
-            &kiro,
-            "#!/bin/sh\nprintf '%s\\0' \"$@\" > \"$KIRO_CATALOG_ARGS\"\n[ \"$1\" = chat ] || exit 64\n[ \"$2\" = --list-sessions ] || exit 65\n[ \"$3\" = --format ] || exit 66\n[ \"$4\" = json ] || exit 67\nprintf '[{\"cwd\":\"%s\",\"sessions\":[{\"sessionId\":\"kiro-observed\",\"source\":\"v3\",\"title\":\"Triage Slack issue thread\",\"executionTarget\":\"local\"},{\"sessionId\":\"kiro-history\",\"source\":\"v2\",\"title\":\"Unobserved history\"}],\"complete\":true}]\\n' \"$KIRO_CATALOG_CWD\"\n",
-        )
-        .unwrap();
-        fs::set_permissions(&kiro, fs::Permissions::from_mode(0o755)).unwrap();
-        command
-            .env("PATH", &bin)
-            .env("KIRO_CATALOG_CWD", runtime_dir)
-            .env("KIRO_CATALOG_ARGS", runtime_dir.join("kiro-catalog-args"));
-    });
-    let workspace = daemon
-        .client
-        .create_workspace(
-            "kiro-catalog",
-            vec![ShellSpec {
-                name: "kiro".into(),
-                command: vec!["/bin/sleep".into(), "300".into()],
-                cwd: daemon.runtime_dir.clone(),
-            }],
-        )
-        .unwrap();
-    let shell_id = workspace.shells[0].id.clone();
-    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
-    daemon
-        .client
-        .register_agent(
-            &shell_id,
-            &run_id,
-            AgentRegistrationSpec {
-                name: "Kiro CLI".into(),
-                integration: "kiro".into(),
-                external_session_id: Some("kiro-observed".into()),
-                report: AgentReport {
-                    state: AgentState::Inactive,
-                    authority: AgentAuthority::LifecycleIntegration,
-                    evidence: "historical Session".into(),
-                    confidence: 100,
-                },
-            },
-        )
-        .unwrap();
-
-    let output = daemon
-        .command()
-        .args(["session", "list", "--workspace", &workspace.id, "--json"])
-        .output()
-        .unwrap();
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let sessions = output["data"]["sessions"].as_array().unwrap();
-    assert_eq!(sessions.len(), 1);
-    assert_eq!(sessions[0]["integration"], "kiro");
-    assert_eq!(sessions[0]["external_session_id"], "kiro-observed");
-    assert_eq!(sessions[0]["description"], "Triage Slack issue thread");
-    assert_eq!(sessions[0]["occurrence_count"], 1);
-    assert_eq!(
-        fs::read(daemon.runtime_dir.join("kiro-catalog-args")).unwrap(),
-        b"chat\0--list-sessions\0--format\0json\0"
-    );
-
-    drop(attachment);
-    daemon.stop_with_cli();
-}
-
-#[test]
-fn pi_and_claude_titles_enrich_exact_observed_sessions_without_projecting_history() {
-    let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
-        let pi_sessions = runtime_dir.join("pi-title-sessions");
-        fs::create_dir(&pi_sessions).unwrap();
-        for (id, title) in [
-            ("pi-observed", "Named Pi session"),
-            ("pi-history", "Unobserved Pi history"),
-        ] {
-            fs::write(
-                pi_sessions.join(format!("{id}.jsonl")),
-                format!(
-                    "{{\"type\":\"session\",\"version\":3,\"id\":\"{id}\",\"cwd\":\"{}\"}}\n{{\"type\":\"session_info\",\"name\":\"{title}\"}}\n",
-                    runtime_dir.display()
-                ),
-            )
-            .unwrap();
-        }
-
-        let claude_config = runtime_dir.join("claude-title-config");
-        let encoded_directory = runtime_dir
-            .to_string_lossy()
-            .chars()
-            .map(|character| {
-                if character.is_ascii_alphanumeric() {
-                    character
-                } else {
-                    '-'
-                }
-            })
-            .collect::<String>();
-        let claude_sessions = claude_config.join("projects").join(encoded_directory);
-        fs::create_dir_all(&claude_sessions).unwrap();
-        for (id, title) in [
-            ("claude-observed", "Claude exact title"),
-            ("claude-history", "Unobserved Claude history"),
-        ] {
-            fs::write(
-                claude_sessions.join(format!("{id}.jsonl")),
-                format!(
-                    "{{\"type\":\"user\",\"sessionId\":\"{id}\",\"cwd\":\"{}\"}}\n{{\"type\":\"ai-title\",\"sessionId\":\"{id}\",\"aiTitle\":\"{title}\"}}\n",
-                    runtime_dir.display()
-                ),
-            )
-            .unwrap();
-        }
-        command
-            .env("PI_CODING_AGENT_SESSION_DIR", pi_sessions)
-            .env("CLAUDE_CONFIG_DIR", claude_config);
-    });
-    let workspace = daemon
-        .client
-        .create_workspace(
-            "title-only-hosts",
-            vec![ShellSpec {
-                name: "agents".into(),
-                command: vec!["/bin/sleep".into(), "300".into()],
-                cwd: daemon.runtime_dir.clone(),
-            }],
-        )
-        .unwrap();
-    let shell_id = workspace.shells[0].id.clone();
-    let attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
-    let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
-    for (integration, external_session_id, name) in [
-        ("pi", "pi-observed", "Pi"),
-        ("claude", "claude-observed", "Claude Code"),
-    ] {
-        daemon
-            .client
-            .register_agent(
-                &shell_id,
-                &run_id,
-                AgentRegistrationSpec {
-                    name: name.into(),
-                    integration: integration.into(),
-                    external_session_id: Some(external_session_id.into()),
-                    report: AgentReport {
-                        state: AgentState::Inactive,
-                        authority: AgentAuthority::LifecycleIntegration,
-                        evidence: "historical Session".into(),
-                        confidence: 100,
-                    },
-                },
-            )
-            .unwrap();
-    }
-
-    let output = daemon
-        .command()
-        .args(["session", "list", "--workspace", &workspace.id, "--json"])
-        .output()
-        .unwrap();
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let output: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let sessions = output["data"]["sessions"].as_array().unwrap();
-    assert_eq!(sessions.len(), 2);
-    for (integration, external_session_id, title) in [
-        ("pi", "pi-observed", "Named Pi session"),
-        ("claude", "claude-observed", "Claude exact title"),
-    ] {
-        let session = sessions
-            .iter()
-            .find(|session| session["integration"] == integration)
-            .unwrap();
-        assert_eq!(session["external_session_id"], external_session_id);
-        assert_eq!(session["description"], title);
-        assert_eq!(session["occurrence_count"], 1);
-        assert_eq!(session["state"], "inactive");
-    }
-
-    drop(attachment);
-    daemon.stop_with_cli();
-}
-
-#[test]
-fn exact_durable_session_inspection_bypasses_host_catalogs() {
+fn retired_session_host_services_do_not_invoke_catalogs() {
     let mut daemon = TestDaemon::start_with(|command, runtime_dir| {
         let bin = runtime_dir.join("slow-catalog-bin");
         fs::create_dir(&bin).unwrap();
@@ -768,39 +493,21 @@ fn exact_durable_session_inspection_bypasses_host_catalogs() {
             },
         )
         .unwrap();
-    let session_id = match daemon
-        .client
-        .request(Request::HostService {
-            operation: protocol::HostServiceOperation::ResolveAgentSession {
-                workspace_id: workspace.id,
-                agent_id: agent.id,
-            },
-        })
-        .unwrap()
-    {
-        Response::HostService {
-            result: protocol::HostServiceResult::ResolvedAgentSession { session },
-        } => session.id,
-        response => panic!("unexpected Session resolution: {response:?}"),
-    };
-
-    let started = Instant::now();
-    assert!(matches!(
-        daemon
-            .client
-            .request(Request::HostService {
-                operation: protocol::HostServiceOperation::InspectAgentSession { session_id },
-            })
-            .unwrap(),
-        Response::HostService {
-            result: protocol::HostServiceResult::AgentSession { .. }
-        }
-    ));
-    let elapsed = started.elapsed();
-    assert!(
-        elapsed < Duration::from_secs(1),
-        "exact durable Session inspection took {elapsed:?}"
-    );
+    for operation in [
+        protocol::HostServiceOperation::ListAgentSessions {
+            workspace_id: Some(workspace.id.clone()),
+        },
+        protocol::HostServiceOperation::InspectAgentSession {
+            session_id: "retired-session".into(),
+        },
+        protocol::HostServiceOperation::ResolveAgentSession {
+            workspace_id: workspace.id,
+            agent_id: agent.id,
+        },
+    ] {
+        let error = daemon.client.host_service(operation).unwrap_err();
+        assert_remote_code(&error, ErrorCode::UnsupportedVersion);
+    }
     assert!(!daemon.runtime_dir.join("catalog-invoked").exists());
 
     drop(attachment);
@@ -1782,57 +1489,6 @@ fn agent_runtime_is_revisioned_and_durable() {
         1
     );
 
-    let host_bin = daemon.runtime_dir.join("host-bin");
-    fs::create_dir(&host_bin).unwrap();
-    let terminal_resolver = host_bin.join("xdg-terminal-exec");
-    fs::write(
-        &terminal_resolver,
-        "#!/bin/sh\nif [ \"${1-}\" = --print-id ]; then printf 'test.desktop\\n'; else printf '/bin/true\\0'; fi\n",
-    )
-    .unwrap();
-    fs::set_permissions(&terminal_resolver, fs::Permissions::from_mode(0o755)).unwrap();
-    let blocked_sessions = daemon
-        .command()
-        .args(["session", "list", "--workspace", &workspace.id, "--json"])
-        .env("PATH", &host_bin)
-        .output()
-        .unwrap();
-    assert!(blocked_sessions.status.success());
-    let blocked_sessions: serde_json::Value =
-        serde_json::from_slice(&blocked_sessions.stdout).unwrap();
-    let blocked_session_id = blocked_sessions["data"]["sessions"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .find(|session| session["attentions"][0]["agent_id"] == adapter_id)
-        .and_then(|session| session["id"].as_str())
-        .expect("blocked Agent attention was not projected onto its Session");
-    let opened = daemon
-        .command()
-        .args([
-            "--terminal",
-            "test.desktop",
-            "session",
-            "open",
-            blocked_session_id,
-        ])
-        .env("PATH", &host_bin)
-        .output()
-        .unwrap();
-    assert!(
-        opened.status.success(),
-        "{}",
-        String::from_utf8_lossy(&opened.stderr)
-    );
-    assert!(
-        daemon
-            .client
-            .get_agent(&adapter_id)
-            .unwrap()
-            .attention
-            .is_none()
-    );
-
     let completion = AgentReport {
         state: AgentState::Done,
         authority: AgentAuthority::LifecycleIntegration,
@@ -1889,25 +1545,6 @@ fn agent_runtime_is_revisioned_and_durable() {
         attention["data"]["attention"][0]["observation"]["revision"],
         3
     );
-    let session_attention = daemon
-        .command()
-        .args(["session", "list", "--workspace", &workspace.id, "--json"])
-        .env("PATH", &host_bin)
-        .output()
-        .unwrap();
-    assert!(session_attention.status.success());
-    let session_attention: serde_json::Value =
-        serde_json::from_slice(&session_attention.stdout).unwrap();
-    let adapter_session = session_attention["data"]["sessions"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .find(|session| session["attentions"][0]["agent_id"] == adapter_id)
-        .expect("completed Agent attention was not projected onto its Session");
-    assert_eq!(adapter_session["attentions"][0]["reason"], "completed");
-    assert_eq!(adapter_session["attentions"][0]["observation_revision"], 3);
-    assert!(adapter_session["git_branch"].is_null());
-
     let restart = daemon
         .command()
         .args(["daemon", "restart"])
@@ -2055,140 +1692,6 @@ fn agent_runtime_is_revisioned_and_durable() {
     assert_eq!(list["command"], "agent.list");
     assert_eq!(list["data"]["agents"][0]["id"], agent_id);
     assert_eq!(list["data"]["agents"][0]["observation"]["revision"], 1);
-    let session_list = daemon
-        .command()
-        .args(["session", "list", "--workspace", &workspace.id, "--json"])
-        .env("PATH", &host_bin)
-        .output()
-        .unwrap();
-    assert!(
-        session_list.status.success(),
-        "{}",
-        String::from_utf8_lossy(&session_list.stderr)
-    );
-    let session_list: serde_json::Value = serde_json::from_slice(&session_list.stdout).unwrap();
-    assert_eq!(session_list["command"], "session.list");
-    let sessions = session_list["data"]["sessions"].as_array().unwrap();
-    assert_eq!(sessions.len(), 2);
-    assert!(
-        sessions
-            .iter()
-            .all(|session| session["workspace_id"] == workspace.id)
-    );
-    let projected = sessions
-        .iter()
-        .find(|session| session["external_session_id"] == "session-1")
-        .unwrap();
-    let session_id = projected["id"].as_str().unwrap();
-    assert_eq!(projected["description"], generated_name);
-    assert_eq!(projected["occurrence_count"], 1);
-    let workspace_revision = projected["workspace_revision"].as_u64().unwrap();
-
-    let renamed = daemon
-        .command()
-        .args([
-            "session",
-            "rename",
-            session_id,
-            "Checkout retry investigation",
-            "--revision",
-            &workspace_revision.to_string(),
-            "--json",
-        ])
-        .env("PATH", &host_bin)
-        .output()
-        .unwrap();
-    assert!(
-        renamed.status.success(),
-        "{}",
-        String::from_utf8_lossy(&renamed.stderr)
-    );
-    let renamed: serde_json::Value = serde_json::from_slice(&renamed.stdout).unwrap();
-    assert_eq!(renamed["command"], "session.rename");
-    assert_eq!(
-        renamed["data"]["result"]["user_display_name"],
-        "Checkout retry investigation"
-    );
-    assert_eq!(renamed["data"]["result"]["session_id"], session_id);
-    assert_eq!(renamed["data"]["result"]["workspace_id"], workspace.id);
-    assert_eq!(renamed["data"]["result"]["changed"], true);
-    let renamed_revision = renamed["data"]["result"]["workspace_revision"]
-        .as_u64()
-        .unwrap();
-    assert_eq!(renamed_revision, workspace_revision + 1);
-
-    let stale = daemon
-        .command()
-        .args([
-            "session",
-            "reset-name",
-            session_id,
-            "--revision",
-            &workspace_revision.to_string(),
-            "--json",
-        ])
-        .env("PATH", &host_bin)
-        .output()
-        .unwrap();
-    assert!(!stale.status.success());
-    let stale: serde_json::Value = serde_json::from_slice(&stale.stderr).unwrap();
-    assert_eq!(stale["command"], "session.reset-name");
-    assert_eq!(stale["error"]["code"], "revision_ahead");
-
-    let reset = daemon
-        .command()
-        .args([
-            "session",
-            "reset-name",
-            session_id,
-            "--revision",
-            &renamed_revision.to_string(),
-            "--json",
-        ])
-        .env("PATH", &host_bin)
-        .output()
-        .unwrap();
-    assert!(
-        reset.status.success(),
-        "{}",
-        String::from_utf8_lossy(&reset.stderr)
-    );
-    let reset: serde_json::Value = serde_json::from_slice(&reset.stdout).unwrap();
-    assert_eq!(reset["command"], "session.reset-name");
-    assert!(reset["data"]["result"]["user_display_name"].is_null());
-    assert_eq!(reset["data"]["result"]["session_id"], session_id);
-    assert_eq!(reset["data"]["result"]["changed"], true);
-
-    let session_inspect = daemon
-        .command()
-        .args(["session", "inspect", session_id, "--json"])
-        .env("PATH", &host_bin)
-        .output()
-        .unwrap();
-    assert!(session_inspect.status.success());
-    let session_inspect: serde_json::Value =
-        serde_json::from_slice(&session_inspect.stdout).unwrap();
-    assert_eq!(session_inspect["command"], "session.inspect");
-    assert_eq!(session_inspect["data"]["session"]["id"], session_id);
-    assert_eq!(
-        session_inspect["data"]["session"]["occurrences"][0]["agent_id"],
-        agent_id
-    );
-    assert_eq!(
-        session_inspect["data"]["session"]["occurrences"][0]["shell_id"],
-        shell_id
-    );
-
-    let missing_session = daemon
-        .command()
-        .args(["session", "inspect", "session-1", "--json"])
-        .output()
-        .unwrap();
-    assert!(!missing_session.status.success());
-    let missing_session: serde_json::Value =
-        serde_json::from_slice(&missing_session.stderr).unwrap();
-    assert_eq!(missing_session["command"], "session.inspect");
-    assert_eq!(missing_session["error"]["code"], "not_found");
     let inspect = daemon
         .command()
         .args(["agent", "inspect", &adapter_id])
@@ -2288,7 +1791,7 @@ fn unnamed_agent_registration_and_supervision_generate_names() {
 }
 
 #[test]
-fn session_context_survives_shell_removal_and_cold_restart() {
+fn agent_context_survives_shell_removal_and_cold_restart() {
     let mut daemon = TestDaemon::start();
     let project = daemon.runtime_dir.join("durable-source-project");
     fs::create_dir(&project).unwrap();
@@ -2393,49 +1896,6 @@ fn session_context_survives_shell_removal_and_cold_restart() {
             ))
     );
 
-    let result = daemon
-        .client
-        .host_service(protocol::HostServiceOperation::ListAgentSessions {
-            workspace_id: Some(workspace.id.clone()),
-        })
-        .unwrap();
-    let protocol::HostServiceResult::AgentSessions { sessions } = result else {
-        panic!("unexpected Session list response");
-    };
-    let projected = &sessions[0];
-    assert_eq!(
-        projected.git_branch.as_deref(),
-        Some("feat/durable-context")
-    );
-    assert_eq!(projected.working_context_count, 1);
-    assert_eq!(
-        projected.working_contexts[0].repository,
-        "durable-observed-project"
-    );
-    assert_eq!(
-        projected.working_contexts[0].branch,
-        "feat/observed-context"
-    );
-    assert_eq!(projected.working_contexts[0].push_status, None);
-    assert_eq!(
-        projected.working_contexts[0].worktree_status,
-        Some(protocol::HostGitWorktreeStatus {
-            staged: true,
-            unstaged_or_untracked: true,
-        })
-    );
-    let operation_id = Uuid::new_v4().to_string();
-    let session_id = projected.id.clone();
-    let expected_revision = projected.workspace_revision;
-    let accepted = daemon
-        .client
-        .set_agent_session_display_name(
-            operation_id.clone(),
-            session_id.clone(),
-            expected_revision,
-            Some("Durable investigation".into()),
-        )
-        .unwrap();
     daemon
         .client
         .rename_workspace(&workspace.id, "renamed-durable-source")
@@ -2449,79 +1909,15 @@ fn session_context_survives_shell_removal_and_cold_restart() {
 
     let restored_agent = daemon.client.get_agent(&agent.id).unwrap();
     assert_eq!(restored_agent.working_contexts, observed.working_contexts);
-
-    let replayed = daemon
-        .client
-        .set_agent_session_display_name(
-            operation_id,
-            session_id,
-            expected_revision,
-            Some("Durable investigation".into()),
-        )
-        .unwrap();
-    assert_eq!(replayed, accepted);
-
-    let sessions = daemon
-        .command()
-        .args(["session", "list", "--workspace", &workspace.id, "--json"])
-        .output()
-        .unwrap();
-    assert!(sessions.status.success());
-    let sessions: serde_json::Value = serde_json::from_slice(&sessions.stdout).unwrap();
     assert_eq!(
-        sessions["data"]["sessions"][0]["description"],
-        "Durable investigation"
+        restored_agent.external_session_id,
+        agent.external_session_id
     );
+    assert_eq!(restored_agent.cwd, agent.cwd);
     assert_eq!(
-        sessions["data"]["sessions"][0]["user_display_name"],
-        "Durable investigation"
-    );
-    assert_eq!(
-        sessions["data"]["sessions"][0]["workspace_name"],
+        daemon.client.get_workspace(&workspace.id).unwrap().name,
         "renamed-durable-source"
     );
-    assert_eq!(sessions["data"]["sessions"][0]["working_context_count"], 1);
-    assert_eq!(
-        sessions["data"]["sessions"][0]["working_contexts"][0]["repository"],
-        "durable-observed-project"
-    );
-    assert_eq!(
-        sessions["data"]["sessions"][0]["working_contexts"][0]["branch"],
-        "feat/observed-context"
-    );
-    assert_eq!(
-        sessions["data"]["sessions"][0]["working_contexts"][0]["worktree_status"]["staged"],
-        true
-    );
-    assert_eq!(
-        sessions["data"]["sessions"][0]["working_contexts"][0]["worktree_status"]["unstaged_or_untracked"],
-        true
-    );
-    let protocol_fifty = versioned_raw_request(
-        &daemon.client,
-        50,
-        Request::HostService {
-            operation: protocol::HostServiceOperation::ListAgentSessions {
-                workspace_id: Some(workspace.id.clone()),
-            },
-        },
-    );
-    let old_context = &protocol_fifty.message["result"]["sessions"][0]["working_contexts"][0];
-    assert_eq!(protocol_fifty.version, 50);
-    assert!(old_context.get("push_status").is_none());
-    assert!(old_context.get("worktree_status").is_none());
-    let session_id = sessions["data"]["sessions"][0]["id"].as_str().unwrap();
-    let inspect = daemon
-        .command()
-        .args(["session", "inspect", session_id, "--json"])
-        .output()
-        .unwrap();
-    assert!(inspect.status.success());
-    let inspect: serde_json::Value = serde_json::from_slice(&inspect.stdout).unwrap();
-    let occurrence = &inspect["data"]["session"]["occurrences"][0];
-    assert!(occurrence["retained_shell_name"].is_null());
-    assert!(occurrence["retained_shell_cwd"].is_null());
-    assert_eq!(occurrence["source_cwd"], project.display().to_string());
 }
 
 #[test]
@@ -2739,7 +2135,7 @@ fn cold_recovery_presents_resumable_agent() {
 }
 
 #[test]
-fn session_hide_is_durable_non_destructive_and_protocol_scoped() {
+fn legacy_session_access_is_typed_unsupported_and_non_destructive() {
     let mut daemon = TestDaemon::start();
     let workspace = daemon
         .client
@@ -2773,74 +2169,15 @@ fn session_hide_is_durable_non_destructive_and_protocol_scoped() {
             },
         )
         .unwrap();
-    let protocol::HostServiceResult::AgentSessions { sessions } = daemon
-        .client
-        .host_service(protocol::HostServiceOperation::ListAgentSessions {
-            workspace_id: Some(workspace.id.clone()),
-        })
-        .unwrap()
-    else {
-        panic!("unexpected Session list response");
-    };
-    let session_id = sessions[0].id.clone();
-    assert!(matches!(
-        versioned_request(
-            &daemon.client,
-            50,
-            Request::HideAgentSession {
-                operation_id: Uuid::new_v4().to_string(),
-                session_id: session_id.clone(),
-                workspace_id: workspace.id.clone(),
-                expected_workspace_revision: sessions[0].workspace_revision,
-            },
-        ),
-        Response::Error {
-            code: Some(ErrorCode::UnsupportedVersion),
-            ..
-        }
-    ));
-    let cursor = daemon.client.events(None, 256, 0).unwrap().cursor;
-
-    let hidden = daemon
-        .command()
-        .args([
-            "session",
-            "hide",
-            &session_id,
-            "--workspace",
-            &workspace.id,
-            "--json",
-        ])
-        .output()
-        .unwrap();
-    assert!(
-        hidden.status.success(),
-        "{}",
-        String::from_utf8_lossy(&hidden.stderr)
-    );
-    let hidden: serde_json::Value = serde_json::from_slice(&hidden.stdout).unwrap();
-    assert_eq!(hidden["command"], "session.hide");
-    assert_eq!(hidden["data"]["result"]["session_id"], session_id);
-    assert_eq!(hidden["data"]["result"]["workspace_id"], workspace.id);
-    assert_eq!(hidden["data"]["result"]["changed"], true);
-    let hidden_revision = hidden["data"]["result"]["workspace_revision"]
-        .as_u64()
-        .unwrap();
-
-    let protocol::HostServiceResult::AgentSessions { sessions } = daemon
-        .client
-        .host_service(protocol::HostServiceOperation::ListAgentSessions {
-            workspace_id: Some(workspace.id.clone()),
-        })
-        .unwrap()
-    else {
-        panic!("unexpected Session list response");
-    };
-    assert!(sessions.is_empty());
     for request in [
         Request::HostService {
+            operation: protocol::HostServiceOperation::ListAgentSessions {
+                workspace_id: Some(workspace.id.clone()),
+            },
+        },
+        Request::HostService {
             operation: protocol::HostServiceOperation::InspectAgentSession {
-                session_id: session_id.clone(),
+                session_id: "retired-session".into(),
             },
         },
         Request::HostService {
@@ -2850,116 +2187,33 @@ fn session_hide_is_durable_non_destructive_and_protocol_scoped() {
             },
         },
         Request::ResumeAgentSession {
-            session_id: session_id.clone(),
+            session_id: "retired-session".into(),
             profile: profile(),
         },
     ] {
         assert!(matches!(
-            versioned_request(&daemon.client, 51, request),
+            versioned_request(&daemon.client, protocol::PROTOCOL_VERSION, request),
             Response::Error {
-                code: Some(ErrorCode::NotFound),
+                code: Some(ErrorCode::UnsupportedVersion),
                 ..
             }
         ));
     }
 
-    let Response::HostService {
-        result: protocol::HostServiceResult::AgentSessions { sessions },
-    } = versioned_request(
-        &daemon.client,
-        50,
-        Request::HostService {
-            operation: protocol::HostServiceOperation::ListAgentSessions {
-                workspace_id: Some(workspace.id.clone()),
-            },
-        },
-    )
-    else {
-        panic!("unexpected protocol-50 Session list response");
-    };
-    assert_eq!(sessions.len(), 1);
-    assert!(matches!(
-        versioned_request(
-            &daemon.client,
-            50,
-            Request::HostService {
-                operation: protocol::HostServiceOperation::InspectAgentSession {
-                    session_id: session_id.clone(),
-                },
-            },
-        ),
-        Response::HostService {
-            result: protocol::HostServiceResult::AgentSession { .. }
-        }
-    ));
-
-    let current_events = daemon.client.events(Some(cursor.clone()), 256, 0).unwrap();
-    assert!(current_events.events.iter().any(|event| matches!(
-        event.kind,
-        protocol::DaemonEventKind::AgentSessionHidden { .. }
-    )));
-    let Response::Events {
-        cursor: old_cursor,
-        events: old_events,
-        ..
-    } = versioned_request(
-        &daemon.client,
-        50,
-        Request::Events {
-            after: Some(cursor),
-            limit: 256,
-            wait_ms: 0,
-        },
-    )
-    else {
-        panic!("unexpected protocol-50 events response");
-    };
-    assert_eq!(old_cursor, current_events.cursor);
-    assert!(old_events.is_empty());
+    for arguments in [
+        vec!["session", "list", "--json"],
+        vec!["session", "inspect", "retired-session", "--json"],
+    ] {
+        let output = daemon.command().args(arguments).output().unwrap();
+        assert!(!output.status.success());
+        let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error"]["code"], "unsupported_version");
+    }
     assert_eq!(daemon.client.get_agent(&agent.id).unwrap(), agent);
-    let shell = daemon.client.get_shell(&shell_id).unwrap();
-    assert_eq!(
-        shell.run.as_ref().map(|run| run.id.as_str()),
-        Some(run_id.as_str())
-    );
-
-    let repeated = daemon
-        .command()
-        .args([
-            "session",
-            "hide",
-            &session_id,
-            "--workspace",
-            &workspace.id,
-            "--json",
-        ])
-        .output()
-        .unwrap();
-    assert!(repeated.status.success());
-    let repeated: serde_json::Value = serde_json::from_slice(&repeated.stdout).unwrap();
-    assert_eq!(repeated["data"]["result"]["changed"], false);
-    assert_eq!(
-        repeated["data"]["result"]["workspace_revision"],
-        hidden_revision
-    );
-
-    let persisted = fs::read_to_string(daemon.runtime_dir.join("state/boomux/state.json")).unwrap();
-    assert!(persisted.contains("\"version\": 17"));
-    assert!(persisted.contains("\"hidden_sessions\""));
     drop(attachment);
     daemon.crash();
     daemon.restart();
-    let protocol::HostServiceResult::AgentSessions { sessions } = daemon
-        .client
-        .host_service(protocol::HostServiceOperation::ListAgentSessions {
-            workspace_id: Some(workspace.id.clone()),
-        })
-        .unwrap()
-    else {
-        panic!("unexpected restored Session list response");
-    };
-    assert!(sessions.is_empty());
-    assert_eq!(daemon.client.get_agent(&agent.id).unwrap().id, agent.id);
+    assert_eq!(daemon.client.get_agent(&agent.id).unwrap(), agent);
 
     daemon.stop_with_cli();
 }
@@ -2979,18 +2233,4 @@ fn versioned_request(
         protocol::read_message(&mut stream).unwrap();
     assert_eq!(response.version, version);
     response.message
-}
-
-fn versioned_raw_request(
-    client: &Client,
-    version: u32,
-    request: protocol::Request,
-) -> protocol::Envelope<serde_json::Value> {
-    let mut stream = UnixStream::connect(client.socket_path()).unwrap();
-    protocol::write_message(
-        &mut stream,
-        &protocol::Envelope::with_version(version, request),
-    )
-    .unwrap();
-    protocol::read_message(&mut stream).unwrap()
 }

--- a/tests/native_backend/daemon_lifecycle.rs
+++ b/tests/native_backend/daemon_lifecycle.rs
@@ -83,7 +83,6 @@ fn native_daemon_lifecycle() {
         "integration.status",
         "integration.install",
         "integration.verify",
-        "session.hide",
     ] {
         assert!(json_commands.iter().any(|current| current == command));
     }
@@ -91,6 +90,12 @@ fn native_daemon_lifecycle() {
         "opencode.claim.ensure",
         "opencode.claim.release",
         "opencode.claim.report",
+        "session.list",
+        "session.inspect",
+        "session.open",
+        "session.rename",
+        "session.reset-name",
+        "session.hide",
     ] {
         assert!(!json_commands.iter().any(|current| current == command));
     }
@@ -124,7 +129,6 @@ fn native_daemon_lifecycle() {
         "protocol_42",
         "protocol_47",
         "protocol_51",
-        "workspace_session_hiding",
         "opencode_shared_runtime_claims",
         "node_registration_management",
         "node_projection_sync",
@@ -139,8 +143,6 @@ fn native_daemon_lifecycle() {
         "remote_project_discovery",
         "remote_launcher_invocation",
         "remote_integration_management",
-        "remote_agent_session_catalog",
-        "remote_exact_session_resume",
         "global_workspaces",
         "multi_node_workspace_placements",
         "guarded_workspace_adoption",

--- a/tests/native_backend/remote_host_services.rs
+++ b/tests/native_backend/remote_host_services.rs
@@ -1,15 +1,14 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 use boomux::protocol::{
-    AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, AttachFrame,
-    HostServiceIntegrationAction, HostServiceOperation, HostServiceResult, RoutedOperation,
-    RoutedOperationResult, ShellSpec, WorkspaceLauncherSpec,
+    AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, ErrorCode,
+    HostServiceIntegrationAction, HostServiceOperation, HostServiceResult, ShellSpec,
+    WorkspaceLauncherSpec,
 };
 
-use crate::support::{CONTROL_MASTER_PREFIX, TestDaemon, profile, wait_until};
+use crate::support::{CONTROL_MASTER_PREFIX, TestDaemon, assert_remote_code, profile, wait_until};
 
 #[test]
 fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv() {
@@ -41,27 +40,6 @@ fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv(
     )
     .unwrap();
     fs::set_permissions(&launcher, fs::Permissions::from_mode(0o700)).unwrap();
-    let resume_output = root.join("owner-resume-output");
-    let pi = owner_bin.join("pi");
-    fs::write(
-        &pi,
-        format!(
-            "#!/bin/sh\nprintf '%s\\n%s\\n%s\\n' \"$1\" \"$2\" \"$PWD\" > '{}'\nprintf 'owner resume\\n'\n",
-            resume_output.display()
-        ),
-    )
-    .unwrap();
-    fs::set_permissions(&pi, fs::Permissions::from_mode(0o700)).unwrap();
-    let pi_sessions = root.join("owner-pi-sessions");
-    fs::create_dir(&pi_sessions).unwrap();
-    fs::write(
-        pi_sessions.join("owner-session.jsonl"),
-        format!(
-            "{{\"type\":\"session\",\"version\":3,\"id\":\"pi-exact; touch local-session-pwned\",\"cwd\":\"{}\"}}\n{{\"type\":\"session_info\",\"name\":\"Owner Pi title\"}}\n",
-            owner_projects.join("remote-only").display()
-        ),
-    )
-    .unwrap();
     let kiro = owner_bin.join("kiro-cli");
     fs::write(&kiro, "#!/bin/sh\nexit 1\n").unwrap();
     fs::set_permissions(&kiro, fs::Permissions::from_mode(0o700)).unwrap();
@@ -71,7 +49,6 @@ fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv(
         command
             .env("PATH", &owner_path)
             .env("BOOMUX_CONFIG", &owner_config)
-            .env("PI_CODING_AGENT_SESSION_DIR", &pi_sessions)
             .env("HOME", root.join("owner-home"));
     });
     let owner_id = owner.client.node_identity().unwrap();
@@ -191,68 +168,29 @@ fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv(
             },
         )
         .unwrap();
-    let current_sessions = local
+    for operation in [
+        HostServiceOperation::ListAgentSessions {
+            workspace_id: Some(session_workspace.id.clone()),
+        },
+        HostServiceOperation::InspectAgentSession {
+            session_id: "retired-session".into(),
+        },
+        HostServiceOperation::ResolveAgentSession {
+            workspace_id: session_workspace.id.clone(),
+            agent_id: agent.id.clone(),
+        },
+    ] {
+        let error = local
+            .client
+            .route_node_host_service(&owner_id, operation)
+            .unwrap_err();
+        assert_remote_code(&error, ErrorCode::UnsupportedVersion);
+    }
+    let error = local
         .client
-        .route_node_host_service(
-            &owner_id,
-            HostServiceOperation::ListAgentSessions {
-                workspace_id: Some(session_workspace.id.clone()),
-            },
-        )
-        .unwrap();
-    let HostServiceResult::AgentSessions {
-        sessions: current_sessions,
-    } = current_sessions
-    else {
-        panic!("unexpected current Agent Session response");
-    };
-    assert_eq!(current_sessions.len(), 1);
-    assert!(current_sessions[0].state_is_current);
-    assert_eq!(current_sessions[0].description, "Owner Pi title");
-    let current_inspection = local
-        .client
-        .route_node_host_service(
-            &owner_id,
-            HostServiceOperation::InspectAgentSession {
-                session_id: current_sessions[0].id.clone(),
-            },
-        )
-        .unwrap();
-    let HostServiceResult::AgentSession {
-        session: current_inspection,
-    } = current_inspection
-    else {
-        panic!("unexpected current Agent Session inspection response");
-    };
-    assert_eq!(current_inspection.occurrences.len(), 1);
-    assert_eq!(current_inspection.occurrences[0].shell_id, shell_id);
-    assert_eq!(current_inspection.occurrences[0].run_id, run_id);
-    let renamed = local
-        .client
-        .route_node_operation(
-            &owner_id,
-            RoutedOperation::SetAgentSessionDisplayName {
-                operation_id: uuid::Uuid::new_v4().to_string(),
-                session_id: current_sessions[0].id.clone(),
-                expected_workspace_revision: current_sessions[0].workspace_revision,
-                display_name: Some("Remote owner name".into()),
-            },
-        )
-        .unwrap();
-    let RoutedOperationResult::AgentSessionDisplayName { outcome: renamed } = renamed else {
-        panic!("unexpected routed Session display-name response");
-    };
-    assert_eq!(
-        renamed.user_display_name.as_deref(),
-        Some("Remote owner name")
-    );
-    assert_eq!(
-        renamed.workspace_revision,
-        current_sessions[0].workspace_revision + 1
-    );
-    assert_eq!(renamed.session_id, current_sessions[0].id);
-    assert_eq!(renamed.workspace_id, session_workspace.id);
-    assert!(renamed.changed);
+        .resume_agent_session(Some(&owner_id), "retired-session", profile())
+        .unwrap_err();
+    assert_remote_code(&error, ErrorCode::UnsupportedVersion);
     assert!(local.client.snapshot().unwrap().workspaces.is_empty());
     owner
         .client
@@ -267,104 +205,14 @@ fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv(
             },
         )
         .unwrap();
-    let sessions = local
-        .client
-        .route_node_host_service(
-            &owner_id,
-            HostServiceOperation::ListAgentSessions {
-                workspace_id: Some(session_workspace.id.clone()),
-            },
-        )
-        .unwrap();
-    let HostServiceResult::AgentSessions { sessions } = sessions else {
-        panic!("unexpected Agent Session response");
-    };
-    assert_eq!(sessions.len(), 1);
-    let mut resumed = local
-        .client
-        .resume_agent_session(Some(&owner_id), &sessions[0].id, profile())
-        .unwrap();
-    let mut terminal_output = Vec::new();
-    loop {
-        match AttachFrame::read_from(&mut resumed.stream).unwrap() {
-            AttachFrame::Output(bytes) => terminal_output.extend(bytes),
-            AttachFrame::Detached => break,
-            _ => {}
-        }
-    }
-    assert!(String::from_utf8_lossy(&terminal_output).contains("owner resume"));
+    let recovered_agent = owner.client.get_agent(&agent.id).unwrap();
     assert_eq!(
-        fs::read_to_string(&resume_output).unwrap(),
-        format!(
-            "--session\n{}\n{}\n",
-            hostile_session_id,
-            owner_projects.join("remote-only").display(),
-        )
+        recovered_agent.external_session_id.as_deref(),
+        Some(hostile_session_id)
     );
-    assert!(!root.join("local-session-pwned").exists());
+    assert_eq!(recovered_agent.observation.state, AgentState::Inactive);
     assert!(local.client.snapshot().unwrap().workspaces.is_empty());
     drop(owner_attachment);
-
-    let hidden = local
-        .client
-        .route_node_operation(
-            &owner_id,
-            RoutedOperation::HideAgentSession {
-                operation_id: uuid::Uuid::new_v4().to_string(),
-                session_id: sessions[0].id.clone(),
-                workspace_id: session_workspace.id.clone(),
-                expected_workspace_revision: sessions[0].workspace_revision,
-            },
-        )
-        .unwrap();
-    assert!(matches!(
-        hidden,
-        RoutedOperationResult::AgentSessionHidden { ref outcome } if outcome.changed
-    ));
-    assert!(
-        local
-            .client
-            .resume_agent_session(Some(&owner_id), &sessions[0].id, profile())
-            .is_err()
-    );
-    let HostServiceResult::AgentSessions { sessions: current } = local
-        .client
-        .route_node_host_service(
-            &owner_id,
-            HostServiceOperation::ListAgentSessions {
-                workspace_id: Some(session_workspace.id.clone()),
-            },
-        )
-        .unwrap()
-    else {
-        panic!("unexpected hidden Agent Session response");
-    };
-    assert!(current.is_empty());
-
-    let mut stream = UnixStream::connect(local.client.socket_path()).unwrap();
-    boomux::protocol::write_message(
-        &mut stream,
-        &boomux::protocol::Envelope::with_version(
-            50,
-            boomux::protocol::Request::RouteNodeHostService {
-                node_id: owner_id.clone(),
-                operation: HostServiceOperation::ListAgentSessions {
-                    workspace_id: Some(session_workspace.id.clone()),
-                },
-            },
-        ),
-    )
-    .unwrap();
-    let response: boomux::protocol::Envelope<boomux::protocol::Response> =
-        boomux::protocol::read_message(&mut stream).unwrap();
-    let boomux::protocol::Response::HostService {
-        result: HostServiceResult::AgentSessions { sessions: old },
-    } = response.message
-    else {
-        panic!("unexpected protocol-50 remote Session response");
-    };
-    assert_eq!(response.version, 50);
-    assert_eq!(old.len(), 1);
 
     let preview = local
         .client


### PR DESCRIPTION
## Summary

- retire the public Agent Session CLI, TUI, capabilities, and daemon operations
- preserve protocol-51 decoding, schema-17 compatibility, external Agent lifecycle identity, and cold recovery
- stop supported dashboard paths from inspecting provider history catalogs and document the staged retirement in ADR 0014

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --lib --bins --locked -- --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`
- benchmark smoke and Bun integration suites

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>