### PR TITLE
feat(desktop): remove workspaces with no shells

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -40,6 +40,13 @@ The launcher starts or reuses the Boomux service automatically.
 
 ## Workspaces And Shells
 
+Desktop automatically removes Workspaces that have no Shells, including empty
+entries left from earlier use. Opening a project again creates a fresh Workspace;
+project shortcuts and files on disk are preserved. Workspace-specific launchers,
+folder defaults, and retained Agent history are removed with the Workspace.
+Exited Shells still count as Shells until explicitly removed. Unavailable remote
+Workspaces remain visible until their owning machine can confirm they are empty.
+
 | To… | Use… |
 | --- | --- |
 | Create a Workspace | **+ → New workspace** |

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -5036,7 +5036,7 @@ impl Workspace {
             loop {
                 cx.background_executor().timer(Duration::from_secs(1)).await;
                 let result = cx
-                    .background_spawn(async { terminal::discover_overview_and_nodes() })
+                    .background_spawn(async { terminal::refresh_overview_and_nodes() })
                     .await;
                 let mut removed_setup_shells = Vec::new();
                 let mut setup_workspace_cleanups = Vec::new();

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -620,6 +620,89 @@ pub fn discover_overview() -> Result<BoomuxOverview, String> {
     discover_overview_and_nodes().0
 }
 
+/// Desktop refresh policy, separate from read-only discovery. Only the owner
+/// can confirm emptiness; the guarded close rejects concurrent Shell creation.
+pub fn refresh_overview_and_nodes() -> (
+    Result<BoomuxOverview, String>,
+    Result<Vec<crate::nodes::NodeView>, String>,
+) {
+    let (mut overview, nodes) = discover_overview_and_nodes();
+    if let Ok(current) = &mut overview {
+        let candidates = current
+            .workspaces
+            .iter()
+            .filter(|workspace| {
+                workspace.shells.is_empty()
+                    && crate::remote::identity(&workspace.id).is_none_or(|id| {
+                        nodes.as_ref().is_ok_and(|nodes| {
+                            nodes
+                                .iter()
+                                .any(|node| node.id == id.node_id && node.connected())
+                        })
+                    })
+            })
+            .take(8)
+            .map(|workspace| workspace.id.clone())
+            .collect::<Vec<_>>();
+        if !candidates.is_empty() {
+            let cleanup = (|| {
+                let client = client::connect_if_running()
+                    .map_err(|error| error.to_string())?
+                    .ok_or("Boomux is not running")?;
+                for id in candidates {
+                    if close_empty_workspace(&client, &id).map_err(|error| error.to_string())? {
+                        current.workspaces.retain(|workspace| workspace.id != id);
+                    }
+                }
+                Ok::<_, String>(())
+            })();
+            if let Err(error) = cleanup {
+                overview = Err(format!("Could not remove empty Workspace: {error}"));
+            }
+        }
+    }
+    (overview, nodes)
+}
+
+fn close_empty_workspace(client: &Client, id: &str) -> Result<bool, client::ClientError> {
+    use boomux::protocol::{RoutedOperation, RoutedOperationResult};
+    let result = (|| {
+        let workspace = crate::remote::workspace(client, id)?;
+        if !workspace.shells.is_empty() {
+            return Ok(false);
+        }
+        if let Some(owner) = crate::remote::identity(id) {
+            match client.route_node_operation(
+                owner.node_id,
+                RoutedOperation::CloseWorkspace {
+                    workspace_id: owner.inner_id,
+                    expected_revision: workspace.revision,
+                },
+            )? {
+                RoutedOperationResult::Ok => Ok(true),
+                _ => Ok(false),
+            }
+        } else {
+            match client.request(Request::GuardedCloseWorkspace {
+                workspace_id: workspace.id,
+                expected_revision: workspace.revision,
+            })? {
+                Response::Ok => Ok(true),
+                _ => Ok(false),
+            }
+        }
+    })();
+    match result {
+        Err(client::ClientError::Remote(error)) if error.code == Some(ErrorCode::NotFound) => {
+            Ok(true)
+        }
+        Err(client::ClientError::Remote(error)) if error.code == Some(ErrorCode::RevisionAhead) => {
+            Ok(false)
+        }
+        result => result,
+    }
+}
+
 fn discover_local_overview() -> Result<BoomuxOverview, String> {
     let Some(client) = client::connect_if_running()
         .map_err(|error| format!("could not connect to Boomux: {error}"))?
@@ -2667,6 +2750,80 @@ mod tests {
         super::reconnect(&client, &shell.id, Some("run"), &profile).unwrap();
         server.join().unwrap();
         std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn empty_workspace_cleanup_rechecks_shells_and_rejects_concurrent_changes() {
+        use boomux::protocol::{self, Envelope, ErrorCode, Request, Response};
+        use std::os::unix::net::UnixListener;
+
+        for (has_shell, race) in [(true, false), (false, false), (false, true)] {
+            let directory =
+                std::env::temp_dir().join(format!("desktop-empty-cleanup-{}", fastrand::u64(..)));
+            std::fs::create_dir(&directory).unwrap();
+            let socket = directory.join("daemon.sock");
+            let listener = UnixListener::bind(&socket).unwrap();
+            let mut workspace = setup_workspace_creation();
+            if !has_shell {
+                workspace.shells.clear();
+            }
+            workspace.revision = 7;
+            let (finished_sender, finished_receiver) = std::sync::mpsc::channel();
+            let server = std::thread::spawn(move || {
+                let mut exchanges = vec![(
+                    Request::GetWorkspace {
+                        workspace_id: workspace.id.clone(),
+                    },
+                    Response::Workspace { workspace },
+                )];
+                if !has_shell {
+                    exchanges.push((
+                        Request::GuardedCloseWorkspace {
+                            workspace_id: "created-workspace".into(),
+                            expected_revision: 7,
+                        },
+                        if race {
+                            Response::Error {
+                                code: Some(ErrorCode::RevisionAhead),
+                                message: "Shell added after inspection".into(),
+                            }
+                        } else {
+                            Response::Ok
+                        },
+                    ));
+                }
+                for (expected, response) in exchanges {
+                    let (mut stream, _) = listener.accept().unwrap();
+                    stream
+                        .set_read_timeout(Some(Duration::from_secs(2)))
+                        .unwrap();
+                    let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                    assert_eq!(request.message, expected);
+                    protocol::write_message(
+                        &mut stream,
+                        &Envelope::with_version(request.version, response),
+                    )
+                    .unwrap();
+                }
+                finished_receiver
+                    .recv_timeout(Duration::from_secs(2))
+                    .unwrap();
+                listener.set_nonblocking(true).unwrap();
+                assert!(
+                    listener.accept().is_err(),
+                    "never retry an empty-workspace close after a race"
+                );
+            });
+            let result = super::close_empty_workspace(
+                &boomux::client::Client::from_socket_path(socket),
+                "created-workspace",
+            )
+            .unwrap();
+            assert_eq!(result, !has_shell && !race);
+            finished_sender.send(()).unwrap();
+            server.join().unwrap();
+            std::fs::remove_dir_all(directory).unwrap();
+        }
     }
 
     #[test]

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -69,6 +69,14 @@ shows a dimming overlay and animated tile icon by default. The saved
 when disabled, while retaining the mode badge and input behavior. Overlay removal
 shares the badge’s single cancelable exit task; it does not delay restoring input.
 
+Desktop's existing background overview refresh removes Workspaces with no Shells,
+including entries found on startup. Read-only discovery remains separate. Each
+pass considers at most eight candidates, skips unavailable remote Nodes, reads
+the exact Workspace from its owner, and closes it at that observed revision.
+Concurrent changes reject the close without an unguarded fallback. Exited and
+pending Shells prevent cleanup. This Desktop policy removes Workspace metadata
+and history but does not remove project shortcuts or filesystem contents.
+
 ## Module Map
 
 - `src/main.rs`: application model, Boomux sidebar projection, input routing,


### PR DESCRIPTION
Desktop currently retains empty Workspace cards after their Shells are removed. Remove Workspaces with zero Shells during the existing background refresh, including empty entries from previous use. Opening a project creates a fresh Workspace; project shortcuts and files remain intact. Workspace-owned defaults, launchers, and Agent history are removed with the Workspace. Exited and pending Shells prevent cleanup.

Cleanup processes at most eight candidates per refresh, skips unavailable remote Nodes, rechecks the exact Workspace at its owner, and uses a revision-guarded close. A concurrent change prevents deletion without an unguarded fallback. Read-only discovery remains separate from this Desktop policy.

Validation: Desktop cargo check passed; the focused socket fixture passed for a populated Workspace, successful empty cleanup, and rejection of concurrent changes without retry. Formatting and diff checks passed. Live Desktop and remote-owner cleanup have not been manually exercised.
