### PR TITLE
fix(codex): clear cached bash command paths

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1112,9 +1112,11 @@ and exports `BOOMUX_CODEX_RUN_SCOPED=1`. Option-led invocations including
 explicit `--remote`, other Codex subcommands, an absent or modified installation,
 and use outside Boomux remain untracked. An exact configured primary executable
 is forwarded through `BOOMUX_REAL_CODEX`; typing an absolute path in a login
-Shell bypasses the scoped shim. Hooks silently do nothing unless the run-scoped
-marker and exact `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID` are present. An explicitly
-remote TUI therefore cannot claim authority inherited from its app-server.
+Shell bypasses the scoped shim. Bash startup clears cached executable paths after
+reasserting the shim-first `PATH`, so a prior direct Codex resolution cannot bypass
+the scoped launcher. Hooks silently do nothing unless the run-scoped marker and
+exact `BOOMUX_SHELL_ID` and `BOOMUX_RUN_ID` are present. An explicitly remote TUI
+therefore cannot claim authority inherited from its app-server.
 
 Codex hook `session_id` is the canonical thread identity and ensures the exact
 `(codex, thread, shell, run)` Agent key. SessionStart reports Idle, except compact

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -161,6 +161,7 @@ done
 BOOMUX_ORIGINAL_PATH="$(IFS=:; printf '%s' "${_boomux_filtered[*]}")"
 PATH="$BOOMUX_OPENCODE_SHIM_DIR${BOOMUX_ORIGINAL_PATH:+:$BOOMUX_ORIGINAL_PATH}"
 export BOOMUX_ORIGINAL_PATH PATH
+builtin hash -r
 unset _boomux_entry _boomux_filtered _boomux_path
 "#;
 const OPENCODE_ZSH_ENV: &[u8] = br#"if [[ -r "$BOOMUX_USER_ZDOTDIR/.zshenv" ]]; then
@@ -18064,6 +18065,11 @@ mod tests {
                     .contains("BOOMUX_OPENCODE_SHIM_DIR")
             );
         }
+        assert!(
+            std::str::from_utf8(OPENCODE_BASH_RC)
+                .unwrap()
+                .contains("builtin hash -r")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- clear Bash's executable cache after reasserting Boomux's shim-first PATH
- retain exact ShellRun lifecycle authority for normally launched Codex sessions
- document and regression-test the startup adapter behavior

## Validation
- cargo test --lib common_shell_startup_adapters_reassert_the_scoped_shim_after_user_config --locked -- --test-threads=1
- cargo test --test native_backend bare_codex_typed_in_managed_login_shell_uses_run_scoped_hooks --locked -- --test-threads=1
- cargo test --test native_backend bare_codex_command_uses_run_scoped_hooks_without_rewriting_stored_argv --locked -- --test-threads=1
- cargo fmt --all -- --check
- git diff --check