### PR TITLE
ci(release): update omarchy compatibility pin

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -233,7 +233,7 @@ jobs:
       - publish-release
     permissions:
       contents: read
-    uses: gardnmi/omarchy-boomux/.github/workflows/boomux-compatibility.yml@6c26ce52c5dbfad6185037b374d98d0933f4b8fe
+    uses: gardnmi/omarchy-boomux/.github/workflows/boomux-compatibility.yml@77a25abfc294bd101901d743c5153e3a13608d20
     with:
       boomux_tag: ${{ needs.release-please.outputs.tag-name }}
-      plugin_ref: 6c26ce52c5dbfad6185037b374d98d0933f4b8fe
+      plugin_ref: 77a25abfc294bd101901d743c5153e3a13608d20


### PR DESCRIPTION
## Summary

- pin the Boomux release compatibility job to released `omarchy-boomux v2.8.1` commit `77a25ab`
- update the reusable workflow ref and `plugin_ref` together
- validate against the post-Session-retirement plugin contract instead of the obsolete `exact_session_open` requirement

## Validation

- `bun test tests/compatibility.test.js` in `omarchy-boomux@77a25ab`
- `bash scripts/test-boomux-releases.sh v1.9.1` in `omarchy-boomux@77a25ab`
- Boomux 1.7.0 and 1.9.1 both satisfy the pinned contract
- `git diff --check`

After merge, manually dispatch the Release Please workflow with tag `v1.9.1` to recover the failed post-release compatibility job.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>