### PR TITLE
fix(integrations): preserve harness failure reporting

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1366,14 +1366,17 @@ Boomux environment ensure the exact `(claude, session, shell, run)` Agent key.
 Subagent hooks retain the root `session_id` and therefore reduce into that Agent
 Instance rather than creating separate Agents.
 
-Session start, a completed foreground turn, and an API-error turn report Idle;
+Session start and a completed foreground turn report Idle;
 prompts, tool work, denied tool permissions, and subagent activity report
-Working; permission or user-input waits report Blocked; session end reports
-Inactive and never Done. A Stop with reported background tasks or session crons
+Working; permission or user-input waits and StopFailure report Blocked; session
+end reports Inactive and never Done. A Stop with reported background tasks or session crons
 remains Working. Reports use LifecycleIntegration authority and reuse the existing
 protocol Agent operations, so lifecycle reporting needs no Claude-specific wire
 request or durable state. Hook failures are fail-open for Claude Code and are
-written only to stderr.
+written only to stderr. StopFailure retains blocked attention even if SessionEnd
+subsequently reports Inactive or a new turn reports Working. Attention remains
+until acknowledged, following the common attention contract. A failed
+turn is not successful idle completion or permanent Session completion.
 
 While Remote Control is connected, Claude exposes
 `CLAUDE_CODE_BRIDGE_SESSION_ID` only to hook subprocesses. The hook synchronizes
@@ -1438,6 +1441,16 @@ timeout, bounded output, and the stable JSON envelope. Unclaimed Sessions are a
 no-op; Boomux, ancestry, claim, or version-gating failures are rate-limited and
 fail open so OpenCode continues. `run_changed` or runtime-generation replacement
 removes report authority rather than redirecting it.
+
+OpenCode's event callbacks are not awaited by the host. On hosts with plugin
+disposal support (source-verified at `1.18.29`), the server plugin's `dispose`
+hook drains already-queued lifecycle reports before shutdown. The total drain
+has a five-second deadline; late events and work still queued after the deadline
+are discarded, and an already-running command retains its own bounded deadline.
+This preserves observed error reports during short-lived `run` failures without
+polling or inferring completion from process exit. Disposal itself reports no
+lifecycle transition. Older hosts without this hook retain their existing
+best-effort event delivery.
 
 ### Pi Lifecycle Extension
 

--- a/docs/lifecycle-validation.md
+++ b/docs/lifecycle-validation.md
@@ -11,6 +11,105 @@ This record separates observed host behavior from reducer fixtures and intended
 semantics. Host compatibility is not inferred from process names, terminal
 output, or database recency.
 
+## 2026-09-09: installed harness smoke refresh
+
+Tested on Linux with a freshly built debug Boomux `1.11.1`, protocol `54`.
+Root and integration sources match `fd4c072` (also unchanged in `3ebbdb9`).
+Each probe used an empty temporary Git repository, a private daemon, and
+isolated home/config/state/runtime directories. Current integrations were
+explicitly installed in that fixture; this does **not** revalidate automatic
+installation, remote deployment, or Desktop presentation.
+
+Lifecycle evidence below comes from public `agent list` observations, joined
+to the exact Agent, external session, Shell, and ShellRun. Terminal output
+established the provider outcome only. Short-lived revisions missed by polling
+are not claimed as observed.
+
+### Live results
+
+| Harness | Tested version | Observed lifecycle | Limits |
+| --- | --- | --- | --- |
+| Pi | `0.85.1` | Successful OpenAI Codex `gpt-6-astra` print-mode turn: Working → Idle (`Pi agent settled`) → Inactive. Provider rejection: Idle → Working → Blocked → Inactive, retaining blocked attention. | Interactive permission waits, retry recovery, `/reload`, and session switching were not exercised. |
+| Codex | `0.153.4` | Successful `exec` turn: Idle → Working → Idle → Inactive. Real Ctrl+C during Working: Idle → Working → Idle (`Codex turn interrupted`) → Inactive. | Same-conversation follow-up after interruption, TUI conversation switching, subagents, and network-failure cancellation remain outside this smoke. |
+| Claude Code | `2.1.263` | Successful Haiku print-mode turn after refreshing login: Working → Idle → Inactive. Expired-login attempt: Working → Idle (`Claude turn failed`), with no blocked attention. | Permission dialogs, background tasks, subagents, Remote Control, and interactive interruption were not refreshed. |
+| OpenCode | `1.18.29` | Standalone `run` with `openai/gpt-6-astra`: Working → Idle. A failed free-provider run registered Idle → Working but never reported the failure to Boomux. | Shared Harness Runtime/TUI claims, permission recovery, subagents, and shutdown cleanup were not revalidated on this host version. |
+| Kiro CLI | `2.21.1` | Launch attempted with the current integration installed; the isolated host stopped at its sign-in prompt before registering an Agent. | No authenticated provider lifecycle claim for `2.21.1`; earlier `2.18.0` evidence below remains historical, not coverage for this version. |
+
+Successful prompts requested only `lifecycle-ok`, without tools. Pi's failure
+was an actual provider rejection of `gpt-5.4-mini` for the copied ChatGPT login,
+not an injected hook event. Its final assistant error produced Blocked before
+shutdown; the attention item survived the Inactive observation.
+
+Codex used the reviewed fixture hooks and invocation-local hook-trust bypass,
+with a read-only sandbox. Ctrl+C was sent through its PTY after an authoritative
+Working observation during a long, tool-free response. The exact Agent reported
+`Codex turn interrupted` at revision 3, then Inactive at revision 4. This closes
+the earlier **live Interrupt** evidence gap for `0.153.4`; it does not extend the
+claim to older hosts or every cancellation path.
+
+### Initial issues exposed by these probes
+
+The two failure-reporting issues below were subsequently fixed and replayed;
+see the follow-up evidence after this initial record. Kiro remains unvalidated.
+
+- **OpenCode failure can leave stale Working.** Selecting
+  `opencode/deepseek-v4-flash-free` failed with `UnknownError: Unexpected server
+  error`. The same error reproduced outside Boomux with a separate, plugin-free
+  configuration. Boomux did not cause that provider/host failure, but its Agent
+  remained at Working revision 2 after the ShellRun exited, without blocked
+  attention. A successful turn through another provider worked. The missing
+  failure observation needs host-event/adapter investigation; process exit must
+  not be used to manufacture permanent Agent completion.
+- **Claude authentication failure is not surfaced as blocked.** The expired
+  OAuth attempt exited with status 1. `StopFailure` produced Idle with evidence
+  `Claude turn failed`, no blocked attention, and no later Inactive observation
+  before fixture teardown. The Idle mapping is explicit in `claude_hooks.rs`,
+  not a missed Working hook. Decide and test failure-attention semantics and
+  failure-path shutdown handling; the successful refreshed-login run did emit
+  Inactive.
+- **Kiro still needs an authenticated isolated smoke.** No user login or running
+  session was modified to bypass this limit. Startup at a login prompt is not
+  evidence that provider-driven hooks work.
+
+### Checks and boundaries
+
+`cargo test --bin boomux _hooks::tests --locked` passed all 14 Claude, Codex,
+and Kiro hook-reducer tests. Bun `1.3.14` passed all 50 focused OpenCode plugin,
+OpenCode TUI, and Pi tests using the repository's `./integrations/...` paths.
+These fixtures do not replace the missing live scenarios listed above.
+
+The initial refresh made no runtime fixes and did not exercise remote machines,
+daemon handoff, notification delivery, forced crashes, or the full lifecycle
+matrix. Private fixture processes and copied authentication were cleaned up;
+existing user sessions were left alone.
+
+### Same-day failure-reporting fixes
+
+With the follow-up working-tree patch, OpenCode `1.18.29`'s same failed `run`
+reported Working → Blocked and retained blocked attention before process exit.
+A metadata-only event trace showed the host already emitted `session.error`
+with the exact Session ID and a model-not-found error. The report was lost
+because event callbacks were not awaited before shutdown, not because error
+classification was absent. OpenCode's
+[tagged plugin implementation](https://github.com/anomalyco/opencode/blob/v1.18.29/packages/opencode/src/plugin/index.ts)
+awaits `dispose`; Boomux now drains pending reports there with a five-second
+total limit. Trailing Idle events no longer replace the failure evidence.
+No lifecycle state is inferred from disposal or process exit.
+
+Claude Code `2.1.263`, run with no credentials in the private fixture, now
+reported Working → Blocked (`Claude turn failed`) with durable blocked attention.
+The host still did not emit SessionEnd on this authentication-failure path;
+Boomux leaves the failure visible instead of inventing inactivity. A native
+fixture verifies that a later SessionEnd can report Inactive and a later prompt
+can report Working on the same Agent, while preserving unacknowledged attention.
+
+Follow-up checks passed: `cargo check --locked`, formatting, six Claude reducer
+tests, the focused native Claude lifecycle/bridge test, and 44 OpenCode server/TUI
+tests. New shutdown cases cover standalone and shared report routing, unawaited
+errors, trailing Idle, idempotent disposal, deadline expiry, and fail-open daemon
+errors. Shared-host shutdown itself was not exercised live. No full suite or
+release build was run. These fixes do not close the other live-test limits above.
+
 ## 2026-09-06: combined Desktop update handoff
 
 Source `138e6d9` was tested on Linux x86_64, kernel `7.2.3-arch1-2`, glibc

--- a/integrations/opencode/boomux.js
+++ b/integrations/opencode/boomux.js
@@ -257,7 +257,9 @@ function reduce(state, action, isRootEvent) {
       break;
     case "idle":
       if (!isRootEvent) return undefined;
-      next = isBlocked(state) ? "blocked" : "idle";
+      // A trailing idle event cannot resolve a failure or overwrite its evidence.
+      if (isBlocked(state)) return undefined;
+      next = "idle";
       break;
     case "deleted": {
       if (isRootEvent) {
@@ -551,6 +553,7 @@ function createLifecycle({
   initialWorkingContexts = [],
   log = console.error,
   now,
+  disposeTimeoutMs = COMMAND_TIMEOUT_MS,
 }) {
   const environmentShellID = text(env?.BOOMUX_SHELL_ID);
   const environmentRunID = text(env?.BOOMUX_RUN_ID);
@@ -561,6 +564,9 @@ function createLifecycle({
   const roots = new Map();
   const reportError = rateLimitedLogger(log, now);
   let queue = Promise.resolve();
+  let accepting = true;
+  let abandoned = false;
+  let disposal;
 
   function tracked(rootID) {
     let value = roots.get(rootID);
@@ -580,6 +586,7 @@ function createLifecycle({
   }
 
   async function send(rootID, derived) {
+    if (abandoned) return;
     const item = tracked(rootID);
     if (item.disabled) return;
     try {
@@ -629,6 +636,7 @@ function createLifecycle({
           return;
         }
       }
+      if (abandoned) return;
       await run(
         reportArgv(
           item.agentID,
@@ -650,6 +658,7 @@ function createLifecycle({
   async function observe(item, paths) {
     if (!item.agentID || !item.shellID || !item.runID) return;
     for (const path of paths) {
+      if (abandoned) return;
       try {
         await run(
           observeWorkingContextArgv(
@@ -666,6 +675,7 @@ function createLifecycle({
   }
 
   async function handle(event) {
+    if (abandoned) return;
     const info = event?.properties?.info;
     if (info) resolver.remember(info);
     const action = classifyEvent(event);
@@ -707,12 +717,39 @@ function createLifecycle({
   }
 
   function enqueue(event) {
+    if (!accepting) return Promise.resolve();
     const pending = queue.then(() => handle(event));
     queue = pending.catch(reportError);
     return queue;
   }
 
-  return { enqueue, resolver, roots };
+  function dispose() {
+    if (disposal) return disposal;
+    accepting = false;
+    // OpenCode does not await event callbacks, but does await plugin disposal.
+    // Drain already-observed lifecycle evidence before a short-lived run exits.
+    // Cap the total wait, not just each individual subprocess's deadline.
+    disposal = (async () => {
+      let timer;
+      try {
+        await Promise.race([
+          queue,
+          new Promise((resolve) => {
+            timer = setTimeout(() => {
+              abandoned = true;
+              reportError(new Error("lifecycle shutdown drain timed out"));
+              resolve();
+            }, disposeTimeoutMs);
+          }),
+        ]);
+      } finally {
+        clearTimeout(timer);
+      }
+    })();
+    return disposal;
+  }
+
+  return { enqueue, dispose, resolver, roots };
 }
 
 function hookEvent(type, input) {
@@ -732,6 +769,7 @@ export async function BoomuxOpenCodePlugin({ client, directory, worktree }) {
   });
   return {
     event: ({ event }) => lifecycle.enqueue(event),
+    dispose: () => lifecycle.dispose(),
     "chat.message": (input) =>
       lifecycle.enqueue(hookEvent("chat.message", input)),
     "tool.execute.before": (input) =>

--- a/integrations/opencode/boomux.test.js
+++ b/integrations/opencode/boomux.test.js
@@ -83,6 +83,75 @@ function successfulEnsure(
   };
 }
 
+describe("lifecycle shutdown", () => {
+  for (const environment of [env, { BOOMUX_OPENCODE_SHARED_GENERATION: "generation" }]) {
+    test(`drains an unawaited error before disposal (${environment === env ? "standalone" : "shared"})`, async () => {
+      const calls = [];
+      let release;
+      const gate = new Promise((resolve) => { release = resolve; });
+      const lifecycle = createLifecycle({
+        client: {}, env: environment, log: () => {},
+        run: async (argv) => {
+          calls.push(argv);
+          if (calls.length === 1) await gate;
+          return successfulEnsure("agent", "idle", "OpenCode root session created");
+        },
+      });
+      void lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+      void lifecycle.enqueue(event("session.error", { sessionID: "root", error: { message: "model unavailable" } }));
+      void lifecycle.enqueue(event("session.idle", { sessionID: "root" }));
+      const disposal = lifecycle.dispose();
+      expect(lifecycle.dispose()).toBe(disposal);
+      let finished = false;
+      void disposal.then(() => { finished = true; });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(finished).toBe(false);
+      release();
+      await disposal;
+      expect(calls.at(-1)[calls.at(-1).indexOf("--state") + 1]).toBe("blocked");
+      expect(lifecycle.roots.get("root").reducer.lastState).toBe("blocked");
+      expect(lifecycle.roots.get("root").reducer.lastEvidence).toBe("OpenCode error: model unavailable");
+      const count = calls.length;
+      await lifecycle.enqueue(event("chat.message", { sessionID: "root" }));
+      expect(calls).toHaveLength(count);
+    });
+  }
+
+  test("caps the drain and abandons queued work after the deadline", async () => {
+    let release;
+    const gate = new Promise((resolve) => { release = resolve; });
+    const calls = [];
+    const errors = [];
+    const lifecycle = createLifecycle({
+      client: {}, env, disposeTimeoutMs: 5, log: (error) => errors.push(error),
+      run: async (argv) => {
+        calls.push(argv);
+        await gate;
+        return successfulEnsure("agent", "idle", "OpenCode root session created");
+      },
+    });
+    void lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    const pending = lifecycle.enqueue(event("session.error", { sessionID: "root", error: { message: "failed" } }));
+    await lifecycle.dispose();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("shutdown drain timed out");
+    release();
+    await pending;
+    expect(calls).toHaveLength(1);
+  });
+
+  test("report failure remains fail-open during disposal", async () => {
+    const errors = [];
+    const lifecycle = createLifecycle({
+      client: {}, env, log: (error) => errors.push(error),
+      run: async () => { throw new Error("daemon unavailable"); },
+    });
+    void lifecycle.enqueue(event("session.created", { info: { id: "root" } }));
+    await lifecycle.dispose();
+    expect(errors).toHaveLength(1);
+  });
+});
+
 describe("event mapping and reducer", () => {
   test("extracts only structured allowlisted working-context paths", () => {
     expect(
@@ -211,9 +280,10 @@ describe("event mapping and reducer", () => {
       ).state,
     ).toBe("blocked");
     expect(
-      reduce(state, { kind: "idle", sessionID: "root", evidence: "idle" }, true)
-        .state,
-    ).toBe("blocked");
+      reduce(state, { kind: "idle", sessionID: "root", evidence: "idle" }, true),
+    ).toBeUndefined();
+    expect(state.lastState).toBe("blocked");
+    expect(state.lastEvidence).toBe("error");
     expect(
       reduce(
         state,

--- a/src/claude_hooks.rs
+++ b/src/claude_hooks.rs
@@ -127,7 +127,7 @@ fn reduce(input: HookInput) -> Option<LifecycleObservation> {
             (AgentState::Working, "Claude background work active")
         }
         HookEvent::Stop => (AgentState::Idle, "Claude session idle"),
-        HookEvent::StopFailure => (AgentState::Idle, "Claude turn failed"),
+        HookEvent::StopFailure => (AgentState::Blocked, "Claude turn failed"),
         HookEvent::SessionEnd if in_subagent => {
             (AgentState::Working, "Claude subagent session ended")
         }
@@ -186,7 +186,7 @@ mod tests {
                 "Claude subagent stopped",
             ),
             ("Stop", AgentState::Idle, "Claude session idle"),
-            ("StopFailure", AgentState::Idle, "Claude turn failed"),
+            ("StopFailure", AgentState::Blocked, "Claude turn failed"),
             (
                 "SessionEnd",
                 AgentState::Inactive,

--- a/tests/native_backend/agents_sessions.rs
+++ b/tests/native_backend/agents_sessions.rs
@@ -128,6 +128,23 @@ fn claude_hook_reports_lifecycle_and_synchronizes_ephemeral_bridge_binding() {
             .is_none()
     );
 
+    run_hook("StopFailure", None);
+    let failed = daemon.client.get_agent(&agent.id).unwrap();
+    assert_eq!(failed.observation.state, AgentState::Blocked);
+    let attention = failed.attention.unwrap();
+    assert_eq!(attention.reason, protocol::AgentAttentionReason::Blocked);
+    assert!(failed.ended_at_ms.is_none());
+
+    run_hook("SessionEnd", None);
+    let inactive = daemon.client.get_agent(&agent.id).unwrap();
+    assert_eq!(inactive.observation.state, AgentState::Inactive);
+    assert_eq!(inactive.attention, Some(attention.clone()));
+
+    run_hook("UserPromptSubmit", None);
+    let resumed = daemon.client.get_agent(&agent.id).unwrap();
+    assert_eq!(resumed.observation.state, AgentState::Working);
+    assert_eq!(resumed.attention, Some(attention));
+
     daemon.stop_with_cli();
 }
 


### PR DESCRIPTION
## Summary

- Drain queued OpenCode lifecycle events during plugin disposal with a five-second total deadline, preserving error evidence across trailing idle events.
- Report Claude StopFailure as Blocked with durable attention; preserve existing acknowledgement and resumability semantics.
- Refresh version-specific lifecycle evidence for all five harnesses and explicitly record remaining live-test limits.

## Validation

- cargo check --locked
- cargo fmt --all -- --check
- Six Claude reducer tests and the focused serial native Claude lifecycle/bridge test passed.
- 44 OpenCode server/TUI tests passed, including shutdown draining, timeout, and fail-open coverage.
- Live OpenCode 1.18.29 failure and Claude Code 2.1.263 authentication failure both reported Blocked after the fixes in an isolated daemon.
- Private fixture daemon stopped and copied credentials removed. Existing user sessions untouched.

## Boundaries

No protocol or persistence changes, no idle polling, and no inference of completion from process exit. Kiro 2.21.1 authenticated provider behavior remains unvalidated. Shared-host disposal and the complete lifecycle matrix were not replayed live; selected CI owns comprehensive validation.
BEGIN_COMMIT_OVERRIDE
fix(integrations): preserve harness failure reporting
END_COMMIT_OVERRIDE
