### PR TITLE
feat: add remote workspaces and refine desktop experience

### DIFF
--- a/.github/scripts/classify-ci.py
+++ b/.github/scripts/classify-ci.py
@@ -17,6 +17,12 @@ def documentation(path):
             or (path.startswith("docs/") and path.endswith(".md")))
 
 
+def website(path):
+    # Static marketing assets are not embedded or packaged by either binary.
+    # The separate Website workflow owns their build and browser validation.
+    return path.startswith("website/") or path == ".github/workflows/website.yml"
+
+
 def git(*args):
     return subprocess.check_output(["git", *args], timeout=30)
 
@@ -94,11 +100,13 @@ def classify(base, head, proof=validated_base):
         paths = set(git("diff", "--name-only", "--no-renames", "-z", base, head).decode().rstrip("\0").split("\0")) - {""}
         if all(documentation(path) for path in paths):
             return dict.fromkeys(FULL, False), "Documentation-only change; no executable or packaged inputs changed."
+        if all(documentation(path) or website(path) for path in paths):
+            return dict.fromkeys(FULL, False), "Website-only change; the Website workflow owns validation."
         if release_only(base, head, paths):
             if proof(base):
                 return {"run_code": False, "run_desktop": False, "run_package": True, "run_benchmarks": False}, f"Version-only release; reuse successful push CI for {base}. Build and smoke test the new version."
             return FULL.copy(), "Version-only change has no successful base push CI; full validation."
-        executable_paths = {path for path in paths if not documentation(path)}
+        executable_paths = {path for path in paths if not documentation(path) and not website(path)}
         if executable_paths and all(path.startswith("desktop/src/") and path.endswith(".rs")
                                     for path in executable_paths):
             return {"run_code": False, "run_desktop": True, "run_package": False, "run_benchmarks": False}, "Desktop-only Rust change; validate and build Desktop. Backend, dependencies, and packaging inputs are unchanged."

--- a/.github/scripts/test_ci_selection.py
+++ b/.github/scripts/test_ci_selection.py
@@ -57,6 +57,31 @@ class SelectionTests(unittest.TestCase):
         self.write("docs/architecture.md", "updated")
         self.assertEqual(self.classify(), dict.fromkeys(selection.FULL, False))
 
+    def test_website_has_separate_validation(self):
+        self.write("website/src/pages/index.astro", "page")
+        self.write("website/package-lock.json", "lock")
+        self.write(".github/workflows/website.yml", "workflow")
+        self.write("docs/ci.md", "guidance")
+        self.assertEqual(self.classify(), dict.fromkeys(selection.FULL, False))
+
+    def test_website_cannot_hide_core_changes(self):
+        self.write("website/src/pages/index.astro", "page")
+        self.write("src/lib.rs", "changed")
+        self.assertEqual(self.classify(), selection.FULL)
+
+    def test_website_with_desktop_source_still_checks_desktop(self):
+        self.write("website/src/pages/index.astro", "page")
+        self.write("desktop/src/main.rs", "changed")
+        self.assertEqual(self.classify(), {
+            "run_code": False, "run_desktop": True,
+            "run_package": False, "run_benchmarks": False,
+        })
+
+    def test_moving_packaged_content_to_website_cannot_skip_checks(self):
+        Path("website").mkdir()
+        self.git("mv", "README.md", "website/README.md")
+        self.assertTrue(self.classify()["run_code"])
+
     def test_desktop_source_and_guidance_select_only_desktop(self):
         self.write("desktop/src/terminal.rs", "changed")
         self.write("docs/desktop/architecture.md", "updated")

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,55 @@
+name: Website
+
+on:
+  pull_request:
+    paths: ['website/**', 'assets/boomux-workspace-desktop.png', '.github/workflows/website.yml']
+  push:
+    branches: [main]
+    paths: ['website/**', 'assets/boomux-workspace-desktop.png', '.github/workflows/website.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: website-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Website build and browser tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: npm test
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: website/dist
+
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy static site
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,25 @@ an ambiguous start is never replayed automatically. Closing a Workspace retains
 its metadata and unresolved membership until every owning Node has confirmed
 the guarded removal of its resources.
 
+## Remote Workspace (Desktop)
+
+A machine-owned Workspace presented in Desktop with a remote-machine icon and
+connection status. It contains only resources owned by that machine. Desktop
+retains both Node identity and owner-local resource identity for every action;
+the display name or SSH alias never establishes ownership. New Shells inherit
+the owner's Workspace directory, not the Desktop machine's environment or cwd.
+
+Remote Workspaces reuse the existing owner-local Workspace representation. They
+do not change the multi-placement coordinator Workspace contract above. Existing
+coordinator membership is neither inferred nor rewritten by Desktop discovery.
+One registered machine can host multiple Remote Workspaces. Removing one does
+not forget the connection, uninstall Boomux, or remove other Workspaces.
+
+The Desktop **Remotes** tab manages machine connections, sign-in, and updates.
+Node remains the protocol and lifecycle-authority term, not the primary Desktop
+navigation label. A disconnected Remote Workspace remains visible from its last
+observation; that observation cannot authorize mutation or establish completion.
+
 ## Workspace Launcher
 
 A durable detached argument-vector command associated with a workspace and invoked on every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,7 @@ dependencies = [
  "smallvec",
  "toml 0.9.12+spec-1.1.0",
  "toml_edit 0.25.13+spec-1.1.0",
+ "uuid",
 ]
 
 [[package]]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -99,21 +99,35 @@ isolated development runtime. The first optimized build takes longer; keep the
 default debug build for routine iteration. Close the previous Desktop window
 before comparing the same workload.
 
-The helper builds both executables, sets a matching CLI PATH, and uses XDG
-runtime/config/state directories under `target/desktop-dev/`. Closing the window
+The helper builds both executables, sets a matching CLI PATH, and uses Boomux-only
+runtime/config/state directories under `target/desktop-dev/`. It sets
+`BOOMUX_RUNTIME_DIR`, `BOOMUX_CONFIG_HOME`, and `BOOMUX_STATE_HOME` instead of
+changing XDG variables. These override only Boomux's corresponding XDG roots
+(including Desktop settings); terminal applications retain normal configuration,
+plugins, credentials, and desktop runtime services. Closing the window
 keeps these development sessions alive. After rebuilding, the helper starts an
 absent development daemon or gracefully restarts an existing one with the rebuilt
 CLI's explicit executable path, preserving compatible live Shells. A failed
 handoff aborts the launch rather than falling back to a destructive stop.
+After executable handoff, `--refresh-environment` performs an additional graceful
+handoff using the launcher's environment, so daemon-owned sound delivery also
+uses the normal desktop audio socket. Existing Shell and shared-harness processes
+keep their original environments and PIDs.
 The helper prints the isolated runtime
 path; it does not replace installed binaries or use the ordinary daemon.
-This isolation does not cover harness configuration under the user's `HOME` or
-explicit harness overrides. Core's automatic integration maintenance can update
+This isolation does not cover harness configuration under XDG directories, the
+user's `HOME`, or explicit harness overrides. Core's automatic integration maintenance can update
 those shared integration files. Before testing integration maintenance, use a
 temporary home and harness-specific configuration roots; the focused native
 integration fixture demonstrates this without touching real harness settings.
 See `desktop/AGENTS.md` for additional validation and `docs/desktop/releases.md`
 for packaging and headless GUI smoke tests.
+
+When upgrading from the old XDG-isolated helper, existing running Shells retain
+their old environment across handoff. Launch the helper from a normal terminal
+and create new Shells to get the corrected environment. Existing development
+state and preferences stay at the same paths; no application data is copied or
+deleted. Do not stop the daemon just to refresh Shell environments.
 
 ## Use An Isolated Daemon
 
@@ -192,6 +206,11 @@ PTY, and daemon lifecycle behavior. Use the change-type coverage table in
 [`AGENTS.md`](AGENTS.md) to select additional compatibility tests.
 
 ## Web And Integration Changes
+
+The public landing page is a separate Astro site in `website/`, not the embedded
+web dashboard. See [`website/README.md`](website/README.md) for its local preview,
+browser tests, and GitHub Pages setup. Website-only work does not require Rust
+builds or live daemon operations.
 
 Install the pinned JavaScript dependencies and rebuild embedded terminal assets:
 

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -22,3 +22,4 @@ toml = "=0.9.12"
 toml_edit = "=0.25.13"
 serde_json = "=1.0.151"
 semver = "=1.0.28"
+uuid = { version = "1", features = ["v4"] }

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -10,7 +10,7 @@ The prototype uses [GPUI Community Edition](https://gpui-ce.github.io/) and `lib
 
 The layout panes are managed inside one GPUI window, and every pane hosts an independent **real local Boomux shell**. Each pane renders its shell's terminal output in GPUI and sends keyboard input and terminal resize events back through Boomux's attachment protocol. This lets us test the product shape without embedding Wayland client buffers or running a terminal emulator process per tile.
 
-An Omarchy Boomux-inspired sidebar presents the local workspace tree, shell status, and current/attention-bearing agents. When an agent settles from working to idle, its row remains marked **finished** until **Dismiss** is clicked; durable Boomux attention is acknowledged with the exact observation revision. Workspace rows expand and collapse. Clicking a shell or agent focuses its existing tile, or attaches its shell in a new tile when it is not already open. The overview refreshes from Boomux in the background without putting daemon requests on the GPUI render path. Nodes and web controls remain outside this proof of concept.
+An Omarchy Boomux-inspired sidebar presents local and remote workspaces, shell status, and current/attention-bearing agents. When an agent settles from working to idle, its row remains marked **finished** until **Dismiss** is clicked; durable Boomux attention is acknowledged with the exact observation revision. Workspace rows expand and collapse. Clicking a shell or agent focuses its existing tile, or attaches its shell in a new tile when it is not already open. The overview refreshes from Boomux in the background without putting daemon requests on the GPUI render path. Remote machine controls live in the lower sidebar's Remotes tab.
 
 When several visible Agents share a Shell, their rows include distinct Agent ID
 prefixes. They represent separate threads, and clicking either row opens the
@@ -49,14 +49,35 @@ are preserved. See
 [release packaging](../docs/desktop/releases.md) for version selection, install locations,
 release preparation, uninstall instructions, and the required platform smoke tests.
 
-Core installs detected harness integrations in the background when the Boomux
-service starts, including after an update handoff. Unchanged Boomux-managed
+Core prepares all bundled harness integrations in the background when the Boomux
+service starts, including after an update handoff. Installation does not require
+the harness to be visible on the service's PATH. Unchanged Boomux-managed
 integrations are refreshed to the bundled version automatically. Desktop has no
 harness detection, install prompts, or update prompts. User customizations and
 uninstall choices are preserved. Running harnesses may need a restart; Codex
 still requires its own hook trust approval. See [automatic integration management](../docs/install.md#automatic-integration-management).
 
-The header menu contains **Nodes**, updates, and keyboard shortcuts. The gear
+The header menu contains updates and keyboard shortcuts. **Agents | Git | Remotes**
+share the lower sidebar. Remote workspaces use a monitor icon, show their machine's
+connection status, and keep all Shells on that owner. Use **+ → New remote workspace…**
+to choose or connect a machine. Connecting creates its initial workspace and Shell;
+open it from the tree. **Remotes → New remote workspace** creates and opens another
+workspace on the selected machine. Each machine card contains its own sign-in
+and update controls; connecting another machine is a separate action above the
+cards. Closing a workspace does not uninstall the remote machine.
+Machine cards start collapsed, showing only their name and connection status.
+Click a card header to expand or collapse its details; Enter or Space toggles
+the selected machine when the Remotes panel has keyboard focus.
+**Remove machine & uninstall Boomux…** opens a terminal for explicit confirmation:
+it stops all Boomux-managed processes on that machine and removes its executable
+and unchanged integration assets, preserving durable state, configuration, and
+customizations. The connection is forgotten only after confirmed remote removal;
+an unavailable machine cannot be silently removed as if uninstallation succeeded.
+If Boomux was already removed remotely, or the machine is no longer reachable,
+use **Forget connection only…** and confirm. This removes only the local
+registration and cached presentation; it does not contact the machine, uninstall
+software, or stop remote work.
+The gear
 opens Settings. **Settings → Open advanced setup in terminal** remains available
 for the guided terminal checklist: **Up/Down** to choose, **Space** to toggle,
 **Enter** to apply, and **Esc** to cancel. See the
@@ -212,8 +233,9 @@ Settings default to **Workspace** pane scope: opening a Workspace replaces the
 canvas with its remembered non-minimized Shells, while opening a Shell restores
 only that Shell. **Mixed** scope preserves the free-form behavior where Shells
 from different Workspaces can share the canvas. Settings can also hide pane
-headings and switch the pane layout between **Tiled** (the default) and
-**Tabs**. Tabs leaves every open terminal in the tiled and floating canvas.
+headings and switch the pane layout between **Tree** and
+**Tabs** (the default). Existing saved layout preferences are preserved.
+Tabs leaves every open terminal in the tiled and floating canvas.
 When `Ctrl+W` minimizes a pane, its detached Boomux Shell appears in a strip
 across the top; clicking that tab restores the Shell as a pane. Tabs keeps the
 sidebar's Workspace list compact by hiding all nested Shell rows. The strip's

--- a/desktop/scripts/run-dev.py
+++ b/desktop/scripts/run-dev.py
@@ -17,18 +17,14 @@ def main():
                    cwd=root, check=True)
     target = root / "target" / ("release" if options.release else "debug")
     env = {key: value for key, value in os.environ.items() if not key.startswith("BOOMUX_")}
-    display = env.get("WAYLAND_DISPLAY")
-    if display and not Path(display).is_absolute() and env.get("XDG_RUNTIME_DIR"):
-        env["WAYLAND_DISPLAY"] = str(Path(env["XDG_RUNTIME_DIR"]) / display)
-    # Keep the user's existing GitHub CLI authentication available to read-only
-    # PR inspection while Boomux's runtime/configuration remain isolated.
-    env.setdefault("GH_CONFIG_DIR", str(Path(env.get("XDG_CONFIG_HOME") or Path.home() / ".config") / "gh"))
-    for name in ["RUNTIME_DIR", "CONFIG_HOME", "STATE_HOME", "DATA_HOME", "CACHE_HOME"]:
+    # Only Boomux reads these overrides. Terminal applications retain the user's
+    # XDG configuration, data, cache, runtime services, and authentication.
+    for name in ["RUNTIME_DIR", "CONFIG_HOME", "STATE_HOME"]:
         path = root / "target/desktop-dev" / name.lower()
         path.mkdir(parents=True, exist_ok=True, mode=0o700)
-        env[f"XDG_{name}"] = str(path)
+        env[f"BOOMUX_{name}"] = str(path)
     env["PATH"] = str(target) + os.pathsep + env.get("PATH", "")
-    print(f"Development runtime: {env['XDG_RUNTIME_DIR']}", flush=True)
+    print(f"Development runtime: {env['BOOMUX_RUNTIME_DIR']}", flush=True)
     cli = target / "boomux"
     status = subprocess.run([cli, "daemon", "status", "--json"], env=env,
                             check=True, timeout=30, capture_output=True, text=True)
@@ -36,7 +32,7 @@ def main():
     if state not in {"running", "stopped"}:
         raise RuntimeError(f"Unexpected development daemon status: {state}")
     # Start does not reload an existing daemon; explicitly select this build for handoff.
-    action = ["restart", "--executable", str(cli)] if state == "running" else ["start"]
+    action = ["restart", "--executable", str(cli), "--refresh-environment"] if state == "running" else ["start"]
     subprocess.run([cli, "daemon", *action], env=env, check=True, timeout=30)
     executable = str(target / "boomux-desktop")
     os.execve(executable, [executable, *desktop_args], env)

--- a/desktop/scripts/test-run-dev.py
+++ b/desktop/scripts/test-run-dev.py
@@ -22,6 +22,10 @@ class DevelopmentLaunchTests(unittest.TestCase):
             "PATH": "/usr/bin", "XDG_RUNTIME_DIR": "/ordinary/runtime",
             "WAYLAND_DISPLAY": "wayland-1", "BOOMUX_CONFIG": "/ordinary/config",
             "XDG_CONFIG_HOME": "/ordinary/config-home",
+            "XDG_DATA_HOME": "/ordinary/data-home",
+            "XDG_STATE_HOME": "/ordinary/state-home",
+            "XDG_CACHE_HOME": "/ordinary/cache-home",
+            "HOME": "/ordinary/home", "KIRO_HOME": "/explicit/kiro",
             **({"GH_CONFIG_DIR": gh_config} if gh_config else {}),
         }, clear=True), patch.object(Path, "mkdir"), \
                 patch("subprocess.run", side_effect=[Mock(), status, failure or Mock()]) as run, \
@@ -41,22 +45,27 @@ class DevelopmentLaunchTests(unittest.TestCase):
             self.assertEqual(calls[1].args[0], [cli, "daemon", "status", "--json"])
             for call in calls[1:]:
                 env = call.kwargs["env"]
-                for name in ["RUNTIME_DIR", "CONFIG_HOME", "STATE_HOME", "DATA_HOME", "CACHE_HOME"]:
-                    self.assertEqual(env[f"XDG_{name}"], str(ROOT / "target/desktop-dev" / name.lower()))
-                self.assertEqual(env["GH_CONFIG_DIR"], gh_config or "/ordinary/config-home/gh")
-                self.assertEqual(env["WAYLAND_DISPLAY"], "/ordinary/runtime/wayland-1")
-                self.assertFalse(any(key.startswith("BOOMUX_") for key in env))
+                for name in ["RUNTIME_DIR", "CONFIG_HOME", "STATE_HOME"]:
+                    self.assertEqual(env[f"BOOMUX_{name}"], str(ROOT / "target/desktop-dev" / name.lower()))
+                self.assertEqual(env["XDG_RUNTIME_DIR"], "/ordinary/runtime")
+                for name in ["CONFIG", "STATE", "DATA", "CACHE"]:
+                    self.assertEqual(env[f"XDG_{name}_HOME"], f"/ordinary/{name.lower()}-home")
+                self.assertEqual(env.get("GH_CONFIG_DIR"), gh_config)
+                self.assertEqual(env["WAYLAND_DISPLAY"], "wayland-1")
+                self.assertEqual(env["HOME"], "/ordinary/home")
+                self.assertEqual(env["KIRO_HOME"], "/explicit/kiro")
+                self.assertNotIn("BOOMUX_CONFIG", env)
                 self.assertEqual(env["PATH"], str(cli.parent) + os.pathsep + "/usr/bin")
                 self.assertTrue(call.kwargs["check"])
                 self.assertEqual(call.kwargs["timeout"], 30)
             return calls[-1].args[0]
 
     def test_running_daemon_hands_off_to_the_exact_rebuilt_executable(self):
-        self.assertEqual(self.launch("running"), [CLI, "daemon", "restart", "--executable", str(CLI)])
+        self.assertEqual(self.launch("running"), [CLI, "daemon", "restart", "--executable", str(CLI), "--refresh-environment"])
 
     def test_release_handoff_uses_release_binaries_and_the_same_runtime(self):
         cli = ROOT / "target/release/boomux"
-        self.assertEqual(self.launch("running", release=True), [cli, "daemon", "restart", "--executable", str(cli)])
+        self.assertEqual(self.launch("running", release=True), [cli, "daemon", "restart", "--executable", str(cli), "--refresh-environment"])
 
     def test_explicit_github_config_is_preserved(self):
         self.launch("stopped", gh_config="/explicit/gh")

--- a/desktop/src/boomux_settings.rs
+++ b/desktop/src/boomux_settings.rs
@@ -114,6 +114,52 @@ pub struct Snapshot {
     defaults: DocumentMut,
 }
 impl Snapshot {
+    /// Append picker selections without rewriting existing paths or splitting
+    /// legitimate whitespace in directory names through the manual text editor.
+    pub fn add_project_folders(&mut self, paths: &[PathBuf]) -> Result<bool, String> {
+        let mut roots = self
+            .value("projects.roots")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let original_len = roots.len();
+        for path in paths {
+            if !path.is_absolute() {
+                return Err("Select an absolute project folder path".into());
+            }
+            let text = path
+                .to_str()
+                .ok_or("Project folder paths must be valid UTF-8")?;
+            let exists = roots.iter().filter_map(Value::as_str).any(|root| {
+                if root == text {
+                    return true;
+                }
+                let relative = if root == "~" {
+                    Some("")
+                } else {
+                    root.strip_prefix("~/")
+                };
+                relative
+                    .and_then(|relative| {
+                        std::env::var_os("HOME").map(|home| PathBuf::from(home).join(relative))
+                    })
+                    .as_deref()
+                    == Some(path.as_path())
+            });
+            if !exists {
+                roots.push(text);
+            }
+        }
+        if roots.len() == original_len {
+            return Ok(false);
+        }
+        if self.document.get("projects").is_none() {
+            self.document["projects"] = Item::Table(toml_edit::Table::new());
+        }
+        self.document["projects"]["roots"] = Item::Value(Value::Array(roots));
+        Ok(true)
+    }
+
     pub fn notifications_enabled(&self) -> bool {
         self.value("notifications.enabled").and_then(Value::as_bool) == Some(true)
             || self
@@ -327,9 +373,22 @@ impl Drop for Temporary {
 }
 
 // Coreutils timeout owns the entire process group, including our editor helper.
-// Pipe readers retain at most 64 KiB each. All waits happen on a worker thread.
+// Pipe readers retain at most 64 KiB (1 MiB for project discovery).
+// All waits happen on a worker thread.
 fn run(args: &[&str], editor: Option<String>) -> Result<String, String> {
     run_layer(args, editor, false)
+}
+
+pub fn discover_projects() -> Result<boomux::protocol::HostProjectDiscovery, String> {
+    let output = run(&["project", "list", "--json"], None)?;
+    let envelope: serde_json::Value = serde_json::from_str(&output).map_err(|e| e.to_string())?;
+    serde_json::from_value(
+        envelope
+            .get("data")
+            .cloned()
+            .ok_or("Missing project discovery result")?,
+    )
+    .map_err(|e| format!("Invalid project discovery result: {e}"))
 }
 fn run_layer(args: &[&str], editor: Option<String>, global: bool) -> Result<String, String> {
     let mut command = Command::new("timeout");
@@ -358,11 +417,16 @@ fn run_layer(args: &[&str], editor: Option<String>, global: bool) -> Result<Stri
         .map_err(|e| format!("Could not run Boomux: {e}"))?;
     let output = child.stdout.take().ok_or("Missing Boomux output pipe")?;
     let errors = child.stderr.take().ok_or("Missing Boomux error pipe")?;
+    let output_limit = if args == ["project", "list", "--json"] {
+        LIMIT
+    } else {
+        65536
+    };
     let collect = |reader: Box<dyn Read + Send>| {
         std::thread::spawn(move || {
             let mut text = String::new();
             reader
-                .take(65536)
+                .take(output_limit)
                 .read_to_string(&mut text)
                 .map(|_| text)
                 .map_err(|e| e.to_string())
@@ -502,6 +566,100 @@ mod tests {
         assert_eq!(snapshot.control_text(0), "true");
         snapshot.set_control(0, "false").unwrap();
         assert!(!snapshot.notifications_enabled());
+    }
+
+    #[test]
+    fn folder_picker_appends_inherited_roots_and_preserves_path_text() {
+        let mut snapshot = Snapshot {
+            path: PathBuf::new(),
+            original: None,
+            document: "# user comment\n[projects]\nmax_depth = 4\n"
+                .parse()
+                .unwrap(),
+            inherited: "[projects]\nroots = ['/existing']\n".parse().unwrap(),
+            defaults: defaults(),
+        };
+        assert!(
+            snapshot
+                .add_project_folders(&[
+                    PathBuf::from("/existing"),
+                    PathBuf::from("/Side projects"),
+                    PathBuf::from("/Side projects"),
+                    PathBuf::from("/ whitespace \nfolder "),
+                ])
+                .unwrap()
+        );
+        let roots = snapshot
+            .value("projects.roots")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(
+            roots.iter().filter_map(Value::as_str).collect::<Vec<_>>(),
+            ["/existing", "/Side projects", "/ whitespace \nfolder "]
+        );
+        assert_eq!(snapshot.text(11), "4");
+        assert!(snapshot.document.to_string().contains("# user comment"));
+        assert!(!snapshot.restart_changed());
+    }
+
+    #[test]
+    fn folder_picker_cancel_duplicates_and_invalid_paths_do_not_change_settings() {
+        let mut snapshot = Snapshot {
+            path: PathBuf::new(),
+            original: None,
+            document: "[projects]\nroots = ['/existing']\n".parse().unwrap(),
+            inherited: DocumentMut::new(),
+            defaults: defaults(),
+        };
+        let original = snapshot.document.to_string();
+        assert!(!snapshot.add_project_folders(&[]).unwrap());
+        assert!(
+            !snapshot
+                .add_project_folders(&[PathBuf::from("/existing")])
+                .unwrap()
+        );
+        assert!(
+            snapshot
+                .add_project_folders(&[PathBuf::from("/new"), PathBuf::from("relative")])
+                .is_err()
+        );
+        assert_eq!(snapshot.document.to_string(), original);
+    }
+
+    #[test]
+    fn project_roots_preserve_spaces_and_do_not_require_restart() {
+        let mut snapshot = Snapshot {
+            path: PathBuf::new(),
+            original: None,
+            document: DocumentMut::new(),
+            inherited: DocumentMut::new(),
+            defaults: defaults(),
+        };
+        snapshot
+            .set_control(10, "~/Work\n/home/person/Side projects")
+            .unwrap();
+        let roots = snapshot
+            .value("projects.roots")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(roots.len(), 2);
+        assert_eq!(
+            roots.get(1).unwrap().as_str(),
+            Some("/home/person/Side projects")
+        );
+        assert!(!snapshot.restart_changed());
+        snapshot.set_control(10, "").unwrap();
+        assert!(
+            snapshot
+                .value("projects.roots")
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+        assert!(!snapshot.restart_changed());
     }
 
     #[test]

--- a/desktop/src/git_panel.rs
+++ b/desktop/src/git_panel.rs
@@ -72,7 +72,7 @@ fn fetch(previous: Vec<NodeOverview>, refresh: bool) -> Vec<NodeOverview> {
                     Duration::from_secs(2),
                 )
             } else {
-                item.error = Some("Node unavailable; last Git observation retained".into());
+                item.error = Some("Machine unavailable; last Git observation retained".into());
                 nodes.push(item);
                 continue;
             };
@@ -87,8 +87,8 @@ fn fetch(previous: Vec<NodeOverview>, refresh: bool) -> Vec<NodeOverview> {
         }
         if snapshot.nodes.len() > 16 {
             nodes.push(NodeOverview {
-                label: "More Nodes".into(),
-                error: Some("Showing the first 16 Nodes".into()),
+                label: "More machines".into(),
+                error: Some("Showing the first 16 machines".into()),
                 ..Default::default()
             });
         }
@@ -98,7 +98,8 @@ fn fetch(previous: Vec<NodeOverview>, refresh: bool) -> Vec<NodeOverview> {
         let mut previous = previous;
         if previous.is_empty() {
             previous.push(NodeOverview {
-                label: "Local Node".into(),
+                label: "This machine".into(),
+                local: true,
                 ..Default::default()
             });
         }
@@ -254,6 +255,7 @@ impl Workspace {
     }
 
     pub(crate) fn select_git_tab(&mut self, git: bool, cx: &mut Context<Self>) {
+        self.nodes_open = false;
         if self.git_panel.open == git {
             self.save_settings();
             cx.notify();
@@ -406,9 +408,9 @@ impl Workspace {
                         .text_xs()
                         .text_color(rgb(0xa6adc8))
                         .child(if node.local {
-                            "Node · This machine".into()
+                            "This machine".into()
                         } else {
-                            format!("Node · {}", node.label)
+                            format!("Remote · {}", node.label)
                         })
                         .into_any_element(),
                 );

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -5,6 +5,7 @@ mod git_panel;
 mod layout;
 mod layout_badge;
 mod nodes;
+mod remote;
 mod runtime;
 mod settings;
 mod terminal;
@@ -49,6 +50,34 @@ fn rgb(color: u32) -> gpui::Rgba {
 }
 
 struct HeaderTooltip(&'static str);
+
+fn sidebar_brand_mark() -> impl IntoElement {
+    div()
+        .size(px(32.0))
+        .flex_none()
+        .rounded(px(9.0))
+        .bg(rgb(0x89b4fa))
+        .child(
+            canvas(
+                |_, _, _| (),
+                |bounds, (), window, _| {
+                    // Vector strokes stay crisp at small sizes and do not
+                    // depend on the user's font or symbol coverage.
+                    let mut prompt = gpui::PathBuilder::stroke(px(2.5));
+                    let at = |x, y| point(bounds.left() + px(x), bounds.top() + px(y));
+                    prompt.move_to(at(8.0, 10.0));
+                    prompt.line_to(at(14.0, 16.0));
+                    prompt.line_to(at(8.0, 22.0));
+                    prompt.move_to(at(17.0, 22.0));
+                    prompt.line_to(at(24.0, 22.0));
+                    if let Ok(path) = prompt.build() {
+                        window.paint_path(path, rgb(0x11111b));
+                    }
+                },
+            )
+            .size_full(),
+        )
+}
 
 impl Render for HeaderTooltip {
     fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
@@ -95,7 +124,7 @@ fn sidebar_header_button(
         .child(glyph)
 }
 
-fn sidebar_menu_row(id: &'static str) -> Stateful<Div> {
+fn sidebar_menu_row(id: impl Into<gpui::ElementId>) -> Stateful<Div> {
     div()
         .id(id)
         .role(gpui::Role::MenuItem)
@@ -724,8 +753,8 @@ enum WorkspacePaneMode {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 enum PaneLayoutMode {
-    #[default]
     Tiled,
+    #[default]
     Tabbed,
 }
 
@@ -952,6 +981,14 @@ impl Render for TerminalSelectionDrag {
 struct TerminalSelection {
     anchor: (usize, usize),
     head: (usize, usize),
+}
+
+fn lifted_drag_bounds(mut bounds: FloatingPane, delta: (f32, f32)) -> FloatingPane {
+    // A tiled pane may span the entire panel. Keep the grab point under the
+    // pointer even when part of the temporary floating pane leaves the panel.
+    bounds.x += delta.0;
+    bounds.y += delta.1;
+    bounds
 }
 
 fn dragged_bounds(
@@ -1426,10 +1463,19 @@ struct Workspace {
     minimized_tab_scroll_handle: ScrollHandle,
     sidebar_menu: Option<SidebarMenu>,
     sidebar_header_menu_open: bool,
+    project_menu_open: bool,
+    projects_loading: bool,
+    projects_result: Option<Result<boomux::protocol::HostProjectDiscovery, String>>,
+    project_folder_picker_pending: bool,
+    project_folder_picker_open: bool,
     nodes_open: bool,
     node_views: Vec<nodes::NodeView>,
     nodes_error: Option<String>,
+    node_forget_confirm: Option<String>,
+    node_forget_busy: bool,
+    node_forget_error: Option<String>,
     selected_node: Option<String>,
+    expanded_node: Option<String>,
     resource_dialog: Option<ResourceDialog>,
     sidebar_visible: bool,
     sidebar_preferred_width: f32,
@@ -1612,10 +1658,19 @@ impl Workspace {
             minimized_tab_scroll_handle,
             sidebar_menu: None,
             sidebar_header_menu_open: false,
+            project_menu_open: false,
+            projects_loading: false,
+            projects_result: None,
+            project_folder_picker_pending: false,
+            project_folder_picker_open: false,
             nodes_open: false,
             node_views: Vec::new(),
             nodes_error: None,
+            node_forget_confirm: None,
+            node_forget_busy: false,
+            node_forget_error: None,
             selected_node: None,
+            expanded_node: None,
             resource_dialog: None,
             sidebar_visible: saved.sidebar_visible,
             sidebar_preferred_width: saved.sidebar_width,
@@ -2498,6 +2553,7 @@ impl Workspace {
         cx: &mut Context<Self>,
     ) {
         let previous_width = self.sidebar_width();
+        self.project_menu_open = false;
         self.sidebar_visible = !self.sidebar_visible;
         self.nodes_open = false;
         self.save_settings();
@@ -2517,6 +2573,7 @@ impl Workspace {
     }
 
     fn toggle_settings(&mut self, cx: &mut Context<Self>) {
+        self.project_menu_open = false;
         self.git_panel.search_focused = false;
         self.sidebar_header_menu_open = false;
         if self.settings_open {
@@ -2535,6 +2592,7 @@ impl Workspace {
     }
 
     fn close_settings(&mut self, cx: &mut Context<Self>) {
+        self.project_folder_picker_pending = false;
         if !self.settings_open {
             return;
         }
@@ -3074,7 +3132,13 @@ impl Workspace {
             self.begin_layout_animation(previous_rects);
         }
 
-        if let (Some(duration), Some(from)) = (self.motion_speed.duration(), from) {
+        // Restore tabs must be available as soon as their pane leaves the layout.
+        // Keeping the pane alive for the minimize animation delays tab creation.
+        let minimize_duration = self
+            .motion_speed
+            .duration()
+            .filter(|_| self.pane_layout_mode != PaneLayoutMode::Tabbed);
+        if let (Some(duration), Some(from)) = (minimize_duration, from) {
             self.animation_generation = self.animation_generation.wrapping_add(1);
             let generation = self.animation_generation;
             self.minimizing_panes.push(PaneMinimizeAnimation {
@@ -3986,6 +4050,7 @@ impl Workspace {
         }
         let (panel_width, panel_height) = self.panel_size(window);
 
+        let lifted = matches!(drag.subject, PointerSubject::Lifted(_));
         match drag.subject {
             PointerSubject::Floating(start_bounds) | PointerSubject::Lifted(start_bounds) => {
                 let Some(pane) = self
@@ -3996,12 +4061,16 @@ impl Workspace {
                     self.pointer_drag = None;
                     return;
                 };
-                *pane = dragged_bounds(
-                    start_bounds,
-                    drag.operation,
-                    (dx, dy),
-                    (panel_width, panel_height),
-                );
+                *pane = if lifted && matches!(drag.operation, PointerOperation::Move) {
+                    lifted_drag_bounds(start_bounds, (dx, dy))
+                } else {
+                    dragged_bounds(
+                        start_bounds,
+                        drag.operation,
+                        (dx, dy),
+                        (panel_width, panel_height),
+                    )
+                };
             }
             PointerSubject::Tiled(start_layout) => match drag.operation {
                 PointerOperation::Move => unreachable!("tiled moves are lifted before dragging"),
@@ -4471,7 +4540,7 @@ impl Workspace {
             return;
         }
 
-        if self.nodes_open {
+        if self.nodes_open && self.navigation_region == NavigationRegion::Sidebar {
             let modifiers = event.keystroke.modifiers;
             if modifiers.control
                 || modifiers.alt
@@ -4485,23 +4554,34 @@ impl Workspace {
             match event.keystroke.key.as_str() {
                 "escape" => self.nodes_open = false,
                 "up" | "down" => {
-                    let len = self.node_views.len();
+                    let nodes = self
+                        .node_views
+                        .iter()
+                        .filter(|node| !node.local)
+                        .collect::<Vec<_>>();
+                    let len = nodes.len();
                     if len > 0 {
                         let current = self
                             .selected_node
                             .as_ref()
-                            .and_then(|id| self.node_views.iter().position(|node| &node.id == id));
+                            .and_then(|id| nodes.iter().position(|node| &node.id == id));
                         let index = match (current, event.keystroke.key.as_str()) {
                             (Some(index), "up") => (index + len - 1) % len,
                             (Some(index), _) => (index + 1) % len,
                             (None, "up") => len - 1,
                             _ => 0,
                         };
-                        self.selected_node = Some(self.node_views[index].id.clone());
+                        self.selected_node = Some(nodes[index].id.clone());
                     }
                 }
                 "a" => self.launch_node_action(terminal::WorkspaceLaunch::AddNode, window, cx),
-                "d" => self.launch_node_action(terminal::WorkspaceLaunch::Dashboard, window, cx),
+                "enter" | "space" => {
+                    self.expanded_node = if self.expanded_node == self.selected_node {
+                        None
+                    } else {
+                        self.selected_node.clone()
+                    };
+                }
                 "r" => {
                     if let Some(node) = self.node_views.iter().find(|node| Some(&node.id) == self.selected_node.as_ref()
                         && !node.local && node.health == boomux::protocol::NodeProjectionHealthCode::AuthenticationRequired) {
@@ -4542,6 +4622,12 @@ impl Workspace {
         }
         if self.sidebar_menu.is_some() && event.keystroke.key == "escape" {
             self.sidebar_menu = None;
+            cx.stop_propagation();
+            cx.notify();
+            return;
+        }
+        if self.project_menu_open && event.keystroke.key == "escape" {
+            self.project_menu_open = false;
             cx.stop_propagation();
             cx.notify();
             return;
@@ -4739,7 +4825,7 @@ impl Workspace {
         cx.spawn(async move |this, cx| {
             let result = cx
                 .background_spawn(async move {
-                    let shell = terminal::create_shell(&anchor)?;
+                    let shell = terminal::create_shell(&anchor, size)?;
                     let session = match TerminalSession::attach(
                         shell.clone(),
                         size.0,
@@ -4753,8 +4839,9 @@ impl Workspace {
                             return Err(error);
                         }
                     };
-                    let overview = terminal::discover_overview().ok();
-                    Ok::<_, String>((shell, session, overview))
+                    // The existing overview worker refreshes sidebar resources.
+                    // Do not hold an attached terminal behind that extra request.
+                    Ok::<_, String>((shell, session))
                 })
                 .await;
             this.update(cx, |this, cx| {
@@ -4763,14 +4850,11 @@ impl Workspace {
                 };
                 pane.attaching = false;
                 match result {
-                    Ok((shell, session, overview)) => {
+                    Ok((shell, session)) => {
                         let shell_id = session.shell_id.clone();
                         pane.screen = Some(session.screen());
                         pane.shell = Some(shell);
                         pane.session = Some(session);
-                        if let Some(overview) = overview {
-                            this.set_boomux_overview(overview);
-                        }
                         this.watch_terminal(pane_id, shell_id, cx);
                     }
                     Err(error) => pane.error = Some(error),
@@ -4829,7 +4913,7 @@ impl Workspace {
         cx.spawn(async move |this, cx| {
             let result = cx
                 .background_spawn(async move {
-                    let shell = terminal::create_shell_in_workspace(&workspace_id)?;
+                    let shell = terminal::create_shell_in_workspace(&workspace_id, size)?;
                     let session = match TerminalSession::attach(
                         shell.clone(),
                         size.0,
@@ -4843,8 +4927,9 @@ impl Workspace {
                             return Err(error);
                         }
                     };
-                    let overview = terminal::discover_overview().ok();
-                    Ok::<_, String>((shell, session, overview))
+                    // The existing overview worker refreshes sidebar resources.
+                    // Do not hold an attached terminal behind that extra request.
+                    Ok::<_, String>((shell, session))
                 })
                 .await;
             this.update(cx, |this, cx| {
@@ -4853,14 +4938,11 @@ impl Workspace {
                 };
                 pane.attaching = false;
                 match result {
-                    Ok((shell, session, overview)) => {
+                    Ok((shell, session)) => {
                         let shell_id = session.shell_id.clone();
                         pane.screen = Some(session.screen());
                         pane.shell = Some(shell);
                         pane.session = Some(session);
-                        if let Some(overview) = overview {
-                            this.set_boomux_overview(overview);
-                        }
                         this.watch_terminal(pane_id, shell_id, cx);
                     }
                     Err(error) => pane.error = Some(error),
@@ -4873,6 +4955,7 @@ impl Workspace {
     }
 
     fn create_and_attach_new_workspace(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.project_menu_open = false;
         self.create_workspace_terminal(terminal::WorkspaceLaunch::Shell, window, cx);
     }
 
@@ -4913,15 +4996,16 @@ impl Workspace {
                         Ok(session) => session,
                         Err(error) => {
                             // Setup ownership does not authorize deleting resources added meanwhile.
-                            if !shell.desktop_setup {
+                            if !shell.desktop_setup && remote::identity(&shell.id).is_none() {
                                 let _ = terminal::remove_workspace(&shell.workspace_id);
                             }
                             return Err(error);
                         }
                     };
                     session.setup_workspace_cleanup = setup_workspace_cleanup;
-                    let overview = terminal::discover_overview().ok();
-                    Ok::<_, String>((shell, session, overview))
+                    // The existing overview worker refreshes sidebar resources.
+                    // Do not hold an attached terminal behind that extra request.
+                    Ok::<_, String>((shell, session))
                 })
                 .await;
             this.update(cx, |this, cx| {
@@ -4930,7 +5014,7 @@ impl Workspace {
                 };
                 pane.attaching = false;
                 match result {
-                    Ok((shell, session, overview)) => {
+                    Ok((shell, session)) => {
                         let shell_id = session.shell_id.clone();
                         let workspace_id = shell.workspace_id.clone();
                         pane.screen = Some(session.screen());
@@ -4943,9 +5027,6 @@ impl Workspace {
                         );
                         if !this.workspace_order.contains(&workspace_id) {
                             this.workspace_order.push(workspace_id.clone());
-                        }
-                        if let Some(overview) = overview {
-                            this.set_boomux_overview(overview);
                         }
                         this.watch_terminal(pane_id, shell_id, cx);
                     }
@@ -5197,6 +5278,7 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.project_menu_open = false;
         let Some(shells) = self
             .boomux_overview
             .workspaces
@@ -5374,6 +5456,7 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.project_menu_open = false;
         if let Some(pane_id) = self.terminals.iter().find_map(|(pane_id, pane)| {
             pane.shell
                 .as_ref()
@@ -5605,14 +5688,29 @@ impl Workspace {
     }
 
     fn open_nodes(&mut self, cx: &mut Context<Self>) {
+        self.project_menu_open = false;
         self.git_panel.search_focused = false;
         self.sidebar_header_menu_open = false;
         self.sidebar_menu = None;
         self.nodes_open = true;
+        self.git_panel.open = false;
+        self.git_panel.task = None;
+        self.sidebar_visible = true;
+        self.navigation_region = NavigationRegion::Sidebar;
         self.selected_node = self
             .selected_node
             .take()
-            .or_else(|| self.node_views.first().map(|node| node.id.clone()));
+            .filter(|id| {
+                self.node_views
+                    .iter()
+                    .any(|node| !node.local && node.id == *id)
+            })
+            .or_else(|| {
+                self.node_views
+                    .iter()
+                    .find(|node| !node.local)
+                    .map(|node| node.id.clone())
+            });
         cx.notify();
     }
 
@@ -5629,6 +5727,40 @@ impl Workspace {
         self.create_workspace_terminal(launch, window, cx);
     }
 
+    fn forget_remote_connection(&mut self, id: String, cx: &mut Context<Self>) {
+        if self.node_forget_busy || self.node_forget_confirm.as_ref() != Some(&id) {
+            return;
+        }
+        self.node_forget_busy = true;
+        self.node_forget_error = None;
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    boomux::client::connect()
+                        .and_then(|client| client.forget_node_registration(id))
+                        .map_err(|error| error.to_string())
+                })
+                .await;
+            this.update(cx, |this, cx| {
+                this.node_forget_busy = false;
+                match result {
+                    Ok(_) => {
+                        this.node_forget_confirm = None;
+                    }
+                    Err(error) => {
+                        this.node_forget_error =
+                            Some(format!("Could not forget connection: {error}"));
+                    }
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+        cx.notify();
+    }
+
     fn nodes_panel(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
         if !self.nodes_open {
             return None;
@@ -5636,13 +5768,10 @@ impl Workspace {
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_or(0, |duration| duration.as_millis() as u64);
-        let selected = self
-            .selected_node
-            .as_ref()
-            .and_then(|id| self.node_views.iter().find(|node| &node.id == id));
         let rows = self
             .node_views
             .iter()
+            .filter(|node| !node.local)
             .map(|node| {
                 let id = node.id.clone();
                 div()
@@ -5660,64 +5789,399 @@ impl Workspace {
                     .on_click(cx.listener(move |this, _, _, cx| {
                         cx.stop_propagation();
                         this.selected_node = Some(id.clone());
+                        this.expanded_node = if this.expanded_node.as_ref() == Some(&id) {
+                            None
+                        } else {
+                            Some(id.clone())
+                        };
                         cx.notify();
                     }))
-                    .child(div().text_sm().child(node.label.clone()))
+                    .child(div().flex().items_center().gap_2()
+                        .child(div().flex_1().min_w_0().text_sm().truncate().child(node.label.clone()))
+                        .child(div().flex_none().text_xs().text_color(rgb(0x7f849c))
+                            .child(if self.expanded_node.as_ref() == Some(&node.id) { "▾" } else { "▸" })))
                     .child(
                         div()
                             .text_xs()
                             .text_color(rgb(if node.connected() { 0xa6e3a1 } else { 0xf9e2af }))
                             .child(node.status()),
                     )
-            })
-            .collect::<Vec<_>>();
-        Some(div().id("nodes-backdrop").absolute().occlude().size_full().top_0().left_0()
-            .on_mouse_down(MouseButton::Left, cx.listener(|this, _, _, cx| {
-                this.nodes_open = false;
-                cx.stop_propagation();
-                cx.notify();
-            }))
-            .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
-            .child(div().id("nodes-panel").absolute().occlude()
-            .top(px(54.0)).left(px(10.0)).w(px(280.0)).max_h(relative(0.85)).overflow_y_scroll()
-            .p_3().flex().flex_col().gap_2().rounded_lg().border_1()
-            .border_color(rgb(0x45475a)).bg(rgb(0x1e1e2e)).shadow_lg()
-            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
-            .child(div().flex().items_center().justify_between()
-                .child(div().font_weight(gpui::FontWeight::BOLD).child("Nodes"))
-                .child(Self::settings_option("close-nodes", "Close", false)
-                    .on_click(cx.listener(|this, _, _, cx| { this.nodes_open = false; cx.notify(); }))))
-            .when_some(self.nodes_error.clone(), |panel, error| panel.child(div().text_xs().text_color(rgb(0xf9e2af)).child(error)))
-            .child(div().id("node-list").max_h(px(180.0)).overflow_y_scroll().children(rows))
-            .when_some(selected, |panel, node| {
-                panel.child(div().flex().flex_col().gap_2().text_xs()
-                    .when_some(node.route.clone(), |detail, route| detail.child(div().child(route)))
-                    .child(format!("{} Workspaces · {} Shells{}", node.workspace_count, node.shell_count,
+            .when(self.expanded_node.as_ref() == Some(&node.id), |panel| {
+                panel.child(div().mt_2().pt_2().border_t_1().border_color(rgb(0x45475a))
+                    .id("remote-machine-details")
+                    .on_click(cx.listener(|_, _, _, cx| cx.stop_propagation()))
+                    .flex().flex_col().gap_2().text_xs().text_color(rgb(0xa6adc8))
+                    .when_some(node.route.clone(), |detail, route| detail.child(div().truncate().child(format!("SSH · {route}"))))
+                    .child(format!("{} workspace{} · {} shell{}{}", node.workspace_count,
+                        if node.workspace_count == 1 { "" } else { "s" }, node.shell_count,
+                        if node.shell_count == 1 { "" } else { "s" },
                         if node.connected() { "" } else { " · cached" }))
-                    .child(node.last_seen(now_ms))
                     .when_some(node.version.clone(), |detail, version| detail.child(format!("Boomux {version}")))
-                    .child(node.guidance())
+                    .when(!node.connected(), |detail| detail.child(node.last_seen(now_ms)).child(node.guidance()))
+                    .when(!node.local && node.connected(), |detail| {
+                        let node_id = node.id.clone();
+                        let name = node.label.clone();
+                        let upgrade_id = node.id.clone();
+                        detail.child(Self::settings_option("create-remote-workspace", "New workspace", false)
+                            .flex_none()
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                cx.stop_propagation();
+                                let name = terminal::project_workspace_name(&name, this.boomux_overview.workspaces.iter()
+                                    .filter(|w| remote::identity(&w.id).is_some_and(|id| id.node_id == node_id))
+                                    .map(|w| w.name.as_str()));
+                                this.launch_node_action(terminal::WorkspaceLaunch::RemoteWorkspace { node_id: node_id.clone(), name }, window, cx);
+                            })))
+                            .child(Self::settings_option("update-remote", "Update Boomux", false)
+                            .flex_none()
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                cx.stop_propagation();
+                                this.launch_node_action(terminal::WorkspaceLaunch::UpgradeNode(upgrade_id.clone()), window, cx);
+                            })))
+                    })
                     .when(!node.local && node.health == boomux::protocol::NodeProjectionHealthCode::AuthenticationRequired, |detail| {
                         let id = node.id.clone();
                         detail.child(Self::settings_option("reauthenticate-node", "Sign in…", false)
+                            .flex_none()
                             .on_click(cx.listener(move |this, _, window, cx| {
+                                cx.stop_propagation();
                                 this.launch_node_action(terminal::WorkspaceLaunch::ReauthenticateNode(id.clone()), window, cx);
                             })))
-                    }))
+                    })
+                    .child(div().mt_2().pt_2().border_t_1().border_color(rgb(0x45475a))
+                        .flex().flex_col().gap_2()
+                        .child(Self::settings_option("remove-remote-machine", "Remove machine & uninstall Boomux…", false)
+                            .flex_none()
+                            .text_color(rgb(0xf38ba8))
+                            .on_click(cx.listener({
+                                let id = node.id.clone();
+                                move |this, _, window, cx| {
+                                    cx.stop_propagation();
+                                    this.launch_node_action(terminal::WorkspaceLaunch::UninstallNode(id.clone()), window, cx);
+                                }
+                            })))
+                        .child(format!("Stops all managed shells on {}. Opens a terminal for confirmation.", node.label))
+                        .child(Self::settings_control("forget-remote-machine", "Forget connection only…", false, !self.node_forget_busy)
+                            .flex_none()
+                            .on_click(cx.listener({
+                                let id = node.id.clone();
+                                move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    if !this.node_forget_busy { this.node_forget_confirm = Some(id.clone()); }
+                                    cx.notify();
+                                }
+                            })))
+                        .when(self.node_forget_confirm.as_ref() == Some(&node.id), |section| {
+                            section.child(div().flex().flex_col().gap_2()
+                                .when_some(self.node_forget_error.clone(), |confirmation, error| confirmation.child(div().text_color(rgb(0xf38ba8)).child(error)))
+                                .child("Remove this connection and its cached workspaces from this computer? This does not contact the machine, uninstall Boomux, or stop remote work.")
+                                .child(Self::settings_control("confirm-forget-remote", if self.node_forget_busy { "Forgetting…" } else { "Forget connection" }, false, !self.node_forget_busy)
+                                    .flex_none().text_color(rgb(0xf38ba8))
+                                    .on_click(cx.listener({
+                                        let id = node.id.clone();
+                                        move |this, _, _, cx| {
+                                            cx.stop_propagation();
+                                            this.forget_remote_connection(id.clone(), cx);
+                                        }
+                                    })))
+                                .child(Self::settings_option("cancel-forget-remote", "Cancel", false).flex_none()
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        cx.stop_propagation();
+                                        if !this.node_forget_busy { this.node_forget_confirm = None; }
+                                        cx.notify();
+                                    }))))
+                        })))
             })
-            .child(div().h(px(1.0)).bg(rgb(0x45475a)))
-            .child(Self::settings_option("add-remote-node", "Add remote Node…", false)
-                .on_click(cx.listener(|this, _, window, cx| {
-                    this.launch_node_action(terminal::WorkspaceLaunch::AddNode, window, cx);
-                })))
-            .child(Self::settings_option("manage-nodes", "Open Boomux dashboard", false)
-                .on_click(cx.listener(|this, _, window, cx| {
-                    this.launch_node_action(terminal::WorkspaceLaunch::Dashboard, window, cx);
-                })))
-            .child(div().text_xs().text_color(rgb(0xa6adc8))
-                .child("Setup and sign-in open a terminal. Manage remote work in the dashboard’s Nodes tab."))
-            .child(div().text_xs().text_color(rgb(0x7f849c)).child("↑/↓ select · A add · R sign in · D dashboard · Esc close")))
-            .into_any_element())
+            })
+            .collect::<Vec<_>>();
+        Some(
+            div()
+                .id("nodes-panel")
+                .flex_1()
+                .min_h_0()
+                .overflow_y_scroll()
+                .px_3()
+                .pb_3()
+                .flex()
+                .flex_col()
+                .gap_2()
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, _, window, cx| {
+                        this.navigation_region = NavigationRegion::Sidebar;
+                        window.focus(&this.focus_handle, cx);
+                        cx.stop_propagation();
+                        cx.notify();
+                    }),
+                )
+                .child(
+                    Self::settings_option("add-remote-node", "Connect another machine…", false)
+                        .flex_none()
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.launch_node_action(terminal::WorkspaceLaunch::AddNode, window, cx);
+                        })),
+                )
+                .when_some(self.nodes_error.clone(), |panel, error| {
+                    panel.child(div().text_xs().text_color(rgb(0xf9e2af)).child(error))
+                })
+                .when(!self.node_views.iter().any(|node| !node.local), |panel| {
+                    panel.child(
+                        div()
+                            .text_sm()
+                            .text_color(rgb(0x9399b2))
+                            .child("Connect a machine to create your first remote workspace."),
+                    )
+                })
+                .child(
+                    div()
+                        .mt_1()
+                        .text_xs()
+                        .text_color(rgb(0x9399b2))
+                        .child("REMOTE MACHINES"),
+                )
+                .children(rows)
+                .into_any_element(),
+        )
+    }
+
+    fn toggle_project_menu(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.project_menu_open = !self.project_menu_open;
+        self.sidebar_header_menu_open = false;
+        self.sidebar_menu = None;
+        window.focus(&self.focus_handle, cx);
+        if self.project_menu_open && !self.projects_loading {
+            self.projects_loading = true;
+            self.projects_result = None;
+            cx.spawn(async move |this, cx| {
+                let result = cx
+                    .background_executor()
+                    .spawn(async { boomux_settings::discover_projects() })
+                    .await;
+                this.update(cx, |this, cx| {
+                    this.projects_loading = false;
+                    this.projects_result = Some(result);
+                    cx.notify();
+                })
+                .ok();
+            })
+            .detach();
+        }
+        cx.notify();
+    }
+
+    fn open_project_settings(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.project_menu_open = false;
+        self.settings_open = true;
+        self.help_open = false;
+        self.nodes_open = false;
+        self.boomux_settings_message = None;
+        self.browse_project_folders(cx);
+        window.focus(&self.focus_handle, cx);
+        cx.notify();
+    }
+
+    fn browse_project_folders(&mut self, cx: &mut Context<Self>) {
+        if self.project_folder_picker_open {
+            return;
+        }
+        if self.boomux_settings_snapshot.is_none() {
+            self.project_folder_picker_pending = true;
+            self.load_boomux_settings(cx);
+            return;
+        }
+        if self.boomux_settings_busy || self.boomux_setting_input.is_some() {
+            self.boomux_settings_message =
+                Some("Finish saving or editing settings before choosing a folder.".into());
+            cx.notify();
+            return;
+        }
+        self.project_folder_picker_open = true;
+        self.boomux_settings_message = None;
+        let selection = cx.prompt_for_paths(gpui::PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: true,
+            prompt: Some("Add project folders".into()),
+        });
+        cx.spawn(async move |this, cx| {
+            let result = selection.await.map_err(|error| error.to_string())
+                .and_then(|result| result.map_err(|error| error.to_string()));
+            this.update(cx, |this, cx| {
+                this.project_folder_picker_open = false;
+                match result {
+                    Ok(Some(paths)) => {
+                        if let Some(snapshot) = &mut this.boomux_settings_snapshot {
+                            match snapshot.add_project_folders(&paths) {
+                                Ok(true) => this.save_boomux_settings(cx),
+                                Ok(false) => {},
+                                Err(error) => this.boomux_settings_message = Some(error),
+                            }
+                        }
+                    }
+                    Ok(None) => {},
+                    Err(error) => this.boomux_settings_message = Some(format!("Could not open folder picker: {error}. You can still use Edit to enter folders manually.")),
+                }
+                cx.notify();
+            }).ok();
+        }).detach();
+        cx.notify();
+    }
+
+    fn project_menu(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
+        if !self.project_menu_open {
+            return None;
+        }
+        let mut entries = div()
+            .id("project-menu-list")
+            .max_h(px(320.0))
+            .overflow_y_scroll();
+        let mut configured = false;
+        if self.projects_loading {
+            entries = entries.child(
+                div()
+                    .p_3()
+                    .text_sm()
+                    .text_color(rgb(0x9399b2))
+                    .child("Loading projects…"),
+            );
+        } else if let Some(result) = &self.projects_result {
+            match result {
+                Ok(discovery) => {
+                    configured = discovery.roots_configured;
+                    if discovery.projects.is_empty() {
+                        entries =
+                            entries.child(div().p_3().text_sm().text_color(rgb(0x9399b2)).child(
+                                if configured {
+                                    "No projects found in your folders."
+                                } else {
+                                    "Add a project folder to find projects here."
+                                },
+                            ));
+                    }
+                    for (index, project) in discovery.projects.iter().enumerate() {
+                        let project = project.clone();
+                        entries = entries.child(
+                            sidebar_menu_row(("project-choice", index))
+                                .h_auto()
+                                .py_2()
+                                .flex_col()
+                                .items_start()
+                                .gap_1()
+                                .child(
+                                    div()
+                                        .w_full()
+                                        .truncate()
+                                        .text_sm()
+                                        .child(project.name.clone()),
+                                )
+                                .child(
+                                    div()
+                                        .w_full()
+                                        .truncate()
+                                        .text_xs()
+                                        .text_color(rgb(0x9399b2))
+                                        .child(project.path.display().to_string()),
+                                )
+                                .on_click(cx.listener(move |this, _, window, cx| {
+                                    cx.stop_propagation();
+                                    this.project_menu_open = false;
+                                    if this.settings_open {
+                                        this.close_settings(cx);
+                                    }
+                                    this.create_workspace_terminal(
+                                        terminal::WorkspaceLaunch::Project {
+                                            name: project.name.clone(),
+                                            path: project.path.clone(),
+                                        },
+                                        window,
+                                        cx,
+                                    );
+                                })),
+                        );
+                    }
+                    for warning in &discovery.warnings {
+                        entries = entries.child(
+                            div()
+                                .p_2()
+                                .text_xs()
+                                .text_color(rgb(0xf9e2af))
+                                .child(warning.clone()),
+                        );
+                    }
+                }
+                Err(error) => {
+                    entries = entries.child(
+                        div()
+                            .p_3()
+                            .text_sm()
+                            .text_color(rgb(0xf38ba8))
+                            .child(format!("Could not load projects: {error}")),
+                    )
+                }
+            }
+        }
+        Some(
+            div()
+                .id("project-menu")
+                .role(gpui::Role::Menu)
+                .aria_label("Create Workspace")
+                .absolute()
+                .occlude()
+                .top(px(54.0))
+                .left(px(10.0))
+                .right(px(10.0))
+                .p_1()
+                .rounded_lg()
+                .border_1()
+                .border_color(rgb(0x45475a))
+                .bg(rgb(0x1e1e2e))
+                .shadow_lg()
+                .child(
+                    sidebar_menu_row("project-new-workspace")
+                        .child("New Workspace")
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            cx.stop_propagation();
+                            if this.settings_open {
+                                this.close_settings(cx);
+                            }
+                            this.create_and_attach_new_workspace(window, cx);
+                        })),
+                )
+                .child(
+                    sidebar_menu_row("project-new-remote-workspace")
+                        .child("New remote workspace…")
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            cx.stop_propagation();
+                            if this.settings_open {
+                                this.close_settings(cx);
+                            }
+                            this.open_nodes(cx);
+                        })),
+                )
+                .child(div().mx_2().my_1().h(px(1.0)).bg(rgb(0x313244)))
+                .child(
+                    div()
+                        .px_3()
+                        .py_1()
+                        .text_xs()
+                        .text_color(rgb(0x9399b2))
+                        .child("LOCAL PROJECTS"),
+                )
+                .child(entries)
+                .child(div().mx_2().my_1().h(px(1.0)).bg(rgb(0x313244)))
+                .child(
+                    sidebar_menu_row("project-manage-folders")
+                        .child(if configured {
+                            "Manage project folders…"
+                        } else {
+                            "Add project folder…"
+                        })
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            cx.stop_propagation();
+                            this.open_project_settings(window, cx);
+                        })),
+                )
+                .into_any_element(),
+        )
     }
 
     fn sidebar_header_menu(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
@@ -5737,14 +6201,6 @@ impl Workspace {
                 .border_color(rgb(0x45475a))
                 .bg(rgb(0x1e1e2e))
                 .shadow_lg()
-                .child(
-                    sidebar_menu_row("header-menu-nodes")
-                        .child("Nodes")
-                        .on_click(cx.listener(|this, _, _, cx| {
-                            cx.stop_propagation();
-                            this.open_nodes(cx);
-                        })),
-                )
                 .child(
                     sidebar_menu_row("header-menu-updates")
                         .child(if self.updates_checking {
@@ -5804,6 +6260,7 @@ impl Workspace {
     }
 
     fn sidebar(&self, window: &Window, cx: &mut Context<Self>) -> Div {
+        let project_menu = self.project_menu(cx);
         let header_menu = self.sidebar_header_menu(cx);
         let settings_panel = self.settings_overlay(cx);
         let (workspaces, agents) =
@@ -5845,6 +6302,10 @@ impl Workspace {
                     && self.sidebar_item.as_ref() == Some(&workspace_item);
                 let expanded = self.expanded_workspaces.contains(&workspace.id);
                 let active = focused_workspace_id == Some(workspace.id.as_str());
+                let remote_identity = remote::identity(&workspace.id);
+                let remote_machine = remote_identity
+                    .as_ref()
+                    .and_then(|id| self.node_views.iter().find(|node| node.id == id.node_id));
                 let shell_count = workspace.shells.len();
                 let shell_rows =
                     workspace
@@ -5872,7 +6333,7 @@ impl Workspace {
                             let status = shell.status_label();
                             div()
                                 .id(SharedString::from(format!("sidebar-shell-{}", shell.id)))
-                                .ml_6()
+                                .ml_8()
                                 .h(px(39.0))
                                 .px_2()
                                 .flex()
@@ -5904,7 +6365,11 @@ impl Workspace {
                                                 0x6c7086
                                             },
                                         ))
-                                        .child(pane_presence.glyph()),
+                                        .child(if self.shell_has_agent(&shell) {
+                                            "✦"
+                                        } else {
+                                            pane_presence.glyph()
+                                        }),
                                 )
                                 .child(
                                     div()
@@ -5915,7 +6380,7 @@ impl Workspace {
                                         .child(
                                             div()
                                                 .text_sm()
-                                                .font_weight(gpui::FontWeight::SEMIBOLD)
+                                                .font_weight(gpui::FontWeight::NORMAL)
                                                 .text_color(rgb(0xcdd6f4))
                                                 .child(shell.name),
                                         )
@@ -5964,7 +6429,6 @@ impl Workspace {
                     )))
                     .w_full()
                     .rounded_md()
-                    .bg(if active { rgb(0x202235) } else { rgb(0x181825) })
                     .when(active, |element| {
                         element.border_l_2().border_color(rgb(0x45475a))
                     })
@@ -5979,6 +6443,8 @@ impl Workspace {
                                     .then(|| self.sidebar_scroll_anchor.clone()),
                             )
                             .h(px(52.0))
+                            .rounded_md()
+                            .bg(if active { rgb(0x313244) } else { rgb(0x252536) })
                             .px_2()
                             .flex()
                             .items_center()
@@ -5989,7 +6455,7 @@ impl Workspace {
                                     .border_l_2()
                                     .border_color(rgb(0xcba6f7))
                             })
-                            .hover(|element| element.bg(rgb(0x29293d)))
+                            .hover(|element| element.bg(rgb(0x313244)))
                             .cursor_pointer()
                             .on_drag(
                                 WorkspaceRowDrag {
@@ -6012,22 +6478,66 @@ impl Workspace {
                             }))
                             .child(
                                 div()
-                                    .w(px(14.0))
-                                    .text_xs()
-                                    .text_color(if active { rgb(0x89b4fa) } else { rgb(0x6c7086) })
-                                    .child(if self.pane_layout_mode == PaneLayoutMode::Tabbed {
-                                        ""
-                                    } else if expanded {
-                                        "▾"
+                                    .relative()
+                                    .flex_none()
+                                    .w(px(16.0))
+                                    .h(px(14.0))
+                                    .rounded(px(2.0))
+                                    .border_1()
+                                    .border_color(if active {
+                                        rgb(0x89b4fa)
                                     } else {
-                                        "▸"
+                                        rgb(0x9399b2)
+                                    })
+                                    .when(remote_identity.is_some(), |icon| {
+                                        icon.child(
+                                            div()
+                                                .absolute()
+                                                .left(px(6.0))
+                                                .top(px(13.0))
+                                                .w(px(2.0))
+                                                .h(px(3.0))
+                                                .bg(rgb(0x9399b2)),
+                                        )
+                                        .child(
+                                            div()
+                                                .absolute()
+                                                .left(px(3.0))
+                                                .top(px(16.0))
+                                                .w(px(8.0))
+                                                .h(px(1.0))
+                                                .bg(rgb(0x9399b2)),
+                                        )
+                                    })
+                                    .when(remote_identity.is_none(), |icon| {
+                                        icon.child(
+                                            div()
+                                                .absolute()
+                                                .top_0()
+                                                .bottom_0()
+                                                .left(px(5.0))
+                                                .w(px(1.0))
+                                                .bg(if active {
+                                                    rgb(0x89b4fa)
+                                                } else {
+                                                    rgb(0x9399b2)
+                                                }),
+                                        )
+                                        .child(
+                                            div()
+                                                .absolute()
+                                                .top(px(6.0))
+                                                .left(px(6.0))
+                                                .right_0()
+                                                .h(px(1.0))
+                                                .bg(if active {
+                                                    rgb(0x89b4fa)
+                                                } else {
+                                                    rgb(0x9399b2)
+                                                }),
+                                        )
                                     }),
                             )
-                            .child(div().size_2().rounded_full().bg(if active {
-                                rgb(0x89b4fa)
-                            } else {
-                                rgb(0x6c7086)
-                            }))
                             .child(
                                 div()
                                     .min_w_0()
@@ -6037,25 +6547,35 @@ impl Workspace {
                                     .child(
                                         div()
                                             .text_sm()
-                                            .font_weight(if active {
-                                                gpui::FontWeight::SEMIBOLD
-                                            } else {
-                                                gpui::FontWeight::NORMAL
-                                            })
+                                            .font_weight(gpui::FontWeight::SEMIBOLD)
                                             .child(workspace.name.clone()),
                                     )
-                                    .child(div().text_xs().text_color(rgb(0x6c7086)).child(
-                                        format!(
-                                            "{shell_count} {} · {} {}",
-                                            if shell_count == 1 { "shell" } else { "shells" },
-                                            workspace.agent_count,
-                                            if workspace.agent_count == 1 {
-                                                "agent"
+                                    .child(
+                                        div().truncate().text_xs().text_color(rgb(0x6c7086)).child(
+                                            if let Some(node) = remote_machine {
+                                                format!(
+                                                    "{} · {} · {shell_count} shells",
+                                                    node.label,
+                                                    node.status()
+                                                )
                                             } else {
-                                                "agents"
-                                            }
+                                                format!(
+                                                    "{shell_count} {} · {} {}",
+                                                    if shell_count == 1 {
+                                                        "shell"
+                                                    } else {
+                                                        "shells"
+                                                    },
+                                                    workspace.agent_count,
+                                                    if workspace.agent_count == 1 {
+                                                        "agent"
+                                                    } else {
+                                                        "agents"
+                                                    }
+                                                )
+                                            },
                                         ),
-                                    )),
+                                    ),
                             )
                             .child(
                                 div()
@@ -6157,18 +6677,7 @@ impl Workspace {
                             .flex()
                             .items_center()
                             .gap_3()
-                            .child(
-                                div()
-                                    .size(px(28.0))
-                                    .flex_none()
-                                    .rounded_full()
-                                    .flex()
-                                    .items_center()
-                                    .justify_center()
-                                    .bg(rgb(0x11111b))
-                                    .text_color(rgb(0xf9e2af))
-                                    .child("✦"),
-                            )
+                            .child(sidebar_brand_mark())
                             .child(
                                 div()
                                     .min_w_0()
@@ -6198,13 +6707,19 @@ impl Workspace {
                                                         .count();
                                                     if unavailable == 0 {
                                                         format!(
-                                                            "{} Nodes · connected",
-                                                            self.node_views.len()
+                                                            "{} remotes · connected",
+                                                            self.node_views
+                                                                .iter()
+                                                                .filter(|node| !node.local)
+                                                                .count()
                                                         )
                                                     } else {
                                                         format!(
-                                                            "{} Nodes · {} unavailable",
-                                                            self.node_views.len(),
+                                                            "{} remotes · {} unavailable",
+                                                            self.node_views
+                                                                .iter()
+                                                                .filter(|node| !node.local)
+                                                                .count(),
                                                             unavailable
                                                         )
                                                     }
@@ -6227,15 +6742,15 @@ impl Workspace {
                             .child(
                                 sidebar_header_button(
                                     "create-workspace",
-                                    "New Workspace",
+                                    "New Workspace or project",
                                     "+",
-                                    false,
+                                    self.project_menu_open,
                                 )
                                 .on_click(cx.listener(
                                     |this, _, window, cx| {
                                         cx.stop_propagation();
                                         this.sidebar_header_menu_open = false;
-                                        this.create_and_attach_new_workspace(window, cx);
+                                        this.toggle_project_menu(window, cx);
                                     },
                                 )),
                             )
@@ -6265,6 +6780,7 @@ impl Workspace {
                                         cx.stop_propagation();
                                         this.sidebar_header_menu_open =
                                             !this.sidebar_header_menu_open;
+                                        this.project_menu_open = false;
                                         this.sidebar_menu = None;
                                         cx.notify();
                                     },
@@ -6351,36 +6867,44 @@ impl Workspace {
                                 .px_3()
                                 .py_1()
                                 .items_center()
-                                .children([false, true].map(|git| {
+                                .children([0, 1, 2].map(|tab| {
+                                    let selected = if self.nodes_open {
+                                        tab == 2
+                                    } else {
+                                        tab == usize::from(self.git_panel.open)
+                                    };
                                     div()
-                                        .id(if git {
-                                            "sidebar-git-tab"
-                                        } else {
-                                            "sidebar-agents-tab"
+                                        .id(match tab {
+                                            0 => "sidebar-agents-tab",
+                                            1 => "sidebar-git-tab",
+                                            _ => "sidebar-nodes-tab",
                                         })
                                         .cursor_pointer()
                                         .text_sm()
                                         .pb_1()
                                         .border_b_2()
-                                        .border_color(rgb(if self.git_panel.open == git {
+                                        .border_color(rgb(if selected {
                                             0x89b4fa
                                         } else {
                                             0x181825
                                         }))
-                                        .text_color(rgb(if self.git_panel.open == git {
-                                            0xcdd6f4
-                                        } else {
-                                            0x7f849c
-                                        }))
-                                        .child(if git {
+                                        .text_color(rgb(if selected { 0xcdd6f4 } else { 0x7f849c }))
+                                        .child(if tab == 2 {
+                                            "Remotes".to_owned()
+                                        } else if tab == 1 {
                                             "Git".to_owned()
                                         } else if attention > 0 {
                                             format!("Agents · {attention}")
                                         } else {
                                             "Agents".to_owned()
                                         })
-                                        .on_click(cx.listener(move |this, _, _, cx| {
-                                            this.select_git_tab(git, cx)
+                                        .on_click(cx.listener(move |this, _, window, cx| {
+                                            window.focus(&this.focus_handle, cx);
+                                            if tab == 2 {
+                                                this.open_nodes(cx);
+                                            } else {
+                                                this.select_git_tab(tab == 1, cx);
+                                            }
                                         }))
                                 }))
                                 .child(div().flex_1())
@@ -6389,7 +6913,8 @@ impl Workspace {
                                 }),
                         )
                         .when_some(self.render_git_panel(cx), |section, git| section.child(git))
-                        .when(!self.git_panel.open, |section| {
+                        .when_some(self.nodes_panel(cx), |section, nodes| section.child(nodes))
+                        .when(!self.git_panel.open && !self.nodes_open, |section| {
                             section.child(
                                 div()
                                     .id("sidebar-agents-scroll")
@@ -6415,6 +6940,7 @@ impl Workspace {
             })
             .when_some(settings_panel, |element, settings| element.child(settings))
             .when_some(header_menu, |element, menu| element.child(menu))
+            .when_some(project_menu, |element, menu| element.child(menu))
     }
 
     fn sidebar_menu_overlay(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
@@ -6530,7 +7056,7 @@ impl Workspace {
 
     fn settings_option(
         id: impl Into<gpui::ElementId>,
-        label: &'static str,
+        label: impl Into<SharedString>,
         selected: bool,
     ) -> Stateful<Div> {
         Self::settings_control(id, label, selected, true)
@@ -6538,30 +7064,32 @@ impl Workspace {
 
     fn settings_control(
         id: impl Into<gpui::ElementId>,
-        label: &'static str,
+        label: impl Into<SharedString>,
         selected: bool,
         enabled: bool,
     ) -> Stateful<Div> {
         div()
             .id(id)
-            .h(px(34.0))
+            .h(px(30.0))
             .flex_1()
+            .min_w_0()
+            .px_2()
             .flex()
             .items_center()
             .justify_center()
             .rounded_md()
             .border_1()
-            .border_color(rgb(if selected { 0xcba6f7 } else { 0x45475a }))
+            .border_color(rgb(if selected { 0x89b4fa } else { 0x313244 }))
             .bg(rgb(if selected { 0x313244 } else { 0x181825 }))
-            .text_sm()
-            .text_color(rgb(0xcdd6f4))
+            .text_xs()
+            .text_color(rgb(if selected { 0xcdd6f4 } else { 0xa6adc8 }))
             .when(enabled, |button| {
                 button
                     .cursor_pointer()
                     .hover(|button| button.bg(rgb(0x313244)))
             })
             .when(!enabled, |button| button.cursor_default())
-            .child(label)
+            .child(label.into())
     }
 
     fn settings_shell(&self, id: &'static str, cx: &mut Context<Self>) -> Stateful<Div> {
@@ -6630,12 +7158,96 @@ impl Workspace {
     fn settings_category(label: &'static str) -> Div {
         div()
             .mt_2()
-            .pt_3()
-            .border_t_1()
-            .border_color(rgb(0x313244))
+            .px_1()
             .text_sm()
             .font_weight(gpui::FontWeight::SEMIBOLD)
             .child(label)
+    }
+
+    fn settings_group() -> Div {
+        div()
+            .flex_none()
+            .flex()
+            .flex_col()
+            .rounded_lg()
+            .border_1()
+            .border_color(rgb(0x313244))
+            .bg(rgb(0x1e1e2e))
+            .overflow_hidden()
+    }
+
+    fn settings_row() -> Div {
+        div()
+            .flex_none()
+            .p_3()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .border_b_1()
+            .border_color(rgb(0x313244))
+    }
+
+    fn settings_field(label: &'static str, description: &'static str) -> Div {
+        Self::settings_row()
+            .child(div().text_sm().child(label))
+            .when(!description.is_empty(), |row| {
+                row.child(div().text_xs().text_color(rgb(0x7f849c)).child(description))
+            })
+    }
+
+    fn settings_switch(
+        id: impl Into<gpui::ElementId>,
+        label: &'static str,
+        checked: bool,
+        enabled: bool,
+    ) -> Stateful<Div> {
+        div()
+            .id(id)
+            .role(gpui::Role::Switch)
+            .aria_label(label)
+            .aria_toggled(if checked {
+                gpui::Toggled::True
+            } else {
+                gpui::Toggled::False
+            })
+            .w(px(36.0))
+            .h(px(22.0))
+            .flex_none()
+            .p(px(3.0))
+            .flex()
+            .items_center()
+            .rounded_full()
+            .bg(rgb(if checked { 0x89b4fa } else { 0x45475a }))
+            .when(checked, |track| track.justify_end())
+            .when(enabled, |track| track.cursor_pointer())
+            .when(!enabled, |track| track.cursor_default())
+            .child(div().size(px(16.0)).rounded_full().bg(rgb(0xcdd6f4)))
+    }
+
+    fn settings_toggle_row(
+        label: &'static str,
+        description: &'static str,
+        control: impl IntoElement,
+    ) -> Div {
+        Self::settings_row().child(
+            div()
+                .flex()
+                .items_center()
+                .gap_3()
+                .child(
+                    div()
+                        .min_w_0()
+                        .flex_1()
+                        .flex()
+                        .flex_col()
+                        .gap_1()
+                        .child(div().text_sm().child(label))
+                        .when(!description.is_empty(), |text| {
+                            text.child(div().text_xs().text_color(rgb(0x7f849c)).child(description))
+                        }),
+                )
+                .child(control),
+        )
     }
 
     fn settings_status(&self, cx: &mut Context<Self>) -> Div {
@@ -6743,6 +7355,10 @@ impl Workspace {
                     Ok(snapshot) => {
                         this.boomux_settings_snapshot = Some(snapshot);
                         this.boomux_settings_message = None;
+                        if this.project_folder_picker_pending {
+                            this.project_folder_picker_pending = false;
+                            this.browse_project_folders(cx);
+                        }
                     }
                     Err(error) => {
                         this.boomux_settings_snapshot = None;
@@ -6857,12 +7473,62 @@ impl Workspace {
             for &index in indices {
                 let field = &boomux_settings::FIELDS[index];
                 let enabled = snapshot.control_enabled(index);
-                let mut row = div()
-                    .flex()
-                    .flex_col()
-                    .gap_2()
-                    .when(!enabled, |row| row.opacity(0.4))
-                    .child(div().text_xs().text_color(rgb(0x7f849c)).child(field.label));
+                if matches!(field.kind, boomux_settings::Kind::Bool) {
+                    let description = match field.key {
+                        "notifications.enabled" => "Desktop alerts when an Agent needs attention.",
+                        "notifications.blocked" => "An Agent needs your input to continue.",
+                        "notifications.completed" => "An Agent reports that its work is done.",
+                        "notifications.sound.enabled" => "Play a sound with Agent alerts.",
+                        "recovery.resume_agents" => "Resume supported Agents after recovery.",
+                        "recovery.persist_terminal_history" => {
+                            "Keep terminal history across recovery."
+                        }
+                        _ => "",
+                    };
+                    let control = Self::settings_switch(
+                        ("boomux-switch", index),
+                        field.label,
+                        snapshot.control_text(index) == "true",
+                        enabled && !self.boomux_settings_busy,
+                    )
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        if this.boomux_settings_busy {
+                            return;
+                        }
+                        if let Some(snapshot) = &mut this.boomux_settings_snapshot {
+                            if !snapshot.control_enabled(index) {
+                                return;
+                            }
+                            let value = if snapshot.control_text(index) == "true" {
+                                "false"
+                            } else {
+                                "true"
+                            };
+                            this.boomux_settings_message = None;
+                            if let Err(error) = snapshot.set_control(index, value) {
+                                this.boomux_settings_message = Some(error);
+                            } else {
+                                if this
+                                    .boomux_setting_input
+                                    .as_ref()
+                                    .is_some_and(|(field, _)| !snapshot.control_enabled(*field))
+                                {
+                                    this.boomux_setting_input = None;
+                                }
+                                this.save_boomux_settings(cx);
+                            }
+                        }
+                        cx.notify();
+                    }));
+                    rows.push(
+                        Self::settings_toggle_row(field.label, description, control)
+                            .when(!enabled, |row| row.opacity(0.4))
+                            .into_any_element(),
+                    );
+                    continue;
+                }
+                let mut row =
+                    Self::settings_field(field.label, "").when(!enabled, |row| row.opacity(0.4));
                 if self
                     .boomux_setting_input
                     .as_ref()
@@ -6876,8 +7542,11 @@ impl Workspace {
                                 .min_h(px(32.0))
                                 .max_h(px(140.0))
                                 .overflow_hidden()
-                                .bg(rgb(0x313244))
-                                .text_xs()
+                                .rounded_md()
+                                .border_1()
+                                .border_color(rgb(0x89b4fa))
+                                .bg(rgb(0x181825))
+                                .text_sm()
                                 .child(if text.is_empty() {
                                     "Type a value…".into()
                                 } else {
@@ -6947,7 +7616,17 @@ impl Workspace {
                                 }
                             })
                             .unwrap_or_else(|| "Not set".into());
-                        row = row.child(div().text_xs().text_color(rgb(0xa6adc8)).child(preview));
+                        row = row.child(
+                            div()
+                                .p_2()
+                                .rounded_md()
+                                .border_1()
+                                .border_color(rgb(0x313244))
+                                .bg(rgb(0x181825))
+                                .text_xs()
+                                .text_color(rgb(0xa6adc8))
+                                .child(preview),
+                        );
                     }
                     let mut buttons = div().flex().gap_2();
                     for (option_index, (label, value)) in options.into_iter().enumerate() {
@@ -6999,154 +7678,68 @@ impl Workspace {
     }
 
     fn settings_overlay(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
-        self.settings_open.then(|| {
-            let content = div().flex_none().flex().flex_col().gap_4()
-                .child(Self::settings_control("manual-setup", "Open advanced setup in terminal", false, true)
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.close_settings(cx);
-                        this.create_workspace_terminal(terminal::WorkspaceLaunch::Setup, window, cx);
-                    })))
-                .child(Self::settings_category("Layout & workspaces"))
-                .when_some(self.settings_error.clone(), |panel, error| panel.child(
-                    div().text_xs().text_color(rgb(0xf38ba8)).child(format!("Settings could not be saved or loaded: {error}. Check settings.toml and restart."))
-                ))
+        if !self.settings_open {
+            return None;
+        }
+        {
+            let layout = Self::settings_group()
                 .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(rgb(0x7f849c))
-                                .child("Pane layout"),
-                        )
+                    Self::settings_field("Pane layout", "Choose how open Shells are arranged.")
                         .child(
                             div()
                                 .flex()
-                                .gap_2()
+                                .gap_1()
                                 .child(
-                                    div()
-                                        .id("pane-layout-tiled")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.pane_layout_mode == PaneLayoutMode::Tiled {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(
-                                            if self.pane_layout_mode == PaneLayoutMode::Tiled {
-                                                0x313244
-                                            } else {
-                                                0x181825
-                                            },
-                                        ))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, window, cx| {
+                                    Self::settings_control(
+                                        "pane-layout-tiled",
+                                        "Tree",
+                                        self.pane_layout_mode == PaneLayoutMode::Tiled,
+                                        true,
+                                    )
+                                    .on_click(cx.listener(
+                                        |this, _, window, cx| {
                                             this.set_pane_layout_mode(
                                                 PaneLayoutMode::Tiled,
                                                 window,
                                                 cx,
                                             );
-                                        }))
-                                        .child("Tiled"),
+                                        },
+                                    )),
                                 )
                                 .child(
-                                    div()
-                                        .id("pane-layout-tabbed")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.pane_layout_mode == PaneLayoutMode::Tabbed {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(
-                                            if self.pane_layout_mode == PaneLayoutMode::Tabbed {
-                                                0x313244
-                                            } else {
-                                                0x181825
-                                            },
-                                        ))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, window, cx| {
+                                    Self::settings_control(
+                                        "pane-layout-tabbed",
+                                        "Tabs",
+                                        self.pane_layout_mode == PaneLayoutMode::Tabbed,
+                                        true,
+                                    )
+                                    .on_click(cx.listener(
+                                        |this, _, window, cx| {
                                             this.set_pane_layout_mode(
                                                 PaneLayoutMode::Tabbed,
                                                 window,
                                                 cx,
                                             );
-                                        }))
-                                        .child("Tabs"),
+                                        },
+                                    )),
                                 ),
-                        )
-                        .child(div().text_xs().text_color(rgb(0x6c7086)).child(
-                            if self.pane_layout_mode == PaneLayoutMode::Tiled {
-                                "Show every open pane in the tiled and floating canvas."
-                            } else {
-                                "Keep windows tiled; minimized Shells become tabs at the top."
-                            },
-                        )),
+                        ),
                 )
                 .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(rgb(0x7f849c))
-                                .child("Pane scope"),
-                        )
+                    Self::settings_field("Pane scope", "")
                         .child(
                             div()
                                 .flex()
-                                .gap_2()
+                                .gap_1()
                                 .child(
-                                    div()
-                                        .id("pane-scope-workspace")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.workspace_pane_mode
-                                                == WorkspacePaneMode::Workspace
-                                            {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(
-                                            if self.workspace_pane_mode
-                                                == WorkspacePaneMode::Workspace
-                                            {
-                                                0x313244
-                                            } else {
-                                                0x181825
-                                            },
-                                        ))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, window, cx| {
+                                    Self::settings_control(
+                                        "pane-scope-workspace",
+                                        "Workspace",
+                                        self.workspace_pane_mode == WorkspacePaneMode::Workspace,
+                                        true,
+                                    )
+                                    .on_click(cx.listener(
+                                        |this, _, window, cx| {
                                             this.workspace_pane_mode = WorkspacePaneMode::Workspace;
                                             let workspace_id = this
                                                 .terminals
@@ -7164,50 +7757,21 @@ impl Workspace {
                                                 cx.notify();
                                             }
                                             this.save_settings();
-                                        }))
-                                        .child("Workspace"),
+                                        },
+                                    )),
                                 )
                                 .child(
-                                    div()
-                                        .id("pane-scope-mixed")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.workspace_pane_mode == WorkspacePaneMode::Mixed
-                                            {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(
-                                            if self.workspace_pane_mode == WorkspacePaneMode::Mixed
-                                            {
-                                                0x313244
-                                            } else {
-                                                0x181825
-                                            },
-                                        ))
-                                        .when(
-                                            pane_layout_supports_scope(
-                                                self.pane_layout_mode,
-                                                WorkspacePaneMode::Mixed,
-                                            ),
-                                            |button| button.cursor_pointer(),
-                                        )
-                                        .text_color(rgb(
-                                            if self.pane_layout_mode == PaneLayoutMode::Tabbed {
-                                                0x6c7086
-                                            } else {
-                                                0xcdd6f4
-                                            },
-                                        ))
-                                        .on_click(cx.listener(|this, _, _, cx| {
+                                    Self::settings_control(
+                                        "pane-scope-mixed",
+                                        "Mixed",
+                                        self.workspace_pane_mode == WorkspacePaneMode::Mixed,
+                                        pane_layout_supports_scope(
+                                            self.pane_layout_mode,
+                                            WorkspacePaneMode::Mixed,
+                                        ),
+                                    )
+                                    .on_click(cx.listener(
+                                        |this, _, _, cx| {
                                             if pane_layout_supports_scope(
                                                 this.pane_layout_mode,
                                                 WorkspacePaneMode::Mixed,
@@ -7216,547 +7780,284 @@ impl Workspace {
                                                 this.save_settings();
                                                 cx.notify();
                                             }
-                                        }))
-                                        .child("Mixed"),
+                                        },
+                                    )),
                                 ),
                         )
-                        .child(div().text_xs().text_color(rgb(0x6c7086)).child(
+                        .child(div().text_xs().text_color(rgb(0x7f849c)).child(
                             if self.pane_layout_mode == PaneLayoutMode::Tabbed {
-                                "Tabs is Workspace-only; Mixed is unavailable in this layout."
+                                "Tabs keeps each Workspace separate; Mixed is unavailable."
                             } else if self.workspace_pane_mode == WorkspacePaneMode::Workspace {
-                                "Opening a Workspace replaces the canvas with all of its Shells."
+                                "Opening a Workspace replaces the canvas with its Shells."
                             } else {
-                                "Shells from different Workspaces can share the canvas."
+                                "Shells from different Workspaces share the canvas."
                             },
                         )),
+                );
+            let appearance = Self::settings_group()
+                .child(Self::settings_toggle_row(
+                    "Window headings",
+                    "Show a heading above each pane.",
+                    Self::settings_switch(
+                        "pane-headings",
+                        "Window headings",
+                        self.pane_headings_visible,
+                        true,
+                    )
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.pane_headings_visible = !this.pane_headings_visible;
+                        this.save_settings();
+                        cx.notify();
+                    })),
+                ))
+                .child(
+                    Self::settings_field("Window edges", "").child(
+                        div()
+                            .flex()
+                            .gap_1()
+                            .child(
+                                Self::settings_control(
+                                    "pane-edges-rounded",
+                                    "Rounded",
+                                    self.pane_corner_style == PaneCornerStyle::Rounded,
+                                    true,
+                                )
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        this.pane_corner_style = PaneCornerStyle::Rounded;
+                                        this.save_settings();
+                                        cx.notify();
+                                    },
+                                )),
+                            )
+                            .child(
+                                Self::settings_control(
+                                    "pane-edges-square",
+                                    "Square",
+                                    self.pane_corner_style == PaneCornerStyle::Square,
+                                    true,
+                                )
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        this.pane_corner_style = PaneCornerStyle::Square;
+                                        this.save_settings();
+                                        cx.notify();
+                                    },
+                                )),
+                            )
+                            .child(
+                                Self::settings_control(
+                                    "pane-edges-mixed",
+                                    "Mixed",
+                                    self.pane_corner_style == PaneCornerStyle::Mixed,
+                                    true,
+                                )
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        this.pane_corner_style = PaneCornerStyle::Mixed;
+                                        this.save_settings();
+                                        cx.notify();
+                                    },
+                                )),
+                            ),
+                    ),
                 )
+                .child(
+                    Self::settings_field("Window spacing", "Space between panes.").child(
+                        div()
+                            .flex()
+                            .gap_1()
+                            .child(
+                                Self::settings_control("decrease-pane-gap", "−", false, true)
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.pane_gap = (this.pane_gap - 2.0).max(0.0);
+                                        this.save_settings();
+                                        cx.notify();
+                                    }))
+                                    .flex_none()
+                                    .w(px(30.0)),
+                            )
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .h(px(30.0))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .text_sm()
+                                    .child(format!("{:.0} px", self.pane_gap)),
+                            )
+                            .child(
+                                Self::settings_control("increase-pane-gap", "+", false, true)
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.pane_gap = (this.pane_gap + 2.0).min(32.0);
+                                        this.save_settings();
+                                        cx.notify();
+                                    }))
+                                    .flex_none()
+                                    .w(px(30.0)),
+                            ),
+                    ),
+                )
+                .child(
+                    Self::settings_field("Motion", "Speed of pane transitions.").child(
+                        div()
+                            .flex()
+                            .gap_1()
+                            .child(
+                                Self::settings_control(
+                                    "motion-instant",
+                                    "Instant",
+                                    self.motion_speed == MotionSpeed::Instant,
+                                    true,
+                                )
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        this.motion_speed = MotionSpeed::Instant;
+                                        this.layout_animation = None;
+                                        this.floating_animation = None;
+                                        this.save_settings();
+                                        cx.notify();
+                                    },
+                                )),
+                            )
+                            .child(
+                                Self::settings_control(
+                                    "motion-fast",
+                                    "Fast",
+                                    self.motion_speed == MotionSpeed::Fast,
+                                    true,
+                                )
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        this.motion_speed = MotionSpeed::Fast;
+                                        this.save_settings();
+                                        cx.notify();
+                                    },
+                                )),
+                            )
+                            .child(
+                                Self::settings_control(
+                                    "motion-smooth",
+                                    "Smooth",
+                                    self.motion_speed == MotionSpeed::Smooth,
+                                    true,
+                                )
+                                .on_click(cx.listener(
+                                    |this, _, _, cx| {
+                                        this.motion_speed = MotionSpeed::Smooth;
+                                        this.save_settings();
+                                        cx.notify();
+                                    },
+                                )),
+                            ),
+                    ),
+                )
+                .child(
+                    Self::settings_field(
+                        "Focus highlight",
+                        "Strength of the active pane highlight.",
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .gap_1()
+                            .child(
+                                Self::settings_control(
+                                    "decrease-focus-highlight",
+                                    "−",
+                                    false,
+                                    true,
+                                )
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    this.focus_highlight_strength =
+                                        this.focus_highlight_strength.saturating_sub(10);
+                                    this.save_settings();
+                                    cx.notify();
+                                }))
+                                .flex_none()
+                                .w(px(30.0)),
+                            )
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .h(px(30.0))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .text_sm()
+                                    .child(format!("{}%", self.focus_highlight_strength)),
+                            )
+                            .child(
+                                Self::settings_control(
+                                    "increase-focus-highlight",
+                                    "+",
+                                    false,
+                                    true,
+                                )
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    this.focus_highlight_strength =
+                                        this.focus_highlight_strength.saturating_add(10).min(100);
+                                    this.save_settings();
+                                    cx.notify();
+                                }))
+                                .flex_none()
+                                .w(px(30.0)),
+                            ),
+                    ),
+                );
+            let content = div().flex_none().flex().flex_col().gap_2()
+                .when_some(self.settings_error.clone(), |panel, error| panel.child(
+                    div().p_3().rounded_md().bg(rgb(0x1e1e2e)).text_xs().text_color(rgb(0xf38ba8))
+                        .child(format!("Settings could not be saved or loaded: {error}. Check settings.toml and restart."))
+                ))
+                .child(Self::settings_category("Layout & workspaces"))
+                .child(layout)
                 .child(Self::settings_category("Appearance"))
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(rgb(0x7f849c))
-                                .child("Window headings"),
-                        )
-                        .child(
-                            div()
-                                .flex()
-                                .gap_2()
-                                .child(
-                                    div()
-                                        .id("pane-headings-on")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(if self.pane_headings_visible {
-                                            0xcba6f7
-                                        } else {
-                                            0x45475a
-                                        }))
-                                        .bg(rgb(if self.pane_headings_visible {
-                                            0x313244
-                                        } else {
-                                            0x181825
-                                        }))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.pane_headings_visible = true;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("On"),
-                                )
-                                .child(
-                                    div()
-                                        .id("pane-headings-off")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(if !self.pane_headings_visible {
-                                            0xcba6f7
-                                        } else {
-                                            0x45475a
-                                        }))
-                                        .bg(rgb(if !self.pane_headings_visible {
-                                            0x313244
-                                        } else {
-                                            0x181825
-                                        }))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.pane_headings_visible = false;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("Off"),
-                                ),
-                        ),
-                )
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(rgb(0x7f849c))
-                                .child("Window edges"),
-                        )
-                        .child(
-                            div()
-                                .flex()
-                                .gap_2()
-                                .child(
-                                    div()
-                                        .id("pane-edges-rounded")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.pane_corner_style == PaneCornerStyle::Rounded {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(
-                                            if self.pane_corner_style == PaneCornerStyle::Rounded {
-                                                0x313244
-                                            } else {
-                                                0x181825
-                                            },
-                                        ))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.pane_corner_style = PaneCornerStyle::Rounded;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("Rounded"),
-                                )
-                                .child(
-                                    div()
-                                        .id("pane-edges-square")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.pane_corner_style == PaneCornerStyle::Square {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(
-                                            if self.pane_corner_style == PaneCornerStyle::Square {
-                                                0x313244
-                                            } else {
-                                                0x181825
-                                            },
-                                        ))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.pane_corner_style = PaneCornerStyle::Square;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("Square"),
-                                )
-                                .child(
-                                    div()
-                                        .id("pane-edges-mixed")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.pane_corner_style == PaneCornerStyle::Mixed {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(
-                                            if self.pane_corner_style == PaneCornerStyle::Mixed {
-                                                0x313244
-                                            } else {
-                                                0x181825
-                                            },
-                                        ))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.pane_corner_style = PaneCornerStyle::Mixed;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("Mixed"),
-                                ),
-                        ),
-                )
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(rgb(0x7f849c))
-                                .child("Window spacing"),
-                        )
-                        .child(
-                            div()
-                                .flex()
-                                .gap_2()
-                                .child(
-                                    div()
-                                        .id("decrease-pane-gap")
-                                        .w(px(44.0))
-                                        .h(px(34.0))
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(0x45475a))
-                                        .cursor_pointer()
-                                        .hover(|button| button.bg(rgb(0x313244)))
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.pane_gap = (this.pane_gap - 2.0).max(0.0);
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("−"),
-                                )
-                                .child(
-                                    div()
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(0x45475a))
-                                        .bg(rgb(0x1e1e2e))
-                                        .text_sm()
-                                        .text_color(rgb(0xa6adc8))
-                                        .child(format!("{:.0}px", self.pane_gap)),
-                                )
-                                .child(
-                                    div()
-                                        .id("increase-pane-gap")
-                                        .w(px(44.0))
-                                        .h(px(34.0))
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(0x45475a))
-                                        .cursor_pointer()
-                                        .hover(|button| button.bg(rgb(0x313244)))
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.pane_gap = (this.pane_gap + 2.0).min(32.0);
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("+"),
-                                ),
-                        ),
-                )
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(rgb(0x7f849c))
-                                .child("Window motion"),
-                        )
-                        .child(
-                            div()
-                                .flex()
-                                .gap_2()
-                                .child(
-                                    div()
-                                        .id("motion-instant")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.motion_speed == MotionSpeed::Instant {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(if self.motion_speed == MotionSpeed::Instant {
-                                            0x313244
-                                        } else {
-                                            0x181825
-                                        }))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.motion_speed = MotionSpeed::Instant;
-                                            this.layout_animation = None;
-                                            this.floating_animation = None;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("Instant"),
-                                )
-                                .child(
-                                    div()
-                                        .id("motion-fast")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.motion_speed == MotionSpeed::Fast {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(if self.motion_speed == MotionSpeed::Fast {
-                                            0x313244
-                                        } else {
-                                            0x181825
-                                        }))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.motion_speed = MotionSpeed::Fast;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("Fast"),
-                                )
-                                .child(
-                                    div()
-                                        .id("motion-smooth")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(
-                                            if self.motion_speed == MotionSpeed::Smooth {
-                                                0xcba6f7
-                                            } else {
-                                                0x45475a
-                                            },
-                                        ))
-                                        .bg(rgb(if self.motion_speed == MotionSpeed::Smooth {
-                                            0x313244
-                                        } else {
-                                            0x181825
-                                        }))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.motion_speed = MotionSpeed::Smooth;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("Smooth"),
-                                ),
-                        ),
-                )
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(rgb(0x7f849c))
-                                .child("Focus highlight"),
-                        )
-                        .child(
-                            div()
-                                .flex()
-                                .gap_2()
-                                .child(
-                                    div()
-                                        .id("decrease-focus-highlight")
-                                        .w(px(44.0))
-                                        .h(px(34.0))
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(0x45475a))
-                                        .cursor_pointer()
-                                        .hover(|button| button.bg(rgb(0x313244)))
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.focus_highlight_strength =
-                                                this.focus_highlight_strength.saturating_sub(10);
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("−"),
-                                )
-                                .child(
-                                    div()
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(0x45475a))
-                                        .bg(rgb(0x1e1e2e))
-                                        .text_sm()
-                                        .text_color(rgb(0xa6adc8))
-                                        .child(format!("{}%", self.focus_highlight_strength)),
-                                )
-                                .child(
-                                    div()
-                                        .id("increase-focus-highlight")
-                                        .w(px(44.0))
-                                        .h(px(34.0))
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(0x45475a))
-                                        .cursor_pointer()
-                                        .hover(|button| button.bg(rgb(0x313244)))
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.focus_highlight_strength = this
-                                                .focus_highlight_strength
-                                                .saturating_add(10)
-                                                .min(100);
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("+"),
-                                ),
-                        ),
-                )
+                .child(appearance)
                 .child(Self::settings_category("Notifications & sounds"))
-                .children(self.shared_settings_rows(&[0, 1, 2, 3, 4, 5], cx))
+                .child(Self::settings_group().children(self.shared_settings_rows(&[0, 1, 2, 3, 4, 5], cx)))
                 .child(Self::settings_category("Recovery & history"))
-                .children(self.shared_settings_rows(&[6, 7], cx))
+                .child(Self::settings_group().children(self.shared_settings_rows(&[6, 7], cx)))
                 .child(Self::settings_category("Safety"))
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(rgb(0x7f849c))
-                                .child("Confirm removals"),
-                        )
-                        .child(
-                            div()
-                                .flex()
-                                .gap_2()
-                                .child(
-                                    div()
-                                        .id("removal-confirmation-on")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(if self.confirm_destructive_actions {
-                                            0xcba6f7
-                                        } else {
-                                            0x45475a
-                                        }))
-                                        .bg(rgb(if self.confirm_destructive_actions {
-                                            0x313244
-                                        } else {
-                                            0x181825
-                                        }))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.confirm_destructive_actions = true;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("On"),
-                                )
-                                .child(
-                                    div()
-                                        .id("removal-confirmation-off")
-                                        .h(px(34.0))
-                                        .flex_1()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .rounded_md()
-                                        .border_1()
-                                        .border_color(rgb(if !self.confirm_destructive_actions {
-                                            0xcba6f7
-                                        } else {
-                                            0x45475a
-                                        }))
-                                        .bg(rgb(if !self.confirm_destructive_actions {
-                                            0x313244
-                                        } else {
-                                            0x181825
-                                        }))
-                                        .cursor_pointer()
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.confirm_destructive_actions = false;
-                                            this.save_settings();
-                                    cx.notify();
-                                        }))
-                                        .child("Off"),
-                                ),
-                        ),
-                )
-                ;
-            let body = div().id("settings-list").flex_1().min_h_0().overflow_y_scroll()
+                .child(Self::settings_group().child(Self::settings_toggle_row("Confirm removals", "Ask before permanently removing a Shell or Workspace.", Self::settings_switch("removal-confirmation", "Confirm removals", self.confirm_destructive_actions, true).on_click(cx.listener(|this, _, _, cx| { this.confirm_destructive_actions = !this.confirm_destructive_actions; this.save_settings(); cx.notify(); })))))
+                .child(Self::settings_category("Projects"))
+                .child(div().text_xs().text_color(rgb(0x9399b2)).child("Scan these folders for projects to open from the + menu. Local Node only; no restart needed."))
+                .child(Self::settings_group()
+                    .child(Self::settings_row().child(Self::settings_control("browse-project-folders", "Browse for folders…", false, !self.boomux_settings_busy && !self.project_folder_picker_open)
+                        .on_click(cx.listener(|this, _, _, cx| this.browse_project_folders(cx)))))
+                    .children(self.shared_settings_rows(&[10, 11], cx)))
+                .child(Self::settings_category("Advanced"))
+                .child(Self::settings_group().child(
+                    Self::settings_field("Core configuration", "Open in your configured editor. Changes are validated before saving.")
+                        .when_some(self.boomux_settings_snapshot.as_ref(), |row, snapshot| row.child(
+                            div().text_xs().text_color(rgb(0x7f849c))
+                                .child(snapshot.path.display().to_string())
+                        ))
+                        .child(Self::settings_control("open-config-file", "Open config file", false, !self.boomux_settings_busy)
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                if this.boomux_settings_busy { return; }
+                                this.close_settings(cx);
+                                this.create_workspace_terminal(terminal::WorkspaceLaunch::ConfigEdit, window, cx);
+                            })))
+                ))
+                .child(Self::settings_control("manual-setup", "Open advanced setup in terminal", false, true)
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.close_settings(cx);
+                        this.create_workspace_terminal(terminal::WorkspaceLaunch::Setup, window, cx);
+                    })));
+            let body = div()
+                .id("settings-list")
+                .flex_1()
+                .min_h_0()
+                .overflow_y_scroll()
                 .child(content.child(div().h(px(16.0)).flex_none()));
-            self.settings_shell("settings", cx).child(body).into_any_element()
-        })
+            Some(
+                self.settings_shell("settings", cx)
+                    .child(body)
+                    .into_any_element(),
+            )
+        }
     }
 
     fn resource_dialog_overlay(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
@@ -8468,6 +8769,14 @@ impl Workspace {
         handles
     }
 
+    fn shell_has_agent(&self, shell: &ShellChoice) -> bool {
+        self.boomux_overview.agents.iter().any(|agent| {
+            agent.shell_id == shell.id
+                && shell.run_id.as_deref() == Some(agent.run_id.as_str())
+                && !matches!(agent.state, AgentState::Inactive | AgentState::Done)
+        })
+    }
+
     fn pane(&self, id: usize, cx: &mut Context<Self>) -> Stateful<Div> {
         self.pane_with_heading(id, self.pane_headings_visible, cx)
     }
@@ -8487,6 +8796,9 @@ impl Workspace {
             |terminal| terminal.shell_name.clone().into(),
         );
         let accent = rgb(0xa6e3a1);
+        let is_agent = pane
+            .and_then(|pane| pane.shell.as_ref())
+            .is_some_and(|shell| self.shell_has_agent(shell));
         let corners = pane_corner_radii(id, self.pane_corner_style);
         let focused_border = blend_rgb(
             theme::resolve_legacy(0x313244),
@@ -8567,7 +8879,11 @@ impl Workspace {
                                 .flex()
                                 .items_center()
                                 .gap_2()
-                                .child(div().size_2().rounded_full().bg(accent))
+                                .child(if is_agent {
+                                    div().flex_none().text_sm().text_color(accent).child("✦")
+                                } else {
+                                    div().size_2().flex_none().rounded_full().bg(accent)
+                                })
                                 .child(div().min_w_0().overflow_hidden().child(title))
                                 .child(
                                     div()
@@ -8798,7 +9114,7 @@ impl Workspace {
                         div()
                             .min_w_0()
                             .flex_1()
-                            .overflow_hidden()
+                            .truncate()
                             .text_sm()
                             .font_weight(gpui::FontWeight::SEMIBOLD)
                             .child(shell.name),
@@ -9308,7 +9624,6 @@ impl Render for Workspace {
             })
             .into_any_element();
         let sidebar_menu = self.sidebar_menu_overlay(cx);
-        let nodes_panel = self.nodes_panel(cx);
         let resource_dialog = self.resource_dialog_overlay(cx);
         let settings_restart = self.settings_restart_overlay(cx);
         let help = self.help_overlay(cx);
@@ -9317,7 +9632,7 @@ impl Render for Workspace {
             .id("workspace")
             .track_focus(&self.focus_handle)
             .key_context(
-                if self.nodes_open
+                if (self.nodes_open && self.navigation_region == NavigationRegion::Sidebar)
                     || self.git_panel.search_focused
                     || self.boomux_setting_input.is_some()
                     || self.settings_restart_confirm
@@ -9406,7 +9721,6 @@ impl Render for Workspace {
             .text_color(rgb(0xcdd6f4))
             .child(content)
             .when_some(sidebar_menu, |element, menu| element.child(menu))
-            .when_some(nodes_panel, |element, panel| element.child(panel))
             .when_some(resource_dialog, |element, dialog| element.child(dialog))
             .when_some(settings_restart, |element, dialog| element.child(dialog))
             .when_some(help, |element, help| element.child(help))
@@ -10133,6 +10447,23 @@ mod pointer_tests {
     use boomux::protocol::{AgentState, ShellStatus};
 
     #[test]
+    fn lifted_pane_follows_pointer_beyond_panel_edges_without_resizing() {
+        let start = FloatingPane {
+            id: 7,
+            x: 0.0,
+            y: 0.0,
+            width: 1000.0,
+            height: 800.0,
+        };
+        for delta in [(-200.0, -150.0), (300.0, 250.0), (0.0, 0.0)] {
+            let moved = lifted_drag_bounds(start.clone(), delta);
+            assert_eq!((moved.x, moved.y), delta);
+            assert_eq!((moved.width, moved.height), (1000.0, 800.0));
+            assert_eq!(moved.id, start.id);
+        }
+    }
+
+    #[test]
     fn corner_drag_resizes_both_axes_and_preserves_opposite_corner() {
         for (horizontal, vertical, expected) in [
             (Direction::Left, Direction::Up, (130.0, 140.0, 370.0, 260.0)),
@@ -10733,8 +11064,8 @@ mod pointer_tests {
     }
 
     #[test]
-    fn minimized_tabs_are_opt_in_and_hide_shell_rows_from_the_sidebar() {
-        assert_eq!(PaneLayoutMode::default(), PaneLayoutMode::Tiled);
+    fn minimized_tabs_are_default_and_hide_shell_rows_from_the_sidebar() {
+        assert_eq!(PaneLayoutMode::default(), PaneLayoutMode::Tabbed);
         assert!(pane_layout_supports_scope(
             PaneLayoutMode::Tiled,
             WorkspacePaneMode::Mixed
@@ -11106,6 +11437,7 @@ mod pointer_tests {
                 agent_count: 1,
             }],
             agents: vec![AgentChoice {
+                run_id: "run-1".into(),
                 id: "agent-1".into(),
                 shell_name: "lively-dolphin".into(),
                 display_name: "lively-dolphin".into(),

--- a/desktop/src/nodes.rs
+++ b/desktop/src/nodes.rs
@@ -45,7 +45,7 @@ impl NodeView {
                 "This route no longer identifies the expected Node. Inspect it before changing the registration."
             }
             NodeProjectionHealthCode::Unsupported => {
-                "The remote helper or daemon is incompatible. Review it in the Boomux dashboard."
+                "The remote Boomux version is incompatible. Update Boomux on that machine to match this installation."
             }
             _ if !self.connected() => {
                 "Showing the last observation. A lost connection does not establish whether remote work has stopped."

--- a/desktop/src/remote.rs
+++ b/desktop/src/remote.rs
@@ -1,0 +1,247 @@
+//! Desktop keys retain both owner and resource identity. They are never wire IDs.
+use boomux::client::{Client, ClientError};
+use boomux::protocol::ShellSpec;
+use boomux::protocol::{
+    QualifiedIdentity, RoutedOperation, RoutedOperationResult, ShellSnapshot, WorkspaceSnapshot,
+};
+use std::path::PathBuf;
+
+pub fn qualify_shell(node: &str, shell: &mut ShellSnapshot) {
+    shell.id = key(node, &shell.id);
+    shell.workspace_id = key(node, &shell.workspace_id);
+}
+
+pub fn create_workspace(client: &Client, node: &str, name: &str) -> Result<ShellSnapshot, String> {
+    let mut shell = client
+        .create_remote_workspace(node, name)
+        .map_err(|e| e.to_string())?;
+    qualify_shell(node, &mut shell);
+    Ok(shell)
+}
+
+pub fn create_shell(client: &Client, workspace_key: &str) -> Result<ShellSnapshot, String> {
+    let id = identity(workspace_key).ok_or("Remote workspace identity is missing")?;
+    let workspace = workspace(client, workspace_key).map_err(|e| e.to_string())?;
+    let cwd = workspace
+        .default_cwd
+        .or_else(|| workspace.shells.first().map(|s| s.cwd.clone()))
+        .ok_or("Remote workspace has no starting directory")?;
+    create(client, &id.node_id, &id.inner_id, &workspace.name, cwd)
+}
+
+fn create(
+    client: &Client,
+    node: &str,
+    workspace: &str,
+    name: &str,
+    cwd: PathBuf,
+) -> Result<ShellSnapshot, String> {
+    let shell_name = boomux::generated_names::random_excluding(std::iter::empty())
+        .ok_or("Shell names exhausted")?;
+    // Exact IDs are generated once. An ambiguous response is surfaced, never retried as new work.
+    match client
+        .route_node_operation(
+            node,
+            RoutedOperation::CreateWorkspaceShell {
+                workspace_id: workspace.into(),
+                workspace_name: name.into(),
+                default_cwd: Some(cwd.clone()),
+                shell_id: uuid::Uuid::new_v4().to_string(),
+                shell: ShellSpec::login(shell_name, cwd),
+            },
+        )
+        .map_err(|e| e.to_string())?
+    {
+        RoutedOperationResult::Shell { mut shell } => {
+            qualify_shell(node, &mut shell);
+            Ok(shell)
+        }
+        _ => Err("Unexpected remote creation response".into()),
+    }
+}
+
+pub fn rename(
+    client: &Client,
+    resource: &str,
+    name: &str,
+    is_workspace: bool,
+) -> Result<(), String> {
+    let id = identity(resource).ok_or("Remote identity missing")?;
+    let operation = if is_workspace {
+        let current = workspace(client, resource).map_err(|e| e.to_string())?;
+        RoutedOperation::RenameWorkspace {
+            workspace_id: id.inner_id,
+            name: name.into(),
+            expected_revision: current.revision,
+        }
+    } else {
+        let current = shell(client, resource).map_err(|e| e.to_string())?;
+        RoutedOperation::RenameShell {
+            shell_id: id.inner_id,
+            name: name.into(),
+            expected_revision: current.revision,
+        }
+    };
+    client
+        .route_node_operation(id.node_id, operation)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+pub fn close(client: &Client, resource: &str, is_workspace: bool) -> Result<(), String> {
+    let id = identity(resource).ok_or("Remote identity missing")?;
+    let operation = if is_workspace {
+        let current = workspace(client, resource).map_err(|e| e.to_string())?;
+        RoutedOperation::CloseWorkspace {
+            workspace_id: id.inner_id,
+            expected_revision: current.revision,
+        }
+    } else {
+        let current = shell(client, resource).map_err(|e| e.to_string())?;
+        RoutedOperation::CloseShell {
+            shell_id: id.inner_id,
+            expected_revision: current.revision,
+        }
+    };
+    client
+        .route_node_operation(id.node_id, operation)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+pub fn key(node: &str, resource: &str) -> String {
+    format!("remote:{node}:{resource}")
+}
+
+pub fn identity(key: &str) -> Option<QualifiedIdentity> {
+    let (node_id, inner_id) = key.strip_prefix("remote:")?.split_once(':')?;
+    Some(QualifiedIdentity {
+        node_id: node_id.into(),
+        inner_id: inner_id.into(),
+    })
+}
+
+pub fn shell(client: &Client, key: &str) -> Result<ShellSnapshot, ClientError> {
+    let Some(id) = identity(key) else {
+        return client.get_shell(key);
+    };
+    match client.route_node_operation(
+        id.node_id,
+        RoutedOperation::GetShell {
+            shell_id: id.inner_id,
+        },
+    )? {
+        RoutedOperationResult::Shell { shell } => Ok(shell),
+        _ => Err(std::io::Error::other("unexpected remote Shell response").into()),
+    }
+}
+
+pub fn workspace(client: &Client, key: &str) -> Result<WorkspaceSnapshot, ClientError> {
+    let Some(id) = identity(key) else {
+        return client.get_workspace(key);
+    };
+    match client.route_node_operation(
+        id.node_id,
+        RoutedOperation::GetWorkspace {
+            workspace_id: id.inner_id,
+        },
+    )? {
+        RoutedOperationResult::Workspace { workspace } => Ok(workspace),
+        _ => Err(std::io::Error::other("unexpected remote Workspace response").into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn remote_workspace_resolves_owner_directory_and_routes_creation_without_local_fallback() {
+        use boomux::protocol::{
+            self, Envelope, HostServiceOperation, HostServiceResult, Request, Response,
+        };
+        use std::os::unix::net::UnixListener;
+        let directory =
+            std::env::temp_dir().join(format!("remote-workspace-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(
+                request.message,
+                Request::RouteNodeHostService {
+                    node_id: "remote-owner".into(),
+                    operation: HostServiceOperation::ResolveDirectory {
+                        path: PathBuf::from(".")
+                    },
+                }
+            );
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    protocol::PROTOCOL_VERSION,
+                    Response::HostService {
+                        result: HostServiceResult::Directory {
+                            path: PathBuf::from("/remote/start"),
+                        },
+                    },
+                ),
+            )
+            .unwrap();
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            let Request::RouteNodeOperation {
+                node_id,
+                operation:
+                    RoutedOperation::CreateWorkspaceShell {
+                        workspace_id,
+                        workspace_name,
+                        default_cwd,
+                        shell_id,
+                        shell,
+                    },
+            } = request.message
+            else {
+                panic!("creation must be routed")
+            };
+            assert_eq!(node_id, "remote-owner");
+            assert_eq!(workspace_name, "development");
+            assert_eq!(shell.cwd, PathBuf::from("/remote/start"));
+            assert_eq!(default_cwd, Some(shell.cwd.clone()));
+            assert!(shell.command.is_empty());
+            assert!(uuid::Uuid::parse_str(&workspace_id).is_ok());
+            assert!(uuid::Uuid::parse_str(&shell_id).is_ok());
+            let snapshot: ShellSnapshot = serde_json::from_value(serde_json::json!({
+                "id": shell_id, "workspace_id": workspace_id, "name": shell.name, "cwd": shell.cwd, "status": "pending"
+            })).unwrap();
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    protocol::PROTOCOL_VERSION,
+                    Response::RoutedNodeOperation {
+                        result: RoutedOperationResult::Shell { shell: snapshot },
+                    },
+                ),
+            )
+            .unwrap();
+        });
+        let client = Client::from_socket_path(socket);
+        let shell = create_workspace(&client, "remote-owner", "development").unwrap();
+        assert_eq!(identity(&shell.id).unwrap().node_id, "remote-owner");
+        assert_eq!(
+            identity(&shell.workspace_id).unwrap().node_id,
+            "remote-owner"
+        );
+        server.join().unwrap();
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+    #[test]
+    fn keys_keep_same_named_resources_on_different_owners_distinct() {
+        assert_ne!(key("one", "shell"), key("two", "shell"));
+        let id = identity(&key("one", "shell")).unwrap();
+        assert_eq!(id.node_id, "one");
+        assert_eq!(id.inner_id, "shell");
+        assert!(identity("shell").is_none());
+    }
+}

--- a/desktop/src/settings.rs
+++ b/desktop/src/settings.rs
@@ -39,12 +39,18 @@ impl Default for Settings {
             focus_highlight_strength: 100,
             motion_speed: MotionSpeed::Smooth,
             workspace_pane_mode: WorkspacePaneMode::Workspace,
-            pane_layout_mode: PaneLayoutMode::Tiled,
+            pane_layout_mode: PaneLayoutMode::default(),
             confirm_destructive_actions: true,
         }
     }
 }
 pub fn path() -> Option<PathBuf> {
+    if let Some(root) = std::env::var_os("BOOMUX_CONFIG_HOME") {
+        let root = PathBuf::from(root);
+        return root
+            .is_absolute()
+            .then(|| root.join("boomux-desktop/settings.toml"));
+    }
     std::env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
         .filter(|p| p.is_absolute())
@@ -318,6 +324,13 @@ mod tests {
         };
         assert_eq!(Settings::parse(&settings.encode()).unwrap(), settings);
         assert_eq!(Settings::parse("").unwrap(), Settings::default());
+        assert_eq!(Settings::default().pane_layout_mode, PaneLayoutMode::Tabbed);
+        assert_eq!(
+            Settings::parse("pane_layout_mode = 'tiled'")
+                .unwrap()
+                .pane_layout_mode,
+            PaneLayoutMode::Tiled
+        );
         assert_eq!(
             Settings::parse("pane_layout_mode = 'tabbed'\nworkspace_pane_mode = 'mixed'")
                 .unwrap()

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -74,6 +74,7 @@ pub struct WorkspaceChoice {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AgentChoice {
     pub id: String,
+    pub run_id: String,
     pub shell_name: String,
     pub display_name: String,
     pub workspace: String,
@@ -411,11 +412,16 @@ impl TerminalSession {
         start_emulator(&shared, rows, cols, pixel_width, pixel_height)?;
         shared.process(attachment.reconstruction);
 
-        let expected_run_id = client
-            .get_shell(&shell.id)
-            .ok()
-            .and_then(|snapshot| snapshot.run.map(|run| run.id))
-            .or(shell.run_id.clone());
+        // An exact-running attach already validated this run on the owner.
+        // Only a newly started/restarted Shell needs its new run fetched.
+        let expected_run_id =
+            if matches!(shell.status, ShellStatus::Running) && shell.run_id.is_some() {
+                shell.run_id.clone()
+            } else {
+                crate::remote::shell(&client, &shell.id)
+                    .ok()
+                    .and_then(|snapshot| snapshot.run.map(|run| run.id))
+            };
         spawn_reader(
             client,
             shell.id.clone(),
@@ -611,6 +617,10 @@ impl Drop for TerminalSession {
 }
 
 pub fn discover_overview() -> Result<BoomuxOverview, String> {
+    discover_overview_and_nodes().0
+}
+
+fn discover_local_overview() -> Result<BoomuxOverview, String> {
     let Some(client) = client::connect_if_running()
         .map_err(|error| format!("could not connect to Boomux: {error}"))?
     else {
@@ -637,17 +647,114 @@ pub fn discover_overview_and_nodes() -> (
     match combined {
         Ok(combined) => {
             let nodes = crate::nodes::project(&combined);
-            let overview = combined
+            let mut overview = combined
                 .nodes
-                .into_iter()
+                .iter()
                 .find(|node| node.local)
-                .and_then(|node| node.local_snapshot)
+                .and_then(|node| node.local_snapshot.clone())
                 .map(overview_from_snapshot)
                 .ok_or_else(|| "Boomux omitted the local Node snapshot".into());
+            if let Ok(overview) = &mut overview {
+                append_remote_workspaces(overview, &combined);
+            }
             (overview, Ok(nodes))
         }
         // Federation availability must not stop local discovery.
-        Err(error) => (discover_overview(), Err(error)),
+        Err(error) => (discover_local_overview(), Err(error)),
+    }
+}
+
+fn append_remote_workspaces(
+    overview: &mut BoomuxOverview,
+    combined: &boomux::protocol::CombinedNodeSnapshot,
+) {
+    for node in combined.nodes.iter().filter(|node| !node.local) {
+        let Some(projection) = &node.remote_projection else {
+            continue;
+        };
+        let shell_index = projection
+            .shells
+            .iter()
+            .map(|s| (s.id.as_str(), s))
+            .collect::<HashMap<_, _>>();
+        let workspace_index = projection
+            .workspaces
+            .iter()
+            .map(|w| (w.id.as_str(), w))
+            .collect::<HashMap<_, _>>();
+        let mut shell_groups = HashMap::<&str, Vec<_>>::new();
+        for shell in &projection.shells {
+            shell_groups
+                .entry(&shell.workspace_id)
+                .or_default()
+                .push(shell);
+        }
+        let mut agent_counts = HashMap::<&str, usize>::new();
+        for agent in &projection.agents {
+            let current = shell_index
+                .get(agent.shell_id.as_str())
+                .is_some_and(|shell| shell.run_id.as_ref() == Some(&agent.run_id));
+            if agent_is_visible(agent.state, agent.attention.is_some(), current) {
+                *agent_counts.entry(&agent.workspace_id).or_default() += 1;
+            }
+        }
+        for workspace in &projection.workspaces {
+            let shells = shell_groups
+                .remove(workspace.id.as_str())
+                .unwrap_or_default()
+                .into_iter()
+                .map(|shell| ShellChoice {
+                    id: crate::remote::key(&node.node_id, &shell.id),
+                    workspace_id: crate::remote::key(&node.node_id, &workspace.id),
+                    name: shell.name.clone(),
+                    cwd: PathBuf::new(),
+                    status: shell.status.clone(),
+                    run_id: shell.run_id.clone(),
+                    desktop_setup: false,
+                })
+                .collect();
+            overview.workspaces.push(WorkspaceChoice {
+                id: crate::remote::key(&node.node_id, &workspace.id),
+                name: workspace.name.clone(),
+                shells,
+                agent_count: agent_counts
+                    .get(workspace.id.as_str())
+                    .copied()
+                    .unwrap_or_default(),
+            });
+        }
+        for agent in &projection.agents {
+            let current = shell_index
+                .get(agent.shell_id.as_str())
+                .is_some_and(|s| s.run_id.as_ref() == Some(&agent.run_id));
+            if !agent_is_visible(agent.state, agent.attention.is_some(), current) {
+                continue;
+            }
+            overview.agents.push(AgentChoice {
+                id: crate::remote::key(&node.node_id, &agent.id),
+                run_id: agent.run_id.clone(),
+                shell_id: crate::remote::key(&node.node_id, &agent.shell_id),
+                shell_name: shell_index
+                    .get(agent.shell_id.as_str())
+                    .map_or_else(|| agent.name.clone(), |s| s.name.clone()),
+                display_name: agent.name.clone(),
+                workspace: workspace_index
+                    .get(agent.workspace_id.as_str())
+                    .map_or_else(|| node.alias.clone(), |w| w.name.clone()),
+                integration: agent.integration.clone(),
+                state: agent.state,
+                updated_at_ms: agent.observed_at_ms,
+                needs_attention: agent
+                    .attention
+                    .as_ref()
+                    .is_some_and(|a| a.reason == AgentAttentionReason::Blocked),
+                completed_attention: agent
+                    .attention
+                    .as_ref()
+                    .is_some_and(|a| a.reason == AgentAttentionReason::Completed),
+                attention_revision: agent.attention.as_ref().map(|a| a.observation_revision),
+            });
+        }
     }
 }
 
@@ -692,6 +799,7 @@ fn overview_from_snapshot(snapshot: boomux::protocol::Snapshot) -> BoomuxOvervie
                 .is_some_and(|attention| attention.reason == AgentAttentionReason::Blocked);
             AgentChoice {
                 id: agent.id.clone(),
+                run_id: agent.run_id.clone(),
                 shell_name: workspace
                     .shells
                     .iter()
@@ -784,6 +892,18 @@ pub fn acknowledge_agent_attention(
     else {
         return Err("Boomux is not running".into());
     };
+    if let Some(id) = crate::remote::identity(agent_id) {
+        return client
+            .route_node_operation(
+                id.node_id,
+                boomux::protocol::RoutedOperation::AcknowledgeAgentAttention {
+                    agent_id: id.inner_id,
+                    observation_revision,
+                },
+            )
+            .map(|_| ())
+            .map_err(|e| e.to_string());
+    }
     client
         .acknowledge_agent_attention(agent_id, observation_revision)
         .map(|_| ())
@@ -803,13 +923,27 @@ fn shell_choice(shell: ShellSnapshot) -> ShellChoice {
         cwd: shell.cwd,
         status: shell.status,
         run_id: shell.run.map(|run| run.id),
-        desktop_setup: shell.command.len() == 2 && shell.command[1] == "__desktop-setup",
+        desktop_setup: match shell.command.get(1).map(String::as_str) {
+            Some("__desktop-setup" | "__guided-node-add") => shell.command.len() == 2,
+            Some(
+                "__guided-node-upgrade"
+                | "__guided-node-reauthenticate"
+                | "__guided-node-uninstall",
+            ) => shell.command.len() == 3,
+            _ => false,
+        },
     }
 }
 
 /// Create a pending shell next to an existing shell. Boomux remains the owner
 /// of the PTY; the caller can immediately attach the returned choice.
-pub fn create_shell(anchor: &ShellChoice) -> Result<ShellChoice, String> {
+pub fn create_shell(
+    anchor: &ShellChoice,
+    size: (u16, u16, u16, u16),
+) -> Result<ShellChoice, String> {
+    if crate::remote::identity(&anchor.workspace_id).is_some() {
+        return create_shell_in_workspace(&anchor.workspace_id, size);
+    }
     let Some(client) = client::connect_if_running()
         .map_err(|error| format!("could not connect to Boomux: {error}"))?
     else {
@@ -822,23 +956,30 @@ pub fn create_shell(anchor: &ShellChoice) -> Result<ShellChoice, String> {
         generated_names::random_excluding(workspace.shells.iter().map(|shell| shell.name.as_str()))
             .ok_or_else(|| "Boomux shell names are exhausted".to_string())?;
     let shell = client
-        .create_shell(
+        .create_started_shell(
             &workspace.id,
             ShellSpec::login(
                 name,
                 workspace.default_cwd.unwrap_or_else(|| anchor.cwd.clone()),
             ),
+            terminal_profile(size.0, size.1, size.2, size.3),
         )
         .map_err(|error| format!("could not create Boomux shell: {error}"))?;
     Ok(shell_choice(shell))
 }
 
-pub fn create_shell_in_workspace(workspace_id: &str) -> Result<ShellChoice, String> {
+pub fn create_shell_in_workspace(
+    workspace_id: &str,
+    size: (u16, u16, u16, u16),
+) -> Result<ShellChoice, String> {
     let Some(client) = client::connect_if_running()
         .map_err(|error| format!("could not connect to Boomux: {error}"))?
     else {
         return Err("Boomux is not running".into());
     };
+    if crate::remote::identity(workspace_id).is_some() {
+        return crate::remote::create_shell(&client, workspace_id).map(shell_choice);
+    }
     let workspace = client
         .get_workspace(workspace_id)
         .map_err(|error| format!("could not read Boomux workspace: {error}"))?;
@@ -851,7 +992,11 @@ pub fn create_shell_in_workspace(workspace_id: &str) -> Result<ShellChoice, Stri
         .or_else(|| std::env::current_dir().ok())
         .ok_or_else(|| "could not determine a working directory for the new shell".to_string())?;
     client
-        .create_shell(&workspace.id, ShellSpec::login(name, cwd))
+        .create_started_shell(
+            &workspace.id,
+            ShellSpec::login(name, cwd),
+            terminal_profile(size.0, size.1, size.2, size.3),
+        )
         .map(shell_choice)
         .map_err(|error| format!("could not create Boomux shell: {error}"))
 }
@@ -860,25 +1005,86 @@ pub fn create_shell_in_workspace(workspace_id: &str) -> Result<ShellChoice, Stri
 #[derive(Clone, Debug)]
 pub enum WorkspaceLaunch {
     Shell,
+    Project {
+        name: String,
+        path: std::path::PathBuf,
+    },
     Setup,
+    ConfigEdit,
     AddNode,
+    RemoteWorkspace {
+        node_id: String,
+        name: String,
+    },
+    UpgradeNode(String),
+    UninstallNode(String),
     ReauthenticateNode(String),
-    Dashboard,
 }
 
 impl WorkspaceLaunch {
-    fn command(&self) -> Option<(&'static str, Vec<String>)> {
-        match self {
-            Self::Shell => None,
-            Self::Setup => Some(("Set up agents", vec!["__desktop-setup".into()])),
-            Self::AddNode => Some(("Add remote Node", vec!["__guided-node-add".into()])),
-            Self::ReauthenticateNode(id) => Some((
-                "Sign in to Node",
-                vec!["__guided-node-reauthenticate".into(), id.clone()],
-            )),
-            Self::Dashboard => Some(("Boomux dashboard", vec![])),
+    fn temporary_setup(&self) -> bool {
+        matches!(
+            self,
+            Self::Setup
+                | Self::AddNode
+                | Self::UpgradeNode(_)
+                | Self::ReauthenticateNode(_)
+                | Self::UninstallNode(_)
+        )
+    }
+    fn working_directory(&self) -> Result<std::path::PathBuf, String> {
+        if let Self::Project { path, .. } = self {
+            let path = path
+                .canonicalize()
+                .map_err(|error| format!("Project folder is unavailable: {error}"))?;
+            if !path.is_dir() {
+                return Err("Project path is no longer a directory".into());
+            }
+            Ok(path)
+        } else {
+            std::env::current_dir().map_err(|error| {
+                format!("could not determine the new workspace directory: {error}")
+            })
         }
     }
+
+    fn command(&self) -> Option<(&'static str, Vec<String>)> {
+        match self {
+            Self::Shell | Self::Project { .. } | Self::RemoteWorkspace { .. } => None,
+            Self::Setup => Some(("Set up agents", vec!["__desktop-setup".into()])),
+            Self::ConfigEdit => Some(("Edit Boomux config", vec!["config".into(), "edit".into()])),
+            Self::AddNode => Some(("Connect remote machine", vec!["__guided-node-add".into()])),
+            Self::UpgradeNode(id) => Some((
+                "Update remote Boomux",
+                vec!["__guided-node-upgrade".into(), id.clone()],
+            )),
+            Self::UninstallNode(id) => Some((
+                "Remove remote machine",
+                vec!["__guided-node-uninstall".into(), id.clone()],
+            )),
+            Self::ReauthenticateNode(id) => Some((
+                "Sign in to remote machine",
+                vec!["__guided-node-reauthenticate".into(), id.clone()],
+            )),
+        }
+    }
+}
+
+pub(crate) fn project_workspace_name<'a>(
+    name: &str,
+    existing: impl Iterator<Item = &'a str>,
+) -> String {
+    let existing: std::collections::HashSet<_> = existing.collect();
+    if !existing.contains(name) {
+        return name.to_owned();
+    }
+    for suffix in 2..=existing.len() + 2 {
+        let candidate = format!("{name}-{suffix}");
+        if !existing.contains(candidate.as_str()) {
+            return candidate;
+        }
+    }
+    unreachable!()
 }
 
 /// Create a local Workspace and its first pending Shell; Boomux owns both.
@@ -890,25 +1096,38 @@ pub fn create_workspace_with_shell(
     else {
         return Err("Boomux is not running".into());
     };
-    let setup_node = if matches!(launch, WorkspaceLaunch::Setup) {
+    let setup_node = if launch.temporary_setup() {
         Some(client.node_identity().map_err(|error| error.to_string())?)
     } else {
         None
     };
+    if let WorkspaceLaunch::RemoteWorkspace { node_id, name } = &launch {
+        return crate::remote::create_workspace(&client, node_id, name)
+            .map(|shell| (shell_choice(shell), None));
+    }
     let snapshot = client
         .snapshot()
         .map_err(|error| format!("could not read Boomux workspaces: {error}"))?;
-    let workspace_name = generated_names::random_excluding(
-        snapshot
-            .workspaces
-            .iter()
-            .map(|workspace| workspace.name.as_str()),
-    )
-    .ok_or_else(|| "Boomux workspace names are exhausted".to_string())?;
+    let workspace_name = if let WorkspaceLaunch::Project { name, .. } = &launch {
+        project_workspace_name(
+            name,
+            snapshot
+                .workspaces
+                .iter()
+                .map(|workspace| workspace.name.as_str()),
+        )
+    } else {
+        generated_names::random_excluding(
+            snapshot
+                .workspaces
+                .iter()
+                .map(|workspace| workspace.name.as_str()),
+        )
+        .ok_or_else(|| "Boomux workspace names are exhausted".to_string())?
+    };
     let shell_name = generated_names::random_excluding(std::iter::empty())
         .ok_or_else(|| "Boomux shell names are exhausted".to_string())?;
-    let cwd = std::env::current_dir()
-        .map_err(|error| format!("could not determine the new workspace directory: {error}"))?;
+    let cwd = launch.working_directory()?;
     let mut spec = ShellSpec::login(shell_name, cwd.clone());
     if let Some((label, arguments)) = launch.command() {
         let executable = std::env::current_exe().map_err(|error| error.to_string())?;
@@ -960,11 +1179,14 @@ impl SetupWorkspaceCleanup {
         node_id: String,
         workspace: &WorkspaceSnapshot,
     ) -> Option<Self> {
-        if !matches!(launch, WorkspaceLaunch::Setup)
+        if !launch.temporary_setup()
             || workspace.shells.len() != 1
             || !workspace.launchers.is_empty()
             || !workspace.agents.is_empty()
         {
+            return None;
+        }
+        if launch.command()?.1 != workspace.shells[0].command.get(1..)? {
             return None;
         }
         Some(Self {
@@ -1027,6 +1249,9 @@ pub fn rename_workspace(workspace_id: &str, name: &str) -> Result<(), String> {
     else {
         return Err("Boomux is not running".into());
     };
+    if crate::remote::identity(workspace_id).is_some() {
+        return crate::remote::rename(&client, workspace_id, name, true);
+    }
     client
         .rename_workspace(workspace_id, name)
         .map_err(|error| format!("could not rename Boomux workspace: {error}"))
@@ -1038,6 +1263,9 @@ pub fn rename_shell(shell_id: &str, name: &str) -> Result<(), String> {
     else {
         return Err("Boomux is not running".into());
     };
+    if crate::remote::identity(shell_id).is_some() {
+        return crate::remote::rename(&client, shell_id, name, false);
+    }
     client
         .rename_shell(shell_id, name)
         .map_err(|error| format!("could not rename Boomux shell: {error}"))
@@ -1049,6 +1277,9 @@ pub fn remove_workspace(workspace_id: &str) -> Result<(), String> {
     else {
         return Err("Boomux is not running".into());
     };
+    if crate::remote::identity(workspace_id).is_some() {
+        return crate::remote::close(&client, workspace_id, true);
+    }
     client
         .close_workspace(workspace_id)
         .map_err(|error| format!("could not remove Boomux workspace: {error}"))
@@ -1060,6 +1291,9 @@ pub fn close_shell(shell_id: &str) -> Result<(), String> {
     else {
         return Err("Boomux is not running".into());
     };
+    if crate::remote::identity(shell_id).is_some() {
+        return crate::remote::close(&client, shell_id, false);
+    }
     client
         .close_shell(shell_id)
         .map_err(|error| format!("could not close Boomux shell: {error}"))
@@ -1084,6 +1318,17 @@ fn attach_shell(
     profile: TerminalProfile,
     takeover: bool,
 ) -> Result<client::Attachment, String> {
+    if let Some(identity) = crate::remote::identity(&shell.id) {
+        return client
+            .attach_node(
+                identity,
+                takeover,
+                matches!(shell.status, ShellStatus::Exited { .. }),
+                shell.run_id.clone(),
+                profile,
+            )
+            .map_err(|error| format!("could not attach {}: {error}", shell.name));
+    }
     let result = match (&shell.status, shell.run_id.as_deref()) {
         (ShellStatus::Running, Some(run_id)) => {
             client.attach_exact_run_with_client_environment(&shell.id, run_id, takeover, profile)
@@ -1864,7 +2109,15 @@ fn reconnect(
 ) -> Result<client::Attachment, String> {
     let mut last_error = None;
     for _ in 0..RECONNECT_ATTEMPTS {
-        let result = if let Some(run_id) = expected_run_id {
+        let result = if let Some(identity) = crate::remote::identity(shell_id) {
+            client.attach_node(
+                identity,
+                false,
+                false,
+                expected_run_id.map(str::to_owned),
+                profile.clone(),
+            )
+        } else if let Some(run_id) = expected_run_id {
             client.attach_exact_run(shell_id, run_id, false, profile.clone())
         } else {
             client.attach(shell_id, false, profile.clone())
@@ -2301,6 +2554,122 @@ mod tests {
     }
 
     #[test]
+    fn remote_setup_cleanup_owns_only_the_created_temporary_workspace() {
+        for launch in [
+            super::WorkspaceLaunch::AddNode,
+            super::WorkspaceLaunch::UpgradeNode("remote".into()),
+            super::WorkspaceLaunch::UninstallNode("remote".into()),
+            super::WorkspaceLaunch::ReauthenticateNode("remote".into()),
+        ] {
+            let mut created = setup_workspace_creation();
+            created.shells[0].command = vec!["/build/boomux".into()];
+            created.shells[0]
+                .command
+                .extend(launch.command().unwrap().1);
+            assert!(super::shell_choice(created.shells[0].clone()).desktop_setup);
+            let cleanup = super::SetupWorkspaceCleanup::from_creation(
+                &launch,
+                "local-owner".into(),
+                &created,
+            )
+            .unwrap();
+            assert!(cleanup.close_request("local-owner", &created).is_none());
+            created.shells.clear();
+            created.revision += 1;
+            assert!(cleanup.close_request("local-owner", &created).is_some());
+            assert!(cleanup.close_request("remote", &created).is_none());
+            created.revision += 1;
+            assert!(cleanup.close_request("local-owner", &created).is_none());
+        }
+    }
+
+    #[test]
+    fn remote_projection_keeps_owner_identity_and_cached_shells() {
+        let nodes = ["first", "second"].map(|owner| serde_json::json!({
+            "node_id": owner, "alias": "same-machine-label", "local": false,
+            "health": "unreachable", "current": false, "stale": true, "observed_at_ms": 1,
+            "remote_projection": {"node_id": owner,
+                "workspaces": [{"id": "same-workspace", "name": "work", "item_count": 1, "attention_count": 0}],
+                "shells": [{"id": "same-shell", "workspace_id": "same-workspace", "name": "shell", "status": "running", "run_id": "run"}],
+                "agents": [], "launchers": []}
+        }));
+        let combined = serde_json::from_value(serde_json::json!({"nodes": nodes})).unwrap();
+        let mut overview = super::BoomuxOverview::default();
+        super::append_remote_workspaces(&mut overview, &combined);
+        assert_eq!(overview.workspaces.len(), 2);
+        let first = &overview.workspaces[0];
+        let second = &overview.workspaces[1];
+        assert_ne!(first.id, second.id);
+        assert_ne!(first.shells[0].id, second.shells[0].id);
+        assert_eq!(first.shells[0].workspace_id, first.id);
+        assert_eq!(
+            first.shells[0].status,
+            boomux::protocol::ShellStatus::Running
+        );
+        assert!(first.shells[0].cwd.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn remote_attachment_and_reconnect_keep_exact_owner_and_run() {
+        use boomux::protocol::{self, Envelope, Request, Response};
+        use std::os::unix::net::UnixListener;
+        let directory =
+            std::env::temp_dir().join(format!("remote-attach-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            for takeover in [true, false] {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                let Request::AttachNode {
+                    identity,
+                    takeover: actual,
+                    restart_exited,
+                    expected_run_id,
+                    ..
+                } = request.message
+                else {
+                    panic!("must not attach locally")
+                };
+                assert_eq!(identity.node_id, "owner");
+                assert_eq!(identity.inner_id, "shell");
+                assert_eq!(actual, takeover);
+                assert!(!restart_exited);
+                assert_eq!(expected_run_id.as_deref(), Some("run"));
+                protocol::write_message(
+                    &mut stream,
+                    &Envelope::with_version(
+                        protocol::PROTOCOL_VERSION,
+                        Response::Attached {
+                            token: "token".into(),
+                            reconstruction: vec![],
+                            warning: None,
+                            profile: None,
+                        },
+                    ),
+                )
+                .unwrap();
+            }
+        });
+        let client = boomux::client::Client::from_socket_path(socket);
+        let shell = super::ShellChoice {
+            id: crate::remote::key("owner", "shell"),
+            workspace_id: crate::remote::key("owner", "workspace"),
+            name: "shell".into(),
+            cwd: std::path::PathBuf::new(),
+            status: boomux::protocol::ShellStatus::Running,
+            run_id: Some("run".into()),
+            desktop_setup: false,
+        };
+        let profile = terminal_profile(24, 80, 800, 480);
+        super::attach_shell(&client, &shell, profile.clone(), true).unwrap();
+        super::reconnect(&client, &shell.id, Some("run"), &profile).unwrap();
+        server.join().unwrap();
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
     fn setup_workspace_cleanup_requires_creation_identity_and_only_its_shell_removal() {
         let created = setup_workspace_creation();
         let cleanup = super::SetupWorkspaceCleanup::from_creation(
@@ -2311,7 +2680,7 @@ mod tests {
         .unwrap();
         for launch in [
             super::WorkspaceLaunch::Shell,
-            super::WorkspaceLaunch::Dashboard,
+            super::WorkspaceLaunch::ConfigEdit,
             super::WorkspaceLaunch::AddNode,
         ] {
             assert!(
@@ -2483,6 +2852,42 @@ mod tests {
     }
 
     #[test]
+    fn project_launch_uses_the_selected_directory_without_a_command() {
+        let path = std::env::temp_dir();
+        let launch = super::WorkspaceLaunch::Project {
+            name: "project with spaces".into(),
+            path: path.clone(),
+        };
+        assert_eq!(
+            launch.working_directory().unwrap(),
+            path.canonicalize().unwrap()
+        );
+        assert!(launch.command().is_none());
+        let missing = super::WorkspaceLaunch::Project {
+            name: "missing".into(),
+            path: path.join(format!("boomux-missing-project-{}", fastrand::u64(..))),
+        };
+        assert!(missing.working_directory().is_err());
+        let file = super::WorkspaceLaunch::Project {
+            name: "not a directory".into(),
+            path: std::env::current_exe().unwrap(),
+        };
+        assert!(file.working_directory().is_err());
+    }
+
+    #[test]
+    fn project_workspace_names_do_not_reuse_existing_workspaces() {
+        assert_eq!(
+            super::project_workspace_name("api", ["other"].into_iter()),
+            "api"
+        );
+        assert_eq!(
+            super::project_workspace_name("api", ["api", "api-2", "api-4"].into_iter()),
+            "api-3"
+        );
+    }
+
+    #[test]
     fn node_launches_preserve_exact_arguments_and_do_not_request_upgrades() {
         use super::WorkspaceLaunch;
         assert!(WorkspaceLaunch::Shell.command().is_none());
@@ -2490,14 +2895,28 @@ mod tests {
             WorkspaceLaunch::AddNode.command().unwrap().1,
             ["__guided-node-add"]
         );
-        assert!(WorkspaceLaunch::Dashboard.command().unwrap().1.is_empty());
         let id = "node with spaces; $(touch should-not-exist)";
+        assert_eq!(
+            WorkspaceLaunch::UninstallNode(id.into())
+                .command()
+                .unwrap()
+                .1,
+            ["__guided-node-uninstall", id]
+        );
         assert_eq!(
             WorkspaceLaunch::ReauthenticateNode(id.into())
                 .command()
                 .unwrap()
                 .1,
             ["__guided-node-reauthenticate", id]
+        );
+    }
+
+    #[test]
+    fn config_editor_launch_uses_the_validated_cli_flow() {
+        assert_eq!(
+            super::WorkspaceLaunch::ConfigEdit.command().unwrap(),
+            ("Edit Boomux config", vec!["config".into(), "edit".into()])
         );
     }
 
@@ -2539,6 +2958,7 @@ mod tests {
     #[test]
     fn shared_shell_agents_keep_distinct_labels_and_lifecycle_observations() {
         let original = AgentChoice {
+            run_id: "run-1".into(),
             id: "12345678-original".into(),
             shell_name: "fair-koala".into(),
             display_name: String::new(),
@@ -3011,6 +3431,49 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(&lines[..3], ["abcde", "fghij", "klmno"]);
         assert!(lines[3].starts_with('p'));
+    }
+
+    #[test]
+    fn ghostty_resize_redraw_does_not_insert_blank_history() {
+        let shared = Arc::new(SharedTerminal::new(terminal_profile(6, 80, 800, 120)));
+        let mut core = EmulatorCore::new(&shared, 6, 80, 800, 120).unwrap();
+        for cols in [80, 40, 120, 60, 80] {
+            core.apply(EmulatorCommand::Resize {
+                rows: 6,
+                cols,
+                cell_width: 10,
+                cell_height: 20,
+            })
+            .unwrap();
+            // Kiro's width-change redraw clears scrollback and the screen,
+            // then writes the complete frame inside synchronized output.
+            let frame = format!(
+                "\x1b[?2026h\x1b[3J\x1b[2J\x1b[H{}\x1b[?2026l",
+                (0..30)
+                    .map(|line| format!("row-{line:02}"))
+                    .collect::<Vec<_>>()
+                    .join("\r\n")
+            );
+            // PTY reads need not align with escape sequences or lines.
+            for chunk in frame.as_bytes().chunks(7) {
+                core.apply(EmulatorCommand::Output(chunk.to_vec())).unwrap();
+            }
+            for first in [0, 6, 12, 18, 24] {
+                core.apply(EmulatorCommand::Scroll(
+                    libghostty_vt::terminal::ScrollViewport::Row(first),
+                ))
+                .unwrap();
+                let screen = core.screen().unwrap();
+                assert_eq!(screen.scroll_total, 30, "width {cols}");
+                for (offset, row) in screen.cells.chunks(usize::from(cols)).enumerate() {
+                    let text = row
+                        .iter()
+                        .map(|cell| cell.text.as_str())
+                        .collect::<String>();
+                    assert_eq!(text.trim_end(), format!("row-{:02}", first + offset));
+                }
+            }
+        }
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,11 +51,19 @@
 
 ## Managed Integration Assets
 
+Per-Shell runtime shim preparation compares existing owner-controlled regular
+files through no-follow descriptors using bounded scratch space. Identical content
+and mode are reused without rewrite or fsync; changed content or permissions still
+use atomic replacement. Durable Shell state and event publication ordering are
+unchanged. This avoids repeating shared-asset disk flushes under the mutation lock
+for every login Shell.
+
 After cold startup or finalized handoff, the committed daemon owner starts one
 bounded background maintenance pass. It never delays terminal admission, restarts
-harnesses, or polls in steady state. Successfully probed local harnesses receive
-missing assets; existing managed targets are reconciled even if the executable
-is temporarily absent. `integration sync` exposes the same local operation as a
+harnesses, or polls in steady state. All bundled integrations receive missing
+assets without host probes or PATH discovery, including on remote owners started
+through SSH with a restricted environment. Harnesses need not be installed yet.
+`integration sync` exposes the same local operation as a
 human-only CLI command. Read-only status/capabilities calls remain non-mutating.
 
 Each resolved asset target has a sibling `.<filename>.boomux-managed.json`
@@ -73,7 +81,8 @@ An owner-validated nonblocking per-directory file lock serializes core writers.
 Reads reject symlinks/non-regular or foreign-owned files and are bounded to 1 MiB.
 Updates use temporary files, baseline revalidation, atomic rename, and fsync;
 receipt failure is surfaced, not treated as permission to replace unknown assets.
-Host probes have existing five-second/output limits; there is at most one worker
+Explicit status host probes retain their five-second/output limits; maintenance
+executes no host processes. There is at most one worker
 and one receipt per bundled integration target. Errors are logged without failing
 daemon startup. Desktop owns no integration discovery worker or update prompts.
 
@@ -285,6 +294,20 @@ event readers filter that event while retaining cursor progress. Coordinator
 Workspace schema 8 explicitly migrates schema 7 with empty pending and completed
 default-cwd operation ledgers. Owner state schema 14 and handoff generation 8 are
 unchanged because owner Workspaces already persist `default_cwd`.
+Protocol 54 adds `create_started_shell`: local `CreateStartedShell` creates a
+Shell and its first ShellRun in one durable state replacement. The PTY reader
+stays paused until persistence succeeds; `shell_created` then `run_started` are
+published in the same event batch before output is released. Failed creation,
+spawn, or persistence rolls back membership and reaps any newly started process
+and reader. The supplied startup environment is ephemeral, never persisted.
+As with first attachment, the child can execute before the commit is acknowledged;
+rollback does not undo external command side effects.
+The response carries the exact first run for subsequent exact-run attachment.
+Clients negotiate before mutation and use ordinary pending-Shell creation plus
+attachment on older peers; they do not replay an ambiguous create response.
+Remote routing is unchanged. Existing state schema and cold-recovery semantics
+are unchanged: the stored Shell and run use their existing representations.
+
 Protocol 53 adds `git_work_overview`: a read-only `GitOverview` host-service
 operation and result, available locally and through verified Node routing.
 The owner discovers repositories from managed Shells and observed Agent contexts,
@@ -531,6 +554,11 @@ are synchronized after commit.
 
 `src/daemon.rs` owns all PTY masters and child processes. Its runtime directory
 is restricted to the current user and the socket mode is `0600`.
+When no connection is queued, the accept loop waits for socket readability with
+the existing 25 ms maintenance timeout rather than sleeping unconditionally.
+Connection arrival wakes it immediately without adding a worker or increasing
+the idle maintenance rate. State-directory ownership/type/mode checks still run
+on each save, but correct `0700` permissions are not rewritten unnecessarily.
 
 The daemon is composed from state-owning services rather than one shared
 registry. `DurableRegistry` owns workspace, shell, launcher, and Agent
@@ -1208,7 +1236,12 @@ Boomux does not share that file with unrelated Kiro configuration.
 Eligible managed Kiro invocations pass through the common Shell-scoped shim and
 hidden launcher. A bare `kiro-cli` becomes `kiro-cli --v3`, while an explicit
 leading `--v3` is preserved. The launcher supervises the exact argument vector
-with inherited terminal streams and foreground process-group behavior, and
+with the matching Boomux executable directory first on the sanitized child PATH,
+so bare lifecycle hook commands cannot select an older user installation instead
+of the launcher's CLI. Managed Codex launches use the same path priority; the
+selected harness executable and argument vector remain unchanged. Unmanaged
+invocations retain their ordinary PATH. The launcher inherits terminal streams
+and foreground process-group behavior, and
 acquires a private daemon-owned Launch Holder
 only while the installed asset is current. Only that Kiro process tree receives
 the holder capability. Eligible login ShellRuns stage the delegating shim even
@@ -1606,6 +1639,16 @@ this boundary, but sink dispatch occurs only after all coordinator and mutation
 locks are released.
 
 ## Runtime Semantics
+
+Local development can isolate Boomux without changing application environments:
+`BOOMUX_RUNTIME_DIR`, `BOOMUX_STATE_HOME`, and `BOOMUX_CONFIG_HOME` override the
+corresponding XDG roots only for Boomux-owned socket/shim paths, state (including
+Node identity and Workspace selection), and core/Desktop configuration. The
+development helper supplies absolute paths at the existing development locations.
+These routing variables remain inherited by local Shells and the Shared Harness
+Runtime so integration callbacks reach the same Node; Shell/Agent identity is
+still stripped from the shared runtime. XDG variables remain application-owned,
+and remote attachments continue to use the owning Node's environment.
 
 Closing a terminal window closes only its socket attachment. The daemon retains
 the PTY master and child. Reopening a native window acquires the primary

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -23,6 +23,14 @@ binary and used by update/packaging behavior.
 
 ## Conservative Selection
 
+The static marketing site in `website/` has a separate Website workflow with
+an Astro production build and desktop/mobile browser tests. Website-only changes
+(including its own workflow) do not select Rust or packaging checks. Mixed
+changes retain the validation for their affected product components; renames
+out of packaged/runtime paths cannot use the website-only skip. The site workflow
+also watches its imported repository screenshot. Successful main site builds
+deploy to GitHub Pages once Pages is enabled; local builds never publish.
+
 `.github/scripts/classify-ci.py` produces independent decisions for backend
 validation, Desktop validation, packaging, and backend benchmark smoke. A failed diff, missing Git base,
 unavailable CI evidence, or malformed release metadata requires full validation.

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -25,6 +25,15 @@ encoding and forwarding them; this keeps Kitty keyboard, modifyOtherKeys,
 cursor, keypad, and backarrow negotiation ordered with terminal output.
 Detaching a pane never implies closing its Boomux Shell.
 
+New terminal creation publishes the attachment before any sidebar overview refresh;
+the existing overview worker refreshes resource rows independently. New local
+Shells in existing Workspaces use protocol-54 `CreateStartedShell` to combine
+creation and first-run persistence, then attach to the returned exact run.
+Older owners fall back to pending creation followed by attachment; remote and
+new-Workspace creation retain their existing paths. Reattachment
+to a running Shell retains the exact run already validated by attach, without a
+second owner lookup. Newly started/restarted Shells still resolve their new run.
+
 GPUI key contexts separate ordinary terminal input from desktop layout actions.
 The default `Terminal` context reserves only explicit lifecycle, clipboard, and
 mode-entry commands; other keys reach the pane encoder. `Ctrl+Space` activates
@@ -117,8 +126,9 @@ Settings replaces the sidebar resource list while open, so scrolling its control
 does not build or lay out the covered Workspace, Shell, and Agent rows. The
 sidebar scroll handle remains window-owned and restores its offset on close.
 
-The default presentation draws the binary tile layout and floating layer. The
-optional tabbed-minimization presentation keeps every open pane in that canvas.
+Both Tree and Tabs draw the binary tile layout and floating layer. The
+default Tabs presentation keeps every open pane in that canvas; saved Tree
+preferences retain their existing behavior.
 `Ctrl+W` still detaches and releases the pane-owned emulator and GPU state, but
 the minimized Shell is represented in a restorable strip above the canvas and
 is represented only by its restore tab. Tabs hides all nested Shell rows from
@@ -126,6 +136,24 @@ the sidebar, leaving Workspace rows as its navigation surface. Restoring a tab
 creates a new pane attachment without changing Boomux's durable Shell identity.
 
 ## Resource Projection
+
+Workspace rows use split-pane icons, semibold names, and distinct header surfaces;
+Shell rows use deeper indentation and regular-weight names. Status indicators
+and activation behavior remain separate from this visual hierarchy.
+
+The sidebar `+` opens a local creation menu with New Workspace first, followed by
+projects discovered through the existing bounded `boomux project list --json`
+flow. One background scan runs per opening, without polling or concurrent scans;
+loading, empty, warning, and error states remain visible. Settings exposes
+`projects.roots` and `projects.max_depth` through the validated core config editor,
+with no daemon restart required. Settings and the menu's Add/Manage project folders
+action open a native directory-only picker through GPUI's desktop portal support.
+Selections append to the effective roots without replacing existing entries;
+duplicates are skipped and cancel is a no-op. The manual editor remains available,
+including when a desktop file-picker portal is unavailable. Selecting a project creates a new local Workspace named after
+the project (adding a numeric suffix on collision), with its default directory
+and initial login Shell set to the revalidated project path. It does not infer
+membership from an existing Workspace's equal name or launch commands from files.
 
 The sidebar is a bounded, read-only Boomux snapshot. Active Agent rows require an
 exact current ShellRun. Historical records appear only through explicit Boomux
@@ -146,7 +174,25 @@ Workspace authority.
 
 ## Remote Node Entry Points
 
-The sidebar overflow menu opens a bounded, scrollable Nodes popover. Once remote
+The lower sidebar has Agents, Git, and Remotes tabs. Remotes contains the scrollable
+machine cards with selected-machine details and create/update/sign-in controls.
+The general connect action sits above the cards, outside any machine's controls;
+it is no longer an overflow-menu popover. Node shortcuts apply only while the
+sidebar has keyboard focus, so the selected tab does not consume terminal input.
+Remote-owned Workspaces appear in the main tree with a monitor icon and machine
+status. Desktop keys encode both owner and resource identity, and are decoded
+only at the RPC boundary; encoded keys are never passed as owner-local IDs.
+Shell creation, attachment, reconnect, rename, close, and attention acknowledgment
+use the registered owner's existing guarded APIs. Cached directories are not
+invented from local paths. Remote creation resolves the owner's starting directory
+and creates the owner-local Workspace and first pending Shell with fresh exact IDs;
+ambiguous mutation failures are surfaced without automatic replay.
+The initial connect flow creates this Workspace after successful registration.
+Open its Shell from the sidebar; creating another Workspace from Remotes also
+attaches its first Shell. Multi-placement coordinator metadata is left unchanged.
+The Remotes tab retains sign-in actions and adds an explicitly confirmed
+remote update action. No background installation or upgrade is performed.
+Once remote
 Nodes are registered, the existing sidebar subtitle shows a compact Node count
 and connection summary. Selection uses stable Node IDs, including when aliases
 or routes happen to match. Details show observed health, last observation,
@@ -157,25 +203,34 @@ The existing window-owned overview worker reads one combined snapshot per
 refresh for both local resources and Node summaries. It falls back to local
 discovery if federation is unavailable. A failed refresh retains prior Node
 summaries but removes their connected presentation. Observation timestamp changes
-do not alone repaint a closed popover. There is no additional SSH worker,
+do not alone repaint an inactive Remotes tab. There is no additional SSH worker,
 registration store, or discovery loop in Desktop. Snapshot and registration
 bounds remain daemon-owned; the client retains only the latest summary per Node.
 
-Add Node and reauthentication open the matching Boomux CLI's existing guided
+Connect, update, uninstall, and reauthentication open the matching Boomux CLI's guided
 flow in a local daemon-owned Shell, using exact argument vectors. Reauthentication
 passes the stable Node ID and leaves route/identity verification to Boomux.
 SSH credentials, browser challenges, host verification, installation consent,
-and protocol compatibility remain owned by that interactive flow. These Shells
-and their Workspaces follow the existing setup-terminal lifecycle and remain
-visible after the command exits until explicitly removed. An Open Boomux
-dashboard action provides access to the existing TUI's Nodes tab.
+and protocol compatibility remain owned by that interactive flow. After the
+result acknowledgment, the exact dedicated command Shell/run is removed with a
+revision guard. Desktop removes its temporary Workspace only with ephemeral
+creation proof, the expected post-removal revision, and no remaining resources.
+Ordinary Shells invoking the CLI are not cleanup targets. Remotes does not launch
+the separate terminal dashboard. Healthy cards omit generic lifecycle guidance;
+unavailable machines retain their observation age and recovery guidance.
+The machine-card remove action uses `node uninstall` with the exact Node ID,
+retaining its interactive consent, identity/revision checks, and confirmed-removal
+registration cleanup. Desktop never substitutes a local forget on failure.
+An independent, inline-confirmed **Forget connection only…** action uses the
+existing local `ForgetNodeRegistration` request with the selected exact Node ID.
+It runs off the UI thread, does not require remote availability, and is never
+presented as successful remote uninstall. Concurrent clicks are suppressed;
+normal overview refresh removes the forgotten registration's cached rows.
 
-This first native entry point does not yet put remote Shells in the Desktop
-canvas. Local Shell/Agent projection and attachment retain their current scope.
-Node-qualified remote pane identities, coordinated Workspace presentation, and
-connection-loss recovery are the next implementation stages. The popover has its
-own input context, closes on Escape or outside click, and blocks terminal input
-while open; releases for keys sent before opening still reach their original pane.
+Remote attachment uses `AttachNode`, preserving the exact owner/run on reconnect
+and leaving environment ownership on that machine. Local attachment continues
+to supply the local ephemeral client environment. This presentation does not
+flatten or adopt existing multi-placement coordinator Workspaces.
 
 ## Dependency Boundary
 
@@ -206,7 +261,15 @@ defaults come from its public library; CLI-only display defaults mirror the
 workspace version and must be reviewed on dependency updates. This is a presentation
 projection, not the running daemon's state. Only edited fields are written.
 The comment-preserving active draft and global fallback are each capped at 1 MiB.
-Text entry is limited to 16 KiB. The UI presents one categorized list with shared control styling.
+Text entry is limited to 16 KiB. The UI presents one categorized list with
+bordered section groups, label/description rows, compact boolean switches,
+segmented choices, and inset editable fields. These are native GPUI-CE controls
+using the existing theme palette, not a GPUI Kit dependency. Advanced terminal
+setup is placed after the everyday settings.
+The Advanced section shows the active core configuration path and opens
+`boomux config edit` in a local terminal using the matching CLI. This preserves
+the core editor's validation and transactional save behavior; it does not edit
+Desktop's separate `boomux-desktop/settings.toml` appearance preferences.
 
 Each completed edit invokes `boomux config edit` with Desktop as its temporary-file editor.
 The helper runs before GPUI initialization, checks the original active-layer

--- a/docs/desktop/performance.md
+++ b/docs/desktop/performance.md
@@ -36,6 +36,78 @@ Measure these independently before combining them:
 
 ## Metrics
 
+### Local Shell startup diagnostic (2026-09-08)
+
+An opt-in native diagnostic separates create, attach, run lookup, first usable
+output, and exact-run reopening without using live user Workspaces:
+
+```console
+cargo test --test native_backend shell_startup_phase_timings --locked -- --ignored --nocapture --test-threads=1
+BOOMUX_TIMING_STATE_ROOT=/absolute/path/on/test/filesystem cargo test --test native_backend shell_startup_phase_timings --locked -- --ignored --nocapture --test-threads=1
+```
+
+The second form creates and removes a uniquely named state directory under the
+specified root; runtime sockets and harness settings remain isolated. On the
+development host, the same debug test binary and three plain `/bin/sh` Shells
+took 75–76 ms from creation through usable output with the default temporary
+state location, versus 1.32–1.48 s with state under the project's Btrfs `target`.
+On Btrfs, creation took 515–753 ms and first attachment 704–803 ms; exact-run
+reopening took 25 ms in both runs. These are backend diagnostic measurements,
+not Desktop end-to-end latency, remote latency, or a before/after speedup claim.
+They identify the two durable commits as a substantial remaining startup cost.
+Do not remove persistence barriers or move durable state to volatile storage as
+a latency workaround.
+
+The diagnostic now alternates the old create/attach path with protocol-54
+create-and-start, three samples each, six sequential 24×80 plain `/bin/sh`
+Shells in one isolated Workspace. An optimized same-binary comparison on this
+host's Btrfs state directory used:
+
+```console
+BOOMUX_TIMING_STATE_ROOT=/home/gardnmi/Projects/boomux/target cargo test --release --test native_backend shell_startup_phase_timings --locked -- --ignored --nocapture --test-threads=1
+```
+
+Old-path usable-output times were 1.631, 1.494, and 1.325 seconds; combined-path
+times were 0.780, 0.479, and 0.697 seconds (median reduction about 53%). First
+attachment after combined creation took 7–25 ms instead of 600–904 ms. Exact-run
+reopening remained about 25 ms. The test took 10.84 seconds including setup and
+cleanup. It includes an extra run lookup on both paths; Desktop uses the returned
+run directly on the combined path. Disk timings vary with filesystem activity.
+These are backend timings, not an end-to-end Desktop or remote benchmark.
+Steady-state CPU, memory, and frame latency were not measured in this diagnostic;
+the change uses the existing process/reader lifecycle and adds no idle polling,
+cache, queue, or per-Shell runtime beyond the existing one.
+
+#### Follow-up: connection wakeups and directory metadata
+
+The daemon now waits for listener readability instead of sleeping 25 ms after
+an empty accept. The idle timeout and maintenance checks remain 25 ms; incoming
+connections wake the same thread immediately. State-directory validation also
+avoids reapplying `0700` when it is already correct, while still checking ownership,
+rejecting symlinks, and repairing incorrect modes on every call.
+
+Using the same optimized diagnostic on the same host, exact-run reopen fell from
+about 25 ms to 0.088–0.129 ms. Combined creation through usable output with disk
+state was 0.603, 0.598, and 0.400 seconds. A fresh pre-change comparison was
+0.401, 0.800, and 0.201 seconds, so disk variability prevents claiming an overall
+creation speedup from this follow-up. With default temporary memory-backed state,
+the new optimized combined path took 1.87–2.04 ms. That measures the backend's
+non-disk floor, not a recommended volatile-state configuration or Desktop latency.
+
+An opt-in 8 KiB storage diagnostic separates writing, file synchronization,
+rename/directory synchronization, and append/data synchronization:
+
+```console
+BOOMUX_TIMING_STATE_ROOT=/absolute/path/on/test/filesystem cargo test --lib persistence_barrier_timings --locked -- --ignored --nocapture --test-threads=1
+```
+
+On this host, buffered writes took under 0.2 ms but individual synchronization
+barriers took up to about 402 ms. Even the synthetic append-only case varied
+from 46 to 402 ms. This is not a production journal implementation or a promise
+that switching formats would eliminate disk waits. The follow-up leaves state
+formats, fsync barriers, event ordering, and recovery guarantees unchanged.
+It adds no worker, queue, or cache; idle CPU and retained memory were not measured.
+
 - RSS and PSS for Boomux Desktop and the Boomux daemon
 - private clean/dirty memory and swap
 - incremental memory per attached idle pane

--- a/docs/event-stream.md
+++ b/docs/event-stream.md
@@ -1,5 +1,11 @@
 # Daemon Event Stream
 
+Protocol 54's local `CreateStartedShell` publishes the existing `shell_created`
+and `run_started` events in order as one batch after the single durable commit.
+Its reader remains paused until that commit, so output cannot precede creation.
+Failed creation emits neither event. Older event readers need no new fields or
+event filtering for this operation.
+
 > **Status: Current protocol contract.** Source and compatibility tests are
 > authoritative for exact version gates; this document defines event and cursor
 > semantics.

--- a/docs/install.md
+++ b/docs/install.md
@@ -74,17 +74,20 @@ exact retry command, and exits nonzero.
 
 The Boomux service makes one background integration-maintenance pass when it
 starts, including after a committed update handoff. It installs missing
-integrations for detected, successfully probed harnesses and updates unchanged
+bundled integrations without requiring harness detection and updates unchanged
 Boomux-managed integrations to the version bundled with that binary. Desktop
 does not separately detect harnesses or ask users to install/update integrations.
+Integration files are prepared even for tools not yet installed or absent from
+the service's PATH, including remote machines started through SSH. Maintenance
+does not execute harnesses or interactive shell startup scripts.
 Already-running harnesses may need restarting to load changed files. Codex's
 own hook trust approval is still required; Boomux does not bypass it.
 
 Use `boomux integration uninstall <name>` to opt out, and
 `boomux integration install <name>` to opt back in. Uninstall choices survive
 service restarts and Boomux updates. Removing a previously managed asset by hand
-also leaves it off. `boomux integration sync` runs maintenance immediately after
-installing a new harness, without restarting the service or existing Shells.
+also leaves it off. `boomux integration sync` runs maintenance immediately,
+without restarting the service or existing Shells.
 `integration status` remains read-only. Maintenance failures are logged to the
 service's stderr and can be retried with `integration sync`.
 

--- a/docs/live-pty-handoff.md
+++ b/docs/live-pty-handoff.md
@@ -35,6 +35,17 @@ executable. Versioned Desktop bundles instead use:
 boomux daemon restart --executable /absolute/release/path/bin/boomux
 ```
 
+`--refresh-environment` explicitly refreshes daemon-owned services from the
+invoking client's ephemeral environment. The existing
+`RestartWithNotificationConfig.environment` field carries it; it is never
+persisted. The receiver validates the environment and requires the same resolved
+runtime and state directories before beginning handoff. Running Shells and the
+Shared Harness Runtime retain their original processes and environments.
+Without the option, restart preserves the daemon environment. Combined with
+`--executable`, the CLI first completes and verifies executable handoff, then
+requests a second environment-refresh handoff. A second-step failure leaves the
+upgraded daemon running and is reported as a failure, never a destructive stop.
+
 Protocol 52 adds `restart_executable` and `RestartWithExecutable`. The current
 client refuses this mutation on older daemons before requesting a restart. The
 owner daemon requires a canonical absolute path to a regular native ELF binary,

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -37,6 +37,16 @@ Package-managed, root-owned, source, development, custom, symlinked, multiply
 linked, changed, and otherwise unprovable executables are refused. Package
 installations must be removed with their owning package manager.
 
+Registered remote uninstall also accepts source/development copies at that exact
+canonical user-owned path, because remote bootstrap can install the pinned current
+binary. Build distribution is not used as remote ownership evidence. The private
+fingerprint probe and removal share this check; owner-controlled directories,
+regular single-link executable, pinned Node identity, explicit confirmation, and
+unchanged executable fingerprint remain required. No installer provenance receipt
+is assumed. Local self-update and self-uninstall remain official-release-only.
+Older remote helpers with the release-only check must be updated before removing
+a development copy; the coordinator does not bypass their refusal.
+
 Unchanged bundled integration assets and the unchanged Boomux Agent Skill are
 removed. Modified or uninspectable assets are preserved and reported; uninstall
 never uses integration force-removal implicitly. Host configuration and session

--- a/src/client.rs
+++ b/src/client.rs
@@ -337,7 +337,8 @@ impl std::fmt::Display for RemoteError {
 impl Error for RemoteError {}
 
 pub fn socket_path() -> io::Result<PathBuf> {
-    let runtime = env::var_os("XDG_RUNTIME_DIR")
+    let runtime = env::var_os("BOOMUX_RUNTIME_DIR")
+        .or_else(|| env::var_os("XDG_RUNTIME_DIR"))
         .map(PathBuf::from)
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "XDG_RUNTIME_DIR is not set"))?;
     if !runtime.is_absolute() {
@@ -987,6 +988,42 @@ impl Client {
         }
     }
 
+    /// Create an owner-local remote Workspace and its first Shell. The owner
+    /// resolves the initial directory; this never forwards local environment or paths.
+    pub fn create_remote_workspace(&self, node_id: &str, name: &str) -> Result<ShellSnapshot> {
+        let cwd = match self.route_node_host_service(
+            node_id,
+            protocol::HostServiceOperation::ResolveDirectory {
+                path: std::path::PathBuf::from("."),
+            },
+        )? {
+            protocol::HostServiceResult::Directory { path } => path,
+            response => {
+                return Err(io::Error::other(format!(
+                    "unexpected remote directory response: {response:?}"
+                ))
+                .into());
+            }
+        };
+        let name_shell = crate::generated_names::random_excluding(std::iter::empty())
+            .ok_or_else(|| io::Error::other("Shell names exhausted"))?;
+        let operation = RoutedOperation::CreateWorkspaceShell {
+            workspace_id: uuid::Uuid::new_v4().to_string(),
+            workspace_name: name.into(),
+            default_cwd: Some(cwd.clone()),
+            shell_id: uuid::Uuid::new_v4().to_string(),
+            shell: ShellSpec::login(name_shell, cwd),
+        };
+        // Do not retry an ambiguous mutation with different resource identities.
+        match self.route_node_operation(node_id, operation)? {
+            RoutedOperationResult::Shell { shell } => Ok(shell),
+            response => Err(io::Error::other(format!(
+                "unexpected remote workspace response: {response:?}"
+            ))
+            .into()),
+        }
+    }
+
     pub fn set_agent_session_display_name(
         &self,
         operation_id: impl Into<String>,
@@ -1263,6 +1300,18 @@ impl Client {
         })
     }
 
+    /// Refresh daemon-owned services from the caller without changing live PTYs.
+    /// The caller must retain the same Boomux socket and durable state roots.
+    pub fn restart_with_client_environment(
+        &self,
+        notifications: NotificationDeliveryConfig,
+    ) -> Result<()> {
+        self.restart_request(Request::RestartWithNotificationConfig {
+            notifications,
+            environment: Some(current_environment()),
+        })
+    }
+
     fn restart_request(&self, request: Request) -> Result<()> {
         expect_ok(self.request(request)?, Response::Ok)?;
         let mut last_error = None;
@@ -1373,6 +1422,29 @@ impl Client {
         match self.request(Request::CreateShell {
             workspace_id: None,
             shell,
+        })? {
+            Response::Shell { shell } => Ok(shell),
+            other => unexpected(other),
+        }
+    }
+
+    /// Create and start with one durable commit when supported. Older peers
+    /// return a Pending Shell, which the caller must start by attaching as usual.
+    /// Never retry creation after an ambiguous transport failure.
+    pub fn create_started_shell(
+        &self,
+        workspace_id: &str,
+        shell: ShellSpec,
+        profile: TerminalProfile,
+    ) -> Result<ShellSnapshot> {
+        if !self.supports(protocol::ProtocolFeature::CreateStartedShell)? {
+            return self.create_shell(workspace_id, shell);
+        }
+        match self.request(Request::CreateStartedShell {
+            workspace_id: workspace_id.into(),
+            shell,
+            profile,
+            environment: Some(current_environment()),
         })? {
             Response::Shell { shell } => Ok(shell),
             other => unexpected(other),
@@ -2541,6 +2613,77 @@ mod tests {
 
         server.join().unwrap();
         fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn create_started_shell_negotiates_before_creation_and_never_replays() {
+        for peer_version in [53, protocol::PROTOCOL_VERSION] {
+            let directory = env::temp_dir().join(format!("boomux-client-start-{}", Uuid::new_v4()));
+            fs::create_dir_all(&directory).unwrap();
+            let socket = directory.join("daemon.sock");
+            let listener = UnixListener::bind(&socket).unwrap();
+            let server = thread::spawn(move || {
+                for version in (peer_version..=protocol::PROTOCOL_VERSION).rev() {
+                    let (mut stream, _) = listener.accept().unwrap();
+                    let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                    assert_eq!(request.message, Request::Ping);
+                    assert_eq!(request.version, version);
+                    let response = if version > peer_version {
+                        Response::Error {
+                            message: "unsupported".into(),
+                            code: Some(ErrorCode::UnsupportedVersion),
+                        }
+                    } else {
+                        Response::Pong
+                    };
+                    protocol::write_message(
+                        &mut stream,
+                        &Envelope::with_version(peer_version, response),
+                    )
+                    .unwrap();
+                }
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                assert_eq!(request.version, peer_version);
+                if peer_version == 53 {
+                    assert!(matches!(request.message, Request::CreateShell { .. }));
+                } else {
+                    assert!(matches!(
+                        request.message,
+                        Request::CreateStartedShell {
+                            environment: Some(_),
+                            ..
+                        }
+                    ));
+                }
+                // Lose the response after receiving a potentially committed mutation.
+                drop(stream);
+                listener.set_nonblocking(true).unwrap();
+                listener
+            });
+            let client = Client::from_socket_path(socket);
+            let profile = TerminalProfile {
+                term: None,
+                colorterm: None,
+                term_program: None,
+                term_program_version: None,
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            };
+            assert!(
+                client
+                    .create_started_shell("workspace", ShellSpec::login("shell", "/tmp"), profile)
+                    .is_err()
+            );
+            let listener = server.join().unwrap();
+            assert_eq!(
+                listener.accept().unwrap_err().kind(),
+                io::ErrorKind::WouldBlock
+            );
+            fs::remove_dir_all(directory).unwrap();
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -356,6 +356,10 @@ fn verify_inherited_baseline(
 }
 
 pub(crate) fn global_config_path() -> Option<PathBuf> {
+    if let Some(root) = env::var_os("BOOMUX_CONFIG_HOME") {
+        let root = PathBuf::from(root);
+        return root.is_absolute().then(|| root.join("boomux/config.toml"));
+    }
     env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
         .filter(|path| path.is_absolute())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -63,13 +63,11 @@ use crate::protocol::{
     WorkspaceLauncherSnapshot, WorkspaceLauncherSpec, WorkspaceSnapshot,
 };
 use crate::ssh_bootstrap::{self, RemoteBootstrapPlan, SshAuthenticationMode, SshTarget};
-#[cfg(debug_assertions)]
-use crate::state_store::state_directory_from_environment;
 use crate::state_store::{
     PersistedAgentInstance, PersistedHiddenSession, PersistedSessionDisplayName,
     PersistedSessionDisplayNameOperation, PersistedSessionHideOperation, PersistedSessionIdentity,
     PersistedShell, PersistedShellRun, PersistedState, PersistedWorkspace,
-    PersistedWorkspaceLauncher, StateStore,
+    PersistedWorkspaceLauncher, StateStore, state_directory_from_environment,
 };
 use crate::terminal_state::TerminalState;
 
@@ -617,7 +615,10 @@ fn run_daemon(
                 );
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                thread::sleep(Duration::from_millis(25));
+                // Wake immediately for new connections instead of adding a
+                // fixed sleep to each request in a create/attach sequence.
+                // Retain the maintenance/shutdown check interval when idle.
+                wait_for_listener(&listener, Duration::from_millis(25))?;
             }
             Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
             Err(error) => return Err(error),
@@ -644,6 +645,30 @@ fn run_daemon(
     drop(socket_cleanup);
     drop(daemon_lock);
     result
+}
+
+fn wait_for_listener(listener: &UnixListener, timeout: Duration) -> io::Result<bool> {
+    let mut descriptor = libc::pollfd {
+        fd: listener.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let milliseconds = timeout.as_millis().min(i32::MAX as u128) as i32;
+    // The listener remains owned for the whole wait and poll receives one
+    // initialized, writable descriptor. No per-connection timer or worker.
+    let result = unsafe { libc::poll(&mut descriptor, 1, milliseconds) };
+    if result < 0 {
+        let error = io::Error::last_os_error();
+        return if error.kind() == io::ErrorKind::Interrupted {
+            Ok(false)
+        } else {
+            Err(error)
+        };
+    }
+    if descriptor.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+        return Err(io::Error::other("daemon listener became unavailable"));
+    }
+    Ok(descriptor.revents & libc::POLLIN != 0)
 }
 
 #[cfg(debug_assertions)]
@@ -1375,9 +1400,11 @@ fn inject_opencode_shim_environment(
     claude_remote_control: bool,
 ) -> io::Result<UnixEnvironment> {
     let runtime_root = PathBuf::from(
-        environment_value(environment, b"XDG_RUNTIME_DIR").ok_or_else(|| {
-            io::Error::new(io::ErrorKind::NotFound, "XDG_RUNTIME_DIR is unavailable")
-        })?,
+        environment_value(environment, b"BOOMUX_RUNTIME_DIR")
+            .or_else(|| environment_value(environment, b"XDG_RUNTIME_DIR"))
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "XDG_RUNTIME_DIR is unavailable")
+            })?,
     );
     if !runtime_root.is_absolute() {
         return Err(io::Error::new(
@@ -1522,6 +1549,43 @@ fn configure_opencode_shell_startup(
 }
 
 fn atomic_runtime_asset(path: &Path, content: &[u8], mode: u32) -> io::Result<()> {
+    // Runtime support files are shared by all Shells. Avoid rewriting and
+    // fsyncing identical assets on every start while holding the mutation lock.
+    // Compare through a no-follow descriptor with bounded scratch space.
+    match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(mut file) => {
+            let metadata = file.metadata()?;
+            if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "runtime asset is not an owned regular file",
+                ));
+            }
+            if metadata.len() == content.len() as u64
+                && metadata.mode() & 0o7777 == mode
+                && metadata.nlink() == 1
+            {
+                let mut buffer = [0u8; 8192];
+                let mut matches = true;
+                for expected in content.chunks(buffer.len()) {
+                    let actual = &mut buffer[..expected.len()];
+                    if file.read_exact(actual).is_err() || actual != expected {
+                        matches = false;
+                        break;
+                    }
+                }
+                if matches {
+                    return Ok(());
+                }
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
     if let Ok(metadata) = fs::symlink_metadata(path)
         && (metadata.file_type().is_symlink() || !metadata.is_file())
     {
@@ -1643,6 +1707,32 @@ struct ReplacementOptions {
     opencode_runtime: Option<OutgoingOpenCodeRuntime>,
     claude_remote_control_bindings: Vec<ClaudeRemoteControlBindingSnapshot>,
     kiro_launch_holders: Vec<handoff::KiroLaunchHolderManifest>,
+}
+
+fn validate_restart_environment_roots(environment: &UnixEnvironment) -> io::Result<()> {
+    let runtime = environment_value(environment, b"BOOMUX_RUNTIME_DIR")
+        .or_else(|| environment_value(environment, b"XDG_RUNTIME_DIR"))
+        .map(PathBuf::from)
+        .ok_or_else(|| io::Error::other("restart environment has no runtime root"))?;
+    let state = environment_value(environment, b"BOOMUX_STATE_HOME")
+        .or_else(|| environment_value(environment, b"XDG_STATE_HOME").filter(|p| !p.is_empty()))
+        .map(PathBuf::from)
+        .or_else(|| {
+            environment_value(environment, b"HOME").map(|p| PathBuf::from(p).join(".local/state"))
+        })
+        .ok_or_else(|| io::Error::other("restart environment has no state root"))?;
+    if !runtime.is_absolute()
+        || !state.is_absolute()
+        || fs::canonicalize(runtime.join("boomux"))?
+            != fs::canonicalize(client::socket_path()?.parent().expect("socket parent"))?
+        || fs::canonicalize(state.join("boomux"))?
+            != fs::canonicalize(state_directory_from_environment()?)?
+    {
+        return Err(io::Error::other(
+            "restart environment must preserve Boomux runtime and state roots",
+        ));
+    }
+    Ok(())
 }
 
 fn launch_replacement_process(
@@ -2269,6 +2359,7 @@ fn handle_connection_inner(
         } => {
             if let Some(environment) = environment
                 && let Err(error) = validate_unix_environment(environment)
+                    .and_then(|()| validate_restart_environment_roots(environment))
             {
                 return send_response(
                     &mut stream,
@@ -3775,7 +3866,12 @@ impl OpenCodeCoordinator {
             .stderr(Stdio::null())
             .env_clear();
         for variable in sanitized_environment.variables {
-            if !variable.name.starts_with(b"BOOMUX_") {
+            if !variable.name.starts_with(b"BOOMUX_")
+                || matches!(
+                    variable.name.as_slice(),
+                    b"BOOMUX_RUNTIME_DIR" | b"BOOMUX_STATE_HOME" | b"BOOMUX_CONFIG_HOME"
+                )
+            {
                 command.env(
                     std::ffi::OsString::from_vec(variable.name),
                     std::ffi::OsString::from_vec(variable.value),
@@ -11628,6 +11724,99 @@ impl DaemonService {
         request: Request,
         response_version: u32,
     ) -> DaemonResult<Response> {
+        if let Request::CreateStartedShell {
+            workspace_id,
+            shell,
+            profile,
+            environment,
+        } = request
+        {
+            validate_terminal_profile(&profile)?;
+            if let Some(environment) = &environment {
+                validate_unix_environment(environment)?;
+            }
+            let mut started = None;
+            let result = self.durable_mutation(|undo| {
+                let created = self.create_shell_mutation(undo, Some(&workspace_id), shell)?;
+                let shell = self.shell(&created.id)?;
+                let workspace = self.workspace(&workspace_id)?;
+                let workspace_name = lock(&workspace.name)?.clone();
+                let run = Arc::new(ShellRun::new(1));
+                let persisted_run = run.persisted(profile.clone())?;
+                let mut lifecycle = lock(&shell.lifecycle)?;
+                let (runtime, reader) = self
+                    .runtimes
+                    .spawn_runtime(
+                        &shell,
+                        &run,
+                        RuntimeStart {
+                            workspace_name: &workspace_name,
+                            shell_name: &created.name,
+                            profile: &profile,
+                            environment: environment.as_ref(),
+                            recovery: RuntimeRecovery::default(),
+                            claude_remote_control: self.notification_settings.claude_remote_control,
+                        },
+                    )
+                    .map_err(|error| {
+                        DaemonError::lifecycle(
+                            ErrorCode::ShellStartFailed,
+                            format!("could not start shell: {error}"),
+                        )
+                    })?;
+                *lifecycle = ShellLifecycle::Running {
+                    profile: profile.clone(),
+                    run: Arc::clone(&run),
+                    runtime: Arc::clone(&runtime),
+                };
+                started = Some((Arc::clone(&shell), Arc::clone(&runtime)));
+                drop(lifecycle);
+                *lock(&shell.last_run)? = Some(persisted_run);
+                self.runtimes.start_pty_reader(
+                    Arc::downgrade(self),
+                    Arc::clone(&shell),
+                    Arc::clone(&run),
+                    runtime,
+                    reader,
+                    true,
+                )?;
+                let snapshot = shell.snapshot()?;
+                Ok((
+                    Response::Shell { shell: snapshot },
+                    vec![
+                        DaemonEventKind::ShellCreated {
+                            workspace_id: workspace_id.clone(),
+                            shell_id: created.id.clone(),
+                            name: created.name,
+                        },
+                        DaemonEventKind::RunStarted {
+                            workspace_id: workspace_id.clone(),
+                            shell_id: created.id,
+                            run: run.snapshot()?,
+                        },
+                    ],
+                ))
+            });
+            return match (result, started) {
+                (Ok(response), Some((_, runtime))) => {
+                    self.runtimes.resume_reader(&runtime)?;
+                    Ok(response)
+                }
+                (Err(error), Some((shell, _))) => {
+                    // CreatedShell rollback removes membership but retains this
+                    // exact runtime, so failed persistence also reaps the child
+                    // and its paused reader before returning the original error.
+                    match self.runtimes.kill(&shell) {
+                        Ok(()) => Err(error),
+                        Err(cleanup) => Err(Self::append_error_context(
+                            error,
+                            format!("process cleanup also failed: {cleanup}"),
+                        )),
+                    }
+                }
+                (result, None) => result,
+            };
+        }
         if matches!(request, Request::AddNodeRegistration { .. }) {
             let response = self.dispatch_for_version(request, response_version)?;
             if let Response::NodeRegistration { registration } = &response {
@@ -13117,6 +13306,9 @@ impl DaemonService {
                     self.add_recovery_presentation(shell)?;
                 }
                 Ok(Response::Workspace { workspace })
+            }
+            Request::CreateStartedShell { .. } => {
+                unreachable!("started Shell creation requires Arc dispatch")
             }
             Request::GetShell { shell_id } => {
                 let mut shell = self.shell(&shell_id)?.snapshot()?;
@@ -18072,6 +18264,86 @@ mod tests {
     }
 
     #[test]
+    fn create_started_shell_rolls_back_process_and_events_on_failure() {
+        for failure in ["spawn", "mutation", "persistence"] {
+            let directory = env::temp_dir().join(format!("boomux-start-{}", Uuid::new_v4()));
+            fs::create_dir_all(&directory).unwrap();
+            let registry = Arc::new(
+                DaemonService::restore(StateStore::at(directory.join("state.json")), false, None)
+                    .unwrap(),
+            );
+            let workspace = registry.create_workspace("test".into(), vec![]).unwrap();
+            let events_before = registry.events.manifest().unwrap().events.len();
+            let pid_file = directory.join("pid");
+            if failure == "mutation" {
+                registry.fail_after_mutation.store(true, Ordering::Release);
+            }
+            if failure == "persistence" {
+                registry.fail_next_persistence();
+            }
+            let result = registry.dispatch_arc(
+                Request::CreateStartedShell {
+                    workspace_id: workspace.id.clone(),
+                    shell: ShellSpec {
+                        name: "test".into(),
+                        cwd: directory.clone(),
+                        command: if failure == "spawn" {
+                            vec![directory.join("missing").to_string_lossy().into_owned()]
+                        } else {
+                            vec![
+                                "/bin/sh".into(),
+                                "-c".into(),
+                                "echo $$ > pid; exec sleep 60".into(),
+                            ]
+                        },
+                    },
+                    profile: profile(),
+                    environment: None,
+                },
+                protocol::PROTOCOL_VERSION,
+            );
+            assert!(result.is_err(), "{failure}");
+            assert!(
+                lock(&registry.workspace(&workspace.id).unwrap().shell_ids)
+                    .unwrap()
+                    .is_empty()
+            );
+            assert!(lock(&registry.durable.state).unwrap().shells.is_empty());
+            assert_eq!(
+                registry.events.manifest().unwrap().events.len(),
+                events_before
+            );
+            if let Ok(pid) = fs::read_to_string(pid_file) {
+                let pid: i32 = pid.trim().parse().unwrap();
+                assert_eq!(
+                    unsafe { libc::kill(pid, 0) },
+                    -1,
+                    "failed start leaked process {pid}"
+                );
+            }
+            drop(registry);
+            fs::remove_dir_all(directory).unwrap();
+        }
+    }
+
+    #[test]
+    fn listener_wait_is_bounded_and_wakes_for_connections() {
+        let directory = env::temp_dir().join(format!("boomux-listener-{}", Uuid::new_v4()));
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("socket");
+        let listener = UnixListener::bind(&path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        assert!(!wait_for_listener(&listener, Duration::ZERO).unwrap());
+        let connecting = thread::spawn(move || UnixStream::connect(path).unwrap());
+        assert!(wait_for_listener(&listener, Duration::from_secs(1)).unwrap());
+        let (accepted, _) = listener.accept().unwrap();
+        let client = connecting.join().unwrap();
+        assert!(!wait_for_listener(&listener, Duration::ZERO).unwrap());
+        drop((accepted, client, listener));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
     fn new_shell_terminal_starts_without_injected_output() {
         let terminal = initial_terminal_state(24, 80, None);
 
@@ -18422,6 +18694,37 @@ mod tests {
             "{}",
             String::from_utf8_lossy(&output.stderr)
         );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn runtime_assets_reuse_matching_files_and_repair_changed_content_or_mode() {
+        let directory = env::temp_dir().join(format!("boomux-runtime-asset-{}", Uuid::new_v4()));
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("shim");
+        let content = vec![b'x'; 20_000];
+        atomic_runtime_asset(&path, &content, 0o700).unwrap();
+        let before = fs::metadata(&path).unwrap();
+        for _ in 0..12 {
+            atomic_runtime_asset(&path, &content, 0o700).unwrap();
+        }
+        let after = fs::metadata(&path).unwrap();
+        assert_eq!(before.ino(), after.ino());
+        assert_eq!(
+            (before.ctime(), before.ctime_nsec()),
+            (after.ctime(), after.ctime_nsec())
+        );
+        let mut changed = content.clone();
+        changed[19_999] = b'y';
+        atomic_runtime_asset(&path, &changed, 0o700).unwrap();
+        assert_eq!(fs::read(&path).unwrap(), changed);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o777)).unwrap();
+        atomic_runtime_asset(&path, &changed, 0o700).unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o700);
+        let link = directory.join("link");
+        std::os::unix::fs::symlink(&path, &link).unwrap();
+        assert!(atomic_runtime_asset(&link, &changed, 0o700).is_err());
+        assert_eq!(fs::read(&path).unwrap(), changed);
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/src/integration_management/managed.rs
+++ b/src/integration_management/managed.rs
@@ -331,18 +331,15 @@ fn reconcile_locked(id: IntegrationId, target: &InstallTarget) -> Result<bool, B
     Ok(true)
 }
 
-/// One bounded pass, never a polling loop. No daemon connection or host restart.
+/// Prepare bundled assets regardless of the daemon's PATH. Remote services may
+/// not see tools installed through interactive shell configuration. One bounded
+/// pass, with no host execution, daemon connection, or host restart.
 pub(crate) fn synchronize(environment: &Environment) -> Vec<String> {
     let mut errors = Vec::new();
     for id in IntegrationId::all() {
         let result = (|| -> Result<(), Box<dyn Error>> {
             let target = install_target(id, environment)?;
             validate_existing_directory_chain(&target.directory)?;
-            if load(&target)?.is_none()
-                && inspect_host(id.installation(), environment).state != HostState::Available
-            {
-                return Ok(());
-            }
             reconcile(id, &target)
         })();
         if let Err(error) = result {
@@ -539,10 +536,55 @@ mod tests {
     }
 
     #[test]
-    fn managed_integration_sync_does_not_create_config_for_absent_hosts() {
+    fn managed_integration_sync_preinstalls_assets_without_hosts_on_path() {
         let fixture = Fixture::new();
-        assert!(synchronize(&fixture.environment()).is_empty());
-        assert_eq!(fs::read_dir(&fixture.0).unwrap().count(), 0);
+        let environment = fixture.environment();
+        assert!(synchronize(&environment).is_empty());
+        for id in IntegrationId::all() {
+            let target = install_target(id, &environment).unwrap();
+            assert!(is_owned(id, &target).unwrap(), "{}", id.spec().key);
+            assert_eq!(
+                inspect_without_host_probe(id, &environment, None)
+                    .asset
+                    .state,
+                AssetState::Current
+            );
+        }
+        // Repeated startup must not overwrite assets or ownership receipts.
+        let id = IntegrationId::OPENCODE;
+        let target = install_target(id, &environment).unwrap();
+        let asset_inode = fs::metadata(&target.path).unwrap().ino();
+        let receipt_inode = fs::metadata(receipt_path(&target)).unwrap().ino();
+        assert!(synchronize(&environment).is_empty());
+        assert_eq!(fs::metadata(&target.path).unwrap().ino(), asset_inode);
+        assert_eq!(
+            fs::metadata(receipt_path(&target)).unwrap().ino(),
+            receipt_inode
+        );
+    }
+
+    #[test]
+    fn managed_integration_sync_preserves_opt_outs_and_customizations_without_hosts() {
+        let fixture = Fixture::new();
+        let environment = fixture.environment();
+        assert!(synchronize(&environment).is_empty());
+        let opted_out = IntegrationId::OPENCODE;
+        uninstall(opted_out, &environment, false).unwrap();
+        let customized = install_target(IntegrationId::PI, &environment).unwrap();
+        fs::write(&customized.path, "// user customization").unwrap();
+        let errors = synchronize(&environment);
+        assert_eq!(errors.len(), 1, "{errors:?}");
+        assert!(errors[0].contains("customized integration preserved"));
+        assert!(
+            !install_target(opted_out, &environment)
+                .unwrap()
+                .path
+                .exists()
+        );
+        assert_eq!(
+            fs::read(&customized.path).unwrap(),
+            b"// user customization"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,6 +467,8 @@ enum Commands {
     GuidedNodeAdd,
     #[command(name = "__guided-node-upgrade", hide = true)]
     GuidedNodeUpgrade { selector: String },
+    #[command(name = "__guided-node-uninstall", hide = true)]
+    GuidedNodeUninstall { selector: String },
     #[command(name = "__guided-node-reauthenticate", hide = true)]
     GuidedNodeReauthenticate { selector: String },
     #[command(name = "__bootstrap-activate", hide = true)]
@@ -553,6 +555,8 @@ enum NodeCommands {
     Add {
         alias: Option<String>,
         target: Option<String>,
+        #[arg(long, hide = true)]
+        desktop_workspace: bool,
     },
     /// List registered remote Nodes
     List,
@@ -1229,6 +1233,9 @@ enum DaemonCommands {
         /// Hand off to this executable (requires daemon protocol 52+)
         #[arg(long)]
         executable: Option<PathBuf>,
+        /// Refresh daemon services from this terminal's environment; retain the same Boomux roots
+        #[arg(long)]
+        refresh_environment: bool,
     },
     /// Stop the daemon and its managed shells
     Stop,
@@ -1622,6 +1629,7 @@ impl Cli {
             Some(Commands::FederationStdio) => CommandKey::Attach,
             Some(Commands::GuidedNodeAdd) => CommandKey::NodeAdd,
             Some(Commands::GuidedNodeUpgrade { .. }) => CommandKey::NodeUpgrade,
+            Some(Commands::GuidedNodeUninstall { .. }) => CommandKey::NodeUninstall,
             Some(Commands::GuidedNodeReauthenticate { .. }) => CommandKey::NodeReauthenticate,
             Some(Commands::UninstallRemote { .. }) => CommandKey::UninstallRemote,
             Some(Commands::UninstallFingerprint) => CommandKey::UninstallFingerprint,
@@ -1861,13 +1869,16 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             return Ok(CliExit::Success);
         }
         Some(Commands::GuidedNodeAdd) => {
-            return guided_node_add().map(CliExit::Child);
+            return finish_guided_shell(guided_node_add()?).map(CliExit::Child);
         }
         Some(Commands::GuidedNodeUpgrade { selector }) => {
-            return guided_node_upgrade(selector).map(CliExit::Child);
+            return finish_guided_shell(guided_node_upgrade(selector)?).map(CliExit::Child);
+        }
+        Some(Commands::GuidedNodeUninstall { selector }) => {
+            return finish_guided_shell(guided_node_uninstall(selector)?).map(CliExit::Child);
         }
         Some(Commands::GuidedNodeReauthenticate { selector }) => {
-            return guided_node_reauthenticate(selector).map(CliExit::Child);
+            return finish_guided_shell(guided_node_reauthenticate(selector)?).map(CliExit::Child);
         }
         Some(Commands::BootstrapActivate {
             transaction,
@@ -2069,13 +2080,14 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::FederationStdio) => unreachable!(),
         Some(Commands::GuidedNodeAdd) => unreachable!(),
         Some(Commands::GuidedNodeUpgrade { .. }) => unreachable!(),
+        Some(Commands::GuidedNodeUninstall { .. }) => unreachable!(),
         Some(Commands::GuidedNodeReauthenticate { .. }) => unreachable!(),
         Some(Commands::UninstallRemote {
             expected_node_id,
             expected_executable,
         }) => uninstall::remote_uninstall(&expected_node_id, &expected_executable),
         Some(Commands::UninstallFingerprint) => {
-            let target = update::uninstall_target()?;
+            let target = update::remote_uninstall_target()?;
             println!(
                 "boomux-uninstall-fingerprint-v1 {}",
                 target.authorization_token()
@@ -2459,7 +2471,16 @@ fn reauthenticate_node(selector: &str) -> Result<(), Box<dyn Error>> {
 
 fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>> {
     match command {
-        NodeCommands::Add { alias, target } => {
+        NodeCommands::Add {
+            alias,
+            target,
+            desktop_workspace,
+        } => {
+            if desktop_workspace && json {
+                return Err(
+                    io::Error::other("Desktop remote workspace setup is interactive only").into(),
+                );
+            }
             let (alias, target) = resolve_node_add_inputs(alias, target, json)?;
             let remote = verified_remote_connection(&target, !json)?;
             let registration = client::connect_or_start()?.add_node_registration(
@@ -2467,7 +2488,16 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
                 target,
                 remote.handshake.node_id.clone(),
             )?;
-            print_node_registration(CommandKey::NodeAdd, &registration, json)
+            print_node_registration(CommandKey::NodeAdd, &registration, json)?;
+            if desktop_workspace {
+                let shell = client::connect_or_start()?
+                    .create_remote_workspace(&registration.node_id, &registration.alias)?;
+                println!(
+                    "Remote workspace created with Shell {}. Open it from the Desktop sidebar.",
+                    shell.name
+                );
+            }
+            Ok(())
         }
         NodeCommands::List => {
             let client = client::connect_or_start()?;
@@ -2697,6 +2727,54 @@ fn guided_node_add() -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
     )
 }
 
+fn finish_guided_shell(
+    status: process_adapter::ProcessExit,
+) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
+    let (Ok(shell_id), Ok(run_id)) = (env::var("BOOMUX_SHELL_ID"), env::var("BOOMUX_RUN_ID"))
+    else {
+        return Ok(status);
+    };
+    let client = client::connect()?;
+    let shell = client.get_shell(&shell_id)?;
+    if let Some(request) =
+        guided_shell_close_request(&shell, &shell_id, &run_id, &env::current_exe()?)
+    {
+        client.request(request)?;
+    }
+    Ok(status)
+}
+
+fn guided_shell_close_request(
+    shell: &protocol::ShellSnapshot,
+    shell_id: &str,
+    run_id: &str,
+    executable: &Path,
+) -> Option<protocol::Request> {
+    let command_matches = match shell.command.get(1).map(String::as_str) {
+        Some("__guided-node-add") => shell.command.len() == 2,
+        Some(
+            "__guided-node-upgrade" | "__guided-node-reauthenticate" | "__guided-node-uninstall",
+        ) => shell.command.len() == 3,
+        _ => false,
+    };
+    (command_matches
+        && shell.id == shell_id
+        && shell.status == protocol::ShellStatus::Running
+        && shell
+            .command
+            .first()
+            .is_some_and(|command| Path::new(command) == executable)
+        && !run_id.is_empty()
+        && shell
+            .run
+            .as_ref()
+            .is_some_and(|run| run.id == run_id && run.ended_at_ms.is_none()))
+    .then(|| protocol::Request::GuardedCloseShell {
+        shell_id: shell_id.into(),
+        expected_revision: shell.revision,
+    })
+}
+
 fn guided_node_upgrade(selector: &str) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
     let executable = env::current_exe()?;
     let stdin = io::stdin();
@@ -2707,6 +2785,23 @@ fn guided_node_upgrade(selector: &str) -> Result<process_adapter::ProcessExit, B
         &executable,
         &["node", "upgrade", selector],
         "Node upgrade",
+        &mut input,
+        &mut output,
+        interactive,
+        interactive.then(|| stdin.as_raw_fd()),
+    )
+}
+
+fn guided_node_uninstall(selector: &str) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
+    let executable = env::current_exe()?;
+    let stdin = io::stdin();
+    let interactive = stdin.is_terminal() && io::stdout().is_terminal();
+    let mut input = stdin.lock();
+    let mut output = io::stdout().lock();
+    guided_node_command_with(
+        &executable,
+        &["node", "uninstall", selector],
+        "Remote machine removal",
         &mut input,
         &mut output,
         interactive,
@@ -2750,7 +2845,7 @@ fn guided_node_add_with(
 ) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
     guided_node_command_with(
         executable,
-        &["node", "add"],
+        &["node", "add", "--desktop-workspace"],
         "Node setup",
         input,
         output,
@@ -3286,13 +3381,17 @@ fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Err
                 client.socket_path().display()
             );
         }
-        DaemonCommands::Restart { executable } => {
+        DaemonCommands::Restart {
+            executable,
+            refresh_environment,
+        } => {
             let client = running_client.as_ref().ok_or_else(|| {
                 io::Error::new(io::ErrorKind::NotConnected, "Boomux daemon is stopped")
             })?;
-            let notifications = config::load_notification_settings()?.into();
+            let notifications: protocol::NotificationDeliveryConfig =
+                config::load_notification_settings()?.into();
             if let Some(executable) = executable {
-                client.restart_with_executable(executable.clone(), notifications)?;
+                client.restart_with_executable(executable.clone(), notifications.clone())?;
                 let deadline = Instant::now() + Duration::from_secs(10);
                 loop {
                     if daemon_process_identity(client)
@@ -3309,8 +3408,11 @@ fn daemon_control(command: DaemonCommands, json: bool) -> Result<(), Box<dyn Err
                     }
                     std::thread::sleep(Duration::from_millis(20));
                 }
-            } else {
-                client.restart_with_notification_config(notifications)?;
+            } else if !refresh_environment {
+                client.restart_with_notification_config(notifications.clone())?;
+            }
+            if refresh_environment {
+                client.restart_with_client_environment(notifications)?;
             }
             println!("Restarted Boomux daemon");
         }
@@ -10058,6 +10160,7 @@ fn launch_codex(arguments: Vec<OsString>) -> Result<(), Box<dyn Error>> {
     let mut command = Command::new(executable);
     sanitize_inherited_opencode_shim(&mut command);
     if managed_chat && hooks_current {
+        prioritize_boomux_hook_executable(&mut command)?;
         command
             .args(["--enable", "hooks"])
             .env("BOOMUX_CODEX_RUN_SCOPED", "1");
@@ -10143,6 +10246,9 @@ fn launch_kiro(arguments: Vec<OsString>) -> Result<process_adapter::ProcessExit,
     let argv = kiro_argv(executable, arguments, managed_v3 && hooks_current);
     let mut command = Command::new(&argv[0]);
     sanitize_inherited_opencode_shim(&mut command);
+    if managed_v3 && hooks_current {
+        prioritize_boomux_hook_executable(&mut command)?;
+    }
     let holder = if managed_v3 && hooks_current {
         match (
             env::var("BOOMUX_SHELL_ID").ok(),
@@ -10955,6 +11061,29 @@ fn invoke_workspace_launcher(
             let _ = child.wait();
         })
         .map_err(|error| io::Error::other(format!("could not start launcher reaper: {error}")))?;
+    Ok(())
+}
+
+fn prioritize_boomux_hook_executable(command: &mut Command) -> io::Result<()> {
+    let executable = env::current_exe()?;
+    let directory = executable
+        .parent()
+        .ok_or_else(|| io::Error::other("Boomux executable has no parent directory"))?;
+    // Sanitization restores the user's PATH, which can put another Boomux
+    // installation first. Hooks must resolve this launcher's matching CLI.
+    let path = command
+        .get_envs()
+        .find_map(|(key, value)| {
+            (key == "PATH")
+                .then_some(value)
+                .flatten()
+                .map(OsString::from)
+        })
+        .or_else(|| env::var_os("PATH"))
+        .unwrap_or_default();
+    let paths = std::iter::once(directory.to_path_buf())
+        .chain(env::split_paths(&path).filter(|entry| entry != directory));
+    command.env("PATH", env::join_paths(paths).map_err(io::Error::other)?);
     Ok(())
 }
 
@@ -12616,6 +12745,7 @@ mod tests {
                 command: NodeCommands::Add {
                     alias: Some(alias),
                     target: Some(target),
+                    desktop_workspace: false,
                 }
             }) if alias == "work" && target == "user@host"
         ));
@@ -12626,6 +12756,7 @@ mod tests {
                 command: NodeCommands::Add {
                     alias: None,
                     target: None,
+                    desktop_workspace: false,
                 }
             })
         ));
@@ -12639,6 +12770,52 @@ mod tests {
         let held = Cli::try_parse_from(["boomux", "__guided-node-add"]).unwrap();
         assert!(matches!(held.command, Some(Commands::GuidedNodeAdd)));
         assert_eq!(held.command_descriptor().key, "node.add");
+    }
+
+    #[test]
+    fn guided_remote_cleanup_requires_exact_command_owner_and_run() {
+        let cli =
+            Cli::try_parse_from(["boomux", "__guided-node-uninstall", "exact-owner"]).unwrap();
+        assert!(
+            matches!(cli.command.as_ref(), Some(Commands::GuidedNodeUninstall { selector }) if selector == "exact-owner")
+        );
+        assert_eq!(cli.command_descriptor().key, "node.uninstall");
+        assert_eq!(cli.command_descriptor().output, OutputMode::HumanOnly);
+        let mut shell: protocol::ShellSnapshot = serde_json::from_value(serde_json::json!({
+            "id": "setup-shell", "revision": 7, "workspace_id": "workspace",
+            "name": "Connect remote", "cwd": "/tmp", "status": "running",
+            "command": ["/bin/boomux", "__guided-node-add"],
+            "run": {"id": "setup-run", "generation": 1, "started_at_ms": 1,
+                "ended_at_ms": null, "exit_reason": null, "output_revision": 0,
+                "environment_has_run_id": true}
+        }))
+        .unwrap();
+        let request = |shell: &protocol::ShellSnapshot| {
+            guided_shell_close_request(shell, "setup-shell", "setup-run", Path::new("/bin/boomux"))
+        };
+        assert_eq!(
+            request(&shell),
+            Some(protocol::Request::GuardedCloseShell {
+                shell_id: "setup-shell".into(),
+                expected_revision: 7
+            })
+        );
+        shell.command[0] = "/other/boomux".into();
+        assert!(request(&shell).is_none());
+        shell.command[0] = "/bin/boomux".into();
+        shell.command[1] = "__guided-node-uninstall".into();
+        assert!(request(&shell).is_none());
+        shell.command.push("exact-owner".into());
+        assert!(request(&shell).is_some());
+        shell.command.pop();
+        shell.command[1] = "node".into();
+        assert!(request(&shell).is_none());
+        shell.command[1] = "__guided-node-add".into();
+        shell.run.as_mut().unwrap().id = "other-run".into();
+        assert!(request(&shell).is_none());
+        shell.run.as_mut().unwrap().id = "setup-run".into();
+        shell.id = "other-shell".into();
+        assert!(request(&shell).is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15757,7 +15757,7 @@ mod tests {
                 .validated_version,
             "2.1.236"
         );
-        assert_eq!(protocol::PROTOCOL_VERSION, 53);
+        assert_eq!(protocol::PROTOCOL_VERSION, 54);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 53;
+pub const PROTOCOL_VERSION: u32 = 54;
 pub const MIN_PROTOCOL_VERSION: u32 = 47;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -201,6 +201,7 @@ define_protocol_features! {
         "workspace_session_hiding",
     ]),
     GitWorkOverview => (53, "Git work overview", ["protocol_53", "git_work_overview"]),
+    CreateStartedShell => (54, "atomic Shell creation and start", ["protocol_54", "create_started_shell"]),
     RestartExecutable => (52, "restart executable", ["protocol_52", "restart_executable"]),
 }
 
@@ -1897,6 +1898,13 @@ pub enum Request {
         workspace_id: Option<String>,
         shell: ShellSpec,
     },
+    CreateStartedShell {
+        workspace_id: String,
+        shell: ShellSpec,
+        profile: TerminalProfile,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        environment: Option<UnixEnvironment>,
+    },
     CreateLauncher {
         workspace_id: String,
         spec: WorkspaceLauncherSpec,
@@ -2225,6 +2233,7 @@ impl Request {
             | Self::CreateShell {
                 workspace_id: None, ..
             } => Some(ProtocolFeature::WorkspaceDefaultCwd),
+            Self::CreateStartedShell { .. } => Some(ProtocolFeature::CreateStartedShell),
             Self::RestartWithExecutable { .. } => Some(ProtocolFeature::RestartExecutable),
             Self::RestartWithNotificationConfig { .. } => {
                 Some(ProtocolFeature::RestartNotificationConfig)
@@ -2848,9 +2857,33 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_fifty_three_with_forty_seven_floor() {
-        assert_eq!(PROTOCOL_VERSION, 53);
+    fn protocol_version_is_fifty_four_with_forty_seven_floor() {
+        assert_eq!(PROTOCOL_VERSION, 54);
         assert_eq!(MIN_PROTOCOL_VERSION, 47);
+    }
+
+    #[test]
+    fn create_started_shell_requires_fifty_four_and_defaults_ephemeral_environment() {
+        let request = Request::CreateStartedShell {
+            workspace_id: "w1".into(),
+            shell: ShellSpec::login("shell", "/tmp"),
+            profile: TerminalProfile {
+                term: None,
+                colorterm: None,
+                term_program: None,
+                term_program_version: None,
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            },
+            environment: None,
+        };
+        assert_eq!(request.minimum_protocol_version(), 54);
+        let encoded = serde_json::to_value(&request).unwrap();
+        assert!(encoded.get("environment").is_none());
+        assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
+        assert!(!ProtocolFeature::CreateStartedShell.is_supported_by(53));
     }
 
     #[test]
@@ -4496,6 +4529,7 @@ mod tests {
             ),
             (51, &["workspace_session_hiding"][..]),
             (53, &["protocol_53", "git_work_overview"][..]),
+            (54, &["protocol_54", "create_started_shell"][..]),
             (52, &["protocol_52", "restart_executable"][..]),
         ];
 

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -3808,6 +3808,35 @@ fn run_bounded_command(mut command: Command, timeout: Duration) -> io::Result<Ss
 }
 
 fn classify_ssh_command_failure(status: Option<i32>, stderr: &[u8]) -> io::Error {
+    // Surface known ownership refusals without relaying arbitrary remote stderr
+    // (which can contain secrets or terminal control sequences).
+    if status == Some(1) {
+        for (reason, message) in [
+            (
+                "this Boomux executable is a source or development build; remove it through its build or installation workflow",
+                "the remote helper rejects development-build uninstall; update Boomux on this machine to a build with remote development-uninstall support, then retry",
+            ),
+            (
+                "this Boomux executable is package-managed; uninstall it with the package manager that installed it",
+                "remote Boomux is package-managed; remove it using its package manager",
+            ),
+            (
+                "remote uninstall requires the canonical user-owned ~/.local/bin/boomux installation",
+                "remote uninstall requires the canonical user-owned ~/.local/bin/boomux installation",
+            ),
+        ] {
+            if stderr
+                .split(|byte| *byte == b'\n')
+                .any(|line| line.strip_prefix(b"boomux: ") == Some(reason.as_bytes()))
+            {
+                return classified_error(
+                    io::ErrorKind::PermissionDenied,
+                    "remote_uninstall_ineligible",
+                    message,
+                );
+            }
+        }
+    }
     let lower = String::from_utf8_lossy(stderr).to_ascii_lowercase();
     if lower.contains("permission denied")
         || lower.contains("authentication failed")
@@ -6178,6 +6207,24 @@ mod tests {
                 .any(|path| path.as_str() == destination.to_str().unwrap())
         );
         fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn remote_uninstall_refusal_is_actionable_without_exposing_stderr() {
+        let stderr = b"private output\nboomux: this Boomux executable is a source or development build; remove it through its build or installation workflow\n";
+        let error = classify_ssh_command_failure(Some(1), stderr);
+        assert_eq!(error_code(&error), "remote_uninstall_ineligible");
+        assert!(error.to_string().contains("update Boomux"));
+        assert!(!error.to_string().contains("private output"));
+        assert!(
+            !classify_ssh_command_failure(Some(1), b"secret token")
+                .to_string()
+                .contains("secret token")
+        );
+        assert_eq!(
+            error_code(&classify_ssh_command_failure(Some(255), stderr)),
+            "bootstrap_transport_failed"
+        );
     }
 
     #[test]

--- a/src/state_store.rs
+++ b/src/state_store.rs
@@ -1105,7 +1105,9 @@ fn unix_time_ms() -> u64 {
 }
 
 pub(crate) fn state_directory_from_environment() -> io::Result<PathBuf> {
-    let root = match env::var_os("XDG_STATE_HOME").filter(|path| !path.is_empty()) {
+    let root = match env::var_os("BOOMUX_STATE_HOME")
+        .or_else(|| env::var_os("XDG_STATE_HOME").filter(|path| !path.is_empty()))
+    {
         Some(path) => PathBuf::from(path),
         None => PathBuf::from(
             env::var_os("HOME")
@@ -1135,7 +1137,13 @@ pub(crate) fn secure_state_dir(path: &Path) -> io::Result<()> {
             "boomux state path is not an owned directory",
         ));
     }
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+    // Reapplying an unchanged mode still dirties directory metadata. This
+    // helper runs on every durable save; validate every time, but only repair
+    // permissions when needed so the following fsync has no redundant work.
+    if metadata.mode() & 0o7777 != 0o700 {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
 }
 
 pub(crate) fn effective_uid() -> u32 {
@@ -1146,6 +1154,90 @@ pub(crate) fn effective_uid() -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn secure_state_directory_reuses_safe_permissions_and_repairs_unsafe_modes() {
+        let directory = env::temp_dir().join(format!("boomux-permissions-{}", Uuid::new_v4()));
+        let state = directory.join("state");
+        secure_state_dir(&state).unwrap();
+        let before = fs::symlink_metadata(&state).unwrap();
+        assert_eq!(before.mode() & 0o7777, 0o700);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        for _ in 0..8 {
+            secure_state_dir(&state).unwrap();
+        }
+        let after = fs::symlink_metadata(&state).unwrap();
+        assert_eq!(
+            (before.ctime(), before.ctime_nsec()),
+            (after.ctime(), after.ctime_nsec())
+        );
+        for mode in [0o755, 0o1700, 0o2700] {
+            fs::set_permissions(&state, fs::Permissions::from_mode(mode)).unwrap();
+            secure_state_dir(&state).unwrap();
+            assert_eq!(fs::symlink_metadata(&state).unwrap().mode() & 0o7777, 0o700);
+        }
+        let link = directory.join("link");
+        std::os::unix::fs::symlink(&state, &link).unwrap();
+        assert_eq!(
+            secure_state_dir(&link).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        let file = directory.join("file");
+        fs::write(&file, b"not a directory").unwrap();
+        assert!(secure_state_dir(&file).is_err());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    #[ignore = "explicit disk diagnostic; set BOOMUX_TIMING_STATE_ROOT to the test filesystem"]
+    fn persistence_barrier_timings() {
+        use std::time::Instant;
+        let root = env::var_os("BOOMUX_TIMING_STATE_ROOT").expect("choose a test filesystem");
+        let directory = PathBuf::from(root).join(format!("boomux-barriers-{}", Uuid::new_v4()));
+        secure_state_dir(&directory).unwrap();
+        let mut journal = OpenOptions::new()
+            .create_new(true)
+            .append(true)
+            .mode(0o600)
+            .open(directory.join("journal"))
+            .unwrap();
+        journal.sync_all().unwrap();
+        File::open(&directory).unwrap().sync_all().unwrap();
+        let payload = vec![b'x'; 8192];
+        for round in 0..3 {
+            for change_mode in [true, false] {
+                let start = Instant::now();
+                if change_mode {
+                    fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).unwrap();
+                }
+                let temporary = directory.join("temporary");
+                let mut file = OpenOptions::new()
+                    .create_new(true)
+                    .write(true)
+                    .mode(0o600)
+                    .open(&temporary)
+                    .unwrap();
+                file.write_all(&payload).unwrap();
+                let written = start.elapsed();
+                file.sync_all().unwrap();
+                let synced = start.elapsed();
+                fs::rename(temporary, directory.join("state")).unwrap();
+                File::open(&directory).unwrap().sync_all().unwrap();
+                eprintln!(
+                    "round {round} chmod={change_mode}: write={written:?} file_sync={:?} rename_directory_sync={:?} total={:?}",
+                    synced - written,
+                    start.elapsed() - synced,
+                    start.elapsed()
+                );
+            }
+            let start = Instant::now();
+            journal.write_all(&payload).unwrap();
+            journal.sync_data().unwrap();
+            eprintln!("round {round} append_sync={:?}", start.elapsed());
+        }
+        drop(journal);
+        fs::remove_dir_all(directory).unwrap();
+    }
 
     #[test]
     fn rejects_unsupported_state_versions() {

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -210,7 +210,7 @@ pub(crate) fn remote_uninstall(
 ) -> Result<(), Box<dyn std::error::Error>> {
     uuid::Uuid::parse_str(expected_node_id)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "expected Node ID is invalid"))?;
-    let target = update::uninstall_target()?;
+    let target = update::remote_uninstall_target()?;
     if target.authorization_token() != expected_executable {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,

--- a/src/update.rs
+++ b/src/update.rs
@@ -273,6 +273,36 @@ pub(crate) fn uninstall_target() -> io::Result<UninstallTarget> {
     })
 }
 
+/// Remote bootstrap may install a pinned development executable. Build flavor
+/// is not ownership: require the same canonical, private user installation and
+/// retain the exact fingerprint for the separately identity-guarded removal.
+pub(crate) fn remote_uninstall_target() -> io::Result<UninstallTarget> {
+    remote_uninstall_target_at(
+        &env::current_exe()?,
+        env::var_os("HOME").as_deref().map(Path::new),
+    )
+}
+
+fn remote_uninstall_target_at(path: &Path, home: Option<&Path>) -> io::Result<UninstallTarget> {
+    let home = home.filter(|home| home.is_absolute()).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "remote uninstall requires an absolute HOME",
+        )
+    })?;
+    if path != home.join(".local/bin/boomux") || unsafe { libc::geteuid() } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "remote uninstall requires the canonical user-owned ~/.local/bin/boomux installation",
+        ));
+    }
+    validate_install_path(home, path, unsafe { libc::geteuid() })?;
+    Ok(UninstallTarget {
+        path: path.to_owned(),
+        baseline: fingerprint(path)?,
+    })
+}
+
 pub(crate) fn stop_daemon_for_uninstall(
     target: &UninstallTarget,
 ) -> io::Result<client::DaemonLockReservation> {
@@ -1302,6 +1332,36 @@ mod tests {
             classify_installation(&executable, Some(&home), Some("github-release")).0,
             InstallKind::GithubRelease
         );
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn remote_uninstall_accepts_canonical_development_copy_but_preserves_ownership_guards() {
+        let home = temporary_directory();
+        let bin = home.join(".local/bin");
+        fs::create_dir_all(&bin).unwrap();
+        let path = bin.join("boomux");
+        fs::write(&path, b"development binary").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        let target = remote_uninstall_target_at(&path, Some(&home)).unwrap();
+        assert!(matches!(
+            classify_installation(&path, Some(&home), None).0,
+            InstallKind::DevelopmentBuild | InstallKind::SourceBuild
+        ));
+        assert!(remote_uninstall_target_at(&path, None).is_err());
+        assert!(remote_uninstall_target_at(Path::new("/usr/bin/boomux"), Some(&home)).is_err());
+        let other = bin.join("other");
+        fs::hard_link(&path, &other).unwrap();
+        assert!(remote_uninstall_target_at(&path, Some(&home)).is_err());
+        fs::remove_file(&other).unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o777)).unwrap();
+        assert!(remote_uninstall_target_at(&path, Some(&home)).is_err());
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::write(&path, b"replacement").unwrap();
+        assert!(revalidate_uninstall_target(&target).is_err());
+        fs::rename(&path, &other).unwrap();
+        std::os::unix::fs::symlink(&other, &path).unwrap();
+        assert!(remote_uninstall_target_at(&path, Some(&home)).is_err());
         fs::remove_dir_all(home).unwrap();
     }
 

--- a/src/workspace_selection.rs
+++ b/src/workspace_selection.rs
@@ -56,7 +56,9 @@ pub(crate) fn clear_from_environment() -> io::Result<bool> {
 }
 
 fn selection_path_from_environment() -> io::Result<PathBuf> {
-    let root = match env::var_os("XDG_STATE_HOME").filter(|path| !path.is_empty()) {
+    let root = match env::var_os("BOOMUX_STATE_HOME")
+        .or_else(|| env::var_os("XDG_STATE_HOME").filter(|path| !path.is_empty()))
+    {
         Some(path) => PathBuf::from(path),
         None => PathBuf::from(
             env::var_os("HOME")

--- a/tests/config_cli.rs
+++ b/tests/config_cli.rs
@@ -29,6 +29,9 @@ impl TestDirectory {
             .env("XDG_CONFIG_HOME", self.path().join("xdg"))
             .env("XDG_RUNTIME_DIR", self.path().join("runtime"))
             .env_remove("BOOMUX_CONFIG")
+            .env_remove("BOOMUX_CONFIG_HOME")
+            .env_remove("BOOMUX_STATE_HOME")
+            .env_remove("BOOMUX_RUNTIME_DIR")
             .env_remove("VISUAL")
             .env_remove("EDITOR");
         command
@@ -77,6 +80,34 @@ fn path_uses_environment_override_then_canonical_global_path() {
     assert_eq!(
         String::from_utf8(output.stdout).unwrap().trim(),
         override_path.display().to_string()
+    );
+}
+
+#[test]
+fn development_config_home_does_not_load_the_users_global_config() {
+    let test = TestDirectory::new();
+    let global = test.path().join("xdg/boomux/config.toml");
+    fs::create_dir_all(global.parent().unwrap()).unwrap();
+    fs::write(&global, "this is intentionally invalid TOML").unwrap();
+    let private = test.path().join("development-config");
+    let output = test
+        .command()
+        .env("BOOMUX_CONFIG_HOME", &private)
+        .args(["config", "path"])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim(),
+        private.join("boomux/config.toml").display().to_string()
+    );
+    assert_success(
+        &test
+            .command()
+            .env("BOOMUX_CONFIG_HOME", &private)
+            .args(["config", "validate"])
+            .output()
+            .unwrap(),
     );
 }
 

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -4,6 +4,7 @@ use std::net::TcpListener;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -321,10 +322,21 @@ fn sequential_kiro_process_holders_inactivate_only_the_exited_session() {
     let kiro = daemon.runtime_dir.join("kiro-holder-cli");
     fs::write(
         &kiro,
-        "#!/bin/sh\nprintf '%s' \"$$\" > \"$KIRO_TEST_PID\"\nprintf '{\"session_id\":\"%s\",\"hook_event_name\":\"UserPromptSubmit\"}' \"$KIRO_TEST_SESSION\" | \"$KIRO_TEST_BOOMUX\" kiro hook\nwhile [ ! -e \"$KIRO_TEST_STOP\" ]; do sleep 0.01; done\nprintf '{\"session_id\":\"%s\",\"hook_event_name\":\"Stop\"}' \"$KIRO_TEST_SESSION\" | \"$KIRO_TEST_BOOMUX\" kiro hook\n/bin/sleep 300 &\nprintf '%s' \"$!\" > \"$KIRO_TEST_DESCENDANT_PID\"\nwait\n",
+        "#!/bin/sh\nprintf '%s' \"$$\" > \"$KIRO_TEST_PID\"\nprintf '{\"session_id\":\"%s\",\"hook_event_name\":\"UserPromptSubmit\"}' \"$KIRO_TEST_SESSION\" | boomux kiro hook\nwhile [ ! -e \"$KIRO_TEST_STOP\" ]; do sleep 0.01; done\nprintf '{\"session_id\":\"%s\",\"hook_event_name\":\"Stop\"}' \"$KIRO_TEST_SESSION\" | boomux kiro hook\n/bin/sleep 300 &\nprintf '%s' \"$!\" > \"$KIRO_TEST_DESCENDANT_PID\"\nwait\n",
     )
     .unwrap();
     fs::set_permissions(&kiro, fs::Permissions::from_mode(0o755)).unwrap();
+
+    // An unrelated installation wins in both the caller's and restored PATH.
+    // Real hooks use bare `boomux`, not an absolute fixture-only executable.
+    let stale_bin = daemon.runtime_dir.join("old-installation");
+    fs::create_dir(&stale_bin).unwrap();
+    let stale_cli = stale_bin.join("boomux");
+    fs::write(&stale_cli, "#!/bin/sh\nexit 91\n").unwrap();
+    fs::set_permissions(&stale_cli, fs::Permissions::from_mode(0o755)).unwrap();
+    let hook_path =
+        std::env::join_paths([stale_bin, PathBuf::from("/usr/bin"), PathBuf::from("/bin")])
+            .unwrap();
 
     let run_unclaimed_hook = || {
         let mut command = daemon.command();
@@ -366,7 +378,8 @@ fn sequential_kiro_process_holders_inactivate_only_the_exited_session() {
             .env("KIRO_TEST_PID", &pid_file)
             .env("KIRO_TEST_DESCENDANT_PID", &descendant_pid_file)
             .env("KIRO_TEST_STOP", &stop_file)
-            .env("KIRO_TEST_BOOMUX", env!("CARGO_BIN_EXE_boomux"));
+            .env("PATH", &hook_path)
+            .env("BOOMUX_ORIGINAL_PATH", &hook_path);
         command.process_group(0);
         let mut child = command.spawn().unwrap();
         wait_until(

--- a/tests/native_backend/notifications.rs
+++ b/tests/native_backend/notifications.rs
@@ -20,6 +20,105 @@ struct RemoteSubscriber {
 }
 
 #[test]
+fn environment_refresh_restores_sound_without_restarting_shells() {
+    let (mut daemon, _, notify_send, sound_capture) = start_with_notifications();
+    let player = notify_send.with_file_name("canberra-gtk-play");
+    fs::write(&player, "#!/bin/sh\n[ \"$XDG_RUNTIME_DIR\" = \"$EXPECTED_AUDIO_RUNTIME\" ] || exit 1\nprintf '%s\\0' \"$@\" >> \"$BOOMUX_SOUND_CAPTURE\"\n").unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "sound-refresh",
+            vec![ShellSpec::login("shell", daemon.runtime_dir.clone())],
+        )
+        .unwrap();
+    let shell_id = &workspace.shells[0].id;
+    let attachment = daemon.client.attach(shell_id, false, profile()).unwrap();
+    let before = daemon.client.get_shell(shell_id).unwrap();
+    let run_id = &before.run.as_ref().unwrap().id;
+    drop(attachment);
+    let audio_runtime = daemon.runtime_dir.join("user-runtime");
+    fs::create_dir(&audio_runtime).unwrap();
+    let mut paths = vec![player.parent().unwrap().to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let restart = daemon
+        .command()
+        .env("BOOMUX_RUNTIME_DIR", &daemon.runtime_dir)
+        .env("XDG_RUNTIME_DIR", &audio_runtime)
+        .env("EXPECTED_AUDIO_RUNTIME", &audio_runtime)
+        .env("BOOMUX_CONFIG", daemon.runtime_dir.join("config.toml"))
+        .env("BOOMUX_SOUND_CAPTURE", &sound_capture)
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .args(["daemon", "restart", "--refresh-environment"])
+        .arg("--executable")
+        .arg(&daemon.executable)
+        .output()
+        .unwrap();
+    assert!(
+        restart.status.success(),
+        "{}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    let after = daemon.client.get_shell(shell_id).unwrap();
+    assert_eq!(before.status, after.status);
+    assert_eq!(before.run, after.run);
+    let agent = daemon
+        .client
+        .register_agent(
+            shell_id,
+            run_id,
+            AgentRegistrationSpec {
+                name: "sound-agent".into(),
+                integration: "native-test".into(),
+                external_session_id: None,
+                report: AgentReport {
+                    state: AgentState::Blocked,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "blocked after environment refresh".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    wait_until(
+        || captured_notification_count(&sound_capture) == 1,
+        "refreshed blocked sound was not delivered",
+    );
+    for state in [AgentState::Working, AgentState::Idle] {
+        daemon
+            .client
+            .report_agent(
+                &agent.id,
+                run_id,
+                AgentReport {
+                    state,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "test turn transition".into(),
+                    confidence: 100,
+                },
+            )
+            .unwrap();
+    }
+    wait_until(
+        || captured_notification_count(&sound_capture) == 2,
+        "refreshed completion sound was not delivered",
+    );
+    let wrong_state = daemon.runtime_dir.join("wrong-state/boomux");
+    fs::create_dir_all(&wrong_state).unwrap();
+    let rejected = daemon
+        .command()
+        .env("BOOMUX_STATE_HOME", wrong_state.parent().unwrap())
+        .args(["daemon", "restart", "--refresh-environment"])
+        .output()
+        .unwrap();
+    assert!(!rejected.status.success());
+    assert!(String::from_utf8_lossy(&rejected.stderr).contains("must preserve"));
+    assert_eq!(daemon.client.get_shell(shell_id).unwrap().run, after.run);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn desktop_notifications_are_deduplicated_private_and_survive_handoff() {
     let (daemon, capture, notify_send, sound_capture) = start_with_notifications();
     let workspace = daemon

--- a/tests/native_backend/shell_lifecycle.rs
+++ b/tests/native_backend/shell_lifecycle.rs
@@ -15,6 +15,223 @@ use crate::support::{
 };
 
 #[test]
+#[ignore = "explicit startup timing diagnostic; optionally set BOOMUX_TIMING_STATE_ROOT"]
+fn shell_startup_phase_timings() {
+    use std::time::Instant;
+    let state = std::env::var_os("BOOMUX_TIMING_STATE_ROOT").map(|root| {
+        std::path::PathBuf::from(root).join(format!("boomux-timing-{}", Uuid::new_v4()))
+    });
+    let daemon = TestDaemon::start_with(|command, _| {
+        if let Some(state) = &state {
+            command.env("BOOMUX_STATE_HOME", state);
+        }
+    });
+    let workspace = daemon.client.create_workspace("timing", vec![]).unwrap();
+    for index in 0..6 {
+        let combined = index % 2 == 1;
+        let start = Instant::now();
+        let spec = ShellSpec::login(format!("shell-{index}"), &daemon.runtime_dir);
+        let shell = if combined {
+            let response = daemon
+                .client
+                .request(protocol::Request::CreateStartedShell {
+                    workspace_id: workspace.id.clone(),
+                    shell: spec,
+                    profile: profile(),
+                    environment: None,
+                })
+                .unwrap();
+            let protocol::Response::Shell { shell } = response else {
+                panic!("unexpected response")
+            };
+            shell
+        } else {
+            daemon.client.create_shell(&workspace.id, spec).unwrap()
+        };
+        let created = start.elapsed();
+        let mut attachment = daemon.client.attach(&shell.id, true, profile()).unwrap();
+        let attached = start.elapsed();
+        let current = daemon.client.get_shell(&shell.id).unwrap();
+        let inspected = start.elapsed();
+        AttachFrame::Input(b"printf 'timing-%s\\n' ready\n".to_vec())
+            .write_to(&mut attachment.stream)
+            .unwrap();
+        read_until(&mut attachment.stream, b"timing-ready");
+        let ready = start.elapsed();
+        AttachFrame::Detached
+            .write_to(&mut attachment.stream)
+            .unwrap();
+        drop(attachment);
+        let reattach_start = Instant::now();
+        let run = current.run.unwrap().id;
+        let mut reopened = daemon
+            .client
+            .attach_exact_run(&shell.id, &run, true, profile())
+            .unwrap();
+        let reopened_at = reattach_start.elapsed();
+        AttachFrame::Detached
+            .write_to(&mut reopened.stream)
+            .unwrap();
+        assert_eq!(
+            daemon.client.get_shell(&shell.id).unwrap().run.unwrap().id,
+            run
+        );
+        eprintln!(
+            "shell {index} combined={combined}: create={created:?}, attach={:?}, inspect={:?}, ready={ready:?}, reopen={reopened_at:?}",
+            attached - created,
+            inspected - attached
+        );
+    }
+    drop(daemon);
+    if let Some(state) = state {
+        fs::remove_dir_all(state).unwrap();
+    }
+}
+
+#[test]
+fn create_started_shell_persists_one_run_and_attaches_without_restarting() {
+    let mut daemon = TestDaemon::start();
+    let workspace = daemon.client.create_workspace("started", vec![]).unwrap();
+    let cursor = daemon.client.events(None, 100, 0).unwrap().cursor;
+    let request = protocol::Request::CreateStartedShell {
+        workspace_id: workspace.id.clone(),
+        shell: ShellSpec {
+            name: "started".into(),
+            command: vec!["/bin/sh".into()],
+            cwd: daemon.runtime_dir.clone(),
+        },
+        profile: profile(),
+        environment: Some(UnixEnvironment {
+            variables: vec![UnixEnvironmentVariable {
+                name: b"START_TEST_VALUE".to_vec(),
+                value: b"ephemeral-secret".to_vec(),
+            }],
+        }),
+    };
+    // A protocol-53 caller cannot accidentally execute the new mutation.
+    let mut stream = UnixStream::connect(daemon.client.socket_path()).unwrap();
+    protocol::write_message(
+        &mut stream,
+        &protocol::Envelope::with_version(53, request.clone()),
+    )
+    .unwrap();
+    let response: protocol::Envelope<protocol::Response> =
+        protocol::read_message(&mut stream).unwrap();
+    assert!(matches!(
+        response.message,
+        protocol::Response::Error {
+            code: Some(ErrorCode::UnsupportedVersion),
+            ..
+        }
+    ));
+    assert!(
+        daemon
+            .client
+            .get_workspace(&workspace.id)
+            .unwrap()
+            .shells
+            .is_empty()
+    );
+    let protocol::Response::Shell { shell } = daemon.client.request(request).unwrap() else {
+        panic!("unexpected response")
+    };
+    assert_eq!(shell.status, ShellStatus::Running);
+    let run = shell.run.unwrap();
+    assert_eq!(run.generation, 1);
+    let saved = fs::read_to_string(daemon.runtime_dir.join("state/boomux/state.json")).unwrap();
+    assert!(saved.contains(&shell.id));
+    assert!(saved.contains(&run.id));
+    assert!(!saved.contains("ephemeral-secret"));
+    assert!(!saved.contains("START_TEST_VALUE"));
+    let events = daemon.client.events(Some(cursor), 100, 0).unwrap().events;
+    assert!(
+        matches!(&events[0].kind, protocol::DaemonEventKind::ShellCreated { shell_id, .. } if shell_id == &shell.id)
+    );
+    assert!(
+        matches!(&events[1].kind, protocol::DaemonEventKind::RunStarted { shell_id, run: started, .. } if shell_id == &shell.id && started.id == run.id)
+    );
+    let mut attachment = daemon
+        .client
+        .attach_exact_run(&shell.id, &run.id, true, profile())
+        .unwrap();
+    AttachFrame::Input(b"printf 'value-%s\\n' \"$START_TEST_VALUE\"\n".to_vec())
+        .write_to(&mut attachment.stream)
+        .unwrap();
+    read_until(&mut attachment.stream, b"value-ephemeral-secret");
+    assert_eq!(
+        daemon.client.get_shell(&shell.id).unwrap().run.unwrap().id,
+        run.id
+    );
+    drop(attachment);
+    daemon.crash();
+    daemon.restart();
+    let recovered = daemon.client.get_shell(&shell.id).unwrap();
+    assert_eq!(recovered.status, ShellStatus::Pending);
+    assert!(recovered.run.is_none());
+    let persisted: serde_json::Value = serde_json::from_slice(
+        &fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap(),
+    )
+    .unwrap();
+    let last_run = &persisted["workspaces"][0]["shells"][0]["last_run"];
+    assert_eq!(last_run["id"], run.id);
+    assert_eq!(last_run["exit_reason"]["reason"], "interrupted");
+    let restarted = daemon.client.attach(&shell.id, false, profile()).unwrap();
+    let next_run = daemon.client.get_shell(&shell.id).unwrap().run.unwrap();
+    assert_ne!(next_run.id, run.id);
+    assert_eq!(next_run.generation, 2);
+    drop(restarted);
+}
+
+#[test]
+fn boomux_path_overrides_preserve_application_environment() {
+    let mut daemon = TestDaemon::start_with(|command, root| {
+        command
+            .env("BOOMUX_RUNTIME_DIR", root)
+            .env("BOOMUX_STATE_HOME", root.join("state"))
+            .env("BOOMUX_CONFIG_HOME", root.join("config"))
+            .env("XDG_RUNTIME_DIR", root.join("user-runtime"))
+            .env("XDG_STATE_HOME", root.join("user-state"))
+            .env("XDG_CONFIG_HOME", root.join("user-config"))
+            .env("XDG_DATA_HOME", root.join("user-data"));
+    });
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "private-paths",
+            vec![ShellSpec::login("shell", daemon.runtime_dir.clone())],
+        )
+        .unwrap();
+    let mut attachment = daemon
+        .client
+        .attach(&workspace.shells[0].id, false, profile())
+        .unwrap();
+    AttachFrame::Input(b"printf '%s\\n' \"$XDG_CONFIG_HOME\" \"$XDG_DATA_HOME\" \"$XDG_RUNTIME_DIR\" \"$BOOMUX_OPENCODE_SHIM_DIR\"; printf 'paths-%s\\n' done\n".to_vec())
+        .write_to(&mut attachment.stream).unwrap();
+    let output = read_until(&mut attachment.stream, b"paths-done");
+    for suffix in ["user-config", "user-data", "user-runtime", "boomux/shims"] {
+        assert!(contains(
+            &output,
+            daemon.runtime_dir.join(suffix).to_str().unwrap().as_bytes()
+        ));
+    }
+    assert!(daemon.runtime_dir.join("state/boomux/state.json").exists());
+    assert!(!daemon.runtime_dir.join("user-state/boomux").exists());
+    assert!(!daemon.runtime_dir.join("user-runtime/boomux").exists());
+    let status = daemon
+        .command()
+        .env("BOOMUX_RUNTIME_DIR", &daemon.runtime_dir)
+        .env("XDG_RUNTIME_DIR", daemon.runtime_dir.join("user-runtime"))
+        .args(["daemon", "status", "--json"])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    let status: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(status["data"]["status"], "running");
+    drop(attachment);
+    daemon.stop_with_cli();
+}
+
+#[test]
 fn bare_claude_command_uses_owner_remote_control_policy_without_rewriting_stored_argv() {
     for (enabled, expected) in [
         (true, b"--remote-control\0".as_slice()),
@@ -86,7 +303,8 @@ fn bare_codex_command_uses_run_scoped_hooks_without_rewriting_stored_argv() {
         fs::write(
             &codex,
             format!(
-                "#!/bin/sh\nif [ \"${{1-}}\" = --version ]; then printf '1.0.0\\n'; exit 0; fi\n: > '{}'\nfor arg do printf '%s\\0' \"$arg\" >> '{}'; done\nprintf '%s' \"${{BOOMUX_CODEX_RUN_SCOPED-unset}}\" > '{}'\nprintf '%s' \"${{CODEX_HOME-unset}}\" > '{}'\n",
+                "#!/bin/sh\nif [ \"${{1-}}\" = --version ]; then printf '1.0.0\\n'; exit 0; fi\ncommand -v boomux > '{}'\n: > '{}'\nfor arg do printf '%s\\0' \"$arg\" >> '{}'; done\nprintf '%s' \"${{BOOMUX_CODEX_RUN_SCOPED-unset}}\" > '{}'\nprintf '%s' \"${{CODEX_HOME-unset}}\" > '{}'\n",
+                runtime_dir.join("codex-boomux").display(),
                 runtime_dir.join("codex-argv").display(),
                 runtime_dir.join("codex-argv").display(),
                 runtime_dir.join("codex-marker").display(),
@@ -95,6 +313,8 @@ fn bare_codex_command_uses_run_scoped_hooks_without_rewriting_stored_argv() {
         )
         .unwrap();
         fs::set_permissions(&codex, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::write(bin.join("boomux"), "#!/bin/sh\nexit 91\n").unwrap();
+        fs::set_permissions(bin.join("boomux"), fs::Permissions::from_mode(0o700)).unwrap();
         command.env("CODEX_HOME", codex_home).env("PATH", &bin);
     });
     let codex = daemon.runtime_dir.join("codex-bin/codex");
@@ -123,6 +343,12 @@ fn bare_codex_command_uses_run_scoped_hooks_without_rewriting_stored_argv() {
         "marker={marker} CODEX_HOME={codex_home}"
     );
     assert_eq!(marker, "1");
+    assert_eq!(
+        fs::read_to_string(daemon.runtime_dir.join("codex-boomux"))
+            .unwrap()
+            .trim(),
+        daemon.executable.to_str().unwrap()
+    );
     assert_eq!(
         daemon.client.get_shell(shell_id).unwrap().command,
         [codex.display().to_string()]
@@ -195,7 +421,8 @@ fn claude_typed_in_managed_login_shell_preserves_dispatch_shim_and_arguments() {
     let home = daemon.runtime_dir.join("home");
     let output = daemon.runtime_dir.join("typed-claude-argv");
     fs::create_dir(&bin).unwrap();
-    fs::create_dir(&home).unwrap();
+    // Automatic integration preparation may already have created this home.
+    fs::create_dir_all(&home).unwrap();
     let dispatcher = bin.join("mise");
     fs::write(
         &dispatcher,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -35,6 +35,14 @@ pub(crate) struct TestDaemon {
 }
 
 fn remove_boomux_shim_environment(command: &mut Command) {
+    // Test daemons must never inherit the developer's private daemon routing.
+    for name in [
+        "BOOMUX_RUNTIME_DIR",
+        "BOOMUX_CONFIG_HOME",
+        "BOOMUX_STATE_HOME",
+    ] {
+        command.env_remove(name);
+    }
     let original_path = env::var_os("BOOMUX_ORIGINAL_PATH");
     let shim_dir = env::var_os("BOOMUX_OPENCODE_SHIM_DIR").map(PathBuf::from);
     let user_zdotdir = env::var_os("BOOMUX_USER_ZDOTDIR");

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,4 @@
+dist/
+.astro/
+test-results/
+playwright-report/

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,56 @@
+# Boomux Website
+
+Static Astro landing page, independent of the Rust application and the embedded
+web dashboard. No backend, analytics, or GPUI dependencies.
+
+## Local preview
+
+Use Node 22.12 or newer:
+
+```console
+cd website
+npm ci
+npm run dev
+```
+
+Open `http://localhost:4322/boomux/`. Browser tests reserve port 4321, so they
+can run alongside your preview. For a production preview and browser checks:
+
+```console
+npm run build
+npx playwright install chromium
+npm test
+npm run preview
+```
+
+An existing Chromium can be used with `CHROMIUM_PATH=/usr/bin/chromium npm test`.
+Tests cover mobile layout, assets, install modes, clipboard failure, theme
+persistence, blocked storage, and the no-JavaScript fallback.
+
+## Content and assets
+
+- `src/pages/index.astro`: copy, links, and official installer commands.
+- `src/components/WorkspacePreview.astro`: explicitly labeled illustration with
+  fictional sample content, not live terminal output or an actual screenshot.
+- `src/styles/site.css`: responsive dark/light design.
+- The expandable screenshot imports `../assets/boomux-workspace-desktop.png`;
+  it is explicitly labeled as an earlier interface and optimized at build time.
+  Replace with a reviewed current capture before a marketing launch. Do not use
+  private paths, conversations, credentials, or client data in new captures.
+- A current demo recording is not included. Add only after recording and review;
+  do not label an illustration as a recording.
+
+## Publishing
+
+The Website workflow checks pull requests and deploys successful builds from
+`main`. Enable **Settings → Pages → Build and deployment → GitHub Actions** in
+the repository when ready to publish. No Pages setting is changed by local builds.
+The default URL is `https://gardnmi.github.io/boomux/`.
+
+For a custom domain, set `SITE_URL` and `BASE_PATH` in the build environment
+(for example `https://boomux.example` and `/`) and configure Pages/DNS separately.
+The browser fixtures deliberately test the default project subpath.
+
+Website-only changes have their own checks and do not select Rust builds.
+Screenshot changes also trigger the site workflow. Keep installer claims aligned
+with `docs/install.md`; the website does not publish a separate installer.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  site: process.env.SITE_URL || "https://gardnmi.github.io",
+  base: process.env.BASE_PATH || "/boomux",
+  output: "static",
+});

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,4264 @@
+{
+  "name": "boomux-website",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "boomux-website",
+      "dependencies": {
+        "@fontsource/dm-sans": "5.3.0",
+        "@fontsource/ibm-plex-mono": "5.3.0",
+        "astro": "7.3.1"
+      },
+      "devDependencies": {
+        "@playwright/test": "1.63.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.4.0.tgz",
+      "integrity": "sha512-x2RjDUuWfwLNtc3mjAdSRInwqh/rqbLar9cm/5FOMbHvmYZB7yfKewzSclAxWjIZsypJDXv1lhaP2WG+P8TK3g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@astrojs/compiler-binding-darwin-arm64": "0.4.0",
+        "@astrojs/compiler-binding-darwin-x64": "0.4.0",
+        "@astrojs/compiler-binding-linux-arm64-gnu": "0.4.0",
+        "@astrojs/compiler-binding-linux-arm64-musl": "0.4.0",
+        "@astrojs/compiler-binding-linux-x64-gnu": "0.4.0",
+        "@astrojs/compiler-binding-linux-x64-musl": "0.4.0",
+        "@astrojs/compiler-binding-wasm32-wasi": "0.4.0",
+        "@astrojs/compiler-binding-win32-arm64-msvc": "0.4.0",
+        "@astrojs/compiler-binding-win32-x64-msvc": "0.4.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-darwin-arm64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-ZVUwHundaQyFNjE6uoa0usaC0WOCitDCLS/4mdb4rOiJXwVUuKJBMxI5WMzXLWmamsXtK/Z//ifLXvV5Yeh4Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-darwin-x64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-FI6G8AY8u6fR1SI/QRR5yGMwtvZwP34CDmZpZ5HwJGa50UM1VISTLhqkhV4a476pmgd25X1Aur2dqw6hUnrlKA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-lB9gLFJK7m82EnjaU8nlRBEfcwGNeHidW3sSjODTUjMNaoewVuUz9fwwdY5M4jiSXIqWLH3yl6TX8FTDKA74Sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.4.0.tgz",
+      "integrity": "sha512-HPbvWqbxFxyaoQJhLxCaSjtYBx9KBo7JGVzEFZCmMl968a2PsSH0UfiODYgYPXofTOIsIH2aoCcrHXML0IA3ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-tQKolMxoJ/+0AmLWm1PmJ/i+z3i10ZU1bNuVjEDulCf48azEMtUNjTZgHJ5MPtpYRNc7dlETr8QujUfduzoC7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.4.0.tgz",
+      "integrity": "sha512-5v5YymudsxMHp3NBLCS8BUlu5CRqeLtWD9cKS/4nIhIEHCbpz9okmVV6I0HWqmBAPhWYcDa3vw/vltYPrOQCTA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.4.0.tgz",
+      "integrity": "sha512-m/phuH3x3PREvv1OnkM44NoPh4MatUadix1fB1u5SvMLCyDTUZykDJbKnWf1cjnYmHdlB8HcjTjl6JrCqAIXcw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.4.0.tgz",
+      "integrity": "sha512-B9zYf3okEY83kM8gydlpH2BHP00w4ifxPqlYlWrgTwuD6wnkrJDCwBlgy1q31cERjCJRXN1lrE2VmkLvFjv/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.4.0.tgz",
+      "integrity": "sha512-zB0Nrv0dGc0zZWPGDRmmETTPhDRqyZjAjk+gWMlVrJX5U89obpB3VUUE1ZiHxOCN5LQojeLK6O8L/dnoHolvNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-rs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.4.0.tgz",
+      "integrity": "sha512-koVikeon1kreEy+/JzLQRy3vzHHQVOjycs4degg4vFufKApZOwMZvSSAEztYNhmcQVfNVsVZZI4cEge3cexAbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler-binding": "0.4.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/internal-helpers": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.11.0.tgz",
+      "integrity": "sha512-3rzxJ+xbo0+8YyqOzLziIN32wmsHdCjEVz2sGOpRxJ+Ben/KiLph4ItxBy1abEL+E8fkRzqjg0rfXmaHJGw9JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.3.0",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.0.tgz",
+      "integrity": "sha512-wykOOW9KsUVcZweOpY/CeXpdKcCKZy6fQbdcteWFuI75+sQCiqxYM7VKsGa5b+aGl3cYQscFY37rsbbyal5MRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "satteri": "^0.10.3"
+      }
+    },
+    "node_modules/@astrojs/prism": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/telemetry": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
+      "integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.4.0",
+        "dset": "^3.1.4",
+        "is-docker": "^4.0.0",
+        "package-manager-detector": "^1.6.0"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bruits/satteri-darwin-arm64": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.10.5.tgz",
+      "integrity": "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-darwin-x64": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.10.5.tgz",
+      "integrity": "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-gnu": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.10.5.tgz",
+      "integrity": "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-musl": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.10.5.tgz",
+      "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-gnu": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.10.5.tgz",
+      "integrity": "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-musl": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.10.5.tgz",
+      "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.10.5.tgz",
+      "integrity": "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-win32-arm64-msvc": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.10.5.tgz",
+      "integrity": "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@bruits/satteri-win32-x64-msvc": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.10.5.tgz",
+      "integrity": "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@capsizecss/unpack": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+      "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-zNikCcd8BbcEvzzG1sbXFrRHFk5kHPrpwZwksPvf9qyQO1Teb7JaXaOAxXZei9nZLDW0gaZawiuTCji88bTBhw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.8.0.tgz",
+      "integrity": "sha512-PXzLZ8N34rxmuo4dJg3xtOXhcBse94qGjDqsteoEYrFrrZ5FSjIGwMAuOcv64ln8rHVBBD06XeVGr+/JX+plcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.5.0",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/dm-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/dm-sans/-/dm-sans-5.3.0.tgz",
+      "integrity": "sha512-lYJtMXXO28q1z+yz+z8XKd0s4hXaa9QdkETzkyD760sidCv5heI86weYA0sx0Nc4pAMAQTUuyf4gO44cYKKS9g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/nlcst": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "license": "ISC"
+    },
+    "node_modules/am-i-vibing": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
+      "integrity": "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==",
+      "license": "MIT",
+      "dependencies": {
+        "process-ancestry": "^0.1.0"
+      },
+      "bin": {
+        "am-i-vibing": "dist/cli.mjs"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/astro": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.3.1.tgz",
+      "integrity": "sha512-A/bJYHtc6n0UAdROY9W948fW6lX0pnUA+JWKW+IGCXRyDIGN2MsXC0OlS8onZGJjr+sv8htemwOc9W5PBRXCkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler-rs": "^0.4.0",
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/markdown-satteri": "0.4.0",
+        "@astrojs/telemetry": "3.3.3",
+        "@capsizecss/unpack": "^4.0.0",
+        "@clack/prompts": "^1.1.0",
+        "@oslojs/encoding": "^1.1.0",
+        "am-i-vibing": "^0.4.0",
+        "aria-query": "^5.3.2",
+        "axobject-query": "^4.1.0",
+        "ci-info": "^4.4.0",
+        "clsx": "^2.1.1",
+        "common-ancestor-path": "^2.0.0",
+        "cookie": "^2.0.1",
+        "devalue": "^5.8.1",
+        "diff": "^9.0.0",
+        "dset": "^3.1.4",
+        "es-module-lexer": "^2.0.0",
+        "esbuild": "^0.28.0",
+        "find-proc": "0.1.0",
+        "flattie": "^1.1.1",
+        "fontace": "~0.4.1",
+        "get-tsconfig": "5.0.0-beta.4",
+        "github-slugger": "^2.0.0",
+        "html-escaper": "3.0.3",
+        "http-cache-semantics": "^4.2.0",
+        "js-yaml": "^4.3.0",
+        "jsonc-parser": "^3.3.1",
+        "magic-string": "^1.0.0",
+        "magicast": "^0.5.2",
+        "mrmime": "^2.0.1",
+        "neotraverse": "^1.0.1",
+        "obug": "^2.1.1",
+        "p-limit": "^7.3.0",
+        "p-queue": "^9.1.0",
+        "package-manager-detector": "^1.6.0",
+        "piccolore": "^0.1.3",
+        "picomatch": "^4.0.4",
+        "semver": "^7.7.4",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
+        "tinyglobby": "^0.2.15",
+        "ultrahtml": "^1.6.0",
+        "unifont": "~0.7.5",
+        "unstorage": "^1.17.5",
+        "vite": "^8.0.13",
+        "vitefu": "^1.1.2",
+        "xxhash-wasm": "^1.1.0",
+        "yargs-parser": "^22.0.0",
+        "zod": "^4.5.4"
+      },
+      "bin": {
+        "astro": "bin/astro.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/astrodotbuild"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.35.4"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-remark": "^7.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-remark": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+      "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^7.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "nth-check": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+      "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+      "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-proc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/find-proc/-/find-proc-0.1.0.tgz",
+      "integrity": "sha512-OaOpEYv2PiQ7SQ5LIrl+deA1XaWcxEjnpM6VuWXTUvn+teIXxeFTLDmu18/zDQpFmHN4o3oDBX+BT0AGwEhemg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/flattie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fontace": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.2"
+      }
+    },
+    "node_modules/fontkitten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+      "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neotraverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+      "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/nlcst-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.2.tgz",
+      "integrity": "sha512-Ll0w3fU24vYpXoZmjjZIee6bJQDgG0oAyo1PdmFYI8UDwJJddaHAypxIH9avUu+t+lSsAwKVsb1jDCMIIChliw==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/process-ancestry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/process-ancestry/-/process-ancestry-0.1.0.tgz",
+      "integrity": "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retext-smartypants": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
+      }
+    },
+    "node_modules/satteri": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.10.5.tgz",
+      "integrity": "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.5",
+        "@types/hast": "^3.0.5",
+        "@types/mdast": "^4.0.4",
+        "@types/unist": "^3.0.3"
+      },
+      "optionalDependencies": {
+        "@bruits/satteri-darwin-arm64": "0.10.5",
+        "@bruits/satteri-darwin-x64": "0.10.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.10.5",
+        "@bruits/satteri-linux-arm64-musl": "0.10.5",
+        "@bruits/satteri-linux-x64-gnu": "0.10.5",
+        "@bruits/satteri-linux-x64-musl": "0.10.5",
+        "@bruits/satteri-wasm32-wasi": "0.10.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.10.5",
+        "@bruits/satteri-win32-x64-msvc": "0.10.5"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.3",
+        "@shikijs/engine-javascript": "4.4.3",
+        "@shikijs/engine-oniguruma": "4.4.3",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+      "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^6.0.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^7.0.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "1.6.1"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyclip": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
+      "integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/ultrahtml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+      "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+      "license": "MIT"
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unifont": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+      "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.1.0",
+        "ohash": "^2.0.11",
+        "undici": "^8.0.0"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "boomux-website",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev --host 127.0.0.1 --port 4322",
+    "build": "astro build",
+    "preview": "astro preview --host 127.0.0.1 --port 4322",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "astro": "7.3.1",
+    "@fontsource/dm-sans": "5.3.0",
+    "@fontsource/ibm-plex-mono": "5.3.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.63.0"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  }
+}

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    baseURL: "http://127.0.0.1:4321/boomux/",
+    trace: "retain-on-failure",
+    launchOptions: process.env.CHROMIUM_PATH
+      ? { executablePath: process.env.CHROMIUM_PATH }
+      : {},
+  },
+  projects: [
+    {
+      name: "desktop",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 1000 },
+      },
+    },
+    {
+      name: "mobile",
+      use: { ...devices["iPhone 13"], defaultBrowserType: "chromium" },
+    },
+  ],
+  webServer: {
+    command: "node scripts/preview-test.mjs",
+    url: "http://127.0.0.1:4321/boomux/",
+    reuseExistingServer: false,
+  },
+});

--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="9" fill="#a9b8ff"/><path d="m8 10 6 6-6 6m9 0h7" fill="none" stroke="#151620" stroke-width="2.5"/></svg>

--- a/website/scripts/preview-test.mjs
+++ b/website/scripts/preview-test.mjs
@@ -1,0 +1,11 @@
+// Keep the server owned by Playwright, even when Astro's CLI detects an agent
+// environment and would otherwise start a detached background process.
+import { preview } from "astro";
+
+const server = await preview({ server: { host: "127.0.0.1", port: 4321 } });
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, async () => {
+    await server.stop();
+    process.exit(0);
+  });
+}

--- a/website/src/components/WorkspacePreview.astro
+++ b/website/src/components/WorkspacePreview.astro
@@ -1,0 +1,21 @@
+---
+const projects = ['website', 'api-server', 'design-system'];
+---
+<figure class="product-preview">
+  <div class="preview-top"><span><span class="live-dot"></span> YOUR WORK, IN ONE PLACE</span><span>LOCAL NODE <span class="subtle">/</span> CONNECTED</span></div>
+  <div class="preview-app" aria-label="Illustration of a Boomux workspace with terminals and Agent status">
+    <aside class="preview-sidebar">
+      <div class="preview-brand"><span class="mini-logo">&gt;_</span> BOOMUX</div>
+      <p class="micro">WORKSPACES</p>
+      {projects.map((name, index) => <div class:list={['project-row', { current: index === 0 }]}><span class="project-name">{index === 0 ? '⌄' : '›'} &nbsp; {name}</span><small>{index === 0 ? '3 Shells · 1 Agent' : '1 Shell'}</small></div>)}
+      <div class="preview-agents"><p class="micro">AGENTS</p><div class="agent-line"><span class="live-dot"></span><div>mellow-raven<small>Working · Codex</small></div></div></div>
+      <div class="preview-bottom"><span class="live-dot"></span> Processes stay with Boomux.</div>
+    </aside>
+    <div class="preview-terminals">
+      <section class="sample-terminal agent-terminal"><div class="terminal-title"><span><span class="live-dot"></span> mellow-raven</span><span>CODEx / AGENT</span></div><div class="terminal-content"><p class="terminal-path">~/work/website <span>main</span></p><p><span class="prompt">❯</span> codex</p><p class="agent-prompt">Add keyboard navigation to the settings menu.</p><p class="output"><span class="accent">›</span> Reviewing the existing focus behavior.</p><p class="output"><span class="accent">›</span> Updating the settings controls.</p><div class="code-diff"><span>+ Arrow keys move between options</span><span>+ Escape returns focus to the terminal</span><span>+ Tests cover keyboard interaction</span></div><p class="working"><span class="live-dot"></span> Working <span class="subtle">· your other terminals are ready</span></p></div></section>
+      <section class="sample-terminal git-terminal"><div class="terminal-title"><span>silver-raven</span><span>SHELL</span></div><div class="terminal-content"><p class="terminal-path">~/work/website <span>main</span></p><p><span class="prompt">❯</span> git status --short</p><p class="file-change">M &nbsp; src/settings.rs</p><p class="file-change">M &nbsp; tests/keyboard.rs</p><p class="terminal-command"><span class="prompt">❯</span> <span class="cursor-block"></span></p></div></section>
+      <section class="sample-terminal test-terminal"><div class="terminal-title"><span>golden-beaver</span><span>SHELL</span></div><div class="terminal-content"><p><span class="prompt">❯</span> cargo test keyboard</p><p class="output">running 3 tests</p><p class="test-output">test focus_next … <span>ok</span><br/>test focus_previous … <span>ok</span><br/>test escape_restores_focus … <span>ok</span></p><p class="success">3 passed. 0 failed.</p></div></section>
+    </div>
+  </div>
+  <figcaption><span>Illustrative workspace · not a live session</span><span><kbd>Ctrl</kbd> + <kbd>Space</kbd> <span class="caption-hint">to enter layout mode</span></span></figcaption>
+</figure>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,0 +1,86 @@
+---
+import { Image } from 'astro:assets';
+import WorkspacePreview from '../components/WorkspacePreview.astro';
+import workspaceCapture from '../../../assets/boomux-workspace-desktop.png';
+import '../styles/site.css';
+
+const repo = 'https://github.com/gardnmi/boomux';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const install = "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/gardnmi/boomux/releases/latest/download/boomux-installer.sh | sh -s --";
+const features = [
+  ['01', 'Your terminals have a home.', 'Organize Shells into persistent Workspaces. Closing a Desktop pane detaches the view; it does not terminate the Shell.'],
+  ['02', 'Know when you’re needed.', 'See Agent activity and attention across your work. Keep a long-running task in motion while you focus on something else.'],
+  ['03', 'Less reaching. More doing.', 'Tile, resize, and navigate panes from the keyboard. Tap Ctrl + Space to stay in layout mode, or hold it for a quick adjustment.'],
+  ['04', 'A little more perspective.', 'Check repositories, worktrees, local changes, and available pull-request status from the Git tab. No extra terminal shuffle.'],
+  ['05', 'Local or a Node away.', 'Connect remote Nodes over SSH. Each Node keeps ownership of its processes while Boomux brings the workspace into view.'],
+  ['06', 'Native, through and through.', 'A Rust core and a native GPUI-CE Desktop, with Ghostty terminal decoding. Built for Linux, with an interface that follows your Omarchy theme.'],
+];
+---
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Boomux brings persistent terminals, AI agents, and Git context into one native Linux workspace. Close the view. Keep the work." />
+    <meta name="theme-color" content="#151620" />
+    <link rel="canonical" href={new URL(`${base}/`, Astro.site)} />
+    <link rel="icon" type="image/svg+xml" href={`${base}/favicon.svg`} />
+    <meta property="og:title" content="Boomux — Close the view. Keep the work." />
+    <meta property="og:description" content="Persistent terminals and AI agents. One native workspace. Built for Linux." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={new URL(`${base}/`, Astro.site)} />
+    <meta name="color-scheme" content="dark light" />
+    <title>Boomux — Close the view. Keep the work.</title>
+    <script is:inline>
+      try {
+        const theme = localStorage.getItem('boomux-site-theme');
+        if (theme === 'light' || theme === 'dark') document.documentElement.dataset.theme = theme;
+      } catch {}
+    </script>
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Skip to content</a>
+    <header class="site-header wrap">
+      <a href={`${base}/`} class="brand" aria-label="Boomux home"><svg viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="9" fill="currentColor"/><path d="m8 10 6 6-6 6m9 0h7" fill="none" stroke="var(--bg)" stroke-width="2.5"/></svg>boomux<span class="brand-period">.</span></a>
+      <nav aria-label="Main navigation"><a href="#workflow">Workflow</a><a href={`${repo}/tree/main/docs`}>Docs <span aria-hidden="true">↗</span></a><a href={repo}>GitHub <span aria-hidden="true">↗</span></a><button id="theme-toggle" class="icon-button" type="button" aria-label="Use light theme" aria-pressed="false" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M2 12h2m16 0h2M5 5l1.5 1.5m11 11L19 19M5 19l1.5-1.5m11-11L19 5"/></svg></button></nav>
+    </header>
+    <main id="main">
+      <section class="hero wrap" aria-labelledby="hero-title">
+        <p class="eyebrow"><span class="live-dot"></span> YOUR WORKSPACE. STILL WORKING.</p>
+        <h1 id="hero-title">Close the view.<br/><span>Keep the work.</span></h1>
+        <p class="hero-description">Your terminals, AI agents, and Git context.<br class="desktop-break"/> Together in one persistent, native workspace.</p>
+        <div class="hero-actions"><a class="button primary" href="#install">Get Boomux <span aria-hidden="true">↗</span></a><a class="button quiet" href="#workflow">Find your flow <span aria-hidden="true">↓</span></a></div>
+        <p class="platform-note">GNU/Linux <span>·</span> x86_64 & ARM64 <span>·</span> Open source</p>
+        <WorkspacePreview />
+      </section>
+      <section class="harnesses wrap" aria-label="Supported harness integrations"><p>YOUR HARNESS. YOUR WAY.</p><ul>{['Claude Code', 'Codex', 'OpenCode', 'Pi', 'Kiro'].map(name => <li>{name}</li>)}</ul><span>Integrations managed by Boomux.<br/>Your customizations stay protected.</span></section>
+      <section id="workflow" class="section wrap" aria-labelledby="workflow-title">
+        <div class="section-heading"><p class="eyebrow">01 / THE WORKFLOW</p><h2 id="workflow-title">Pick up where<br/>you left off.</h2><p>A workspace is more than a window.<br/>Boomux keeps the processes behind it.</p></div>
+        <ol class="workflow-steps">
+          <li><span class="step-number">01</span><div><h3>Make room for your work.</h3><p>Open a Workspace. Bring up a Shell, your editor, or an AI harness. Arrange the panes around what you’re doing.</p></div><span class="step-symbol" aria-hidden="true">⌘</span></li>
+          <li><span class="step-number">02</span><div><h3>Keep the right things in view.</h3><p>Follow an Agent’s progress, check Git, and move between terminals. Stay on the keyboard with layout mode.</p></div><span class="step-symbol" aria-hidden="true">⊞</span></li>
+          <li><span class="step-number">03</span><div><h3>Step away. Come back.</h3><p>Detach the view without ending the Shell. Reattach to the running process when you’re ready—not a replacement terminal.</p></div><span class="step-symbol" aria-hidden="true">↳</span></li>
+        </ol>
+        <p class="workflow-footnote">Detaching is not stopping. Explicitly removing a Shell or stopping the daemon ends its processes.</p>
+      </section>
+      <section class="section wrap" aria-labelledby="features-title">
+        <div class="section-heading horizontal"><div><p class="eyebrow">02 / BUILT AROUND YOUR WORK</p><h2 id="features-title">Less window management.<br/><span>More headspace.</span></h2></div><a class="text-link" href={`${repo}/blob/main/CONTEXT.md`}>How Boomux fits together ↗</a></div>
+        <div class="features">{features.map(([number, title, description]) => <article><span class="feature-number">{number} /</span><h3>{title}</h3><p>{description}</p></article>)}</div>
+        <details class="capture"><summary>See a real workspace capture <span>Earlier interface · from the repository <span aria-hidden="true">↗</span></span></summary><figure><Image src={workspaceCapture} width={1400} format="webp" quality={80} loading="lazy" alt="Earlier Boomux workspace interface alongside an Agent terminal, a browser, and a Git terminal."/><figcaption>Earlier workspace capture. Current Desktop controls differ; the illustration above shows the intended workflow, not a screenshot.</figcaption></figure></details>
+      </section>
+      <section id="install" class="section wrap install-section" aria-labelledby="install-title">
+        <div><p class="eyebrow">03 / MAKE YOURSELF AT HOME</p><h2 id="install-title">Your next workspace<br/>starts here.</h2><p>One installer. Choose the native Desktop<br class="desktop-break"/> or just the command line.</p><a class="text-link" href={`${repo}/blob/main/docs/install.md`}>Read the installation guide ↗</a></div>
+        <div class="install-card">
+          <div id="install-tabs" class="install-tabs" role="tablist" aria-label="Installation type" hidden><button id="tab-desktop" type="button" role="tab" aria-selected="true" aria-controls="install-desktop" data-install="desktop">Desktop + CLI</button><button id="tab-cli" type="button" role="tab" aria-selected="false" aria-controls="install-cli" tabindex="-1" data-install="cli">CLI only</button></div>
+          {['desktop', 'cli'].map(mode => <div id={`install-${mode}`} class="install-panel" data-panel={mode}><h3>{mode === 'desktop' ? 'The complete workspace.' : 'The core, in your terminal.'}</h3><p>{mode === 'desktop' ? 'Native Desktop with the matching Boomux CLI.' : 'Persistent Shells, Agent coordination, and the terminal dashboard.'}</p><div class="command-box"><code id={`command-${mode}`}>{install} --{mode}</code><button type="button" class="copy-button" data-copy={`command-${mode}`} aria-label={`Copy ${mode} install command`} hidden>Copy</button></div></div>)}
+          <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+          <div class="install-footer"><span class="live-dot"></span> GNU/Linux · x86_64 / aarch64<a href={`${repo}/releases/latest`}>Release downloads ↗</a></div>
+          <p class="install-disclosure">Downloads and runs the official release installer. <a href={`${repo}/blob/main/docs/install.md#integrity`}>Review how it works.</a> Existing installations use their update flow.</p>
+        </div>
+      </section>
+      <section class="closing wrap"><p>Built for your machine.<br/><span>And the way you work.</span></p><a href={repo} class="text-link">Explore the source <span aria-hidden="true">↗</span></a></section>
+    </main>
+    <footer class="site-footer wrap"><a href={`${base}/`} class="brand">boomux.</a><p>Independent. Open source. Made for Linux.</p><div><a href={`${repo}/blob/main/LICENSE`}>License</a><a href={`${repo}/issues`}>Feedback ↗</a><a href={`${repo}/releases`}>Changelog ↗</a></div></footer>
+    <script src="../scripts/site.ts"></script>
+  </body>
+</html>

--- a/website/src/scripts/site.ts
+++ b/website/src/scripts/site.ts
@@ -1,0 +1,86 @@
+const themeButton = document.querySelector<HTMLButtonElement>("#theme-toggle");
+const root = document.documentElement;
+function updateTheme(theme: string) {
+  root.dataset.theme = theme;
+  themeButton?.setAttribute(
+    "aria-label",
+    theme === "dark" ? "Use light theme" : "Use dark theme",
+  );
+  themeButton?.setAttribute("aria-pressed", String(theme === "light"));
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute("content", theme === "dark" ? "#151620" : "#f5f3ed");
+}
+updateTheme(root.dataset.theme || "dark");
+if (themeButton) {
+  themeButton.hidden = false;
+  themeButton.addEventListener("click", () => {
+    const theme = root.dataset.theme === "dark" ? "light" : "dark";
+    updateTheme(theme);
+    try {
+      localStorage.setItem("boomux-site-theme", theme);
+    } catch {}
+  });
+}
+
+const tabs = [
+  ...document.querySelectorAll<HTMLButtonElement>("[data-install]"),
+];
+function selectInstall(selected: HTMLButtonElement) {
+  for (const tab of tabs) {
+    const active = tab === selected;
+    tab.setAttribute("aria-selected", String(active));
+    tab.tabIndex = active ? 0 : -1;
+    const panel = document.getElementById(tab.getAttribute("aria-controls")!);
+    if (panel) panel.hidden = !active;
+  }
+  document.getElementById("copy-status")!.textContent = "";
+}
+const tablist = document.getElementById("install-tabs");
+if (tablist && tabs.length) {
+  tablist.hidden = false;
+  document.querySelectorAll<HTMLElement>("[data-panel]").forEach((panel) => {
+    panel.setAttribute("role", "tabpanel");
+    panel.setAttribute("aria-labelledby", `tab-${panel.dataset.panel}`);
+    panel.tabIndex = 0;
+  });
+  selectInstall(tabs[0]);
+  tabs.forEach((tab, index) => {
+    tab.addEventListener("click", () => selectInstall(tab));
+    tab.addEventListener("keydown", (event) => {
+      const next =
+        event.key === "ArrowRight"
+          ? (index + 1) % tabs.length
+          : event.key === "ArrowLeft"
+            ? (index + tabs.length - 1) % tabs.length
+            : event.key === "Home"
+              ? 0
+              : event.key === "End"
+                ? tabs.length - 1
+                : -1;
+      if (next < 0) return;
+      event.preventDefault();
+      selectInstall(tabs[next]);
+      tabs[next].focus();
+    });
+  });
+}
+document
+  .querySelectorAll<HTMLButtonElement>("[data-copy]")
+  .forEach((button) => {
+    button.hidden = false;
+    button.addEventListener("click", async () => {
+      const status = document.getElementById("copy-status");
+      const command =
+        document.getElementById(button.dataset.copy!)?.textContent || "";
+      try {
+        await navigator.clipboard.writeText(command);
+        if (status)
+          status.textContent = "Copied. Paste into your terminal to install.";
+      } catch {
+        if (status)
+          status.textContent =
+            "Clipboard unavailable. Select and copy the command above.";
+      }
+    });
+  });

--- a/website/src/styles/site.css
+++ b/website/src/styles/site.css
@@ -1,0 +1,1034 @@
+@import "@fontsource/dm-sans/latin-400.css";
+@import "@fontsource/dm-sans/latin-500.css";
+@import "@fontsource/dm-sans/latin-600.css";
+@import "@fontsource/ibm-plex-mono/latin-400.css";
+@import "@fontsource/ibm-plex-mono/latin-500.css";
+
+:root {
+  color-scheme: dark;
+  --bg: #151620;
+  --surface: #1c1e2b;
+  --raised: #242737;
+  --text: #ededf5;
+  --muted: #a1a4b9;
+  --subtle: #737990;
+  --border: #303342;
+  --accent: #b4bffe;
+  --green: #a9c9a1;
+  --mono: "IBM Plex Mono", monospace;
+  --sans: "DM Sans", system-ui, sans-serif;
+}
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f5f3ed;
+  --surface: #fffef9;
+  --raised: #eae7e1;
+  --text: #232638;
+  --muted: #5a5f72;
+  --subtle: #696e80;
+  --border: #d5d3d0;
+  --accent: #5056a6;
+  --green: #3b704b;
+}
+* {
+  box-sizing: border-box;
+}
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 28px;
+}
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+button {
+  font: inherit;
+  cursor: pointer;
+}
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+button:focus-visible,
+a:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 5px;
+}
+button[hidden],
+[hidden] {
+  display: none !important;
+}
+::selection {
+  background: var(--accent);
+  color: var(--bg);
+}
+p,
+h1,
+h2,
+h3,
+figure {
+  margin: 0;
+}
+svg {
+  display: block;
+}
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+.wrap {
+  width: min(1160px, calc(100% - 96px));
+  margin-inline: auto;
+}
+.skip-link {
+  position: absolute;
+  top: -90px;
+  left: 16px;
+  z-index: 5;
+  padding: 10px 20px;
+  background: var(--accent);
+  color: var(--bg);
+}
+.skip-link:focus {
+  top: 12px;
+}
+.site-header {
+  height: 104px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  font-weight: 650;
+  font-size: 25px;
+  letter-spacing: -1px;
+}
+.brand svg {
+  width: 30px;
+  color: var(--accent);
+}
+.brand-period {
+  color: var(--accent);
+  margin-left: -10px;
+}
+.site-header nav {
+  display: flex;
+  align-items: center;
+  gap: 30px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.site-header nav a:hover,
+.text-link:hover,
+.site-footer a:hover {
+  color: var(--accent);
+}
+.icon-button {
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  background: transparent;
+}
+.icon-button svg {
+  width: 17px;
+}
+.hero {
+  padding-top: 80px;
+  text-align: center;
+}
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 1.6px;
+  color: var(--muted);
+}
+.hero .eyebrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+.live-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--green);
+}
+h1 {
+  font-size: clamp(52px, 6.5vw, 86px);
+  line-height: 1.06;
+  letter-spacing: -4.8px;
+  font-weight: 550;
+  margin: 25px 0 25px;
+}
+h1 > span,
+h2 > span {
+  color: var(--accent);
+}
+.hero-description {
+  font-size: 19px;
+  line-height: 1.7;
+  color: var(--muted);
+  letter-spacing: -0.2px;
+}
+.hero-actions {
+  display: flex;
+  justify-content: center;
+  gap: 13px;
+  margin-top: 30px;
+}
+.button {
+  padding: 11px 21px;
+  border-radius: 7px;
+  display: inline-flex;
+  gap: 25px;
+  align-items: center;
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+}
+.button.primary {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+.button.primary:hover {
+  filter: brightness(1.1);
+}
+.button.quiet:hover {
+  background: var(--surface);
+}
+.platform-note {
+  margin-top: 17px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--subtle);
+}
+.platform-note > span {
+  margin: 0 8px;
+}
+.product-preview {
+  margin-top: 58px;
+  text-align: left;
+}
+.preview-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font: 9px var(--mono);
+  letter-spacing: 1.2px;
+  padding: 0 2px 14px;
+  color: var(--muted);
+}
+.preview-top > span:first-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.subtle {
+  color: var(--subtle);
+}
+.preview-app {
+  display: grid;
+  grid-template-columns: 210px 1fr;
+  border: 1px solid #41485f;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 28px 65px -40px #000;
+  background: #151620;
+  color: #d8dcee;
+  height: 436px;
+  --green: #a9c9a1;
+  --accent: #b4bffe;
+  --subtle: #8991aa;
+}
+.preview-sidebar {
+  display: flex;
+  flex-direction: column;
+  background: #1a1c28;
+  border-right: 1px solid #343848;
+  padding: 20px 13px;
+  font-size: 12px;
+}
+.preview-brand {
+  font: 500 12px var(--mono);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 6px 25px;
+}
+.mini-logo {
+  background: #b4bffe;
+  color: #151620;
+  padding: 3px 5px;
+  border-radius: 5px;
+}
+.micro {
+  font: 9px var(--mono);
+  color: #959db3;
+  letter-spacing: 1px;
+  margin: 0 10px 11px;
+}
+.project-row {
+  border-radius: 5px;
+  margin-bottom: 5px;
+  padding: 10px;
+}
+.project-row.current {
+  background: #282c3e;
+}
+.project-row small,
+.agent-line small {
+  display: block;
+  color: #9ba3ba;
+  font-size: 10px;
+  margin: 3px 0 0 18px;
+}
+.preview-agents {
+  border-top: 1px solid #343848;
+  margin-top: 27px;
+  padding-top: 19px;
+}
+.agent-line {
+  display: flex;
+  align-items: start;
+  gap: 8px;
+  padding: 0 10px;
+}
+.agent-line > .live-dot {
+  margin-top: 7px;
+}
+.agent-line small {
+  margin-left: 0;
+}
+.preview-bottom {
+  margin-top: auto;
+  color: #9ba3ba;
+  font-size: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.preview-bottom .live-dot {
+  width: 4px;
+  height: 4px;
+}
+.preview-terminals {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 6px;
+  padding: 7px;
+}
+.sample-terminal {
+  min-width: 0;
+  border: 1px solid #343848;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.agent-terminal {
+  grid-row: span 2;
+  border-color: #8198d2;
+}
+.terminal-title {
+  padding: 9px 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  border-bottom: 1px solid #2b2e3e;
+  font: 9px var(--mono);
+  color: #b1b8cc;
+}
+.terminal-title > span:last-child {
+  font-size: 8px;
+  color: #9ba3ba;
+  text-transform: uppercase;
+}
+.terminal-title .live-dot {
+  width: 4px;
+  height: 4px;
+  margin-right: 3px;
+}
+.terminal-content {
+  font: 11px/1.9 var(--mono);
+  padding: 16px 15px;
+}
+.terminal-content p {
+  margin-bottom: 8px;
+}
+.terminal-path {
+  color: #b4bffe;
+}
+.terminal-path > span {
+  color: #a9c9a1;
+  margin-left: 8px;
+}
+.prompt,
+.accent {
+  color: #b4bffe;
+}
+.agent-prompt {
+  background: #272b3e;
+  border-left: 2px solid #b4bffe;
+  margin-top: 27px !important;
+  padding: 10px 12px;
+}
+.output {
+  color: #a6aec6;
+  font-size: 10px;
+}
+.code-diff {
+  margin: 18px 0;
+  padding: 8px 0;
+  font-size: 9px;
+  color: #acd3a5;
+}
+.code-diff > span {
+  display: block;
+}
+.working {
+  font-size: 9px;
+  color: #b4bffe;
+}
+.working .subtle {
+  display: block;
+  margin-left: 12px;
+}
+.working .live-dot {
+  width: 4px;
+  height: 4px;
+}
+.file-change {
+  color: #ddc295;
+}
+.terminal-command {
+  margin-top: 18px !important;
+}
+.cursor-block {
+  display: inline-block;
+  width: 6px;
+  height: 12px;
+  vertical-align: middle;
+  background: #b4bffe;
+}
+.test-output {
+  font-size: 9px;
+}
+.test-output span,
+.success {
+  color: #acd3a5;
+}
+.success {
+  font-size: 10px;
+}
+.product-preview figcaption {
+  display: flex;
+  justify-content: space-between;
+  gap: 15px;
+  color: var(--subtle);
+  font: 10px var(--mono);
+  margin-top: 17px;
+}
+kbd {
+  font: 10px var(--mono);
+  border: 1px solid var(--border);
+  padding: 2px 5px;
+  border-radius: 4px;
+  color: var(--muted);
+}
+.harnesses {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 25px;
+  padding-block: 38px 42px;
+  border-bottom: 1px solid var(--border);
+}
+.harnesses > p {
+  font: 9px var(--mono);
+  letter-spacing: 1px;
+  max-width: 110px;
+  line-height: 1.8;
+  color: var(--subtle);
+}
+.harnesses ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px;
+  font-size: 15px;
+  font-weight: 550;
+  color: var(--muted);
+}
+.harnesses > span {
+  font-size: 10px;
+  color: var(--subtle);
+  line-height: 1.8;
+}
+.section {
+  padding-block: 85px;
+  border-bottom: 1px solid var(--border);
+}
+.section-heading {
+  margin-bottom: 36px;
+}
+.section-heading .eyebrow,
+.install-section .eyebrow {
+  margin-bottom: 18px;
+}
+h2 {
+  font-size: clamp(30px, 4vw, 45px);
+  letter-spacing: -1.8px;
+  line-height: 1.2;
+  font-weight: 500;
+}
+.section-heading > p:last-child:not(.eyebrow) {
+  margin-top: 19px;
+  color: var(--muted);
+  font-size: 15px;
+}
+.horizontal {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 30px;
+}
+.text-link {
+  font-size: 12px;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 3px;
+  white-space: nowrap;
+}
+.workflow-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-top: 1px solid var(--border);
+}
+.workflow-steps li {
+  display: flex;
+  gap: 35px;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  padding: 27px 8px;
+}
+.step-number {
+  font: 12px var(--mono);
+  color: var(--accent);
+}
+h3 {
+  font-size: 18px;
+  letter-spacing: -0.4px;
+  font-weight: 550;
+}
+.workflow-steps p {
+  color: var(--muted);
+  font-size: 14px;
+  max-width: 700px;
+  margin-top: 6px;
+}
+.step-symbol {
+  margin-left: auto;
+  font-size: 30px;
+  color: var(--accent);
+  padding-left: 20px;
+}
+.workflow-footnote {
+  font-size: 11px;
+  color: var(--subtle);
+  margin-top: 17px;
+}
+.features {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--border);
+}
+.features article {
+  padding: 30px 28px 30px 0;
+  border-bottom: 1px solid var(--border);
+}
+.features article:not(:nth-child(3n + 1)) {
+  padding-left: 28px;
+  border-left: 1px solid var(--border);
+}
+.feature-number {
+  font: 10px var(--mono);
+  color: var(--subtle);
+}
+.features h3 {
+  margin-top: 14px;
+  font-size: 17px;
+}
+.features p {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 10px;
+  line-height: 1.8;
+}
+.capture {
+  margin-top: 26px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.capture summary {
+  cursor: pointer;
+  padding: 15px 18px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.capture summary > span {
+  float: right;
+  color: var(--subtle);
+  font-size: 10px;
+}
+.capture figure {
+  border-top: 1px solid var(--border);
+  padding: 10px;
+}
+.capture img {
+  border-radius: 3px;
+}
+.capture figcaption {
+  font-size: 11px;
+  color: var(--muted);
+  padding: 10px 5px;
+}
+.install-section {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 65px;
+  align-items: center;
+}
+.install-section > div > p:not(.eyebrow) {
+  color: var(--muted);
+  font-size: 14px;
+  margin: 20px 0;
+}
+.install-card {
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--surface);
+  padding: 22px;
+  min-width: 0;
+}
+.install-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  gap: 25px;
+  margin-bottom: 23px;
+}
+.install-tabs button {
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  padding: 0 0 11px;
+  color: var(--muted);
+  font-size: 12px;
+}
+.install-tabs button[aria-selected="true"] {
+  color: var(--text);
+  border-color: var(--accent);
+}
+.install-panel h3 {
+  font-size: 16px;
+}
+.install-panel > p {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 7px;
+}
+.command-box {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 16px;
+  border-radius: 5px;
+  margin-top: 20px;
+  position: relative;
+}
+.command-box code {
+  display: block;
+  font: 11px/1.85 var(--mono);
+  overflow-wrap: anywhere;
+  color: var(--accent);
+  padding-bottom: 35px;
+  user-select: all;
+}
+.copy-button {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  padding: 4px 10px;
+  font-size: 10px;
+  color: var(--text);
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.copy-button:hover {
+  border-color: var(--accent);
+}
+.install-card .copy-status {
+  font-size: 11px;
+  min-height: 34px;
+  color: var(--green);
+  margin: 8px 0 !important;
+}
+.install-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font: 9px var(--mono);
+  padding-top: 13px;
+  border-top: 1px solid var(--border);
+}
+.install-footer > a {
+  margin-left: auto;
+}
+.install-card .install-disclosure {
+  font-size: 10px;
+  line-height: 1.7;
+  color: var(--subtle);
+  margin: 12px 0 0 !important;
+}
+.install-disclosure a {
+  text-decoration: underline;
+}
+.closing {
+  padding-block: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.closing p {
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: -0.8px;
+}
+.closing p > span {
+  color: var(--subtle);
+}
+.site-footer {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  border-top: 1px solid var(--border);
+  padding-block: 28px 38px;
+}
+.site-footer .brand {
+  font-size: 18px;
+}
+.site-footer p {
+  font-size: 11px;
+  color: var(--subtle);
+}
+.site-footer > div {
+  margin-left: auto;
+  display: flex;
+  gap: 20px;
+  font-size: 11px;
+  color: var(--muted);
+}
+@media (min-width: 1000px) {
+  #workflow {
+    display: grid;
+    grid-template-columns: 0.75fr 1.25fr;
+    gap: 0 65px;
+  }
+  #workflow .section-heading {
+    grid-row: span 2;
+  }
+  .workflow-steps li {
+    gap: 20px;
+  }
+  .workflow-steps p {
+    font-size: 13px;
+  }
+  .workflow-footnote {
+    grid-column: 2;
+  }
+}
+@media (max-width: 1000px) {
+  .wrap {
+    width: calc(100% - 64px);
+  }
+  .preview-app {
+    grid-template-columns: 170px 1fr;
+  }
+  .terminal-content {
+    padding: 12px 10px;
+    font-size: 10px;
+  }
+  .terminal-title {
+    padding: 8px;
+    font-size: 8px;
+  }
+  .terminal-title > span:last-child {
+    display: none;
+  }
+  .code-diff {
+    font-size: 8px;
+  }
+  .harnesses {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+  .harnesses > p {
+    max-width: none;
+  }
+  .harnesses > span {
+    display: none;
+  }
+  .harnesses ul {
+    gap: 24px;
+  }
+  .install-section {
+    gap: 35px;
+  }
+  .features h3 {
+    font-size: 16px;
+  }
+}
+@media (max-width: 700px) {
+  .wrap {
+    width: calc(100% - 36px);
+  }
+  .site-header {
+    height: 78px;
+  }
+  .brand {
+    font-size: 22px;
+  }
+  .brand svg {
+    width: 26px;
+  }
+  .site-header nav {
+    gap: 17px;
+    font-size: 11px;
+  }
+  .site-header nav > a:first-child {
+    display: none;
+  }
+  .hero {
+    padding-top: 54px;
+  }
+  h1 {
+    font-size: 56px;
+    letter-spacing: -3.4px;
+  }
+  .hero-description {
+    font-size: 16px;
+  }
+  .eyebrow {
+    font-size: 9px;
+    letter-spacing: 1px;
+  }
+  .product-preview {
+    margin-top: 42px;
+  }
+  .preview-top {
+    font-size: 8px;
+  }
+  .preview-top > span:last-child {
+    display: none;
+  }
+  .preview-app {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+  .preview-sidebar {
+    display: none;
+  }
+  .preview-terminals {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+  }
+  .agent-terminal {
+    grid-row: auto;
+    grid-column: span 2;
+  }
+  .agent-terminal .terminal-content {
+    padding: 15px;
+  }
+  .agent-prompt {
+    margin-top: 12px !important;
+  }
+  .code-diff {
+    margin: 8px 0;
+    font-size: 9px;
+  }
+  .working .subtle {
+    display: inline;
+    margin-left: 0;
+  }
+  .terminal-content {
+    font-size: 10px;
+  }
+  .preview-terminals .git-terminal,
+  .preview-terminals .test-terminal {
+    min-height: 180px;
+  }
+  .product-preview figcaption {
+    font-size: 8px;
+    align-items: center;
+  }
+  .caption-hint {
+    display: none;
+  }
+  .harnesses {
+    padding-block: 29px;
+    gap: 15px;
+  }
+  .harnesses > p {
+    width: 100%;
+    text-align: center;
+  }
+  .harnesses ul {
+    justify-content: center;
+    gap: 12px 22px;
+    font-size: 13px;
+  }
+  .section {
+    padding-block: 55px;
+  }
+  h2 {
+    font-size: 34px;
+    letter-spacing: -1.3px;
+  }
+  .section-heading {
+    margin-bottom: 25px;
+  }
+  .horizontal {
+    display: block;
+  }
+  .horizontal > .text-link {
+    display: inline-block;
+    margin-top: 20px;
+  }
+  .workflow-steps li {
+    gap: 20px;
+    padding: 24px 0;
+  }
+  .workflow-steps p {
+    font-size: 13px;
+  }
+  .step-symbol {
+    display: none;
+  }
+  .features {
+    grid-template-columns: 1fr 1fr;
+  }
+  .features article {
+    padding: 23px 18px 23px 0 !important;
+    border-left: 0 !important;
+  }
+  .features article:nth-child(even) {
+    border-left: 1px solid var(--border) !important;
+    padding-left: 18px !important;
+  }
+  .features h3 {
+    font-size: 16px;
+  }
+  .features p {
+    font-size: 12px;
+  }
+  .capture summary > span {
+    float: none;
+    display: block;
+    margin-top: 5px;
+  }
+  .install-section {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+  .install-card {
+    padding: 20px;
+  }
+  .closing {
+    padding-block: 38px;
+    gap: 20px;
+  }
+  .closing p {
+    font-size: 21px;
+  }
+  .closing > a {
+    font-size: 10px;
+  }
+  .site-footer {
+    gap: 13px;
+    flex-wrap: wrap;
+  }
+  .site-footer > div {
+    width: 100%;
+    margin-left: 0;
+  }
+  .site-footer p {
+    font-size: 10px;
+  }
+  .platform-note {
+    font-size: 9px;
+  }
+  .platform-note > span {
+    margin: 0 4px;
+  }
+}
+@media (max-width: 380px) {
+  h1 {
+    font-size: 48px;
+  }
+  .features {
+    grid-template-columns: 1fr;
+  }
+  .features article:nth-child(even) {
+    border-left: 0 !important;
+    padding-left: 0 !important;
+  }
+  .test-output {
+    font-size: 8px;
+  }
+  .working .subtle {
+    display: none;
+  }
+  .site-header nav {
+    gap: 12px;
+  }
+  .desktop-break {
+    display: none;
+  }
+  .button {
+    gap: 15px;
+    padding: 10px 15px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/website/tests/site.spec.ts
+++ b/website/tests/site.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "@playwright/test";
+
+test("page, base-prefixed assets, and expanded capture fit the viewport", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("response", (response) => {
+    if (
+      response.url().startsWith("http://127.0.0.1:4321") &&
+      response.status() >= 400
+    )
+      errors.push(response.url());
+  });
+  await page.goto("./");
+  await expect(page.getByRole("heading", { level: 1 })).toContainText(
+    "Keep the work.",
+  );
+  await page.getByText("See a real workspace capture").click();
+  const capture = page.locator(".capture img");
+  await expect(capture).toBeVisible();
+  await expect
+    .poll(() =>
+      capture.evaluate(
+        (img: HTMLImageElement) => img.complete && img.naturalWidth > 0,
+      ),
+    )
+    .toBeTruthy();
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+    ),
+  ).toBeTruthy();
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    "https://gardnmi.github.io/boomux/",
+  );
+  expect(errors).toEqual([]);
+});
+
+test("install selection preserves exact mode-specific commands and supports keyboard navigation", async ({
+  page,
+}) => {
+  await page.goto("./#install");
+  const desktop = page.getByRole("tab", { name: "Desktop + CLI" });
+  await expect(desktop).toHaveAttribute("aria-selected", "true");
+  await desktop.focus();
+  await page.keyboard.press("ArrowRight");
+  await expect(page.getByRole("tab", { name: "CLI only" })).toBeFocused();
+  await expect(page.locator("#install-desktop")).toBeHidden();
+  await expect(page.locator("#command-cli")).toHaveText(
+    "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/gardnmi/boomux/releases/latest/download/boomux-installer.sh | sh -s -- --cli",
+  );
+  await page.keyboard.press("Home");
+  await expect(page.locator("#install-desktop")).toBeVisible();
+  await expect(page.locator("#command-desktop")).toContainText(
+    "sh -s -- --desktop",
+  );
+});
+
+test("clipboard copies displayed command and reports denied access", async ({
+  page,
+}) => {
+  await page.goto("./#install");
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (value: string) => {
+          document.documentElement.dataset.copied = value;
+        },
+      },
+    });
+  });
+  await page
+    .getByRole("button", { name: "Copy desktop install command" })
+    .click();
+  expect(await page.locator("html").getAttribute("data-copied")).toEqual(
+    await page.locator("#command-desktop").textContent(),
+  );
+  await expect(page.getByRole("status")).toContainText("Copied.");
+  await page.evaluate(() =>
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async () => {
+          throw new Error("denied");
+        },
+      },
+    }),
+  );
+  await page
+    .getByRole("button", { name: "Copy desktop install command" })
+    .click();
+  await expect(page.getByRole("status")).toContainText("Select and copy");
+});
+
+test("theme persists and remains usable when storage is blocked", async ({
+  page,
+}) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "Use light theme" }).click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  await page.reload();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  await page.addInitScript(() => {
+    Storage.prototype.getItem = () => {
+      throw new Error("blocked");
+    };
+    Storage.prototype.setItem = () => {
+      throw new Error("blocked");
+    };
+  });
+  await page.reload();
+  await page.getByRole("button", { name: "Use light theme" }).click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+});
+
+test("both install commands and navigation work without JavaScript", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ javaScriptEnabled: false });
+  const page = await context.newPage();
+  await page.goto("http://127.0.0.1:4321/boomux/");
+  await expect(page.locator("#command-desktop")).toBeVisible();
+  await expect(page.locator("#command-cli")).toBeVisible();
+  await expect(page.locator("#install-tabs")).toBeHidden();
+  await page.getByRole("link", { name: "Get Boomux" }).click();
+  await expect(page).toHaveURL(/#install$/);
+  await context.close();
+});

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "astro/tsconfigs/strict" }


### PR DESCRIPTION
## Summary
- Present remote machines as remote workspaces, with clearer connection, update, uninstall, and forget controls.
- Refine Desktop settings, project-folder browsing, sidebar and Git presentation, and terminal attachment behavior.
- Install bundled harness integrations automatically on local and remote owners while preserving opt-outs and customizations.
- Reduce local Shell startup persistence work and eliminate the fixed connection acceptance delay without weakening recovery guarantees.
- Add a static project website with dedicated build and browser-test CI.

## Validation
- Root and Desktop compile checks and formatting passed during implementation.
- Focused protocol, client negotiation, rollback, environment privacy, cold recovery, attachment restart, permission, integration, and notification checks passed during implementation.
- All 45 CI-helper Python fixtures pass.
- Optimized isolated startup benchmarks are documented in docs/desktop/performance.md; disk-backed startup remains variable, while exact-run reattachment dropped from roughly 25 ms to 0.1 ms.
- Complete selected validation is delegated to PR CI. Final Desktop visual behavior and remote end-to-end latency are not independently verified by the backend benchmarks.

## Notes
- Preserves existing state recovery and persistence-before-event guarantees.
- GitHub Pages must be enabled separately before website deployment; no repository Pages setting has been changed.