### PR TITLE
docs: clarify stable desktop support and install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ The installer checks glibc and required graphics libraries; it does not install
 system packages. Rust and Zig are only needed for source builds.
 
 > [!NOTE]
-> Boomux Desktop is experimental. Its interface and supported feature set are
-> still evolving. See the [Desktop guide](desktop/README.md) for current limitations.
+> Stable Desktop releases support the Linux platforms listed above. Shells
+> persist when you close Desktop, but pane arrangements and window geometry are
+> not yet saved. See [current limitations](desktop/README.md#current-limitations)
+> for terminal features that remain incomplete.
 
 ## Get Into Your Flow
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -8,8 +8,10 @@ Ghostty’s terminal core, backed by persistent Boomux Shells.
 [Controls](#controls) · [Settings](#settings) · [Development](#run-from-source)
 
 > [!NOTE]
-> Desktop is experimental. Its interface and supported feature set are evolving.
-> See [current limitations](#current-limitations).
+> Stable Desktop releases support GNU/Linux x86_64 with glibc 2.39+, X11 or
+> Wayland, and a working Vulkan driver. Ubuntu 24.04+ and current Arch are the
+> runtime baseline. Shells persist when you close Desktop; pane arrangements
+> and window geometry are not yet saved. See [current limitations](#current-limitations).
 
 ## Install Release Builds
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -71,6 +71,7 @@ const features = [
           <div id="install-desktop" class="install-panel"><h3>Boomux Desktop</h3><p>The native app, with the matching Boomux CLI included.</p><div class="command-box"><code id="command-desktop">{install} --desktop</code><button type="button" class="copy-button" data-copy="command-desktop" aria-label="Copy desktop install command" hidden>Copy</button></div></div>
           <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
           <div class="install-footer"><span class="live-dot"></span> GNU/Linux · x86_64<a href={`${repo}/releases/latest`}>Release downloads ↗</a></div>
+          <p class="install-disclosure">Requires glibc 2.39+, X11 or Wayland, and a working Vulkan driver. Ubuntu 24.04+ and current Arch are the runtime baseline. <a href={`${repo}/blob/main/README.md#requirements`}>Required system packages ↗</a></p>
           <p class="install-disclosure">Downloads and runs the official release installer. <a href={`${repo}/blob/main/docs/install.md#integrity`}>Review how it works.</a> Existing installations use their update flow.</p>
         </div>
       </section>


### PR DESCRIPTION
Desktop documentation still describes the app as experimental, and the website install card omits its runtime requirements. Describe stable support using the existing Linux baseline, keep unsaved pane arrangements/window geometry and incomplete terminal features explicit, and show glibc 2.39+, X11/Wayland, Vulkan, and a runtime-package link beside the installer.

Validation: website production build passed; six focused desktop/mobile browser checks passed for viewport layout, the installer command, and navigation without JavaScript; links and claims reviewed; `git diff --check` passed.

The unified update notice is already merged separately in #385. This PR changes documentation and website copy only.
