### PR TITLE
test(attachment): include reconstructed output

### DIFF
--- a/tests/native_backend/remote_attachment.rs
+++ b/tests/native_backend/remote_attachment.rs
@@ -6,7 +6,8 @@ use boomux::protocol::{AttachFrame, QualifiedIdentity, ShellSpec};
 use uuid::Uuid;
 
 use crate::support::{
-    CONTROL_MASTER_PREFIX, TestDaemon, contains, parse_pid, profile, read_until, wait_until,
+    CONTROL_MASTER_PREFIX, TestDaemon, contains, parse_pid, profile, read_until, read_until_after,
+    wait_until,
 };
 
 fn install_fake_ssh(
@@ -328,7 +329,12 @@ fn two_daemon_remote_attachment_keeps_environment_and_runtime_on_owner() {
             profile(),
         )
         .unwrap();
-    let output = read_until(&mut attachment.stream, b"term=attachment-term");
+    let reconstruction = std::mem::take(&mut attachment.reconstruction);
+    let output = read_until_after(
+        &mut attachment.stream,
+        b"term=attachment-term",
+        reconstruction,
+    );
     assert!(contains(&output, b"remote=owner-only"));
     assert!(contains(&output, b"local=unset"));
     let pid = parse_pid(&output, "pid=").expect("remote shell PID");


### PR DESCRIPTION
## Summary
- seed the remote attachment assertion with its initial reconstruction
- continue reading live frames when the expected startup output is beyond the reconstruction boundary
- remove timing dependence exposed by the startup banner removal

## Context
The merged `main` run failed once because immediate child output landed entirely in `Attachment::reconstruction`, while the test inspected only subsequent `AttachFrame::Output` frames. The failed workflow rerun passed without product changes: https://github.com/gardnmi/boomux/actions/runs/33835549257

## Validation
- `cargo fmt --all -- --check`
- `cargo test --test native_backend remote_attachment::two_daemon_remote_attachment_keeps_environment_and_runtime_on_owner --locked -- --exact --test-threads=1`
- `cargo test --test native_backend --locked -- --test-threads=1`