### PR TITLE
test: wait for executed output before web terminal attachment

### DIFF
--- a/tests/native_backend/mobile_web.rs
+++ b/tests/native_backend/mobile_web.rs
@@ -387,8 +387,10 @@ fn current_local_agent_from_any_harness_can_collaborate_from_web_terminal() {
     drop(pty.slave);
     let mut native_reader = pty.master.try_clone_reader().unwrap();
     let mut native_writer = pty.master.take_writer().unwrap();
+    // Match executed output, not input echoed before __attach enters raw mode.
+    // Input is forwarded only after the initial resize nudge has settled.
     native_writer
-        .write_all(b"printf 'native-before-web\\n'\n")
+        .write_all(b"printf 'native-%s-web\\n' before\n")
         .unwrap();
     read_terminal_until(native_reader.as_mut(), b"native-before-web");
 


### PR DESCRIPTION
The web-terminal native test could accept the PTY's echo of its readiness command before `__attach` entered raw mode. The web client could then connect during the native attachment's temporary 24-to-23-row resize nudge and fail its expected 24-row assertion, as in https://github.com/gardnmi/boomux/actions/runs/34303747934.

Split the readiness marker across printf's format and argument so only executed shell output satisfies the wait. Native input forwarding starts after resize resynchronization, preserving the existing attachment-size and resize-authority assertions.

Validation: the exact failing native test passes; focused rustfmt and `git diff --check` pass. Complete validation is left to PR CI.
