### PR TITLE
fix(codex): handle interrupted turns in lifecycle hooks

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1133,9 +1133,15 @@ therefore cannot claim authority inherited from its app-server.
 Codex hook `session_id` is the canonical thread identity and ensures the exact
 `(codex, thread, shell, run)` Agent key. SessionStart reports Idle, except compact
 starts remain Working; prompt, tool, compaction, and subagent activity report
-Working; PermissionRequest reports Blocked; Stop reports Idle; and SessionEnd
-reports Inactive. Codex hooks never report Done. Input, identity, and reporting
-are bounded and fail open for the host.
+Working; PermissionRequest reports Blocked; Stop and Interrupt report Idle;
+SessionEnd reports Inactive. Codex hooks never report Done. Input, identity, and
+reporting are bounded and fail open for the host.
+
+Interrupt records an interrupted turn, not permanent completion or thread
+inactivity. The documented hook interface does not identify the selected thread:
+switching away does not immediately emit SessionEnd. Multiple exact threads can
+therefore retain observations in one ShellRun. A new SessionStart never retires
+another thread based on recency, shared Shell identity, or fork metadata.
 
 Exact resume uses `codex resume <thread-id>`. The experimental catalog
 adapter starts bounded `codex app-server --stdio`, completes `initialize` and

--- a/docs/lifecycle-validation.md
+++ b/docs/lifecycle-validation.md
@@ -7,6 +7,26 @@ This record separates observed host behavior from reducer fixtures and intended
 semantics. Host compatibility is not inferred from process names, terminal
 output, or database recency.
 
+## 2026-09-06
+
+Read-only diagnosis with Codex `0.153.4` and Boomux `1.9.6` found two exact
+thread identities registered to the same ShellRun. Codex session metadata
+identified the newer thread as a fork of the original. This explains the two
+Agent records; it does not establish that the original thread ended or which
+thread a connected client currently selects.
+
+The [Codex hook reference](https://learn.chatgpt.com/docs/hooks) documents
+Interrupt for an interrupted root turn and says switching conversations does
+not immediately emit SessionEnd. Reducer and native CLI fixtures cover Interrupt
+returning the exact Agent to Idle and a subsequent prompt returning it to
+Working. This is fixture coverage, not a live Interrupt compatibility claim or
+a guarantee that a network failure emits Interrupt. Earlier hook installations
+need the updated Interrupt handler installed and trusted before reporting it.
+Source inspection of Codex's tagged `hook_config.rs` confirms that `0.153.4`
+accepts Interrupt. The earlier `0.147.0` event configuration ignores unknown
+event keys and has no Interrupt handler, so that host retains its earlier
+coverage; the additional event requires a host that emits it.
+
 ## 2026-08-31
 
 Pi Coding Agent `0.84.4` documentation and the installed session store were

--- a/integrations/codex/hooks.json
+++ b/integrations/codex/hooks.json
@@ -11,6 +11,7 @@
     "PostCompact": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
     "SubagentStart": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
     "SubagentStop": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
-    "Stop": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }]
+    "Stop": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }],
+    "Interrupt": [{ "hooks": [{ "type": "command", "command": "boomux codex hook", "timeout": 5 }] }]
   }
 }

--- a/src/codex_hooks.rs
+++ b/src/codex_hooks.rs
@@ -21,6 +21,7 @@ enum HookEvent {
     SubagentStart,
     SubagentStop,
     Stop,
+    Interrupt,
 }
 
 #[derive(Debug, Deserialize)]
@@ -93,6 +94,7 @@ fn reduce(input: &HookInput) -> LifecycleObservation {
         HookEvent::SubagentStart => (AgentState::Working, "Codex subagent working"),
         HookEvent::SubagentStop => (AgentState::Working, "Codex subagent stopped"),
         HookEvent::Stop => (AgentState::Idle, "Codex session idle"),
+        HookEvent::Interrupt => (AgentState::Idle, "Codex turn interrupted"),
     };
     LifecycleObservation { state, evidence }
 }
@@ -125,6 +127,7 @@ mod tests {
             ("SubagentStart", AgentState::Working),
             ("SubagentStop", AgentState::Working),
             ("Stop", AgentState::Idle),
+            ("Interrupt", AgentState::Idle),
         ];
         for (event, state) in cases {
             let update = update(event, "");

--- a/src/integration_management.rs
+++ b/src/integration_management.rs
@@ -33,6 +33,7 @@ const CODEX_HOOK_EVENTS: &[&str] = &[
     "SubagentStart",
     "SubagentStop",
     "Stop",
+    "Interrupt",
 ];
 
 #[cfg(test)]

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -148,7 +148,7 @@ fn codex_hook_requires_run_scoped_launch_and_reuses_exact_thread_agent() {
     let _attachment = daemon.client.attach(&shell_id, false, profile()).unwrap();
     let run_id = daemon.client.get_shell(&shell_id).unwrap().run.unwrap().id;
 
-    let run_hook = |event: &str, run_scoped: bool| {
+    let run_hook = |session_id: &str, event: &str, run_scoped: bool| {
         let mut command = daemon.command();
         command
             .args(["codex", "hook"])
@@ -164,7 +164,7 @@ fn codex_hook_requires_run_scoped_launch_and_reuses_exact_thread_agent() {
         let mut child = command.spawn().unwrap();
         write!(
             child.stdin.take().unwrap(),
-            "{{\"session_id\":\"codex-thread\",\"hook_event_name\":\"{event}\"}}"
+            "{{\"session_id\":\"{session_id}\",\"hook_event_name\":\"{event}\"}}"
         )
         .unwrap();
         let output = child.wait_with_output().unwrap();
@@ -172,7 +172,7 @@ fn codex_hook_requires_run_scoped_launch_and_reuses_exact_thread_agent() {
         assert!(output.stdout.is_empty());
     };
 
-    run_hook("SessionStart", false);
+    run_hook("codex-thread", "SessionStart", false);
     assert!(
         daemon.client.snapshot().unwrap().workspaces[0]
             .agents
@@ -184,10 +184,12 @@ fn codex_hook_requires_run_scoped_launch_and_reuses_exact_thread_agent() {
         ("UserPromptSubmit", AgentState::Working),
         ("PermissionRequest", AgentState::Blocked),
         ("PostToolUse", AgentState::Working),
+        ("Interrupt", AgentState::Idle),
+        ("UserPromptSubmit", AgentState::Working),
         ("Stop", AgentState::Idle),
         ("SessionEnd", AgentState::Inactive),
     ] {
-        run_hook(event, true);
+        run_hook("codex-thread", event, true);
         let agents = &daemon.client.snapshot().unwrap().workspaces[0].agents;
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].integration, "codex");
@@ -198,6 +200,45 @@ fn codex_hook_requires_run_scoped_launch_and_reuses_exact_thread_agent() {
         assert_eq!(agents[0].observation.state, expected, "{event}");
         assert_ne!(agents[0].observation.state, AgentState::Done);
     }
+
+    run_hook("codex-thread", "UserPromptSubmit", true);
+    run_hook("codex-fork", "SessionStart", true);
+    let before = daemon.client.snapshot().unwrap().workspaces[0]
+        .agents
+        .clone();
+    assert_eq!(before.len(), 2);
+    let original = before
+        .iter()
+        .find(|agent| agent.external_session_id.as_deref() == Some("codex-thread"))
+        .unwrap();
+    let fork = before
+        .iter()
+        .find(|agent| agent.external_session_id.as_deref() == Some("codex-fork"))
+        .unwrap();
+    assert_eq!(original.observation.state, AgentState::Working);
+    assert_eq!(fork.observation.state, AgentState::Idle);
+    assert_eq!(original.run_id, fork.run_id);
+    assert_ne!(original.id, fork.id);
+
+    // An explicit interruption affects only its exact thread, never its sibling.
+    run_hook("codex-thread", "Interrupt", true);
+    let after = daemon.client.snapshot().unwrap().workspaces[0]
+        .agents
+        .clone();
+    assert_eq!(after.len(), 2);
+    assert_eq!(
+        after
+            .iter()
+            .find(|agent| agent.id == original.id)
+            .unwrap()
+            .observation
+            .state,
+        AgentState::Idle
+    );
+    assert_eq!(
+        after.iter().find(|agent| agent.id == fork.id).unwrap(),
+        fork
+    );
 
     daemon.stop_with_cli();
 }


### PR DESCRIPTION
Codex Interrupt events were absent from the managed hook asset and decoder, so an interrupted turn could retain its last Working observation. Register and reduce Interrupt to Idle for the exact run-scoped thread, allowing a later prompt to return it to Working.

Extend the daemon-backed regression with two threads sharing one ShellRun: creating the second thread preserves the first observation, and interrupting the first updates only that Agent. Document the diagnosis and the host interface's limits: a fork or a newer SessionStart does not prove the older thread ended, and a network failure is not guaranteed to emit Interrupt. Desktop row disambiguation is handled separately in gardnmi/boomux-desktop#11.

The updated hook asset must be installed and trusted to receive Interrupt. Existing older assets follow the normal modified-asset repair flow; no live hook configuration, daemon, or Agent was changed during this work. No protocol or persistence changes.

Validation: formatting and Clippy passed; 491 library tests, 489 binary tests, seven CLI configuration tests, three benchmark fixtures, both optimized benchmark smoke targets, cargo-deny, and 46 JavaScript integration tests passed. The full native suite passed 136/137 cases; its unrelated interactive SSH-install fixture hit the 30-second timeout and passed on an isolated retry (27.77 seconds). The expanded Codex regression passed both focused and full-suite execution.
