### PR TITLE
fix(desktop): show one update notice for the shared release

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -276,6 +276,8 @@ See [checklist details](../docs/install.md#harness-checklist).
 
 Desktop checks for stable releases after startup and every six hours.
 Checks do not download updates or restart anything.
+One **Boomux update available** notice covers Desktop and the CLI; dismissing
+it hides that release for both. Different detected versions share one version line.
 
 1. Choose **Update** to download and verify the complete bundle.
 2. Choose **Restart now** for a graceful handoff, or **Later** to keep working.

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1960,32 +1960,18 @@ impl Workspace {
                     .on_click(cx.listener(move |this, _, _, cx| {
                         if !this.update_busy {
                             this.dismissed_desktop_update = version.clone();
+                            this.dismissed_boomux_update = version.clone();
                             this.save_settings();
                             cx.notify();
                         }
                     })))
                 .into_any_element());
         }
-        for (index, notice, dismissed, name) in [
-            (
-                0usize,
-                &self.update_check.desktop,
-                &self.dismissed_desktop_update,
-                "Desktop",
-            ),
-            (
-                1,
-                &self.update_check.boomux,
-                &self.dismissed_boomux_update,
-                "Boomux",
-            ),
-        ] {
-            let Some(notice) = notice.as_ref().filter(|notice| notice.visible(dismissed)) else {
-                continue;
-            };
-            if index == 0 && self.prepared_update.is_some() {
-                continue;
-            }
+        if let Some(notice) = self.update_check.release_notice(
+            &self.dismissed_desktop_update,
+            &self.dismissed_boomux_update,
+        ) && self.prepared_update.is_none()
+        {
             let download_version = notice.latest.clone();
             let version = notice.latest.clone();
             let url = notice.url.clone();
@@ -2003,55 +1989,57 @@ impl Workspace {
                         div()
                             .text_sm()
                             .text_color(rgb(0xcdd6f4))
-                            .child(format!("{name} update available")),
+                            .child("Boomux update available"),
                     )
                     .child(
                         div()
                             .text_xs()
                             .text_color(rgb(0xa6adc8))
-                            .child(format!("{} → {}", notice.current, notice.latest)),
+                            .child(self.update_check.version_summary(notice)),
                     )
                     .child(
                         div()
                             .flex()
                             .gap_2()
                             .child(
-                                Self::settings_option(
-                                    ("view-update", index),
-                                    "View release",
-                                    false,
-                                )
-                                .on_click(cx.listener(move |_, _, _, cx| cx.open_url(&url))),
+                                Self::settings_option("view-update", "View release", false)
+                                    .on_click(cx.listener(move |_, _, _, cx| cx.open_url(&url))),
                             )
-                            .when(index == 0 && self.update_check.installable, |row| {
-                                row.child(
-                                    Self::settings_option(
-                                        "download-update",
-                                        if self.update_busy {
-                                            "Updating…"
-                                        } else {
-                                            "Update"
-                                        },
-                                        true,
+                            .when(
+                                self.update_check.installable
+                                    && self
+                                        .update_check
+                                        .desktop
+                                        .as_ref()
+                                        .is_some_and(|desktop| desktop.latest == notice.latest),
+                                |row| {
+                                    row.child(
+                                        Self::settings_option(
+                                            "download-update",
+                                            if self.update_busy {
+                                                "Updating…"
+                                            } else {
+                                                "Update"
+                                            },
+                                            true,
+                                        )
+                                        .on_click(
+                                            cx.listener(move |this, _, _, cx| {
+                                                this.download_update(download_version.clone(), cx)
+                                            }),
+                                        ),
                                     )
-                                    .on_click(cx.listener(
-                                        move |this, _, _, cx| {
-                                            this.download_update(download_version.clone(), cx)
-                                        },
-                                    )),
-                                )
-                            })
+                                },
+                            )
                             .child(
-                                Self::settings_option(("dismiss-update", index), "Dismiss", false)
-                                    .on_click(cx.listener(move |this, _, _, cx| {
-                                        if index == 0 {
-                                            this.dismissed_desktop_update = version.clone();
-                                        } else {
-                                            this.dismissed_boomux_update = version.clone();
-                                        }
+                                Self::settings_option("dismiss-update", "Dismiss", false).on_click(
+                                    cx.listener(move |this, _, _, cx| {
+                                        this.dismissed_desktop_update = version.clone();
+                                        this.dismissed_boomux_update = version.clone();
                                         this.save_settings();
                                         cx.notify();
-                                    })),
+                                    }),
+                                ),
                             ),
                     )
                     .into_any_element(),

--- a/desktop/src/updates.rs
+++ b/desktop/src/updates.rs
@@ -31,6 +31,36 @@ pub struct Check {
     pub prepared: Option<crate::bundle_update::Prepared>,
 }
 
+impl Check {
+    /// One release notice, even when a development install checks both binaries.
+    pub fn release_notice(
+        &self,
+        desktop_dismissed: &str,
+        boomux_dismissed: &str,
+    ) -> Option<&Notice> {
+        if self.prepared.is_some() {
+            return None;
+        }
+        self.boomux
+            .iter()
+            .chain(self.desktop.iter())
+            .max_by_key(|notice| Version::parse(&notice.latest).ok())
+            .filter(|notice| notice.visible(desktop_dismissed) && notice.visible(boomux_dismissed))
+    }
+
+    pub fn version_summary(&self, notice: &Notice) -> String {
+        if let (Some(desktop), Some(boomux)) = (&self.desktop, &self.boomux)
+            && desktop.current != boomux.current
+        {
+            return format!(
+                "Desktop {} · CLI {} → {}",
+                desktop.current, boomux.current, notice.latest
+            );
+        }
+        format!("{} → {}", notice.current, notice.latest)
+    }
+}
+
 pub fn valid_dismissal(text: &str) -> bool {
     text.is_empty() || (text.len() <= 64 && Version::parse(text).is_ok())
 }
@@ -164,6 +194,38 @@ pub fn check() -> Check {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn release_notice_unifies_components_and_honors_either_saved_dismissal() {
+        let check = Check {
+            desktop: notice("1.10.0", "v1.11.1", "boomux"),
+            boomux: notice("1.10.0", "v1.11.1", "boomux"),
+            ..Check::default()
+        };
+        let release = check.release_notice("", "").unwrap();
+        assert_eq!(check.version_summary(release), "1.10.0 → 1.11.1");
+        assert!(check.release_notice("1.11.1", "").is_none());
+        assert!(check.release_notice("", "1.11.1").is_none());
+        assert!(check.release_notice("1.11.0", "1.11.0").is_some());
+    }
+
+    #[test]
+    fn release_notice_retains_partial_checks_and_different_component_versions() {
+        let mut check = Check {
+            boomux: notice("1.9.0", "v1.12.0", "boomux"),
+            ..Check::default()
+        };
+        assert_eq!(check.release_notice("", "").unwrap().latest, "1.12.0");
+        check.desktop = notice("1.10.0", "v1.11.1", "boomux");
+        let release = check.release_notice("1.11.1", "").unwrap();
+        assert_eq!(release.latest, "1.12.0");
+        assert_eq!(
+            check.version_summary(release),
+            "Desktop 1.10.0 · CLI 1.9.0 → 1.12.0"
+        );
+        assert!(check.release_notice("", "1.12.0").is_none());
+        check.boomux = None;
+        assert_eq!(check.release_notice("", "").unwrap().latest, "1.11.1");
+    }
     #[test]
     fn only_newer_stable_releases_are_offered() {
         for tag in ["v0.1.0", "v0.0.9", "v0.2.0-beta.1", "bad", "v0.1.0+rebuild"] {


### PR DESCRIPTION
## Summary

- Present one Boomux release card instead of separate Desktop and CLI update cards.
- Apply dismissal to both components and honor existing version-specific dismissals.
- Preserve different detected component versions in one summary and retain partial-check results.
- Suppress available-update cards while a prepared update is present, and preserve installer eligibility checks.
- Document the unified notice behavior.

## Validation

- cargo check -p boomux-desktop --locked passed.
- All six focused updates::tests passed, including unified dismissal and partial/different-version discovery.
- Formatting and git diff --check passed.
- Live GUI appearance has not been manually checked.