### PR TITLE
feat(desktop): add git work overview and draggable pane resizing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -229,3 +229,17 @@ permanently closing its Shell is a distinct daemon mutation. The **terminal core
 is the pane-owned Ghostty decoder and render state; it does not own the PTY.
 Both executable packages share a repository and release version, but the daemon
 remains usable without the native Desktop application.
+
+## Git Work Overview
+
+A disposable, owner-local observation of Git repositories and worktrees related
+to managed Shells and active Agent working contexts. Repository identity within
+an observation is the owning Node and canonical Git common directory; a worktree
+also retains its root path. These are filesystem observations, not new durable
+Boomux resources or Workspace membership.
+
+A Shell's current managed-process cwd can associate it with a worktree without
+changing its launch cwd. This association is distinct from an Agent Working
+Context supplied by lifecycle integration. Neither Git cleanliness, push status,
+PR state, nor CI results establish Agent completion. Local Git and remote PR
+observations retain separate freshness and failure states.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -93,6 +93,12 @@ cargo check -p boomux-desktop --locked
 cargo test -p boomux-desktop <test-name> --locked -- --test-threads=1
 ```
 
+For a performance comparison, run `python3 desktop/scripts/run-dev.py --release`.
+This builds and launches optimized Desktop and daemon binaries against the same
+isolated development runtime. The first optimized build takes longer; keep the
+default debug build for routine iteration. Close the previous Desktop window
+before comparing the same workload.
+
 The helper builds both executables, sets a matching CLI PATH, and uses XDG
 runtime/config/state directories under `target/desktop-dev/`. Closing the window
 keeps these development sessions alive. After rebuilding, the helper starts an

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -143,6 +143,9 @@ The prototype uses Ctrl on Linux so its input reaches the app while it is runnin
 | `Ctrl + Space` | Enter or leave Layout mode; press twice quickly to send Ctrl+Space to the terminal |
 | `Ctrl + left drag` | Lift, move, and re-tile a tiled pane |
 | `Ctrl + right drag` | Resize a tiled split or floating pane in both axes |
+| `Left drag on a pane edge` | Resize a floating pane or the adjoining tiled divider |
+| `Left drag on a pane corner` | Resize both axes; tiled corners require two adjoining dividers |
+| `Left drag on the sidebar’s right edge` | Resize the sidebar; width is saved |
 | Layout: `Arrow keys` | Focus a spatially adjacent pane (`H/K/L` also focus left/up/right) |
 | Layout: `Tab` or `Shift + Tab` | Cycle focus through panes forward or backward |
 | Layout: `Shift + Arrow keys` or `Shift + H/J/K/L` | Slide-swap a tiled pane, or move a floating pane |
@@ -301,3 +304,7 @@ Boomux owns server-side scale across Shells and attached clients. Boomux Desktop
 owns the incremental cost of each visible terminal pane, decoded image, and
 frame. See [docs/performance.md](../docs/desktop/performance.md) for the measurement model
 and [docs/architecture.md](../docs/desktop/architecture.md) for the ownership boundary.
+
+## Git overview
+
+Open **Git · Branches and worktrees** in the sidebar, or use Layout mode (`Ctrl+Space`, then `G`). The resizable panel connects worktrees to their Shells and Agents and shows local changes, upstream comparisons, and GitHub PR/check status. See [Git panel](../docs/desktop/git-panel.md) for refresh behavior and status semantics.

--- a/desktop/scripts/run-dev.py
+++ b/desktop/scripts/run-dev.py
@@ -1,22 +1,28 @@
 #!/usr/bin/env python3
 """Build and open Desktop against this worktree's isolated development daemon."""
 
+import argparse
 import json
 import os
 from pathlib import Path
 import subprocess
-import sys
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__, add_help=False)
+    parser.add_argument("--release", action="store_true")
+    options, desktop_args = parser.parse_known_args()
     root = Path(__file__).resolve().parents[2]
-    subprocess.run(["cargo", "build", "--locked", "-p", "boomux", "-p", "boomux-desktop", "--target-dir", str(root / "target")],
+    subprocess.run(["cargo", "build", "--locked", "-p", "boomux", "-p", "boomux-desktop", "--target-dir", str(root / "target"), *(["--release"] if options.release else [])],
                    cwd=root, check=True)
-    target = root / "target/debug"
+    target = root / "target" / ("release" if options.release else "debug")
     env = {key: value for key, value in os.environ.items() if not key.startswith("BOOMUX_")}
     display = env.get("WAYLAND_DISPLAY")
     if display and not Path(display).is_absolute() and env.get("XDG_RUNTIME_DIR"):
         env["WAYLAND_DISPLAY"] = str(Path(env["XDG_RUNTIME_DIR"]) / display)
+    # Keep the user's existing GitHub CLI authentication available to read-only
+    # PR inspection while Boomux's runtime/configuration remain isolated.
+    env.setdefault("GH_CONFIG_DIR", str(Path(env.get("XDG_CONFIG_HOME") or Path.home() / ".config") / "gh"))
     for name in ["RUNTIME_DIR", "CONFIG_HOME", "STATE_HOME", "DATA_HOME", "CACHE_HOME"]:
         path = root / "target/desktop-dev" / name.lower()
         path.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -33,7 +39,7 @@ def main():
     action = ["restart", "--executable", str(cli)] if state == "running" else ["start"]
     subprocess.run([cli, "daemon", *action], env=env, check=True, timeout=30)
     executable = str(target / "boomux-desktop")
-    os.execve(executable, [executable, *sys.argv[1:]], env)
+    os.execve(executable, [executable, *desktop_args], env)
 
 
 if __name__ == "__main__":

--- a/desktop/scripts/test-run-dev.py
+++ b/desktop/scripts/test-run-dev.py
@@ -14,11 +14,15 @@ CLI = ROOT / "target/debug/boomux"
 
 
 class DevelopmentLaunchTests(unittest.TestCase):
-    def launch(self, state, failure=None):
+    def launch(self, state, failure=None, gh_config=None, release=False):
+        target = ROOT / "target" / ("release" if release else "debug")
+        cli = target / "boomux"
         status = Mock(stdout=json.dumps({"data": {"status": state}}))
-        with patch.dict(os.environ, {
+        with patch("sys.argv", ["run-dev.py", *(["--release"] if release else []), "--example-desktop-flag"]), patch.dict(os.environ, {
             "PATH": "/usr/bin", "XDG_RUNTIME_DIR": "/ordinary/runtime",
             "WAYLAND_DISPLAY": "wayland-1", "BOOMUX_CONFIG": "/ordinary/config",
+            "XDG_CONFIG_HOME": "/ordinary/config-home",
+            **({"GH_CONFIG_DIR": gh_config} if gh_config else {}),
         }, clear=True), patch.object(Path, "mkdir"), \
                 patch("subprocess.run", side_effect=[Mock(), status, failure or Mock()]) as run, \
                 patch("os.execve") as execute:
@@ -29,23 +33,33 @@ class DevelopmentLaunchTests(unittest.TestCase):
             else:
                 DEV["main"]()
                 execute.assert_called_once()
-                self.assertEqual(execute.call_args.args[0], str(ROOT / "target/debug/boomux-desktop"))
+                self.assertEqual(execute.call_args.args[1], [str(target / "boomux-desktop"), "--example-desktop-flag"])
+                self.assertEqual(execute.call_args.args[0], str(target / "boomux-desktop"))
                 self.assertEqual(execute.call_args.args[2], run.call_args.kwargs["env"])
             calls = run.call_args_list
-            self.assertEqual(calls[1].args[0], [CLI, "daemon", "status", "--json"])
+            self.assertEqual("--release" in calls[0].args[0], release)
+            self.assertEqual(calls[1].args[0], [cli, "daemon", "status", "--json"])
             for call in calls[1:]:
                 env = call.kwargs["env"]
                 for name in ["RUNTIME_DIR", "CONFIG_HOME", "STATE_HOME", "DATA_HOME", "CACHE_HOME"]:
                     self.assertEqual(env[f"XDG_{name}"], str(ROOT / "target/desktop-dev" / name.lower()))
+                self.assertEqual(env["GH_CONFIG_DIR"], gh_config or "/ordinary/config-home/gh")
                 self.assertEqual(env["WAYLAND_DISPLAY"], "/ordinary/runtime/wayland-1")
                 self.assertFalse(any(key.startswith("BOOMUX_") for key in env))
-                self.assertEqual(env["PATH"], str(CLI.parent) + os.pathsep + "/usr/bin")
+                self.assertEqual(env["PATH"], str(cli.parent) + os.pathsep + "/usr/bin")
                 self.assertTrue(call.kwargs["check"])
                 self.assertEqual(call.kwargs["timeout"], 30)
             return calls[-1].args[0]
 
     def test_running_daemon_hands_off_to_the_exact_rebuilt_executable(self):
         self.assertEqual(self.launch("running"), [CLI, "daemon", "restart", "--executable", str(CLI)])
+
+    def test_release_handoff_uses_release_binaries_and_the_same_runtime(self):
+        cli = ROOT / "target/release/boomux"
+        self.assertEqual(self.launch("running", release=True), [cli, "daemon", "restart", "--executable", str(cli)])
+
+    def test_explicit_github_config_is_preserved(self):
+        self.launch("stopped", gh_config="/explicit/gh")
 
     def test_absent_daemon_starts_without_an_unnecessary_restart(self):
         self.assertEqual(self.launch("stopped"), [CLI, "daemon", "start"])

--- a/desktop/src/git_panel.rs
+++ b/desktop/src/git_panel.rs
@@ -1,0 +1,919 @@
+//! Git presentation and navigation; no terminal or repository lifecycle ownership.
+use super::*;
+use boomux::git_work::{AgentLink, Overview, Worktree};
+use std::path::PathBuf;
+
+struct AgentAssociation<'a> {
+    agent: &'a AgentLink,
+    associated_shell: bool,
+    observed_context: bool,
+}
+
+fn agent_associations(links: &[AgentLink]) -> Vec<AgentAssociation<'_>> {
+    let mut agents = std::collections::BTreeMap::new();
+    for link in links {
+        let association = agents
+            .entry((link.id.as_str(), link.run_id.as_str()))
+            .or_insert(AgentAssociation {
+                agent: link,
+                associated_shell: false,
+                observed_context: false,
+            });
+        association.associated_shell |= !link.observed_context;
+        association.observed_context |= link.observed_context;
+    }
+    agents.into_values().collect()
+}
+
+#[derive(Clone, Default, PartialEq, Eq)]
+pub(crate) struct NodeOverview {
+    pub id: String,
+    pub label: String,
+    pub local: bool,
+    pub overview: Overview,
+    pub error: Option<String>,
+}
+#[derive(Default)]
+pub(crate) struct Model {
+    pub open: bool,
+    pub compact: bool,
+    pub wide: bool,
+    pub width: Option<f32>,
+    pub resizing: bool,
+    pub search: String,
+    pub search_focused: bool,
+    pub search_open: bool,
+    pub filters_open: bool,
+    pub current_workspace: bool,
+    pub needs_attention: bool,
+    pub busy: bool,
+    pub nodes: Vec<NodeOverview>,
+    pub expanded: HashSet<(String, PathBuf)>,
+    pub task: Option<gpui::Task<()>>,
+}
+fn fetch(previous: Vec<NodeOverview>, refresh: bool) -> Vec<NodeOverview> {
+    let result = (|| -> Result<Vec<NodeOverview>, String> {
+        let client = boomux::client::Client::from_socket_path(
+            boomux::client::socket_path().map_err(|e| e.to_string())?,
+        );
+        let snapshot = client
+            .combined_node_snapshot_with_timeout(Duration::from_secs(2))
+            .map_err(|e| e.to_string())?;
+        let mut nodes = Vec::new();
+        for node in snapshot.nodes.iter().take(16) {
+            let mut item = previous
+                .iter()
+                .find(|p| p.id == node.node_id)
+                .cloned()
+                .unwrap_or_default();
+            item.id = node.node_id.clone();
+            item.label = node.alias.clone();
+            item.local = node.local;
+            let response = if node.current {
+                client.git_overview(
+                    (!node.local).then_some(node.node_id.as_str()),
+                    refresh,
+                    Duration::from_secs(2),
+                )
+            } else {
+                item.error = Some("Node unavailable; last Git observation retained".into());
+                nodes.push(item);
+                continue;
+            };
+            match response {
+                Ok(overview) => {
+                    item.overview = overview;
+                    item.error = None;
+                }
+                Err(error) => item.error = Some(error.to_string()),
+            }
+            nodes.push(item);
+        }
+        if snapshot.nodes.len() > 16 {
+            nodes.push(NodeOverview {
+                label: "More Nodes".into(),
+                error: Some("Showing the first 16 Nodes".into()),
+                ..Default::default()
+            });
+        }
+        Ok(nodes)
+    })();
+    result.unwrap_or_else(|error| {
+        let mut previous = previous;
+        if previous.is_empty() {
+            previous.push(NodeOverview {
+                label: "Local Node".into(),
+                ..Default::default()
+            });
+        }
+        for node in &mut previous {
+            node.error = Some(error.clone());
+        }
+        previous
+    })
+}
+fn toolbar_button(
+    id: &'static str,
+    label: &'static str,
+    glyph: &'static str,
+    active: bool,
+) -> Stateful<Div> {
+    sidebar_header_button(id, label, glyph, active)
+        .border_0()
+        .text_color(rgb(if active { 0xcba6f7 } else { 0xa6adc8 }))
+}
+
+fn status(row: &Worktree) -> String {
+    let Some(status) = &row.status else {
+        return row
+            .error
+            .clone()
+            .unwrap_or_else(|| "Git status unknown".into());
+    };
+    let local = if status.conflicts > 0 {
+        format!("{} conflicts", status.conflicts)
+    } else if status.staged + status.unstaged + status.untracked == 0 {
+        "Clean".into()
+    } else {
+        [
+            (status.staged, "staged"),
+            (status.unstaged, "unstaged"),
+            (status.untracked, "untracked"),
+        ]
+        .into_iter()
+        .filter(|(count, _)| *count > 0)
+        .map(|(count, label)| format!("{count} {label}"))
+        .collect::<Vec<_>>()
+        .join(" · ")
+    };
+    let push = if status.upstream.is_none() {
+        "No upstream".into()
+    } else if !status.divergence_known {
+        "Upstream comparison unavailable".into()
+    } else if status.ahead == 0 && status.behind == 0 {
+        "Matches upstream".into()
+    } else {
+        format!("{} ahead · {} behind", status.ahead, status.behind)
+    };
+    format!("{local} · {push}")
+}
+fn attention(row: &Worktree) -> bool {
+    row.error.is_some()
+        || row.pr.error.is_some()
+        || row.status.as_ref().is_some_and(|s| {
+            s.conflicts + s.staged + s.unstaged + s.untracked + s.ahead + s.behind > 0
+                || s.upstream.is_none()
+                || !s.divergence_known
+        })
+        || row.agents.iter().any(|a| a.state == AgentState::Blocked)
+        || row.pr.summary.contains("failed")
+        || row.pr.summary.contains("changes requested")
+}
+fn state_label(state: AgentState) -> &'static str {
+    match state {
+        AgentState::Working => "working",
+        AgentState::Blocked => "blocked",
+        AgentState::Idle => "idle",
+        AgentState::Inactive => "inactive",
+        AgentState::Done => "done",
+        AgentState::Unknown => "unknown",
+    }
+}
+fn age(timestamp: u64) -> String {
+    if timestamp == 0 {
+        return "not checked".into();
+    }
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let seconds = now.saturating_sub(timestamp) / 1000;
+    if seconds < 60 {
+        format!("{seconds}s ago")
+    } else {
+        format!("{}m ago", seconds / 60)
+    }
+}
+impl Workspace {
+    pub(crate) fn toggle_git_panel(&mut self, cx: &mut Context<Self>) {
+        self.git_panel.open = !self.git_panel.open;
+        if self.git_panel.open {
+            self.git_panel.task = Some(cx.spawn(async move |this, cx| {
+                loop {
+                    let proceed = this
+                        .update(cx, |this, cx| {
+                            if !this.git_panel.open {
+                                return false;
+                            }
+                            this.refresh_git_panel(false, cx);
+                            true
+                        })
+                        .unwrap_or(false);
+                    if !proceed {
+                        break;
+                    }
+                    cx.background_executor().timer(Duration::from_secs(3)).await;
+                }
+            }));
+        } else {
+            self.git_panel.task = None;
+            self.git_panel.search_focused = false;
+            self.git_panel.resizing = false;
+        }
+        cx.notify();
+    }
+    fn refresh_git_panel(&mut self, refresh: bool, cx: &mut Context<Self>) {
+        if self.git_panel.busy {
+            return;
+        }
+        self.git_panel.busy = true;
+        let previous = self.git_panel.nodes.clone();
+        cx.spawn(async move |this, cx| {
+            let nodes = cx
+                .background_executor()
+                .spawn(async move { fetch(previous, refresh) })
+                .await;
+            this.update(cx, |this, cx| {
+                this.git_panel.busy = false;
+                if this.git_panel.nodes != nodes {
+                    this.git_panel.nodes = nodes;
+                    this.git_panel.expanded.retain(|(node, path)| {
+                        this.git_panel.nodes.iter().any(|n| {
+                            &n.id == node && n.overview.worktrees.iter().any(|r| &r.root == path)
+                        })
+                    });
+                    cx.notify();
+                }
+            })
+            .ok();
+        })
+        .detach();
+    }
+    pub(crate) fn git_panel_width(&self, window: &Window) -> f32 {
+        if !self.git_panel.open {
+            return 0.0;
+        }
+        let available =
+            (f32::from(window.viewport_size().width) - self.sidebar_width() - 240.0).max(0.0);
+        available.min(self.git_panel.width.unwrap_or(if self.git_panel.wide {
+            720.0
+        } else {
+            420.0
+        }))
+    }
+    pub(crate) fn render_git_panel(
+        &self,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        if !self.git_panel.open {
+            return None;
+        }
+        let workspace = self
+            .terminals
+            .get(&self.focused)
+            .and_then(|p| p.shell.as_ref())
+            .map(|s| s.workspace_id.as_str());
+        let mut rows = Vec::new();
+        let query = self.git_panel.search.to_lowercase();
+        let refreshing = self
+            .git_panel
+            .nodes
+            .iter()
+            .any(|node| node.overview.refreshing);
+        let show_nodes =
+            self.git_panel.nodes.len() > 1 || self.git_panel.nodes.iter().any(|node| !node.local);
+        for node in &self.git_panel.nodes {
+            if show_nodes {
+                rows.push(
+                    div()
+                        .text_xs()
+                        .text_color(rgb(0xa6adc8))
+                        .child(if node.local {
+                            "Node · This machine".into()
+                        } else {
+                            format!("Node · {}", node.label)
+                        })
+                        .into_any_element(),
+                );
+            }
+            if let Some(error) = &node.error {
+                rows.push(
+                    div()
+                        .text_xs()
+                        .text_color(rgb(0xf9e2af))
+                        .child(format!("Stale / unavailable: {error}"))
+                        .into_any_element(),
+                );
+            }
+            for warning in &node.overview.warnings {
+                rows.push(
+                    div()
+                        .text_xs()
+                        .text_color(rgb(0xf9e2af))
+                        .child(warning.clone())
+                        .into_any_element(),
+                );
+            }
+            if node.overview.worktrees.is_empty() && !node.overview.refreshing {
+                rows.push(
+                    div()
+                        .text_xs()
+                        .child("No Git repositories discovered from managed Shells or Agents.")
+                        .into_any_element(),
+                );
+            }
+            let mut previous_repository = None;
+            let mut repository: Option<Div> = None;
+            for row in &node.overview.worktrees {
+                if self.git_panel.current_workspace
+                    && !row
+                        .shells
+                        .iter()
+                        .any(|s| Some(s.workspace_id.as_str()) == workspace)
+                    && !row
+                        .agents
+                        .iter()
+                        .any(|a| Some(a.workspace_id.as_str()) == workspace)
+                {
+                    continue;
+                }
+                if self.git_panel.needs_attention && !attention(row) {
+                    continue;
+                }
+                if !query.is_empty()
+                    && !format!(
+                        "{} {} {} {}",
+                        row.repository,
+                        row.branch,
+                        row.root.display(),
+                        row.shells
+                            .iter()
+                            .map(|s| s.workspace.as_str())
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    )
+                    .to_lowercase()
+                    .contains(&query)
+                {
+                    continue;
+                }
+                let agents = agent_associations(&row.agents);
+                if previous_repository.as_ref() != Some(&row.common_dir) {
+                    if let Some(group) = repository.take() {
+                        rows.push(group.into_any_element());
+                    }
+                    repository = Some(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .min_w_0()
+                            .flex_none()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(rgb(0x313244))
+                            .overflow_hidden()
+                            .child(
+                                div()
+                                    .px_3()
+                                    .py_2()
+                                    .text_sm()
+                                    .font_weight(gpui::FontWeight::BOLD)
+                                    .child(row.repository.clone()),
+                            ),
+                    );
+                    previous_repository = Some(row.common_dir.clone());
+                }
+                let key = (node.id.clone(), row.root.clone());
+                let expanded = self.git_panel.expanded.contains(&key);
+                let toggle = key.clone();
+                let mut card = div()
+                    .id(SharedString::from(format!(
+                        "git-row-{}-{}",
+                        node.id,
+                        row.root.display()
+                    )))
+                    .flex()
+                    .flex_col()
+                    .min_w_0()
+                    .gap_1()
+                    .px_3()
+                    .py_2()
+                    .border_t_1()
+                    .border_color(rgb(0x313244))
+                    .child(
+                        div()
+                            .id(SharedString::from(format!(
+                                "git-expand-{}-{}",
+                                node.id,
+                                row.root.display()
+                            )))
+                            .cursor_pointer()
+                            .flex()
+                            .items_center()
+                            .gap_2()
+                            .min_w_0()
+                            .text_sm()
+                            .text_color(rgb(0x89b4fa))
+                            .on_click(cx.listener(move |this, _, _, cx| {
+                                if !this.git_panel.expanded.remove(&toggle) {
+                                    this.git_panel.expanded.clear();
+                                    this.git_panel.expanded.insert(toggle.clone());
+                                }
+                                cx.notify();
+                            }))
+                            .child(div().flex_1().min_w_0().truncate().child(format!(
+                                "{} {}",
+                                if expanded { "▾" } else { "▸" },
+                                row.branch
+                            )))
+                            .when(!agents.is_empty(), |header| {
+                                header.child(
+                                    div().text_xs().flex_none().text_color(rgb(0xa6adc8)).child(
+                                        format!(
+                                            "{} {}",
+                                            agents.len(),
+                                            if agents.len() == 1 { "Agent" } else { "Agents" }
+                                        ),
+                                    ),
+                                )
+                            }),
+                    );
+                let pr = if row.pr.summary.is_empty() {
+                    if row.pr.error.is_some() {
+                        "PR unavailable"
+                    } else {
+                        "PR pending"
+                    }
+                } else if row.pr.summary == "No matching PR" {
+                    "No PR"
+                } else {
+                    &row.pr.summary
+                };
+                let summary = format!(
+                    "{} · {}{}{}",
+                    status(row),
+                    pr,
+                    if row.pr.error.is_some() {
+                        " · stale/unavailable"
+                    } else {
+                        ""
+                    },
+                    if row.pr.head.as_ref().is_some_and(|head| head != &row.head) {
+                        " · PR at different commit"
+                    } else {
+                        ""
+                    }
+                );
+                card = card.child(
+                    div()
+                        .text_xs()
+                        .text_color(rgb(if attention(row) { 0xf9e2af } else { 0xa6adc8 }))
+                        .child(summary),
+                );
+                if expanded {
+                    card = card
+                        .child(
+                            div()
+                                .mt_1()
+                                .text_xs()
+                                .text_color(rgb(0xa6adc8))
+                                .child(row.root.display().to_string()),
+                        )
+                        .child(div().text_xs().text_color(rgb(0xa6adc8)).child(format!(
+                            "{} Shells · {} {}",
+                            row.shells.len(),
+                            agents.len(),
+                            if agents.len() == 1 { "Agent" } else { "Agents" }
+                        )))
+                        .when_some(row.pr.error.clone(), |card, error| {
+                            card.child(
+                                div()
+                                    .text_xs()
+                                    .text_color(rgb(0xf9e2af))
+                                    .child(format!("PR unavailable / stale: {error}")),
+                            )
+                        });
+                    if let Some(commit) = &row.last_commit {
+                        card = card.child(div().text_xs().child(format!("Last commit: {commit}")));
+                    }
+                    if let Some(upstream) = row.status.as_ref().and_then(|s| s.upstream.as_ref()) {
+                        card = card.child(div().text_xs().child(format!("Upstream: {upstream}")));
+                    }
+                    for shell in &row.shells {
+                        let id = shell.id.clone();
+                        let local = node.local;
+                        let expected = shell.run_id.clone();
+                        card = card.child(
+                            div()
+                                .id(SharedString::from(format!(
+                                    "git-shell-{}-{}",
+                                    node.id, shell.id
+                                )))
+                                .text_xs()
+                                .text_color(rgb(0x89b4fa))
+                                .cursor(if local {
+                                    gpui::CursorStyle::PointingHand
+                                } else {
+                                    gpui::CursorStyle::Arrow
+                                })
+                                .on_click(cx.listener(move |this, _, window, cx| {
+                                    this.git_panel.search_focused = false;
+                                    if local
+                                        && this
+                                            .boomux_shells
+                                            .iter()
+                                            .any(|s| s.id == id && s.run_id == expected)
+                                    {
+                                        this.activate_sidebar_shell(&id, window, cx);
+                                    }
+                                }))
+                                .child(format!(
+                                    "{} / {} · {}{}",
+                                    shell.workspace,
+                                    shell.name,
+                                    if shell.live_cwd {
+                                        "Shell process cwd"
+                                    } else {
+                                        "launch cwd"
+                                    },
+                                    if local { "" } else { " · remote" }
+                                )),
+                        );
+                    }
+                    for association in &agents {
+                        let agent = association.agent;
+                        let shell_id = agent.shell_id.clone();
+                        let run_id = agent.run_id.clone();
+                        let local = node.local;
+                        card = card.child(
+                            div()
+                                .id(SharedString::from(format!(
+                                    "git-agent-{}-{}-{}",
+                                    node.id, agent.id, agent.run_id
+                                )))
+                                .text_xs()
+                                .cursor(if local {
+                                    gpui::CursorStyle::PointingHand
+                                } else {
+                                    gpui::CursorStyle::Arrow
+                                })
+                                .on_click(cx.listener(move |this, _, window, cx| {
+                                    if local
+                                        && this.boomux_shells.iter().any(|s| {
+                                            s.id == shell_id && s.run_id.as_deref() == Some(&run_id)
+                                        })
+                                    {
+                                        this.git_panel.search_focused = false;
+                                        this.activate_sidebar_shell(&shell_id, window, cx);
+                                    }
+                                }))
+                                .child(format!(
+                                    "{} · {} · {}{}",
+                                    agent.name,
+                                    state_label(agent.state),
+                                    age(agent.observed_at_ms),
+                                    match (
+                                        association.associated_shell,
+                                        association.observed_context
+                                    ) {
+                                        (true, true) => " · associated Shell · observed work here",
+                                        (false, true) => " · observed work here",
+                                        _ => " · associated Shell",
+                                    }
+                                )),
+                        );
+                    }
+                    if !row.branches.is_empty() {
+                        card =
+                            card.child(div().text_xs().text_color(rgb(0xa6adc8)).child(format!(
+                                "Other local branches: {}",
+                                row.branches.join(", ")
+                            )));
+                    }
+                    card = card.child(div().text_xs().text_color(rgb(0xa6adc8)).child(format!(
+                        "Git: {} · PR: {} · Upstream uses local refs",
+                        age(row.observed_at_ms),
+                        age(row.pr.observed_at_ms)
+                    )));
+                    let path = row.root.display().to_string();
+                    card = card.child(
+                        Self::settings_option(
+                            SharedString::from(format!("git-copy-{}-{}", node.id, path)),
+                            "Copy path",
+                            false,
+                        )
+                        .flex_none()
+                        .self_start()
+                        .py_1()
+                        .px_2()
+                        .border_0()
+                        .text_xs()
+                        .on_click(cx.listener(move |_, _, _, cx| {
+                            cx.write_to_clipboard(ClipboardItem::new_string(path.clone()))
+                        })),
+                    );
+                    if let Some(url) = &row.pr.url {
+                        let url = url.clone();
+                        card = card.child(
+                            Self::settings_option(
+                                SharedString::from(format!(
+                                    "git-pr-{}-{}",
+                                    node.id,
+                                    row.root.display()
+                                )),
+                                "Open PR",
+                                false,
+                            )
+                            .flex_none()
+                            .self_start()
+                            .py_1()
+                            .px_2()
+                            .border_0()
+                            .text_xs()
+                            .on_click(cx.listener(move |_, _, _, cx| cx.open_url(&url))),
+                        );
+                    }
+                }
+                repository = repository.map(|group| group.child(card));
+            }
+            if let Some(group) = repository {
+                rows.push(group.into_any_element());
+            }
+        }
+        if rows.is_empty() && !refreshing {
+            rows.push(
+                div()
+                    .text_xs()
+                    .text_color(rgb(0xa6adc8))
+                    .child("No worktrees match these filters.")
+                    .into_any_element(),
+            );
+        }
+        Some(
+            div()
+                .relative()
+                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                .w(px(self.git_panel_width(window)))
+                .h_full()
+                .min_w_0()
+                .flex_none()
+                .flex()
+                .flex_col()
+                .border_l_1()
+                .border_color(rgb(0x45475a))
+                .bg(rgb(0x181825))
+                .overflow_hidden()
+                .child(
+                    div()
+                        .id("git-resize")
+                        .absolute()
+                        .left_0()
+                        .top_0()
+                        .bottom_0()
+                        .w(px(5.0))
+                        .cursor(gpui::CursorStyle::ResizeLeftRight)
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _, _, cx| {
+                                this.git_panel.resizing = true;
+                                cx.stop_propagation();
+                            }),
+                        ),
+                )
+                .child(
+                    div()
+                        .px_3()
+                        .py_2()
+                        .flex_none()
+                        .flex()
+                        .items_center()
+                        .gap_1()
+                        .child(
+                            div()
+                                .flex_1()
+                                .flex()
+                                .items_center()
+                                .gap_2()
+                                .child("Git")
+                                .child(
+                                    div()
+                                        .id("git-refresh-indicator")
+                                        .size(px(6.0))
+                                        .flex_none()
+                                        .rounded_full()
+                                        .bg(rgb(0x89b4fa))
+                                        .opacity(if refreshing { 1.0 } else { 0.0 })
+                                        .tooltip(|_, cx| {
+                                            cx.new(|_| HeaderTooltip("Refreshing Git status"))
+                                                .into()
+                                        }),
+                                ),
+                        )
+                        .child(
+                            toolbar_button(
+                                "git-search-toggle",
+                                "Search worktrees",
+                                "⌕",
+                                self.git_panel.search_open,
+                            )
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.git_panel.search_open = !this.git_panel.search_open;
+                                this.git_panel.search_focused = this.git_panel.search_open;
+                                if !this.git_panel.search_open {
+                                    this.git_panel.search.clear();
+                                }
+                                this.git_panel.filters_open = false;
+                                cx.notify();
+                            })),
+                        )
+                        .child(
+                            toolbar_button(
+                                "git-filter-toggle",
+                                "Filter worktrees",
+                                "≡",
+                                self.git_panel.filters_open
+                                    || self.git_panel.current_workspace
+                                    || self.git_panel.needs_attention,
+                            )
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.git_panel.filters_open = !this.git_panel.filters_open;
+                                this.git_panel.search_focused = false;
+                                cx.notify();
+                            })),
+                        )
+                        .child(
+                            toolbar_button("git-refresh", "Refresh Git status", "↻", false)
+                                .on_click(
+                                    cx.listener(|this, _, _, cx| this.refresh_git_panel(true, cx)),
+                                ),
+                        )
+                        .child(
+                            toolbar_button(
+                                "git-expand-panel",
+                                "Expand or narrow panel",
+                                "↔",
+                                self.git_panel.wide,
+                            )
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.git_panel.wide = !this.git_panel.wide;
+                                this.git_panel.width = None;
+                                cx.notify();
+                            })),
+                        )
+                        .child(
+                            toolbar_button("git-close", "Close Git panel", "×", false)
+                                .on_click(cx.listener(|this, _, _, cx| this.toggle_git_panel(cx))),
+                        ),
+                )
+                .when(self.git_panel.search_open, |panel| {
+                    panel.child(
+                        div()
+                            .id("git-search")
+                            .mx_3()
+                            .mb_2()
+                            .p_2()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(rgb(if self.git_panel.search_focused {
+                                0x89b4fa
+                            } else {
+                                0x45475a
+                            }))
+                            .text_xs()
+                            .cursor_pointer()
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.git_panel.search_focused = true;
+                                cx.notify();
+                            }))
+                            .child(if self.git_panel.search.is_empty() {
+                                "Filter repository, branch, path…".into()
+                            } else {
+                                self.git_panel.search.clone()
+                            }),
+                    )
+                })
+                .child(
+                    div()
+                        .id("git-panel-scroll")
+                        .flex_1()
+                        .min_h_0()
+                        .overflow_y_scroll()
+                        .px_3()
+                        .pb_3()
+                        .flex()
+                        .flex_col()
+                        .gap_2()
+                        .children(rows),
+                )
+                .when(self.git_panel.filters_open, |panel| {
+                    panel.child(
+                        div()
+                            .absolute()
+                            .top(px(42.0))
+                            .right(px(12.0))
+                            .w(px(220.0))
+                            .p_2()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(rgb(0x45475a))
+                            .bg(rgb(0x1e1e2e))
+                            .shadow_lg()
+                            .occlude()
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .child(
+                                Self::settings_option(
+                                    "git-workspace-filter",
+                                    if self.git_panel.current_workspace {
+                                        "Current Workspace"
+                                    } else {
+                                        "All Workspaces"
+                                    },
+                                    self.git_panel.current_workspace,
+                                )
+                                .flex_none()
+                                .py_1()
+                                .text_xs()
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        this.git_panel.current_workspace =
+                                            !this.git_panel.current_workspace;
+                                        cx.notify();
+                                    },
+                                )),
+                            )
+                            .child(
+                                Self::settings_option(
+                                    "git-attention-filter",
+                                    "Needs attention",
+                                    self.git_panel.needs_attention,
+                                )
+                                .flex_none()
+                                .py_1()
+                                .text_xs()
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        this.git_panel.needs_attention =
+                                            !this.git_panel.needs_attention;
+                                        cx.notify();
+                                    },
+                                )),
+                            ),
+                    )
+                })
+                .into_any_element(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn git_panel_counts_agents_once_and_preserves_association_evidence() {
+        let shell = AgentLink {
+            id: "agent-1".into(),
+            run_id: "run-1".into(),
+            workspace_id: "workspace-1".into(),
+            observed_at_ms: 1,
+            shell_id: "shell-1".into(),
+            name: "Codex".into(),
+            state: AgentState::Working,
+            observed_context: false,
+        };
+        let context = AgentLink {
+            observed_context: true,
+            ..shell.clone()
+        };
+        for links in [
+            vec![shell.clone(), context.clone(), context.clone()],
+            vec![context.clone(), shell.clone()],
+        ] {
+            let agents = agent_associations(&links);
+            assert_eq!(agents.len(), 1);
+            assert!(agents[0].associated_shell);
+            assert!(agents[0].observed_context);
+        }
+        let links = [context];
+        let agents = agent_associations(&links);
+        assert!(!agents[0].associated_shell);
+        assert!(agents[0].observed_context);
+
+        // Same display names do not merge distinct Agents or ShellRuns.
+        let other_agent = AgentLink {
+            id: "agent-2".into(),
+            ..shell.clone()
+        };
+        let other_run = AgentLink {
+            run_id: "run-2".into(),
+            ..shell.clone()
+        };
+        assert_eq!(
+            agent_associations(&[shell, other_agent, other_run]).len(),
+            3
+        );
+    }
+}

--- a/desktop/src/layout.rs
+++ b/desktop/src/layout.rs
@@ -345,6 +345,74 @@ impl Node {
         true
     }
 
+    pub fn has_resize_edge(&self, focused: usize, edge: Direction) -> bool {
+        let Self::Split {
+            axis,
+            first,
+            second,
+            ..
+        } = self
+        else {
+            return false;
+        };
+        let in_first = first.contains(focused);
+        if !in_first && !second.contains(focused) {
+            return false;
+        }
+        let child = if in_first { first } else { second };
+        child.has_resize_edge(focused, edge)
+            || (*axis == edge.axis()
+                && in_first == matches!(edge, Direction::Right | Direction::Down))
+    }
+
+    /// Move only the divider bordering the selected edge, never an unrelated
+    /// split on the other side of the pane. Delta is a fraction of root size.
+    pub fn resize_edge_from_pointer(
+        &mut self,
+        focused: usize,
+        edge: Direction,
+        delta: f32,
+    ) -> bool {
+        self.resize_edge_in_span(focused, edge, delta, 1.0)
+    }
+
+    fn resize_edge_in_span(
+        &mut self,
+        focused: usize,
+        edge: Direction,
+        delta: f32,
+        span: f32,
+    ) -> bool {
+        let Self::Split {
+            axis,
+            ratio,
+            first,
+            second,
+        } = self
+        else {
+            return false;
+        };
+        let in_first = first.contains(focused);
+        if !in_first && !second.contains(focused) {
+            return false;
+        }
+        let child_span = if *axis == edge.axis() {
+            span * if in_first { *ratio } else { 1.0 - *ratio }
+        } else {
+            span
+        };
+        let child = if in_first { first } else { second };
+        if child.resize_edge_in_span(focused, edge, delta, child_span) {
+            return true;
+        }
+        if *axis == edge.axis() && in_first == matches!(edge, Direction::Right | Direction::Down) {
+            *ratio = (*ratio + delta / span.max(f32::EPSILON)).clamp(0.2, 0.8);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Moves the nearest matching split divider by a delta expressed as a
     /// fraction of the root layout. The divider follows the pointer regardless
     /// of which side contains the focused pane.
@@ -400,6 +468,42 @@ impl Node {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn edge_drag_selects_adjacent_divider_and_preserves_outer_edges() {
+        let mut layout = Node::pane(1);
+        layout.split(1, 2, Axis::Horizontal);
+        layout.split(2, 3, Axis::Horizontal);
+        assert!(!layout.has_resize_edge(1, Direction::Left));
+        assert!(!layout.has_resize_edge(3, Direction::Right));
+        assert!(!layout.has_resize_edge(2, Direction::Up));
+        assert!(layout.has_resize_edge(2, Direction::Left));
+        assert!(layout.has_resize_edge(2, Direction::Right));
+        assert!(!layout.resize_edge_from_pointer(1, Direction::Left, 0.1));
+        // Pane 2's left edge belongs to the outer split; its right belongs to the inner.
+        layout.resize_edge_from_pointer(2, Direction::Left, 0.1);
+        let rects = layout.rects();
+        assert!((rects.iter().find(|(id, _)| *id == 1).unwrap().1.width - 0.6).abs() < 0.001);
+        layout.resize_edge_from_pointer(2, Direction::Right, 0.05);
+        let rects = layout.rects();
+        let middle = rects.iter().find(|(id, _)| *id == 2).unwrap().1;
+        assert!((middle.x - 0.6).abs() < 0.001);
+        assert!((middle.width - 0.25).abs() < 0.001);
+        layout.resize_edge_from_pointer(2, Direction::Right, 100.0);
+        assert!(layout.rects().iter().all(|(_, rect)| rect.width > 0.0));
+    }
+
+    #[test]
+    fn edge_drag_moves_vertical_divider_from_either_side() {
+        let mut above = Node::pane(1);
+        above.split(1, 2, Axis::Vertical);
+        let mut below = above.clone();
+        above.resize_edge_from_pointer(1, Direction::Down, 0.1);
+        below.resize_edge_from_pointer(2, Direction::Up, 0.1);
+        assert_eq!(format!("{above:?}"), format!("{below:?}"));
+        assert!(!above.has_resize_edge(1, Direction::Up));
+        assert!(!above.has_resize_edge(2, Direction::Down));
+    }
 
     fn sample() -> Node {
         Node::Split {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,6 +1,7 @@
 mod boomux_settings;
 mod bundle_update;
 mod generated_names;
+mod git_panel;
 mod harness_integrations;
 mod layout;
 mod layout_badge;
@@ -90,6 +91,45 @@ fn sidebar_header_button(
         .child(glyph)
 }
 
+fn git_branch_icon(active: bool) -> Div {
+    let color = rgb(if active { 0xcba6f7 } else { 0xa6adc8 });
+    div()
+        .relative()
+        .size(px(18.0))
+        .child(
+            div()
+                .absolute()
+                .left(px(3.0))
+                .top(px(4.0))
+                .w(px(2.0))
+                .h(px(11.0))
+                .bg(color),
+        )
+        .child(
+            div()
+                .absolute()
+                .left(px(4.0))
+                .top(px(4.0))
+                .w(px(10.0))
+                .h(px(7.0))
+                .border_b_2()
+                .border_r_2()
+                .rounded_br(px(4.0))
+                .border_color(color),
+        )
+        .children([(1.0, 0.0), (1.0, 12.0), (10.0, 0.0)].map(|(x, y)| {
+            div()
+                .absolute()
+                .left(px(x))
+                .top(px(y))
+                .size(px(6.0))
+                .rounded_full()
+                .border_2()
+                .border_color(color)
+                .bg(rgb(0x181825))
+        }))
+}
+
 fn sidebar_menu_row(id: &'static str) -> Stateful<Div> {
     div()
         .id(id)
@@ -145,6 +185,7 @@ actions!(
         ToggleSidebarDrawer,
         ToggleSidebarFocus,
         ToggleHelp,
+        ToggleGitPanel,
         RenameResource,
         RemoveShell,
         CopySelection,
@@ -260,6 +301,11 @@ const KEY_TOGGLE_LAYOUT_MODE: &str = "ctrl-space";
 const LAYOUT_LEADER_PASSTHROUGH_WINDOW: Duration = Duration::from_millis(500);
 
 const HELP_SHORTCUTS: &[ShortcutSpec] = &[
+    ShortcutSpec {
+        section: ShortcutSection::Navigation,
+        keys: "Layout: G",
+        description: "Toggle Git branches and worktrees panel",
+    },
     ShortcutSpec {
         section: ShortcutSection::General,
         keys: "F1",
@@ -685,6 +731,8 @@ struct WorkspaceTransition {
 enum PointerOperation {
     Move,
     Resize,
+    ResizeEdge(Direction),
+    ResizeCorner(Direction, Direction),
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -944,6 +992,45 @@ fn dragged_bounds(
         PointerOperation::Move => {
             bounds.x = (bounds.x + delta.0).clamp(0.0, (panel_size.0 - bounds.width).max(0.0));
             bounds.y = (bounds.y + delta.1).clamp(0.0, (panel_size.1 - bounds.height).max(0.0));
+        }
+        PointerOperation::ResizeCorner(horizontal, vertical) => {
+            bounds = dragged_bounds(
+                bounds,
+                PointerOperation::ResizeEdge(horizontal),
+                delta,
+                panel_size,
+            );
+            bounds = dragged_bounds(
+                bounds,
+                PointerOperation::ResizeEdge(vertical),
+                delta,
+                panel_size,
+            );
+        }
+        PointerOperation::ResizeEdge(edge) => {
+            let right = bounds.x + bounds.width;
+            let bottom = bounds.y + bounds.height;
+            match edge {
+                Direction::Left => {
+                    bounds.x = (bounds.x + delta.0).clamp(0.0, (right - MIN_FLOAT_WIDTH).max(0.0));
+                    bounds.width = right - bounds.x;
+                }
+                Direction::Up => {
+                    bounds.y =
+                        (bounds.y + delta.1).clamp(0.0, (bottom - MIN_FLOAT_HEIGHT).max(0.0));
+                    bounds.height = bottom - bounds.y;
+                }
+                Direction::Right => {
+                    let available = (panel_size.0 - bounds.x).max(0.0);
+                    bounds.width =
+                        (bounds.width + delta.0).clamp(MIN_FLOAT_WIDTH.min(available), available);
+                }
+                Direction::Down => {
+                    let available = (panel_size.1 - bounds.y).max(0.0);
+                    bounds.height =
+                        (bounds.height + delta.1).clamp(MIN_FLOAT_HEIGHT.min(available), available);
+                }
+            }
         }
         PointerOperation::Resize => {
             let available_width = (panel_size.0 - bounds.x).max(0.0);
@@ -1336,6 +1423,7 @@ fn desktop_window_title(workspace_name: Option<&str>) -> String {
 }
 
 struct Workspace {
+    git_panel: git_panel::Model,
     layout: Option<Node>,
     floating: Vec<FloatingPane>,
     pointer_drag: Option<PointerDrag>,
@@ -1370,6 +1458,9 @@ struct Workspace {
     selected_node: Option<String>,
     resource_dialog: Option<ResourceDialog>,
     sidebar_visible: bool,
+    sidebar_preferred_width: f32,
+    sidebar_viewport_width: f32,
+    sidebar_resizing: bool,
     drawer_animation_from: Option<f32>,
     drawer_animation_generation: u64,
     pane_headings_visible: bool,
@@ -1507,6 +1598,7 @@ impl Workspace {
         let mut workspace = Self {
             layout: Some(layout),
             floating: Vec::new(),
+            git_panel: git_panel::Model::default(),
             pointer_drag: None,
             terminal_scrollbar_drag: None,
             layout_animation: None,
@@ -1543,6 +1635,9 @@ impl Workspace {
             selected_node: None,
             resource_dialog: None,
             sidebar_visible: saved.sidebar_visible,
+            sidebar_preferred_width: saved.sidebar_width,
+            sidebar_viewport_width: f32::from(window.viewport_size().width),
+            sidebar_resizing: false,
             drawer_animation_from: None,
             drawer_animation_generation: 0,
             pane_headings_visible: saved.pane_headings_visible,
@@ -1636,6 +1731,7 @@ impl Workspace {
             let _ = writer.force_send(settings::Settings {
                 onboarding_complete: self.onboarding_complete,
                 sidebar_visible: self.sidebar_visible,
+                sidebar_width: self.sidebar_preferred_width,
                 pane_headings_visible: self.pane_headings_visible,
                 pane_corner_style: self.pane_corner_style,
                 pane_gap: self.pane_gap,
@@ -2284,6 +2380,7 @@ impl Workspace {
     }
 
     fn focus_terminal_pane(&mut self, pane_id: usize, window: &mut Window, cx: &mut Context<Self>) {
+        self.git_panel.search_focused = false;
         if !self.terminals.contains_key(&pane_id) {
             return;
         }
@@ -2630,6 +2727,7 @@ impl Workspace {
     }
 
     fn toggle_settings(&mut self, cx: &mut Context<Self>) {
+        self.git_panel.search_focused = false;
         self.sidebar_header_menu_open = false;
         if self.settings_open {
             self.close_settings(cx);
@@ -3353,7 +3451,11 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.pointer_drag.is_some() || self.terminal_scrollbar_drag.is_some() {
+        if self.pointer_drag.is_some()
+            || self.terminal_scrollbar_drag.is_some()
+            || self.sidebar_resizing
+            || self.git_panel.resizing
+        {
             return;
         }
 
@@ -3416,8 +3518,9 @@ impl Workspace {
     }
 
     fn sidebar_width(&self) -> f32 {
-        if self.sidebar_visible {
-            SIDEBAR_WIDTH
+        if self.sidebar_visible && !(self.git_panel.open && self.git_panel.compact) {
+            self.sidebar_preferred_width
+                .min((self.sidebar_viewport_width - 240.0).max(0.0))
         } else {
             0.0
         }
@@ -3431,7 +3534,8 @@ impl Workspace {
             0.0
         };
         (
-            (f32::from(viewport.width) - self.sidebar_width()).max(0.0),
+            (f32::from(viewport.width) - self.sidebar_width() - self.git_panel_width(window))
+                .max(0.0),
             (f32::from(viewport.height) - tab_bar_height).max(0.0),
         )
     }
@@ -3651,6 +3755,7 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.git_panel.search_focused = false;
         self.floating_animation = None;
         self.focused = id;
         self.raise_floating_pane(id);
@@ -3672,7 +3777,12 @@ impl Workspace {
         event: &MouseDownEvent,
         cx: &mut Context<Self>,
     ) {
-        if matches!(operation, PointerOperation::Resize) {
+        if matches!(
+            operation,
+            PointerOperation::Resize
+                | PointerOperation::ResizeEdge(_)
+                | PointerOperation::ResizeCorner(_, _)
+        ) {
             self.layout_animation = None;
         }
         let subject = self.pointer_subject(id);
@@ -3707,7 +3817,11 @@ impl Workspace {
             return;
         }
         // Keep the dragged pane focused even while it crosses other panes.
-        if self.pointer_drag.is_some() || self.terminal_scrollbar_drag.is_some() {
+        if self.pointer_drag.is_some()
+            || self.terminal_scrollbar_drag.is_some()
+            || self.sidebar_resizing
+            || self.git_panel.resizing
+        {
             return;
         }
         if self.navigation_region == NavigationRegion::Sidebar
@@ -3985,6 +4099,31 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.sidebar_resizing {
+            if event.pressed_button == Some(MouseButton::Left) {
+                self.sidebar_preferred_width = f32::from(event.position.x).clamp(280.0, 600.0);
+            } else {
+                self.sidebar_resizing = false;
+                self.save_settings();
+            }
+            cx.notify();
+            cx.stop_propagation();
+            return;
+        }
+        if self.git_panel.resizing {
+            if event.pressed_button == Some(MouseButton::Left) {
+                self.git_panel.width = Some(
+                    (f32::from(window.viewport_size().width) - f32::from(event.position.x))
+                        .clamp(280.0, 900.0),
+                );
+            } else {
+                self.git_panel.resizing = false;
+            }
+            cx.notify();
+            cx.stop_propagation();
+            return;
+        }
+
         if let Some(drag) = self.terminal_scrollbar_drag.clone() {
             if event.pressed_button != Some(MouseButton::Left) {
                 self.terminal_scrollbar_drag = None;
@@ -4056,6 +4195,29 @@ impl Workspace {
             }
             PointerSubject::Tiled(start_layout) => match drag.operation {
                 PointerOperation::Move => unreachable!("tiled moves are lifted before dragging"),
+                PointerOperation::ResizeCorner(horizontal, vertical) => {
+                    let mut layout = start_layout;
+                    layout.resize_edge_from_pointer(
+                        drag.pane_id,
+                        horizontal,
+                        dx / panel_width.max(1.0),
+                    );
+                    layout.resize_edge_from_pointer(
+                        drag.pane_id,
+                        vertical,
+                        dy / panel_height.max(1.0),
+                    );
+                    self.layout = Some(layout);
+                }
+                PointerOperation::ResizeEdge(edge) => {
+                    let mut layout = start_layout;
+                    let delta = match edge {
+                        Direction::Left | Direction::Right => dx / panel_width.max(1.0),
+                        Direction::Up | Direction::Down => dy / panel_height.max(1.0),
+                    };
+                    layout.resize_edge_from_pointer(drag.pane_id, edge, delta);
+                    self.layout = Some(layout);
+                }
                 PointerOperation::Resize => {
                     self.layout = Some(resized_tiled_layout(
                         start_layout,
@@ -4075,6 +4237,20 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.sidebar_resizing {
+            self.sidebar_resizing = false;
+            self.save_settings();
+            cx.notify();
+            cx.stop_propagation();
+            return;
+        }
+        if self.git_panel.resizing {
+            self.git_panel.resizing = false;
+            cx.notify();
+            cx.stop_propagation();
+            return;
+        }
+
         if let Some(drag) = self.terminal_scrollbar_drag.take() {
             if let Some(pane) = self.terminals.get_mut(&drag.pane_id)
                 && !pane.scrollbar_hovered
@@ -4436,6 +4612,29 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.git_panel.search_focused {
+            match event.keystroke.key.as_str() {
+                "escape" | "enter" => self.git_panel.search_focused = false,
+                "backspace" => {
+                    self.git_panel.search.pop();
+                }
+                _ if !event.keystroke.modifiers.control
+                    && !event.keystroke.modifiers.platform
+                    && !event.keystroke.modifiers.alt =>
+                {
+                    if let Some(text) = &event.keystroke.key_char
+                        && self.git_panel.search.len() + text.len() <= 256
+                    {
+                        self.git_panel.search.push_str(text);
+                    }
+                }
+                _ => (),
+            }
+            cx.stop_propagation();
+            cx.notify();
+            return;
+        }
+
         if self.nodes_open {
             let modifiers = event.keystroke.modifiers;
             if modifiers.control
@@ -5538,6 +5737,7 @@ impl Workspace {
     }
 
     fn open_nodes(&mut self, cx: &mut Context<Self>) {
+        self.git_panel.search_focused = false;
         self.sidebar_header_menu_open = false;
         self.sidebar_menu = None;
         self.nodes_open = true;
@@ -5738,8 +5938,10 @@ impl Workspace {
     fn sidebar(&self, cx: &mut Context<Self>) -> Div {
         let header_menu = self.sidebar_header_menu(cx);
         let settings_panel = self.settings_overlay(cx);
-        let (workspaces, agents) =
-            sidebar_render_sources(&self.boomux_overview, self.settings_open);
+        let (workspaces, agents) = sidebar_render_sources(
+            &self.boomux_overview,
+            self.settings_open || self.git_panel.compact,
+        );
         let focused_shell_id = self
             .terminals
             .get(&self.focused)
@@ -6059,7 +6261,7 @@ impl Workspace {
 
         div()
             .relative()
-            .w(px(SIDEBAR_WIDTH))
+            .w(px(self.sidebar_width()))
             .h_full()
             .flex_none()
             .flex()
@@ -6168,6 +6370,21 @@ impl Workspace {
                                         cx.stop_propagation();
                                         this.sidebar_header_menu_open = false;
                                         this.create_and_attach_new_workspace(window, cx);
+                                    },
+                                )),
+                            )
+                            .child(
+                                sidebar_header_button(
+                                    "toggle-git-panel",
+                                    "Git branches and worktrees · Ctrl+Space, G",
+                                    "",
+                                    self.git_panel.open,
+                                )
+                                .child(git_branch_icon(self.git_panel.open))
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        cx.stop_propagation();
+                                        this.toggle_git_panel(cx);
                                     },
                                 )),
                             )
@@ -6283,7 +6500,7 @@ impl Workspace {
                 .id("sidebar-resource-menu")
                 .absolute()
                 .occlude()
-                .left(px(SIDEBAR_WIDTH - 188.0))
+                .left(px((self.sidebar_width() - 188.0).max(0.0)))
                 .top(px(menu.top))
                 .w(px(178.0))
                 .p_1()
@@ -6419,7 +6636,7 @@ impl Workspace {
             .left_0()
             .top(px(64.0))
             .bottom_0()
-            .w(px(SIDEBAR_WIDTH))
+            .w(px(self.sidebar_width()))
             .min_h_0()
             .p_4()
             .flex()
@@ -8175,6 +8392,143 @@ impl Workspace {
             .into_any_element()
     }
 
+    fn pane_resize_handles(&self, id: usize, cx: &mut Context<Self>) -> Vec<gpui::AnyElement> {
+        if self.fullscreen == Some(id) || self.workspace_transition.is_some() {
+            return Vec::new();
+        }
+        let floating = self.floating.iter().any(|pane| pane.id == id);
+        let mut handles = [
+            Direction::Left,
+            Direction::Right,
+            Direction::Up,
+            Direction::Down,
+        ]
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, edge)| {
+            if !floating
+                && !self
+                    .layout
+                    .as_ref()
+                    .is_some_and(|layout| layout.has_resize_edge(id, edge))
+            {
+                return None;
+            }
+            let handle = div()
+                .id(SharedString::from(format!("pane-resize-{id}-{index}")))
+                .absolute()
+                .occlude()
+                .hover(|handle| handle.bg(rgb(0x89b4fa)))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, event, window, cx| {
+                        this.begin_pointer_interaction_focus(id, window, cx);
+                        this.start_pointer_drag(id, PointerOperation::ResizeEdge(edge), event, cx);
+                    }),
+                )
+                .on_mouse_move(cx.listener(Self::on_pointer_move))
+                .on_mouse_up(
+                    MouseButton::Left,
+                    cx.listener(Self::end_pointer_interaction),
+                );
+            Some(
+                match edge {
+                    Direction::Left => handle
+                        .left_0()
+                        .top_0()
+                        .bottom_0()
+                        .w(px(4.0))
+                        .cursor(gpui::CursorStyle::ResizeLeftRight),
+                    Direction::Right => handle
+                        .right_0()
+                        .top_0()
+                        .bottom_0()
+                        .w(px(4.0))
+                        .cursor(gpui::CursorStyle::ResizeLeftRight),
+                    Direction::Up => handle
+                        .top_0()
+                        .left_0()
+                        .right_0()
+                        .h(px(4.0))
+                        .cursor(gpui::CursorStyle::ResizeUpDown),
+                    Direction::Down => handle
+                        .bottom_0()
+                        .left_0()
+                        .right_0()
+                        .h(px(4.0))
+                        .cursor(gpui::CursorStyle::ResizeUpDown),
+                }
+                .into_any_element(),
+            )
+        })
+        .collect::<Vec<_>>();
+        // Paint corner hitboxes after side handles so diagonal dragging wins
+        // where the two side targets meet.
+        for (index, (horizontal, vertical)) in [
+            (Direction::Left, Direction::Up),
+            (Direction::Right, Direction::Up),
+            (Direction::Left, Direction::Down),
+            (Direction::Right, Direction::Down),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if !floating
+                && !self.layout.as_ref().is_some_and(|layout| {
+                    layout.has_resize_edge(id, horizontal) && layout.has_resize_edge(id, vertical)
+                })
+            {
+                continue;
+            }
+            let handle = div()
+                .id(SharedString::from(format!(
+                    "pane-corner-resize-{id}-{index}"
+                )))
+                .absolute()
+                .size(px(12.0))
+                .occlude()
+                .cursor(
+                    if matches!(
+                        (horizontal, vertical),
+                        (Direction::Left, Direction::Up) | (Direction::Right, Direction::Down)
+                    ) {
+                        gpui::CursorStyle::ResizeUpLeftDownRight
+                    } else {
+                        gpui::CursorStyle::ResizeUpRightDownLeft
+                    },
+                )
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, event, window, cx| {
+                        this.begin_pointer_interaction_focus(id, window, cx);
+                        this.start_pointer_drag(
+                            id,
+                            PointerOperation::ResizeCorner(horizontal, vertical),
+                            event,
+                            cx,
+                        );
+                    }),
+                )
+                .on_mouse_move(cx.listener(Self::on_pointer_move))
+                .on_mouse_up(
+                    MouseButton::Left,
+                    cx.listener(Self::end_pointer_interaction),
+                );
+            let handle = if horizontal == Direction::Left {
+                handle.left_0()
+            } else {
+                handle.right_0()
+            };
+            let handle = if vertical == Direction::Up {
+                handle.top_0()
+            } else {
+                handle.bottom_0()
+            };
+            handles.push(handle.into_any_element());
+        }
+        handles
+    }
+
     fn pane(&self, id: usize, cx: &mut Context<Self>) -> Stateful<Div> {
         self.pane_with_heading(id, self.pane_headings_visible, cx)
     }
@@ -8211,6 +8565,7 @@ impl Workspace {
 
         div()
             .id(("pane", id))
+            .relative()
             .size_full()
             .flex()
             .flex_col()
@@ -8462,6 +8817,7 @@ impl Workspace {
                         },
                     ),
             )
+            .children(self.pane_resize_handles(id, cx))
     }
 
     fn minimized_tab_strip(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
@@ -8667,6 +9023,9 @@ impl Workspace {
 
 impl Render for Workspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.sidebar_viewport_width = f32::from(window.viewport_size().width);
+        self.git_panel.compact =
+            self.git_panel.open && f32::from(window.viewport_size().width) < 1000.0;
         let workspace_name = self
             .terminals
             .get(&self.focused)
@@ -8911,7 +9270,39 @@ impl Render for Workspace {
             );
 
         let target_drawer_width = self.sidebar_width();
-        let sidebar = self.sidebar(cx);
+        let sidebar = div()
+            .relative()
+            .h_full()
+            .w(px(target_drawer_width))
+            .child(self.sidebar(cx))
+            .when(target_drawer_width > 0.0, |sidebar| {
+                sidebar.child(
+                    div()
+                        .id("sidebar-resize")
+                        .absolute()
+                        .right_0()
+                        .top_0()
+                        .bottom_0()
+                        .w(px(5.0))
+                        .occlude()
+                        .cursor(gpui::CursorStyle::ResizeLeftRight)
+                        .hover(|handle| handle.bg(rgb(0x89b4fa)))
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _, _, cx| {
+                                this.sidebar_resizing = true;
+                                this.drawer_animation_from = None;
+                                this.git_panel.search_focused = false;
+                                cx.stop_propagation();
+                            }),
+                        )
+                        .on_mouse_move(cx.listener(Self::on_pointer_move))
+                        .on_mouse_up(
+                            MouseButton::Left,
+                            cx.listener(Self::end_pointer_interaction),
+                        ),
+                )
+            });
         let drawer = if let Some(from) = self.drawer_animation_from {
             let animation_id = SharedString::from(format!(
                 "sidebar-drawer-{}",
@@ -8941,11 +9332,13 @@ impl Render for Workspace {
                 .into_any_element()
         };
 
+        let git_panel = self.render_git_panel(window, cx);
         let content = div()
             .size_full()
             .flex()
             .child(drawer)
             .child(terminal_area)
+            .when_some(git_panel, |element, panel| element.child(panel))
             .into_any_element();
         let sidebar_menu = self.sidebar_menu_overlay(cx);
         let nodes_panel = self.nodes_panel(cx);
@@ -8958,6 +9351,7 @@ impl Render for Workspace {
             .track_focus(&self.focus_handle)
             .key_context(
                 if self.nodes_open
+                    || self.git_panel.search_focused
                     || self.boomux_setting_input.is_some()
                     || self.settings_restart_confirm
                 {
@@ -9005,6 +9399,7 @@ impl Render for Workspace {
             .on_action(cx.listener(Self::toggle_sidebar_drawer))
             .on_action(cx.listener(Self::toggle_sidebar_focus))
             .on_action(cx.listener(Self::toggle_help))
+            .on_action(cx.listener(|this, _: &ToggleGitPanel, _, cx| this.toggle_git_panel(cx)))
             .on_action(cx.listener(Self::rename_resource))
             .on_action(cx.listener(Self::remove_shell))
             .on_action(cx.listener(Self::copy_selection))
@@ -9489,6 +9884,8 @@ fn main() {
             KeyBinding::new(KEY_DETACH_PANE, ClosePane, Some("Layout")),
             KeyBinding::new(KEY_DETACH_PANE, ClosePane, Some("Sidebar")),
             KeyBinding::new(KEY_DETACH_PANE, ClosePane, Some("SidebarLayout")),
+            KeyBinding::new("g", ToggleGitPanel, Some("Layout")),
+            KeyBinding::new("g", ToggleGitPanel, Some("SidebarLayout")),
             KeyBinding::new(KEY_TOGGLE_HELP, ToggleHelp, Some("Terminal")),
             KeyBinding::new(KEY_TOGGLE_HELP, ToggleHelp, Some("Layout")),
             KeyBinding::new(KEY_TOGGLE_HELP, ToggleHelp, Some("Sidebar")),
@@ -9669,6 +10066,96 @@ mod pointer_tests {
         }
     }
     use boomux::protocol::{AgentState, ShellStatus};
+
+    #[test]
+    fn corner_drag_resizes_both_axes_and_preserves_opposite_corner() {
+        for (horizontal, vertical, expected) in [
+            (Direction::Left, Direction::Up, (130.0, 140.0, 370.0, 260.0)),
+            (
+                Direction::Right,
+                Direction::Up,
+                (100.0, 140.0, 430.0, 260.0),
+            ),
+            (
+                Direction::Left,
+                Direction::Down,
+                (130.0, 100.0, 370.0, 340.0),
+            ),
+            (
+                Direction::Right,
+                Direction::Down,
+                (100.0, 100.0, 430.0, 340.0),
+            ),
+        ] {
+            let start = FloatingPane {
+                id: 1,
+                x: 100.0,
+                y: 100.0,
+                width: 400.0,
+                height: 300.0,
+            };
+            let result = dragged_bounds(
+                start,
+                PointerOperation::ResizeCorner(horizontal, vertical),
+                (30.0, 40.0),
+                (1000.0, 800.0),
+            );
+            assert_eq!((result.x, result.y, result.width, result.height), expected);
+        }
+    }
+
+    #[test]
+    fn edge_drag_floating_keeps_opposite_edge_fixed_and_bounds_size() {
+        let start = FloatingPane {
+            id: 1,
+            x: 100.0,
+            y: 100.0,
+            width: 400.0,
+            height: 300.0,
+        };
+        let left = dragged_bounds(
+            start.clone(),
+            PointerOperation::ResizeEdge(Direction::Left),
+            (50.0, 20.0),
+            (1000.0, 800.0),
+        );
+        assert_eq!(
+            (left.x, left.width, left.y, left.height),
+            (150.0, 350.0, 100.0, 300.0)
+        );
+        let top = dragged_bounds(
+            start.clone(),
+            PointerOperation::ResizeEdge(Direction::Up),
+            (20.0, 50.0),
+            (1000.0, 800.0),
+        );
+        assert_eq!(
+            (top.y, top.height, top.x, top.width),
+            (150.0, 250.0, 100.0, 400.0)
+        );
+        let minimum = dragged_bounds(
+            start.clone(),
+            PointerOperation::ResizeEdge(Direction::Left),
+            (1000.0, 0.0),
+            (1000.0, 800.0),
+        );
+        assert_eq!(minimum.width, MIN_FLOAT_WIDTH);
+        assert_eq!(minimum.x + minimum.width, 500.0);
+        let right = dragged_bounds(
+            start.clone(),
+            PointerOperation::ResizeEdge(Direction::Right),
+            (1000.0, 0.0),
+            (1000.0, 800.0),
+        );
+        assert_eq!((right.x, right.width), (100.0, 900.0));
+        let bottom = dragged_bounds(
+            start,
+            PointerOperation::ResizeEdge(Direction::Down),
+            (0.0, 1000.0),
+            (1000.0, 800.0),
+        );
+        assert_eq!((bottom.y, bottom.height), (100.0, 700.0));
+    }
 
     fn pane() -> FloatingPane {
         FloatingPane {

--- a/desktop/src/settings.rs
+++ b/desktop/src/settings.rs
@@ -12,6 +12,7 @@ pub struct Settings {
     pub dismissed_boomux_update: String,
     pub settings_restart_pending: bool,
     pub sidebar_visible: bool,
+    pub sidebar_width: f32,
     pub pane_headings_visible: bool,
     pub pane_corner_style: PaneCornerStyle,
     pub pane_gap: f32,
@@ -29,6 +30,7 @@ impl Default for Settings {
             dismissed_boomux_update: String::new(),
             settings_restart_pending: false,
             sidebar_visible: true,
+            sidebar_width: crate::SIDEBAR_WIDTH,
             pane_headings_visible: true,
             pane_corner_style: PaneCornerStyle::Rounded,
             pane_gap: 8.0,
@@ -98,6 +100,16 @@ impl Settings {
                 "confirm_destructive_actions" => {
                     s.confirm_destructive_actions = value.as_bool().ok_or_else(invalid)?
                 }
+                "sidebar_width" => {
+                    let n = value
+                        .as_float()
+                        .or_else(|| value.as_integer().map(|n| n as f64))
+                        .ok_or_else(invalid)?;
+                    if !n.is_finite() || !(280.0..=600.0).contains(&n) {
+                        return Err(invalid());
+                    }
+                    s.sidebar_width = n as f32;
+                }
                 "pane_gap" => {
                     let n = value
                         .as_float()
@@ -155,8 +167,9 @@ impl Settings {
     }
     fn encode(&self) -> String {
         format!(
-            "# Boomux Desktop preferences; shared Boomux configuration is separate.\nsidebar_visible = {}\npane_headings_visible = {}\npane_corner_style = \"{}\"\npane_gap = {}\nfocus_highlight_strength = {}\nmotion_speed = \"{}\"\nworkspace_pane_mode = \"{}\"\npane_layout_mode = \"{}\"\nconfirm_destructive_actions = {}\nonboarding_complete = {}\nsettings_restart_pending = {}\ndismissed_desktop_update = \"{}\"\ndismissed_boomux_update = \"{}\"\n",
+            "# Boomux Desktop preferences; shared Boomux configuration is separate.\nsidebar_visible = {}\nsidebar_width = {}\npane_headings_visible = {}\npane_corner_style = \"{}\"\npane_gap = {}\nfocus_highlight_strength = {}\nmotion_speed = \"{}\"\nworkspace_pane_mode = \"{}\"\npane_layout_mode = \"{}\"\nconfirm_destructive_actions = {}\nonboarding_complete = {}\nsettings_restart_pending = {}\ndismissed_desktop_update = \"{}\"\ndismissed_boomux_update = \"{}\"\n",
             self.sidebar_visible,
+            self.sidebar_width,
             self.pane_headings_visible,
             match self.pane_corner_style {
                 PaneCornerStyle::Rounded => "rounded",
@@ -233,6 +246,22 @@ pub fn writer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn edge_drag_sidebar_width_round_trips_and_rejects_invalid_values() {
+        let settings = Settings {
+            sidebar_width: 440.0,
+            ..Settings::default()
+        };
+        assert_eq!(Settings::parse(&settings.encode()).unwrap(), settings);
+        assert_eq!(
+            Settings::parse("").unwrap().sidebar_width,
+            crate::SIDEBAR_WIDTH
+        );
+        for value in ["279", "601", "nan", "inf", "'wide'"] {
+            assert!(Settings::parse(&format!("sidebar_width = {value}")).is_err());
+        }
+    }
+
     #[test]
     fn update_dismissals_round_trip_independently() {
         let settings = Settings {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,7 @@
 | `src/process_adapter.rs` | Exact-argv child supervision and fail-open process-bound Agent observation |
 | `src/config.rs` | Layered configuration resolution, bounded validation, and transactional active-layer editing |
 | `src/workspace_selection.rs` | Owner-only local CLI Workspace selection, validation, locking, and atomic persistence |
+| `src/git_work.rs` | Bounded owner-local Git worktree discovery, Shell/Agent associations, disposable status cache, and GitHub PR observations |
 | `src/projects.rs`, `src/git.rs` | Bounded project discovery and asynchronous Git metadata |
 | `src/cli_output.rs` | Stable `boomux.cli/v1` output and error presentation |
 | `src/desktop_notifications.rs` | Bounded fail-open desktop and sound delivery |
@@ -256,6 +257,15 @@ event readers filter that event while retaining cursor progress. Coordinator
 Workspace schema 8 explicitly migrates schema 7 with empty pending and completed
 default-cwd operation ledgers. Owner state schema 14 and handoff generation 8 are
 unchanged because owner Workspaces already persist `default_cwd`.
+Protocol 53 adds `git_work_overview`: a read-only `GitOverview` host-service
+operation and result, available locally and through verified Node routing.
+The owner discovers repositories from managed Shells and observed Agent contexts,
+inspects Git in bounded background work, and returns disposable cached metadata.
+It does not alter durable Shell cwd, Agent authority, Git refs, or persistence.
+Requests require version 53, including the nested routed operation; older clients
+continue to use their existing snapshots without new unsolicited fields.
+See [Desktop Git panel](desktop/git-panel.md) for status and cache semantics.
+
 Protocol 52 adds `restart_executable` and `RestartWithExecutable` for graceful
 handoff to an explicit release path. The daemon pins a validated ELF inode before
 quiescence and executes it through a close-on-exec descriptor, preserving H8

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -45,6 +45,8 @@ badge’s single cancelable exit task; it does not delay restoring input.
 - `src/terminal.rs`: Boomux discovery/attachment adapter, per-pane terminal
   worker, Ghostty VT state, scrollback, key/paste encoding, and Kitty graphics
   extraction.
+- `src/git_panel.rs`: demand-driven Node Git overview, filtering, resizable panel,
+  and exact local Shell navigation; see [Git panel](git-panel.md).
 - `src/nodes.rs`: read-only Node identity, health, and resource-count presentation
   from the daemon's combined snapshot.
 - `src/boomux_settings.rs`: active-layer settings editor and bounded CLI bridge;
@@ -299,3 +301,21 @@ remain visible and retryable. The update worker serializes operations, bounds
 process lifetime/output, and never starts per-pane tasks. Existing independent
 CLI binaries remain outside its install ownership. A daemon from a different
 executable gets a finish-installation reminder after launching a new bundle.
+
+## Edge Resizing
+
+The sidebar exposes a five-pixel right-edge handle. Its preferred width is bounded
+to 280–600 logical pixels and stored in Desktop preferences when dragging ends;
+older preference files retain the 300-pixel default. The displayed width also
+reserves terminal canvas space on narrow windows. Sidebar content, Settings,
+menus, and terminal pointer coordinates use the same effective width.
+
+Pane edge handles reuse the existing pointer-drag lifecycle. Floating left/top
+resizes preserve the opposite edge, while right/bottom resizes preserve the
+origin; all respect canvas bounds and minimum sizes. Tiled handles exist only
+where a split borders the selected edge. Direction-aware tree traversal selects
+that divider and converts root-relative movement into its local split span.
+Twelve-pixel corner targets paint above side handles and resize both axes with
+diagonal cursors. Tiled corner targets require adjoining dividers on both axes.
+Maximized and transitioning panes omit edge handles. Terminal body selection
+and Ctrl-drag behavior retain their existing input paths.

--- a/docs/desktop/git-panel.md
+++ b/docs/desktop/git-panel.md
@@ -1,0 +1,116 @@
+# Git panel
+
+Boomux Desktop's Git panel shows repositories discovered from managed Shells and
+active Agent working-context observations. Open it with the branch icon beside
+Settings in the sidebar header or press
+`Ctrl+Space`, then `G`. It is a resizable sibling of the terminal canvas; opening,
+resizing, filtering, and closing it do not replace terminal entities or mutate
+Shells, Agents, worktrees, branches, or repositories. In windows narrower than
+1000 logical pixels, the ordinary sidebar temporarily yields its space to the
+Git panel so the terminal canvas remains usable. Closing Git restores the sidebar
+according to its existing preference.
+
+Each repository has one shared container per owning Node, with compact worktree
+rows separated by subtle dividers. Rows show the branch, Agent count, local Git
+status, upstream comparison, and GitHub PR/check/review status. Expand a row for
+the full path, Shell navigation, individual Agent associations, the last commit,
+other local branches, observation ages,
+copy-path, and open-PR actions. Untracked directories count as one entry rather
+than enumerating every file inside them. Search matches repository, branch,
+path, and Workspace name. Filters cover the current Workspace and work needing
+attention. The compact icon toolbar reveals search on demand and opens filters
+in an overlay; active filters highlight their toolbar button. Hiding search
+clears its query. Refresh activity stays in the header without shifting rows.
+Only one worktree row expands at a time.
+
+## Associations and authority
+
+The Git host service starts with each Shell's stored launch cwd. On Linux, the
+owning daemon can instead observe the cwd of its exact current managed process
+under the Shell lifecycle and process locks, checking that it has not exited
+before and after reading `/proc/<pid>/cwd`. This follows ordinary `cd` in the
+managed shell. It does not inspect descendant process trees, interpret an SSH
+session's remote directory, or infer an Agent's cwd. Subshells can have a
+different cwd; the UI therefore labels this source **Shell process cwd**.
+Unavailable process observations fall back to explicitly labeled **launch cwd**.
+Neither observation rewrites the Shell's durable launch directory.
+
+Active Agent associations require the exact current ShellRun. The panel shows
+an Agent's Shell association separately from its structured, bounded observed
+working contexts. Each Agent/ShellRun appears once per worktree, with both sources
+listed together when they refer to the same worktree. An observed context is historical evidence of work there, not
+proof that the Agent is currently modifying that repository. Inactive and Done
+Agents do not decorate current work. Git state never changes Agent lifecycle.
+
+Repositories are grouped by canonical Git common directory on their owning
+Node. Registered sibling worktrees are discovered with `git worktree list`,
+including ones without a managed Shell. Discovery is seeded by managed work;
+there is no whole-machine scan or permanent repository registry. A repository
+with no remaining Shell/active Agent association leaves the overview on refresh.
+
+## Status semantics
+
+- **Clean** describes only the working tree. It does not mean pushed or merged.
+- **No upstream** is distinct from unpublished work.
+- Ahead/behind and **Matches upstream** compare local remote-tracking refs.
+  A missing/pruned upstream ref has unavailable comparison, never zero divergence.
+  Boomux does not automatically fetch. Observation ages accompany expanded rows.
+- Errors and exceeded inspection budgets yield unknown status, never clean.
+- GitHub PR state is independent of local HEAD. A differing PR head explicitly
+  warns that the PR/checks describe a different commit.
+- PR lookup filters by head repository and owner, so same-named fork branches
+  cannot acquire each other's PR. Multiple matching open PRs remain ambiguous.
+  The newest matching historical PR remains visible after merge or closure.
+- Check failures, pending/unknown checks, no checks, and successful checks remain
+  distinct. This is a summary of returned checks, not authorization to merge.
+- Network/authentication failures preserve the prior PR observation with a stale
+  error and its original observation time.
+
+GitHub.com is the initial provider. Its CLI must be installed and authenticated
+on the owning Node. Lookup uses the branch's push remote (`pushRemote`,
+`remote.pushDefault`, then branch remote, with `origin` fallback). The PR target
+uses `gh repo set-default` metadata, then the conventional `upstream` remote,
+then the push repository. GitLab, enterprise hosts, unsupported remotes, and
+missing authentication leave local Git information usable. No credentials are
+copied between Nodes or stored in Boomux state.
+
+## Scheduling and bounds
+
+The client queries only while the panel is open. Socket operations have a
+bounded timeout; remote Nodes are queried through the verified host-service
+route. Unavailable Nodes retain labeled stale presentation. The first 16 Nodes
+are shown with an explicit limit notice when necessary.
+
+Each daemon owns one demand-driven inspection service. Requests return the
+cached overview immediately and coalesce behind a single bounded worker. Local
+inspection starts at five-second intervals and backs off to fifteen seconds
+when semantic results are unchanged. PR observations have a separate sixty-second
+cache. Explicit Refresh refreshes both, subject to a one-second minimum interval.
+Closing the panel stops its polling; no per-Shell timer is created.
+
+A cycle admits at most 512 Shell/Agent associations, 128 worktrees, and 512
+additional branch labels. Git commands have a one-second timeout and a 1 MiB
+output limit; GitHub CLI calls have a three-second timeout and the same output
+limit. Discovery/inspection stops admitting work after a twenty-second cycle
+budget (an already admitted operation may finish its bounded commands). Limits
+and unknown results are surfaced. Commands use exact argv and owned process
+groups; Git inspection disables optional index locks and clears environment
+variables that could redirect it into another repository.
+
+The cache is disposable and is rebuilt after daemon replacement. Protocol 53
+adds `git_work_overview` through `HostService` / `RouteNodeHostService` and the
+corresponding result. Older peers reject the feature before inspection. No
+persistence schema changes or durable Git-status events are required.
+
+## Validation
+
+Focused fixtures cover porcelain parsing with renames/newlines/conflicts,
+unborn and linked worktrees, fork-aware PR matching, ambiguous PRs and unknown
+checks, exact live Shell cwd without changing launch metadata, old-version
+rejection, and owner-side remote execution. UI checks must verify terminal
+visibility, input, and layout preservation while toggling/resizing the panel.
+Comprehensive checks remain in PR CI.
+
+The development launcher preserves `GH_CONFIG_DIR` (or points it at the original
+GitHub CLI config directory) before isolating Boomux XDG directories. It does not
+copy or modify GitHub credentials.

--- a/src/client.rs
+++ b/src/client.rs
@@ -2550,14 +2550,14 @@ mod tests {
         let socket = directory.join("daemon.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = thread::spawn(move || {
-            for version in [52, 51] {
+            for version in (51..=protocol::PROTOCOL_VERSION).rev() {
                 let (mut stream, _) = listener.accept().unwrap();
                 let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
                 assert_eq!(request.version, version);
                 assert_eq!(request.message, Request::Ping);
-                let response = if version == 52 {
+                let response = if version > 51 {
                     Response::Error {
-                        message: "protocol 52 unsupported".into(),
+                        message: format!("protocol {version} unsupported"),
                         code: Some(ErrorCode::UnsupportedVersion),
                     }
                 } else {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1023,6 +1023,56 @@ impl Client {
         }
     }
 
+    /// Bounded read-only Git observations. Older Nodes report UnsupportedVersion.
+    pub fn git_overview(
+        &self,
+        node_id: Option<&str>,
+        refresh: bool,
+        timeout: Duration,
+    ) -> Result<crate::git_work::Overview> {
+        let operation = crate::protocol::HostServiceOperation::GitOverview { refresh };
+        let request = match node_id {
+            Some(node_id) => Request::RouteNodeHostService {
+                node_id: node_id.into(),
+                operation,
+            },
+            None => Request::HostService { operation },
+        };
+        let version = self.protocol_version.load(Ordering::Acquire);
+        if !protocol::ProtocolFeature::GitWorkOverview.is_supported_by(version) {
+            return Err(unsupported_version(
+                "Git panel requires a newer Boomux daemon",
+            ));
+        }
+        match self
+            .send_with_version_timeout(request, version, Some(timeout))?
+            .1
+        {
+            Response::HostService {
+                result: crate::protocol::HostServiceResult::GitOverview { overview },
+            } => Ok(overview),
+            response => unexpected(response),
+        }
+    }
+
+    pub fn combined_node_snapshot_with_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<CombinedNodeSnapshot> {
+        let version = self.protocol_version.load(Ordering::Acquire);
+        match self
+            .send_with_version_timeout(
+                Request::GetCombinedNodeSnapshot { selector: None },
+                version,
+                Some(timeout),
+            )?
+            .1
+        {
+            Response::CombinedNodeSnapshot { snapshot } => Ok(snapshot),
+            response => unexpected(response),
+        }
+    }
+
     pub fn host_service(
         &self,
         operation: crate::protocol::HostServiceOperation,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3301,6 +3301,7 @@ struct DaemonService {
     claude_remote_control: ClaudeRemoteControlBindings,
     remote_attachments: RemoteAttachmentManager,
     host_service_previews: Mutex<HashMap<String, HostServicePreview>>,
+    git_work: crate::git_work::Service,
     host_session_catalog: HostSessionCatalogCache,
     workspace_operation_locks: Mutex<HashMap<String, Weak<Mutex<()>>>>,
     mutation_lock: Mutex<()>,
@@ -7313,6 +7314,7 @@ impl Default for DaemonService {
             claude_remote_control: ClaudeRemoteControlBindings::default(),
             remote_attachments: RemoteAttachmentManager::default(),
             host_service_previews: Mutex::new(HashMap::new()),
+            git_work: crate::git_work::Service::default(),
             host_session_catalog: HostSessionCatalogCache::default(),
             workspace_operation_locks: Mutex::new(HashMap::new()),
             mutation_lock: Mutex::new(()),
@@ -9617,6 +9619,38 @@ impl DaemonService {
         _requester_version: u32,
     ) -> DaemonResult<HostServiceResult> {
         match operation {
+            HostServiceOperation::GitOverview { refresh } => {
+                if let Some(overview) = self.git_work.cached_if_fresh(refresh) {
+                    return Ok(HostServiceResult::GitOverview { overview });
+                }
+                let snapshot = self.snapshot()?;
+                let mut live = HashMap::new();
+                for observed in snapshot.workspaces.iter().flat_map(|w| &w.shells).take(512) {
+                    let Some(expected) = &observed.run else {
+                        continue;
+                    };
+                    let Ok(shell) = self.durable.shell(&observed.id) else {
+                        continue;
+                    };
+                    let lifecycle = lock(&shell.lifecycle)?;
+                    if let ShellLifecycle::Running { run, runtime, .. } = &*lifecycle
+                        && run.snapshot()?.id == expected.id
+                    {
+                        let mut process = lock(&runtime.process)?;
+                        if process.try_wait_code()?.is_none()
+                            && let Some(pid) = process.process_id()
+                            && let Ok(path) = fs::read_link(format!("/proc/{pid}/cwd"))
+                            && path.is_absolute()
+                            && process.try_wait_code()?.is_none()
+                        {
+                            live.insert(observed.id.clone(), path);
+                        }
+                    }
+                }
+                Ok(HostServiceResult::GitOverview {
+                    overview: self.git_work.query(snapshot, live, refresh),
+                })
+            }
             HostServiceOperation::DiscoverProjects => Ok(HostServiceResult::Projects {
                 discovery: host_services::discover_projects().map_err(DaemonError::from)?,
             }),
@@ -13816,6 +13850,7 @@ impl DaemonService {
             claude_remote_control: ClaudeRemoteControlBindings::default(),
             remote_attachments: RemoteAttachmentManager::default(),
             host_service_previews: Mutex::new(HashMap::new()),
+            git_work: crate::git_work::Service::default(),
             host_session_catalog: HostSessionCatalogCache::default(),
             workspace_operation_locks: Mutex::new(HashMap::new()),
             mutation_lock: Mutex::new(()),

--- a/src/git.rs
+++ b/src/git.rs
@@ -133,7 +133,7 @@ impl Drop for Cache {
 
 // Drain a nonblocking pipe in this worker, with one absolute deadline covering
 // both process exit and EOF. A descendant keeping stdout open cannot wedge it.
-fn command_output(
+pub(crate) fn command_output(
     command: &mut Command,
     timeout: Duration,
     limit: usize,

--- a/src/git_work.rs
+++ b/src/git_work.rs
@@ -1,0 +1,841 @@
+//! Disposable, owner-local Git observations. Never mutates repositories or Agent state.
+use crate::protocol::{AgentState, Snapshot};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::{Path, PathBuf},
+    process::Command,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+const MAX_ROOTS: usize = 128;
+const MAX_LINKS: usize = 512;
+const MAX_OUTPUT: usize = 1024 * 1024;
+const MAX_CYCLE: Duration = Duration::from_secs(20);
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Overview {
+    pub worktrees: Vec<Worktree>,
+    pub warnings: Vec<String>,
+    pub refreshing: bool,
+    pub observed_at_ms: u64,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Worktree {
+    pub root: PathBuf,
+    pub common_dir: PathBuf,
+    pub repository: String,
+    pub branch: String,
+    pub head: String,
+    pub last_commit: Option<String>,
+    pub status: Option<Status>,
+    pub error: Option<String>,
+    pub shells: Vec<ShellLink>,
+    pub agents: Vec<AgentLink>,
+    pub branches: Vec<String>,
+    pub pr: PullRequest,
+    pub observed_at_ms: u64,
+}
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Status {
+    pub staged: usize,
+    pub unstaged: usize,
+    pub untracked: usize,
+    pub conflicts: usize,
+    pub upstream: Option<String>,
+    pub divergence_known: bool,
+    pub ahead: usize,
+    pub behind: usize,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShellLink {
+    pub id: String,
+    pub run_id: Option<String>,
+    pub name: String,
+    pub workspace_id: String,
+    pub workspace: String,
+    pub live_cwd: bool,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentLink {
+    pub id: String,
+    pub run_id: String,
+    pub workspace_id: String,
+    pub observed_at_ms: u64,
+    pub shell_id: String,
+    pub name: String,
+    pub state: AgentState,
+    pub observed_context: bool,
+}
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequest {
+    pub error: Option<String>,
+    pub checked_at_ms: u64,
+    pub summary: String,
+    pub url: Option<String>,
+    pub head: Option<String>,
+    pub observed_at_ms: u64,
+}
+#[derive(Default)]
+struct State {
+    overview: Overview,
+    requested: Option<Instant>,
+    refresh_interval: Duration,
+    prs: HashMap<(PathBuf, String), PullRequest>,
+}
+#[derive(Default)]
+pub(crate) struct Service(Arc<Mutex<State>>);
+
+impl Service {
+    pub(crate) fn cached_if_fresh(&self, refresh: bool) -> Option<Overview> {
+        let state = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        (state.overview.refreshing
+            || state.requested.is_some_and(|at| {
+                at.elapsed()
+                    < if refresh {
+                        Duration::from_secs(1)
+                    } else {
+                        state.refresh_interval
+                    }
+            }))
+        .then(|| state.overview.clone())
+    }
+    pub(crate) fn query(
+        &self,
+        snapshot: Snapshot,
+        live: HashMap<String, PathBuf>,
+        refresh: bool,
+    ) -> Overview {
+        let mut state = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        if !state.overview.refreshing
+            && state.requested.is_none_or(|at| {
+                at.elapsed()
+                    >= if refresh {
+                        Duration::from_secs(1)
+                    } else {
+                        state.refresh_interval
+                    }
+            })
+        {
+            state.overview.refreshing = true;
+            state.requested = Some(Instant::now());
+            let shared = Arc::clone(&self.0);
+            let previous = state.overview.worktrees.clone();
+            let mut prs = std::mem::take(&mut state.prs);
+            if refresh {
+                for pr in prs.values_mut() {
+                    pr.checked_at_ms = 0;
+                }
+            }
+            let spawn = std::thread::Builder::new()
+                .name("git-overview".into())
+                .spawn(move || {
+                    let result = inspect(snapshot, live, &mut prs, previous);
+                    let mut state = shared.lock().unwrap_or_else(|e| e.into_inner());
+                    let changed = state.overview.worktrees.len() != result.worktrees.len()
+                        || state.overview.worktrees.iter().zip(&result.worktrees).any(
+                            |(old, new)| {
+                                old.root != new.root
+                                    || old.branch != new.branch
+                                    || old.head != new.head
+                                    || old.status != new.status
+                                    || old.shells != new.shells
+                                    || old.agents != new.agents
+                                    || old.pr.summary != new.pr.summary
+                                    || old.pr.error != new.pr.error
+                                    || old.error != new.error
+                            },
+                        );
+                    state.refresh_interval = Duration::from_secs(if changed { 5 } else { 15 });
+                    state.requested = Some(Instant::now());
+                    state.overview = result;
+                    state.prs = prs;
+                });
+            if let Err(error) = spawn {
+                state.overview.refreshing = false;
+                state.overview.warnings = vec![format!("Could not inspect Git: {error}")];
+            }
+        }
+        state.overview.clone()
+    }
+}
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+fn output(path: &Path, args: &[&str]) -> Result<Vec<u8>, String> {
+    crate::git_metadata::command_output(
+        Command::new("git")
+            .arg("--no-optional-locks")
+            .arg("-C")
+            .arg(path)
+            .args(args)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_COMMON_DIR")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_NAMESPACE"),
+        Duration::from_secs(1),
+        MAX_OUTPUT,
+    )
+    .map_err(|e| e.to_string())?
+    .ok_or_else(|| "Git inspection unavailable".into())
+}
+fn string(path: &Path, args: &[&str]) -> Result<String, String> {
+    output(path, args).map(|v| String::from_utf8_lossy(&v).trim().to_string())
+}
+fn identity(path: &Path) -> Result<(PathBuf, PathBuf), String> {
+    use std::os::unix::ffi::OsStrExt;
+    let path_output = |args: &[&str]| -> Result<PathBuf, String> {
+        let bytes = output(path, args)?;
+        let bytes = bytes.strip_suffix(b"\n").unwrap_or(&bytes);
+        PathBuf::from(std::ffi::OsStr::from_bytes(bytes))
+            .canonicalize()
+            .map_err(|e| e.to_string())
+    };
+    Ok((
+        path_output(&["rev-parse", "--show-toplevel"])?,
+        path_output(&["rev-parse", "--path-format=absolute", "--git-common-dir"])?,
+    ))
+}
+fn inspect(
+    snapshot: Snapshot,
+    live: HashMap<String, PathBuf>,
+    prs: &mut HashMap<(PathBuf, String), PullRequest>,
+    previous: Vec<Worktree>,
+) -> Overview {
+    let started = Instant::now();
+    let mut result = Overview::default();
+    let mut paths: BTreeMap<PathBuf, (Vec<ShellLink>, Vec<AgentLink>)> = BTreeMap::new();
+    let mut count = 0;
+    for workspace in snapshot.workspaces {
+        for shell in &workspace.shells {
+            if count >= MAX_LINKS {
+                break;
+            }
+            count += 1;
+            let path = live.get(&shell.id).unwrap_or(&shell.cwd).clone();
+            let links = paths.entry(path).or_default();
+            links.0.push(ShellLink {
+                id: shell.id.clone(),
+                run_id: shell.run.as_ref().map(|r| r.id.clone()),
+                name: shell.name.clone(),
+                workspace_id: workspace.id.clone(),
+                workspace: workspace.name.clone(),
+                live_cwd: live.contains_key(&shell.id),
+            });
+            for agent in workspace
+                .agents
+                .iter()
+                .filter(|a| {
+                    a.shell_id == shell.id
+                        && shell.run.as_ref().is_some_and(|r| r.id == a.run_id)
+                        && !matches!(a.observation.state, AgentState::Done | AgentState::Inactive)
+                })
+                .take(16)
+            {
+                if count >= MAX_LINKS {
+                    break;
+                }
+                count += 1;
+                links.1.push(AgentLink {
+                    id: agent.id.clone(),
+                    run_id: agent.run_id.clone(),
+                    workspace_id: workspace.id.clone(),
+                    observed_at_ms: agent.observation.observed_at_ms,
+                    shell_id: shell.id.clone(),
+                    name: format!("{} · {}", agent.integration, agent.name),
+                    state: agent.observation.state,
+                    observed_context: false,
+                });
+            }
+        }
+        for agent in workspace.agents.iter().filter(|a| {
+            !matches!(a.observation.state, AgentState::Done | AgentState::Inactive)
+                && workspace.shells.iter().any(|shell| {
+                    shell.id == a.shell_id
+                        && shell.run.as_ref().is_some_and(|run| run.id == a.run_id)
+                })
+        }) {
+            for context in &agent.working_contexts {
+                if count >= MAX_LINKS {
+                    break;
+                }
+                count += 1;
+                paths
+                    .entry(context.worktree_root.clone())
+                    .or_default()
+                    .1
+                    .push(AgentLink {
+                        id: agent.id.clone(),
+                        run_id: agent.run_id.clone(),
+                        workspace_id: workspace.id.clone(),
+                        observed_at_ms: agent.observation.observed_at_ms,
+                        shell_id: agent.shell_id.clone(),
+                        name: format!("{} · {}", agent.integration, agent.name),
+                        state: agent.observation.state,
+                        observed_context: true,
+                    });
+            }
+        }
+    }
+    if count >= MAX_LINKS {
+        result
+            .warnings
+            .push("Showing the first 512 Shell/Agent associations.".into());
+    }
+    let mut roots: BTreeMap<PathBuf, Worktree> = BTreeMap::new();
+    let mut repos = BTreeMap::<PathBuf, PathBuf>::new();
+    for (path, (shells, agents)) in paths {
+        if started.elapsed() >= MAX_CYCLE || roots.len() >= MAX_ROOTS {
+            result
+                .warnings
+                .push("Git discovery limit reached; some work is not shown.".into());
+            break;
+        }
+        if let Ok((root, common)) = identity(&path) {
+            repos.entry(common.clone()).or_insert(root.clone());
+            let row = roots
+                .entry(root.clone())
+                .or_insert_with(|| empty(root, common));
+            row.shells.extend(shells);
+            for agent in agents {
+                if !row
+                    .agents
+                    .iter()
+                    .any(|a| a.id == agent.id && a.observed_context == agent.observed_context)
+                {
+                    row.agents.push(agent);
+                }
+            }
+        }
+    }
+    let mut branch_count = 0;
+    for (common, root) in repos {
+        if started.elapsed() >= MAX_CYCLE {
+            break;
+        }
+        if let Ok(bytes) = output(&root, &["worktree", "list", "--porcelain", "-z"]) {
+            for field in bytes.split(|b| *b == 0) {
+                if let Some(path) = field.strip_prefix(b"worktree ") {
+                    use std::os::unix::ffi::OsStrExt;
+                    let path = PathBuf::from(std::ffi::OsStr::from_bytes(path));
+                    if roots.len() >= MAX_ROOTS {
+                        if !result.warnings.iter().any(|s| s.contains("128 worktrees")) {
+                            result
+                                .warnings
+                                .push("Showing at most 128 worktrees.".into());
+                        }
+                        break;
+                    }
+                    roots
+                        .entry(path.clone())
+                        .or_insert_with(|| empty(path, common.clone()));
+                }
+            }
+        }
+        if let Ok(branches) = string(
+            &root,
+            &[
+                "for-each-ref",
+                "--count=128",
+                "--format=%(refname:short)",
+                "refs/heads/",
+            ],
+        ) {
+            if let Some(row) = roots.get_mut(&root) {
+                row.branches = branches
+                    .lines()
+                    .take(MAX_LINKS - branch_count)
+                    .map(|s| s.chars().take(256).collect())
+                    .collect();
+                branch_count += row.branches.len();
+            }
+        }
+    }
+    for row in roots.values_mut() {
+        if let Some(old) = previous
+            .iter()
+            .find(|old| old.root == row.root && old.common_dir == row.common_dir)
+        {
+            row.branch = old.branch.clone();
+            row.head = old.head.clone();
+            row.last_commit = old.last_commit.clone();
+            row.observed_at_ms = old.observed_at_ms;
+            row.pr = old.pr.clone();
+        }
+    }
+    let mut order: Vec<_> = roots.keys().cloned().collect();
+    order.sort_by_key(|root| roots[root].observed_at_ms);
+    for root in order {
+        let row = roots.get_mut(&root).expect("discovered worktree");
+        if started.elapsed() >= MAX_CYCLE {
+            row.error = Some("Refresh budget reached; retry on next refresh".into());
+            continue;
+        }
+        match output(
+            &row.root,
+            &[
+                "status",
+                "--porcelain=v2",
+                "--branch",
+                "-z",
+                "--untracked-files=normal",
+            ],
+        )
+        .and_then(|bytes| parse_status(&bytes))
+        {
+            Ok((branch, head, status)) => {
+                row.branch = branch;
+                row.head = head;
+                row.status = Some(status);
+            }
+            Err(error) => row.error = Some(error),
+        }
+        if row.status.is_some() && row.head != "(initial)" {
+            row.last_commit = string(
+                &row.root,
+                &["log", "-1", "--format=%h %s", "--no-show-signature"],
+            )
+            .ok()
+            .map(|s| s.chars().take(256).collect());
+        }
+        if row.status.is_some() {
+            let current_head = string(&row.root, &["rev-parse", "--verify", "HEAD"])
+                .unwrap_or_else(|_| "(initial)".into());
+            let current_branch = string(&row.root, &["symbolic-ref", "--short", "-q", "HEAD"])
+                .unwrap_or_else(|_| "(detached)".into());
+            if current_head != row.head || current_branch != row.branch {
+                row.status = None;
+                row.last_commit = None;
+                row.error = Some("Branch changed during inspection; refresh pending".into());
+            }
+        }
+        row.observed_at_ms = now();
+        let key = (row.common_dir.clone(), row.branch.clone());
+        let pr = prs.entry(key).or_default();
+        if now().saturating_sub(pr.checked_at_ms) >= 60_000
+            && started.elapsed() < MAX_CYCLE
+            && row.status.is_some()
+        {
+            let next = inspect_pr(&row.root, &row.branch);
+            if next.error.is_some() && pr.observed_at_ms != 0 {
+                pr.error = next.error;
+                pr.checked_at_ms = next.checked_at_ms;
+            } else {
+                *pr = next;
+            }
+        }
+        row.pr = pr.clone();
+    }
+    prs.retain(|key, _| {
+        roots
+            .values()
+            .any(|r| r.common_dir == key.0 && r.branch == key.1)
+    });
+    let checked: std::collections::HashSet<_> = roots
+        .values()
+        .map(|r| (r.common_dir.clone(), r.branch.clone()))
+        .collect();
+    for row in roots.values_mut() {
+        row.branches
+            .retain(|branch| !checked.contains(&(row.common_dir.clone(), branch.clone())));
+    }
+    result.worktrees = roots.into_values().collect();
+    result
+        .worktrees
+        .sort_by(|a, b| (&a.common_dir, &a.root).cmp(&(&b.common_dir, &b.root)));
+    result.observed_at_ms = now();
+    result
+}
+fn empty(root: PathBuf, common_dir: PathBuf) -> Worktree {
+    let label = if common_dir.file_name().is_some_and(|n| n == ".git") {
+        common_dir.parent().unwrap_or(&common_dir)
+    } else {
+        &common_dir
+    };
+    let repository = label
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .trim_end_matches(".git")
+        .chars()
+        .take(256)
+        .collect();
+    Worktree {
+        root,
+        common_dir,
+        repository,
+        branch: "Unknown".into(),
+        head: String::new(),
+        last_commit: None,
+        status: None,
+        error: None,
+        shells: vec![],
+        agents: vec![],
+        branches: vec![],
+        pr: PullRequest::default(),
+        observed_at_ms: 0,
+    }
+}
+fn parse_status(bytes: &[u8]) -> Result<(String, String, Status), String> {
+    let mut status = Status::default();
+    let mut branch = None;
+    let mut head = String::new();
+    let mut records = bytes.split(|b| *b == 0);
+    while let Some(record) = records.next() {
+        if record.is_empty() {
+            continue;
+        }
+        if let Some(value) = record.strip_prefix(b"# branch.head ") {
+            branch = Some(String::from_utf8_lossy(value).into_owned());
+        } else if let Some(value) = record.strip_prefix(b"# branch.oid ") {
+            head = String::from_utf8_lossy(value).into_owned();
+        } else if let Some(value) = record.strip_prefix(b"# branch.upstream ") {
+            status.upstream = Some(String::from_utf8_lossy(value).into_owned());
+        } else if let Some(value) = record.strip_prefix(b"# branch.ab ") {
+            let text = String::from_utf8_lossy(value);
+            let (ahead, behind) = text.split_once(' ').ok_or("Invalid ahead/behind")?;
+            status.divergence_known = true;
+            status.ahead = ahead
+                .trim_start_matches('+')
+                .parse()
+                .map_err(|_| "Invalid ahead")?;
+            status.behind = behind
+                .trim_start_matches('-')
+                .parse()
+                .map_err(|_| "Invalid behind")?;
+        } else {
+            match record[0] {
+                b'1' | b'2' => {
+                    if record.len() < 5 {
+                        return Err("Truncated Git record".into());
+                    }
+                    status.staged += usize::from(record[2] != b'.');
+                    status.unstaged += usize::from(record[3] != b'.');
+                    if record[0] == b'2' && records.next().is_none() {
+                        return Err("Missing rename source".into());
+                    }
+                }
+                b'?' => status.untracked += 1,
+                b'u' => status.conflicts += 1,
+                b'#' | b'!' => (),
+                _ => return Err("Unknown Git status record".into()),
+            }
+        }
+    }
+    let branch = branch.ok_or("Missing Git branch")?;
+    if branch.is_empty() || head.is_empty() {
+        return Err("Incomplete Git branch metadata".into());
+    }
+    if branch.len() > 1024
+        || head.len() > 128
+        || status.upstream.as_ref().is_some_and(|s| s.len() > 1024)
+    {
+        return Err("Git metadata exceeds label limits".into());
+    }
+    Ok((branch, head, status))
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct GithubRepo {
+    owner: String,
+    name: String,
+}
+fn github_repo(url: &str) -> Option<GithubRepo> {
+    let path = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("git@github.com:"))
+        .or_else(|| url.strip_prefix("ssh://git@github.com/"))?;
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let (owner, name) = path.split_once('/')?;
+    let valid = |part: &str| {
+        !part.is_empty()
+            && part
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+    };
+    (valid(owner) && valid(name)).then(|| GithubRepo {
+        owner: owner.into(),
+        name: name.into(),
+    })
+}
+fn config(path: &Path, key: &str) -> Option<String> {
+    string(path, &["config", "--get", key])
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+fn inspect_pr(path: &Path, branch: &str) -> PullRequest {
+    let mut pr = PullRequest {
+        observed_at_ms: now(),
+        checked_at_ms: now(),
+        ..Default::default()
+    };
+    if matches!(branch, "(detached)" | "Unknown") {
+        pr.summary = "No branch PR lookup".into();
+        return pr;
+    }
+    let push_remote = config(path, &format!("branch.{branch}.pushRemote"))
+        .or_else(|| config(path, "remote.pushDefault"))
+        .or_else(|| config(path, &format!("branch.{branch}.remote")))
+        .unwrap_or_else(|| "origin".into());
+    let Some(head_repo) =
+        config(path, &format!("remote.{push_remote}.url")).and_then(|url| github_repo(&url))
+    else {
+        pr.summary = "PR lookup unavailable: no supported GitHub push remote".into();
+        return pr;
+    };
+    let configured_base = string(
+        path,
+        &["config", "--get-regexp", r"^remote\..*\.gh-resolved$"],
+    )
+    .ok()
+    .and_then(|text| {
+        text.lines().find_map(|line| {
+            let (key, value) = line.split_once(' ')?;
+            (value == "base")
+                .then(|| key.strip_prefix("remote.")?.strip_suffix(".gh-resolved"))
+                .flatten()
+                .map(str::to_owned)
+        })
+    });
+    let base_repo = configured_base
+        .and_then(|name| config(path, &format!("remote.{name}.url")))
+        .or_else(|| config(path, "remote.upstream.url"))
+        .and_then(|url| github_repo(&url))
+        .unwrap_or_else(|| head_repo.clone());
+    let target = format!("github.com/{}/{}", base_repo.owner, base_repo.name);
+    let result = crate::git_metadata::command_output(Command::new("gh").current_dir(path).args(["pr", "list", "--repo", &target, "--head", branch, "--state", "all", "--limit", "50", "--json", "number,state,isDraft,url,headRefOid,headRepository,headRepositoryOwner,reviewDecision,statusCheckRollup,updatedAt"]).env("GH_PROMPT_DISABLED", "1"), Duration::from_secs(3), MAX_OUTPUT);
+    match result {
+        Ok(Some(bytes)) => match serde_json::from_slice::<Vec<serde_json::Value>>(&bytes) {
+            Ok(rows) => {
+                pr = summarize_pr(rows, &head_repo);
+                pr.observed_at_ms = now();
+                pr.checked_at_ms = now();
+            }
+            Err(_) => {
+                pr.error = Some("Invalid GitHub response".into());
+                pr.observed_at_ms = 0;
+            }
+        },
+        _ => {
+            pr.error = Some("Check gh authentication or network".into());
+            pr.observed_at_ms = 0;
+        }
+    }
+    pr
+}
+fn summarize_pr(mut rows: Vec<serde_json::Value>, head_repo: &GithubRepo) -> PullRequest {
+    let mut pr = PullRequest::default();
+    let truncated = rows.len() == 50;
+    rows.retain(|r| {
+        r["headRepositoryOwner"]["login"]
+            .as_str()
+            .is_some_and(|owner| owner.eq_ignore_ascii_case(&head_repo.owner))
+            && r["headRepository"]["name"]
+                .as_str()
+                .is_some_and(|name| name.eq_ignore_ascii_case(&head_repo.name))
+    });
+    rows.sort_by(|a, b| b["updatedAt"].as_str().cmp(&a["updatedAt"].as_str()));
+    let open: Vec<_> = rows.iter().filter(|r| r["state"] == "OPEN").collect();
+    if open.len() > 1 {
+        pr.summary = "Multiple PRs match; inspect on GitHub".into();
+    } else if let Some(row) = open.first().copied().or_else(|| rows.first()) {
+        pr.summary = format!(
+            "#{} {}",
+            row["number"],
+            if row["isDraft"] == true {
+                "Draft"
+            } else {
+                row["state"].as_str().unwrap_or("Unknown")
+            }
+        );
+        let checks = row["statusCheckRollup"]
+            .as_array()
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let failing = checks.iter().any(|c| {
+            matches!(
+                c["conclusion"].as_str().or(c["state"].as_str()),
+                Some(
+                    "FAILURE"
+                        | "ERROR"
+                        | "TIMED_OUT"
+                        | "CANCELLED"
+                        | "ACTION_REQUIRED"
+                        | "STARTUP_FAILURE"
+                )
+            )
+        });
+        let passed = checks.iter().all(|c| {
+            matches!(
+                c["conclusion"].as_str().or(c["state"].as_str()),
+                Some("SUCCESS" | "NEUTRAL" | "SKIPPED")
+            )
+        });
+        pr.summary.push_str(if checks.is_empty() {
+            " · No checks"
+        } else if failing {
+            " · Checks failed"
+        } else if passed {
+            " · Checks passed"
+        } else {
+            " · Checks pending"
+        });
+        if let Some(review) = row["reviewDecision"].as_str().filter(|s| !s.is_empty()) {
+            pr.summary
+                .push_str(&format!(" · {}", review.to_lowercase().replace('_', " ")));
+        }
+        pr.url = row["url"]
+            .as_str()
+            .filter(|u| u.starts_with("https://github.com/"))
+            .map(str::to_owned);
+        pr.head = row["headRefOid"].as_str().map(str::to_owned);
+    } else {
+        pr.summary = if truncated {
+            "PR lookup truncated; matching PR unknown"
+        } else {
+            "No matching PR"
+        }
+        .into();
+    }
+    pr
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn git_work_status_handles_renames_conflicts_and_unusual_paths() {
+        let bytes = b"# branch.oid abc\0# branch.head feat/test\0# branch.upstream origin/feat/test\0# branch.ab +2 -1\0\
+1 M. N... 100644 100644 100644 a b staged\0\
+1 .M N... 100644 100644 100644 a b new\nline\0\
+2 R. N... 100644 100644 100644 a b R100 new\0? old name\0\
+? untracked\nname\0u UU N... 0 0 0 0 a b c conflicted\0";
+        let (branch, head, status) = parse_status(bytes).unwrap();
+        assert_eq!((branch.as_str(), head.as_str()), ("feat/test", "abc"));
+        assert_eq!(
+            (
+                status.staged,
+                status.unstaged,
+                status.untracked,
+                status.conflicts
+            ),
+            (2, 1, 1, 1)
+        );
+        assert_eq!((status.ahead, status.behind), (2, 1));
+        assert!(parse_status(b"").is_err());
+    }
+    #[test]
+    fn git_work_missing_upstream_ref_is_not_a_zero_divergence() {
+        let (_, _, status) = parse_status(
+            b"# branch.oid abc\0# branch.head feature\0# branch.upstream origin/feature\0",
+        )
+        .unwrap();
+        assert_eq!(status.upstream.as_deref(), Some("origin/feature"));
+        assert!(!status.divergence_known);
+        let (_, _, status) = parse_status(b"# branch.oid abc\0# branch.head feature\0# branch.upstream origin/feature\0# branch.ab +0 -0\0").unwrap();
+        assert!(status.divergence_known);
+    }
+
+    #[test]
+    fn git_work_discovers_real_linked_worktrees_and_unborn_branches() {
+        let path = std::env::temp_dir().join(format!("boomux-git-work-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        let repository = path.join("repo");
+        assert!(
+            Command::new("git")
+                .args(["init", "-q", "-b", "main"])
+                .arg(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let (branch, head, status) = parse_status(
+            &output(&repository, &["status", "--porcelain=v2", "--branch", "-z"]).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(branch, "main");
+        assert_eq!(head, "(initial)");
+        assert_eq!(status.upstream, None);
+        string(
+            &repository,
+            &[
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "--allow-empty",
+                "-qm",
+                "initial",
+            ],
+        )
+        .unwrap();
+        let linked = path.join("linked");
+        output(
+            &repository,
+            &["worktree", "add", "-b", "feature", linked.to_str().unwrap()],
+        )
+        .unwrap();
+        let (_, common) = identity(&repository).unwrap();
+        assert_eq!(identity(&linked).unwrap().1, common);
+        std::fs::write(linked.join("new\nfile"), "work").unwrap();
+        let (_, _, status) = parse_status(
+            &output(&linked, &["status", "--porcelain=v2", "--branch", "-z"]).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(status.untracked, 1);
+        std::fs::remove_dir_all(path).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod pr_tests {
+    use super::*;
+    use serde_json::json;
+    #[test]
+    fn git_work_pr_matches_fork_and_distinguishes_unknown_checks() {
+        let repo = GithubRepo {
+            owner: "me".into(),
+            name: "project".into(),
+        };
+        let unrelated = json!({"number": 1, "state": "OPEN", "headRepositoryOwner": {"login": "other"}, "headRepository": {"name": "project"}});
+        let mine = json!({"number": 2, "state": "OPEN", "headRepositoryOwner": {"login": "me"}, "headRepository": {"name": "project"}, "headRefOid": "abc", "url": "https://github.com/upstream/project/pull/2", "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}, {"status": "EXPECTED"}] });
+        let pr = summarize_pr(vec![unrelated.clone(), mine.clone()], &repo);
+        assert!(pr.summary.starts_with("#2 OPEN"));
+        assert!(pr.summary.contains("pending"));
+        assert_eq!(pr.head.as_deref(), Some("abc"));
+        assert!(
+            summarize_pr(vec![unrelated], &repo)
+                .summary
+                .contains("No matching")
+        );
+        assert!(summarize_pr(vec![mine.clone(), mine], &repo).url.is_none());
+    }
+    #[test]
+    fn git_work_pr_retains_merged_state_and_supports_remote_url_forms() {
+        let repo = github_repo("git@github.com:me/project.git").unwrap();
+        assert_eq!(
+            github_repo("https://github.com/me/project"),
+            Some(repo.clone())
+        );
+        assert_eq!(
+            github_repo("ssh://git@github.com/me/project.git"),
+            Some(repo.clone())
+        );
+        assert!(github_repo("https://gitlab.com/me/project.git").is_none());
+        assert!(github_repo("https://github.com/me/project/extra").is_none());
+        let pr = summarize_pr(
+            vec![
+                json!({"number": 374, "state": "MERGED", "headRepositoryOwner": {"login":"me"}, "headRepository": {"name": "project"}, "headRefOid": "old"}),
+            ],
+            &repo,
+        );
+        assert!(pr.summary.contains("MERGED"));
+        assert!(pr.summary.contains("No checks"));
+        assert_eq!(pr.head.as_deref(), Some("old"));
+    }
+}

--- a/src/git_work.rs
+++ b/src/git_work.rs
@@ -345,15 +345,14 @@ fn inspect(
                 "--format=%(refname:short)",
                 "refs/heads/",
             ],
-        ) {
-            if let Some(row) = roots.get_mut(&root) {
-                row.branches = branches
-                    .lines()
-                    .take(MAX_LINKS - branch_count)
-                    .map(|s| s.chars().take(256).collect())
-                    .collect();
-                branch_count += row.branches.len();
-            }
+        ) && let Some(row) = roots.get_mut(&root)
+        {
+            row.branches = branches
+                .lines()
+                .take(MAX_LINKS - branch_count)
+                .map(|s| s.chars().take(256).collect())
+                .collect();
+            branch_count += row.branches.len();
         }
     }
     for row in roots.values_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@ mod fd_transfer;
 pub mod federation;
 #[allow(dead_code)]
 mod generated_names;
+#[path = "git.rs"]
+#[allow(dead_code)]
+mod git_metadata;
+pub mod git_work;
 pub(crate) mod global_workspace_store;
 mod handoff;
 pub mod host_services;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15553,7 +15553,7 @@ mod tests {
                 .validated_version,
             "2.1.236"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 52);
+        assert_eq!(protocol::PROTOCOL_VERSION, 53);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 52;
+pub const PROTOCOL_VERSION: u32 = 53;
 pub const MIN_PROTOCOL_VERSION: u32 = 47;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -200,6 +200,7 @@ define_protocol_features! {
     WorkspaceSessionHiding => (51, "Workspace Agent Session hiding", [
         "workspace_session_hiding",
     ]),
+    GitWorkOverview => (53, "Git work overview", ["protocol_53", "git_work_overview"]),
     RestartExecutable => (52, "restart executable", ["protocol_52", "restart_executable"]),
 }
 
@@ -227,6 +228,10 @@ pub enum HostServiceIntegrationAction {
 #[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
 pub enum HostServiceOperation {
     DiscoverProjects,
+    GitOverview {
+        #[serde(default)]
+        refresh: bool,
+    },
     ResolveDirectory {
         path: PathBuf,
     },
@@ -448,6 +453,9 @@ pub struct HostAgentSessionResumePlan {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "result", rename_all = "snake_case", deny_unknown_fields)]
 pub enum HostServiceResult {
+    GitOverview {
+        overview: crate::git_work::Overview,
+    },
     Projects {
         discovery: HostProjectDiscovery,
     },
@@ -2189,6 +2197,13 @@ impl Request {
             | Self::GuardedCloseShell { .. }
             | Self::GuardedRestartShell { .. }
             | Self::GuardedRemoveLauncher { .. } => Some(ProtocolFeature::GuardedNodeRouting),
+            Self::HostService {
+                operation: HostServiceOperation::GitOverview { .. },
+            }
+            | Self::RouteNodeHostService {
+                operation: HostServiceOperation::GitOverview { .. },
+                ..
+            } => Some(ProtocolFeature::GitWorkOverview),
             Self::HostService { .. }
             | Self::RouteNodeHostService { .. }
             | Self::ResumeAgentSession { .. }
@@ -2833,9 +2848,36 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_fifty_two_with_forty_seven_floor() {
-        assert_eq!(PROTOCOL_VERSION, 52);
+    fn protocol_version_is_fifty_three_with_forty_seven_floor() {
+        assert_eq!(PROTOCOL_VERSION, 53);
         assert_eq!(MIN_PROTOCOL_VERSION, 47);
+    }
+
+    #[test]
+    fn git_work_overview_requires_protocol_fifty_three_and_round_trips() {
+        for request in [
+            Request::HostService {
+                operation: HostServiceOperation::GitOverview { refresh: false },
+            },
+            Request::RouteNodeHostService {
+                node_id: "remote".into(),
+                operation: HostServiceOperation::GitOverview { refresh: true },
+            },
+        ] {
+            assert_eq!(request.minimum_protocol_version(), 53);
+            assert!(!request.required_feature().unwrap().is_supported_by(52));
+            let value = serde_json::to_value(&request).unwrap();
+            assert_eq!(serde_json::from_value::<Request>(value).unwrap(), request);
+        }
+        let response = Response::HostService {
+            result: HostServiceResult::GitOverview {
+                overview: crate::git_work::Overview::default(),
+            },
+        };
+        assert_eq!(
+            serde_json::from_value::<Response>(serde_json::to_value(&response).unwrap()).unwrap(),
+            response
+        );
     }
 
     #[test]
@@ -4453,6 +4495,7 @@ mod tests {
                 ][..],
             ),
             (51, &["workspace_session_hiding"][..]),
+            (53, &["protocol_53", "git_work_overview"][..]),
             (52, &["protocol_52", "restart_executable"][..]),
         ];
 

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -32,3 +32,6 @@ mod shell_name_suggestion;
 mod update;
 #[path = "native_backend/workspace_creation.rs"]
 mod workspace_creation;
+
+#[path = "native_backend/git_work.rs"]
+mod git_work;

--- a/tests/native_backend/git_work.rs
+++ b/tests/native_backend/git_work.rs
@@ -1,0 +1,190 @@
+use crate::support::{TestDaemon, profile, wait_until};
+use boomux::{
+    git_work::Overview,
+    protocol::{self, ShellSpec},
+};
+use std::{fs, process::Command, time::Duration};
+
+#[test]
+fn git_work_overview_tracks_live_cwd_deduplicates_shells_and_preserves_launch_directory() {
+    let mut daemon = TestDaemon::start();
+    let repo = daemon.runtime_dir.join("repo");
+    assert!(
+        Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .arg(&repo)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args([
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "--allow-empty",
+                "-qm",
+                "initial"
+            ])
+            .status()
+            .unwrap()
+            .success()
+    );
+    let linked = daemon.runtime_dir.join("linked");
+    assert!(
+        Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(["worktree", "add", "-qb", "feature"])
+            .arg(&linked)
+            .status()
+            .unwrap()
+            .success()
+    );
+    fs::write(linked.join("unfinished"), "work").unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "Git work",
+            vec![
+                ShellSpec {
+                    name: "live".into(),
+                    cwd: repo.clone(),
+                    command: vec![
+                        "/bin/sh".into(),
+                        "-c".into(),
+                        "cd \"$1\"; printf ready; read answer".into(),
+                        "git-fixture".into(),
+                        linked.display().to_string(),
+                    ],
+                },
+                ShellSpec {
+                    name: "second".into(),
+                    cwd: linked.clone(),
+                    command: vec![],
+                },
+            ],
+        )
+        .unwrap();
+    let attached = daemon
+        .client
+        .attach(&workspace.shells[0].id, false, profile())
+        .unwrap();
+    let run_id = daemon
+        .client
+        .get_shell(&workspace.shells[0].id)
+        .unwrap()
+        .run
+        .unwrap()
+        .id;
+    let agent = daemon
+        .client
+        .ensure_agent(
+            &workspace.shells[0].id,
+            &run_id,
+            protocol::AgentRegistrationSpec {
+                name: "fixture agent".into(),
+                integration: "codex".into(),
+                external_session_id: Some("git-panel-fixture".into()),
+                report: protocol::AgentReport {
+                    state: protocol::AgentState::Working,
+                    authority: protocol::AgentAuthority::LifecycleIntegration,
+                    evidence: "fixture".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    daemon
+        .client
+        .observe_agent_working_context(&agent.id, &workspace.shells[0].id, &run_id, repo.clone())
+        .unwrap();
+    let mut observed = Overview::default();
+    wait_until(
+        || {
+            observed = daemon
+                .client
+                .git_overview(None, true, Duration::from_secs(2))
+                .unwrap();
+            observed.worktrees.iter().any(|row| {
+                row.root == linked && row.shells.len() == 2 && row.shells.iter().any(|s| s.live_cwd)
+            })
+        },
+        "Git overview did not observe the Shell's live worktree",
+    );
+    assert_eq!(observed.worktrees.len(), 2);
+    let row = observed
+        .worktrees
+        .iter()
+        .find(|r| r.root == linked)
+        .unwrap();
+    assert_eq!(row.branch, "feature");
+    assert!(
+        row.agents
+            .iter()
+            .any(|a| a.id == agent.id && !a.observed_context)
+    );
+    assert!(
+        observed
+            .worktrees
+            .iter()
+            .find(|r| r.root == repo)
+            .unwrap()
+            .agents
+            .iter()
+            .any(|a| a.id == agent.id && a.observed_context)
+    );
+
+    assert_eq!(row.status.as_ref().unwrap().untracked, 1);
+    assert_eq!(
+        daemon
+            .client
+            .get_shell(&workspace.shells[0].id)
+            .unwrap()
+            .cwd,
+        repo
+    );
+    // No implicit start or lifecycle mutation for the second Shell.
+    assert_eq!(
+        daemon
+            .client
+            .get_shell(&workspace.shells[1].id)
+            .unwrap()
+            .status,
+        protocol::ShellStatus::Pending
+    );
+    drop(attached);
+    daemon.stop_with_cli();
+}
+
+#[test]
+fn git_work_overview_rejects_old_wire_version_before_inspection() {
+    use protocol::{Envelope, ErrorCode, HostServiceOperation, Request, Response};
+    use std::os::unix::net::UnixStream;
+    let mut daemon = TestDaemon::start();
+    let mut stream = UnixStream::connect(daemon.client.socket_path()).unwrap();
+    protocol::write_message(
+        &mut stream,
+        &Envelope::with_version(
+            52,
+            Request::HostService {
+                operation: HostServiceOperation::GitOverview { refresh: true },
+            },
+        ),
+    )
+    .unwrap();
+    let response: Envelope<Response> = protocol::read_message(&mut stream).unwrap();
+    assert!(matches!(
+        response.message,
+        Response::Error {
+            code: Some(ErrorCode::UnsupportedVersion),
+            ..
+        }
+    ));
+    daemon.stop_with_cli();
+}

--- a/tests/native_backend/remote_host_services.rs
+++ b/tests/native_backend/remote_host_services.rs
@@ -146,6 +146,32 @@ fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv(
             }],
         )
         .unwrap();
+    assert!(
+        std::process::Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .arg(owner_projects.join("remote-only"))
+            .status()
+            .unwrap()
+            .success()
+    );
+    let local_git = ssh_bin.join("git");
+    fs::write(&local_git, "#!/bin/sh\nexit 77\n").unwrap();
+    fs::set_permissions(&local_git, fs::Permissions::from_mode(0o700)).unwrap();
+    wait_until(
+        || {
+            local
+                .client
+                .git_overview(Some(&owner_id), true, Duration::from_secs(2))
+                .is_ok_and(|overview| {
+                    overview.worktrees.iter().any(|row| {
+                        row.root == owner_projects.join("remote-only")
+                            && row.branch == "main"
+                            && row.status.is_some()
+                    })
+                })
+        },
+        "Git inspection did not execute on the owning Node",
+    );
     let shell_id = session_workspace.shells[0].id.clone();
     let owner_attachment = owner.client.attach(&shell_id, false, profile()).unwrap();
     let run_id = owner.client.get_shell(&shell_id).unwrap().run.unwrap().id;


### PR DESCRIPTION
Boomux Desktop now provides a Git panel for tracking repositories discovered from managed Shells and active Agent working contexts. Repositories group compact worktree rows with local changes, upstream comparisons, unique Agent counts, and GitHub PR/review/check status. Search and filters are tucked into the toolbar; expanding a row reveals paths, Shell navigation, and observation details.

The owning Node inspects Git and uses its existing GitHub CLI authentication. Protocol 53 adds a bounded, cached host service and verified remote routing; no Git mutations, automatic fetches, durable Git state, or Agent lifecycle changes are introduced. Unavailable comparisons and stale PR observations remain explicit. GitHub.com is the initial PR provider.

Desktop also gains a saved, draggable sidebar width and pane edge/corner resizing. Floating resizes preserve the opposite edge/corner; tiled resizes select the adjoining dividers. The development launcher supports `--release` for performance comparisons using the same isolated development sessions.

Validation:
- Focused Git parsing, linked/unborn worktree, fork-aware PR, missing-upstream, native live-cwd/Agent association, protocol-version rejection, and remote-owner execution tests passed during development.
- Focused unique-Agent presentation, pane edge/corner geometry, sidebar preference, and development-launcher tests passed.
- Desktop compile checks, formatting, and whitespace checks passed.
- Earlier live Git-panel checks verified terminal visibility, input, and ShellRun preservation. The subsequent compact layout and edge/corner mouse hitboxes have not been visually verified by automation.
- Full validation is delegated to PR CI; no performance improvement is claimed from the unoptimized development checks.
