### PR TITLE
ci: reuse release validation and cache rust builds

### DIFF
--- a/.github/scripts/ci-release-source.py
+++ b/.github/scripts/ci-release-source.py
@@ -1,0 +1,39 @@
+"""Bind CI archives to their source commit, version, target, and checksum."""
+
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+
+
+def metadata(directory, sha, tag, target):
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise ValueError("source must be an exact commit SHA")
+    if not re.fullmatch(r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", tag):
+        raise ValueError("invalid release tag")
+    if target not in {"x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"}:
+        raise ValueError("unsupported release target")
+    name = f"boomux-{tag}-{target}.tar.gz"
+    with (directory / name).open("rb") as archive:
+        digest = hashlib.file_digest(archive, "sha256").hexdigest()
+    if (directory / (name + ".sha256")).read_text().strip() != f"{digest}  {name}":
+        raise ValueError("archive checksum mismatch")
+    return {"sha": sha, "tag": tag, "target": target, "sha256": digest}
+
+
+def process(mode, directory, sha, tag, target):
+    expected = metadata(directory, sha, tag, target)
+    source = directory / "ci-source.json"
+    if mode == "record":
+        source.write_text(json.dumps(expected) + "\n")
+    elif mode == "verify":
+        if json.loads(source.read_text()) != expected:
+            raise ValueError("CI archive does not match the validated release source")
+    else:
+        raise ValueError("expected record or verify")
+
+
+if __name__ == "__main__":
+    mode, directory, sha, tag, target = sys.argv[1:]
+    process(mode, Path(directory), sha, tag, target)

--- a/.github/scripts/classify-ci.py
+++ b/.github/scripts/classify-ci.py
@@ -1,0 +1,100 @@
+"""Conservative CI selection; unknown inputs always require full validation."""
+
+import json
+import os
+import re
+import subprocess
+import tomllib
+
+DOCS = {"AGENTS.md", "CONTEXT.md", "DEVELOPMENT.md", "BENCHMARKING.md",
+        "CHANGELOG.md", "SECURITY.md"}
+RELEASE_FILES = {"Cargo.toml", "Cargo.lock", ".release-please-manifest.json", "CHANGELOG.md"}
+FULL = {"run_code": True, "run_package": True, "run_benchmarks": True}
+
+
+def git(*args):
+    return subprocess.check_output(["git", *args], timeout=30)
+
+
+def read(ref, path):
+    return git("show", f"{ref}:{path}").decode()
+
+
+def release_only(base, head, paths):
+    if not paths <= RELEASE_FILES or not {"Cargo.toml", "Cargo.lock"} <= paths:
+        return False
+    before = tomllib.loads(read(base, "Cargo.toml"))
+    after = tomllib.loads(read(head, "Cargo.toml"))
+    old, new = before["package"]["version"], after["package"]["version"]
+    if old == new or not re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", new):
+        return False
+    after["package"]["version"] = old
+    if before != after:
+        return False
+    locks = [tomllib.loads(read(ref, "Cargo.lock")) for ref in (base, head)]
+    for lock, version in zip(locks, (old, new)):
+        roots = [p for p in lock["package"] if p["name"] == "boomux" and "source" not in p]
+        if len(roots) != 1 or roots[0]["version"] != version:
+            return False
+        roots[0]["version"] = old
+    if locks[0] != locks[1]:
+        return False
+    manifests = [json.loads(read(ref, ".release-please-manifest.json")) for ref in (base, head)]
+    if manifests[1].get(".") != new:
+        return False
+    manifests[1]["."] = manifests[0]["."]
+    return manifests[0] == manifests[1]
+
+
+def validated_base(sha):
+    repo = os.environ["GITHUB_REPOSITORY"]
+    branch = os.environ["DEFAULT_BRANCH"]
+    # Bounded run/job queries. A green docs-only run is not test evidence.
+    response = subprocess.check_output([
+        "gh", "api", f"repos/{repo}/actions/workflows/ci.yml/runs?event=push&head_sha={sha}&status=success&per_page=100"
+    ], timeout=30)
+    runs = [run for run in json.loads(response)["workflow_runs"]
+            if run["head_sha"] == sha and run["event"] == "push"
+            and run["conclusion"] == "success" and run["head_branch"] == branch
+            and run["head_repository"]["full_name"] == repo]
+    if not runs:
+        return False
+    run_id = int(runs[0]["id"])
+    jobs = json.loads(subprocess.check_output([
+        "gh", "api", f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"
+    ], timeout=30))["jobs"]
+    required = {"Run Clippy", "Run Rust unit tests", "Run configuration CLI tests", "Run native backend tests"}
+    return any(job["name"] == "Rust" and job["conclusion"] == "success"
+               and required <= {step["name"] for step in job["steps"] if step["conclusion"] == "success"}
+               for job in jobs)
+
+
+
+def classify(base, head, proof=validated_base):
+    try:
+        if not re.fullmatch(r"[0-9a-f]{40}", base) or base == "0" * 40:
+            return FULL.copy(), "No usable comparison base; full validation."
+        paths = set(git("diff", "--name-only", "--no-renames", "-z", base, head).decode().rstrip("\0").split("\0")) - {""}
+        if all(path in DOCS or (path.startswith("docs/") and path.endswith(".md")) for path in paths):
+            return dict.fromkeys(FULL, False), "Documentation-only change; no executable or packaged inputs changed."
+        if release_only(base, head, paths):
+            if proof(base):
+                return {"run_code": False, "run_package": True, "run_benchmarks": False}, f"Version-only release; reuse successful push CI for {base}. Build and smoke test the new version."
+            return FULL.copy(), "Version-only change has no successful base push CI; full validation."
+        # Rust/core/build/CI changes retain benchmark smoke. Packaging and JS-only
+        # changes still receive ordinary validation without optimized benchmarks.
+        benchmarks = any(path.startswith(("src/", "benches/", "tests/", ".cargo/", ".github/"))
+                         or path in {"Cargo.toml", "Cargo.lock", "build.rs", "rust-toolchain", "rust-toolchain.toml"}
+                         for path in paths)
+        return {"run_code": True, "run_package": True, "run_benchmarks": benchmarks}, "Validate changed executable or packaging inputs."
+    except (subprocess.SubprocessError, OSError, ValueError, KeyError, TypeError) as error:
+        return FULL.copy(), f"Classification unavailable ({type(error).__name__}); full validation."
+
+
+if __name__ == "__main__":
+    selection, reason = classify(os.environ.get("BASE_SHA", ""), os.environ["HEAD_SHA"])
+    with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+        for key, value in selection.items():
+            print(f"{key}={str(value).lower()}", file=output)
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+        print(reason, file=summary)

--- a/.github/scripts/test_ci_release_source.py
+++ b/.github/scripts/test_ci_release_source.py
@@ -1,0 +1,56 @@
+"""Provenance verification rejects wrong sources and altered archives."""
+
+import hashlib
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location("source", Path(__file__).with_name("ci-release-source.py"))
+source = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(source)
+
+
+class SourceTests(unittest.TestCase):
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.directory = Path(temp.name)
+        self.args = (self.directory, "a" * 40, "v1.2.3", "x86_64-unknown-linux-gnu")
+        self.name = "boomux-v1.2.3-x86_64-unknown-linux-gnu.tar.gz"
+        (self.directory / self.name).write_bytes(b"fixture")
+        self.checksum()
+        source.process("record", *self.args)
+
+    def checksum(self):
+        digest = hashlib.sha256((self.directory / self.name).read_bytes()).hexdigest()
+        (self.directory / (self.name + ".sha256")).write_text(f"{digest}  {self.name}\n")
+
+    def test_matching_archive_passes(self):
+        source.process("verify", *self.args)
+
+    def test_wrong_source_fails(self):
+        with self.assertRaises(ValueError):
+            source.process("verify", self.directory, "b" * 40, *self.args[2:])
+
+    def test_altered_archive_fails_even_with_updated_checksum(self):
+        (self.directory / self.name).write_bytes(b"altered")
+        with self.assertRaises(ValueError):
+            source.process("verify", *self.args)
+        self.checksum()
+        with self.assertRaises(ValueError):
+            source.process("verify", *self.args)
+
+    def test_missing_provenance_fails(self):
+        (self.directory / "ci-source.json").unlink()
+        with self.assertRaises(FileNotFoundError):
+            source.process("verify", *self.args)
+
+    def test_wrong_tag_or_target_fails(self):
+        for tag, target in [("v1.2.4", self.args[3]), (self.args[2], "aarch64-unknown-linux-gnu")]:
+            with self.assertRaises(FileNotFoundError):
+                source.process("verify", self.directory, self.args[1], tag, target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_ci_selection.py
+++ b/.github/scripts/test_ci_selection.py
@@ -1,0 +1,150 @@
+"""Exercise classification with real Git diffs and controlled CI evidence."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location("selection", Path(__file__).with_name("classify-ci.py"))
+selection = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(selection)
+
+
+class SelectionTests(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.previous = Path.cwd()
+        self.root = Path(directory.name)
+        os.chdir(self.root)
+        self.addCleanup(os.chdir, self.previous)
+        self.git("init", "-q")
+        self.git("config", "user.name", "CI fixture")
+        self.git("config", "user.email", "ci@example.invalid")
+        self.write_version("1.2.3")
+        for path in ["docs/architecture.md", "README.md", "THIRD_PARTY_NOTICES.md", ".agents/skills/boomux/SKILL.md", "src/lib.rs"]:
+            self.write(path, "fixture\n")
+        self.base = self.commit()
+
+    def git(self, *args):
+        return subprocess.check_output(["git", *args], stderr=subprocess.DEVNULL).decode().strip()
+
+    def write(self, path, content):
+        file = Path(path)
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.write_text(content)
+
+    def write_version(self, version):
+        self.write("Cargo.toml", f'[package]\nname = "boomux"\nversion = "{version}"\n')
+        self.write("Cargo.lock", f'version = 4\n[[package]]\nname = "boomux"\nversion = "{version}"\n[[package]]\nname = "dependency"\nversion = "2.0.0"\nsource = "registry"\n')
+        self.write(".release-please-manifest.json", json.dumps({".": version}))
+        self.write("CHANGELOG.md", version)
+
+    def commit(self):
+        self.git("add", "-A")
+        self.git("commit", "-qm", "fixture")
+        return self.git("rev-parse", "HEAD")
+
+    def classify(self, proof=lambda sha: True):
+        return selection.classify(self.base, self.commit(), proof)[0]
+
+    def test_documentation_skips_work(self):
+        self.write("docs/architecture.md", "updated")
+        self.assertEqual(self.classify(), dict.fromkeys(selection.FULL, False))
+
+    def test_embedded_and_packaged_markdown_cannot_skip(self):
+        for path in ["README.md", "THIRD_PARTY_NOTICES.md", ".agents/skills/boomux/SKILL.md"]:
+            with self.subTest(path=path):
+                self.write(path, "updated")
+                result = self.classify()
+                self.assertTrue(result["run_code"])
+                self.assertTrue(result["run_package"])
+                self.git("reset", "--hard", self.base)
+
+    def test_deleted_embedded_markdown_cannot_skip(self):
+        Path(".agents/skills/boomux/SKILL.md").unlink()
+        self.assertTrue(self.classify()["run_code"])
+
+    def test_failed_diff_requires_full_validation(self):
+        result, _ = selection.classify("1" * 40, self.base)
+        self.assertEqual(result, selection.FULL)
+
+    def test_missing_and_zero_base_require_full_validation(self):
+        for base in ["", "0" * 40]:
+            self.assertEqual(selection.classify(base, self.base)[0], selection.FULL)
+
+    def test_version_only_with_proof_keeps_packaging(self):
+        self.write_version("1.2.4")
+        seen = []
+        result = self.classify(lambda sha: seen.append(sha) or True)
+        self.assertEqual(seen, [self.base])
+        self.assertEqual(result, {"run_code": False, "run_package": True, "run_benchmarks": False})
+
+    def test_version_only_without_proof_runs_full_validation(self):
+        self.write_version("1.2.4")
+        self.assertEqual(self.classify(lambda sha: False), selection.FULL)
+
+    def test_ci_lookup_failure_runs_full_validation(self):
+        self.write_version("1.2.4")
+        def unavailable(sha):
+            raise subprocess.TimeoutExpired("gh", 30)
+        self.assertEqual(self.classify(unavailable), selection.FULL)
+
+    def test_release_with_source_change_runs_full_validation(self):
+        self.write_version("1.2.4")
+        self.write("src/lib.rs", "changed")
+        self.assertEqual(self.classify(), selection.FULL)
+
+    def test_release_with_dependency_change_runs_full_validation(self):
+        self.write_version("1.2.4")
+        lock = Path("Cargo.lock")
+        lock.write_text(lock.read_text().replace('"2.0.0"', '"2.0.1"'))
+        self.assertEqual(self.classify(), selection.FULL)
+
+    def test_release_with_manifest_change_runs_full_validation(self):
+        self.write_version("1.2.4")
+        with Path("Cargo.toml").open("a") as manifest:
+            manifest.write('edition = "2024"\n')
+        self.assertEqual(self.classify(), selection.FULL)
+
+    def test_wrong_release_manifest_runs_full_validation(self):
+        self.write_version("1.2.4")
+        self.write(".release-please-manifest.json", '{".": "1.2.3"}')
+        self.assertEqual(self.classify(), selection.FULL)
+
+    def test_packaging_and_js_changes_skip_benchmark_smoke(self):
+        for path in ["packaging/test-installer.sh", "integrations/pi/boomux.js"]:
+            self.write(path, "changed")
+        self.assertEqual(self.classify(), {"run_code": True, "run_package": True, "run_benchmarks": False})
+
+    def test_rust_and_workflow_changes_keep_benchmarks(self):
+        self.write(".github/workflows/ci.yml", "changed")
+        self.assertEqual(self.classify(), selection.FULL)
+
+    def test_ci_proof_requires_exact_successful_main_push(self):
+        valid = {"id": 123, "head_sha": self.base, "event": "push", "conclusion": "success", "head_branch": "main", "head_repository": {"full_name": "owner/repo"}}
+        with patch.dict(os.environ, GITHUB_REPOSITORY="owner/repo", DEFAULT_BRANCH="main"):
+            for field, invalid in [(None, None), ("head_sha", "a" * 40), ("event", "pull_request"), ("conclusion", "failure"), ("head_branch", "feature"), ("head_repository", {"full_name": "fork/repo"})]:
+                run = dict(valid)
+                if field:
+                    run[field] = invalid
+                jobs = {"jobs": [{"name": "Rust", "conclusion": "success", "steps": [
+                    {"name": name, "conclusion": "success"} for name in
+                    ["Run Clippy", "Run Rust unit tests", "Run configuration CLI tests", "Run native backend tests"]
+                ]}]}
+                responses = [json.dumps({"workflow_runs": [run]}).encode(), json.dumps(jobs).encode()]
+                with patch.object(selection.subprocess, "check_output", side_effect=responses):
+                    self.assertEqual(selection.validated_base(self.base), field is None)
+            # A successful workflow with skipped tests cannot justify reuse.
+            jobs["jobs"][0]["steps"][-1]["conclusion"] = "skipped"
+            responses = [json.dumps({"workflow_runs": [valid]}).encode(), json.dumps(jobs).encode()]
+            with patch.object(selection.subprocess, "check_output", side_effect=responses):
+                self.assertFalse(selection.validated_base(self.base))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch:
+  merge_group:
   push:
     branches:
       - main
@@ -12,53 +14,48 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   changes:
     name: Classify changes
-    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
     outputs:
       run_code: ${{ steps.classify.outputs.run_code }}
+      run_package: ${{ steps.classify.outputs.run_package }}
+      run_benchmarks: ${{ steps.classify.outputs.run_benchmarks }}
     steps:
       - name: Check out repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
 
-      - name: Detect non-Markdown changes
+      - name: Test CI selection and artifact provenance
+        run: python3 -m unittest discover -s .github/scripts -p 'test_ci_*.py'
+
+      - name: Select required validation
         id: classify
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-        run: |
-          run_code=false
-          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ || "$BASE_SHA" == 0000000000000000000000000000000000000000 ]]; then
-            run_code=true
-          else
-            while IFS= read -r -d '' path; do
-              case "$path" in
-                *.md) ;;
-                *) run_code=true; break ;;
-              esac
-            done < <(git diff --name-only --no-renames -z "$BASE_SHA" "$HEAD_SHA")
-          fi
-          printf 'run_code=%s\n' "$run_code" >> "$GITHUB_OUTPUT"
-          if [[ "$run_code" == false ]]; then
-            printf 'Only Markdown files changed; code and packaging steps will be skipped.\n' >> "$GITHUB_STEP_SUMMARY"
-          fi
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/classify-ci.py
 
   rust:
     name: Rust
     needs: changes
-    if: always()
-    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
     env:
       RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
       RUSTUP_TOOLCHAIN: stable
     steps:
-      - name: Skip code checks for Markdown-only changes
+      - name: Skip code checks when covered or not required
         if: env.RUN_CODE != 'true'
-        run: printf 'Rust checks are not required for Markdown-only changes.\n'
+        run: printf 'Rust checks are covered by base CI or not needed; see Classify changes.\n'
 
       - name: Check out repository
         if: env.RUN_CODE == 'true'
@@ -67,6 +64,13 @@ jobs:
       - name: Install Rust toolchain
         if: env.RUN_CODE == 'true'
         run: rustup toolchain install stable --profile minimal --component rustfmt,clippy
+
+      - name: Cache Rust dependencies
+        if: env.RUN_CODE == 'true'
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: ubuntu-24.04-checks
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Check formatting
         if: env.RUN_CODE == 'true'
@@ -91,14 +95,15 @@ jobs:
   dependency-policy:
     name: Dependency policy
     needs: changes
-    if: always()
-    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
     env:
       RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
     steps:
-      - name: Skip dependency checks for Markdown-only changes
+      - name: Skip dependency checks when covered or not required
         if: env.RUN_CODE != 'true'
-        run: printf 'Dependency checks are not required for Markdown-only changes.\n'
+        run: printf 'Dependency checks are covered by base CI or not needed; see Classify changes.\n'
 
       - name: Check out repository
         if: env.RUN_CODE == 'true'
@@ -111,15 +116,16 @@ jobs:
   benchmarks:
     name: Benchmark smoke
     needs: changes
-    if: always()
+    if: ${{ !cancelled() }}
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     env:
-      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_benchmarks == 'false' && 'false' || 'true' }}
       RUSTUP_TOOLCHAIN: stable
     steps:
-      - name: Skip benchmark checks for Markdown-only changes
+      - name: Skip benchmark checks when covered or not required
         if: env.RUN_CODE != 'true'
-        run: printf 'Benchmark checks are not required for Markdown-only changes.\n'
+        run: printf 'Benchmark checks are covered by base CI or not needed; see Classify changes.\n'
 
       - name: Check out repository
         if: env.RUN_CODE == 'true'
@@ -129,31 +135,33 @@ jobs:
         if: env.RUN_CODE == 'true'
         run: rustup toolchain install stable --profile minimal
 
+      - name: Cache Rust dependencies
+        if: env.RUN_CODE == 'true'
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: ubuntu-24.04-benchmarks
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
       - name: Validate deterministic benchmark fixtures
         if: env.RUN_CODE == 'true'
         run: cargo test --test benchmark_harness --features benchmark-internals --locked
 
-      - name: Compile every benchmark target
-        if: env.RUN_CODE == 'true'
-        run: cargo check --benches --all-features --locked
-
       - name: Smoke test Criterion benchmarks
         if: env.RUN_CODE == 'true'
-        run: |
-          cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
-          cargo bench --bench wire --locked -- --test
+        run: cargo bench --bench core_cpu --bench wire --features benchmark-internals --locked -- --test
 
   integrations:
     name: Integrations
     needs: changes
-    if: always()
-    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
     env:
       RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
     steps:
-      - name: Skip integration checks for Markdown-only changes
+      - name: Skip integration checks when covered or not required
         if: env.RUN_CODE != 'true'
-        run: printf 'Integration checks are not required for Markdown-only changes.\n'
+        run: printf 'Integration checks are covered by base CI or not needed; see Classify changes.\n'
 
       - name: Check out repository
         if: env.RUN_CODE == 'true'
@@ -179,7 +187,7 @@ jobs:
   release-packaging:
     name: Release packaging (${{ matrix.arch }})
     needs: changes
-    if: always()
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:
@@ -190,16 +198,17 @@ jobs:
           - arch: aarch64
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+    timeout-minutes: 30
     runs-on: ${{ matrix.runner }}
     env:
       BOOMUX_DISTRIBUTION: github-release
-      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_package == 'false' && 'false' || 'true' }}
       RUSTUP_TOOLCHAIN: stable
       TARGET: ${{ matrix.target }}
     steps:
-      - name: Skip release packaging for Markdown-only changes
+      - name: Skip release packaging when covered or not required
         if: env.RUN_CODE != 'true'
-        run: printf 'Release packaging is not required for Markdown-only changes.\n'
+        run: printf 'Release packaging is covered by base CI or not needed; see Classify changes.\n'
 
       - name: Check out repository
         if: env.RUN_CODE == 'true'
@@ -208,6 +217,14 @@ jobs:
       - name: Install Rust toolchain
         if: env.RUN_CODE == 'true'
         run: rustup toolchain install stable --profile minimal
+
+      - name: Cache Rust dependencies
+        if: env.RUN_CODE == 'true'
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          shared-key: release-${{ matrix.target }}
+          key: ubuntu-24.04-release-${{ matrix.target }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Read package version
         if: env.RUN_CODE == 'true'
@@ -223,12 +240,20 @@ jobs:
         if: env.RUN_CODE == 'true'
         run: bash .github/scripts/package-release.sh "$TAG" "$TARGET"
 
-      - name: Retain package for compatibility testing
-        if: ${{ env.RUN_CODE == 'true' && matrix.arch == 'x86_64' }}
+      - name: Record package source
+        if: env.RUN_CODE == 'true'
+        run: python3 .github/scripts/ci-release-source.py record dist "$(git rev-parse HEAD)" "$TAG" "$TARGET"
+
+      - name: Retain validated release candidate
+        if: env.RUN_CODE == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: compatibility-${{ matrix.target }}
-          path: dist/boomux-${{ env.TAG }}-${{ matrix.target }}.tar.gz
+          name: release-candidate-${{ matrix.target }}
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+            dist/ci-source.json
+          retention-days: 14
           if-no-files-found: error
 
       - name: Validate release scripts
@@ -242,15 +267,16 @@ jobs:
   aur-package:
     name: AUR package metadata
     needs: changes
-    if: always()
+    if: ${{ !cancelled() }}
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     container: archlinux:base-devel@sha256:68bfc3b0d277b08a99101dc9b94aaa03e5ae70cf1b4fb965c03b2b87b915760d
     env:
       RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
     steps:
-      - name: Skip AUR validation for Markdown-only changes
+      - name: Skip AUR validation when covered or not required
         if: env.RUN_CODE != 'true'
-        run: printf 'AUR validation is not required for Markdown-only changes.\n'
+        run: printf 'AUR validation is covered by base CI or not needed; see Classify changes.\n'
 
       - name: Prepare Arch build user
         if: env.RUN_CODE == 'true'
@@ -286,21 +312,22 @@ jobs:
     needs:
       - changes
       - release-packaging
-    if: always()
+    if: ${{ !cancelled() && needs.release-packaging.result == 'success' }}
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     container: archlinux:base-devel@sha256:68bfc3b0d277b08a99101dc9b94aaa03e5ae70cf1b4fb965c03b2b87b915760d
     env:
-      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_code == 'false' && 'false' || 'true' }}
+      RUN_CODE: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_package == 'false' && 'false' || 'true' }}
     steps:
-      - name: Skip compatibility testing for Markdown-only changes
+      - name: Skip compatibility testing when covered or not required
         if: env.RUN_CODE != 'true'
-        run: printf 'Pinned Arch compatibility is not required for Markdown-only changes.\n'
+        run: printf 'Pinned Arch compatibility is covered by base CI or not needed; see Classify changes.\n'
 
       - name: Download x86_64 release package
         if: env.RUN_CODE == 'true'
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
-          name: compatibility-x86_64-unknown-linux-gnu
+          name: release-candidate-x86_64-unknown-linux-gnu
           path: dist
 
       - name: Smoke test Ubuntu-built binary on pinned Arch

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,12 +9,13 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing release tag to build and publish
-        required: false
+        description: Existing release tag for recovery or compatibility validation
+        required: true
         type: string
 
 permissions:
   contents: write
+  actions: read
   issues: write
   pull-requests: write
 
@@ -26,8 +27,11 @@ jobs:
   release-please:
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||
-          (github.event.workflow_run.conclusion == 'success' &&
+          (github.event.workflow_run.event == 'push' &&
+           github.event.workflow_run.head_repository.full_name == github.repository &&
+           github.event.workflow_run.conclusion == 'success' &&
            github.event.workflow_run.head_branch == github.event.repository.default_branch) }}
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
@@ -51,7 +55,7 @@ jobs:
           fi
 
       - name: Check for pending draft release
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.tag == '' }}
+        if: ${{ github.event_name == 'workflow_run' }}
         id: pending-draft
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
@@ -71,7 +75,7 @@ jobs:
       # Keep proposal generation out of the release-creation invocation.
       - name: Create merged release
         if: >-
-          ${{ (github.event_name != 'workflow_dispatch' || inputs.tag == '') &&
+          ${{ (github.event_name == 'workflow_run') &&
               steps.pending-draft.outputs.exists != 'true' }}
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
@@ -83,7 +87,7 @@ jobs:
 
       - name: Update release proposal
         if: >-
-          ${{ (github.event_name != 'workflow_dispatch' || inputs.tag == '') &&
+          ${{ (github.event_name == 'workflow_run') &&
               steps.pending-draft.outputs.exists != 'true' &&
               steps.release.outputs.release_created != 'true' }}
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
@@ -139,7 +143,7 @@ jobs:
           printf 'published=%s\n' "$published" >> "$GITHUB_OUTPUT"
 
   build-release:
-    name: Build Linux ${{ matrix.arch }} release
+    name: Prepare Linux ${{ matrix.arch }} release
     needs: release-please
     if: >-
       ${{ needs.release-please.outputs.release-created == 'true' ||
@@ -154,6 +158,7 @@ jobs:
           - arch: aarch64
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+    timeout-minutes: 30
     runs-on: ${{ matrix.runner }}
     env:
       BOOMUX_DISTRIBUTION: github-release
@@ -167,20 +172,53 @@ jobs:
         with:
           ref: ${{ env.SOURCE_REF }}
 
-      - name: Install Rust toolchain
+      - name: Download validated CI release candidate
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: release-candidate-${{ matrix.target }}
+          path: dist
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Verify CI release provenance and checksum
+        if: ${{ github.event_name == 'workflow_run' }}
+        env:
+          VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$VALIDATED_SHA"
+          python3 .github/scripts/ci-release-source.py verify dist "$VALIDATED_SHA" "$TAG" "$TARGET"
+
+      # Recovery is explicit. Missing/expired automatic artifacts fail instead
+      # of silently rebuilding different bytes for publication.
+      - name: Install Rust toolchain for recovery
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: rustup toolchain install stable --profile minimal
 
-      - name: Build release binary
+      - name: Cache recovery dependencies
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          shared-key: release-${{ matrix.target }}
+          key: ubuntu-24.04-release-${{ matrix.target }}
+          save-if: false
+
+      - name: Build release binary for recovery
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: cargo build --release --locked --target "$TARGET"
 
-      - name: Package and smoke test release
+      - name: Package and smoke test recovered release
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: bash .github/scripts/package-release.sh "$TAG" "$TARGET"
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: boomux-${{ env.TAG }}-${{ env.TARGET }}
-          path: dist/*
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+          retention-days: 14
           if-no-files-found: error
 
   validate-omarchy-boomux:
@@ -188,6 +226,7 @@ jobs:
     needs:
       - release-please
       - build-release
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -231,6 +270,7 @@ jobs:
       - release-please
       - build-release
       - validate-omarchy-boomux
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 /dist
 /node_modules
+
+# Python CI helper tests
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ module map, then read its colocated tests and the relevant contract document.
 
 ## Validation
 
-Run the same checks as CI:
+Run the complete validation set below. CI selection and reuse rules are in
+`docs/ci.md`; Clippy already checks every benchmark target:
 
 ```console
 cargo fmt --all -- --check
@@ -34,9 +35,7 @@ cargo test --lib --bins --locked -- --test-threads=1
 cargo test --test config_cli --locked -- --test-threads=1
 cargo test --test native_backend --locked -- --test-threads=1
 cargo test --test benchmark_harness --features benchmark-internals --locked
-cargo check --benches --all-features --locked
-cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
-cargo bench --bench wire --locked -- --test
+cargo bench --bench core_cpu --bench wire --features benchmark-internals --locked -- --test
 cargo deny check
 bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
 ```

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -36,9 +36,8 @@ Run the deterministic fixtures and compile every target:
 
 ```console
 cargo test --test benchmark_harness --features benchmark-internals --locked
-cargo check --benches --all-features --locked
-cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
-cargo bench --bench wire --locked -- --test
+cargo clippy --all-targets --all-features --locked -- -D warnings
+cargo bench --bench core_cpu --bench wire --features benchmark-internals --locked -- --test
 ```
 
 Smoke mode executes each Criterion case once. It verifies fixtures and benchmark

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -180,9 +180,7 @@ the deterministic benchmark fixtures and smoke suite:
 
 ```console
 cargo test --test benchmark_harness --features benchmark-internals --locked
-cargo check --benches --all-features --locked
-cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
-cargo bench --bench wire --locked -- --test
+cargo bench --bench core_cpu --bench wire --features benchmark-internals --locked -- --test
 ```
 
 Criterion timing on shared runners is evidence, not a merge gate. Gungraun provides
@@ -200,16 +198,17 @@ cargo test --lib --bins --locked -- --test-threads=1
 cargo test --test config_cli --locked -- --test-threads=1
 cargo test --test native_backend --locked -- --test-threads=1
 cargo test --test benchmark_harness --features benchmark-internals --locked
-cargo check --benches --all-features --locked
-cargo bench --bench core_cpu --features benchmark-internals --locked -- --test
-cargo bench --bench wire --locked -- --test
+cargo bench --bench core_cpu --bench wire --features benchmark-internals --locked -- --test
 cargo deny check
 bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.test.js integrations/pi/boomux.test.js
 ```
 
-Pull requests that modify only Markdown skip code, dependency, integration, and
-packaging jobs after a lightweight CI path check. Any non-Markdown change runs
-the complete CI matrix.
+CI selects work by changed inputs and prior validation, as documented in
+[`docs/ci.md`](docs/ci.md). Documentation skips use an explicit allowlist;
+embedded skill Markdown, notices, and the packaged README still receive checks.
+Version-only release changes can reuse successful base CI while building and
+smoke testing the new release version. Clippy covers every benchmark target;
+optimized benchmark smoke runs for Rust, benchmark, build, and CI changes.
 
 ## Compatibility Checklist
 
@@ -251,10 +250,14 @@ title becomes the squash commit consumed by Release Please.
 
 After CI succeeds for the exact current `main` commit, Release Please creates or
 updates the release pull request. Merging that pull request updates the package
-version and changelog. CI validates the release commit before the release
-workflow builds x86_64 and aarch64 Linux artifacts, renders the installer,
-uploads checksums, and publishes the completed GitHub release. Manual tag
-dispatch is reserved for explicit release recovery.
+version and changelog. CI builds and smoke tests x86_64 and aarch64 artifacts
+for that exact commit. When only release metadata changed and the base has
+successful push CI, it reuses that validation instead of rerunning the test
+suites. The release workflow downloads the exact CI artifacts, checks their
+source metadata and checksums, validates consumer compatibility, renders the
+installer, and publishes the completed release. Manual tag dispatch is reserved
+for explicit recovery, including rebuilding when the CI artifacts have expired.
+See [`docs/ci.md`](docs/ci.md) for the stage-by-stage contract.
 
 ## Clean Up
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,109 @@
+# CI And Release Validation
+
+CI keeps correctness checks on new code and on the merged main commit. Release
+version changes reuse that evidence instead of testing the same code at every
+release stage.
+
+| Stage | Validation |
+| --- | --- |
+| Code PR | Formatting, Clippy, Rust unit/CLI/serial native tests, integration fixtures, dependency policy, release packaging on both architectures, Arch compatibility; benchmark smoke when relevant |
+| Code merge to main | Same checks on the actual merged commit; main also saves dependency caches |
+| Release Please proposal generation | No builds or test suites; runs after successful main push CI |
+| Version-only release PR | Reuse successful base main CI; build and smoke test both release architectures, validate packaging scripts, and check Arch compatibility |
+| Version-only release merge | Same selection, with artifacts built for the exact new main commit |
+| Automatic publication | Download that main CI run's artifacts; verify source SHA, version, architecture, and checksums; validate pinned omarchy-boomux compatibility; upload and publish |
+| Manual release recovery | Rebuild and smoke test the requested draft source, then run consumer compatibility and publication checks; an already published tag retains its compatibility-only path |
+
+PR and main correctness checks cover different integration commits. They remain
+separate. Automatic publication does not rebuild or rerun the unit, native,
+integration, or benchmark suites. The new version is still compiled and smoke
+tested on the release PR and its merge because the version is embedded in the
+binary and used by update/packaging behavior.
+
+## Conservative Selection
+
+`.github/scripts/classify-ci.py` produces independent decisions for ordinary
+validation, packaging, and benchmark smoke. A failed diff, missing Git base,
+unavailable CI evidence, or malformed release metadata requires full validation.
+The workflow also defaults to full work if classification fails. Manual CI runs
+have no diff base and run all checks. Merge-group events are supported.
+
+Documentation-only skips apply to Markdown under `docs/` and the explicitly
+listed root guidance/changelog files. The packaged `README.md`, embedded
+`THIRD_PARTY_NOTICES.md`, and `.agents/skills/boomux/SKILL.md` are executable or
+packaging inputs and cannot use the documentation skip.
+
+A version-only release must satisfy all of these conditions:
+
+- The diff contains only `Cargo.toml`, `Cargo.lock`, the Release Please manifest,
+  and/or `CHANGELOG.md`, with both Cargo files changed.
+- Parsed Cargo manifests differ only in the project's strict release version.
+- Parsed lockfiles differ only in the source-less Boomux package version;
+  dependencies and checksums remain identical.
+- The Release Please manifest matches the new version and has no other changes.
+- GitHub reports successful `CI` push validation for the exact base SHA on this
+  repository's default branch, with the Rust lint/unit/CLI/native steps actually
+  executed successfully. A green documentation-only run is not sufficient.
+  PR names, labels, and authors are not proof.
+
+Each CI lookup has a 30-second timeout: at most one page of 100 runs and one
+page of 100 jobs from the selected successful run. Missing
+or inaccessible evidence causes validation to run. Source or dependency changes
+mixed into a release PR always receive full checks.
+
+Rust source, test, benchmark, Cargo/toolchain/build, and `.github/` changes retain
+optimized benchmark smoke. Packaging and JavaScript-only changes still receive
+ordinary validation but omit the optimized benchmarks. Clippy's
+`--all-targets --all-features` already checks the benchmark targets, so CI does
+not also run a separate `cargo check --benches`. Both Criterion smoke suites
+share one Cargo invocation and feature set to avoid recompiling Boomux between
+them. Weekly/manual Performance
+measurements remain independent of these smoke checks.
+
+## Caches And Artifact Handoff
+
+Rust checks, benchmarks, and each native packaging architecture use separate
+commit-pinned rust-cache action configurations. Only main push jobs save caches;
+PRs restore them. Cargo/toolchain inputs participate in cache invalidation.
+Recovery shares the packaging cache key and restores without saving. Caches
+accelerate dependency compilation; they are not validation evidence.
+
+Both architecture jobs retain their archives, SHA-256 checksum files, and
+`ci-source.json` for 14 days. The source metadata binds the archive digest to
+its exact commit, version, and target. Automatic publication downloads artifacts
+from the successful triggering run ID, using read-only Actions access, and
+verifies that metadata against the release source before forwarding only the
+archive and checksum to publication. GitHub documents the cross-run download
+inputs in [download-artifact](https://github.com/actions/download-artifact#download-artifacts-from-other-workflow-runs-or-repositories).
+
+Missing, expired, corrupted, or mismatched artifacts fail automatic publication.
+There is no silent rebuild fallback. Manually dispatch Release Please with the
+draft tag for explicit recovery. Manual dispatch requires a tag and cannot
+create a new release proposal outside successful main CI. The existing publisher rejects conflicting
+already-uploaded assets instead of replacing them silently.
+
+Jobs retain their existing required-check names when their work is skipped.
+Dependent Arch checks do not attempt to download artifacts after failed
+packaging. Jobs have explicit timeouts and respect workflow cancellation.
+
+## Validation And Measurements
+
+Run focused workflow-helper fixtures with:
+
+```console
+python3 -m unittest discover -s .github/scripts -p 'test_ci_*.py'
+```
+
+They exercise actual Git diffs, version-only changes with/without CI proof,
+embedded Markdown, dependency changes, failure fallbacks, and artifact source
+and digest mismatches. The classifier job runs these fixtures on every event.
+Run actionlint for workflow expressions, plus the repository validation set in
+`AGENTS.md` before opening a PR.
+
+Before this change, main CI run `33948018935` took 6m45s: Rust took 6m34s,
+benchmark smoke 6m22s, and x86-64/ARM packaging 2m10s/1m45s. Release run
+`33948310403` then took 3m08s, including rebuilding both architectures. Parallel
+job durations are not additive. These are observations from one run, not an
+estimated or measured improvement. Hosted cache behavior, release metadata
+selection, artifact download permissions, and elapsed savings need verification
+after deployment.


### PR DESCRIPTION
## Summary

Code changes currently receive full CI on their PR and main merge, and Release Please version bumps repeat those suites on the release PR and merge. Publication then rebuilds both architectures that main CI already packaged.

Reuse successful base-main validation only when parsed Cargo and lockfile changes are limited to Boomux's version, the release manifest matches, and the remaining diff is release metadata. The successful base run must have actually executed its Rust lint/unit/CLI/native steps; green documentation-only runs are insufficient. Keep native packaging and Arch smoke tests for the new version on both the release PR and merge. Ordinary code PRs and main merges retain correctness tests.

- Publish the exact x86-64 and ARM archives from the successful triggering CI run, verifying source SHA, version, target, and checksum. Missing or expired artifacts fail; explicit tag recovery retains its build path.
- Add separate Rust check, benchmark, and packaging dependency caches, saved only on main pushes.
- Skip optimized benchmark smoke for unrelated packaging/JavaScript changes and remove the separate benchmark check already covered by all-target Clippy. Both smoke suites share one Cargo invocation and feature set to avoid recompiling between them.
- Fix change classification so failed Git diffs require validation and embedded/packaged Markdown cannot bypass it.
- Restrict release creation to successful same-repository main push CI. Require a tag for manual recovery, add job timeouts and cancellation handling, and support manual CI/merge-group events.
- Document each stage and add Git-based classification and artifact provenance fixtures.

## Validation

- 20 CI helper fixtures, including missing/failed comparisons, exact successful-main proof, metadata-only releases, mixed dependency/source changes, and corrupted/mismatched artifacts.
- Checked the actual v1.9.7 release diff against GitHub's successful base CI: selected packaging while reusing code validation.
- actionlint, formatting, Clippy, dependency policy, installer/release-note fixtures, and 46 JavaScript tests passed.
- Rust validation passed: 491 library tests, 489 binary tests, 7 configuration CLI tests, 137 serial native-backend tests, and 3 benchmark fixture tests; benchmark target checks and both Criterion smoke suites passed.

The initial local unit run encountered two existing tests that read the installed OpenCode session catalog. Both pass with a CI-like `/usr/bin:/bin` PATH, used for the complete Rust test run. No application code changed.

Hosted cache hits, cross-run artifact permissions, release-PR selection, and wall-clock savings still need verification. Automatic publication retains pinned omarchy-boomux compatibility validation; archives are retained for 14 days.
