### PR TITLE
feat(omp): add Oh My Pi lifecycle integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Run integration tests
         if: env.RUN_CODE == 'true'
-        run: bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
+        run: bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js integrations/omp/boomux.test.js
 
   release-packaging:
     name: Release packaging (${{ matrix.arch }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ cargo check --benches --all-features --locked
 cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
 cargo bench --bench wire --locked -- --test
 cargo deny check
-bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
+bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js integrations/omp/boomux.test.js
 ```
 
 Run the narrowest relevant tests while iterating, then run the complete set

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -168,7 +168,8 @@ Run the integration reducers with:
 ```console
 bun test integrations/opencode/boomux.test.js \
   integrations/opencode/boomux-tui.test.js \
-  integrations/pi/boomux.test.js
+  integrations/pi/boomux.test.js \
+  integrations/omp/boomux.test.js
 ```
 
 ## Performance Benchmarks
@@ -204,7 +205,7 @@ cargo check --benches --all-features --locked
 cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
 cargo bench --bench wire --locked -- --test
 cargo deny check
-bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
+bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js integrations/omp/boomux.test.js
 ```
 
 Pull requests that modify only Markdown skip code, dependency, integration, and

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -378,6 +378,7 @@ Command payloads are:
   time. Protocol-38 responses also include exact `node_id` for local and routed
   owners; older local responses omit it.
 - `shell.inspect`: one `shell` object.
+- `shell.rename`: exact `shell_id` plus the applied `name`.
 - `launcher.list`: workspace identity plus a `launchers` array.
 - `launcher.inspect`: one `launcher` object.
 - `agent.list`: an `agents` array, optionally limited by `--workspace`.

--- a/integrations/omp/boomux.test.js
+++ b/integrations/omp/boomux.test.js
@@ -1,0 +1,625 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import BoomuxOmpExtension, { __internal } from "./boomux.ts";
+
+const HANDLER_KEYS = [
+  "session_start",
+  "session_switch",
+  "agent_start",
+  "tool_approval_requested",
+  "tool_approval_resolved",
+  "tool_execution_start",
+  "tool_execution_end",
+  "agent_end",
+  "agent_settled",
+  "session_shutdown",
+];
+
+function agent(id, state, evidence) {
+  return {
+    data: {
+      agent: {
+        id,
+        ended_at_ms: null,
+        observation: {
+          state,
+          authority: "lifecycle_integration",
+          evidence,
+          confidence: 100,
+        },
+      },
+    },
+  };
+}
+
+function context(sessionID, extras = {}) {
+  return {
+    hasUI: Object.hasOwn(extras, "hasUI") ? extras.hasUI : true,
+    cwd: extras.cwd,
+    isIdle: extras.isIdle,
+    sessionManager: {
+      getSessionId: () => sessionID,
+    },
+  };
+}
+
+function withBoomuxEnv(env, fn) {
+  const previousShell = process.env.BOOMUX_SHELL_ID;
+  const previousRun = process.env.BOOMUX_RUN_ID;
+  try {
+    if (env.BOOMUX_SHELL_ID === undefined) delete process.env.BOOMUX_SHELL_ID;
+    else process.env.BOOMUX_SHELL_ID = env.BOOMUX_SHELL_ID;
+    if (env.BOOMUX_RUN_ID === undefined) delete process.env.BOOMUX_RUN_ID;
+    else process.env.BOOMUX_RUN_ID = env.BOOMUX_RUN_ID;
+    return fn();
+  } finally {
+    if (previousShell === undefined) delete process.env.BOOMUX_SHELL_ID;
+    else process.env.BOOMUX_SHELL_ID = previousShell;
+    if (previousRun === undefined) delete process.env.BOOMUX_RUN_ID;
+    else process.env.BOOMUX_RUN_ID = previousRun;
+  }
+}
+
+function createClock() {
+  let now = 0;
+  let nextId = 1;
+  const timers = new Map();
+  return {
+    now: () => now,
+    setTimeout(fn, ms) {
+      const id = nextId++;
+      timers.set(id, { fn, due: now + ms });
+      return id;
+    },
+    clearTimeout(id) {
+      timers.delete(id);
+    },
+    advance(ms) {
+      now += ms;
+      const due = [...timers.entries()].filter(([, timer]) => timer.due <= now);
+      for (const [id, timer] of due) {
+        timers.delete(id);
+        timer.fn();
+      }
+    },
+  };
+}
+
+function installHandlers(lifecycle, options = {}) {
+  const handlers = new Map();
+  const clock = options.clock ?? createClock();
+  __internal.registerLifecycleHandlers(
+    { on: (event, handler) => handlers.set(event, handler) },
+    lifecycle,
+    {
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+      idleDebounceMs: options.idleDebounceMs ?? 25,
+      retryGraceMs: options.retryGraceMs ?? 50,
+      log: options.log ?? (() => {}),
+    },
+  );
+  return { handlers, clock };
+}
+
+function recordingLifecycle() {
+  const calls = [];
+  return {
+    calls,
+    enqueue: async (...values) => {
+      calls.push(values);
+    },
+    enqueueContexts: async () => {},
+  };
+}
+
+function states(calls) {
+  return calls.map((argv) => argv[argv.indexOf("--state") + 1]);
+}
+
+describe("OMP lifecycle", () => {
+  test("registers no handlers unless both Boomux env vars are set", () => {
+    const cases = [
+      {},
+      { BOOMUX_SHELL_ID: "shell-1" },
+      { BOOMUX_RUN_ID: "run-1" },
+    ];
+    for (const env of cases) {
+      const handlers = new Map();
+      withBoomuxEnv(env, () => {
+        BoomuxOmpExtension({
+          on: (event, handler) => handlers.set(event, handler),
+        });
+      });
+      expect([...handlers.keys()]).toEqual([]);
+    }
+  });
+
+  test("registers the Task 3 lifecycle handler set", () => {
+    const handlers = new Map();
+    withBoomuxEnv(
+      { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      () => {
+        BoomuxOmpExtension({
+          on: (event, handler) => handlers.set(event, handler),
+        });
+      },
+    );
+    expect([...handlers.keys()]).toEqual(HANDLER_KEYS);
+  });
+
+  test("first CLI call ensures omp with the external session id", async () => {
+    const calls = [];
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        return argv[2] === "ensure"
+          ? agent(
+              "agent-1",
+              argv[argv.indexOf("--state") + 1],
+              argv[argv.indexOf("--evidence") + 1],
+            )
+          : { data: { ok: true } };
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue("session-1", "idle", "Oh My Pi session idle");
+
+    expect(calls[0].slice(0, 8)).toEqual([
+      "boomux",
+      "agent",
+      "ensure",
+      "omp",
+      "--integration",
+      "omp",
+      "--external-session-id",
+      "session-1",
+    ]);
+  });
+
+  test("reports idle working settled and inactive states", async () => {
+    const calls = [];
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        return argv[2] === "ensure"
+          ? agent(
+              "agent-1",
+              argv[argv.indexOf("--state") + 1],
+              argv[argv.indexOf("--evidence") + 1],
+            )
+          : { data: { ok: true } };
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue("session-1", "idle", "Oh My Pi session idle");
+    await lifecycle.enqueue("session-1", "working", "Oh My Pi agent working");
+    await lifecycle.enqueue("session-1", "idle", "Oh My Pi agent settled");
+    await lifecycle.enqueue("session-1", "inactive", "Oh My Pi session inactive");
+
+    expect(states(calls.slice(1))).toEqual(["working", "idle", "inactive"]);
+    expect(states(calls).includes("done")).toBe(false);
+    expect(calls.every((argv) => argv.includes("--json"))).toBe(true);
+  });
+
+  test("session_start without hasUI does not report", async () => {
+    const lifecycle = recordingLifecycle();
+    const { handlers } = installHandlers(lifecycle);
+
+    await handlers.get("session_start")(
+      { type: "session_start" },
+      context("session-1", { hasUI: false }),
+    );
+    await handlers.get("session_start")(
+      { type: "session_start" },
+      context("session-1", { hasUI: undefined }),
+    );
+
+    expect(lifecycle.calls).toEqual([]);
+  });
+
+  test("maps idle working idle inactive through handlers without done", async () => {
+    const lifecycle = recordingLifecycle();
+    const { handlers } = installHandlers(lifecycle);
+    const ctx = context("session-1");
+
+    await handlers.get("session_start")({ type: "session_start" }, ctx);
+    await handlers.get("agent_start")({ type: "agent_start" }, ctx);
+    handlers.get("agent_end")(
+      { type: "agent_end", messages: [{ role: "assistant", stopReason: "stop" }] },
+      ctx,
+    );
+    await handlers.get("agent_settled")({ type: "agent_settled" }, ctx);
+    await handlers.get("session_shutdown")({ type: "session_shutdown" }, ctx);
+
+    expect(lifecycle.calls.map((call) => call[1])).toEqual([
+      "idle",
+      "working",
+      "idle",
+      "inactive",
+    ]);
+    expect(lifecycle.calls.at(-1).slice(0, 4)).toEqual([
+      "session-1",
+      "inactive",
+      "Oh My Pi session inactive",
+      2,
+    ]);
+    expect(lifecycle.calls.some((call) => call[1] === "done")).toBe(false);
+  });
+
+  test("blocks on tool approval then restores the prior state", async () => {
+    const lifecycle = recordingLifecycle();
+    const { handlers } = installHandlers(lifecycle);
+    const ctx = context("session-1");
+
+    await handlers.get("session_start")({ type: "session_start" }, ctx);
+    await handlers.get("agent_start")({ type: "agent_start" }, ctx);
+    await handlers.get("tool_approval_requested")(
+      { type: "tool_approval_requested", toolName: "bash", reason: "needs approval" },
+      ctx,
+    );
+    await handlers.get("tool_approval_resolved")(
+      { type: "tool_approval_resolved" },
+      ctx,
+    );
+
+    expect(lifecycle.calls.map((call) => [call[1], call[2]])).toEqual([
+      ["idle", "Oh My Pi session idle"],
+      ["working", "Oh My Pi agent working"],
+      ["blocked", "needs approval"],
+      ["working", "Oh My Pi agent working"],
+    ]);
+  });
+
+  test("retryable agent_end stays working then becomes blocked", async () => {
+    const lifecycle = recordingLifecycle();
+    const { handlers, clock } = installHandlers(lifecycle, {
+      idleDebounceMs: 25,
+      retryGraceMs: 50,
+    });
+    const ctx = context("session-1");
+
+    await handlers.get("session_start")({ type: "session_start" }, ctx);
+    await handlers.get("agent_start")({ type: "agent_start" }, ctx);
+    handlers.get("agent_end")(
+      {
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            stopReason: "error",
+            errorMessage: "429 rate limit",
+          },
+        ],
+      },
+      ctx,
+    );
+
+    expect(lifecycle.calls.at(-1).slice(1, 3)).toEqual([
+      "working",
+      "Oh My Pi retrying",
+    ]);
+
+    clock.advance(50);
+
+    expect(lifecycle.calls.at(-1).slice(1, 3)).toEqual([
+      "blocked",
+      "429 rate limit",
+    ]);
+    expect(lifecycle.calls.some((call) => call[1] === "done")).toBe(false);
+  });
+
+  test("agent_settled prefers idle over the debounce when there is no retry hold", async () => {
+    const lifecycle = recordingLifecycle();
+    const { handlers, clock } = installHandlers(lifecycle, {
+      idleDebounceMs: 25,
+      retryGraceMs: 50,
+    });
+    const ctx = context("session-1");
+
+    await handlers.get("session_start")({ type: "session_start" }, ctx);
+    await handlers.get("agent_start")({ type: "agent_start" }, ctx);
+    handlers.get("agent_end")(
+      { type: "agent_end", messages: [{ role: "assistant", stopReason: "stop" }] },
+      ctx,
+    );
+
+    expect(lifecycle.calls.map((call) => call[1])).toEqual(["idle", "working"]);
+
+    await handlers.get("agent_settled")({ type: "agent_settled" }, ctx);
+    expect(lifecycle.calls.map((call) => call[1])).toEqual([
+      "idle",
+      "working",
+      "idle",
+    ]);
+    expect(lifecycle.calls.at(-1)[2]).toBe("Oh My Pi agent settled");
+
+    clock.advance(25);
+    expect(lifecycle.calls).toHaveLength(3);
+  });
+
+  test("agent_settled during retry hold does not cancel the retrying window", async () => {
+    const lifecycle = recordingLifecycle();
+    const { handlers, clock } = installHandlers(lifecycle, {
+      idleDebounceMs: 25,
+      retryGraceMs: 50,
+    });
+    const ctx = context("session-1");
+
+    await handlers.get("session_start")({ type: "session_start" }, ctx);
+    await handlers.get("agent_start")({ type: "agent_start" }, ctx);
+    handlers.get("agent_end")(
+      {
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            stopReason: "error",
+            errorMessage: "provider returned error",
+          },
+        ],
+      },
+      ctx,
+    );
+    await handlers.get("agent_settled")({ type: "agent_settled" }, ctx);
+
+    expect(lifecycle.calls.at(-1).slice(1, 3)).toEqual([
+      "working",
+      "Oh My Pi retrying",
+    ]);
+
+    clock.advance(25);
+    expect(lifecycle.calls.at(-1).slice(1, 3)).toEqual([
+      "working",
+      "Oh My Pi retrying",
+    ]);
+
+    clock.advance(25);
+    expect(lifecycle.calls.at(-1).slice(1, 3)).toEqual([
+      "blocked",
+      "provider returned error",
+    ]);
+  });
+
+  test("run_changed disables further reports", async () => {
+    const calls = [];
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        if (argv[2] === "ensure") {
+          return agent(
+            "agent-1",
+            argv[argv.indexOf("--state") + 1],
+            argv[argv.indexOf("--evidence") + 1],
+          );
+        }
+        const error = new Error("run changed");
+        error.code = "run_changed";
+        throw error;
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue("session-1", "idle", "Oh My Pi session idle");
+    await lifecycle.enqueue("session-1", "working", "Oh My Pi agent working");
+    await lifecycle.enqueue("session-1", "idle", "Oh My Pi agent settled");
+
+    expect(calls.map((argv) => argv[2])).toEqual(["ensure", "report"]);
+  });
+
+  test("fail-open logger does not throw", async () => {
+    const logs = [];
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async () => {
+        throw new Error("cli exploded");
+      },
+      log: (message) => logs.push(message),
+    });
+
+    await lifecycle.enqueue("session-1", "idle", "Oh My Pi session idle");
+
+    expect(logs.some((message) => String(message).includes("[boomux-omp]"))).toBe(
+      true,
+    );
+
+    const recording = recordingLifecycle();
+    recording.enqueue = () => {
+      throw new Error("enqueue failed");
+    };
+    const { handlers } = installHandlers(recording, {
+      log: (message) => logs.push(message),
+    });
+    await handlers.get("session_start")(
+      { type: "session_start" },
+      context("session-1"),
+    );
+  });
+
+  test("bounds lifecycle evidence", () => {
+    expect(__internal.boundedEvidence(`  ${"x".repeat(200)}  `)).toHaveLength(160);
+  });
+
+  test("reports only final assistant errors as blocked", () => {
+    const outcomes = __internal.createOutcomeTracker();
+    outcomes.record("session-1", [
+      { role: "toolResult", isError: true },
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "provider unavailable",
+      },
+    ]);
+    expect(outcomes.settled("session-1")).toEqual({
+      state: "blocked",
+      evidence: "Oh My Pi error: provider unavailable",
+    });
+
+    outcomes.clear("session-1");
+    outcomes.record("session-1", [
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "recovered",
+      },
+      { role: "assistant", stopReason: "stop" },
+    ]);
+    expect(outcomes.settled("session-1")).toEqual({
+      state: "idle",
+      evidence: "Oh My Pi agent settled",
+    });
+  });
+
+  test("observes cwd and typed tool paths after lifecycle identity exists", async () => {
+    const calls = [];
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        return argv[2] === "ensure"
+          ? agent("agent-1", "working", "Oh My Pi agent working")
+          : { data: { ok: true } };
+      },
+      log: () => {},
+    });
+    await lifecycle.enqueue(
+      "session-1",
+      "working",
+      "Oh My Pi agent working",
+      1,
+      ["/worktrees/boomux"],
+    );
+    await lifecycle.enqueueContexts("session-1", ["/worktrees/omarchy"]);
+
+    expect(calls.map((argv) => argv[2])).toEqual([
+      "ensure",
+      "observe-working-context",
+      "observe-working-context",
+    ]);
+    expect(
+      __internal.workingContextPaths(
+        { cwd: "/worktrees/boomux" },
+        {
+          toolName: "read",
+          input: { path: "/worktrees/omarchy/Panel.qml", command: "ignored" },
+        },
+      ),
+    ).toEqual(["/worktrees/boomux", "/worktrees/omarchy/Panel.qml"]);
+  });
+
+  test("ensures a new identity when OMP switches sessions", async () => {
+    const calls = [];
+    let next = 0;
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        next += 1;
+        return agent(`agent-${next}`, "idle", "Oh My Pi session idle");
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue("session-1", "idle", "Oh My Pi session idle");
+    await lifecycle.enqueue("session-2", "idle", "Oh My Pi session idle");
+
+    expect(calls).toHaveLength(2);
+    expect(calls.map((argv) => argv[7])).toEqual(["session-1", "session-2"]);
+  });
+
+  test("retries an inactive report without creating another identity", async () => {
+    const calls = [];
+    let inactiveAttempts = 0;
+    const lifecycle = __internal.createLifecycle({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        if (argv[2] === "ensure") {
+          return agent("agent-1", "idle", "Oh My Pi session idle");
+        }
+        if (argv[argv.indexOf("--state") + 1] === "inactive") {
+          inactiveAttempts += 1;
+          if (inactiveAttempts === 1) throw new Error("temporary failure");
+        }
+        return { data: { ok: true } };
+      },
+      log: () => {},
+    });
+
+    await lifecycle.enqueue("session-1", "idle", "Oh My Pi session idle");
+    await lifecycle.enqueue(
+      "session-1",
+      "inactive",
+      "Oh My Pi session inactive",
+      2,
+    );
+
+    expect(inactiveAttempts).toBe(2);
+    expect(calls.filter((argv) => argv[2] === "ensure")).toHaveLength(1);
+  });
+
+  test("waits for a timed out process to close before settling", async () => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    const signals = [];
+    child.kill = (signal) => {
+      signals.push(signal ?? "SIGTERM");
+      return true;
+    };
+    const runner = __internal.createProcessRunner({
+      spawn: () => child,
+      timeoutMs: 5,
+      killGraceMs: 5,
+    });
+    let settled = false;
+    const outcome = runner(["boomux"]).then(
+      () => undefined,
+      (error) => error,
+    );
+    outcome.then(() => {
+      settled = true;
+    });
+
+    await Bun.sleep(8);
+    expect(settled).toBe(false);
+    expect(signals).toEqual(["SIGTERM"]);
+
+    child.emit("close", null);
+    expect((await outcome).message).toBe("boomux command timed out");
+    expect(settled).toBe(true);
+  });
+
+  test("settles after escalating a timed out process that never closes", async () => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    const signals = [];
+    child.kill = (signal) => {
+      signals.push(signal ?? "SIGTERM");
+      return true;
+    };
+    const runner = __internal.createProcessRunner({
+      spawn: () => child,
+      timeoutMs: 5,
+      killGraceMs: 5,
+    });
+
+    const outcome = await runner(["boomux"]).then(
+      () => undefined,
+      (error) => error,
+    );
+
+    expect(outcome.message).toBe("boomux command timed out");
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(child.stdout.destroyed).toBe(true);
+    expect(child.stderr.destroyed).toBe(true);
+  });
+});

--- a/integrations/omp/boomux.test.js
+++ b/integrations/omp/boomux.test.js
@@ -99,6 +99,7 @@ function installHandlers(lifecycle, options = {}) {
       idleDebounceMs: options.idleDebounceMs ?? 25,
       retryGraceMs: options.retryGraceMs ?? 50,
       log: options.log ?? (() => {}),
+      renamer: options.renamer,
     },
   );
   return { handlers, clock };
@@ -118,6 +119,61 @@ function recordingLifecycle() {
 function states(calls) {
   return calls.map((argv) => argv[argv.indexOf("--state") + 1]);
 }
+
+function renameArgv(calls) {
+  return calls.filter(
+    (argv) => argv[0] === "boomux" && argv[1] === "shell" && argv[2] === "rename",
+  );
+}
+
+function renameContext(userText, extras = {}) {
+  const model = extras.model ?? {
+    provider: "lm-studio",
+    id: "google/gemma-4-e4b",
+  };
+  const find =
+    extras.find ??
+    ((provider, id) =>
+      provider === "lm-studio" && id === "google/gemma-4-e4b" ? model : null);
+  const branch =
+    extras.branch ??
+    (userText == null
+      ? []
+      : [
+          {
+            type: "message",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: userText }],
+            },
+          },
+        ]);
+  const sessionManager = {
+    getSessionId: () => extras.sessionID ?? "session-1",
+  };
+  if (extras.getBranch !== false) {
+    sessionManager.getBranch = extras.getBranch ?? (() => branch);
+  }
+  const ctx = {
+    hasUI: true,
+    sessionManager,
+  };
+  if (extras.modelRegistry !== null) {
+    ctx.modelRegistry = {
+      find,
+      hasConfiguredAuth: extras.hasConfiguredAuth ?? (() => true),
+      complete: extras.complete,
+    };
+  }
+  return ctx;
+}
+
+function alreadyExists(message = "shell name already exists") {
+  const error = new Error(message);
+  error.code = "already_exists";
+  return error;
+}
+
 
 describe("OMP lifecycle", () => {
   test("registers no handlers unless both Boomux env vars are set", () => {
@@ -623,3 +679,181 @@ describe("OMP lifecycle", () => {
     expect(child.stderr.destroyed).toBe(true);
   });
 });
+
+describe("OMP turn rename", () => {
+  test('sanitizeShellName("Fix Auth Token!") === "fix-auth-token"', () => {
+    expect(__internal.sanitizeShellName("Fix Auth Token!")).toBe(
+      "fix-auth-token",
+    );
+  });
+
+  test('sanitizeShellName("!!!") === undefined', () => {
+    expect(__internal.sanitizeShellName("!!!")).toBeUndefined();
+  });
+
+  test('sanitizeShellName("9lives") starts with t-', () => {
+    expect(__internal.sanitizeShellName("9lives")).toStartWith("t-");
+  });
+
+  test("does not emit shell rename argv when Boomux env vars are missing", async () => {
+    const calls = [];
+    const run = async (argv) => {
+      calls.push(argv);
+      return { data: { ok: true } };
+    };
+    expect(__internal.createTurnRenamer({ env: {}, run })).toBeUndefined();
+    expect(
+      __internal.createTurnRenamer({
+        env: { BOOMUX_SHELL_ID: "shell-1" },
+        run,
+      }),
+    ).toBeUndefined();
+    expect(
+      __internal.createTurnRenamer({ env: { BOOMUX_RUN_ID: "run-1" }, run }),
+    ).toBeUndefined();
+
+    withBoomuxEnv({}, () => {
+      BoomuxOmpExtension({
+        on: () => {
+          throw new Error("should not register handlers");
+        },
+      });
+    });
+
+    expect(renameArgv(calls)).toEqual([]);
+  });
+
+  test("skips rename when model find returns null", async () => {
+    const calls = [];
+    const completeCalls = [];
+    const renamer = __internal.createTurnRenamer({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        return { data: { ok: true } };
+      },
+      log: () => {},
+    });
+    const ctx = renameContext("Fix the login bug", {
+      find: () => null,
+      complete: async (...args) => {
+        completeCalls.push(args);
+        return { content: [{ type: "text", text: "Fix the login bug" }] };
+      },
+    });
+
+    await renamer.enqueue(ctx, { type: "agent_start" });
+    await renamer.idle();
+
+    expect(renameArgv(calls)).toEqual([]);
+    expect(completeCalls).toEqual([]);
+  });
+
+  test("renames the Boomux shell from complete text", async () => {
+    const calls = [];
+    const completeCalls = [];
+    const model = { provider: "lm-studio", id: "google/gemma-4-e4b" };
+    const renamer = __internal.createTurnRenamer({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        return { data: { ok: true } };
+      },
+      log: () => {},
+    });
+    const ctx = renameContext("Please fix the login bug", {
+      model,
+      complete: async (...args) => {
+        completeCalls.push(args);
+        return { content: [{ type: "text", text: "Fix the login bug" }] };
+      },
+    });
+
+    await renamer.enqueue(ctx, { type: "agent_start" });
+    await renamer.idle();
+
+    expect(renameArgv(calls)).toEqual([
+      ["boomux", "shell", "rename", "shell-1", "fix-the-login-bug", "--json"],
+    ]);
+    expect(completeCalls).toHaveLength(1);
+    expect(completeCalls[0][0]).toBe(model);
+  });
+
+  test("re-completes once on already_exists without a local -2 suffix", async () => {
+    const calls = [];
+    const completeTexts = [];
+    const model = { provider: "lm-studio", id: "google/gemma-4-e4b" };
+    let renameAttempts = 0;
+    const renamer = __internal.createTurnRenamer({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run: async (argv) => {
+        calls.push(argv);
+        if (argv[1] === "shell" && argv[2] === "rename") {
+          renameAttempts += 1;
+          if (renameAttempts === 1) throw alreadyExists();
+        }
+        return { data: { ok: true } };
+      },
+      log: () => {},
+    });
+    const ctx = renameContext("Please fix the login bug", {
+      model,
+      complete: async (_model, request) => {
+        const text = request.messages
+          .flatMap((message) => message.content)
+          .filter((part) => part.type === "text")
+          .map((part) => part.text)
+          .join("\n");
+        completeTexts.push(text);
+        if (completeTexts.length === 1) {
+          return { content: [{ type: "text", text: "Fix the login bug" }] };
+        }
+        return { content: [{ type: "text", text: "repair login flow" }] };
+      },
+    });
+
+    await renamer.enqueue(ctx, { type: "agent_start" });
+    await renamer.idle();
+
+    expect(completeTexts).toHaveLength(2);
+    expect(completeTexts[1]).toContain(
+      "That name is taken. Pick a different name.",
+    );
+    expect(renameArgv(calls)).toEqual([
+      ["boomux", "shell", "rename", "shell-1", "fix-the-login-bug", "--json"],
+      ["boomux", "shell", "rename", "shell-1", "repair-login-flow", "--json"],
+    ]);
+    expect(calls.some((argv) => argv.includes("fix-the-login-bug-2"))).toBe(
+      false,
+    );
+  });
+
+  test("rename failure does not throw from agent_start", async () => {
+    const lifecycle = recordingLifecycle();
+    const run = async (argv) => {
+      if (argv[1] === "shell") {
+        const error = new Error("boomux unavailable");
+        error.code = "daemon_unavailable";
+        throw error;
+      }
+      return { data: { ok: true } };
+    };
+    const renamer = __internal.createTurnRenamer({
+      env: { BOOMUX_SHELL_ID: "shell-1", BOOMUX_RUN_ID: "run-1" },
+      run,
+      log: () => {},
+    });
+    const { handlers } = installHandlers(lifecycle, { renamer });
+    const ctx = renameContext("Fix the login bug", {
+      complete: async () => ({
+        content: [{ type: "text", text: "Fix the login bug" }],
+      }),
+    });
+
+    await handlers.get("agent_start")({ type: "agent_start" }, ctx);
+    await renamer.idle();
+
+    expect(lifecycle.calls.map((call) => call[1])).toEqual(["working"]);
+  });
+});
+

--- a/integrations/omp/boomux.ts
+++ b/integrations/omp/boomux.ts
@@ -1,0 +1,2 @@
+// Compile stub for the Boomux Oh My Pi extension. Task 3 owns the implementation.
+export {};

--- a/integrations/omp/boomux.ts
+++ b/integrations/omp/boomux.ts
@@ -1,2 +1,671 @@
-// Compile stub for the Boomux Oh My Pi extension. Task 3 owns the implementation.
-export {};
+import { spawn } from "node:child_process";
+
+const MAX_EVIDENCE = 160;
+const MAX_OUTPUT = 64 * 1024;
+const COMMAND_TIMEOUT_MS = 1_000;
+const LOG_INTERVAL_MS = 30_000;
+const IDLE_DEBOUNCE_MS = 250;
+const RETRY_GRACE_MS = 2500;
+const LIFECYCLE_AUTHORITY = "lifecycle_integration";
+const LIFECYCLE_CONFIDENCE = 100;
+const DEFAULT_EVIDENCE = "Oh My Pi lifecycle event";
+
+const retryableErrorPattern =
+  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+
+function text(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function absolutePath(value) {
+  const path = text(value);
+  return path?.startsWith("/") ? path : undefined;
+}
+
+function workingContextPaths(ctx, event) {
+  const paths = new Set([absolutePath(ctx?.cwd)].filter(Boolean));
+  const tool = text(event?.toolName ?? event?.tool)?.toLowerCase();
+  const input = event?.input ?? event?.args;
+  if (!tool || !input || typeof input !== "object" || Array.isArray(input)) {
+    return [...paths];
+  }
+  let fields = [];
+  if (["read", "write", "edit", "multiedit"].includes(tool)) {
+    fields = ["filePath", "file_path", "path"];
+  } else if (["grep", "find", "ls", "list"].includes(tool)) {
+    fields = ["path"];
+  } else if (["bash", "shell"].includes(tool)) {
+    fields = ["workdir", "cwd"];
+  }
+  for (const field of fields) {
+    const path = absolutePath(input[field]);
+    if (path) paths.add(path);
+  }
+  return [...paths].slice(0, 8);
+}
+
+function boundedEvidence(value) {
+  const clean = String(value ?? DEFAULT_EVIDENCE)
+    .replace(/\s+/g, " ")
+    .trim();
+  return (clean || DEFAULT_EVIDENCE).slice(0, MAX_EVIDENCE);
+}
+
+function agentErrorEvidence(messages) {
+  if (!Array.isArray(messages)) return undefined;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "assistant") continue;
+    if (message.stopReason !== "error") return undefined;
+    return boundedEvidence(
+      `Oh My Pi error: ${text(message.errorMessage) ?? "assistant request failed"}`,
+    );
+  }
+  return undefined;
+}
+
+function createOutcomeTracker() {
+  const errors = new Map();
+  return {
+    clear(sessionID) {
+      if (text(sessionID)) errors.delete(sessionID);
+    },
+    record(sessionID, messages) {
+      if (!text(sessionID)) return;
+      const evidence = agentErrorEvidence(messages);
+      if (evidence) errors.set(sessionID, evidence);
+      else errors.delete(sessionID);
+    },
+    settled(sessionID) {
+      const evidence = errors.get(sessionID);
+      return evidence
+        ? { state: "blocked", evidence }
+        : { state: "idle", evidence: "Oh My Pi agent settled" };
+    },
+  };
+}
+
+function lastAssistantMessage(messages) {
+  if (!Array.isArray(messages)) return undefined;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === "assistant") return message;
+  }
+  return undefined;
+}
+
+function retryableErrorMessage(event) {
+  const assistant = lastAssistantMessage(event?.messages);
+  if (assistant?.stopReason !== "error") return undefined;
+  const errorMessage = String(assistant.errorMessage ?? "");
+  if (!retryableErrorPattern.test(errorMessage)) return undefined;
+  return errorMessage || "retryable provider error";
+}
+
+function askEvidence(event) {
+  const args = event?.args ?? event?.input;
+  if (args && typeof args === "object" && !Array.isArray(args)) {
+    return text(args.question) ?? text(args.prompt) ?? "Ask";
+  }
+  return "Ask";
+}
+
+function parseJSON(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error("boomux returned empty JSON output");
+  }
+  const parsed = JSON.parse(value);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("boomux returned invalid JSON output");
+  }
+  return parsed;
+}
+
+function createProcessRunner(options = {}) {
+  const spawnProcess = options.spawn ?? spawn;
+  const timeoutMs = options.timeoutMs ?? COMMAND_TIMEOUT_MS;
+  const maxOutput = options.maxOutput ?? MAX_OUTPUT;
+  const killGraceMs = options.killGraceMs ?? 250;
+
+  return (argv) =>
+    new Promise((resolve, reject) => {
+      const child = spawnProcess(argv[0], argv.slice(1), {
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: false,
+      });
+      let stdout = "";
+      let stderr = "";
+      let size = 0;
+      let settled = false;
+      let failure;
+      let timer;
+      let killTimer;
+      let abandonTimer;
+      const finish = (callback) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        clearTimeout(killTimer);
+        clearTimeout(abandonTimer);
+        callback();
+      };
+      const terminate = (error) => {
+        if (failure) return;
+        failure = error;
+        child.kill();
+        killTimer = setTimeout(() => {
+          child.kill("SIGKILL");
+          abandonTimer = setTimeout(() => {
+            child.stdout?.destroy();
+            child.stderr?.destroy();
+            finish(() => reject(failure));
+          }, killGraceMs);
+        }, killGraceMs);
+      };
+      const append = (chunk, target) => {
+        if (failure) return;
+        size += chunk.length;
+        if (size > maxOutput) {
+          terminate(new Error("boomux output limit exceeded"));
+          return;
+        }
+        if (target === "stdout") stdout += chunk.toString();
+        else stderr += chunk.toString();
+      };
+      child.stdout?.on("data", (chunk) => append(chunk, "stdout"));
+      child.stderr?.on("data", (chunk) => append(chunk, "stderr"));
+      child.on("error", (error) => finish(() => reject(error)));
+      child.on("close", (code) =>
+        finish(() => {
+          if (failure) {
+            reject(failure);
+            return;
+          }
+          try {
+            const parsed = parseJSON(stdout.trim() ? stdout : stderr);
+            if (code !== 0 || parsed.error) {
+              const error = new Error(
+                boundedEvidence(
+                  parsed.error?.message ?? stderr ?? "boomux command failed",
+                ),
+              );
+              error.code = parsed.error?.code;
+              reject(error);
+              return;
+            }
+            resolve(parsed);
+          } catch (error) {
+            reject(error);
+          }
+        }),
+      );
+      timer = setTimeout(
+        () => terminate(new Error("boomux command timed out")),
+        timeoutMs,
+      );
+    });
+}
+
+function ensureArgv(shellID, runID, sessionID, state, evidence) {
+  return [
+    "boomux",
+    "agent",
+    "ensure",
+    "omp",
+    "--integration",
+    "omp",
+    "--external-session-id",
+    sessionID,
+    "--shell-id",
+    shellID,
+    "--run-id",
+    runID,
+    "--state",
+    state,
+    "--authority",
+    "lifecycle-integration",
+    "--evidence",
+    boundedEvidence(evidence),
+    "--confidence",
+    "100",
+    "--json",
+  ];
+}
+
+function reportArgv(agentID, shellID, runID, state, evidence) {
+  return [
+    "boomux",
+    "agent",
+    "report",
+    agentID,
+    "--shell-id",
+    shellID,
+    "--run-id",
+    runID,
+    "--state",
+    state,
+    "--authority",
+    "lifecycle-integration",
+    "--evidence",
+    boundedEvidence(evidence),
+    "--confidence",
+    "100",
+    "--json",
+  ];
+}
+
+function observeWorkingContextArgv(agentID, shellID, runID, path) {
+  return [
+    "boomux",
+    "agent",
+    "observe-working-context",
+    agentID,
+    path,
+    "--shell-id",
+    shellID,
+    "--run-id",
+    runID,
+    "--json",
+  ];
+}
+
+function agentFromJSON(result) {
+  return result?.data?.agent ?? result?.agent ?? result?.data;
+}
+
+function observationMatches(observation, state, evidence) {
+  return (
+    observation?.state === state &&
+    observation?.authority === LIFECYCLE_AUTHORITY &&
+    observation?.evidence === evidence &&
+    observation?.confidence === LIFECYCLE_CONFIDENCE
+  );
+}
+
+function rateLimitedLogger(log, now = Date.now) {
+  let last = -Infinity;
+  let suppressed = 0;
+  return (error) => {
+    const time = now();
+    if (time - last < LOG_INTERVAL_MS) {
+      suppressed += 1;
+      return;
+    }
+    const suffix = suppressed
+      ? ` (${suppressed} similar errors suppressed)`
+      : "";
+    suppressed = 0;
+    last = time;
+    log(`[boomux-omp] ${boundedEvidence(error?.message ?? error)}${suffix}`);
+  };
+}
+
+function createLifecycle({ env, run, log = console.error, now }) {
+  const shellID = text(env?.BOOMUX_SHELL_ID);
+  const runID = text(env?.BOOMUX_RUN_ID);
+  if (!shellID || !runID) return undefined;
+
+  const reportError = rateLimitedLogger(log, now);
+  let queue = Promise.resolve();
+  let sessionID;
+  let agentID;
+  let disabled = false;
+
+  async function send(nextSessionID, state, rawEvidence) {
+    if (nextSessionID !== sessionID) {
+      sessionID = nextSessionID;
+      agentID = undefined;
+      disabled = false;
+    }
+    if (disabled) return;
+
+    const evidence = boundedEvidence(rawEvidence);
+    try {
+      if (!agentID) {
+        const result = await run(
+          ensureArgv(shellID, runID, sessionID, state, evidence),
+        );
+        const agent = agentFromJSON(result);
+        agentID = text(agent?.id);
+        if (!agentID) throw new Error("boomux ensure response has no agent id");
+        if (agent?.ended_at_ms != null || agent?.observation?.state === "done") {
+          disabled = true;
+          return;
+        }
+        if (observationMatches(agent?.observation, state, evidence)) return;
+      }
+      await run(reportArgv(agentID, shellID, runID, state, evidence));
+    } catch (error) {
+      if (error?.code === "run_changed") disabled = true;
+      throw error;
+    }
+  }
+
+  async function sendWithAttempts(nextSessionID, state, evidence, attempts) {
+    let lastError;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      try {
+        await send(nextSessionID, state, evidence);
+        return;
+      } catch (error) {
+        lastError = error;
+        if (disabled || error?.code === "run_changed") break;
+      }
+    }
+    throw lastError;
+  }
+
+  async function observe(paths) {
+    if (!agentID) return;
+    for (const path of paths) {
+      try {
+        await run(observeWorkingContextArgv(agentID, shellID, runID, path));
+      } catch (error) {
+        reportError(error);
+      }
+    }
+  }
+
+  function enqueue(nextSessionID, state, evidence, attempts = 1, paths = []) {
+    if (!text(nextSessionID)) return Promise.resolve();
+    const pending = queue.then(async () => {
+      await sendWithAttempts(nextSessionID, state, evidence, attempts);
+      await observe(paths);
+    });
+    queue = pending.catch(reportError);
+    return queue;
+  }
+
+  function enqueueContexts(nextSessionID, paths) {
+    if (!text(nextSessionID)) return Promise.resolve();
+    const pending = queue.then(async () => {
+      if (nextSessionID === sessionID) await observe(paths);
+    });
+    queue = pending.catch(reportError);
+    return queue;
+  }
+
+  return { enqueue, enqueueContexts };
+}
+
+function currentSessionID(ctx) {
+  return text(ctx?.sessionManager?.getSessionId?.());
+}
+
+function registerLifecycleHandlers(pi, lifecycle, options = {}) {
+  const outcomes = createOutcomeTracker();
+  const schedule = options.setTimeout ?? setTimeout;
+  const unschedule = options.clearTimeout ?? clearTimeout;
+  const idleDebounceMs = options.idleDebounceMs ?? IDLE_DEBOUNCE_MS;
+  const retryGraceMs = options.retryGraceMs ?? RETRY_GRACE_MS;
+  const reportError = rateLimitedLogger(
+    options.log ?? console.error,
+    options.now,
+  );
+
+  let rootSession = false;
+  let agentActive = false;
+  let retryHoldActive = false;
+  let failureBlocked = false;
+  let failureEvidence;
+  let blockedCount = 0;
+  let blockedEvidence;
+  let idleEvidence = "Oh My Pi session idle";
+  let idleTimer;
+  let retryTimer;
+
+  const report = (ctx, state, evidence, attempts = 1) =>
+    lifecycle.enqueue(
+      currentSessionID(ctx),
+      state,
+      evidence,
+      attempts,
+      workingContextPaths(ctx),
+    );
+
+  function arm(fn, ms) {
+    const handle = schedule(fn, ms);
+    handle?.unref?.();
+    return handle;
+  }
+
+  function clearPendingTimers() {
+    if (idleTimer) unschedule(idleTimer);
+    if (retryTimer) unschedule(retryTimer);
+    idleTimer = undefined;
+    retryTimer = undefined;
+  }
+
+  function clearFailureState() {
+    retryHoldActive = false;
+    failureBlocked = false;
+    failureEvidence = undefined;
+  }
+
+  function resetSessionState() {
+    clearPendingTimers();
+    clearFailureState();
+    agentActive = false;
+    blockedCount = 0;
+    blockedEvidence = undefined;
+    idleEvidence = "Oh My Pi session idle";
+  }
+
+  function desired() {
+    if (blockedCount > 0) {
+      return { state: "blocked", evidence: blockedEvidence };
+    }
+    if (failureBlocked) {
+      return { state: "blocked", evidence: failureEvidence };
+    }
+    if (agentActive || retryHoldActive) {
+      return {
+        state: "working",
+        evidence: retryHoldActive
+          ? "Oh My Pi retrying"
+          : "Oh My Pi agent working",
+      };
+    }
+    return { state: "idle", evidence: idleEvidence };
+  }
+
+  function publish(ctx, attempts = 1) {
+    const next = desired();
+    return report(ctx, next.state, next.evidence, attempts);
+  }
+
+  function activateRoot(ctx) {
+    if (ctx?.hasUI !== true) return false;
+    rootSession = true;
+    return true;
+  }
+
+  function requireRoot(ctx) {
+    return rootSession || activateRoot(ctx);
+  }
+
+  function holdForRetry(ctx, message) {
+    clearPendingTimers();
+    retryHoldActive = true;
+    failureBlocked = false;
+    failureEvidence = boundedEvidence(message);
+    publish(ctx);
+    retryTimer = arm(() => {
+      retryTimer = undefined;
+      retryHoldActive = false;
+      failureBlocked = true;
+      publish(ctx);
+    }, retryGraceMs);
+  }
+
+  function scheduleIdle(ctx) {
+    clearPendingTimers();
+    clearFailureState();
+    idleTimer = arm(() => {
+      idleTimer = undefined;
+      const outcome = outcomes.settled(currentSessionID(ctx));
+      if (outcome.state === "blocked") {
+        failureBlocked = true;
+        failureEvidence = outcome.evidence;
+      } else {
+        idleEvidence = outcome.evidence;
+      }
+      publish(ctx);
+    }, idleDebounceMs);
+  }
+
+  function settleNow(ctx) {
+    clearPendingTimers();
+    retryHoldActive = false;
+    agentActive = false;
+    const outcome = outcomes.settled(currentSessionID(ctx));
+    if (outcome.state === "blocked") {
+      failureBlocked = true;
+      failureEvidence = outcome.evidence;
+    } else {
+      clearFailureState();
+      idleEvidence = outcome.evidence;
+    }
+    publish(ctx);
+  }
+
+  function guard(handler) {
+    return (event, ctx) => {
+      try {
+        return handler(event, ctx);
+      } catch (error) {
+        reportError(error);
+      }
+    };
+  }
+
+  pi.on(
+    "session_start",
+    guard((_event, ctx) => {
+      if (!activateRoot(ctx)) return;
+      outcomes.clear(currentSessionID(ctx));
+      clearPendingTimers();
+      clearFailureState();
+      blockedCount = 0;
+      blockedEvidence = undefined;
+      idleEvidence = "Oh My Pi session idle";
+      agentActive = ctx?.isIdle?.() === false;
+      return publish(ctx);
+    }),
+  );
+  pi.on(
+    "session_switch",
+    guard((_event, ctx) => {
+      if (!activateRoot(ctx)) return;
+      outcomes.clear(currentSessionID(ctx));
+      resetSessionState();
+      return publish(ctx);
+    }),
+  );
+  pi.on(
+    "agent_start",
+    guard((_event, ctx) => {
+      if (!requireRoot(ctx)) return;
+      outcomes.clear(currentSessionID(ctx));
+      clearPendingTimers();
+      clearFailureState();
+      agentActive = true;
+      return publish(ctx);
+    }),
+  );
+  pi.on(
+    "tool_approval_requested",
+    guard((event, ctx) => {
+      if (!requireRoot(ctx)) return;
+      blockedCount += 1;
+      blockedEvidence =
+        event?.reason || `${event?.toolName || "Tool"} approval`;
+      return publish(ctx);
+    }),
+  );
+  pi.on(
+    "tool_approval_resolved",
+    guard((_event, ctx) => {
+      if (!requireRoot(ctx)) return;
+      blockedCount = Math.max(0, blockedCount - 1);
+      if (blockedCount === 0) blockedEvidence = undefined;
+      return publish(ctx);
+    }),
+  );
+  pi.on(
+    "tool_execution_start",
+    guard((event, ctx) => {
+      if (event?.toolName !== "ask") return;
+      if (!requireRoot(ctx)) return;
+      blockedCount += 1;
+      blockedEvidence = askEvidence(event);
+      return publish(ctx);
+    }),
+  );
+  pi.on(
+    "tool_execution_end",
+    guard((event, ctx) => {
+      if (event?.toolName !== "ask") return;
+      if (!requireRoot(ctx)) return;
+      blockedCount = Math.max(0, blockedCount - 1);
+      if (blockedCount === 0) blockedEvidence = undefined;
+      return publish(ctx);
+    }),
+  );
+  pi.on(
+    "agent_end",
+    guard((event, ctx) => {
+      if (!rootSession) return;
+      if (!agentActive) return;
+      agentActive = false;
+      outcomes.record(currentSessionID(ctx), event?.messages);
+      const retryable = retryableErrorMessage(event);
+      if (retryable) {
+        holdForRetry(ctx, retryable);
+        return;
+      }
+      scheduleIdle(ctx);
+    }),
+  );
+  pi.on(
+    "agent_settled",
+    guard((_event, ctx) => {
+      if (!rootSession) return;
+      settleNow(ctx);
+    }),
+  );
+  pi.on(
+    "session_shutdown",
+    guard((_event, ctx) => {
+      clearPendingTimers();
+      outcomes.clear(currentSessionID(ctx));
+      rootSession = false;
+      resetSessionState();
+      return report(ctx, "inactive", "Oh My Pi session inactive", 2);
+    }),
+  );
+}
+
+export default function BoomuxOmpExtension(pi) {
+  const lifecycle = createLifecycle({
+    env: globalThis.process?.env ?? {},
+    run: createProcessRunner(),
+  });
+  if (!lifecycle) return;
+  registerLifecycleHandlers(pi, lifecycle);
+}
+
+export const __internal = Object.freeze({
+  boundedEvidence,
+  createLifecycle,
+  createOutcomeTracker,
+  createProcessRunner,
+  registerLifecycleHandlers,
+  observeWorkingContextArgv,
+  workingContextPaths,
+  retryableErrorPattern,
+  retryableErrorMessage,
+  askEvidence,
+  IDLE_DEBOUNCE_MS,
+  RETRY_GRACE_MS,
+});

--- a/integrations/omp/boomux.ts
+++ b/integrations/omp/boomux.ts
@@ -6,6 +6,9 @@ const COMMAND_TIMEOUT_MS = 1_000;
 const LOG_INTERVAL_MS = 30_000;
 const IDLE_DEBOUNCE_MS = 250;
 const RETRY_GRACE_MS = 2500;
+const RENAME_COMPLETE_MS = 8_000;
+const RENAME_USER_TEXT_MAX = 500;
+
 const LIFECYCLE_AUTHORITY = "lifecycle_integration";
 const LIFECYCLE_CONFIDENCE = 100;
 const DEFAULT_EVIDENCE = "Oh My Pi lifecycle event";
@@ -392,6 +395,211 @@ function currentSessionID(ctx) {
   return text(ctx?.sessionManager?.getSessionId?.());
 }
 
+function sanitizeShellName(raw) {
+  let s = String(raw || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
+  if (s.length < 2) return undefined;
+  if (!/^[a-z]/.test(s)) s = `t-${s}`.slice(0, 40);
+  return s;
+}
+
+function extractTextParts(content) {
+  if (typeof content === "string") return [content];
+  if (!Array.isArray(content)) return [];
+  const parts = [];
+  for (const part of content) {
+    if (part?.type === "text" && typeof part.text === "string") {
+      parts.push(part.text);
+    }
+  }
+  return parts;
+}
+
+function latestUserText(ctx, event) {
+  const branch = ctx?.sessionManager?.getBranch?.();
+  if (Array.isArray(branch)) {
+    for (let index = branch.length - 1; index >= 0; index -= 1) {
+      const entry = branch[index];
+      if (entry?.type !== "message" || entry.message?.role !== "user") continue;
+      const value = extractTextParts(entry.message.content).join("\n").trim();
+      if (value) return value;
+    }
+  }
+  return (
+    text(event?.prompt) ?? text(event?.text) ?? text(event?.userText)
+  );
+}
+
+function renamePrompt(userText, takenHint) {
+  const lines = [
+    "Reply with only a Boomux shell name: 2 to 4 lowercase words joined by hyphens. Characters [a-z0-9-] only. Maximum 40 characters. No quotes, punctuation, or explanation.",
+    "",
+    "User request:",
+    String(userText).slice(0, RENAME_USER_TEXT_MAX),
+  ];
+  if (takenHint) lines.push("That name is taken. Pick a different name.");
+  return lines.join("\n");
+}
+
+function createTurnRenamer({
+  env,
+  run,
+  log = console.error,
+  now,
+  completeTimeoutMs = RENAME_COMPLETE_MS,
+} = {}) {
+  const shellID = text(env?.BOOMUX_SHELL_ID);
+  const runID = text(env?.BOOMUX_RUN_ID);
+  if (!shellID || !runID) return undefined;
+
+  const reportError = rateLimitedLogger(log, now);
+  let queue = Promise.resolve();
+  let generating = false;
+  let pendingText;
+  let pendingCtx;
+
+  async function completeName(ctx, userText, takenHint) {
+    try {
+      const model = ctx?.modelRegistry?.find?.(
+        "lm-studio",
+        "google/gemma-4-e4b",
+      );
+      if (!model || !ctx.modelRegistry.hasConfiguredAuth(model)) {
+        return undefined;
+      }
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), completeTimeoutMs);
+      timer.unref?.();
+      try {
+        const response = await ctx.modelRegistry.complete(
+          model,
+          {
+            messages: [
+              {
+                role: "user",
+                content: [
+                  { type: "text", text: renamePrompt(userText, takenHint) },
+                ],
+              },
+            ],
+          },
+          {
+            reasoningEffort: "off",
+            cacheRetention: "none",
+            signal: controller.signal,
+          },
+        );
+        const content = Array.isArray(response?.content)
+          ? response.content
+          : [];
+        return sanitizeShellName(
+          content
+            .filter((part) => part?.type === "text")
+            .map((part) => part.text)
+            .join(""),
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (error) {
+      reportError(error);
+      return undefined;
+    }
+  }
+
+  async function currentName() {
+    try {
+      const result = await run([
+        "boomux",
+        "shell",
+        "inspect",
+        shellID,
+        "--json",
+      ]);
+      return (
+        text(result?.data?.shell?.name) ??
+        text(result?.shell?.name) ??
+        text(result?.data?.name)
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function runOnce(ctx, userText) {
+    const name = await completeName(ctx, userText, false);
+    if (!name) return;
+    if ((await currentName()) === name) return;
+    try {
+      await run(["boomux", "shell", "rename", shellID, name, "--json"]);
+    } catch (error) {
+      if (error?.code === "invalid_argument") return;
+      if (error?.code !== "already_exists") throw error;
+      const retryName = await completeName(ctx, userText, true);
+      if (!retryName || retryName === name) return;
+      if ((await currentName()) === retryName) return;
+      try {
+        await run([
+          "boomux",
+          "shell",
+          "rename",
+          shellID,
+          retryName,
+          "--json",
+        ]);
+      } catch (retryError) {
+        if (
+          retryError?.code === "already_exists" ||
+          retryError?.code === "invalid_argument"
+        ) {
+          return;
+        }
+        throw retryError;
+      }
+    }
+  }
+
+  function enqueue(ctx, event) {
+    const userText = latestUserText(ctx, event);
+    if (!userText || userText.startsWith("/")) return queue;
+    pendingText = userText;
+    pendingCtx = ctx;
+    if (generating) return queue;
+    generating = true;
+    const pending = queue.then(async () => {
+      try {
+        while (pendingText) {
+          const nextText = pendingText;
+          const nextCtx = pendingCtx;
+          pendingText = undefined;
+          pendingCtx = undefined;
+          try {
+            await runOnce(nextCtx, nextText);
+          } catch (error) {
+            reportError(error);
+          }
+        }
+      } finally {
+        generating = false;
+      }
+      if (pendingText) enqueue(pendingCtx, event);
+    });
+    queue = pending.catch(reportError);
+    return queue;
+  }
+
+  return {
+    enqueue,
+    idle() {
+      return queue;
+    },
+  };
+}
+
 function registerLifecycleHandlers(pi, lifecycle, options = {}) {
   const outcomes = createOutcomeTracker();
   const schedule = options.setTimeout ?? setTimeout;
@@ -565,13 +773,15 @@ function registerLifecycleHandlers(pi, lifecycle, options = {}) {
   );
   pi.on(
     "agent_start",
-    guard((_event, ctx) => {
+    guard((event, ctx) => {
       if (!requireRoot(ctx)) return;
       outcomes.clear(currentSessionID(ctx));
       clearPendingTimers();
       clearFailureState();
       agentActive = true;
-      return publish(ctx);
+      const published = publish(ctx);
+      options.renamer?.enqueue(ctx, event);
+      return published;
     }),
   );
   pi.on(
@@ -648,12 +858,13 @@ function registerLifecycleHandlers(pi, lifecycle, options = {}) {
 }
 
 export default function BoomuxOmpExtension(pi) {
-  const lifecycle = createLifecycle({
-    env: globalThis.process?.env ?? {},
-    run: createProcessRunner(),
-  });
+  const env = globalThis.process?.env ?? {};
+  const run = createProcessRunner();
+  const lifecycle = createLifecycle({ env, run });
   if (!lifecycle) return;
-  registerLifecycleHandlers(pi, lifecycle);
+  registerLifecycleHandlers(pi, lifecycle, {
+    renamer: createTurnRenamer({ env, run }),
+  });
 }
 
 export const __internal = Object.freeze({
@@ -661,12 +872,14 @@ export const __internal = Object.freeze({
   createLifecycle,
   createOutcomeTracker,
   createProcessRunner,
+  createTurnRenamer,
   registerLifecycleHandlers,
   observeWorkingContextArgv,
   workingContextPaths,
   retryableErrorPattern,
   retryableErrorMessage,
   askEvidence,
+  sanitizeShellName,
   IDLE_DEBOUNCE_MS,
   RETRY_GRACE_MS,
 });

--- a/integrations/omp/boomux.ts
+++ b/integrations/omp/boomux.ts
@@ -515,6 +515,7 @@ function registerLifecycleHandlers(pi, lifecycle, options = {}) {
   }
 
   function settleNow(ctx) {
+    if (retryHoldActive) return;
     clearPendingTimers();
     retryHoldActive = false;
     agentActive = false;

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -72,6 +72,7 @@ pub(crate) struct IntegrationId(&'static IntegrationDescriptor);
 impl IntegrationId {
     pub(crate) const OPENCODE: Self = Self(&boomux::integrations::OPENCODE);
     pub(crate) const PI: Self = Self(&boomux::integrations::PI);
+    pub(crate) const OMP: Self = Self(&boomux::integrations::OMP);
     pub(crate) const CODEX: Self = Self(&boomux::integrations::CODEX);
     pub(crate) const KIRO: Self = Self(&boomux::integrations::KIRO);
     #[allow(non_upper_case_globals)]
@@ -950,6 +951,10 @@ fn config_root(id: IntegrationId, environment: &Environment) -> Result<PathBuf, 
             environment.pi_coding_agent_dir.clone(),
             environment.home.clone(),
         ),
+        InstallTargetKind::Omp => omp_config_root(
+            environment.pi_coding_agent_dir.clone(),
+            environment.home.clone(),
+        ),
         InstallTargetKind::Claude => claude_config_root(
             environment.claude_config_dir.clone(),
             environment.home.clone(),
@@ -973,6 +978,10 @@ fn target_at(id: IntegrationId, config_root: &Path) -> InstallTarget {
             directory: config_root.join("extensions"),
             path: config_root.join("extensions/boomux.js"),
         },
+        InstallTargetKind::Omp => InstallTarget {
+            directory: config_root.join("extensions"),
+            path: config_root.join("extensions/boomux.ts"),
+        },
         InstallTargetKind::Claude => InstallTarget {
             directory: config_root.join("skills/boomux/.claude-plugin"),
             path: config_root.join("skills/boomux/.claude-plugin/plugin.json"),
@@ -993,6 +1002,7 @@ const fn config_root_name(id: IntegrationId) -> &'static str {
     match id.installation().target {
         InstallTargetKind::OpenCode => "XDG configuration root",
         InstallTargetKind::Pi => "Pi configuration root",
+        InstallTargetKind::Omp => "Oh My Pi configuration root",
         InstallTargetKind::Claude => "Claude configuration root",
         InstallTargetKind::Codex => "Codex configuration root",
         InstallTargetKind::Kiro => "Kiro configuration root",
@@ -1042,6 +1052,34 @@ pub(crate) fn pi_config_root(
         None => home()?.join(".pi/agent"),
     };
     require_absolute_root(&root, "Pi configuration root")?;
+    Ok(root)
+}
+
+pub(crate) fn omp_config_root(
+    pi_coding_agent_dir: Option<OsString>,
+    home: Option<OsString>,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let home = || -> Result<PathBuf, Box<dyn Error>> {
+        home.clone().map(PathBuf::from).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "HOME must be set to install the Boomux Oh My Pi extension",
+            )
+            .into()
+        })
+    };
+    let root = match pi_coding_agent_dir.filter(|value| !value.is_empty()) {
+        Some(root) => {
+            let root = PathBuf::from(root);
+            if let Ok(suffix) = root.strip_prefix("~") {
+                home()?.join(suffix)
+            } else {
+                root
+            }
+        }
+        None => home()?.join(".omp/agent"),
+    };
+    require_absolute_root(&root, "Oh My Pi configuration root")?;
     Ok(root)
 }
 
@@ -1691,6 +1729,19 @@ mod tests {
             pi_config_root(Some("~/.config/pi".into()), Some("/home/example".into())).unwrap(),
             Path::new("/home/example/.config/pi")
         );
+        assert_eq!(
+            omp_config_root(None, Some("/home/example".into())).unwrap(),
+            Path::new("/home/example/.omp/agent")
+        );
+        assert_eq!(
+            omp_config_root(Some("~/.config/omp".into()), Some("/home/example".into())).unwrap(),
+            Path::new("/home/example/.config/omp")
+        );
+        assert!(omp_config_root(Some("relative".into()), None).is_err());
+        assert_eq!(
+            omp_config_root(None, None).unwrap_err().to_string(),
+            "HOME must be set to install the Boomux Oh My Pi extension"
+        );
         assert!(pi_config_root(Some("relative".into()), None).is_err());
         assert_eq!(
             claude_config_root(Some("/claude".into()), Some("/home/example".into())).unwrap(),
@@ -2032,6 +2083,27 @@ mod tests {
         );
         assert!(!path.exists());
         assert!(path.parent().unwrap().is_dir());
+    }
+
+    #[test]
+    fn omp_install_and_uninstall_leave_herdr_agent_state_untouched() {
+        let home = TestDirectory::new("omp-install");
+        let environment = environment(&home.0);
+        let extensions = home.0.join(".omp/agent/extensions");
+        fs::create_dir_all(&extensions).unwrap();
+        let neighbor = extensions.join("herdr-omp-agent-state.ts");
+        fs::write(&neighbor, "dummy").unwrap();
+
+        let installed = install(IntegrationId::OMP, &environment, false).unwrap();
+        let path = PathBuf::from(&installed.path);
+        assert_eq!(path, home.0.join(".omp/agent/extensions/boomux.ts"));
+        assert!(!installed.path.contains("herdr-omp-agent-state.ts"));
+        assert_eq!(fs::read_to_string(&neighbor).unwrap(), "dummy");
+
+        let removed = uninstall(IntegrationId::OMP, &environment, false).unwrap();
+        assert_eq!(removed.result, UninstallOutcome::Removed);
+        assert!(!path.exists());
+        assert_eq!(fs::read_to_string(&neighbor).unwrap(), "dummy");
     }
 
     #[test]

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -18,6 +18,7 @@ pub fn validate_external_session_id(value: &str) -> Result<(), &'static str> {
 pub enum InstallTargetKind {
     OpenCode,
     Pi,
+    Omp,
     Claude,
     Codex,
     Kiro,
@@ -156,6 +157,27 @@ pub const PI: IntegrationDescriptor = IntegrationDescriptor {
     run_scoped_launcher: None,
 };
 
+pub const OMP: IntegrationDescriptor = IntegrationDescriptor {
+    key: "omp",
+    display_name: "Oh My Pi",
+    installation: Some(InstallationCapability {
+        package: "omp",
+        validated_version: "18.0.4",
+        asset_name: "extension",
+        content: include_str!("../integrations/omp/boomux.ts"),
+        executable: "omp",
+        reload_message: "Restart any running Oh My Pi process to activate the extension",
+        target: InstallTargetKind::Omp,
+    }),
+    titles: None,
+    resume: Some(ResumeCapability {
+        executable: "omp",
+        arguments_before_session: &["--resume"],
+    }),
+    foreground: Some(ForegroundCapability { process_name: "omp" }),
+    run_scoped_launcher: None,
+};
+
 pub const CLAUDE: IntegrationDescriptor = IntegrationDescriptor {
     key: "claude",
     display_name: "Claude Code",
@@ -234,7 +256,7 @@ pub const KIRO: IntegrationDescriptor = IntegrationDescriptor {
     run_scoped_launcher: Some(RunScopedLauncher::Kiro),
 };
 
-pub const ALL: &[IntegrationDescriptor] = &[OPENCODE, PI, CLAUDE, CODEX, KIRO];
+pub const ALL: &[IntegrationDescriptor] = &[OPENCODE, PI, OMP, CLAUDE, CODEX, KIRO];
 
 pub fn by_key(key: &str) -> Option<&'static IntegrationDescriptor> {
     descriptor_by_key(ALL, key)
@@ -387,6 +409,10 @@ mod tests {
                 "--resume-id".into(),
                 "session-3".into()
             ])
+        );
+        assert_eq!(
+            OMP.resume.unwrap().command(&[], "session-omp"),
+            Some(vec!["omp".into(), "--resume".into(), "session-omp".into()])
         );
     }
 }

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -174,7 +174,9 @@ pub const OMP: IntegrationDescriptor = IntegrationDescriptor {
         executable: "omp",
         arguments_before_session: &["--resume"],
     }),
-    foreground: Some(ForegroundCapability { process_name: "omp" }),
+    foreground: Some(ForegroundCapability {
+        process_name: "omp",
+    }),
     run_scoped_launcher: None,
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1301,6 +1301,7 @@ command_keys! {
     NodeRekey => ("node.rekey", HumanOnly),
     ShellSuggestName => ("shell.suggest-name", Json),
     ShellInspect => ("shell.inspect", Json),
+    ShellRename => ("shell.rename", Json),
     Shell => ("shell", HumanOnly),
     LauncherList => ("launcher.list", Json),
     LauncherInspect => ("launcher.inspect", Json),
@@ -1443,6 +1444,9 @@ impl Cli {
             Some(Commands::Shell {
                 command: ShellCommands::Inspect { .. },
             }) => CommandKey::ShellInspect,
+            Some(Commands::Shell {
+                command: ShellCommands::Rename { .. },
+            }) => CommandKey::ShellRename,
             Some(Commands::Launcher {
                 command: LauncherCommands::List { .. },
             }) => CommandKey::LauncherList,
@@ -1539,10 +1543,7 @@ impl Cli {
             }) => CommandKey::Workspace,
             Some(Commands::Desktop { .. }) => CommandKey::Desktop,
             Some(Commands::Shell {
-                command:
-                    ShellCommands::Create { .. }
-                    | ShellCommands::Rename { .. }
-                    | ShellCommands::Close { .. },
+                command: ShellCommands::Create { .. } | ShellCommands::Close { .. },
             }) => CommandKey::Shell,
             Some(Commands::Launcher {
                 command:
@@ -8712,6 +8713,15 @@ fn shell_command(
             )?;
             let shell = resolve_cli_shell(&snapshot, &target, workspace.as_deref())?;
             client.rename_shell(&shell.id, &name)?;
+            if json {
+                return print_json(
+                    CommandKey::ShellRename,
+                    serde_json::json!({
+                        "shell_id": shell.id,
+                        "name": name,
+                    }),
+                );
+            }
             println!("Renamed shell {} to {name}", shell.name);
         }
         ShellCommands::Close { target, workspace } => {
@@ -15557,6 +15567,27 @@ mod tests {
     }
 
     #[test]
+    fn shell_rename_json_is_not_human_only() {
+        let cli = Cli::try_parse_from([
+            "boomux",
+            "shell",
+            "rename",
+            "shell-1",
+            "fix-the-login-bug",
+            "--json",
+        ])
+        .unwrap();
+        assert!(cli.json);
+        assert_eq!(cli.command_descriptor().key, "shell.rename");
+        assert_eq!(cli.command_descriptor().output, OutputMode::Json);
+        assert_ne!(cli.command_descriptor().output, OutputMode::HumanOnly);
+        assert!(
+            json_commands().any(|command| command == "shell.rename"),
+            "shell.rename must be advertised so --json is not InvalidInput"
+        );
+    }
+
+    #[test]
     fn command_descriptors_have_unique_names_and_drive_json_capabilities() {
         let mut names = CommandKey::ALL
             .iter()
@@ -15593,6 +15624,7 @@ mod tests {
                 "node.forget",
                 "shell.suggest-name",
                 "shell.inspect",
+                "shell.rename",
                 "launcher.list",
                 "launcher.inspect",
                 "agent.list",

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -250,7 +250,7 @@ fn remote_integration_cleanup_plan(
         .pointer("/data/integrations")
         .and_then(serde_json::Value::as_array)
         .ok_or_else(|| invalid_probe("remote integration status omitted integrations"))?;
-    let allowed = ["opencode", "pi", "claude", "codex", "kiro"];
+    let allowed = ["opencode", "pi", "omp", "claude", "codex", "kiro"];
     let mut current = Vec::new();
     let mut preserved = Vec::new();
     for row in rows {
@@ -1792,6 +1792,7 @@ impl BootstrapSession {
             let arguments = match integration.as_str() {
                 "opencode" => "integration uninstall opencode --json",
                 "pi" => "integration uninstall pi --json",
+                "omp" => "integration uninstall omp --json",
                 "claude" => "integration uninstall claude --json",
                 "codex" => "integration uninstall codex --json",
                 "kiro" => "integration uninstall kiro --json",
@@ -6698,12 +6699,12 @@ mod tests {
         let node_id = Uuid::new_v4().to_string();
         let helper = compatible_helper_script(&node_id);
         let executable = "/home/person/.local/bin/boomux";
-        let status = r#"{"schema":"boomux.cli/v1","command":"integration.status","data":{"integrations":[{"name":"opencode","display_name":"OpenCode","asset":{"state":"current","path":"/current"}},{"name":"pi","display_name":"Pi","asset":{"state":"modified","path":"/modified"}}]}}"#;
+        let status = r#"{"schema":"boomux.cli/v1","command":"integration.status","data":{"integrations":[{"name":"opencode","display_name":"OpenCode","asset":{"state":"current","path":"/current"}},{"name":"pi","display_name":"Pi","asset":{"state":"modified","path":"/modified"}},{"name":"omp","display_name":"Oh My Pi","asset":{"state":"current","path":"/omp"}}]}}"#;
         let removed = r#"{"schema":"boomux.cli/v1","command":"integration.uninstall","data":{"integrations":[]}}"#;
         let ssh = write_session_bootstrap_ssh(
             &runtime,
             &format!(
-                "  \"'{executable}' __federation-stdio\") {helper} ;;\n  \"'{executable}' --version\") printf 'boomux 1.0.1\\n' ;;\n  *'__uninstall-fingerprint'*) printf 'boomux-uninstall-fingerprint-v1 token\\n' ;;\n  *'integration status --json'*) printf '%s' '{status}' ;;\n  *'integration uninstall opencode --json'*) printf '%s' '{removed}' ;;\n  *'__uninstall-remote'*) : > {} ;;",
+                "  \"'{executable}' __federation-stdio\") {helper} ;;\n  \"'{executable}' --version\") printf 'boomux 1.0.1\\n' ;;\n  *'__uninstall-fingerprint'*) printf 'boomux-uninstall-fingerprint-v1 token\\n' ;;\n  *'integration status --json'*) printf '%s' '{status}' ;;\n  *'integration uninstall opencode --json'*) printf '%s' '{removed}' ;;\n  *'integration uninstall omp --json'*) printf '%s' '{removed}' ;;\n  *'__uninstall-remote'*) : > {} ;;",
                 quote_posix_shell(marker.to_str().unwrap())
             ),
             "/home/person/.local/bin/boomux\\0",

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -914,7 +914,8 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     ));
     let bin = root.join("bin");
     let config = root.join("config");
-    let pi = root.join("pi");
+    let pi = root.join(".pi/agent");
+    let omp = root.join(".omp/agent");
     let claude = root.join("claude");
     let claude_manifest = claude.join("skills/boomux/.claude-plugin/plugin.json");
     let codex_hooks = root.join(".codex/hooks.json");
@@ -925,6 +926,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     for (name, version) in [
         ("opencode", "1.18.18"),
         ("pi", "0.84.1"),
+        ("omp", "18.0.4"),
         ("claude", "2.1.236"),
         ("codex", "0.147.0"),
         ("kiro-cli", "2.18.0"),
@@ -942,7 +944,6 @@ fn integration_management_reports_and_installs_bundled_hosts() {
         command
             .env("HOME", &root)
             .env("XDG_CONFIG_HOME", &config)
-            .env("PI_CODING_AGENT_DIR", &pi)
             .env("CLAUDE_CONFIG_DIR", &claude)
             .env("XDG_RUNTIME_DIR", &runtime)
             .env("PATH", &bin);
@@ -964,7 +965,7 @@ fn integration_management_reports_and_installs_bundled_hosts() {
             .iter()
             .map(|integration| integration["name"].as_str().unwrap())
             .collect::<Vec<_>>(),
-        ["opencode", "pi", "claude", "codex", "kiro"]
+        ["opencode", "pi", "omp", "claude", "codex", "kiro"]
     );
 
     let missing = command()
@@ -990,10 +991,18 @@ fn integration_management_reports_and_installs_bundled_hosts() {
         .unwrap();
     assert!(!preflight_refused.status.success());
     assert!(!config.join("opencode/plugins/boomux.js").exists());
+    assert!(!omp.join("extensions/boomux.ts").exists());
     assert!(!claude_manifest.exists());
     assert!(!codex_hooks.exists());
     assert!(!kiro_hooks.exists());
     fs::remove_file(pi.join("extensions/boomux.js")).unwrap();
+
+    fs::create_dir_all(omp.join("extensions")).unwrap();
+    fs::write(
+        omp.join("extensions/herdr-omp-agent-state.ts"),
+        "keep herdr state",
+    )
+    .unwrap();
 
     let installed = command()
         .args(["integration", "install", "--all", "--json"])
@@ -1012,6 +1021,11 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     }
     assert!(config.join("opencode/plugins/boomux.js").is_file());
     assert!(pi.join("extensions/boomux.js").is_file());
+    assert!(omp.join("extensions/boomux.ts").is_file());
+    assert_eq!(
+        fs::read_to_string(omp.join("extensions/herdr-omp-agent-state.ts")).unwrap(),
+        "keep herdr state"
+    );
     assert!(claude_manifest.is_file());
     assert!(codex_hooks.is_file());
     assert!(kiro_hooks.is_file());
@@ -1095,11 +1109,17 @@ fn integration_management_reports_and_installs_bundled_hosts() {
     }
     assert!(!config.join("opencode/plugins/boomux.js").exists());
     assert!(!pi.join("extensions/boomux.js").exists());
+    assert!(!omp.join("extensions/boomux.ts").exists());
     assert!(!claude_manifest.exists());
     assert!(!codex_hooks.exists());
     assert!(!kiro_hooks.exists());
     assert!(config.join("opencode/plugins").is_dir());
     assert!(pi.join("extensions").is_dir());
+    assert!(omp.join("extensions").is_dir());
+    assert_eq!(
+        fs::read_to_string(omp.join("extensions/herdr-omp-agent-state.ts")).unwrap(),
+        "keep herdr state"
+    );
     assert!(claude.join("skills/boomux/.claude-plugin").is_dir());
     assert!(root.join(".codex").is_dir());
     assert!(root.join(".kiro/hooks").is_dir());


### PR DESCRIPTION
## Summary

Add Oh My Pi (`omp`) as a first-class Boomux Agent host, matching Pi/OpenCode/Claude/Codex/Kiro.

- Register `omp` (display name Oh My Pi) with install target `~/.omp/agent/extensions/boomux.ts`
- Lifecycle extension reports idle/working/blocked/inactive (`session_shutdown` never `done`)
- Per-turn `boomux shell rename --json` from LM Studio `google/gemma-4-e4b`, sanitized slug, `already_exists` re-complete once
- `shell.rename` is a JSON command so the extension argv is not HumanOnly-rejected
- Tests, ssh uninstall allowlist, native_backend bundled-host coverage, and CI bun invocation include `omp`
- Neighbor file `herdr-omp-agent-state.ts` is not written or deleted

## Test plan

- [x] `bun test integrations/omp/boomux.test.js integrations/pi/boomux.test.js`
- [x] `cargo test --lib integrations --locked -- --test-threads=1`
- [x] `cargo test --test native_backend --locked integration_management_reports_and_installs_bundled_hosts -- --test-threads=1`
- [x] `cargo test --lib --locked explicit_uninstall -- --test-threads=1`
- [x] Isolated `./target/debug/boomux integration list --json` includes `omp` / Oh My Pi
- [x] `./target/debug/boomux integration install omp` writes `~/.omp/agent/extensions/boomux.ts` and leaves `herdr-omp-agent-state.ts`

Do not replace the 1.9.4 release binary; this branch is the fork debug CLI.