### PR TITLE
feat(desktop): add node controls and harness integration discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,19 +25,41 @@ module map, then read its colocated tests and the relevant contract document.
 
 ## Validation
 
-Select local validation by changed inputs, matching `docs/ci.md`:
+Use focused local checks during development. PR CI owns the complete validation
+selected by `docs/ci.md`; do not run the full root/Desktop suites or a release
+build locally as a routine prerequisite to opening or updating a PR. Require all
+selected CI checks to pass before merging.
 
-| Change | Local validation before a PR |
+Do not over-apply validation. Choose the smallest check that answers a concrete
+question about the changed behavior, then stop when it passes. Do not stack
+`cargo check`, Clippy, full tests, and release builds "just to be safe," or treat
+the command lists below as mandatory local gates. Documentation-only edits need
+no Rust checks. Small UI edits do not automatically justify a full test build.
+Do not repeat successful checks unless subsequent changes affect what they
+validated. Report any unverified behavior plainly and leave comprehensive
+coverage to PR CI; do not delay reviewable work to duplicate CI locally.
+
+| Change | Local development validation |
 | --- | --- |
 | Unpackaged Markdown/guidance only | Review links and claims; `git diff --check` |
-| Desktop Rust only, optionally with guidance | Formatting, Desktop Clippy/tests, and Desktop release build below |
+| Desktop Rust only, optionally with guidance | Formatting and `cargo check -p boomux-desktop --locked`; focused tests or a manual UI check for the changed behavior |
 | CI/workflow or packaging scripts without Rust/dependency changes | Relevant Python/Bun/shell fixtures and shell syntax; actionlint for workflow changes |
-| Backend Rust, shared dependencies, Cargo/toolchain, or vendored code | Complete root and Desktop validation below |
+| Backend Rust | Formatting, `cargo check --locked`, and focused unit/integration tests for the changed behavior |
+| Shared dependencies, Cargo/toolchain, or vendored code | Check affected packages and run focused compatibility checks; let PR CI cover the full matrix |
 
-CI configuration changes still select the full hosted pipeline. Require its
-selected checks to pass before merging; script-only work does not require a
-second local run of unchanged Rust suites. Unknown or mixed code inputs use the
-complete set. Clippy already checks every benchmark target.
+Scale local checks to the change. A filtered Rust test still compiles its test
+binary and dependencies, so use `cargo check` first for small compile-only edits.
+Do not add tests that only mirror cosmetic UI changes. Broaden local validation
+only for a concrete failure, an identified affected behavior, CI diagnosis, or an
+explicit user request. State what the additional check will resolve; generic
+caution or a desire for extra confidence is not sufficient. Unknown or mixed
+inputs select full validation in CI, not automatically on
+the development machine. Use local release builds for performance measurements,
+release-only issues, or packaging work that needs the actual optimized artifact.
+
+The full commands below are a reference for reproducing CI failures or explicitly
+requested comprehensive local validation, not a per-edit or pre-PR checklist.
+Clippy already checks every benchmark target.
 
 The complete root validation set is:
 
@@ -55,7 +77,7 @@ bun test integrations/opencode/boomux.test.js integrations/opencode/boomux-tui.t
 
 The workspace also contains `desktop/`; read `desktop/AGENTS.md` for GUI changes.
 Core commands above select the default root package and require no Zig or display
-SDK. For backend/shared-code validation also run:
+SDK. For comprehensive backend/shared-code validation, the additional set is:
 
 ```console
 cargo clippy -p boomux-desktop --all-targets --all-features --locked -- -D warnings
@@ -73,9 +95,9 @@ Desktop requires Zig 0.15.2 and the graphics dependencies listed in
 `.github/workflows/desktop-build.yml`. Bundle changes also require X11 and
 Wayland smoke tests described in `docs/desktop/releases.md`.
 
-Run the narrowest relevant tests while iterating, then the applicable set above
-before opening a PR. Require all selected CI checks before merging. Native backend tests are intentionally serial because they
-exercise process, socket, PTY, and daemon lifecycle behavior.
+Run the narrowest relevant tests while iterating and leave the complete selected
+set to PR CI. Native backend tests are intentionally serial because they exercise
+process, socket, PTY, and daemon lifecycle behavior.
 
 ### Testing By Change Type
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,13 +89,17 @@ in `.github/workflows/desktop-build.yml`. From the repository root:
 
 ```console
 python3 desktop/scripts/run-dev.py
-cargo test -p boomux-desktop --locked -- --test-threads=1
-cargo clippy -p boomux-desktop --all-targets --all-features --locked -- -D warnings
+cargo check -p boomux-desktop --locked
+cargo test -p boomux-desktop <test-name> --locked -- --test-threads=1
 ```
 
 The helper builds both executables, sets a matching CLI PATH, and uses XDG
 runtime/config/state directories under `target/desktop-dev/`. Closing the window
-keeps these development sessions alive. The helper prints the isolated runtime
+keeps these development sessions alive. After rebuilding, the helper starts an
+absent development daemon or gracefully restarts an existing one with the rebuilt
+CLI's explicit executable path, preserving compatible live Shells. A failed
+handoff aborts the launch rather than falling back to a destructive stop.
+The helper prints the isolated runtime
 path; it does not replace installed binaries or use the ordinary daemon.
 See `desktop/AGENTS.md` for additional validation and `docs/desktop/releases.md`
 for packaging and headless GUI smoke tests.
@@ -197,8 +201,9 @@ bun test integrations/opencode/boomux.test.js \
 
 Use [`BENCHMARKING.md`](BENCHMARKING.md) for the benchmark tiers, fixture policy,
 local commands, and interpretation rules. Before changing a benchmarked hot path,
-save a local Criterion baseline on the same machine. Before opening a code PR, run
-the deterministic benchmark fixtures and smoke suite:
+save a local Criterion baseline on the same machine. For benchmark changes or
+local reproduction of a benchmark CI failure, run the deterministic fixtures and
+smoke suite below. Ordinary edits leave the full benchmark checks to PR CI:
 
 ```console
 cargo test --test benchmark_harness --features benchmark-internals --locked
@@ -208,10 +213,23 @@ cargo bench --bench core_cpu --bench wire --features benchmark-internals --locke
 Criterion timing on shared runners is evidence, not a merge gate. Gungraun provides
 the deterministic instruction-count tier and requires Valgrind for execution.
 
-## Complete Validation
+## Local Feedback And PR Validation
 
-Before opening a pull request that changes code, configuration, packaging, or
-generated assets, run the same checks as CI:
+Use formatting, `cargo check --locked` (or `cargo check -p boomux-desktop --locked`),
+and the narrowest relevant tests during development. Build or run the app when
+needed to exercise the changed behavior. A filtered test still needs its test
+binary and dependencies compiled; start with a compile check for small edits.
+Avoid full suites and release builds for routine UI or implementation changes.
+
+Open or update the PR after focused local checks; CI runs the complete selected
+validation matrix. Do not duplicate that matrix locally as a pre-PR gate. Require
+all selected CI checks before merging. Use broader local runs to investigate a
+specific failure or cross-cutting risk, or when explicitly requested. Build an
+optimized binary when measuring performance or validating release/packaging
+behavior, rather than on every edit.
+
+The full commands below are a reference for reproducing CI failures or explicitly
+requested comprehensive local validation:
 
 ```console
 cargo fmt --all -- --check

--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -13,21 +13,35 @@ in the backend. GPUI rendering and input live in `desktop/`.
 
 ## Validation
 
-For Desktop Rust-only changes, run:
+Follow the root rule against over-applying validation. Use the smallest relevant
+check and stop after it passes. Do not stack compile checks, Clippy, full tests,
+and release builds for routine Desktop edits. Documentation-only changes need
+only link/claim review and `git diff --check`, not the Rust commands below.
+
+During Desktop development, start with formatting and a compile check:
 
 ```console
 cargo fmt --all -- --check
-cargo clippy -p boomux-desktop --all-targets --all-features --locked -- -D warnings
-cargo test -p boomux-desktop --locked -- --test-threads=1
-cargo build -p boomux-desktop --release --locked
+cargo check -p boomux-desktop --locked
 ```
 
-Building `libghostty-vt` requires Zig 0.15.2 on `PATH`. Run the narrowest
-relevant test while iterating, then the Desktop set above before opening a PR.
-Run `cargo deny check` and the complete root/desktop suite for dependency,
-Cargo/toolchain, backend, or vendored changes, as specified by root `AGENTS.md`.
-For docs-only or packaging/workflow-script changes, use the root validation
-matrix. All selected CI checks must pass before merging.
+Run focused tests for the changed behavior using a test-name filter, and build
+or launch the development app when a visual check is needed. A filtered test
+still compiles the test binary and its dependencies; a cosmetic change does not
+need a full test build solely to repeat unchanged tests.
+
+PR CI owns Desktop Clippy, the complete Desktop tests, and the release build.
+Do not run that full set locally before opening or updating a PR. Local release
+builds are for performance measurements, release-only diagnosis, and packaging
+validation. Broaden checks only for a concrete failure, an identified affected
+behavior, CI diagnosis, or an explicit user request; explain what the additional
+check will resolve. Do not rerun successful checks without a relevant change.
+All selected CI checks must pass before merging.
+
+Building `libghostty-vt` requires Zig 0.15.2 on `PATH`. For dependency,
+Cargo/toolchain, backend, vendored, docs, or packaging/workflow-script changes,
+use the root local-validation matrix. The full command reference in root
+`AGENTS.md` is available for reproducing CI failures.
 
 ### Testing By Change Type
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -49,11 +49,30 @@ are preserved. See
 [release packaging](../docs/desktop/releases.md) for version selection, install locations,
 release preparation, uninstall instructions, and the required platform smoke tests.
 
-On first launch, **Set up agents** opens the interactive Boomux agent setup in an
-embedded terminal. It asks before installing integrations or replacing modified
-agent settings. **Start using Boomux** skips setup; the header menu can reopen it
-later. Setup does not install the optional Omarchy plugin, change Hyprland, or
-require an external terminal emulator.
+Desktop checks for supported AI harnesses on this computer in the background at
+startup. Detected harnesses with missing integrations get an **Install
+integration** prompt in the sidebar. Differing integrations get **Review update**:
+Boomux cannot distinguish an older integration from a customized one, so replacing
+it requires an explicit **Replace integration** confirmation. Nothing is installed
+by discovery, and harnesses that are absent or already current produce no prompt.
+**Not now** dismisses a suggestion for this window. Recheck after installing a
+harness through **Settings → AI integrations → Check installed harnesses**.
+Successful installation explains how to reload the affected harness.
+
+The header menu contains **Nodes**, updates, and keyboard shortcuts. The gear
+opens Settings. **Settings → AI integrations → Manual setup** remains available
+for the guided terminal checklist: **Up/Down** to choose, **Space** to toggle,
+**Enter** to apply, and **Esc** to cancel. See the
+[checklist controls and defaults](../docs/install.md#harness-checklist).
+Setup does not install the optional Omarchy plugin, change Hyprland, or require
+an external terminal emulator.
+After the completion receipt, **Exit and remove this setup Shell? [Y/n]** defaults
+to yes. Enter or `y` removes the dedicated setup Shell and its pane; `n` keeps
+the output available and prompts again. Setup failures remain labelled as failures.
+Its newly created Workspace is also removed if it is still empty and untouched
+apart from that Shell removal. User resources, edits, or uncertain ownership keep
+the Workspace. Reattached setup panes without the original creation receipt also
+retain it. Ordinary CLI `boomux setup` never removes its Shell or Workspace.
 
 Desktop appearance and behavior preferences save automatically to
 `~/.config/boomux-desktop/settings.toml` (`XDG_CONFIG_HOME` is respected).

--- a/desktop/scripts/run-dev.py
+++ b/desktop/scripts/run-dev.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Build and open Desktop against this worktree's isolated development daemon."""
 
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -22,7 +23,15 @@ def main():
         env[f"XDG_{name}"] = str(path)
     env["PATH"] = str(target) + os.pathsep + env.get("PATH", "")
     print(f"Development runtime: {env['XDG_RUNTIME_DIR']}", flush=True)
-    subprocess.run([target / "boomux", "daemon", "start"], env=env, check=True, timeout=30)
+    cli = target / "boomux"
+    status = subprocess.run([cli, "daemon", "status", "--json"], env=env,
+                            check=True, timeout=30, capture_output=True, text=True)
+    state = json.loads(status.stdout)["data"]["status"]
+    if state not in {"running", "stopped"}:
+        raise RuntimeError(f"Unexpected development daemon status: {state}")
+    # Start does not reload an existing daemon; explicitly select this build for handoff.
+    action = ["restart", "--executable", str(cli)] if state == "running" else ["start"]
+    subprocess.run([cli, "daemon", *action], env=env, check=True, timeout=30)
     executable = str(target / "boomux-desktop")
     os.execve(executable, [executable, *sys.argv[1:]], env)
 

--- a/desktop/scripts/test-run-dev.py
+++ b/desktop/scripts/test-run-dev.py
@@ -1,0 +1,58 @@
+"""Development launches use the rebuilt CLI without touching the ordinary daemon."""
+
+import json
+import os
+from pathlib import Path
+import runpy
+import subprocess
+import unittest
+from unittest.mock import Mock, patch
+
+DEV = runpy.run_path(str(Path(__file__).with_name("run-dev.py")))
+ROOT = Path(DEV["__file__"]).resolve().parents[2]
+CLI = ROOT / "target/debug/boomux"
+
+
+class DevelopmentLaunchTests(unittest.TestCase):
+    def launch(self, state, failure=None):
+        status = Mock(stdout=json.dumps({"data": {"status": state}}))
+        with patch.dict(os.environ, {
+            "PATH": "/usr/bin", "XDG_RUNTIME_DIR": "/ordinary/runtime",
+            "WAYLAND_DISPLAY": "wayland-1", "BOOMUX_CONFIG": "/ordinary/config",
+        }, clear=True), patch.object(Path, "mkdir"), \
+                patch("subprocess.run", side_effect=[Mock(), status, failure or Mock()]) as run, \
+                patch("os.execve") as execute:
+            if failure:
+                with self.assertRaises(subprocess.CalledProcessError):
+                    DEV["main"]()
+                execute.assert_not_called()
+            else:
+                DEV["main"]()
+                execute.assert_called_once()
+                self.assertEqual(execute.call_args.args[0], str(ROOT / "target/debug/boomux-desktop"))
+                self.assertEqual(execute.call_args.args[2], run.call_args.kwargs["env"])
+            calls = run.call_args_list
+            self.assertEqual(calls[1].args[0], [CLI, "daemon", "status", "--json"])
+            for call in calls[1:]:
+                env = call.kwargs["env"]
+                for name in ["RUNTIME_DIR", "CONFIG_HOME", "STATE_HOME", "DATA_HOME", "CACHE_HOME"]:
+                    self.assertEqual(env[f"XDG_{name}"], str(ROOT / "target/desktop-dev" / name.lower()))
+                self.assertEqual(env["WAYLAND_DISPLAY"], "/ordinary/runtime/wayland-1")
+                self.assertFalse(any(key.startswith("BOOMUX_") for key in env))
+                self.assertEqual(env["PATH"], str(CLI.parent) + os.pathsep + "/usr/bin")
+                self.assertTrue(call.kwargs["check"])
+                self.assertEqual(call.kwargs["timeout"], 30)
+            return calls[-1].args[0]
+
+    def test_running_daemon_hands_off_to_the_exact_rebuilt_executable(self):
+        self.assertEqual(self.launch("running"), [CLI, "daemon", "restart", "--executable", str(CLI)])
+
+    def test_absent_daemon_starts_without_an_unnecessary_restart(self):
+        self.assertEqual(self.launch("stopped"), [CLI, "daemon", "start"])
+
+    def test_failed_handoff_aborts_without_stop_or_desktop_launch(self):
+        self.launch("running", subprocess.CalledProcessError(1, "restart"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/desktop/src/harness_integrations.rs
+++ b/desktop/src/harness_integrations.rs
@@ -1,0 +1,236 @@
+//! Read-only local discovery and explicitly requested integration installation.
+//! The matching CLI owns host probing, configuration validation, and writes.
+use boomux::integrations::{self, IntegrationDescriptor};
+use serde_json::Value;
+use std::{
+    collections::HashSet,
+    io::Read,
+    os::unix::process::CommandExt,
+    process::{Command, Stdio},
+};
+
+const OUTPUT_LIMIT: u64 = 128 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Need {
+    Install,
+    Review,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Suggestion {
+    pub descriptor: &'static IntegrationDescriptor,
+    pub need: Need,
+}
+
+#[derive(Default)]
+pub struct Report {
+    pub detected: usize,
+    pub unavailable: usize,
+    pub suggestions: Vec<Suggestion>,
+}
+
+#[derive(Default)]
+pub struct Model {
+    pub report: Report,
+    pub checked: bool,
+    pub busy: bool,
+    pub installing: Option<&'static str>,
+    pub dismissed: HashSet<&'static str>,
+    pub confirm_replace: Option<&'static str>,
+    pub message: Option<String>,
+    pub error: Option<String>,
+}
+
+fn data(raw: &[u8], command: &str) -> Result<Value, String> {
+    let envelope: Value = serde_json::from_slice(raw)
+        .map_err(|_| "Boomux returned an invalid integration response".to_string())?;
+    if envelope["schema"] != "boomux.cli/v1" || envelope["command"] != command {
+        return Err("Boomux returned an unexpected integration response".into());
+    }
+    if let Some(message) = envelope["error"]["message"].as_str() {
+        return Err(message.chars().take(2048).collect());
+    }
+    envelope
+        .get("data")
+        .cloned()
+        .ok_or_else(|| "Missing integration response data".into())
+}
+
+fn parse_report(raw: &[u8]) -> Result<Report, String> {
+    let data = data(raw, "integration.status")?;
+    let rows = data["integrations"]
+        .as_array()
+        .filter(|rows| rows.len() <= 256)
+        .ok_or("Invalid integration status list")?;
+    let mut report = Report::default();
+    let mut seen = HashSet::new();
+    for row in rows {
+        let name = row["name"].as_str().ok_or("Missing integration name")?;
+        let Some(descriptor) =
+            integrations::by_key(name).filter(|item| item.installation.is_some())
+        else {
+            continue;
+        };
+        if !seen.insert(descriptor.key) {
+            return Err("Duplicate integration status".into());
+        }
+        match row["host"]["state"].as_str() {
+            Some("missing") => continue,
+            Some("available") => report.detected += 1,
+            Some("probe_failed" | "not_checked") => {
+                report.unavailable += 1;
+                continue;
+            }
+            _ => return Err("Invalid harness detection status".into()),
+        }
+        let need = match row["asset"]["state"].as_str() {
+            Some("missing") => Need::Install,
+            // The CLI deliberately does not distinguish old releases from user edits.
+            Some("modified") => Need::Review,
+            Some("current") => continue,
+            Some("unavailable") => {
+                report.unavailable += 1;
+                continue;
+            }
+            _ => return Err("Invalid integration asset status".into()),
+        };
+        report.suggestions.push(Suggestion { descriptor, need });
+    }
+    Ok(report)
+}
+
+// One background operation per window. timeout owns the process group; output
+// and errors are bounded, stdin is closed, and no shell interpolation is used.
+fn output(args: &[&str]) -> Result<Vec<u8>, String> {
+    let mut child = Command::new("timeout")
+        .args(["--kill-after=1s", "35s", "boomux"])
+        .args(args)
+        .process_group(0)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let mut bytes = Vec::new();
+    let read = child
+        .stdout
+        .take()
+        .expect("piped stdout")
+        .take(OUTPUT_LIMIT + 1)
+        .read_to_end(&mut bytes);
+    if read.is_err() || bytes.len() as u64 > OUTPUT_LIMIT {
+        // This is only the process group created for the child above.
+        unsafe {
+            libc::kill(-(child.id() as i32), libc::SIGKILL);
+        }
+        let _ = child.wait();
+        return Err("Integration command output could not be read within its limit".into());
+    }
+    let status = child.wait().map_err(|error| error.to_string())?;
+    if !status.success() {
+        let message = serde_json::from_slice::<Value>(&bytes)
+            .ok()
+            .and_then(|value| value["error"]["message"].as_str().map(str::to_owned))
+            .map(|message| message.chars().take(2048).collect())
+            .unwrap_or_else(|| {
+                "Integration command failed or timed out. Check again in Settings.".into()
+            });
+        return Err(message);
+    }
+    Ok(bytes)
+}
+
+pub fn check() -> Result<Report, String> {
+    parse_report(&output(&["integration", "status", "--json"])?)
+}
+
+pub fn install(suggestion: Suggestion, replace_confirmed: bool) -> Result<(), String> {
+    if suggestion.need == Need::Review && !replace_confirmed {
+        return Err("Confirm replacement of the existing Boomux integration first".into());
+    }
+    let mut args = vec![
+        "integration",
+        "install",
+        suggestion.descriptor.key,
+        "--json",
+    ];
+    if suggestion.need == Need::Review {
+        args.push("--force");
+    }
+    parse_install_result(&output(&args)?, suggestion.descriptor.key)
+}
+
+fn parse_install_result(raw: &[u8], name: &str) -> Result<(), String> {
+    let response = data(raw, "integration.install")?;
+    let results = response["integrations"]
+        .as_array()
+        .ok_or("Missing installation result")?;
+    if results.len() != 1
+        || results[0]["name"].as_str() != Some(name)
+        || !matches!(
+            results[0]["result"].as_str(),
+            Some("installed" | "replaced" | "unchanged")
+        )
+    {
+        return Err(
+            "Unexpected installation result; check integration status before retrying".into(),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    fn status(rows: Value) -> Vec<u8> {
+        serde_json::to_vec(&json!({"schema":"boomux.cli/v1", "command":"integration.status", "data":{"integrations":rows}})).unwrap()
+    }
+    #[test]
+    fn only_detected_hosts_with_missing_or_different_assets_are_suggested() {
+        let report = parse_report(&status(json!([
+            {"name":"claude","host":{"state":"available"},"asset":{"state":"missing"}},
+            {"name":"pi","host":{"state":"available"},"asset":{"state":"modified"}},
+            {"name":"opencode","host":{"state":"missing"},"asset":{"state":"missing"}},
+            {"name":"codex","host":{"state":"available"},"asset":{"state":"current"}},
+            {"name":"kiro","host":{"state":"probe_failed"},"asset":{"state":"missing"}}
+        ])))
+        .unwrap();
+        assert_eq!(report.detected, 3);
+        assert_eq!(report.unavailable, 1);
+        assert_eq!(report.suggestions.len(), 2);
+        assert_eq!(report.suggestions[0].descriptor.key, "claude");
+        assert_eq!(report.suggestions[0].need, Need::Install);
+        assert_eq!(report.suggestions[1].need, Need::Review);
+    }
+    #[test]
+    fn malformed_and_duplicate_statuses_do_not_report_success() {
+        assert!(parse_report(b"{}").is_err());
+        assert!(parse_report(&status(json!([{"name":"claude"}]))).is_err());
+        let row = json!({"name":"pi","host":{"state":"available"},"asset":{"state":"current"}});
+        assert!(parse_report(&status(json!([row.clone(), row]))).is_err());
+    }
+    #[test]
+    fn installation_results_must_match_the_requested_integration() {
+        for outcome in ["installed", "replaced", "unchanged"] {
+            let raw = serde_json::to_vec(&json!({"schema":"boomux.cli/v1", "command":"integration.install", "data":{"integrations":[{"name":"pi", "result":outcome}]}})).unwrap();
+            assert!(parse_install_result(&raw, "pi").is_ok());
+            assert!(parse_install_result(&raw, "claude").is_err());
+        }
+        assert!(parse_install_result(b"{}", "pi").is_err());
+    }
+
+    #[test]
+    fn replacement_requires_confirmation_before_running_a_command() {
+        let suggestion = Suggestion {
+            descriptor: &integrations::PI,
+            need: Need::Review,
+        };
+        assert!(
+            install(suggestion, false)
+                .unwrap_err()
+                .contains("Confirm replacement")
+        );
+    }
+}

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -3,6 +3,7 @@ mod bundle_update;
 mod generated_names;
 mod layout;
 mod layout_badge;
+mod nodes;
 mod runtime;
 mod settings;
 mod terminal;
@@ -1282,6 +1283,10 @@ struct Workspace {
     minimized_tab_scroll_handle: ScrollHandle,
     sidebar_menu: Option<SidebarMenu>,
     sidebar_header_menu_open: bool,
+    nodes_open: bool,
+    node_views: Vec<nodes::NodeView>,
+    nodes_error: Option<String>,
+    selected_node: Option<String>,
     resource_dialog: Option<ResourceDialog>,
     sidebar_visible: bool,
     drawer_animation_from: Option<f32>,
@@ -1450,6 +1455,10 @@ impl Workspace {
             minimized_tab_scroll_handle,
             sidebar_menu: None,
             sidebar_header_menu_open: false,
+            nodes_open: false,
+            node_views: Vec::new(),
+            nodes_error: None,
+            selected_node: None,
             resource_dialog: None,
             sidebar_visible: saved.sidebar_visible,
             drawer_animation_from: None,
@@ -2285,6 +2294,7 @@ impl Workspace {
     ) {
         let previous_width = self.sidebar_width();
         self.sidebar_visible = !self.sidebar_visible;
+        self.nodes_open = false;
         self.save_settings();
         self.drawer_animation_generation = self.drawer_animation_generation.wrapping_add(1);
         self.drawer_animation_from = Some(previous_width);
@@ -4108,6 +4118,49 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.nodes_open {
+            let modifiers = event.keystroke.modifiers;
+            if modifiers.control
+                || modifiers.alt
+                || modifiers.platform
+                || modifiers.function
+                || (event.is_held && !matches!(event.keystroke.key.as_str(), "up" | "down"))
+            {
+                cx.stop_propagation();
+                return;
+            }
+            match event.keystroke.key.as_str() {
+                "escape" => self.nodes_open = false,
+                "up" | "down" => {
+                    let len = self.node_views.len();
+                    if len > 0 {
+                        let current = self
+                            .selected_node
+                            .as_ref()
+                            .and_then(|id| self.node_views.iter().position(|node| &node.id == id));
+                        let index = match (current, event.keystroke.key.as_str()) {
+                            (Some(index), "up") => (index + len - 1) % len,
+                            (Some(index), _) => (index + 1) % len,
+                            (None, "up") => len - 1,
+                            _ => 0,
+                        };
+                        self.selected_node = Some(self.node_views[index].id.clone());
+                    }
+                }
+                "a" => self.launch_node_action(terminal::WorkspaceLaunch::AddNode, window, cx),
+                "d" => self.launch_node_action(terminal::WorkspaceLaunch::Dashboard, window, cx),
+                "r" => {
+                    if let Some(node) = self.node_views.iter().find(|node| Some(&node.id) == self.selected_node.as_ref()
+                        && !node.local && node.health == boomux::protocol::NodeProjectionHealthCode::AuthenticationRequired) {
+                        self.launch_node_action(terminal::WorkspaceLaunch::ReauthenticateNode(node.id.clone()), window, cx);
+                    }
+                }
+                _ => {}
+            }
+            cx.notify();
+            cx.stop_propagation();
+            return;
+        }
         if self.settings_restart_confirm {
             if event.keystroke.key == "escape" {
                 self.settings_restart_confirm = false;
@@ -4431,16 +4484,16 @@ impl Workspace {
     }
 
     fn create_and_attach_new_workspace(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.create_workspace_terminal(false, window, cx);
+        self.create_workspace_terminal(terminal::WorkspaceLaunch::Shell, window, cx);
     }
 
     fn create_and_attach_setup(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.create_workspace_terminal(true, window, cx);
+        self.create_workspace_terminal(terminal::WorkspaceLaunch::Setup, window, cx);
     }
 
     fn create_workspace_terminal(
         &mut self,
-        setup: bool,
+        launch: terminal::WorkspaceLaunch,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -4463,7 +4516,7 @@ impl Workspace {
         cx.spawn(async move |this, cx| {
             let result = cx
                 .background_spawn(async move {
-                    let shell = terminal::create_workspace_with_shell(setup)?;
+                    let shell = terminal::create_workspace_with_shell(launch)?;
                     let session = match TerminalSession::attach(
                         shell.clone(),
                         size.0,
@@ -4520,10 +4573,42 @@ impl Workspace {
             loop {
                 cx.background_executor().timer(Duration::from_secs(1)).await;
                 let result = cx
-                    .background_spawn(async { terminal::discover_overview() })
+                    .background_spawn(async { terminal::discover_overview_and_nodes() })
                     .await;
                 let keep_watching = this
                     .update(cx, |this, cx| {
+                        let (result, nodes) = result;
+                        let (node_views, nodes_error) = match nodes {
+                            Ok(nodes) => (nodes, None),
+                            Err(error) => {
+                                let mut retained = this.node_views.clone();
+                                for node in &mut retained {
+                                    node.current = false;
+                                }
+                                (retained, Some(error))
+                            }
+                        };
+                        if this.node_views != node_views || this.nodes_error != nodes_error {
+                            let visible_change = this.nodes_open
+                                || this.nodes_error != nodes_error
+                                || this.node_views.len() != node_views.len()
+                                || this.node_views.iter().zip(&node_views).any(
+                                    |(before, after)| {
+                                        before.id != after.id
+                                            || before.connected() != after.connected()
+                                    },
+                                );
+                            this.node_views = node_views;
+                            this.nodes_error = nodes_error;
+                            if this.selected_node.as_ref().is_some_and(|id| {
+                                !this.node_views.iter().any(|node| &node.id == id)
+                            }) {
+                                this.selected_node = None;
+                            }
+                            if visible_change {
+                                cx.notify();
+                            }
+                        }
                         if let Ok(mut overview) = result {
                             reconcile_workspace_order(&mut this.workspace_order, &mut overview);
                             if overview != this.boomux_overview || this.boomux_error.is_some() {
@@ -5074,6 +5159,121 @@ impl Workspace {
         }
     }
 
+    fn open_nodes(&mut self, cx: &mut Context<Self>) {
+        self.sidebar_header_menu_open = false;
+        self.sidebar_menu = None;
+        self.nodes_open = true;
+        self.selected_node = self
+            .selected_node
+            .take()
+            .or_else(|| self.node_views.first().map(|node| node.id.clone()));
+        cx.notify();
+    }
+
+    fn launch_node_action(
+        &mut self,
+        launch: terminal::WorkspaceLaunch,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.nodes_open = false;
+        if self.layout_mode {
+            self.leave_layout_mode(cx);
+        }
+        self.create_workspace_terminal(launch, window, cx);
+    }
+
+    fn nodes_panel(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
+        if !self.nodes_open {
+            return None;
+        }
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_millis() as u64);
+        let selected = self
+            .selected_node
+            .as_ref()
+            .and_then(|id| self.node_views.iter().find(|node| &node.id == id));
+        let rows = self
+            .node_views
+            .iter()
+            .map(|node| {
+                let id = node.id.clone();
+                div()
+                    .id(SharedString::from(format!("node-row-{}", node.id)))
+                    .px_2()
+                    .py_2()
+                    .rounded_md()
+                    .cursor_pointer()
+                    .bg(rgb(if self.selected_node.as_ref() == Some(&node.id) {
+                        0x313244
+                    } else {
+                        0x1e1e2e
+                    }))
+                    .hover(|row| row.bg(rgb(0x313244)))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.selected_node = Some(id.clone());
+                        cx.notify();
+                    }))
+                    .child(div().text_sm().child(node.label.clone()))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(rgb(if node.connected() { 0xa6e3a1 } else { 0xf9e2af }))
+                            .child(node.status()),
+                    )
+            })
+            .collect::<Vec<_>>();
+        Some(div().id("nodes-backdrop").absolute().occlude().size_full().top_0().left_0()
+            .on_mouse_down(MouseButton::Left, cx.listener(|this, _, _, cx| {
+                this.nodes_open = false;
+                cx.stop_propagation();
+                cx.notify();
+            }))
+            .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
+            .child(div().id("nodes-panel").absolute().occlude()
+            .top(px(54.0)).left(px(10.0)).w(px(280.0)).max_h(relative(0.85)).overflow_y_scroll()
+            .p_3().flex().flex_col().gap_2().rounded_lg().border_1()
+            .border_color(rgb(0x45475a)).bg(rgb(0x1e1e2e)).shadow_lg()
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .child(div().flex().items_center().justify_between()
+                .child(div().font_weight(gpui::FontWeight::BOLD).child("Nodes"))
+                .child(Self::settings_option("close-nodes", "Close", false)
+                    .on_click(cx.listener(|this, _, _, cx| { this.nodes_open = false; cx.notify(); }))))
+            .when_some(self.nodes_error.clone(), |panel, error| panel.child(div().text_xs().text_color(rgb(0xf9e2af)).child(error)))
+            .child(div().id("node-list").max_h(px(180.0)).overflow_y_scroll().children(rows))
+            .when_some(selected, |panel, node| {
+                panel.child(div().flex().flex_col().gap_2().text_xs()
+                    .when_some(node.route.clone(), |detail, route| detail.child(div().child(route)))
+                    .child(format!("{} Workspaces · {} Shells{}", node.workspace_count, node.shell_count,
+                        if node.connected() { "" } else { " · cached" }))
+                    .child(node.last_seen(now_ms))
+                    .when_some(node.version.clone(), |detail, version| detail.child(format!("Boomux {version}")))
+                    .child(node.guidance())
+                    .when(!node.local && node.health == boomux::protocol::NodeProjectionHealthCode::AuthenticationRequired, |detail| {
+                        let id = node.id.clone();
+                        detail.child(Self::settings_option("reauthenticate-node", "Sign in…", false)
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                this.launch_node_action(terminal::WorkspaceLaunch::ReauthenticateNode(id.clone()), window, cx);
+                            })))
+                    }))
+            })
+            .child(div().h(px(1.0)).bg(rgb(0x45475a)))
+            .child(Self::settings_option("add-remote-node", "Add remote Node…", false)
+                .on_click(cx.listener(|this, _, window, cx| {
+                    this.launch_node_action(terminal::WorkspaceLaunch::AddNode, window, cx);
+                })))
+            .child(Self::settings_option("manage-nodes", "Open Boomux dashboard", false)
+                .on_click(cx.listener(|this, _, window, cx| {
+                    this.launch_node_action(terminal::WorkspaceLaunch::Dashboard, window, cx);
+                })))
+            .child(div().text_xs().text_color(rgb(0xa6adc8))
+                .child("Setup and sign-in open a terminal. Manage remote work in the dashboard’s Nodes tab."))
+            .child(div().text_xs().text_color(rgb(0x7f849c)).child("↑/↓ select · A add · R sign in · D dashboard · Esc close")))
+            .into_any_element())
+    }
+
     fn sidebar_header_menu(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
         self.sidebar_header_menu_open.then(|| {
             div()
@@ -5108,6 +5308,14 @@ impl Workspace {
                         }))
                         .child(div().min_w_0().flex_1().child("Settings"))
                         .child(div().flex_none().text_color(rgb(0x7f849c)).child("⚙")),
+                )
+                .child(
+                    Self::settings_option("header-menu-nodes", "Nodes…", false).on_click(
+                        cx.listener(|this, _, _, cx| {
+                            cx.stop_propagation();
+                            this.open_nodes(cx);
+                        }),
+                    ),
                 )
                 .child(
                     div()
@@ -5576,12 +5784,43 @@ impl Workspace {
                                     .child(
                                         div().font_weight(gpui::FontWeight::BOLD).child("BOOMUX"),
                                     )
-                                    .child(div().text_xs().text_color(rgb(0x89b4fa)).child(
-                                        format!(
-                                            "active · {} workspaces",
-                                            self.boomux_overview.workspaces.len()
-                                        ),
-                                    )),
+                                    .child(
+                                        div()
+                                            .id("sidebar-node-status")
+                                            .text_xs()
+                                            .text_color(rgb(0x89b4fa))
+                                            .cursor_pointer()
+                                            .on_click(cx.listener(|this, _, _, cx| {
+                                                cx.stop_propagation();
+                                                this.open_nodes(cx);
+                                            }))
+                                            .child(
+                                                if self.node_views.iter().any(|node| !node.local) {
+                                                    let unavailable = self
+                                                        .node_views
+                                                        .iter()
+                                                        .filter(|node| !node.connected())
+                                                        .count();
+                                                    if unavailable == 0 {
+                                                        format!(
+                                                            "{} Nodes · connected",
+                                                            self.node_views.len()
+                                                        )
+                                                    } else {
+                                                        format!(
+                                                            "{} Nodes · {} unavailable",
+                                                            self.node_views.len(),
+                                                            unavailable
+                                                        )
+                                                    }
+                                                } else {
+                                                    format!(
+                                                        "active · {} workspaces",
+                                                        self.boomux_overview.workspaces.len()
+                                                    )
+                                                },
+                                            ),
+                                    ),
                             ),
                     )
                     .child(
@@ -8365,6 +8604,7 @@ impl Render for Workspace {
             .child(terminal_area)
             .into_any_element();
         let sidebar_menu = self.sidebar_menu_overlay(cx);
+        let nodes_panel = self.nodes_panel(cx);
         let resource_dialog = self.resource_dialog_overlay(cx);
         let settings_restart = self.settings_restart_overlay(cx);
         let help = self.help_overlay(cx);
@@ -8373,7 +8613,10 @@ impl Render for Workspace {
             .id("workspace")
             .track_focus(&self.focus_handle)
             .key_context(
-                if self.boomux_setting_input.is_some() || self.settings_restart_confirm {
+                if self.nodes_open
+                    || self.boomux_setting_input.is_some()
+                    || self.settings_restart_confirm
+                {
                     "BoomuxSettingsInput"
                 } else {
                     workspace_key_context(self.help_open, self.navigation_region, self.layout_mode)
@@ -8450,6 +8693,7 @@ impl Render for Workspace {
             .text_color(rgb(0xcdd6f4))
             .child(content)
             .when_some(sidebar_menu, |element, menu| element.child(menu))
+            .when_some(nodes_panel, |element, panel| element.child(panel))
             .when_some(resource_dialog, |element, dialog| element.child(dialog))
             .when_some(settings_restart, |element, dialog| element.child(dialog))
             .when_some(help, |element, help| element.child(help))

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,6 +1,7 @@
 mod boomux_settings;
 mod bundle_update;
 mod generated_names;
+mod harness_integrations;
 mod layout;
 mod layout_badge;
 mod nodes;
@@ -45,6 +46,61 @@ const DRAG_ACTIVATION_DISTANCE: f32 = 4.0;
 
 fn rgb(color: u32) -> gpui::Rgba {
     gpui::rgb(theme::resolve_legacy(color))
+}
+
+struct HeaderTooltip(&'static str);
+
+impl Render for HeaderTooltip {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .px_2()
+            .py_1()
+            .rounded_md()
+            .border_1()
+            .border_color(rgb(0x45475a))
+            .bg(rgb(0x1e1e2e))
+            .text_sm()
+            .text_color(rgb(0xcdd6f4))
+            .child(self.0)
+    }
+}
+
+fn sidebar_header_button(
+    id: &'static str,
+    label: &'static str,
+    glyph: &'static str,
+    active: bool,
+) -> Stateful<Div> {
+    div()
+        .id(id)
+        .role(gpui::Role::Button)
+        .aria_label(label)
+        .tooltip(move |_, cx| cx.new(|_| HeaderTooltip(label)).into())
+        .size(px(28.0))
+        .flex_none()
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded_md()
+        .border_1()
+        .border_color(rgb(if active { 0xcba6f7 } else { 0x45475a }))
+        .cursor_pointer()
+        .text_color(rgb(0xa6adc8))
+        .hover(|button| button.bg(rgb(0x313244)))
+        .child(glyph)
+}
+
+fn sidebar_menu_row(id: &'static str) -> Stateful<Div> {
+    div()
+        .id(id)
+        .role(gpui::Role::MenuItem)
+        .h(px(36.0))
+        .px_3()
+        .flex()
+        .items_center()
+        .rounded_md()
+        .cursor_pointer()
+        .hover(|row| row.bg(rgb(0x313244)))
 }
 
 actions!(
@@ -1187,6 +1243,31 @@ fn drop_placement(layout: &Node, point: (f32, f32)) -> Option<(usize, Axis, bool
     }
 }
 
+fn sidebar_render_sources(
+    overview: &BoomuxOverview,
+    settings_open: bool,
+) -> (&[terminal::WorkspaceChoice], &[AgentChoice]) {
+    if settings_open {
+        (&[], &[])
+    } else {
+        (&overview.workspaces, &overview.agents)
+    }
+}
+
+fn setup_pane_was_removed(
+    shell: &ShellChoice,
+    output_finished: bool,
+    overview: &BoomuxOverview,
+) -> bool {
+    shell.desktop_setup
+        && output_finished
+        && !overview
+            .workspaces
+            .iter()
+            .flat_map(|workspace| &workspace.shells)
+            .any(|current| current.id == shell.id)
+}
+
 fn scrollbar_thumb_fraction(screen: &TerminalScreen, track_height: f32) -> f32 {
     if screen.scroll_total == 0 {
         return 1.0;
@@ -1309,6 +1390,7 @@ struct Workspace {
     update_busy: bool,
     prepared_update: Option<bundle_update::Prepared>,
     onboarding_complete: bool,
+    harness_integrations: harness_integrations::Model,
     updates_status: Option<String>,
     update_task: Option<gpui::Task<()>>,
     dismissed_desktop_update: String,
@@ -1481,6 +1563,7 @@ impl Workspace {
             update_busy: false,
             prepared_update: None,
             onboarding_complete: saved.onboarding_complete,
+            harness_integrations: harness_integrations::Model::default(),
             updates_status: None,
             update_task: None,
             dismissed_desktop_update: saved.dismissed_desktop_update,
@@ -1542,8 +1625,9 @@ impl Workspace {
             .detach();
         }
         workspace.watch_updates(cx);
+        workspace.check_harness_integrations(false, cx);
         workspace.watch_omarchy_theme(cx);
-        workspace.watch_boomux_overview(cx);
+        workspace.watch_boomux_overview(window, cx);
         workspace
     }
 
@@ -1679,29 +1763,245 @@ impl Workspace {
         cx.notify();
     }
 
-    fn onboarding(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
-        if self.onboarding_complete {
-            return None;
+    fn check_harness_integrations(&mut self, manual: bool, cx: &mut Context<Self>) {
+        if self.harness_integrations.busy {
+            return;
         }
-        Some(div().mb_3().p_3().border_1().border_color(rgb(0x45475a))
-            .flex().flex_col().gap_2()
-            .child(div().text_sm().child("Welcome to Boomux"))
-            .child(div().text_xs().text_color(rgb(0xa6adc8))
-                .child("Connect your coding agents to show their status and notifications. Setup opens here and asks before changing any agent configuration."))
-            .child(Self::settings_option("setup-agents", "Set up agents", true)
-                .on_click(cx.listener(|this, _, window, cx| {
-                    this.onboarding_complete = true;
-                    this.save_settings();
-                    this.create_and_attach_setup(window, cx);
-                })))
-            .child(Self::settings_option("skip-setup", "Start using Boomux", false)
-                .on_click(cx.listener(|this, _, _, cx| {
-                    this.onboarding_complete = true;
-                    this.save_settings();
-                    cx.notify();
-                })))
-            .child(div().text_xs().text_color(rgb(0xa6adc8)).child("You can run setup later from the menu."))
-            .into_any_element())
+        self.harness_integrations.busy = true;
+        self.harness_integrations.error = None;
+        self.harness_integrations.confirm_replace = None;
+        if manual {
+            self.harness_integrations.dismissed.clear();
+        }
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_spawn(async { harness_integrations::check() })
+                .await;
+            this.update(cx, |this, cx| {
+                this.harness_integrations.busy = false;
+                match result {
+                    Ok(report) => {
+                        this.harness_integrations.report = report;
+                        this.harness_integrations.checked = true;
+                    }
+                    Err(error) => this.harness_integrations.error = Some(error),
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+        cx.notify();
+    }
+
+    fn install_harness_integration(
+        &mut self,
+        suggestion: harness_integrations::Suggestion,
+        cx: &mut Context<Self>,
+    ) {
+        if self.harness_integrations.busy {
+            return;
+        }
+        let name = suggestion.descriptor.key;
+        let replace_confirmed = self.harness_integrations.confirm_replace == Some(name);
+        if suggestion.need == harness_integrations::Need::Review && !replace_confirmed {
+            self.harness_integrations.confirm_replace = Some(name);
+            cx.notify();
+            return;
+        }
+        self.harness_integrations.busy = true;
+        self.harness_integrations.installing = Some(name);
+        self.harness_integrations.message = None;
+        self.harness_integrations.error = None;
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_spawn(async move {
+                    harness_integrations::install(suggestion, replace_confirmed)
+                })
+                .await;
+            this.update(cx, |this, cx| {
+                let model = &mut this.harness_integrations;
+                model.busy = false;
+                model.installing = None;
+                model.confirm_replace = None;
+                match result {
+                    Ok(()) => {
+                        model
+                            .report
+                            .suggestions
+                            .retain(|item| item.descriptor.key != name);
+                        model.message = Some(format!(
+                            "{} integration is ready. {}.",
+                            suggestion.descriptor.display_name,
+                            suggestion
+                                .descriptor
+                                .installation
+                                .expect("installable descriptor")
+                                .reload_message
+                        ));
+                    }
+                    Err(error) => model.error = Some(error),
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+        cx.notify();
+    }
+
+    fn harness_integration_notices(&self, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
+        let model = &self.harness_integrations;
+        let mut rows = Vec::new();
+        for (kind, message) in [
+            ("result", model.message.as_ref()),
+            ("error", model.error.as_ref()),
+        ] {
+            if let Some(message) = message {
+                rows.push(
+                    div()
+                        .mb_3()
+                        .flex()
+                        .flex_col()
+                        .gap_2()
+                        .child(div().text_xs().child(message.clone()))
+                        .child(
+                            Self::settings_option(
+                                SharedString::from(format!("dismiss-integration-message-{kind}")),
+                                "Dismiss",
+                                false,
+                            )
+                            .on_click(cx.listener(
+                                move |this, _, _, cx| {
+                                    if kind == "result" {
+                                        this.harness_integrations.message = None;
+                                    } else {
+                                        this.harness_integrations.error = None;
+                                    }
+                                    cx.notify();
+                                },
+                            )),
+                        )
+                        .into_any_element(),
+                );
+            }
+        }
+        for &suggestion in &model.report.suggestions {
+            let name = suggestion.descriptor.key;
+            if model.dismissed.contains(name) {
+                continue;
+            }
+            let confirm = model.confirm_replace == Some(name);
+            let replacing = suggestion.need == harness_integrations::Need::Review;
+            let description = if confirm {
+                "Replace the existing Boomux integration with this version? This may replace customizations to the Boomux integration."
+            } else if replacing {
+                "Its Boomux integration differs from this version. It may be older or customized."
+            } else {
+                "Enable its Boomux integration to show agent status and notifications."
+            };
+            let label = if model.installing == Some(name) {
+                "Installing…"
+            } else if confirm {
+                "Replace integration"
+            } else if replacing {
+                "Review update"
+            } else {
+                "Install integration"
+            };
+            rows.push(
+                div()
+                    .mb_3()
+                    .p_3()
+                    .border_1()
+                    .border_color(rgb(0x45475a))
+                    .flex()
+                    .flex_col()
+                    .gap_2()
+                    .child(
+                        div()
+                            .text_sm()
+                            .child(format!("{} detected", suggestion.descriptor.display_name)),
+                    )
+                    .child(div().text_xs().text_color(rgb(0xa6adc8)).child(description))
+                    .child(
+                        Self::settings_control(
+                            SharedString::from(format!("install-integration-{name}")),
+                            label,
+                            true,
+                            !model.busy,
+                        )
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.install_harness_integration(suggestion, cx)
+                        })),
+                    )
+                    .child(
+                        Self::settings_control(
+                            SharedString::from(format!("dismiss-integration-{name}")),
+                            if confirm { "Cancel" } else { "Not now" },
+                            false,
+                            !model.busy,
+                        )
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            if this.harness_integrations.busy {
+                                return;
+                            }
+                            if this.harness_integrations.confirm_replace == Some(name) {
+                                this.harness_integrations.confirm_replace = None;
+                            } else {
+                                this.harness_integrations.dismissed.insert(name);
+                            }
+                            cx.notify();
+                        })),
+                    )
+                    .into_any_element(),
+            );
+        }
+        rows
+    }
+
+    fn harness_integration_settings(&self, cx: &mut Context<Self>) -> Div {
+        let model = &self.harness_integrations;
+        let summary = if model.busy && model.installing.is_none() {
+            "Checking installed harnesses…".into()
+        } else if !model.checked {
+            "Check this computer for supported AI harnesses.".into()
+        } else if model.report.unavailable > 0 {
+            format!(
+                "{} detected; {} checks unavailable.",
+                model.report.detected, model.report.unavailable
+            )
+        } else if model.report.detected == 0 {
+            "No supported AI harnesses detected on this computer.".into()
+        } else if model.report.suggestions.is_empty() {
+            "Detected harness integrations are up to date.".into()
+        } else {
+            format!("{} detected on this computer.", model.report.detected)
+        };
+        div()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .child(div().text_xs().text_color(rgb(0xa6adc8)).child(summary))
+            .child(
+                Self::settings_control(
+                    "check-harness-integrations",
+                    "Check installed harnesses",
+                    false,
+                    !model.busy,
+                )
+                .on_click(cx.listener(|this, _, _, cx| this.check_harness_integrations(true, cx))),
+            )
+            .children(self.harness_integration_notices(cx))
+            .child(
+                Self::settings_control("manual-harness-setup", "Manual setup", false, !model.busy)
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        if !this.harness_integrations.busy {
+                            this.close_settings(cx);
+                            this.create_and_attach_setup(window, cx);
+                        }
+                    })),
+            )
     }
 
     fn update_notices(&self, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
@@ -1712,7 +2012,25 @@ impl Workspace {
                     .mb_3()
                     .text_xs()
                     .text_color(rgb(0xa6adc8))
-                    .child(status.clone())
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(div().flex_1().min_w_0().child(status.clone()))
+                    .when(!self.updates_checking && !self.update_busy, |row| {
+                        row.child(
+                            Self::settings_option("dismiss-update-status", "Dismiss", false)
+                                .flex_none()
+                                .h(px(24.0))
+                                .px_2()
+                                .text_xs()
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    if !this.updates_checking && !this.update_busy {
+                                        this.updates_status = None;
+                                        cx.notify();
+                                    }
+                                })),
+                        )
+                    })
                     .into_any_element(),
             );
         }
@@ -4516,8 +4834,9 @@ impl Workspace {
         cx.spawn(async move |this, cx| {
             let result = cx
                 .background_spawn(async move {
-                    let shell = terminal::create_workspace_with_shell(launch)?;
-                    let session = match TerminalSession::attach(
+                    let (shell, setup_workspace_cleanup) =
+                        terminal::create_workspace_with_shell(launch)?;
+                    let mut session = match TerminalSession::attach(
                         shell.clone(),
                         size.0,
                         size.1,
@@ -4526,10 +4845,14 @@ impl Workspace {
                     ) {
                         Ok(session) => session,
                         Err(error) => {
-                            let _ = terminal::remove_workspace(&shell.workspace_id);
+                            // Setup ownership does not authorize deleting resources added meanwhile.
+                            if !shell.desktop_setup {
+                                let _ = terminal::remove_workspace(&shell.workspace_id);
+                            }
                             return Err(error);
                         }
                     };
+                    session.setup_workspace_cleanup = setup_workspace_cleanup;
                     let overview = terminal::discover_overview().ok();
                     Ok::<_, String>((shell, session, overview))
                 })
@@ -4568,13 +4891,16 @@ impl Workspace {
         .detach();
     }
 
-    fn watch_boomux_overview(&self, cx: &mut Context<Self>) {
+    fn watch_boomux_overview(&self, window: &Window, cx: &mut Context<Self>) {
+        let window_handle = window.window_handle();
         cx.spawn(async move |this, cx| {
             loop {
                 cx.background_executor().timer(Duration::from_secs(1)).await;
                 let result = cx
                     .background_spawn(async { terminal::discover_overview_and_nodes() })
                     .await;
+                let mut removed_setup_shells = Vec::new();
+                let mut setup_workspace_cleanups = Vec::new();
                 let keep_watching = this
                     .update(cx, |this, cx| {
                         let (result, nodes) = result;
@@ -4610,6 +4936,25 @@ impl Workspace {
                             }
                         }
                         if let Ok(mut overview) = result {
+                            for pane in this.terminals.values_mut() {
+                                if let (Some(shell), Some(session)) =
+                                    (&pane.shell, &mut pane.session)
+                                    && setup_pane_was_removed(
+                                        shell,
+                                        session.update_events().is_closed(),
+                                        &overview,
+                                    )
+                                {
+                                    removed_setup_shells.push(SidebarResource::Shell {
+                                        id: shell.id.clone(),
+                                        name: shell.name.clone(),
+                                        workspace_id: shell.workspace_id.clone(),
+                                    });
+                                    if let Some(cleanup) = session.setup_workspace_cleanup.take() {
+                                        setup_workspace_cleanups.push(cleanup);
+                                    }
+                                }
+                            }
                             reconcile_workspace_order(&mut this.workspace_order, &mut overview);
                             if overview != this.boomux_overview || this.boomux_error.is_some() {
                                 this.set_boomux_overview(overview);
@@ -4625,6 +4970,37 @@ impl Workspace {
                     .unwrap_or(false);
                 if !keep_watching {
                     return;
+                }
+                if !removed_setup_shells.is_empty() {
+                    let _ = window_handle.update(cx, |_, window, cx| {
+                        this.update(cx, |this, cx| {
+                            for shell in removed_setup_shells {
+                                this.remove_resource_panes(&shell, window);
+                            }
+                            cx.notify();
+                        })
+                    });
+                }
+                if !setup_workspace_cleanups.is_empty() {
+                    let errors = cx
+                        .background_spawn(async move {
+                            setup_workspace_cleanups
+                                .into_iter()
+                                .filter_map(|cleanup| {
+                                    terminal::cleanup_setup_workspace(cleanup).err()
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                        .await;
+                    if !errors.is_empty() {
+                        let _ = this.update(cx, |this, cx| {
+                            this.boomux_error = Some(format!(
+                                "Could not confirm setup Workspace cleanup: {}",
+                                errors.join("; ")
+                            ));
+                            cx.notify();
+                        });
+                    }
                 }
             }
         })
@@ -5038,7 +5414,9 @@ impl Workspace {
                             revision = next_revision;
                             cx.notify();
                         }
-                        !terminal.is_closed()
+                        // The worker closes the event stream after publishing its final screen.
+                        // Transport closure can arrive before that last update.
+                        true
                     })
                     .unwrap_or(false);
                 if !keep_watching {
@@ -5278,6 +5656,8 @@ impl Workspace {
         self.sidebar_header_menu_open.then(|| {
             div()
                 .id("sidebar-header-menu")
+                .role(gpui::Role::Menu)
+                .aria_label("More actions")
                 .absolute()
                 .occlude()
                 .top(px(54.0))
@@ -5290,67 +5670,22 @@ impl Workspace {
                 .bg(rgb(0x1e1e2e))
                 .shadow_lg()
                 .child(
-                    div()
-                        .id("header-menu-settings")
-                        .h(px(36.0))
-                        .px_3()
-                        .flex()
-                        .items_center()
-                        .justify_between()
-                        .gap_3()
-                        .rounded_md()
-                        .cursor_pointer()
-                        .hover(|row| row.bg(rgb(0x313244)))
+                    sidebar_menu_row("header-menu-nodes")
+                        .child("Nodes")
                         .on_click(cx.listener(|this, _, _, cx| {
                             cx.stop_propagation();
-                            this.sidebar_header_menu_open = false;
-                            this.toggle_settings(cx);
-                        }))
-                        .child(div().min_w_0().flex_1().child("Settings"))
-                        .child(div().flex_none().text_color(rgb(0x7f849c)).child("⚙")),
-                )
-                .child(
-                    Self::settings_option("header-menu-nodes", "Nodes…", false).on_click(
-                        cx.listener(|this, _, _, cx| {
-                            cx.stop_propagation();
                             this.open_nodes(cx);
-                        }),
-                    ),
-                )
-                .child(
-                    div()
-                        .id("header-menu-setup")
-                        .h(px(36.0))
-                        .px_3()
-                        .flex()
-                        .items_center()
-                        .rounded_md()
-                        .cursor_pointer()
-                        .hover(|row| row.bg(rgb(0x313244)))
-                        .child("Set up agents")
-                        .on_click(cx.listener(|this, _, window, cx| {
-                            this.sidebar_header_menu_open = false;
-                            this.onboarding_complete = true;
-                            this.save_settings();
-                            this.create_and_attach_setup(window, cx);
                         })),
                 )
                 .child(
-                    div()
-                        .id("header-menu-updates")
-                        .h(px(36.0))
-                        .px_3()
-                        .flex()
-                        .items_center()
-                        .rounded_md()
-                        .cursor_pointer()
-                        .hover(|row| row.bg(rgb(0x313244)))
+                    sidebar_menu_row("header-menu-updates")
                         .child(if self.updates_checking {
                             "Checking for updates…"
                         } else {
                             "Check for updates"
                         })
                         .on_click(cx.listener(|this, _, _, cx| {
+                            cx.stop_propagation();
                             this.sidebar_header_menu_open = false;
                             this.updates_status = Some("Checking for updates…".into());
                             this.dismissed_desktop_update.clear();
@@ -5360,17 +5695,9 @@ impl Workspace {
                         })),
                 )
                 .child(
-                    div()
-                        .id("header-menu-help")
-                        .h(px(36.0))
-                        .px_3()
-                        .flex()
-                        .items_center()
+                    sidebar_menu_row("header-menu-help")
                         .justify_between()
                         .gap_3()
-                        .rounded_md()
-                        .cursor_pointer()
-                        .hover(|row| row.bg(rgb(0x313244)))
                         .on_click(cx.listener(|this, _, window, cx| {
                             cx.stop_propagation();
                             this.sidebar_header_menu_open = false;
@@ -5387,17 +5714,9 @@ impl Workspace {
                 )
                 .child(div().mx_2().my_1().h(px(1.0)).bg(rgb(0x313244)))
                 .child(
-                    div()
-                        .id("header-menu-hide-sidebar")
-                        .h(px(36.0))
-                        .px_3()
-                        .flex()
-                        .items_center()
+                    sidebar_menu_row("header-menu-hide-sidebar")
                         .justify_between()
                         .gap_3()
-                        .rounded_md()
-                        .cursor_pointer()
-                        .hover(|row| row.bg(rgb(0x313244)))
                         .on_click(cx.listener(|this, _, window, cx| {
                             cx.stop_propagation();
                             this.sidebar_header_menu_open = false;
@@ -5419,6 +5738,8 @@ impl Workspace {
     fn sidebar(&self, cx: &mut Context<Self>) -> Div {
         let header_menu = self.sidebar_header_menu(cx);
         let settings_panel = self.settings_overlay(cx);
+        let (workspaces, agents) =
+            sidebar_render_sources(&self.boomux_overview, self.settings_open);
         let focused_shell_id = self
             .terminals
             .get(&self.focused)
@@ -5434,18 +5755,19 @@ impl Workspace {
             .get(&self.focused)
             .and_then(|pane| pane.shell.as_ref())
             .map(|shell| shell.workspace_id.as_str());
-        let workspace_offsets = sidebar_workspace_offsets(
-            &self.boomux_overview,
-            &self.expanded_workspaces,
-            self.pane_layout_mode,
-        );
+        let workspace_offsets = if self.settings_open {
+            HashMap::new()
+        } else {
+            sidebar_workspace_offsets(
+                &self.boomux_overview,
+                &self.expanded_workspaces,
+                self.pane_layout_mode,
+            )
+        };
         let workspace_order_animation = self.workspace_order_animation.clone();
         let workspace_order_animation_duration = self.motion_speed.duration();
-        let workspace_rows = self
-            .boomux_overview
-            .workspaces
+        let workspace_rows = workspaces
             .iter()
-            .cloned()
             .map(|workspace| {
                 let workspace_id = workspace.id.clone();
                 let workspace_name = workspace.name.clone();
@@ -5459,9 +5781,9 @@ impl Workspace {
                 let shell_rows =
                     workspace
                         .shells
-                        .clone()
-                        .into_iter()
-                        .filter(|_| self.pane_layout_mode != PaneLayoutMode::Tabbed)
+                        .iter()
+                        .filter(|_| expanded && self.pane_layout_mode != PaneLayoutMode::Tabbed)
+                        .cloned()
                         .map(|shell| {
                             let shell_id = shell.id.clone();
                             let shell_target = SidebarResource::Shell {
@@ -5652,7 +5974,7 @@ impl Workspace {
                                             } else {
                                                 gpui::FontWeight::NORMAL
                                             })
-                                            .child(workspace.name),
+                                            .child(workspace.name.clone()),
                                     )
                                     .child(div().text_xs().text_color(rgb(0x6c7086)).child(
                                         format!(
@@ -5729,9 +6051,7 @@ impl Workspace {
             })
             .collect::<Vec<_>>();
 
-        let agent_rows = self
-            .boomux_overview
-            .agents
+        let agent_rows = agents
             .iter()
             .cloned()
             .map(|agent| self.sidebar_agent(agent, focused_shell_id, cx))
@@ -5759,16 +6079,20 @@ impl Workspace {
                     .flex()
                     .items_center()
                     .justify_between()
+                    .gap_2()
                     .border_b_1()
                     .border_color(rgb(0x313244))
                     .child(
                         div()
+                            .min_w_0()
+                            .flex_1()
                             .flex()
                             .items_center()
                             .gap_3()
                             .child(
                                 div()
                                     .size(px(28.0))
+                                    .flex_none()
                                     .rounded_full()
                                     .flex()
                                     .items_center()
@@ -5779,6 +6103,8 @@ impl Workspace {
                             )
                             .child(
                                 div()
+                                    .min_w_0()
+                                    .flex_1()
                                     .flex()
                                     .flex_col()
                                     .child(
@@ -5787,6 +6113,7 @@ impl Workspace {
                                     .child(
                                         div()
                                             .id("sidebar-node-status")
+                                            .truncate()
                                             .text_xs()
                                             .text_color(rgb(0x89b4fa))
                                             .cursor_pointer()
@@ -5828,108 +6155,111 @@ impl Workspace {
                             .flex()
                             .items_center()
                             .gap_1()
+                            .flex_none()
                             .child(
-                                div()
-                                    .id("create-workspace")
-                                    .size(px(28.0))
-                                    .flex()
-                                    .items_center()
-                                    .justify_center()
-                                    .rounded_md()
-                                    .border_1()
-                                    .border_color(rgb(0x45475a))
-                                    .cursor_pointer()
-                                    .text_color(rgb(0xa6adc8))
-                                    .hover(|button| button.bg(rgb(0x313244)))
-                                    .on_click(cx.listener(|this, _, window, cx| {
+                                sidebar_header_button(
+                                    "create-workspace",
+                                    "New Workspace",
+                                    "+",
+                                    false,
+                                )
+                                .on_click(cx.listener(
+                                    |this, _, window, cx| {
                                         cx.stop_propagation();
                                         this.sidebar_header_menu_open = false;
                                         this.create_and_attach_new_workspace(window, cx);
-                                    }))
-                                    .child("+"),
+                                    },
+                                )),
                             )
                             .child(
-                                div()
-                                    .id("open-sidebar-menu")
-                                    .size(px(28.0))
-                                    .flex()
-                                    .items_center()
-                                    .justify_center()
-                                    .rounded_md()
-                                    .border_1()
-                                    .border_color(rgb(if self.sidebar_header_menu_open {
-                                        0xcba6f7
-                                    } else {
-                                        0x45475a
-                                    }))
-                                    .cursor_pointer()
-                                    .text_color(rgb(0xa6adc8))
-                                    .hover(|button| button.bg(rgb(0x313244)))
-                                    .on_click(cx.listener(|this, _, _, cx| {
+                                sidebar_header_button(
+                                    "open-settings",
+                                    "Settings",
+                                    "⚙",
+                                    self.settings_open,
+                                )
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        cx.stop_propagation();
+                                        this.toggle_settings(cx);
+                                    },
+                                )),
+                            )
+                            .child(
+                                sidebar_header_button(
+                                    "open-sidebar-menu",
+                                    "More actions",
+                                    "⋯",
+                                    self.sidebar_header_menu_open,
+                                )
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
                                         cx.stop_propagation();
                                         this.sidebar_header_menu_open =
                                             !this.sidebar_header_menu_open;
                                         this.sidebar_menu = None;
                                         cx.notify();
-                                    }))
-                                    .child("⋯"),
+                                    },
+                                )),
                             ),
                     ),
             )
-            .child(
-                div()
-                    .id("sidebar-scroll")
-                    .track_scroll(&self.sidebar_scroll_handle)
-                    .flex_1()
-                    .min_h_0()
-                    .overflow_y_scroll()
-                    .p_3()
-                    .children(self.onboarding(cx))
-                    .children(self.update_notices(cx))
-                    .child(
-                        div()
-                            .mb_2()
-                            .text_xs()
-                            .font_weight(gpui::FontWeight::BOLD)
-                            .text_color(rgb(0x7f849c))
-                            .child("WORKSPACES"),
-                    )
-                    .when(workspace_rows.is_empty(), |element| {
-                        element.child(
+            .when(!self.settings_open, |sidebar| {
+                sidebar.child(
+                    div()
+                        .id("sidebar-scroll")
+                        .track_scroll(&self.sidebar_scroll_handle)
+                        .flex_1()
+                        .min_h_0()
+                        .overflow_y_scroll()
+                        .p_3()
+                        .children(self.harness_integration_notices(cx))
+                        .children(self.update_notices(cx))
+                        .child(
                             div()
-                                .py_4()
-                                .text_sm()
-                                .text_color(rgb(0x6c7086))
-                                .child("No Boomux workspaces"),
+                                .mb_2()
+                                .text_xs()
+                                .font_weight(gpui::FontWeight::BOLD)
+                                .text_color(rgb(0x7f849c))
+                                .child("WORKSPACES"),
                         )
-                    })
-                    .child(
-                        div()
-                            .id("sidebar-workspace-list")
-                            .w_full()
-                            .on_drag_move(cx.listener(Self::drag_workspace))
-                            .children(workspace_rows),
-                    )
-                    .child(div().mt_4().mb_3().h(px(1.0)).w_full().bg(rgb(0x313244)))
-                    .child(
-                        div()
-                            .mb_2()
-                            .text_xs()
-                            .font_weight(gpui::FontWeight::BOLD)
-                            .text_color(rgb(0x7f849c))
-                            .child("AGENTS"),
-                    )
-                    .when(agent_rows.is_empty(), |element| {
-                        element.child(
+                        .when(workspace_rows.is_empty(), |element| {
+                            element.child(
+                                div()
+                                    .py_4()
+                                    .text_sm()
+                                    .text_color(rgb(0x6c7086))
+                                    .child("No Boomux workspaces"),
+                            )
+                        })
+                        .child(
                             div()
-                                .py_4()
-                                .text_sm()
-                                .text_color(rgb(0x6c7086))
-                                .child("No active Boomux agents"),
+                                .id("sidebar-workspace-list")
+                                .w_full()
+                                .on_drag_move(cx.listener(Self::drag_workspace))
+                                .children(workspace_rows),
                         )
-                    })
-                    .children(agent_rows),
-            )
+                        .child(div().mt_4().mb_3().h(px(1.0)).w_full().bg(rgb(0x313244)))
+                        .child(
+                            div()
+                                .mb_2()
+                                .text_xs()
+                                .font_weight(gpui::FontWeight::BOLD)
+                                .text_color(rgb(0x7f849c))
+                                .child("AGENTS"),
+                        )
+                        .when(agent_rows.is_empty(), |element| {
+                            element.child(
+                                div()
+                                    .py_4()
+                                    .text_sm()
+                                    .text_color(rgb(0x6c7086))
+                                    .child("No active Boomux agents"),
+                            )
+                        })
+                        .children(agent_rows),
+                )
+            })
             .when_some(settings_panel, |element, settings| element.child(settings))
             .when_some(header_menu, |element, menu| element.child(menu))
     }
@@ -6050,6 +6380,15 @@ impl Workspace {
         label: &'static str,
         selected: bool,
     ) -> Stateful<Div> {
+        Self::settings_control(id, label, selected, true)
+    }
+
+    fn settings_control(
+        id: impl Into<gpui::ElementId>,
+        label: &'static str,
+        selected: bool,
+        enabled: bool,
+    ) -> Stateful<Div> {
         div()
             .id(id)
             .h(px(34.0))
@@ -6063,8 +6402,12 @@ impl Workspace {
             .bg(rgb(if selected { 0x313244 } else { 0x181825 }))
             .text_sm()
             .text_color(rgb(0xcdd6f4))
-            .cursor_pointer()
-            .hover(|button| button.bg(rgb(0x313244)))
+            .when(enabled, |button| {
+                button
+                    .cursor_pointer()
+                    .hover(|button| button.bg(rgb(0x313244)))
+            })
+            .when(!enabled, |button| button.cursor_default())
             .child(label)
     }
 
@@ -6461,11 +6804,10 @@ impl Workspace {
                             Some(value) => snapshot.control_text(index) == value,
                         };
                         buttons = buttons.child(
-                            Self::settings_option(
+                            Self::settings_control(
                                 (SharedString::from(format!("boomux-field-{index}")), option_index),
-                                label, selected,
+                                label, selected, enabled,
                             )
-                                .when(!enabled, |button| button.cursor_default().hover(|button| button))
                                 .on_click(cx.listener(move |this, _, window, cx| {
                                     if this.boomux_settings_busy || !enabled {
                                         return;
@@ -6506,6 +6848,8 @@ impl Workspace {
     fn settings_overlay(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
         self.settings_open.then(|| {
             let content = div().flex_none().flex().flex_col().gap_4()
+                .child(Self::settings_category("AI integrations"))
+                .child(self.harness_integration_settings(cx))
                 .child(Self::settings_category("Layout & workspaces"))
                 .when_some(self.settings_error.clone(), |panel, error| panel.child(
                     div().text_xs().text_color(rgb(0xf38ba8)).child(format!("Settings could not be saved or loaded: {error}. Check settings.toml and restart."))
@@ -9204,6 +9548,126 @@ fn main() {
 #[cfg(test)]
 mod pointer_tests {
     use super::*;
+
+    #[test]
+    fn settings_scroll_eliminates_hidden_sidebar_row_preparation() {
+        let fixture = sidebar_overview();
+        let mut overview = BoomuxOverview {
+            workspaces: (0..100)
+                .map(|index| {
+                    let mut workspace = fixture.workspaces[0].clone();
+                    workspace.id = format!("workspace-{index}");
+                    workspace.shells = (0..20)
+                        .map(|shell_index| {
+                            let mut shell = workspace.shells[0].clone();
+                            shell.id = format!("shell-{index}-{shell_index}");
+                            shell
+                        })
+                        .collect();
+                    workspace
+                })
+                .collect(),
+            agents: vec![fixture.agents[0].clone(); 2000],
+            ..BoomuxOverview::default()
+        };
+        // Same fixture/profile: isolate the formerly unconditional clone/row preparation,
+        // not GPU painting or a claim about end-to-end scroll frame rate.
+        let prepare_rows = |workspaces: &[terminal::WorkspaceChoice], agents: &[AgentChoice]| {
+            let mut rows = 0;
+            for workspace in workspaces.iter().cloned() {
+                let shells = workspace.shells.clone();
+                rows += 1 + shells.len();
+                std::hint::black_box(shells);
+            }
+            let agents = agents.to_vec();
+            rows += agents.len();
+            std::hint::black_box(agents);
+            rows
+        };
+        let before = Instant::now();
+        let before_rows: usize = (0..60)
+            .map(|_| prepare_rows(&overview.workspaces, &overview.agents))
+            .sum();
+        let before_time = before.elapsed();
+        let after = Instant::now();
+        let after_rows: usize = (0..60)
+            .map(|_| {
+                let (workspaces, agents) = sidebar_render_sources(&overview, true);
+                prepare_rows(workspaces, agents)
+            })
+            .sum();
+        let after_time = after.elapsed();
+        assert_eq!(before_rows, 246000);
+        assert_eq!(after_rows, 0);
+        eprintln!(
+            "60 Settings scroll preparations: before={before_rows} rows/{before_time:?}, after={after_rows} rows/{after_time:?}"
+        );
+        let (workspaces, agents) = sidebar_render_sources(&overview, false);
+        assert_eq!(workspaces.len(), 100);
+        assert_eq!(agents.len(), 2000);
+        overview.workspaces.clear();
+        overview.agents.clear();
+        let (workspaces, agents) = sidebar_render_sources(&overview, false);
+        assert!(
+            workspaces.is_empty() && agents.is_empty(),
+            "closing Settings must expose current data, not a stale cache"
+        );
+    }
+
+    #[test]
+    fn settings_controls_construct_enabled_and_disabled_selected_states() {
+        for selected in [false, true] {
+            let mut enabled = Workspace::settings_control("enabled", "On", selected, true);
+            let mut disabled = Workspace::settings_control("disabled", "On", selected, false);
+            let mut option = Workspace::settings_option("option", "On", selected);
+            assert_eq!(enabled.style().background, disabled.style().background);
+            assert_eq!(enabled.style().border_color, disabled.style().border_color);
+            assert_eq!(enabled.style().background, option.style().background);
+            assert_eq!(
+                enabled.style().mouse_cursor,
+                Some(gpui::CursorStyle::PointingHand)
+            );
+            assert_eq!(
+                disabled.style().mouse_cursor,
+                Some(gpui::CursorStyle::Arrow)
+            );
+            // GPUI rejects a second hover style; disabled controls must leave it unset.
+            let _ = disabled.hover(|style| style);
+        }
+    }
+
+    #[test]
+    fn sidebar_header_controls_share_geometry_and_distinguish_active_state() {
+        let mut create = sidebar_header_button("create-workspace", "New Workspace", "+", false);
+        let mut settings = sidebar_header_button("open-settings", "Settings", "⚙", false);
+        let mut menu = sidebar_header_button("open-sidebar-menu", "More actions", "⋯", false);
+        for button in [&mut create, &mut settings, &mut menu] {
+            assert_eq!(button.style().size.width, Some(px(28.0).into()));
+            assert_eq!(button.style().size.height, Some(px(28.0).into()));
+            assert_eq!(button.style().flex_shrink, Some(0.0));
+        }
+        assert_eq!(create.style().border_color, settings.style().border_color);
+        assert_eq!(settings.style().border_color, menu.style().border_color);
+        let mut active = sidebar_header_button("open-settings", "Settings", "⚙", true);
+        assert_ne!(settings.style().border_color, active.style().border_color);
+    }
+
+    #[test]
+    fn sidebar_overflow_rows_are_flat_and_left_aligned() {
+        for id in [
+            "header-menu-nodes",
+            "header-menu-setup",
+            "header-menu-updates",
+            "header-menu-help",
+            "header-menu-hide-sidebar",
+        ] {
+            let mut row = sidebar_menu_row(id);
+            assert_eq!(row.style().size.height, Some(px(36.0).into()));
+            assert_eq!(row.style().justify_content, None);
+            assert_eq!(row.style().border_color, None);
+            assert_eq!(row.style().background, None);
+        }
+    }
     use boomux::protocol::{AgentState, ShellStatus};
 
     fn pane() -> FloatingPane {
@@ -9860,6 +10324,7 @@ mod pointer_tests {
                     cwd: "/tmp".into(),
                     status: ShellStatus::Running,
                     run_id: None,
+                    desktop_setup: false,
                 })
                 .collect(),
             agent_count: 0,
@@ -10079,6 +10544,7 @@ mod pointer_tests {
             cwd: "/tmp".into(),
             status: ShellStatus::Running,
             run_id: Some("run-1".into()),
+            desktop_setup: false,
         };
         BoomuxOverview {
             workspaces: vec![terminal::WorkspaceChoice {
@@ -10102,6 +10568,19 @@ mod pointer_tests {
             }],
             focused_shell_id: Some("shell-1".into()),
         }
+    }
+
+    #[test]
+    fn setup_pane_cleanup_requires_finished_output_and_confirmed_shell_absence() {
+        let mut overview = sidebar_overview();
+        let mut shell = overview.workspaces[0].shells[0].clone();
+        shell.desktop_setup = true;
+        assert!(!super::setup_pane_was_removed(&shell, true, &overview));
+        overview.workspaces[0].shells.clear();
+        assert!(!super::setup_pane_was_removed(&shell, false, &overview));
+        assert!(super::setup_pane_was_removed(&shell, true, &overview));
+        shell.desktop_setup = false;
+        assert!(!super::setup_pane_was_removed(&shell, true, &overview));
     }
 
     #[test]

--- a/desktop/src/nodes.rs
+++ b/desktop/src/nodes.rs
@@ -1,0 +1,236 @@
+//! Read-only Node presentation. The daemon owns registrations and observations.
+
+use boomux::protocol::{CombinedNode, CombinedNodeSnapshot, NodeProjectionHealthCode};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeView {
+    pub id: String,
+    pub label: String,
+    pub local: bool,
+    pub route: Option<String>,
+    pub health: NodeProjectionHealthCode,
+    pub current: bool,
+    pub observed_at_ms: u64,
+    pub version: Option<String>,
+    pub workspace_count: usize,
+    pub shell_count: usize,
+}
+
+impl NodeView {
+    pub fn connected(&self) -> bool {
+        self.current && self.health == NodeProjectionHealthCode::Online
+    }
+
+    pub fn status(&self) -> &'static str {
+        match self.health {
+            NodeProjectionHealthCode::Online if self.current => "Connected",
+            NodeProjectionHealthCode::Online | NodeProjectionHealthCode::Stale => "Stale",
+            NodeProjectionHealthCode::Unobserved => "Not yet connected",
+            NodeProjectionHealthCode::Reconnecting => "Reconnecting",
+            NodeProjectionHealthCode::Unreachable => "Unreachable",
+            NodeProjectionHealthCode::AuthenticationRequired => "Sign-in required",
+            NodeProjectionHealthCode::IdentityChanged => "Identity changed",
+            NodeProjectionHealthCode::IdentityConflict => "Identity conflict",
+            NodeProjectionHealthCode::Unsupported => "Incompatible",
+        }
+    }
+
+    pub fn guidance(&self) -> &'static str {
+        match self.health {
+            NodeProjectionHealthCode::AuthenticationRequired => {
+                "Sign in through your existing SSH route to reconnect."
+            }
+            NodeProjectionHealthCode::IdentityChanged
+            | NodeProjectionHealthCode::IdentityConflict => {
+                "This route no longer identifies the expected Node. Inspect it before changing the registration."
+            }
+            NodeProjectionHealthCode::Unsupported => {
+                "The remote helper or daemon is incompatible. Review it in the Boomux dashboard."
+            }
+            _ if !self.connected() => {
+                "Showing the last observation. A lost connection does not establish whether remote work has stopped."
+            }
+            _ => "Closing a terminal pane detaches it; its Shell stays on the owning Node.",
+        }
+    }
+
+    pub fn last_seen(&self, now_ms: u64) -> String {
+        if self.observed_at_ms == 0 {
+            return "No observation yet".into();
+        }
+        let seconds = now_ms.saturating_sub(self.observed_at_ms) / 1_000;
+        if seconds < 60 {
+            "Last observed less than a minute ago".into()
+        } else if seconds < 3_600 {
+            format!("Last observed {} min ago", seconds / 60)
+        } else {
+            format!("Last observed {} h ago", seconds / 3_600)
+        }
+    }
+}
+
+pub fn project(snapshot: &CombinedNodeSnapshot) -> Vec<NodeView> {
+    let mut nodes: Vec<_> = snapshot
+        .nodes
+        .iter()
+        .map(|node: &CombinedNode| {
+            let (workspace_count, shell_count) = if node.local {
+                node.local_snapshot.as_ref().map_or((0, 0), |snapshot| {
+                    (
+                        snapshot.workspaces.len(),
+                        snapshot
+                            .workspaces
+                            .iter()
+                            .map(|workspace| workspace.shells.len())
+                            .sum(),
+                    )
+                })
+            } else {
+                node.remote_projection
+                    .as_ref()
+                    .map_or((0, 0), |projection| {
+                        (projection.workspaces.len(), projection.shells.len())
+                    })
+            };
+            NodeView {
+                id: node.node_id.clone(),
+                label: if node.local {
+                    "This computer".into()
+                } else {
+                    node.alias.clone()
+                },
+                local: node.local,
+                route: node.route.clone(),
+                health: node.health,
+                current: node.current && !node.stale,
+                observed_at_ms: node.observed_at_ms,
+                version: node.observed_helper_version.clone(),
+                workspace_count,
+                shell_count,
+            }
+        })
+        .collect();
+    nodes.sort_by(|a, b| (!a.local, &a.label, &a.id).cmp(&(!b.local, &b.label, &b.id)));
+    nodes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: &str, local: bool) -> CombinedNode {
+        CombinedNode {
+            node_id: id.into(),
+            alias: "same-name".into(),
+            local,
+            route: (!local).then(|| "host".into()),
+            registration_revision: None,
+            health: NodeProjectionHealthCode::Online,
+            current: true,
+            stale: false,
+            observed_at_ms: 1_000,
+            observed_protocol_version: None,
+            observed_capabilities: vec![],
+            observed_helper_version: None,
+            workspace_owner_eligible: true,
+            workspace_owner_unavailable_reason: None,
+            local_snapshot: None,
+            remote_projection: None,
+        }
+    }
+
+    #[test]
+    fn node_identity_survives_equal_labels_and_routes() {
+        let nodes = project(&CombinedNodeSnapshot {
+            nodes: vec![node("b", false), node("local", true), node("a", false)],
+            workspaces: vec![],
+            external_workspaces: vec![],
+            focused_terminal: None,
+        });
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|node| node.id.as_str())
+                .collect::<Vec<_>>(),
+            ["local", "a", "b"]
+        );
+        assert_eq!(nodes[0].label, "This computer");
+    }
+
+    #[test]
+    fn stale_projection_never_looks_connected() {
+        let mut input = node("remote", false);
+        input.stale = true;
+        let nodes = project(&CombinedNodeSnapshot {
+            nodes: vec![input],
+            workspaces: vec![],
+            external_workspaces: vec![],
+            focused_terminal: None,
+        });
+        assert!(!nodes[0].connected());
+        assert_eq!(nodes[0].status(), "Stale");
+        assert_eq!(nodes[0].last_seen(121_000), "Last observed 2 min ago");
+        assert_eq!(
+            nodes[0].last_seen(0),
+            "Last observed less than a minute ago"
+        );
+    }
+    #[test]
+    fn health_states_keep_distinct_recovery_meanings() {
+        let cases = [
+            (NodeProjectionHealthCode::Unobserved, "Not yet connected"),
+            (NodeProjectionHealthCode::Reconnecting, "Reconnecting"),
+            (NodeProjectionHealthCode::Unreachable, "Unreachable"),
+            (
+                NodeProjectionHealthCode::AuthenticationRequired,
+                "Sign-in required",
+            ),
+            (
+                NodeProjectionHealthCode::IdentityChanged,
+                "Identity changed",
+            ),
+            (
+                NodeProjectionHealthCode::IdentityConflict,
+                "Identity conflict",
+            ),
+            (NodeProjectionHealthCode::Unsupported, "Incompatible"),
+        ];
+        for (health, label) in cases {
+            let mut input = node("remote", false);
+            input.health = health;
+            let nodes = project(&CombinedNodeSnapshot {
+                nodes: vec![input],
+                workspaces: vec![],
+                external_workspaces: vec![],
+                focused_terminal: None,
+            });
+            assert_eq!(nodes[0].status(), label);
+            assert!(!nodes[0].connected());
+        }
+    }
+
+    #[test]
+    fn counts_come_from_the_owning_node_projection() {
+        let mut remote = node("remote", false);
+        remote.remote_projection = Some(boomux::protocol::NodeProjectionSnapshot {
+            node_id: "remote".into(),
+            workspaces: vec![boomux::protocol::NodeProjectionWorkspace {
+                id: "workspace".into(),
+                name: "same-name".into(),
+                item_count: 99,
+                attention_count: 99,
+            }],
+            shells: vec![],
+            launchers: vec![],
+            agents: vec![],
+        });
+        let nodes = project(&CombinedNodeSnapshot {
+            nodes: vec![remote],
+            workspaces: vec![],
+            external_workspaces: vec![],
+            focused_terminal: None,
+        });
+        assert_eq!(nodes[0].workspace_count, 1);
+        assert_eq!(nodes[0].shell_count, 0); // Item count is not a Shell count.
+    }
+}

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -609,6 +609,39 @@ pub fn discover_overview() -> Result<BoomuxOverview, String> {
     let snapshot = client
         .snapshot()
         .map_err(|error| format!("could not read Boomux workspaces: {error}"))?;
+    Ok(overview_from_snapshot(snapshot))
+}
+
+pub fn discover_overview_and_nodes() -> (
+    Result<BoomuxOverview, String>,
+    Result<Vec<crate::nodes::NodeView>, String>,
+) {
+    let combined = client::connect_if_running()
+        .map_err(|error| format!("could not connect to Boomux: {error}"))
+        .and_then(|client| client.ok_or_else(|| "Boomux is not running".into()))
+        .and_then(|client| {
+            client
+                .combined_node_snapshot(None)
+                .map_err(|error| format!("could not read Boomux Nodes: {error}"))
+        });
+    match combined {
+        Ok(combined) => {
+            let nodes = crate::nodes::project(&combined);
+            let overview = combined
+                .nodes
+                .into_iter()
+                .find(|node| node.local)
+                .and_then(|node| node.local_snapshot)
+                .map(overview_from_snapshot)
+                .ok_or_else(|| "Boomux omitted the local Node snapshot".into());
+            (overview, Ok(nodes))
+        }
+        // Federation availability must not stop local discovery.
+        Err(error) => (discover_overview(), Err(error)),
+    }
+}
+
+fn overview_from_snapshot(snapshot: boomux::protocol::Snapshot) -> BoomuxOverview {
     let focused_shell_id = snapshot
         .focused_terminal
         .as_ref()
@@ -683,11 +716,11 @@ pub fn discover_overview() -> Result<BoomuxOverview, String> {
     }
     distinguish_agent_rows(&mut agents);
     agents.sort_by_key(|agent| std::cmp::Reverse(agent.updated_at_ms));
-    Ok(BoomuxOverview {
+    BoomuxOverview {
         workspaces,
         agents,
         focused_shell_id,
-    })
+    }
 }
 
 // Labels are presentation only; actions retain the exact Agent and Shell IDs.
@@ -812,9 +845,33 @@ pub fn create_shell_in_workspace(workspace_id: &str) -> Result<ShellChoice, Stri
         .map_err(|error| format!("could not create Boomux shell: {error}"))
 }
 
-/// Create a local Workspace with its first pending login Shell. Boomux owns
-/// both resources; the returned Shell can be attached immediately.
-pub fn create_workspace_with_shell(setup: bool) -> Result<ShellChoice, String> {
+/// Explicit local terminal flows using the matching Boomux executable.
+#[derive(Clone, Debug)]
+pub enum WorkspaceLaunch {
+    Shell,
+    Setup,
+    AddNode,
+    ReauthenticateNode(String),
+    Dashboard,
+}
+
+impl WorkspaceLaunch {
+    fn command(&self) -> Option<(&'static str, Vec<String>)> {
+        match self {
+            Self::Shell => None,
+            Self::Setup => Some(("Set up agents", vec!["setup".into()])),
+            Self::AddNode => Some(("Add remote Node", vec!["__guided-node-add".into()])),
+            Self::ReauthenticateNode(id) => Some((
+                "Sign in to Node",
+                vec!["__guided-node-reauthenticate".into(), id.clone()],
+            )),
+            Self::Dashboard => Some(("Boomux dashboard", vec![])),
+        }
+    }
+}
+
+/// Create a local Workspace and its first pending Shell; Boomux owns both.
+pub fn create_workspace_with_shell(launch: WorkspaceLaunch) -> Result<ShellChoice, String> {
     let Some(client) = client::connect_if_running()
         .map_err(|error| format!("could not connect to Boomux: {error}"))?
     else {
@@ -835,7 +892,7 @@ pub fn create_workspace_with_shell(setup: bool) -> Result<ShellChoice, String> {
     let cwd = std::env::current_dir()
         .map_err(|error| format!("could not determine the new workspace directory: {error}"))?;
     let mut spec = ShellSpec::login(shell_name, cwd.clone());
-    if setup {
+    if let Some((label, arguments)) = launch.command() {
         let executable = std::env::current_exe().map_err(|error| error.to_string())?;
         let bundled = executable
             .parent()
@@ -854,9 +911,9 @@ pub fn create_workspace_with_shell(setup: bool) -> Result<ShellChoice, String> {
             cli.to_str()
                 .ok_or("The setup executable path must be valid UTF-8")?
                 .to_owned(),
-            "setup".into(),
         ];
-        spec.name = "Set up agents".into();
+        spec.command.extend(arguments);
+        spec.name = label.into();
     }
     let workspace = client
         .create_workspace_with_default_cwd(workspace_name, Some(cwd.clone()), vec![spec])
@@ -1962,6 +2019,25 @@ fn indexed_color_with_palette(index: u8, ansi: &[u32; 16]) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn node_launches_preserve_exact_arguments_and_do_not_request_upgrades() {
+        use super::WorkspaceLaunch;
+        assert!(WorkspaceLaunch::Shell.command().is_none());
+        assert_eq!(
+            WorkspaceLaunch::AddNode.command().unwrap().1,
+            ["__guided-node-add"]
+        );
+        assert!(WorkspaceLaunch::Dashboard.command().unwrap().1.is_empty());
+        let id = "node with spaces; $(touch should-not-exist)";
+        assert_eq!(
+            WorkspaceLaunch::ReauthenticateNode(id.into())
+                .command()
+                .unwrap()
+                .1,
+            ["__guided-node-reauthenticate", id]
+        );
+    }
+
     use std::os::unix::net::UnixStream;
     use std::sync::atomic::Ordering;
     use std::time::Duration;

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 
 use boomux::client::{self, Client};
 use boomux::protocol::{
-    AgentAttentionReason, AgentState, AttachFrame, ShellSnapshot, ShellSpec, ShellStatus,
-    TerminalProfile,
+    AgentAttentionReason, AgentState, AttachFrame, ErrorCode, Request, Response, ShellSnapshot,
+    ShellSpec, ShellStatus, TerminalProfile, WorkspaceSnapshot,
 };
 use compact_str::CompactString;
 use gpui::{Keystroke, Modifiers};
@@ -50,6 +50,7 @@ pub struct ShellChoice {
     pub cwd: PathBuf,
     pub status: ShellStatus,
     pub run_id: Option<String>,
+    pub desktop_setup: bool,
 }
 
 impl ShellChoice {
@@ -375,6 +376,7 @@ enum EmulatorCommand {
 pub struct TerminalSession {
     pub shell_id: String,
     pub shell_name: String,
+    pub setup_workspace_cleanup: Option<SetupWorkspaceCleanup>,
     shared: Arc<SharedTerminal>,
     last_size: Mutex<(u16, u16)>,
 }
@@ -390,6 +392,17 @@ impl TerminalSession {
         let client = client::connect_if_running()
             .map_err(|error| format!("could not connect to Boomux: {error}"))?
             .ok_or_else(|| "Boomux is not running".to_string())?;
+        Self::attach_with_client(client, shell, rows, cols, pixel_width, pixel_height)
+    }
+
+    fn attach_with_client(
+        client: Client,
+        shell: ShellChoice,
+        rows: u16,
+        cols: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+    ) -> Result<Self, String> {
         let profile = terminal_profile(rows, cols, pixel_width, pixel_height);
         let attachment = attach_shell(&client, &shell, profile.clone(), true)?;
         let shared = Arc::new(SharedTerminal::new(profile));
@@ -419,6 +432,7 @@ impl TerminalSession {
         Ok(Self {
             shell_id: shell.id,
             shell_name: shell.name,
+            setup_workspace_cleanup: None,
             shared,
             // Attachment already established this geometry. Avoid an unchanged
             // first-render resize canceling the reader's temporary redraw size.
@@ -432,10 +446,6 @@ impl TerminalSession {
 
     pub fn set_theme(&self, theme: TerminalTheme) -> Result<(), String> {
         self.shared.set_theme(theme)
-    }
-
-    pub fn is_closed(&self) -> bool {
-        self.shared.closed.load(Ordering::Acquire)
     }
 
     pub fn status_message(&self) -> Option<String> {
@@ -793,6 +803,7 @@ fn shell_choice(shell: ShellSnapshot) -> ShellChoice {
         cwd: shell.cwd,
         status: shell.status,
         run_id: shell.run.map(|run| run.id),
+        desktop_setup: shell.command.len() == 2 && shell.command[1] == "__desktop-setup",
     }
 }
 
@@ -859,7 +870,7 @@ impl WorkspaceLaunch {
     fn command(&self) -> Option<(&'static str, Vec<String>)> {
         match self {
             Self::Shell => None,
-            Self::Setup => Some(("Set up agents", vec!["setup".into()])),
+            Self::Setup => Some(("Set up agents", vec!["__desktop-setup".into()])),
             Self::AddNode => Some(("Add remote Node", vec!["__guided-node-add".into()])),
             Self::ReauthenticateNode(id) => Some((
                 "Sign in to Node",
@@ -871,11 +882,18 @@ impl WorkspaceLaunch {
 }
 
 /// Create a local Workspace and its first pending Shell; Boomux owns both.
-pub fn create_workspace_with_shell(launch: WorkspaceLaunch) -> Result<ShellChoice, String> {
+pub fn create_workspace_with_shell(
+    launch: WorkspaceLaunch,
+) -> Result<(ShellChoice, Option<SetupWorkspaceCleanup>), String> {
     let Some(client) = client::connect_if_running()
         .map_err(|error| format!("could not connect to Boomux: {error}"))?
     else {
         return Err("Boomux is not running".into());
+    };
+    let setup_node = if matches!(launch, WorkspaceLaunch::Setup) {
+        Some(client.node_identity().map_err(|error| error.to_string())?)
+    } else {
+        None
     };
     let snapshot = client
         .snapshot()
@@ -918,12 +936,89 @@ pub fn create_workspace_with_shell(launch: WorkspaceLaunch) -> Result<ShellChoic
     let workspace = client
         .create_workspace_with_default_cwd(workspace_name, Some(cwd.clone()), vec![spec])
         .map_err(|error| format!("could not create Boomux workspace: {error}"))?;
+    let cleanup = setup_node
+        .and_then(|node_id| SetupWorkspaceCleanup::from_creation(&launch, node_id, &workspace));
     workspace
         .shells
         .into_iter()
         .next()
-        .map(shell_choice)
+        .map(|shell| (shell_choice(shell), cleanup))
         .ok_or_else(|| "Boomux created the workspace without its initial shell".to_string())
+}
+
+/// Ephemeral proof from this setup launch's successful CreateWorkspace response.
+/// Discovery and reattachment never reconstruct cleanup ownership from a name or command.
+pub struct SetupWorkspaceCleanup {
+    node_id: String,
+    workspace_id: String,
+    empty_revision: u64,
+}
+
+impl SetupWorkspaceCleanup {
+    fn from_creation(
+        launch: &WorkspaceLaunch,
+        node_id: String,
+        workspace: &WorkspaceSnapshot,
+    ) -> Option<Self> {
+        if !matches!(launch, WorkspaceLaunch::Setup)
+            || workspace.shells.len() != 1
+            || !workspace.launchers.is_empty()
+            || !workspace.agents.is_empty()
+        {
+            return None;
+        }
+        Some(Self {
+            node_id,
+            workspace_id: workspace.id.clone(),
+            // Removing the sole setup Shell is the only allowed intervening mutation.
+            empty_revision: workspace.revision.checked_add(1)?,
+        })
+    }
+
+    fn close_request(&self, node_id: &str, workspace: &WorkspaceSnapshot) -> Option<Request> {
+        (node_id == self.node_id
+            && workspace.id == self.workspace_id
+            && workspace.revision == self.empty_revision
+            && workspace.shells.is_empty()
+            && workspace.launchers.is_empty()
+            && workspace.agents.is_empty())
+        .then(|| Request::GuardedCloseWorkspace {
+            workspace_id: self.workspace_id.clone(),
+            expected_revision: self.empty_revision,
+        })
+    }
+
+    fn cleanup(&self, client: &Client) -> Result<(), String> {
+        let node_id = client.node_identity().map_err(|error| error.to_string())?;
+        if node_id != self.node_id {
+            return Ok(());
+        }
+        // RouteNodeOperation addresses registered remote Nodes, not this local owner.
+        let workspace = match client.get_workspace(&self.workspace_id) {
+            Ok(workspace) => workspace,
+            Err(client::ClientError::Remote(error)) if error.code == Some(ErrorCode::NotFound) => {
+                return Ok(());
+            }
+            Err(error) => return Err(error.to_string()),
+        };
+        let Some(request) = self.close_request(&node_id, &workspace) else {
+            return Ok(());
+        };
+        // No unguarded fallback or retry against a newer revision after a race.
+        match client.request(request).map_err(|error| error.to_string())? {
+            Response::Ok => Ok(()),
+            response => Err(format!(
+                "unexpected Workspace cleanup response: {response:?}"
+            )),
+        }
+    }
+}
+
+pub fn cleanup_setup_workspace(cleanup: SetupWorkspaceCleanup) -> Result<(), String> {
+    let client = client::connect_if_running()
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "Boomux is not running".to_string())?;
+    cleanup.cleanup(&client)
 }
 
 pub fn rename_workspace(workspace_id: &str, name: &str) -> Result<(), String> {
@@ -1494,62 +1589,8 @@ fn start_emulator(
                 return;
             }
 
-            while let Ok(command) = receiver.recv() {
-                match apply_emulator_command(&mut core, &worker_shared, command) {
-                    Ok(true) => {}
-                    Ok(false) => return,
-                    Err(error) => {
-                        worker_shared.close(error);
-                        return;
-                    }
-                }
-
-                let mut stopped = false;
-                while let Ok(command) = receiver.try_recv() {
-                    match apply_emulator_command(&mut core, &worker_shared, command) {
-                        Ok(true) => {}
-                        Ok(false) => {
-                            stopped = true;
-                            break;
-                        }
-                        Err(error) => {
-                            worker_shared.close(error);
-                            return;
-                        }
-                    }
-                }
-                if stopped {
-                    return;
-                }
-                // A full queue could not accept the wake-up marker, but it did
-                // keep the latest requested row. Apply that row once after the
-                // lossless command queue has been drained.
-                if worker_shared
-                    .pending_scroll_wakeup
-                    .swap(false, Ordering::AcqRel)
-                {
-                    let row = worker_shared.pending_scroll_row.load(Ordering::Acquire) as usize;
-                    if let Err(error) =
-                        core.apply(EmulatorCommand::Scroll(ScrollViewport::Row(row)))
-                    {
-                        worker_shared.close(error);
-                        return;
-                    }
-                }
-                if let Some(theme) = worker_shared.pending_theme.lock().unwrap().take()
-                    && let Err(error) = configure_terminal(&mut core.terminal, theme)
-                {
-                    worker_shared.close(error);
-                    return;
-                }
-                if core.terminal.mode(Mode::SYNC_OUTPUT).unwrap_or(false) {
-                    continue;
-                }
-                if let Err(error) = publish_screen(&mut core, &worker_shared) {
-                    worker_shared.close(error);
-                    return;
-                }
-            }
+            run_emulator(&mut core, &worker_shared, receiver);
+            worker_shared.updates.close();
         })
         .map_err(|error| format!("could not start Ghostty terminal worker: {error}"))?;
 
@@ -1558,6 +1599,72 @@ fn start_emulator(
         .map_err(|_| "Ghostty terminal worker stopped during startup".to_string())??;
     shared.install_emulator(sender);
     Ok(())
+}
+
+fn run_emulator(
+    core: &mut EmulatorCore,
+    worker_shared: &SharedTerminal,
+    receiver: mpsc::Receiver<EmulatorCommand>,
+) {
+    while let Ok(command) = receiver.recv() {
+        match apply_emulator_command(core, worker_shared, command) {
+            Ok(true) => {}
+            Ok(false) => break,
+            Err(error) => {
+                worker_shared.close(error);
+                return;
+            }
+        }
+
+        let mut stopped = false;
+        while let Ok(command) = receiver.try_recv() {
+            match apply_emulator_command(core, worker_shared, command) {
+                Ok(true) => {}
+                Ok(false) => {
+                    stopped = true;
+                    break;
+                }
+                Err(error) => {
+                    worker_shared.close(error);
+                    return;
+                }
+            }
+        }
+        if stopped {
+            break;
+        }
+        // A full queue could not accept the wake-up marker, but it did
+        // keep the latest requested row. Apply that row once after the
+        // lossless command queue has been drained.
+        if worker_shared
+            .pending_scroll_wakeup
+            .swap(false, Ordering::AcqRel)
+        {
+            let row = worker_shared.pending_scroll_row.load(Ordering::Acquire) as usize;
+            if let Err(error) = core.apply(EmulatorCommand::Scroll(ScrollViewport::Row(row))) {
+                worker_shared.close(error);
+                return;
+            }
+        }
+        if let Some(theme) = worker_shared.pending_theme.lock().unwrap().take()
+            && let Err(error) = configure_terminal(&mut core.terminal, theme)
+        {
+            worker_shared.close(error);
+            return;
+        }
+        if core.terminal.mode(Mode::SYNC_OUTPUT).unwrap_or(false) {
+            continue;
+        }
+        if let Err(error) = publish_screen(core, worker_shared) {
+            worker_shared.close(error);
+            return;
+        }
+    }
+    // Stop may share a batch with final output, or end synchronized output.
+    // Preserve those bytes in the detached pane before releasing the core.
+    if let Err(error) = publish_screen(core, worker_shared) {
+        worker_shared.close(error);
+    }
 }
 
 fn publish_screen(core: &mut EmulatorCore, shared: &SharedTerminal) -> Result<(), String> {
@@ -2020,6 +2127,362 @@ fn indexed_color_with_palette(index: u8, ansi: &[u32; 16]) -> u32 {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[ignore = "requires the matching CLI in BOOMUX_TEST_CLI; runs only an isolated fixture daemon"]
+    fn setup_workspace_real_lifecycle_cleans_only_unused_creation() {
+        use boomux::protocol::{Request, ShellSpec};
+        use std::os::unix::fs::DirBuilderExt;
+        use std::process::{Command, Stdio};
+
+        struct Fixture {
+            root: std::path::PathBuf,
+            child: std::process::Child,
+            client: boomux::client::Client,
+        }
+        impl Drop for Fixture {
+            fn drop(&mut self) {
+                let _ = self.client.shutdown();
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+                let _ = std::fs::remove_dir_all(&self.root);
+            }
+        }
+        let executable = std::env::var_os("BOOMUX_TEST_CLI")
+            .expect("set BOOMUX_TEST_CLI to this worktree's built CLI");
+        let root =
+            std::env::temp_dir().join(format!("desktop-setup-lifecycle-{}", fastrand::u64(..)));
+        std::fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&root)
+            .unwrap();
+        let child = Command::new(executable)
+            .args(["daemon", "run"])
+            .env_clear()
+            .env("HOME", &root)
+            .env("PATH", "/usr/bin:/bin")
+            .env("SHELL", "/bin/sh")
+            .env("XDG_RUNTIME_DIR", &root)
+            .env("XDG_CONFIG_HOME", root.join("config"))
+            .env("XDG_STATE_HOME", root.join("state"))
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let fixture = Fixture {
+            client: boomux::client::Client::from_socket_path(root.join("boomux/daemon.sock")),
+            root,
+            child,
+        };
+        let wait = |condition: &mut dyn FnMut() -> bool| {
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while !condition() {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "isolated lifecycle timed out"
+                );
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        };
+        wait(&mut || fixture.client.ping().is_ok());
+        for (reuse, race) in [(false, false), (true, false), (false, true)] {
+            let mut spec = ShellSpec::login("fixture-setup", fixture.root.clone());
+            // A harmless waiting process exercises the same PTY/start/close path, without setup/install.
+            spec.command = vec![
+                "/usr/bin/env".into(),
+                "-i".into(),
+                format!("HOME={}", fixture.root.display()),
+                format!("XDG_RUNTIME_DIR={}", fixture.root.display()),
+                format!("XDG_CONFIG_HOME={}", fixture.root.join("config").display()),
+                format!("XDG_STATE_HOME={}", fixture.root.join("state").display()),
+                "PATH=/usr/bin:/bin".into(),
+                "/bin/sh".into(),
+                "-c".into(),
+                "printf fixture-ready; read answer".into(),
+            ];
+            let created = fixture
+                .client
+                .create_workspace(format!("fixture-{reuse}-{race}"), vec![spec])
+                .unwrap();
+            let receipt = super::SetupWorkspaceCleanup::from_creation(
+                &super::WorkspaceLaunch::Setup,
+                fixture.client.node_identity().unwrap(),
+                &created,
+            )
+            .unwrap();
+            let mut shell = super::shell_choice(created.shells[0].clone());
+            shell.desktop_setup = true;
+            let mut session = super::TerminalSession::attach_with_client(
+                fixture.client.clone(),
+                shell.clone(),
+                24,
+                80,
+                800,
+                480,
+            )
+            .unwrap();
+            session.setup_workspace_cleanup = Some(receipt);
+            wait(&mut || {
+                fixture
+                    .client
+                    .read_shell(&shell.id, 1024)
+                    .is_ok_and(|bytes| bytes.windows(13).any(|bytes| bytes == b"fixture-ready"))
+            });
+            let started = fixture.client.get_workspace(&created.id).unwrap();
+            assert_eq!(
+                started.revision, created.revision,
+                "PTY startup must not be mistaken for user reuse"
+            );
+            if reuse {
+                let user_shell = fixture
+                    .client
+                    .create_shell(
+                        &created.id,
+                        ShellSpec::login("user-work", fixture.root.clone()),
+                    )
+                    .unwrap();
+                fixture.client.close_shell(&user_shell.id).unwrap();
+            }
+            let running = fixture.client.get_shell(&shell.id).unwrap();
+            fixture
+                .client
+                .request(Request::GuardedCloseShell {
+                    shell_id: shell.id.clone(),
+                    expected_revision: running.revision,
+                })
+                .unwrap();
+            wait(&mut || session.update_events().is_closed());
+            let overview = super::overview_from_snapshot(fixture.client.snapshot().unwrap());
+            assert!(crate::setup_pane_was_removed(&shell, true, &overview));
+            let empty = fixture.client.get_workspace(&created.id).unwrap();
+            assert!(empty.shells.is_empty());
+            eprintln!(
+                "setup lifecycle reuse={reuse}: created={}, started={}, removed={}",
+                created.revision, started.revision, empty.revision
+            );
+            assert_eq!(empty.revision, created.revision + if reuse { 3 } else { 1 });
+            let cleanup = session.setup_workspace_cleanup.take().unwrap();
+            if race {
+                let stale = cleanup
+                    .close_request(&fixture.client.node_identity().unwrap(), &empty)
+                    .unwrap();
+                let user_shell = fixture
+                    .client
+                    .create_shell(
+                        &created.id,
+                        ShellSpec::login("concurrent-user-work", fixture.root.clone()),
+                    )
+                    .unwrap();
+                assert!(
+                    matches!(fixture.client.request(stale), Err(boomux::client::ClientError::Remote(error)) if error.code == Some(boomux::protocol::ErrorCode::RevisionAhead))
+                );
+                assert!(fixture.client.get_shell(&user_shell.id).is_ok());
+            }
+            cleanup.cleanup(&fixture.client).unwrap();
+            match fixture.client.get_workspace(&created.id) {
+                Ok(workspace) if reuse || race => assert_eq!(workspace.id, created.id),
+                Err(boomux::client::ClientError::Remote(error)) if !reuse && !race => {
+                    assert_eq!(error.code, Some(boomux::protocol::ErrorCode::NotFound));
+                }
+                result => {
+                    panic!("unexpected cleanup result (reuse={reuse}, race={race}): {result:?}")
+                }
+            }
+        }
+    }
+
+    fn setup_workspace_creation() -> boomux::protocol::WorkspaceSnapshot {
+        serde_json::from_value(serde_json::json!({
+            "id": "created-workspace", "name": "same-name-as-another-workspace", "revision": 1,
+            "shells": [{"id": "setup-shell", "workspace_id": "created-workspace",
+                "name": "Set up agents", "cwd": "/tmp", "status": "pending",
+                "command": ["/build/boomux", "__desktop-setup"]}]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn setup_workspace_cleanup_requires_creation_identity_and_only_its_shell_removal() {
+        let created = setup_workspace_creation();
+        let cleanup = super::SetupWorkspaceCleanup::from_creation(
+            &super::WorkspaceLaunch::Setup,
+            "owner".into(),
+            &created,
+        )
+        .unwrap();
+        for launch in [
+            super::WorkspaceLaunch::Shell,
+            super::WorkspaceLaunch::Dashboard,
+            super::WorkspaceLaunch::AddNode,
+        ] {
+            assert!(
+                super::SetupWorkspaceCleanup::from_creation(&launch, "owner".into(), &created)
+                    .is_none()
+            );
+        }
+        assert!(cleanup.close_request("owner", &created).is_none());
+        let mut empty = created.clone();
+        empty.shells.clear();
+        empty.revision += 1;
+        assert_eq!(
+            cleanup.close_request("owner", &empty),
+            Some(boomux::protocol::Request::GuardedCloseWorkspace {
+                workspace_id: created.id.clone(),
+                expected_revision: 2,
+            })
+        );
+        assert!(cleanup.close_request("different-node", &empty).is_none());
+        empty.id = "existing-workspace-with-the-same-name".into();
+        assert!(cleanup.close_request("owner", &empty).is_none());
+        empty.id = created.id.clone();
+        // Rename/default edits, or adding then removing user work, invalidate ownership.
+        for revision in [0, 1, 3, 4, u64::MAX] {
+            empty.revision = revision;
+            assert!(cleanup.close_request("owner", &empty).is_none());
+        }
+        // An empty/reused snapshot cannot be a successful setup creation receipt.
+        assert!(
+            super::SetupWorkspaceCleanup::from_creation(
+                &super::WorkspaceLaunch::Setup,
+                "owner".into(),
+                &empty
+            )
+            .is_none()
+        );
+        let mut overflow = created;
+        overflow.revision = u64::MAX;
+        assert!(
+            super::SetupWorkspaceCleanup::from_creation(
+                &super::WorkspaceLaunch::Setup,
+                "owner".into(),
+                &overflow
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn setup_workspace_cleanup_preserves_shells_launchers_and_agent_history() {
+        let mut workspace = setup_workspace_creation();
+        let cleanup = super::SetupWorkspaceCleanup::from_creation(
+            &super::WorkspaceLaunch::Setup,
+            "owner".into(),
+            &workspace,
+        )
+        .unwrap();
+        workspace.revision = 2;
+        assert!(cleanup.close_request("owner", &workspace).is_none());
+        workspace.shells.clear();
+        workspace.launchers.push(
+            serde_json::from_value(serde_json::json!({
+                "id": "user-launcher", "workspace_id": workspace.id, "name": "user work",
+                "command": ["user-command"], "cwd": "/tmp"
+            }))
+            .unwrap(),
+        );
+        assert!(cleanup.close_request("owner", &workspace).is_none());
+        workspace.launchers.clear();
+        workspace.agents.push(serde_json::from_value(serde_json::json!({
+            "id": "user-agent", "workspace_id": workspace.id, "shell_id": "old-shell",
+            "run_id": "old-run", "name": "history", "integration": "test",
+            "started_at_ms": 1, "ended_at_ms": 2,
+            "observation": {"revision": 1, "state": "done", "authority": "lifecycle_integration",
+                "evidence": "test", "confidence": 100, "observed_at_ms": 2}
+        })).unwrap());
+        assert!(cleanup.close_request("owner", &workspace).is_none());
+    }
+
+    #[test]
+    fn setup_workspace_cleanup_sends_guarded_close_once_and_never_retries_a_race() {
+        use boomux::protocol::{self, Envelope, ErrorCode, Request, Response};
+        use std::os::unix::net::UnixListener;
+
+        for race in [false, true] {
+            let directory =
+                std::env::temp_dir().join(format!("desktop-setup-cleanup-{}", fastrand::u64(..)));
+            std::fs::create_dir(&directory).unwrap();
+            let socket = directory.join("daemon.sock");
+            let listener = UnixListener::bind(&socket).unwrap();
+            let mut workspace = setup_workspace_creation();
+            let cleanup = super::SetupWorkspaceCleanup::from_creation(
+                &super::WorkspaceLaunch::Setup,
+                "owner".into(),
+                &workspace,
+            )
+            .unwrap();
+            workspace.shells.clear();
+            workspace.revision = 2;
+            let (finished_sender, finished_receiver) = std::sync::mpsc::channel();
+            let server = std::thread::spawn(move || {
+                let exchanges = [
+                    (
+                        Request::GetNodeIdentity,
+                        Response::NodeIdentity {
+                            node_id: "owner".into(),
+                        },
+                    ),
+                    (
+                        Request::GetWorkspace {
+                            workspace_id: workspace.id.clone(),
+                        },
+                        Response::Workspace { workspace },
+                    ),
+                    (
+                        Request::GuardedCloseWorkspace {
+                            workspace_id: "created-workspace".into(),
+                            expected_revision: 2,
+                        },
+                        if race {
+                            Response::Error {
+                                code: Some(ErrorCode::RevisionAhead),
+                                message: "user added work after inspection".into(),
+                            }
+                        } else {
+                            Response::Ok
+                        },
+                    ),
+                ];
+                for (expected, response) in exchanges {
+                    let (mut stream, _) = listener.accept().unwrap();
+                    stream
+                        .set_read_timeout(Some(Duration::from_secs(2)))
+                        .unwrap();
+                    let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                    assert_eq!(request.message, expected);
+                    protocol::write_message(
+                        &mut stream,
+                        &Envelope::with_version(request.version, response),
+                    )
+                    .unwrap();
+                }
+                finished_receiver
+                    .recv_timeout(Duration::from_secs(2))
+                    .unwrap();
+                listener.set_nonblocking(true).unwrap();
+                assert!(
+                    listener.accept().is_err(),
+                    "cleanup must not retry with an unguarded or updated request"
+                );
+            });
+            let result = cleanup.cleanup(&boomux::client::Client::from_socket_path(socket));
+            finished_sender.send(()).unwrap();
+            assert_eq!(result.is_err(), race);
+            if let Err(error) = result {
+                assert!(error.contains("user added work"), "{error}");
+            }
+            server.join().unwrap();
+            std::fs::remove_dir_all(directory).unwrap();
+        }
+    }
+
+    #[test]
+    fn setup_launch_uses_the_dedicated_cleanup_entry_point() {
+        assert_eq!(
+            super::WorkspaceLaunch::Setup.command().unwrap().1,
+            ["__desktop-setup"]
+        );
+    }
+
+    #[test]
     fn node_launches_preserve_exact_arguments_and_do_not_request_upgrades() {
         use super::WorkspaceLaunch;
         assert!(WorkspaceLaunch::Shell.command().is_none());
@@ -2048,12 +2511,13 @@ mod tests {
     use libghostty_vt::terminal::Mode;
 
     use super::{
-        AgentChoice, EmulatorCommand, EmulatorCore, SharedTerminal, agent_is_visible, blank_screen,
-        configure_terminal, distinguish_agent_rows, encode_key, encode_mouse_wheel, encode_paste,
-        image_bgra, indexed_color, resynchronize_terminal_size, spawn_reader, terminal_profile,
+        AgentChoice, EMULATOR_QUEUE_CAPACITY, EmulatorCommand, EmulatorCore, SharedTerminal,
+        agent_is_visible, blank_screen, configure_terminal, distinguish_agent_rows, encode_key,
+        encode_mouse_wheel, encode_paste, image_bgra, indexed_color, resynchronize_terminal_size,
+        run_emulator, spawn_reader, start_emulator, terminal_profile,
     };
     use crate::theme::TerminalTheme;
-    use std::sync::Arc;
+    use std::sync::{Arc, mpsc};
 
     fn key(key: &str, key_char: Option<&str>, modifiers: Modifiers) -> Keystroke {
         Keystroke {
@@ -2734,6 +3198,69 @@ mod tests {
             panic!("expected a keyboard enhancement response");
         };
         assert_eq!(bytes, b"\x1b[?0u");
+    }
+
+    #[test]
+    fn terminal_updates_remain_open_until_the_final_screen_is_published() {
+        let shared = Arc::new(SharedTerminal::new(terminal_profile(6, 80, 800, 120)));
+        start_emulator(&shared, 6, 80, 800, 120).unwrap();
+        let screen = shared.screen.lock().unwrap();
+        while shared.update_events.try_recv().is_ok() {}
+        shared.process(b"Setup completed successfully.".to_vec());
+        shared.close("detached");
+
+        // Hold back screen publication to reproduce the UI observing closure first.
+        assert!(shared.closed.load(Ordering::Acquire));
+        assert!(shared.update_events.try_recv().is_ok());
+        assert!(!shared.update_events.is_closed());
+        drop(screen);
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while !shared.update_events.is_closed() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "worker did not finish"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(shared.update_events.try_recv().is_ok());
+        let screen = shared.screen.lock().unwrap();
+        let text: String = screen.cells.iter().map(|cell| cell.text.as_str()).collect();
+        assert!(text.contains("Setup completed successfully."), "{text}");
+    }
+
+    #[test]
+    fn detached_pane_retains_final_output_and_wakes_the_view() {
+        for queued_output in [true, false] {
+            for receipt in [
+                "Setup completed successfully.",
+                "Setup finished with failures.",
+            ] {
+                let shared = Arc::new(SharedTerminal::new(terminal_profile(6, 80, 800, 120)));
+                let mut core = EmulatorCore::new(&shared, 6, 80, 800, 120).unwrap();
+                let (sender, receiver) = mpsc::sync_channel(EMULATOR_QUEUE_CAPACITY);
+                shared.install_emulator(sender);
+                let output = format!("\x1b[?2026h{receipt}\r\nPress Ctrl+W to close this pane.");
+                if queued_output {
+                    shared.process(output.into_bytes());
+                } else {
+                    // A prior synchronized batch has not published its screen yet.
+                    core.apply(EmulatorCommand::Output(output.into_bytes()))
+                        .unwrap();
+                }
+                shared.close("detached");
+                while shared.update_events.try_recv().is_ok() {}
+
+                run_emulator(&mut core, &shared, receiver);
+
+                let screen = shared.screen.lock().unwrap();
+                let text: String = screen.cells.iter().map(|cell| cell.text.as_str()).collect();
+                assert!(text.contains(receipt), "{text}");
+                assert!(text.contains("Press Ctrl+W to close this pane."), "{text}");
+                assert_eq!(*shared.status.lock().unwrap(), "detached");
+                assert!(shared.update_events.try_recv().is_ok());
+            }
+        }
     }
 
     #[test]

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -118,9 +118,11 @@ python3 -m unittest discover -s .github/scripts -p 'test_ci_*.py'
 They exercise actual Git diffs, version-only changes with/without CI proof,
 embedded Markdown, dependency changes, failure fallbacks, and artifact source
 and digest mismatches. The classifier job runs these fixtures on every event.
-Run actionlint for workflow expressions, plus the applicable local validation in
-`AGENTS.md` before opening a PR. CI/workflow-only changes require the full hosted
-pipeline before merging, without redundantly running unchanged Rust suites locally.
+Run actionlint for workflow expressions and the focused local checks in
+`AGENTS.md`. Opening or updating a PR delegates the complete selected matrix to
+CI; a full local run is not a prerequisite. CI/workflow-only changes require the
+full hosted pipeline before merging, without redundantly running unchanged Rust
+suites locally.
 
 Before this change, main CI run `33948018935` took 6m45s: Rust took 6m34s,
 benchmark smoke 6m22s, and x86-64/ARM packaging 2m10s/1m45s. Release run

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -45,6 +45,8 @@ badge’s single cancelable exit task; it does not delay restoring input.
 - `src/terminal.rs`: Boomux discovery/attachment adapter, per-pane terminal
   worker, Ghostty VT state, scrollback, key/paste encoding, and Kitty graphics
   extraction.
+- `src/nodes.rs`: read-only Node identity, health, and resource-count presentation
+  from the daemon's combined snapshot.
 - `src/boomux_settings.rs`: active-layer settings editor and bounded CLI bridge;
   Boomux retains configuration validation and commit authority.
 - `src/settings.rs`: bounded preference loading, validation, and atomic background
@@ -118,6 +120,39 @@ Workspace ordering is client-owned presentation state keyed by exact Workspace
 identity. Overview refreshes retain the current order, newly discovered
 Workspaces append, and drag or keyboard reordering never mutates Boomux's
 Workspace authority.
+
+## Remote Node Entry Points
+
+The sidebar overflow menu opens a bounded, scrollable Nodes popover. Once remote
+Nodes are registered, the existing sidebar subtitle shows a compact Node count
+and connection summary. Selection uses stable Node IDs, including when aliases
+or routes happen to match. Details show observed health, last observation,
+helper version when available, and owner-local Workspace/Shell counts. Cached
+counts are explicitly labelled; disconnect does not establish process exit.
+
+The existing window-owned overview worker reads one combined snapshot per
+refresh for both local resources and Node summaries. It falls back to local
+discovery if federation is unavailable. A failed refresh retains prior Node
+summaries but removes their connected presentation. Observation timestamp changes
+do not alone repaint a closed popover. There is no additional SSH worker,
+registration store, or discovery loop in Desktop. Snapshot and registration
+bounds remain daemon-owned; the client retains only the latest summary per Node.
+
+Add Node and reauthentication open the matching Boomux CLI's existing guided
+flow in a local daemon-owned Shell, using exact argument vectors. Reauthentication
+passes the stable Node ID and leaves route/identity verification to Boomux.
+SSH credentials, browser challenges, host verification, installation consent,
+and protocol compatibility remain owned by that interactive flow. These Shells
+and their Workspaces follow the existing setup-terminal lifecycle and remain
+visible after the command exits until explicitly removed. An Open Boomux
+dashboard action provides access to the existing TUI's Nodes tab.
+
+This first native entry point does not yet put remote Shells in the Desktop
+canvas. Local Shell/Agent projection and attachment retain their current scope.
+Node-qualified remote pane identities, coordinated Workspace presentation, and
+connection-loss recovery are the next implementation stages. The popover has its
+own input context, closes on Escape or outside click, and blocks terminal input
+while open; releases for keys sent before opening still reach their original pane.
 
 ## Dependency Boundary
 

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -75,6 +75,10 @@ immutable screen snapshot. A bounded one-event mailbox wakes GPUI only when a
 new snapshot or terminal status exists; bursts collapse into one wakeup because
 the consumer always reads the newest snapshot. Synchronized-output mode delays
 publication until the terminal frame is complete.
+When an attachment ends, the worker publishes its final decoded screen before
+stopping, including output batched with the stop command. Detachment itself does
+not establish command success. The UI watches until the worker closes its update
+stream after final publication, rather than stopping at transport closure.
 
 Omarchy theme loading follows the same boundary. A native filesystem watcher
 observes `~/.local/state/omarchy/current`, because Omarchy replaces its `theme`
@@ -93,6 +97,10 @@ Images are explicitly dropped when their generation disappears or their pane
 closes. Each pane also owns one shaped-text paint cache keyed by the exact screen
 snapshot and selection. Layout-only animation frames reuse that cache, while a
 new snapshot or selection invalidates it.
+
+Settings replaces the sidebar resource list while open, so scrolling its controls
+does not build or lay out the covered Workspace, Shell, and Agent rows. The
+sidebar scroll handle remains window-owned and restores its offset on close.
 
 The default presentation draws the binary tile layout and floating layer. The
 optional tabbed-minimization presentation keeps every open pane in that canvas.
@@ -214,20 +222,70 @@ query the installed CLI's public `--json update status` command.
 
 Each process has a 20-second deadline and at most 128 KiB retained output; curl
 also has a 15-second limit. Closing the window cancels its scheduler; in-flight
-work completes within its bounds without retaining the window. Dismissals are
-saved per version and reset by an explicit manual check. Existing settings keys
-remain compatible. No update check installs software or restarts the daemon. Explicit Update and
-Restart actions use the transaction below.
+work completes within its bounds without retaining the window. Release-notice
+dismissals are saved per version and reset by an explicit manual check. Existing settings keys
+remain compatible. Completed manual-check results and update errors have a
+Dismiss control; active checks and installation progress remain visible until
+they finish. No update check installs software or restarts the daemon. Explicit
+Update and Restart actions use the transaction below.
 
 `runtime.rs` provides a display-independent `--check-runtime` mode for fixed
 system graphics libraries. The installer first checks its glibc baseline, then
 both executable versions and this runtime check before committing any active
 release change. GPU/driver/display startup remains a separate smoke-test concern.
 
-The welcome card and menu launch `boomux setup` with an exact argument vector in
-a new daemon-owned Shell. The CLI keeps agent-integration authority and prompts;
-Desktop only presents its terminal. `onboarding_complete` is a persisted UI
-preference, not a record that integrations are installed or ready.
+`harness_integrations.rs` checks the matching CLI's `integration status --json`
+once at startup and on an explicit Settings recheck. Only supported, successfully
+probed local harnesses with missing or differing integration assets produce a
+sidebar suggestion. `current` assets remain quiet; `modified` assets require
+review because status cannot distinguish an older bundled asset from user edits.
+An Install action runs `integration install`; a separate Replace confirmation
+allows `--force` for the reviewed integration. The CLI retains all installation,
+ownership, and configuration authority. No installation or harness restart runs
+as a side effect of discovery. Successful installation displays the integration's
+reload instructions. Not now dismisses per window; a manual recheck clears those
+bounded dismissals. Settings also exposes status and discovery failures.
+
+One operation per window runs off GPUI, with a 35-second timeout, a one-second
+kill grace, and at most 128 KiB retained output. Only bundled integration keys can
+become actions. Process argument vectors are exact, JSON envelopes are validated,
+and no polling loop, per-pane task, host transcript, or credential cache is added.
+
+Settings' Manual setup action launches the private `boomux __desktop-setup`
+entry point with an exact argument vector in a new daemon-owned Shell. It runs
+the same guided setup as `boomux setup`. The CLI keeps agent-integration authority
+and prompts; its Ratatui checklist uses the existing Crossterm input path,
+restores canonical input before applying selections, and never treats deselection
+as uninstall. The legacy `onboarding_complete` preference remains readable but
+no longer gates discovery or a generic first-run card.
+Setup prints an explicit completion message distinguishing success, remaining
+recommended steps, and failures, followed by `Exit and remove this setup Shell?
+[Y/n]`. Enter or yes revalidates the exact Shell/run and stored private command,
+then requests revision-guarded Shell removal. No keeps the process and output
+available and prompts again. EOF or interruption does not authorize removal.
+Desktop removes the pane only after output ends and a successful local overview
+confirms that Shell is absent. The successful setup creation response also gives
+that attachment an ephemeral cleanup receipt containing the owning Node, exact
+Workspace ID, and expected revision after removal of its sole setup Shell.
+The existing overview worker consumes it once, off the UI thread, verifies the
+local Node identity, and uses local `GetWorkspace` and `GuardedCloseWorkspace`
+requests. `RouteNodeOperation` is only for registered remote Nodes and must not
+be used to address the local owner. Cleanup requires no Shells, launchers, or
+Agent history and exactly one revision increment since creation. Edits and adding then removing user resources
+therefore preserve even a currently empty Workspace; a mutation racing the final
+close is rejected by the owner. There is no unguarded fallback or retry with a
+newer revision. Unrelated and reused Workspaces are never selected by name.
+Discovery, reattachment, and reopening Desktop do not reconstruct this ownership
+receipt; without it the Workspace is retained. A setup attachment failure also
+retains its resources rather than invoking unguarded Workspace removal.
+Ordinary `boomux setup` does not prompt for Shell removal or remove its caller's
+Shell. Cleanup does not turn a failed setup into a successful one.
+
+The ignored `setup_workspace_real_lifecycle_cleans_only_unused_creation` test
+requires `BOOMUX_TEST_CLI` pointing to the matching built CLI. It starts a private
+fixture daemon and harmless waiting commands, exercises real PTY start, Shell
+removal, Desktop output closure and snapshots, then tests unused, reused, and
+racing Workspace cleanup without running integration installation.
 
 `bundle_update.rs` owns the local Desktop installation transaction, not PTY or
 daemon authority. Release checks report eligibility and a prepared update on the

--- a/docs/desktop/performance.md
+++ b/docs/desktop/performance.md
@@ -67,6 +67,10 @@ must also track the number and byte size of live image generations.
 - GPU image generations are retained only while referenced by the current screen
   and are dropped explicitly afterward.
 - Overview refresh and Boomux requests stay off the render path.
+- Settings replaces the covered sidebar body rather than rebuilding its hidden
+  Workspace, Shell, Agent, integration-prompt, and update-notice elements on every scroll
+  render. Closing Settings reads the current overview directly, with no stale
+  cached projection. Collapsed Workspaces do not construct hidden Shell rows.
 - Terminal output is coalesced before publishing a new screen snapshot.
 - Each pane has a capacity-one terminal-update mailbox. Idle panes do not poll,
   and output bursts wake GPUI once to consume the newest immutable snapshot.
@@ -94,6 +98,17 @@ must also track the number and byte size of live image generations.
 
 Any new queue, cache, history, retry, image store, or task must document its
 bound and cleanup owner.
+
+## Settings Row Preparation Fixture
+
+`settings_scroll_eliminates_hidden_sidebar_row_preparation` compares the old
+unconditional sidebar clone/row preparation with the Settings visibility gate,
+using the same synthetic overview and debug test binary. On 2026-09-07, 60
+iterations over 100 Workspaces, 2,000 Shells, and 2,000 Agents visited 246,000
+rows before and zero afterward (322.961 ms versus 0.023 ms on this machine).
+These are row-preparation timings, not GUI frame times or a GPU/RSS measurement.
+The deterministic regression asserts eliminated work and fresh data on closing
+Settings, not a timing threshold.
 
 ## Comparison Protocol
 

--- a/docs/desktop/remote-nodes-implementation.md
+++ b/docs/desktop/remote-nodes-implementation.md
@@ -1,0 +1,52 @@
+# Native remote Node implementation
+
+## Development checkpoint
+
+The first implementation exposes a compact Nodes popover, observed health and
+resource counts, and entry points to the matching CLI's guided Add Node and
+reauthentication flows. It uses one combined snapshot in the existing background
+overview worker and retains local-only discovery when federation is unavailable.
+Remote Shells are still accessed through the existing Boomux dashboard.
+
+Validation of this checkpoint: formatting, Desktop Clippy with warnings denied,
+122 Desktop tests, and an optimized Desktop build passed. Isolated GUI interaction
+checks verified that Ctrl+A in the popover does not launch setup, Escape and
+outside clicks return input to the existing terminal, and Add Node starts the
+guided SSH prompt without replacing the original ShellRun. No remote host was
+contacted by the GUI fixture.
+
+## Open repaint finding before PR
+
+In an isolated Weston kiosk compositor nested inside Xvfb with software rendering,
+the new setup Shell accepts input and exposes its prompt through `boomux read`,
+but Desktop can retain the initial “Opening terminal…” frame until a pointer
+click. The sidebar can likewise retain an older resource count until interaction.
+After clicking, the prompt and current count render correctly. The cause and
+behavior on a physical Wayland display remain unconfirmed.
+
+Reproduce with the official v1.10.0 CLI and the checkpoint Desktop binary in
+private XDG directories: open Nodes, choose Add remote Node, then wait without
+moving the pointer. Compare the visible frame with the guided Shell's retained
+output. Click the terminal to check whether the frame advances. Test both the
+keyboard shortcut and mouse activation before accepting a fix.
+
+Changing the affected tasks to `spawn_in`/`update_in` and calling
+`window.refresh()` on completion did not resolve this reproduction; that
+attempt was removed. Do not mask the failure with periodic synthetic input,
+forced resizing, or an unconditional animation loop. Resolve or isolate this
+finding before treating the native entry point as ready to merge.
+
+## Remaining stages
+
+1. Convert Desktop Shell/Agent selection, pane lookup, focus, attention, and
+   actions to exact Node-qualified identities. Retain coordinator Workspace
+   membership when combining placements; equal labels never merge resources.
+2. Open existing remote Shells through `Client::attach_node`, preserving exact
+   ShellRun binding and the owner's environment. Show remote host labels and
+   disable unavailable actions with their specific health reason.
+3. Preserve panes across transport loss, with bounded exact-run reconnection,
+   explicit authentication/identity recovery, and no replay of uncertain input.
+4. Add native placement and remote-directory selection, followed by a richer
+   GUI authentication adapter if the guided terminal flow proves insufficient.
+
+Backend authority remains governed by `CONTEXT.md` and `docs/remote-nodes.md`.

--- a/docs/desktop/roadmap.md
+++ b/docs/desktop/roadmap.md
@@ -23,6 +23,12 @@ tests, `CONTEXT.md`, architecture documentation, and accepted ADRs.
 
 ## Product
 
+- [x] Add compact native Node status and entry points for guided SSH setup and
+  reauthentication, reusing Boomux's terminal flows.
+- Present remote Shells and Agents with exact Node-qualified identities and
+  coordinated Workspace membership in the native canvas.
+- Preserve remote panes across connection loss with exact-run recovery and
+  actionable authentication/identity failures.
 - Extend persisted Desktop preferences to window geometry and pane arrangement restoration.
 - Reach feature parity with the essential `omarchy-boomux` Workspace and Agent
   workflows before considering replacement of that client.

--- a/docs/install.md
+++ b/docs/install.md
@@ -70,6 +70,29 @@ Setup failure does not remove the verified Boomux installation. The installer
 reports that installation succeeded, reports setup as incomplete, prints the
 exact retry command, and exits nonzero.
 
+### Harness Checklist
+
+Guided setup presents a keyboard checklist of supported AI harness integrations.
+Use **Up/Down** to move, **Space** to check or uncheck, and **Enter** to apply the
+selection. **Esc**, **Ctrl+C**, or **Ctrl+D** cancels before integration changes.
+The checklist scrolls with the selection and redraws on resize; terminals smaller
+than 40 columns by 10 rows must be enlarged before confirming.
+
+Available, current integrations start checked and need no installation. Missing
+and modified integrations start unchecked, retaining setup's opt-in policy.
+Checking a **REPLACE MODIFIED** entry explicitly authorizes replacement of that
+integration's files. Missing or unverified harness hosts and unreadable integration
+targets are disabled. Setup installs Boomux integrations, not the harness
+applications themselves. Unchecking an entry never removes existing files.
+
+Selected integrations install without individual yes/no prompts. The receipt
+verifies the selected integrations rather than treating deselected
+harnesses as missing requirements. Inspection or installation failures and
+required harness restarts remain visible.
+The separate Agent Skill keeps its own confirmation, and Desktop's final **[Y/n]** prompt still
+controls removal of the dedicated setup Shell. Automation continues to use the
+integration CLI commands; guided setup still requires an interactive terminal.
+
 ## Desktop Installation And Updates
 
 The Desktop choice includes the matching CLI executable and an application-menu

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,6 +271,8 @@ enum Commands {
     Doctor,
     /// Discover and configure local Agent harnesses and desktop integration
     Setup,
+    #[command(name = "__desktop-setup", hide = true)]
+    DesktopSetup,
     /// Report stable integration capabilities without starting the daemon
     Capabilities,
     /// List all managed shells
@@ -1565,7 +1567,7 @@ impl Cli {
             }) => CommandKey::Daemon,
             Some(Commands::Ui) | None => CommandKey::Ui,
             Some(Commands::Doctor) => CommandKey::Doctor,
-            Some(Commands::Setup) => CommandKey::Setup,
+            Some(Commands::Setup | Commands::DesktopSetup) => CommandKey::Setup,
             Some(Commands::Close { .. }) => CommandKey::Close,
             Some(Commands::Skill {
                 command: SkillCommands::Install { .. },
@@ -1906,6 +1908,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Web { .. }) => unreachable!(),
         Some(Commands::Doctor) => doctor(cli.terminal.as_deref()),
         Some(Commands::Setup) => setup::guided_setup(),
+        Some(Commands::DesktopSetup) => setup::desktop_setup(),
         Some(Commands::Capabilities) => capabilities(cli.json),
         Some(Commands::List) => list_shells(cli.json),
         Some(Commands::Shells) => list_workspace_shells(cli.json),
@@ -12581,6 +12584,9 @@ mod tests {
         assert!(matches!(cli.command.as_ref(), Some(Commands::Setup)));
         assert_eq!(cli.command_descriptor().key, "setup");
         assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+        let desktop = Cli::try_parse_from(["boomux", "__desktop-setup"]).unwrap();
+        assert!(matches!(desktop.command, Some(Commands::DesktopSetup)));
+        assert_eq!(desktop.command_descriptor().output, OutputMode::HumanOnly);
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -11,12 +11,229 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::{
+    layout::{Constraint, Layout},
+    style::{Modifier, Style},
+    widgets::{List, ListItem, ListState, Paragraph, Wrap},
+};
 use serde::Deserialize;
 use uuid::Uuid;
 
 use boomux::client;
+use boomux::protocol::{Request, Response, ShellSnapshot, ShellStatus};
 
-use crate::integration_management::{self, AssetState, HostState, InstallAction, IntegrationId};
+use crate::integration_management::{self, AssetState, HostState, IntegrationId};
+
+struct HarnessChoice {
+    integration: IntegrationId,
+    host: HostState,
+    asset: AssetState,
+    path: Option<String>,
+    selected: bool,
+}
+
+impl HarnessChoice {
+    fn enabled(&self) -> bool {
+        self.host == HostState::Available && self.asset != AssetState::Unavailable
+    }
+
+    fn description(&self) -> &'static str {
+        match (self.host, self.asset) {
+            (HostState::Missing, _) => "host not found (unavailable)",
+            (HostState::ProbeFailed | HostState::NotChecked, _) => {
+                "host not verified (unavailable)"
+            }
+            (_, AssetState::Unavailable) => "integration inspection failed (unavailable)",
+            (_, AssetState::Current) => "integration current; keep existing files",
+            (_, AssetState::Missing) => "install Boomux integration",
+            (_, AssetState::Modified) => "REPLACE MODIFIED integration files",
+        }
+    }
+}
+
+struct HarnessChecklist {
+    choices: Vec<HarnessChoice>,
+    cursor: ListState,
+    confirmed: bool,
+}
+
+impl HarnessChecklist {
+    fn new(statuses: &[(IntegrationId, integration_management::IntegrationStatus)]) -> Self {
+        let choices = statuses
+            .iter()
+            .map(|(integration, status)| HarnessChoice {
+                integration: *integration,
+                host: status.host.state,
+                asset: status.asset.state,
+                path: status.asset.path.clone(),
+                selected: status.host.state == HostState::Available
+                    && status.asset.state == AssetState::Current,
+            })
+            .collect::<Vec<_>>();
+        let focused = choices
+            .iter()
+            .position(HarnessChoice::enabled)
+            .or_else(|| (!choices.is_empty()).then_some(0));
+        Self {
+            choices,
+            cursor: ListState::default().with_selected(focused),
+            confirmed: false,
+        }
+    }
+
+    fn key(&mut self, key: KeyEvent) -> io::Result<bool> {
+        if key.kind == KeyEventKind::Release {
+            return Ok(false);
+        }
+        if key.code == KeyCode::Esc
+            || (key.modifiers.contains(KeyModifiers::CONTROL)
+                && matches!(key.code, KeyCode::Char('c' | 'd')))
+        {
+            self.confirmed = false;
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "harness selection cancelled; no integrations changed",
+            ));
+        }
+        if !key.modifiers.is_empty() {
+            return Ok(false);
+        }
+        match key.code {
+            KeyCode::Enter => {
+                self.confirmed = true;
+                return Ok(true);
+            }
+            KeyCode::Up | KeyCode::Down if !self.choices.is_empty() => {
+                let count = self.choices.len();
+                let current = self.cursor.selected().unwrap_or(0);
+                self.cursor.select(Some(if key.code == KeyCode::Up {
+                    (current + count - 1) % count
+                } else {
+                    (current + 1) % count
+                }));
+            }
+            KeyCode::Char(' ') if key.kind == KeyEventKind::Press => {
+                if let Some(choice) = self
+                    .cursor
+                    .selected()
+                    .and_then(|index| self.choices.get_mut(index))
+                    && choice.enabled()
+                {
+                    choice.selected = !choice.selected;
+                }
+            }
+            _ => {}
+        }
+        Ok(false)
+    }
+
+    fn install_with<T>(&self, index: usize, install: impl FnOnce(bool) -> T) -> Option<T> {
+        let choice = self.choices.get(index)?;
+        (self.confirmed
+            && choice.selected
+            && choice.enabled()
+            && matches!(choice.asset, AssetState::Missing | AssetState::Modified))
+        .then(|| install(choice.asset == AssetState::Modified))
+    }
+
+    fn render(&mut self, frame: &mut ratatui::Frame) -> bool {
+        let area = frame.area();
+        if area.width < 40 || area.height < 10 {
+            frame.render_widget(
+                Paragraph::new("Resize to at least 40x10. Esc cancels.").wrap(Wrap { trim: false }),
+                area,
+            );
+            return false;
+        }
+        let compact = area.height < 14;
+        let [heading, list, details, controls] = Layout::vertical([
+            Constraint::Length(if compact { 1 } else { 3 }),
+            Constraint::Min(1),
+            Constraint::Length(if compact { 2 } else { 4 }),
+            Constraint::Length(3),
+        ])
+        .areas(area);
+        frame.render_widget(
+            Paragraph::new(
+                "AI harness integrations\nSelect Boomux integrations, not harness applications.",
+            ),
+            heading,
+        );
+        let items = self
+            .choices
+            .iter()
+            .map(|choice| {
+                ListItem::new(format!(
+                    "[{}] {} - {}",
+                    if choice.selected {
+                        "x"
+                    } else if choice.enabled() {
+                        " "
+                    } else {
+                        "-"
+                    },
+                    choice.integration.spec().display_name,
+                    choice.description()
+                ))
+                .style(if choice.enabled() {
+                    Style::default()
+                } else {
+                    Style::default().add_modifier(Modifier::DIM)
+                })
+            })
+            .collect::<Vec<_>>();
+        frame.render_stateful_widget(
+            List::new(items)
+                .highlight_symbol("> ")
+                .highlight_style(Style::default().add_modifier(Modifier::REVERSED)),
+            list,
+            &mut self.cursor,
+        );
+        if let Some(choice) = self
+            .cursor
+            .selected()
+            .and_then(|index| self.choices.get(index))
+        {
+            frame.render_widget(
+                Paragraph::new(format!(
+                    "{}\nPath: {}\nUnchecked integrations are never removed.",
+                    choice.description(),
+                    choice.path.as_deref().unwrap_or("unavailable")
+                ))
+                .wrap(Wrap { trim: false }),
+                details,
+            );
+        }
+        frame.render_widget(Paragraph::new("Up/Down move | Space toggle\nEnter apply | Esc cancel\nChecked replacements overwrite files.")
+            .wrap(Wrap { trim: false }), controls);
+        true
+    }
+
+    fn choose(&mut self) -> io::Result<()> {
+        let mut terminal = ratatui::try_init().inspect_err(|_| {
+            let _ = ratatui::try_restore();
+        })?;
+        let result: io::Result<()> = (|| {
+            loop {
+                let mut usable = false;
+                terminal.draw(|frame| usable = self.render(frame))?;
+                if let Event::Key(key) = event::read()?
+                    && (usable
+                        || key.code == KeyCode::Esc
+                        || key.modifiers.contains(KeyModifiers::CONTROL))
+                    && self.key(key)?
+                {
+                    return Ok(());
+                }
+            }
+        })();
+        // Restore canonical input and the original screen before any install or Y/n prompt.
+        let restored = ratatui::try_restore();
+        result?;
+        restored
+    }
+}
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 const PLUGIN_INSTALL_TIMEOUT: Duration = Duration::from_secs(120);
@@ -173,6 +390,103 @@ fn detail(value: impl AsRef<str>) {
     println!("       {}", paint("2", value));
 }
 
+pub(crate) fn desktop_setup() -> Result<(), Box<dyn Error>> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(io::Error::other("Desktop setup requires an interactive terminal").into());
+    }
+    let shell_id = env::var("BOOMUX_SHELL_ID")?;
+    let run_id = env::var("BOOMUX_RUN_ID")?;
+    let executable = env::current_exe()?;
+    let client = client::connect()?;
+    desktop_setup_close_request(
+        &client.get_shell(&shell_id)?,
+        &shell_id,
+        &run_id,
+        &executable,
+    )?;
+
+    let result = guided_setup();
+    finish_desktop_setup(
+        result,
+        &mut io::stdin().lock(),
+        &mut io::stdout().lock(),
+        || {
+            let shell = client.get_shell(&shell_id)?;
+            let request = desktop_setup_close_request(&shell, &shell_id, &run_id, &executable)?;
+            match client.request(request)? {
+                Response::Ok => Ok(()),
+                response => Err(io::Error::other(format!(
+                    "unexpected cleanup response: {response:?}"
+                ))
+                .into()),
+            }
+        },
+    )
+}
+
+fn desktop_setup_close_request(
+    shell: &ShellSnapshot,
+    shell_id: &str,
+    run_id: &str,
+    executable: &Path,
+) -> io::Result<Request> {
+    if shell.id != shell_id
+        || run_id.is_empty()
+        || shell.status != ShellStatus::Running
+        || !shell
+            .run
+            .as_ref()
+            .is_some_and(|run| run.id == run_id && run.ended_at_ms.is_none())
+        || shell.command.len() != 2
+        || Path::new(&shell.command[0]) != executable
+        || shell.command[1] != "__desktop-setup"
+    {
+        return Err(io::Error::other(
+            "refusing cleanup outside the exact dedicated Desktop setup Shell/run",
+        ));
+    }
+    Ok(Request::GuardedCloseShell {
+        shell_id: shell.id.clone(),
+        expected_revision: shell.revision,
+    })
+}
+
+fn finish_desktop_setup(
+    result: Result<(), Box<dyn Error>>,
+    input: &mut impl io::BufRead,
+    output: &mut impl Write,
+    mut close: impl FnMut() -> Result<(), Box<dyn Error>>,
+) -> Result<(), Box<dyn Error>> {
+    if let Err(error) = &result {
+        writeln!(output, "\nSetup completed with failures: {error}")?;
+    }
+    loop {
+        write!(output, "\nExit and remove this setup Shell? [Y/n] ")?;
+        output.flush()?;
+        let mut answer = String::new();
+        io::BufRead::read_line(&mut (&mut *input).take(64), &mut answer)?;
+        if !answer.ends_with('\n') {
+            return Err(io::Error::other(
+                "confirmation input closed or exceeded its limit; setup Shell retained",
+            )
+            .into());
+        }
+        match answer.trim().to_ascii_lowercase().as_str() {
+            "" | "y" | "yes" => {
+                writeln!(output, "Removing this setup Shell...")?;
+                output.flush()?;
+                close()?;
+                return result;
+            }
+            "n" | "no" => writeln!(
+                output,
+                "Setup Shell retained. Review the output; answer Y when ready to remove it."
+            )?,
+            _ => writeln!(output, "Please answer Y or n.")?,
+        }
+    }
+}
+
 pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
     if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
         return Err(io::Error::new(
@@ -230,20 +544,6 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
         .filter(|(_, status)| status.host.state != HostState::Missing)
         .count();
 
-    for (integration, integration_status) in &statuses {
-        if integration_status.host.state != HostState::Missing
-            && matches!(
-                integration_status.asset.state,
-                AssetState::Missing | AssetState::Modified
-            )
-        {
-            integration_management::plan_install(
-                *integration,
-                &environment,
-                integration_status.asset.state == AssetState::Modified,
-            )?;
-        }
-    }
     let skill_before = if detected > 0 {
         let skill = required_home()?.join(".agents/skills/boomux/SKILL.md");
         Some(integration_management::regular_file_matches(
@@ -261,7 +561,7 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
         let (marker, color, plan) = match integration.asset.state {
             AssetState::Current => ("ok", "32", "integration current"),
             AssetState::Missing => ("->", "36", "install integration"),
-            AssetState::Modified => ("!!", "33", "replace only with confirmation"),
+            AssetState::Modified => ("!!", "33", "replace only if checked in the checklist"),
             AssetState::Unavailable => ("xx", "31", "inspection must be repaired"),
         };
         status(marker, color, integration.display_name, plan);
@@ -272,8 +572,11 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
             AssetState::Missing | AssetState::Modified
         ) {
             let force = integration.asset.state == AssetState::Modified;
-            let plan = integration_management::plan_install(*integration_id, &environment, force)?;
-            detail(format!("path: {}", plan.path));
+            if let Ok(plan) =
+                integration_management::plan_install(*integration_id, &environment, force)
+            {
+                detail(format!("path: {}", plan.path));
+            }
         }
     }
     if detected == 0 {
@@ -307,9 +610,13 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
     if detected == 0 {
         status("--", "2", "Harnesses", "none found on PATH");
     }
+    let mut checklist = HarnessChecklist::new(&statuses);
+    if detected > 0 {
+        checklist.choose()?;
+    }
     let mut outcomes = Vec::new();
     let mut changed_harnesses = Vec::new();
-    for (integration, integration_status) in statuses {
+    for (index, (integration, integration_status)) in statuses.into_iter().enumerate() {
         if integration_status.host.state == HostState::Missing {
             continue;
         }
@@ -361,53 +668,29 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
             ));
             continue;
         }
-        let force = integration_status.asset.state == AssetState::Modified;
-        let plan = match integration_management::plan_install(integration, &environment, force) {
-            Ok(plan) => plan,
-            Err(error) => {
-                outcomes.push(SetupOutcome::failed(
-                    integration_status.display_name,
-                    error,
-                    format!(
-                        "`boomux integration status {} --json`",
-                        integration.spec().key
-                    ),
-                ));
-                continue;
-            }
-        };
-        let (action, prompt) = match plan.action {
-            InstallAction::Install => (
-                "Install",
-                format!(
-                    "Install the {} integration?",
-                    integration_status.display_name
-                ),
-            ),
-            InstallAction::Replace => (
-                "Replace modified",
-                format!(
-                    "Replace the modified {} integration?",
-                    integration_status.display_name
-                ),
-            ),
-            InstallAction::Unchanged => continue,
-        };
-        detail(format!("Plan: {action} asset at {}", plan.path));
-        if confirm(&prompt)? {
-            match integration_management::install(integration, &environment, force) {
+        if let Some(result) = checklist.install_with(index, |force| {
+            integration_management::plan_install(integration, &environment, force)?;
+            integration_management::install(integration, &environment, force)
+        }) {
+            match result {
                 Ok(result) => {
-                    status(
-                        "ok",
-                        "32",
-                        integration_status.display_name,
-                        "integration installed",
-                    );
+                    let changed =
+                        result.result != integration_management::InstallOutcome::Unchanged;
+                    let message = if changed {
+                        "integration installed"
+                    } else {
+                        "integration current"
+                    };
+                    status("ok", "32", integration_status.display_name, message);
                     detail(format!("path: {}", result.path));
                     outcomes.push(SetupOutcome::new(
-                        SetupOutcomeKind::Changed,
+                        if changed {
+                            SetupOutcomeKind::Changed
+                        } else {
+                            SetupOutcomeKind::Current
+                        },
                         integration_status.display_name,
-                        "integration installed",
+                        message,
                     ));
                     if result.restart_required {
                         changed_harnesses.push(integration_status.display_name);
@@ -484,9 +767,15 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
         }
     };
 
+    let selected_integrations = checklist
+        .choices
+        .iter()
+        .filter(|choice| choice.selected && choice.enabled())
+        .map(|choice| choice.integration)
+        .collect::<Vec<_>>();
     let recommended_ready = render_setup_receipt(
         &environment,
-        detected,
+        &selected_integrations,
         &changed_harnesses,
         daemon_ready,
         &mut outcomes,
@@ -503,6 +792,7 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
         if !recommended_ready {
             detail("Run `boomux setup` again to finish skipped recommended steps.");
         }
+        print!("{}", setup_completion(recommended_ready, false));
         return Ok(());
     }
     for failure in outcomes
@@ -519,12 +809,23 @@ pub(crate) fn guided_setup() -> Result<(), Box<dyn Error>> {
             eprintln!("       Recovery: {recovery}");
         }
     }
+    print!("{}", setup_completion(false, true));
     Err(io::Error::other(format!(
         "setup completed with {} failure{}",
         failures,
         if failures == 1 { "" } else { "s" }
     ))
     .into())
+}
+
+fn setup_completion(ready: bool, failed: bool) -> &'static str {
+    if failed {
+        "\nSetup finished with failures. Review the errors and recovery steps above.\n"
+    } else if ready {
+        "\nSetup completed successfully.\n"
+    } else {
+        "\nSetup finished; recommended steps remain. Review the receipt above.\n"
+    }
 }
 
 fn apply_outcome(
@@ -544,27 +845,30 @@ fn apply_outcome(
 
 fn render_setup_receipt(
     environment: &integration_management::Environment,
-    detected: usize,
+    selected_integrations: &[IntegrationId],
     changed_harnesses: &[&str],
     daemon_ready: bool,
     outcomes: &mut Vec<SetupOutcome>,
 ) -> bool {
-    let installed_integrations = IntegrationId::all()
+    let selected_count = selected_integrations.len();
+    let installed_integrations = selected_integrations
+        .iter()
+        .copied()
         .map(|integration| integration_management::inspect(integration, environment, None))
         .filter(|integration| {
             integration.host.state == HostState::Available
                 && integration.asset.state == AssetState::Current
         })
         .count();
-    let integrations_ready =
-        detected == 0 || installed_integrations == detected && changed_harnesses.is_empty();
-    if detected == 0 {
+    let integrations_ready = selected_count == 0
+        || installed_integrations == selected_count && changed_harnesses.is_empty();
+    if selected_count == 0 {
         outcomes.push(SetupOutcome::new(
             SetupOutcomeKind::Skipped,
             "Agent lifecycle",
-            "no harnesses detected",
+            "no integrations selected",
         ));
-    } else if installed_integrations != detected
+    } else if installed_integrations != selected_count
         && changed_harnesses.is_empty()
         && !outcomes
             .iter()
@@ -573,7 +877,7 @@ fn render_setup_receipt(
         outcomes.push(SetupOutcome::new(
             SetupOutcomeKind::Warning,
             "Agent lifecycle",
-            format!("{installed_integrations} of {detected} integrations verified"),
+            format!("{installed_integrations} of {selected_count} selected integrations verified"),
         ));
     }
     if !changed_harnesses.is_empty() {
@@ -584,7 +888,7 @@ fn render_setup_receipt(
         ));
     }
 
-    let skill_ready = if detected == 0 {
+    let skill_ready = if selected_count == 0 {
         true
     } else {
         match required_home()
@@ -1053,6 +1357,239 @@ mod tests {
 
     use super::*;
 
+    fn harness_checklist(states: &[(HostState, AssetState)]) -> HarnessChecklist {
+        let statuses = IntegrationId::all()
+            .zip(states)
+            .map(|(id, &(host, asset))| {
+                (
+                    id,
+                    integration_management::IntegrationStatus {
+                        name: id.spec().key,
+                        display_name: id.spec().display_name,
+                        package: id.installation().package,
+                        validated_version: id.installation().validated_version,
+                        host: integration_management::HostStatus {
+                            state: host,
+                            executable: None,
+                            version: None,
+                            compatibility: "test",
+                            error: None,
+                        },
+                        asset: integration_management::AssetStatus {
+                            state: asset,
+                            path: Some("/config/integration".into()),
+                            error: None,
+                        },
+                        runtime: integration_management::RuntimeStatus {
+                            state: integration_management::RuntimeState::NotObservable,
+                            running_processes: 0,
+                            tracked_processes: 0,
+                            untracked_processes: 0,
+                        },
+                        recommended_action: integration_management::RecommendedAction::None,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        HarnessChecklist::new(&statuses)
+    }
+
+    #[test]
+    fn harness_checklist_defaults_and_apply_require_explicit_selection() {
+        let mut checklist = harness_checklist(&[
+            (HostState::Available, AssetState::Missing),
+            (HostState::Available, AssetState::Current),
+            (HostState::Available, AssetState::Modified),
+            (HostState::Missing, AssetState::Missing),
+            (HostState::Available, AssetState::Unavailable),
+        ]);
+        assert_eq!(
+            checklist
+                .choices
+                .iter()
+                .map(|choice| choice.selected)
+                .collect::<Vec<_>>(),
+            [false, true, false, false, false]
+        );
+        for key in [
+            KeyCode::Up,
+            KeyCode::Char(' '),
+            KeyCode::Down,
+            KeyCode::Char(' '),
+            KeyCode::Down,
+            KeyCode::Char(' '),
+            KeyCode::Down,
+            KeyCode::Char(' '),
+        ] {
+            assert!(
+                !checklist
+                    .key(KeyEvent::new(key, KeyModifiers::NONE))
+                    .unwrap()
+            );
+        }
+        assert!(
+            checklist
+                .install_with(0, |_| panic!("must wait for Enter"))
+                .is_none()
+        );
+        assert!(
+            checklist
+                .key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+                .unwrap()
+        );
+        let mut calls = Vec::new();
+        for index in 0..checklist.choices.len() {
+            checklist.install_with(index, |force| calls.push((index, force)));
+        }
+        assert_eq!(calls, [(0, false), (2, true)]);
+        assert_eq!(
+            checklist
+                .install_with(0, |_| Err::<(), _>("install failed"))
+                .unwrap()
+                .unwrap_err(),
+            "install failed"
+        );
+    }
+
+    #[test]
+    fn harness_checklist_enter_alone_does_not_install_or_replace() {
+        let mut checklist = harness_checklist(&[
+            (HostState::Available, AssetState::Missing),
+            (HostState::Available, AssetState::Current),
+            (HostState::Available, AssetState::Modified),
+        ]);
+        checklist
+            .key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+        for index in 0..checklist.choices.len() {
+            assert!(
+                checklist
+                    .install_with(index, |_| panic!(
+                        "new and replacement installs must be opted into"
+                    ))
+                    .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn harness_checklist_disabled_rows_and_cancel_never_install() {
+        for host in [
+            HostState::Missing,
+            HostState::ProbeFailed,
+            HostState::NotChecked,
+        ] {
+            let mut checklist = harness_checklist(&[(host, AssetState::Missing)]);
+            checklist
+                .key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE))
+                .unwrap();
+            checklist
+                .key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+                .unwrap();
+            assert!(
+                checklist
+                    .install_with(0, |_| panic!("disabled host"))
+                    .is_none()
+            );
+        }
+        for cancel in [
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL),
+        ] {
+            let mut checklist = harness_checklist(&[(HostState::Available, AssetState::Missing)]);
+            checklist
+                .key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE))
+                .unwrap();
+            assert_eq!(
+                checklist.key(cancel).unwrap_err().kind(),
+                io::ErrorKind::Interrupted
+            );
+            assert!(
+                checklist
+                    .install_with(0, |_| panic!("cancelled selection"))
+                    .is_none()
+            );
+        }
+        let mut empty = harness_checklist(&[]);
+        assert!(
+            !empty
+                .key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+                .unwrap()
+        );
+        assert!(
+            empty
+                .key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+                .unwrap()
+        );
+        assert!(
+            empty
+                .install_with(0, |_| panic!("empty selection"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn harness_checklist_ignores_modified_release_and_repeat_toggles() {
+        let mut checklist = harness_checklist(&[(HostState::Available, AssetState::Missing)]);
+        for key in [
+            KeyEvent::new_with_kind(KeyCode::Char(' '), KeyModifiers::NONE, KeyEventKind::Repeat),
+            KeyEvent::new_with_kind(KeyCode::Enter, KeyModifiers::NONE, KeyEventKind::Release),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT),
+        ] {
+            assert!(!checklist.key(key).unwrap());
+        }
+        assert!(!checklist.choices[0].selected);
+        assert!(!checklist.confirmed);
+    }
+
+    #[test]
+    fn harness_checklist_renders_controls_replacement_consent_and_small_terminal_guidance() {
+        for (width, height) in [(80, 24), (40, 10), (20, 5)] {
+            let mut checklist = harness_checklist(&[(HostState::Available, AssetState::Modified)]);
+            let mut terminal =
+                ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height)).unwrap();
+            let mut usable = false;
+            terminal
+                .draw(|frame| usable = checklist.render(frame))
+                .unwrap();
+            let text = (0..height)
+                .map(|y| {
+                    (0..width)
+                        .map(|x| terminal.backend().buffer()[(x, y)].symbol())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert_eq!(usable, width >= 40 && height >= 10);
+            if usable {
+                assert!(text.contains("[ ]"), "{text}");
+                assert!(text.contains("REPLACE MODIFIED"), "{text}");
+                assert!(text.contains("Space toggle"), "{text}");
+                assert!(text.contains("Enter apply"), "{text}");
+                assert!(
+                    text.contains("Checked replacements overwrite files."),
+                    "{text}"
+                );
+            } else {
+                assert!(text.contains("Resize to at least"), "{text}");
+            }
+        }
+        let mut checklist = harness_checklist(&[(HostState::Available, AssetState::Missing); 5]);
+        checklist.cursor.select(Some(4));
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(40, 10)).unwrap();
+        terminal
+            .draw(|frame| {
+                assert!(checklist.render(frame));
+            })
+            .unwrap();
+        assert!(
+            checklist.cursor.offset() > 0,
+            "compact list must scroll to the focused harness"
+        );
+    }
+
     struct TestDirectory(PathBuf);
 
     impl TestDirectory {
@@ -1160,6 +1697,114 @@ mod tests {
         assert!(read_confirmation(&mut io::Cursor::new(b"\n"), true).unwrap());
         let error = read_confirmation(&mut io::Cursor::new([]), true).unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn desktop_setup_confirmation_requires_yes_and_keeps_failures_distinct() {
+        for answer in ["\n", "y\n", "YES\n", "n\ny\n", "invalid\ny\n"] {
+            let mut closed = 0;
+            let mut output = Vec::new();
+            finish_desktop_setup(Ok(()), &mut io::Cursor::new(answer), &mut output, || {
+                closed += 1;
+                Ok(())
+            })
+            .unwrap();
+            assert_eq!(closed, 1);
+            let output = String::from_utf8(output).unwrap();
+            assert!(output.contains("Exit and remove this setup Shell? [Y/n]"));
+            if answer.starts_with("n\n") {
+                assert!(output.contains("Setup Shell retained."));
+            }
+        }
+        for answer in ["", "y", "n\n", "invalid\n"] {
+            let mut output = Vec::new();
+            assert!(
+                finish_desktop_setup(Ok(()), &mut io::Cursor::new(answer), &mut output, || {
+                    panic!("input without confirmation must not remove a Shell")
+                })
+                .is_err()
+            );
+        }
+        let mut output = Vec::new();
+        let error = finish_desktop_setup(
+            Err(io::Error::other("integration failed").into()),
+            &mut io::Cursor::new("\n"),
+            &mut output,
+            || Ok(()),
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "integration failed");
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("Setup completed with failures: integration failed"));
+        assert!(!output.contains("successfully"));
+
+        let error =
+            finish_desktop_setup(Ok(()), &mut io::Cursor::new("y\n"), &mut Vec::new(), || {
+                Err(io::Error::other("Shell revision changed").into())
+            })
+            .unwrap_err();
+        assert_eq!(error.to_string(), "Shell revision changed");
+        assert!(
+            finish_desktop_setup(
+                Ok(()),
+                &mut io::Cursor::new(format!("{}\n", "y".repeat(64))),
+                &mut Vec::new(),
+                || panic!("oversized confirmation must not remove a Shell"),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn desktop_setup_cleanup_rejects_other_commands_runs_and_shells() {
+        let mut shell: ShellSnapshot = serde_json::from_value(serde_json::json!({
+            "id": "setup-shell", "revision": 7, "workspace_id": "workspace",
+            "name": "Set up agents", "cwd": "/tmp", "status": "running",
+            "command": ["/bin/boomux", "__desktop-setup"],
+            "run": {"id": "setup-run", "generation": 1, "started_at_ms": 1,
+                "ended_at_ms": null, "exit_reason": null, "output_revision": 0,
+                "environment_has_run_id": true}
+        }))
+        .unwrap();
+        let request = |shell: &ShellSnapshot| {
+            desktop_setup_close_request(shell, "setup-shell", "setup-run", Path::new("/bin/boomux"))
+        };
+        assert_eq!(
+            request(&shell).unwrap(),
+            Request::GuardedCloseShell {
+                shell_id: "setup-shell".into(),
+                expected_revision: 7,
+            }
+        );
+        shell.command[1] = "setup".into();
+        assert!(request(&shell).is_err());
+        shell.command = vec![];
+        assert!(request(&shell).is_err());
+        shell.command = vec!["/other/boomux".into(), "__desktop-setup".into()];
+        assert!(request(&shell).is_err());
+        shell.command[0] = "/bin/boomux".into();
+        shell.run.as_mut().unwrap().id = "replacement-run".into();
+        assert!(request(&shell).is_err());
+        shell.run.as_mut().unwrap().id = "setup-run".into();
+        shell.id = "unrelated-shell".into();
+        assert!(request(&shell).is_err());
+        shell.id = "setup-shell".into();
+        shell.status = ShellStatus::Exited { code: Some(0) };
+        assert!(request(&shell).is_err());
+    }
+
+    #[test]
+    fn setup_completion_distinguishes_success_remaining_steps_and_failures() {
+        for (ready, failed, expected) in [
+            (true, false, "Setup completed successfully."),
+            (false, false, "Setup finished; recommended steps remain."),
+            (false, true, "Setup finished with failures."),
+            (true, true, "Setup finished with failures."),
+        ] {
+            let message = setup_completion(ready, failed);
+            assert!(message.contains(expected), "{message}");
+            assert_eq!(message.contains("successfully"), ready && !failed);
+        }
     }
 
     #[test]

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -78,6 +78,11 @@ fn guided_setup_works_without_external_terminal_or_omarchy() {
     let mut output = String::new();
     std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
     assert!(output.contains("BOOMUX IS READY"), "{output}");
+    assert!(output.contains("Setup completed successfully."), "{output}");
+    assert!(
+        !output.contains("Exit and remove this setup Shell?"),
+        "{output}"
+    );
     assert!(!output.contains("xdg-terminal-exec"), "{output}");
     stop_setup_daemon(Path::new(env!("CARGO_BIN_EXE_boomux")), &root, &runtime);
     fs::remove_dir_all(root).unwrap();
@@ -125,11 +130,40 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
     drop(pty.slave);
     let mut reader = pty.master.try_clone_reader().unwrap();
     let mut writer = pty.master.take_writer().unwrap();
-    writer.write_all(b"yes\nno\n").unwrap();
+    let (output_sender, output_receiver) = std::sync::mpsc::sync_channel(64);
+    let reader_thread = std::thread::spawn(move || {
+        let mut buffer = [0; 4096];
+        while let Ok(count) = std::io::Read::read(reader.as_mut(), &mut buffer) {
+            if count == 0 || output_sender.send(buffer[..count].to_vec()).is_err() {
+                break;
+            }
+        }
+    });
+    let mut output = String::new();
+    // Do not type the later line-mode answer into Crossterm's event buffer.
+    for (prompt, answer) in [
+        ("Space toggle", " \r"),
+        ("Install the Boomux Agent Skill?", "no\n"),
+    ] {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !output.contains(prompt) {
+            let bytes = output_receiver
+                .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
+                .unwrap();
+            output.push_str(&String::from_utf8_lossy(&bytes));
+        }
+        writer.write_all(answer.as_bytes()).unwrap();
+    }
     drop(writer);
     assert!(child.wait().unwrap().success());
-    let mut output = String::new();
-    std::io::Read::read_to_string(reader.as_mut(), &mut output).unwrap();
+    for bytes in output_receiver {
+        output.push_str(&String::from_utf8_lossy(&bytes));
+    }
+    reader_thread.join().unwrap();
+    assert!(
+        !output.contains("Install the OpenCode integration?"),
+        "{output}"
+    );
     assert!(output.contains("OpenCode"));
     assert!(output.contains("Daemon"));
     assert!(output.contains("started"));
@@ -161,6 +195,14 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
         "{plan}"
     );
     assert!(output.contains("integration installed"));
+    assert!(
+        output.contains("Setup finished; recommended steps remain."),
+        "{output}"
+    );
+    assert!(
+        !output.contains("Setup completed successfully."),
+        "{output}"
+    );
     assert!(!output.contains("Omarchy"));
     assert!(!root.join("omarchy-called").exists());
     assert!(!root.join(".config/hypr").exists());

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -140,16 +140,17 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
         }
     });
     let mut output = String::new();
+    // Ratatui may position each word separately, so match one complete word.
     // Do not type the later line-mode answer into Crossterm's event buffer.
     for (prompt, answer) in [
-        ("Space toggle", " \r"),
+        ("toggle", " \r"),
         ("Install the Boomux Agent Skill?", "no\n"),
     ] {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         while !output.contains(prompt) {
             let bytes = output_receiver
                 .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
-                .unwrap();
+                .unwrap_or_else(|error| panic!("waiting for {prompt:?}: {error}; output: {output:?}"));
             output.push_str(&String::from_utf8_lossy(&bytes));
         }
         writer.write_all(answer.as_bytes()).unwrap();

--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -150,7 +150,9 @@ fn guided_setup_discovers_and_installs_one_selected_harness() {
         while !output.contains(prompt) {
             let bytes = output_receiver
                 .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
-                .unwrap_or_else(|error| panic!("waiting for {prompt:?}: {error}; output: {output:?}"));
+                .unwrap_or_else(|error| {
+                    panic!("waiting for {prompt:?}: {error}; output: {output:?}")
+                });
             output.push_str(&String::from_utf8_lossy(&bytes));
         }
         writer.write_all(answer.as_bytes()).unwrap();


### PR DESCRIPTION
## Changes

Add desktop Node health, connection, and reauthentication entry points, and discover installed AI harnesses whose Boomux integrations need installation or review. Each harness gets a dismissible prompt; replacing an existing integration requires explicit confirmation. Settings offers a recheck and manual setup.

Refine the guided setup checklist, preserve final terminal output, and safely clean up completed setup Shells. Fix disabled-control hover styling, make update notices dismissible, and skip hidden sidebar rows while Settings is open. Keep development daemon launches isolated and document focused local validation with full validation in CI.

Native remote Shell attachment remains outside this change; Node entry points use the existing guided CLI flows. The experimental Settings/terminal rendering cache is absent.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Four focused harness integration tests passed.
- Focused native guided-setup test passed after fixing its prompt match to tolerate cursor positioning between words.
- `python3 desktop/scripts/test-run-dev.py` — three tests passed.
- Full selected validation is delegated to this PR's CI and must pass before merging.

The earlier isolated software-compositor repaint finding is recorded in `docs/desktop/remote-nodes-implementation.md`. Physical desktop rendering and scroll smoothness have not been revalidated as part of this PR pass.
