### PR TITLE
feat(desktop): add an option to hide the layout overlay

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -112,7 +112,10 @@ header menu opens the same help.
 | Double-tap **Ctrl + Space** | Send Ctrl + Space to the terminal |
 | **Escape** | Leave layout mode |
 
-Layout mode shows a badge and dims the panes. Terminal output continues, but
+Layout mode shows a badge and dims the panes by default. Turn off **Layout
+overlay** in **Settings → Appearance** to keep terminal contents visible without
+the animated pane overlay. The choice saves automatically; the mode badge and
+layout controls remain available. Terminal output continues, but
 typing, paste, and terminal wheel input are blocked until you leave.
 Layout commands also work with Control held during the temporary chord.
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1489,6 +1489,7 @@ struct Workspace {
     pane_gap: f32,
     focus_highlight_strength: u8,
     motion_speed: MotionSpeed,
+    layout_overlay_visible: bool,
     workspace_pane_mode: WorkspacePaneMode,
     pane_layout_mode: PaneLayoutMode,
     minimized_shells: HashSet<String>,
@@ -1684,6 +1685,7 @@ impl Workspace {
             pane_gap: saved.pane_gap,
             focus_highlight_strength: saved.focus_highlight_strength,
             motion_speed: saved.motion_speed,
+            layout_overlay_visible: saved.layout_overlay_visible,
             workspace_pane_mode: saved.workspace_pane_mode,
             pane_layout_mode: saved.pane_layout_mode,
             minimized_shells: HashSet::new(),
@@ -1793,6 +1795,7 @@ impl Workspace {
                 pane_gap: self.pane_gap,
                 focus_highlight_strength: self.focus_highlight_strength,
                 motion_speed: self.motion_speed,
+                layout_overlay_visible: self.layout_overlay_visible,
                 workspace_pane_mode: self.workspace_pane_mode,
                 pane_layout_mode: self.pane_layout_mode,
                 confirm_destructive_actions: self.confirm_destructive_actions,
@@ -7887,6 +7890,21 @@ impl Workspace {
                             ),
                     ),
                 )
+                .child(Self::settings_toggle_row(
+                    "Layout overlay",
+                    "Dim terminals and show animated tiles in layout mode.",
+                    Self::settings_switch(
+                        "layout-overlay",
+                        "Layout overlay",
+                        self.layout_overlay_visible,
+                        true,
+                    )
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.layout_overlay_visible = !this.layout_overlay_visible;
+                        this.save_settings();
+                        cx.notify();
+                    })),
+                ))
                 .child(
                     Self::settings_field("Motion", "Speed of pane transitions.").child(
                         div()
@@ -9046,9 +9064,10 @@ impl Workspace {
                     .on_mouse_down(MouseButton::Middle, cx.listener(Self::paste_primary))
                     .child(self.boomux_body(id, cx))
                     .when(
-                        self.layout_mode
-                            || (self.layout_badge_exiting
-                                && self.motion_speed.duration().is_some()),
+                        self.layout_overlay_visible
+                            && (self.layout_mode
+                                || (self.layout_badge_exiting
+                                    && self.motion_speed.duration().is_some())),
                         |body| {
                             body.child(layout_badge::render_pane_overlay(
                                 self.theme,

--- a/desktop/src/settings.rs
+++ b/desktop/src/settings.rs
@@ -19,6 +19,7 @@ pub struct Settings {
     pub pane_gap: f32,
     pub focus_highlight_strength: u8,
     pub motion_speed: MotionSpeed,
+    pub layout_overlay_visible: bool,
     pub workspace_pane_mode: WorkspacePaneMode,
     pub pane_layout_mode: PaneLayoutMode,
     pub confirm_destructive_actions: bool,
@@ -38,6 +39,7 @@ impl Default for Settings {
             pane_gap: 8.0,
             focus_highlight_strength: 100,
             motion_speed: MotionSpeed::Smooth,
+            layout_overlay_visible: true,
             workspace_pane_mode: WorkspacePaneMode::Workspace,
             pane_layout_mode: PaneLayoutMode::default(),
             confirm_destructive_actions: true,
@@ -144,6 +146,9 @@ impl Settings {
                         _ => return Err(invalid()),
                     }
                 }
+                "layout_overlay_visible" => {
+                    s.layout_overlay_visible = value.as_bool().ok_or_else(invalid)?
+                }
                 "motion_speed" => {
                     s.motion_speed = match value.as_str() {
                         Some("instant") => MotionSpeed::Instant,
@@ -207,6 +212,10 @@ impl Settings {
             self.dismissed_boomux_update
         );
         encoded.push_str(&format!("sidebar_git_tab = {}\n", self.sidebar_git_tab));
+        encoded.push_str(&format!(
+            "layout_overlay_visible = {}\n",
+            self.layout_overlay_visible
+        ));
         encoded
     }
     fn save(&self, path: &Path) -> Result<(), String> {
@@ -320,10 +329,12 @@ mod tests {
             pane_gap: 0.0,
             motion_speed: MotionSpeed::Instant,
             pane_headings_visible: false,
+            layout_overlay_visible: false,
             ..Settings::default()
         };
         assert_eq!(Settings::parse(&settings.encode()).unwrap(), settings);
         assert_eq!(Settings::parse("").unwrap(), Settings::default());
+        assert!(Settings::parse("").unwrap().layout_overlay_visible);
         assert_eq!(Settings::default().pane_layout_mode, PaneLayoutMode::Tabbed);
         assert_eq!(
             Settings::parse("pane_layout_mode = 'tiled'")
@@ -346,6 +357,7 @@ mod tests {
             "focus_highlight_strength = -1",
             "motion_speed = 'slow'",
             "sidebar_visible = 'true'",
+            "layout_overlay_visible = 'false'",
             "unknown = 3",
             "broken[",
         ] {

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -64,8 +64,10 @@ Control-modified Layout bindings support navigation while holding the chord.
 Keys pressed in Layout are prevented from repeating into the terminal after
 release of the leader; releases for previously forwarded keys still reach their
 original pane. Output processing continues while each visible pane
-shows a dimming overlay and animated tile icon. Overlay removal shares the
-badge’s single cancelable exit task; it does not delay restoring input.
+shows a dimming overlay and animated tile icon by default. The saved
+`layout_overlay_visible` preference skips constructing these per-pane overlays
+when disabled, while retaining the mode badge and input behavior. Overlay removal
+shares the badge’s single cancelable exit task; it does not delay restoring input.
 
 ## Module Map
 

--- a/docs/desktop/releases.md
+++ b/docs/desktop/releases.md
@@ -207,6 +207,7 @@ Example preferences (omitted keys use defaults):
 ```toml
 pane_gap = 8
 motion_speed = "smooth" # instant, fast, smooth
+layout_overlay_visible = true # dim terminals and show tiles in layout mode
 pane_corner_style = "rounded" # rounded, square, mixed
 pane_headings_visible = true
 confirm_destructive_actions = true


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.100.0
Add **Settings → Appearance → Layout overlay** so users can keep terminal contents visible in layout mode. The toggle applies immediately and persists across restarts; existing settings default to enabled. Disabling it skips construction of the dimming overlays and their per-pane animations. The mode badge, layout controls, and terminal input routing remain available as before.

Validation: Desktop cargo check passed; all 15 tests selected by `settings::tests` passed, including preference round-trip/defaulting and malformed-value rejection; formatting and diff checks passed. Live GUI appearance has not been manually checked.


BEGIN_COMMIT_OVERRIDE
feat(desktop): add an option to hide the layout overlay
END_COMMIT_OVERRIDE
