### PR TITLE
fix(runtime): bound background work and preserve terminal state

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -604,14 +604,19 @@ serialization boundary so bytes within a frame cannot interleave. Collaborative
 resize is ignored; only the primary can update the PTY and retained terminal
 dimensions. Explicit takeover detaches the prior primary and all
 collaborators; graceful handoff instead reconnects and awaits every participant.
-The listener admits at most 64 concurrent connection handlers and closes newly
-accepted sockets while that capacity is exhausted. Management responses and
-attachment output use bounded write deadlines. Attachments retain one admission
-slot for their lifetime, and their input handler joins the output worker after
-either side closes the shared socket, so abandoned clients cannot delay shutdown
-indefinitely.
+The listener admits at most 64 concurrent handshake and management handlers and
+closes newly accepted sockets while that capacity is exhausted. Decoded native,
+collaborative, and routed attachment requests move to a separate pool of at most
+1,024 handlers; saturation returns `busy` and preserves management capacity.
+Each pool releases its permit when its handler exits. Management responses and
+attachment output use bounded write deadlines. Attachment input handlers join
+the output worker after either side closes the shared socket, so abandoned
+clients cannot delay shutdown indefinitely.
 It also feeds a shadow `vt100` parser while forwarding the original PTY bytes
-unchanged. Reattachment receives a bounded reconstruction of rendered state,
+unchanged. Alternate-screen reconstruction reads the primary grid and saved
+cursor from a temporary copy of that parser's screen. It does not depend on PTY
+chunk boundaries or retain a second primary-screen snapshot while output runs.
+Reattachment receives a bounded reconstruction of rendered state,
 not historical OSC or graphics commands. Plain reads and structured previews
 clone the bounded shadow screen under the per-shell terminal lock, then format
 that snapshot after releasing the lock. They traverse physical rows from newest
@@ -1530,7 +1535,18 @@ per-shell synchronization. It publishes the latest revision at most once per
 boundaries. Output events may therefore skip intermediate revisions and event
 IDs describe publication order rather than byte-arrival order. Revision-aware
 reads use a per-runtime condition variable and do not depend on global event
-publication for wakeups.
+publication for wakeups. An idle reader blocks on its PTY, an eventfd for control
+commands and pause cancellation, and a pidfd for process exit. Only pending
+output publication supplies a timer; if pidfd acquisition is unavailable, a
+100-millisecond process-check fallback applies. The eventfd and pidfd are
+runtime-local, close on reader teardown, and are recreated after handoff.
+
+The dashboard Git cache uses one worker, at most 64 outstanding inspections,
+bounded request/result queues, and 256 entries evicted by least recent access.
+Saturation serves cached or unknown metadata and retries on a later refresh.
+Each exact-argv Git command has a one-second deadline and a one-MiB stdout limit;
+failure reports unavailable metadata, and cleanup terminates its private process
+group and reaps the child. Dropping the cache discards queued inspections.
 
 Agent registration, ensure, reports, and attention acknowledgment use the same
 durable mutation coordinator.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child as StdChild, Command, Stdio};
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{self, SyncSender, TrySendError};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, TryLockError, Weak};
 use std::thread;
@@ -76,6 +76,7 @@ use crate::terminal_state::TerminalState;
 const CONTROLLER_QUEUE: usize = 64;
 const MAX_COLLABORATORS_PER_SHELL: usize = 4;
 const MAX_CONNECTION_HANDLERS: usize = 64;
+const MAX_ATTACHMENT_HANDLERS: usize = 1_024;
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(50);
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 const RESPONSE_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
@@ -529,6 +530,7 @@ fn run_daemon(
     let mut handed_off = false;
     let mut last_persistence_retry = Instant::now();
     let mut last_kiro_reconciliation = Instant::now();
+    let admission = Arc::new(ConnectionAdmission::default());
 
     while !shutdown.load(Ordering::Acquire) {
         if last_kiro_reconciliation.elapsed() >= KIRO_HOLDER_RECONCILE_INTERVAL {
@@ -577,10 +579,10 @@ fn run_daemon(
         }
         match listener.accept() {
             Ok((stream, _)) => {
-                if handlers.len() >= MAX_CONNECTION_HANDLERS {
+                let Some(permit) = admission.admit() else {
                     drop(stream);
                     continue;
-                }
+                };
                 let registry = Arc::clone(&registry);
                 let shutdown = Arc::clone(&shutdown);
                 let transition = Arc::clone(&transition);
@@ -595,6 +597,7 @@ fn run_daemon(
                                 shutdown,
                                 transition,
                                 restart_sender,
+                                permit,
                             );
                         })?,
                 );
@@ -1778,12 +1781,70 @@ fn select_replacement_executable(current: PathBuf, argument_zero: Option<PathBuf
     current
 }
 
+#[derive(Default)]
+struct ConnectionAdmission {
+    management: AtomicUsize,
+    attachments: AtomicUsize,
+}
+
+struct ConnectionPermit {
+    admission: Arc<ConnectionAdmission>,
+    attachment: bool,
+}
+
+impl ConnectionAdmission {
+    fn admit(self: &Arc<Self>) -> Option<ConnectionPermit> {
+        self.management
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                (count < MAX_CONNECTION_HANDLERS).then_some(count + 1)
+            })
+            .ok()?;
+        Some(ConnectionPermit {
+            admission: Arc::clone(self),
+            attachment: false,
+        })
+    }
+}
+
+impl ConnectionPermit {
+    fn attach(&mut self) -> bool {
+        if self.attachment {
+            return true;
+        }
+        if self
+            .admission
+            .attachments
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                (count < MAX_ATTACHMENT_HANDLERS).then_some(count + 1)
+            })
+            .is_err()
+        {
+            return false;
+        }
+        self.attachment = true;
+        self.admission.management.fetch_sub(1, Ordering::AcqRel);
+        true
+    }
+}
+
+impl Drop for ConnectionPermit {
+    fn drop(&mut self) {
+        let counter = if self.attachment {
+            &self.admission.attachments
+        } else {
+            &self.admission.management
+        };
+        counter.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
 fn handle_connection(
     stream: UnixStream,
     registry: Arc<DaemonService>,
     shutdown: Arc<AtomicBool>,
     transition: Arc<AtomicU8>,
     restart_sender: mpsc::Sender<RestartRequest>,
+    permit: ConnectionPermit,
 ) -> io::Result<()> {
     handle_connection_inner(
         stream,
@@ -1791,7 +1852,7 @@ fn handle_connection(
         shutdown,
         transition,
         restart_sender,
-        true,
+        permit,
         None,
     )
 }
@@ -1802,7 +1863,7 @@ fn handle_connection_inner(
     shutdown: Arc<AtomicBool>,
     transition: Arc<AtomicU8>,
     restart_sender: mpsc::Sender<RestartRequest>,
-    allow_federation_upgrade: bool,
+    mut permit: ConnectionPermit,
     federation_lease: Option<NodeIdentityLease>,
 ) -> io::Result<()> {
     stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
@@ -1832,7 +1893,7 @@ fn handle_connection_inner(
     }
 
     if matches!(&request.message, Request::OpenFederationChannel) {
-        if !allow_federation_upgrade {
+        if federation_lease.is_some() {
             return send_response(
                 &mut stream,
                 response_version,
@@ -1875,8 +1936,23 @@ fn handle_connection_inner(
             shutdown,
             transition,
             restart_sender,
-            false,
+            permit,
             Some(lease),
+        );
+    }
+
+    if matches!(
+        &request.message,
+        Request::Attach { .. } | Request::AttachCollaborative { .. } | Request::AttachNode { .. }
+    ) && !permit.attach()
+    {
+        return send_daemon_error(
+            &mut stream,
+            response_version,
+            DaemonError::lifecycle(
+                ErrorCode::Busy,
+                "attachment connection capacity is exhausted",
+            ),
         );
     }
 
@@ -7418,8 +7494,129 @@ struct PtyReader {
 }
 
 struct ReaderTask {
-    commands: mpsc::Sender<ReaderCommand>,
+    commands: ReaderCommands,
     handle: Mutex<Option<thread::JoinHandle<io::Result<()>>>>,
+}
+
+// One coalescing eventfd wakes the reader for control messages and pause
+// cancellation. Closing the sender also wakes it to observe disconnection.
+struct ReaderWake(OwnedFd);
+
+impl ReaderWake {
+    fn notify(&self) {
+        let value = 1u64;
+        loop {
+            // The eventfd is nonblocking; saturation already means it is readable.
+            let result =
+                unsafe { libc::write(self.0.as_raw_fd(), (&value as *const u64).cast(), 8) };
+            if result >= 0 || io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
+                break;
+            }
+        }
+    }
+
+    fn clear(&self) {
+        let mut value = 0u64;
+        loop {
+            // One read drains every coalesced wakeup without allocating a queue.
+            let result =
+                unsafe { libc::read(self.0.as_raw_fd(), (&mut value as *mut u64).cast(), 8) };
+            if result >= 0 || io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
+                break;
+            }
+        }
+    }
+
+    fn wait(
+        &self,
+        reader: Option<&PtyReader>,
+        process: Option<&OwnedFd>,
+        deadline: Option<Instant>,
+    ) -> io::Result<()> {
+        let mut descriptors = [
+            libc::pollfd {
+                fd: self.0.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: reader.map_or(-1, |reader| reader.descriptor.as_raw_fd()),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: process.map_or(-1, AsRawFd::as_raw_fd),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+        loop {
+            let timeout = deadline.map_or(-1, |deadline| {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                remaining
+                    .as_millis()
+                    .saturating_add(u128::from(remaining.subsec_nanos() % 1_000_000 != 0))
+                    .min(i32::MAX as u128) as i32
+            });
+            // All descriptors remain owned throughout poll; -1 entries are ignored.
+            let result = unsafe {
+                libc::poll(
+                    descriptors.as_mut_ptr(),
+                    descriptors.len() as libc::nfds_t,
+                    timeout,
+                )
+            };
+            if result >= 0 {
+                return Ok(());
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::Interrupted {
+                return Err(error);
+            }
+        }
+    }
+}
+
+struct ReaderCommands {
+    sender: Option<mpsc::Sender<ReaderCommand>>,
+    wake: Arc<ReaderWake>,
+}
+
+impl ReaderCommands {
+    fn channel() -> io::Result<(Self, mpsc::Receiver<ReaderCommand>, Arc<ReaderWake>)> {
+        // eventfd returns a new, exclusively owned, close-on-exec descriptor.
+        let descriptor = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK) };
+        if descriptor == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        let wake = Arc::new(ReaderWake(unsafe { OwnedFd::from_raw_fd(descriptor) }));
+        let (sender, receiver) = mpsc::channel();
+        Ok((
+            Self {
+                sender: Some(sender),
+                wake: Arc::clone(&wake),
+            },
+            receiver,
+            wake,
+        ))
+    }
+
+    fn send(&self, command: ReaderCommand) -> Result<(), mpsc::SendError<ReaderCommand>> {
+        let result = self
+            .sender
+            .as_ref()
+            .expect("live reader command sender")
+            .send(command);
+        self.wake.notify();
+        result
+    }
+}
+
+impl Drop for ReaderCommands {
+    fn drop(&mut self) {
+        self.sender.take();
+        self.wake.notify();
+    }
 }
 
 enum ReaderCommand {
@@ -7720,6 +7917,7 @@ impl ReaderTask {
                 Err(mpsc::TryRecvError::Empty) if self.is_finished() => return self.finish(),
                 Err(mpsc::TryRecvError::Empty) if Instant::now() >= deadline => {
                     cancelled.store(true, Ordering::Release);
+                    self.commands.wake.notify();
                     return Err(io::Error::new(
                         io::ErrorKind::TimedOut,
                         "PTY reader did not pause",
@@ -15728,7 +15926,10 @@ impl ShellRuntimeManager {
         mut reader: PtyReader,
         start_paused: bool,
     ) -> io::Result<()> {
-        let (commands, command_receiver) = mpsc::channel();
+        let (commands, command_receiver, wake) = ReaderCommands::channel()?;
+        let process_wake = lock(&runtime.process)?
+            .process_id()
+            .and_then(|pid| open_pidfd(pid).ok());
         let reader_runtime = Arc::clone(&runtime);
         let reader_run = Arc::clone(&run);
         let handle = thread::Builder::new()
@@ -15742,6 +15943,7 @@ impl ShellRuntimeManager {
                 let mut pending_output_revision = None;
                 let mut output_publication_deadline = None;
                 loop {
+                    wake.clear();
                     if paused {
                         if pause_cancellation
                             .as_ref()
@@ -15751,7 +15953,7 @@ impl ShellRuntimeManager {
                             pause_cancellation = None;
                             continue;
                         }
-                        match command_receiver.recv_timeout(IO_RETRY_DELAY) {
+                        match command_receiver.try_recv() {
                             Ok(ReaderCommand::Pause {
                                 acknowledge,
                                 cancelled,
@@ -15771,11 +15973,11 @@ impl ShellRuntimeManager {
                                 paused = false;
                                 pause_cancellation = None;
                             }
-                            Ok(ReaderCommand::Stop) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                            Ok(ReaderCommand::Stop) | Err(mpsc::TryRecvError::Disconnected) => {
                                 stopped = true;
                                 break;
                             }
-                            Err(mpsc::RecvTimeoutError::Timeout) => {}
+                            Err(mpsc::TryRecvError::Empty) => wake.wait(None, None, None)?,
                         }
                         continue;
                     }
@@ -15912,7 +16114,14 @@ impl ShellRuntimeManager {
                             if process_exited {
                                 break;
                             }
-                            thread::sleep(IO_RETRY_DELAY);
+                            // A deadline is needed only for coalesced output, or
+                            // the compatibility fallback if pidfd_open is unavailable.
+                            let deadline = output_publication_deadline.or_else(|| {
+                                process_wake
+                                    .is_none()
+                                    .then(|| Instant::now() + Duration::from_millis(100))
+                            });
+                            wake.wait(Some(&reader), process_wake.as_ref(), deadline)?;
                         }
                         Err(_) => break,
                     }
@@ -24750,8 +24959,54 @@ mod tests {
     }
 
     #[test]
+    fn attachment_admission_preserves_management_capacity_and_releases_permits() {
+        let admission = Arc::new(ConnectionAdmission::default());
+        let mut attachments = Vec::new();
+        for _ in 0..MAX_ATTACHMENT_HANDLERS {
+            let mut permit = admission.admit().unwrap();
+            assert!(permit.attach());
+            attachments.push(permit);
+        }
+        let mut management = Vec::new();
+        for _ in 0..MAX_CONNECTION_HANDLERS {
+            let mut permit = admission.admit().unwrap();
+            assert!(!permit.attach());
+            management.push(permit);
+        }
+        assert!(admission.admit().is_none());
+        attachments.pop();
+        assert!(management[0].attach());
+        assert!(admission.admit().is_some());
+        drop(attachments);
+        drop(management);
+        assert_eq!(admission.management.load(Ordering::Acquire), 0);
+        assert_eq!(admission.attachments.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn reader_wait_wakes_for_commands_and_disconnection() {
+        let (commands, receiver, wake) = ReaderCommands::channel().unwrap();
+        let (observed, observation) = mpsc::sync_channel(0);
+        let waiter = thread::spawn(move || {
+            wake.wait(None, None, None).unwrap();
+            wake.clear();
+            assert!(matches!(receiver.try_recv(), Ok(ReaderCommand::Resume)));
+            observed.send(()).unwrap();
+            wake.wait(None, None, None).unwrap();
+            assert!(matches!(
+                receiver.try_recv(),
+                Err(mpsc::TryRecvError::Disconnected)
+            ));
+        });
+        commands.send(ReaderCommand::Resume).unwrap();
+        observation.recv_timeout(Duration::from_secs(2)).unwrap();
+        drop(commands);
+        waiter.join().unwrap();
+    }
+
+    #[test]
     fn timed_out_reader_pause_cancels_queued_command() {
-        let (commands, receiver) = mpsc::channel();
+        let (commands, receiver, _wake) = ReaderCommands::channel().unwrap();
         let (observed, observation) = mpsc::sync_channel(1);
         let handle = thread::spawn(move || {
             thread::sleep(Duration::from_millis(30));

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,12 +1,20 @@
 use std::collections::{HashMap, HashSet};
+use std::io::{self, Read};
+use std::os::fd::AsRawFd;
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
-use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::thread;
 use std::time::{Duration, Instant};
 
 const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+const MAX_CACHE_ENTRIES: usize = 256;
+const MAX_PENDING_INSPECTIONS: usize = 64;
+const MAX_GIT_OUTPUT_BYTES: usize = 1024 * 1024;
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Metadata {
@@ -30,12 +38,14 @@ impl Default for Metadata {
 struct CachedMetadata {
     value: Metadata,
     inspected_at: Instant,
+    accessed_at: Instant,
 }
 
 pub(crate) struct Cache {
     entries: HashMap<PathBuf, CachedMetadata>,
     pending: HashSet<PathBuf>,
-    requests: Sender<PathBuf>,
+    requests: SyncSender<PathBuf>,
+    stopped: Arc<AtomicBool>,
     results: Receiver<(PathBuf, Metadata)>,
 }
 
@@ -47,10 +57,16 @@ impl Default for Cache {
 
 impl Cache {
     fn with_inspector(inspector: Arc<dyn Fn(&Path) -> Metadata + Send + Sync>) -> Self {
-        let (request_sender, request_receiver) = mpsc::channel::<PathBuf>();
-        let (result_sender, result_receiver) = mpsc::channel();
+        let (request_sender, request_receiver) =
+            mpsc::sync_channel::<PathBuf>(MAX_PENDING_INSPECTIONS);
+        let (result_sender, result_receiver) = mpsc::sync_channel(MAX_PENDING_INSPECTIONS);
+        let stopped = Arc::new(AtomicBool::new(false));
+        let worker_stopped = Arc::clone(&stopped);
         thread::spawn(move || {
             while let Ok(directory) = request_receiver.recv() {
+                if worker_stopped.load(Ordering::Acquire) {
+                    break;
+                }
                 let metadata = inspector(&directory);
                 if result_sender.send((directory, metadata)).is_err() {
                     break;
@@ -61,6 +77,7 @@ impl Cache {
             entries: HashMap::new(),
             pending: HashSet::new(),
             requests: request_sender,
+            stopped,
             results: result_receiver,
         }
     }
@@ -68,24 +85,36 @@ impl Cache {
     pub(crate) fn inspect(&mut self, directory: &Path) -> Metadata {
         for (directory, value) in self.results.try_iter() {
             self.pending.remove(&directory);
+            if !self.entries.contains_key(&directory)
+                && self.entries.len() >= MAX_CACHE_ENTRIES
+                && let Some(oldest) = self
+                    .entries
+                    .iter()
+                    .min_by_key(|(_, entry)| entry.accessed_at)
+                    .map(|(path, _)| path.clone())
+            {
+                self.entries.remove(&oldest);
+            }
             self.entries.insert(
                 directory,
                 CachedMetadata {
                     value,
                     inspected_at: Instant::now(),
+                    accessed_at: Instant::now(),
                 },
             );
         }
 
-        if let Some(cached) = self.entries.get(directory)
-            && cached.inspected_at.elapsed() < REFRESH_INTERVAL
-        {
-            return cached.value.clone();
+        if let Some(cached) = self.entries.get_mut(directory) {
+            cached.accessed_at = Instant::now();
+            if cached.inspected_at.elapsed() < REFRESH_INTERVAL {
+                return cached.value.clone();
+            }
         }
 
-        if !self.pending.contains(directory) {
+        if self.pending.len() < MAX_PENDING_INSPECTIONS && !self.pending.contains(directory) {
             let directory = directory.to_owned();
-            if self.requests.send(directory.clone()).is_ok() {
+            if self.requests.try_send(directory.clone()).is_ok() {
                 self.pending.insert(directory);
             }
         }
@@ -96,24 +125,142 @@ impl Cache {
     }
 }
 
+impl Drop for Cache {
+    fn drop(&mut self) {
+        self.stopped.store(true, Ordering::Release);
+    }
+}
+
+// Drain a nonblocking pipe in this worker, with one absolute deadline covering
+// both process exit and EOF. A descendant keeping stdout open cannot wedge it.
+fn command_output(
+    command: &mut Command,
+    timeout: Duration,
+    limit: usize,
+) -> io::Result<Option<Vec<u8>>> {
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn()?;
+    let group = child.id() as libc::pid_t;
+    let result = (|| {
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| io::Error::other("Git stdout is unavailable"))?;
+        let descriptor = stdout.as_raw_fd();
+        // The pipe remains owned by stdout until the operation finishes.
+        let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+        if flags == -1
+            || unsafe { libc::fcntl(descriptor, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1
+        {
+            return Err(io::Error::last_os_error());
+        }
+        let deadline = Instant::now() + timeout;
+        let mut bytes = Vec::new();
+        let mut buffer = [0u8; 8192];
+        let mut eof = false;
+        loop {
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "Git metadata inspection timed out",
+                ));
+            }
+            if !eof {
+                match stdout.read(&mut buffer) {
+                    Ok(0) => eof = true,
+                    Ok(count) => {
+                        if bytes.len().saturating_add(count) > limit {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "Git output exceeds the size limit",
+                            ));
+                        }
+                        bytes.extend_from_slice(&buffer[..count]);
+                        continue;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+                    Err(error) => return Err(error),
+                }
+            }
+            if eof {
+                // Observe exit without reaping, so its process-group ID cannot
+                // be reused before we clean up any remaining Git helpers.
+                let mut status: libc::siginfo_t = unsafe { std::mem::zeroed() };
+                if unsafe {
+                    libc::waitid(
+                        libc::P_PID,
+                        child.id(),
+                        &mut status,
+                        libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+                    )
+                } == -1
+                {
+                    let error = io::Error::last_os_error();
+                    if error.kind() == io::ErrorKind::Interrupted {
+                        continue;
+                    }
+                    return Err(error);
+                }
+                if unsafe { status.si_pid() } != 0 {
+                    return Ok(bytes);
+                }
+            }
+            let mut descriptor = libc::pollfd {
+                fd: if eof { -1 } else { descriptor },
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let timeout = deadline
+                .saturating_duration_since(Instant::now())
+                .as_millis()
+                .min(20) as i32;
+            // Only active Git work polls; an idle cache sleeps on its queue.
+            if unsafe { libc::poll(&mut descriptor, 1, timeout) } == -1 {
+                let error = io::Error::last_os_error();
+                if error.kind() != io::ErrorKind::Interrupted {
+                    return Err(error);
+                }
+            }
+        }
+    })();
+    // Git helpers share this dedicated process group. Reap the direct child on
+    // every path and close the pipe before accepting the next inspection.
+    unsafe {
+        libc::kill(-group, libc::SIGKILL);
+    }
+    let status = child.wait();
+    let bytes = result?;
+    Ok(status?.success().then_some(bytes))
+}
+
+fn git_output(directory: &Path, arguments: &[&str]) -> Option<Vec<u8>> {
+    command_output(
+        Command::new("git").arg("-C").arg(directory).args(arguments),
+        GIT_COMMAND_TIMEOUT,
+        MAX_GIT_OUTPUT_BYTES,
+    )
+    .ok()
+    .flatten()
+}
+
 fn inspect(directory: &Path) -> Option<Metadata> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(directory)
-        .args([
+    let output = git_output(
+        directory,
+        &[
             "rev-parse",
             "--path-format=absolute",
             "--show-toplevel",
             "--git-dir",
             "--git-common-dir",
-        ])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
+        ],
+    )?;
 
-    let output = String::from_utf8_lossy(&output.stdout);
+    let output = String::from_utf8_lossy(&output);
     let mut lines = output.lines();
     let (Some(root), Some(git_directory), Some(common_directory), None) =
         (lines.next(), lines.next(), lines.next(), lines.next())
@@ -136,30 +283,17 @@ fn inspect(directory: &Path) -> Option<Metadata> {
 }
 
 fn inspect_branch(directory: &Path) -> String {
-    let symbolic = Command::new("git")
-        .arg("-C")
-        .arg(directory)
-        .args(["symbolic-ref", "--short", "-q", "HEAD"])
-        .output();
-    if let Ok(output) = symbolic
-        && output.status.success()
-    {
-        return String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    }
-    "detached".into()
+    git_output(directory, &["symbolic-ref", "--short", "-q", "HEAD"])
+        .map(|output| String::from_utf8_lossy(&output).trim().to_owned())
+        .unwrap_or_else(|| "detached".into())
 }
 
 fn inspect_state(directory: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(directory)
-        .args(["status", "--porcelain=v1", "--untracked-files=normal"])
-        .output()
-        .ok()?;
-    output
-        .status
-        .success()
-        .then(|| summarize_status(&String::from_utf8_lossy(&output.stdout)))
+    git_output(
+        directory,
+        &["status", "--porcelain=v1", "--untracked-files=normal"],
+    )
+    .map(|output| summarize_status(&String::from_utf8_lossy(&output)))
 }
 
 fn summarize_status(status: &str) -> String {
@@ -247,6 +381,79 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
         }
+    }
+
+    #[test]
+    fn command_output_bounds_runtime_output_and_inherited_pipes() {
+        for script in ["sleep 10", "sleep 10 & exit 0", "exec 1>&-; sleep 10"] {
+            let started = Instant::now();
+            let error = command_output(
+                Command::new("/bin/sh").args(["-c", script]),
+                Duration::from_millis(50),
+                100,
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+            assert!(started.elapsed() < Duration::from_secs(2));
+        }
+        let error = command_output(
+            Command::new("/bin/sh").args(["-c", "while :; do printf '0123456789'; done"]),
+            Duration::from_secs(2),
+            100,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            command_output(
+                Command::new("/bin/sh").args(["-c", "printf ready"]),
+                Duration::from_secs(1),
+                100
+            )
+            .unwrap(),
+            Some(b"ready".to_vec())
+        );
+    }
+
+    #[test]
+    fn cache_bounds_pending_work_and_stops_queued_inspections_on_drop() {
+        let (started, start) = mpsc::sync_channel(1);
+        let (release, released) = mpsc::sync_channel(1);
+        let released = std::sync::Mutex::new(released);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let worker_calls = Arc::clone(&calls);
+        let mut cache = Cache::with_inspector(Arc::new(move |_| {
+            worker_calls.fetch_add(1, Ordering::SeqCst);
+            started.send(()).unwrap();
+            released.lock().unwrap().recv().unwrap();
+            Metadata::default()
+        }));
+        cache.inspect(Path::new("/first"));
+        start.recv_timeout(Duration::from_secs(2)).unwrap();
+        for index in 0..MAX_PENDING_INSPECTIONS * 4 {
+            cache.inspect(&PathBuf::from(format!("/directory-{index}")));
+        }
+        assert_eq!(cache.pending.len(), MAX_PENDING_INSPECTIONS);
+        drop(cache);
+        release.send(()).unwrap();
+        assert!(start.recv_timeout(Duration::from_secs(2)).is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn cache_evicts_old_directories() {
+        let mut cache = Cache::with_inspector(Arc::new(|_| Metadata::default()));
+        for index in 0..MAX_CACHE_ENTRIES + 10 {
+            let path = PathBuf::from(format!("/directory-{index}"));
+            cache.inspect(&path);
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while cache.pending.contains(&path) {
+                cache.inspect(&path);
+                assert!(Instant::now() < deadline);
+                thread::yield_now();
+            }
+        }
+        assert_eq!(cache.entries.len(), MAX_CACHE_ENTRIES);
+        assert!(!cache.entries.contains_key(Path::new("/directory-0")));
     }
 
     #[test]

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::protocol::{
     TerminalColor, TerminalPreview, TerminalPreviewLine, TerminalPreviewSpan, TerminalStyle,
 };
@@ -8,7 +10,6 @@ const MAX_RECONSTRUCTION_BYTES: usize = 1024 * 1024;
 
 pub(crate) struct TerminalState {
     parser: vt100::Parser,
-    primary_before_alternate: Option<vt100::Screen>,
     terminal_modes: TerminalModes,
 }
 
@@ -21,27 +22,41 @@ impl TerminalState {
         let parser = vt100::Parser::new(rows, cols, SCROLLBACK_ROWS);
         Self {
             parser,
-            primary_before_alternate: None,
             terminal_modes: TerminalModes::default(),
         }
     }
 
     pub(crate) fn process(&mut self, bytes: &[u8]) {
         self.terminal_modes.process(bytes);
-        let was_alternate = self.parser.screen().alternate_screen();
-        if !was_alternate && let Some(offset) = alternate_screen_start(bytes) {
-            self.parser.process(&bytes[..offset]);
-            self.primary_before_alternate = Some(self.parser.screen().clone());
-            self.parser.process(&bytes[offset..]);
-            if !self.parser.screen().alternate_screen() {
-                self.primary_before_alternate = None;
-            }
-            return;
-        }
         self.parser.process(bytes);
-        if was_alternate && !self.parser.screen().alternate_screen() {
-            self.primary_before_alternate = None;
+    }
+
+    fn primary_screen(&self) -> Cow<'_, vt100::Screen> {
+        let screen = self.parser.screen();
+        if !screen.alternate_screen() {
+            return Cow::Borrowed(screen);
         }
+        // Screen already retains both grids, including the saved primary cursor.
+        // Switch a temporary copy through the parser instead of recognizing raw
+        // escape sequences, whose boundaries need not match PTY reads.
+        let mut primary = vt100::Parser::new(1, 1, 0);
+        let mut screen = screen.clone();
+        std::mem::swap(primary.screen_mut(), &mut screen);
+        // Mode 47 does not save the cursor. Keep the primary grid's actual
+        // position even if an earlier DECSC saved a different one. Mode 1049
+        // also restores drawing attributes; cursor restoration can redraw the
+        // last cell of a wrapped row, so restore those attributes afterwards.
+        primary.process(b"\x1b[?47l");
+        let cursor = primary.screen().cursor_state_formatted();
+        primary.process(b"\x1b[?1049l");
+        let attributes = primary.screen().attributes_formatted();
+        // cursor_state_formatted uses physical coordinates, even when the
+        // primary grid had origin mode enabled within a scrolling region.
+        primary.process(b"\x1b[?6l");
+        primary.process(&cursor);
+        primary.process(&attributes);
+        std::mem::swap(primary.screen_mut(), &mut screen);
+        Cow::Owned(screen)
     }
 
     pub(crate) fn resize(&mut self, rows: u16, cols: u16) {
@@ -50,8 +65,8 @@ impl TerminalState {
         }
 
         let screen = self.parser.screen();
-        let primary = self.primary_before_alternate.as_ref().unwrap_or(screen);
-        let mut reconstruction = reflowable_contents_formatted(primary);
+        let primary = self.primary_screen();
+        let mut reconstruction = reflowable_contents_formatted(&primary);
         if screen.alternate_screen() {
             reconstruction.extend_from_slice(b"\x1b[?1049h");
             reconstruction.extend(screen.contents_formatted());
@@ -74,9 +89,9 @@ impl TerminalState {
 
     pub(crate) fn reconstruction(&self) -> Vec<u8> {
         let screen = self.parser.screen();
-        let primary = self.primary_before_alternate.as_ref().unwrap_or(screen);
+        let primary = self.primary_screen();
         let mut output = b"\x1b[?1049l\x1b[0m\x1b[?25h\x1b[H\x1b[2J".to_vec();
-        append_scrollback(&mut output, primary);
+        append_scrollback(&mut output, &primary);
         output.extend_from_slice(b"\x1b[H\x1b[2J");
         output.extend(primary.contents_formatted());
         if screen.alternate_screen() {
@@ -605,17 +620,6 @@ fn preview_line_is_blank(line: &TerminalPreviewLine) -> bool {
     line.spans.iter().all(|span| span.text.trim().is_empty())
 }
 
-fn alternate_screen_start(bytes: &[u8]) -> Option<usize> {
-    [b"\x1b[?1049h".as_slice(), b"\x1b[?1047h", b"\x1b[?47h"]
-        .into_iter()
-        .filter_map(|sequence| {
-            bytes
-                .windows(sequence.len())
-                .position(|window| window == sequence)
-        })
-        .min()
-}
-
 #[cfg(test)]
 fn scrollback_text(screen: &vt100::Screen) -> String {
     let mut screen = screen.clone();
@@ -949,6 +953,76 @@ mod tests {
                 .iter()
                 .all(|cell| cell.fgcolor() == vt100::Color::Idx(1))
         );
+    }
+
+    #[test]
+    fn alternate_screen_reconstruction_is_independent_of_chunk_boundaries() {
+        for sequence in [b"\x1b[?1049h".as_slice(), b"\x1b[?25;1049h", b"\x1b[?47h"] {
+            for split in 0..=sequence.len() {
+                for resize in [false, true] {
+                    let mut source = TerminalState::new(4, 20);
+                    source.process(b"primary");
+                    source.process(&sequence[..split]);
+                    source.process(&sequence[split..]);
+                    source.process(b"alt");
+                    if resize {
+                        source.resize(5, 25);
+                    }
+                    let mut restored = TerminalState::new(5, 25);
+                    restored.process(&source.reconstruction());
+                    assert_eq!(restored.plain_text(), "alt");
+                    restored.process(b"\x1b[?1049l");
+                    assert_eq!(
+                        restored.plain_text(),
+                        "primary",
+                        "sequence={sequence:?}, split={split}, resize={resize}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn alternate_reconstruction_preserves_primary_cursor_and_saved_attributes() {
+        let mut source = TerminalState::new(4, 30);
+        source.process(b"\x1b7primary\x1b[?47halt");
+        let mut restored = TerminalState::new(4, 30);
+        restored.process(&source.reconstruction());
+        restored.process(b"\x1b[?47l!");
+        assert_eq!(restored.plain_text(), "primary!");
+
+        let mut source = TerminalState::new(4, 30);
+        source.process(b"\x1b[31mprimary\x1b[?1049h\x1b[32malt");
+        let mut restored = TerminalState::new(4, 30);
+        restored.process(&source.reconstruction());
+        restored.process(b"\x1b[?1049l!");
+        assert_eq!(restored.plain_text(), "primary!");
+        assert_eq!(
+            restored.parser.screen().cell(0, 7).unwrap().fgcolor(),
+            vt100::Color::Idx(1)
+        );
+    }
+
+    #[test]
+    fn alternate_reconstruction_preserves_cursor_with_primary_origin_mode() {
+        let mut source = TerminalState::new(6, 20);
+        source.process(b"\x1b[2;5r\x1b[?6hprimary\x1b[?1049halt");
+        let mut restored = TerminalState::new(6, 20);
+        restored.process(&source.reconstruction());
+        restored.process(b"\x1b[?1049l!");
+        source.process(b"\x1b[?1049l!");
+        assert_eq!(restored.plain_text(), source.plain_text());
+    }
+
+    #[test]
+    fn repeated_alternate_transitions_capture_the_latest_primary() {
+        let mut source = TerminalState::new(4, 30);
+        source.process(b"first\x1b[?1049hone\x1b[?1049l second\x1b[?1049htwo");
+        let mut restored = TerminalState::new(4, 30);
+        restored.process(&source.reconstruction());
+        assert_eq!(restored.plain_text(), "two");
+        restored.process(b"\x1b[?1049l third");
+        assert_eq!(restored.plain_text(), "first second third");
     }
 
     #[test]

--- a/tests/native_backend/protocol_control.rs
+++ b/tests/native_backend/protocol_control.rs
@@ -12,6 +12,50 @@ use uuid::Uuid;
 use crate::support::{TestDaemon, assert_remote_code, contains, profile, read_until, wait_until};
 
 #[test]
+fn attached_terminals_do_not_exhaust_management_connections() {
+    let daemon = TestDaemon::start();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "attachment-capacity",
+            (0..70)
+                .map(|index| ShellSpec {
+                    name: format!("shell-{index}"),
+                    command: vec!["/bin/sleep".into(), "120".into()],
+                    cwd: daemon.runtime_dir.clone(),
+                })
+                .collect(),
+        )
+        .unwrap();
+    for _ in 0..2 {
+        let attachments = workspace
+            .shells
+            .iter()
+            .map(|shell| daemon.client.attach(&shell.id, true, profile()).unwrap())
+            .collect::<Vec<_>>();
+        daemon.client.ping().unwrap();
+        assert_eq!(
+            daemon
+                .client
+                .get_workspace(&workspace.id)
+                .unwrap()
+                .shells
+                .len(),
+            70
+        );
+        daemon
+            .client
+            .rename_workspace(&workspace.id, "still-manageable")
+            .unwrap();
+        drop(attachments);
+    }
+    daemon.client.ping().unwrap();
+    for shell in &workspace.shells {
+        daemon.client.close_shell(&shell.id).unwrap();
+    }
+}
+
+#[test]
 fn daemon_bounds_stalled_connections_and_recovers_capacity() {
     let daemon = TestDaemon::start();
     let mut stalled = (0..64)


### PR DESCRIPTION
Idle Shells poll every 2 ms, and long-lived attachments consume the same 64 connection slots as management requests. Terminal reconstruction can also replace primary-screen contents when an alternate-screen escape sequence spans PTY reads, while one stalled Git command can block every dashboard Git inspection.

This change fixes those behaviors:

- Wait for PTY readiness, process exit, and reader-control wakeups. Preserve output publication deadlines and handoff pause/cancellation; use a 100 ms process-check fallback when pidfd acquisition is unavailable.
- Move decoded attachments into a separate bounded 1,024-handler pool, preserving the 64 handshake/management slots. Return `busy` at attachment capacity and release permits on handler exit.
- Reconstruct the primary screen from the VT parser's retained grid. Remove the persistent duplicate primary snapshot and cover split/combined escapes, repeated transitions, resizing, saved cursors, colors, and origin mode.
- Bound Git commands to one second and one MiB of stdout; clean up the private process group and reap the child. Bound outstanding inspections to 64 and cached directories to 256, with eviction and queued-work cancellation on drop.

Validation covers the full Rust unit, native backend, configuration CLI, integration, and benchmark suites, plus formatting and all-target/all-feature Clippy. The native suite passed 137 tests, including 70 simultaneously attached terminals with continued management access and repeated attachment cycles. The final handoff rerun passed all nine scenarios. The unit suites used an isolated short `TMPDIR` because existing host catalog data associated with `/tmp` affected two unrelated fixtures; 490 library and 489 binary tests passed, and the final expanded terminal suite passed 25 tests. Deterministic benchmark fixtures, benchmark target compilation, and both Criterion smoke suites passed. Dependency policy validation also passed.

Local measurements used the same machine, development build profile, and synthetic workloads (Intel i5-10210U, Linux 7.2.3, Rust 1.98.1). Desktop activity was present, so timing is evidence rather than a release guarantee.

| Measurement | Before | After |
| --- | ---: | ---: |
| Empty daemon RSS | 12,968 KiB | 11,532 KiB |
| Marginal RSS per running Shell, between 1 and 128 Shells | ~107 KiB | ~106 KiB |
| 128 idle Shells: CPU, percent of one core | 71.77% | 0.33% |
| 128 idle Shells: context switches/second | 61,326 | 39 |
| 128 idle Shells: RSS | 27,600 KiB | 27,268 KiB |
| 128 idle Shells: descriptors | 263 | 519 |
| After closing the idle workload: RSS | 23,656 KiB | 23,180 KiB |
| After closing the idle workload: descriptors / threads | 7 / 3 | 7 / 3 |
| 16 Shells × 50,000 output lines, three cycles: median daemon CPU time | 4.12 s | 3.47 s |
| Output cycles: maximum sampled RSS | 125,576 KiB | 129,608 KiB |
| Output cycles: RSS after final cleanup | 103,004 KiB | 97,220 KiB |
| 32 full-scrollback terminals in alternate-screen mode: RSS | ~327 MiB | ~166 MiB |
| Terminal fixture: peak RSS | ~332 MiB | ~176 MiB |
| Terminal fixture: RSS after dropping terminals | ~159 MiB | ~159 MiB |

The readiness wait costs two additional descriptors per live reader and retains one reader thread per live Shell. Every output cycle returned to seven descriptors and three daemon threads. RSS remained elevated and grew across output cycles in both versions; these measurements do not establish complete heap reclamation or a long-run plateau. The terminal fixture produced identical reconstructed byte counts in three paired runs.
