### PR TITLE
feat(desktop): add configurable copy on select and fix selection anchoring

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,7 +106,12 @@ before comparing the same workload.
 The helper builds both executables, sets a matching CLI PATH, and uses Boomux-only
 runtime/config/state directories under `target/desktop-dev/`. It sets
 `BOOMUX_RUNTIME_DIR`, `BOOMUX_CONFIG_HOME`, and `BOOMUX_STATE_HOME` instead of
-changing XDG variables. These override only Boomux's corresponding XDG roots
+changing XDG variables. When a worktree path would exceed the Unix socket path
+limit, the helper uses a
+private `/tmp/boomux-dev-<uid>-<worktree-hash>` runtime directory instead; config
+and state remain under `target/desktop-dev/`. The runtime path is stable for that
+worktree and shared by debug and release launches.
+These override only Boomux's corresponding XDG roots
 (including Desktop settings); terminal applications retain normal configuration,
 plugins, credentials, and desktop runtime services. Closing the window
 keeps these development sessions alive. After rebuilding, the helper starts an

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -264,6 +264,11 @@ system clipboard when you release the left mouse button. It defaults to on and
 changes take effect immediately. Disable it to copy only with the manual copy
 shortcut. Middle-click paste continues to use the primary selection either way.
 The preference is saved as `copy_on_select = true` in Desktop's settings file.
+Desktop shows a brief **Copied** indicator in the source pane after automatic or
+manual selection copying. It does not watch the clipboard or add notifications
+for copies performed by a harness. Left-drag selection is currently local to
+Desktop; mouse-wheel reporting is separate, so the same selection gesture does
+not also invoke a harness's mouse-based copy handler.
 
 ### Themes And Saved Preferences
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -171,7 +171,7 @@ Outside layout mode, ordinary typing and control keys reach the Shell.
 
 | Shortcut | Action |
 | --- | --- |
-| Left-drag over text | Select visible cells; publish to the primary clipboard |
+| Left-drag over text | Select visible cells; copy to the clipboard on release by default |
 | **Ctrl + Shift + C / V** | Copy / paste the system clipboard |
 | Middle click | Paste the Linux primary selection |
 | Mouse wheel | Scroll retained history |
@@ -251,12 +251,19 @@ a service restart produce one reminder after you finish editing.
 | Layout | Tree/Tabs, Workspace/Mixed scope, pane headings |
 | Appearance | Rounded/square/mixed corners, pane spacing, focus emphasis |
 | Motion | Instant, Fast, or Smooth — the default |
+| Clipboard | Copy on select (enabled by default) |
 | Projects | Browse for folders and set search depth |
 | Notifications | Desktop and sound notifications |
 | Advanced | Open service configuration or optional terminal setup |
 
 Motion affects swaps, reflow, minimize/restore, floating transitions, and
 Workspace switches. Zero pane spacing removes gaps and canvas insets.
+
+**Settings → Clipboard → Copy on select** copies selected terminal text to the
+system clipboard when you release the left mouse button. It defaults to on and
+changes take effect immediately. Disable it to copy only with the manual copy
+shortcut. Middle-click paste continues to use the primary selection either way.
+The preference is saved as `copy_on_select = true` in Desktop's settings file.
 
 ### Themes And Saved Preferences
 

--- a/desktop/scripts/run-dev.py
+++ b/desktop/scripts/run-dev.py
@@ -2,10 +2,29 @@
 """Build and open Desktop against this worktree's isolated development daemon."""
 
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
 import subprocess
+import stat
+
+
+def runtime_directory(root):
+    path = root / "target/desktop-dev/runtime_dir"
+    if len(os.fsencode(path / "boomux/daemon.sock")) >= 108:
+        identity = hashlib.sha256(os.fsencode(root)).hexdigest()[:20]
+        path = Path("/tmp") / f"boomux-dev-{os.getuid()}-{identity}"
+    return path
+
+
+def prepare_runtime_directory(path):
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    metadata = path.lstat()
+    if (not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or stat.S_IMODE(metadata.st_mode) & 0o077):
+        raise RuntimeError(f"Development runtime must be an owned private directory: {path}")
 
 
 def main():
@@ -19,15 +38,22 @@ def main():
     env = {key: value for key, value in os.environ.items() if not key.startswith("BOOMUX_")}
     # Only Boomux reads these overrides. Terminal applications retain the user's
     # XDG configuration, data, cache, runtime services, and authentication.
-    for name in ["RUNTIME_DIR", "CONFIG_HOME", "STATE_HOME"]:
+    for name in ["CONFIG_HOME", "STATE_HOME"]:
         path = root / "target/desktop-dev" / name.lower()
         path.mkdir(parents=True, exist_ok=True, mode=0o700)
         env[f"BOOMUX_{name}"] = str(path)
+    runtime = runtime_directory(root)
+    prepare_runtime_directory(runtime)
+    env["BOOMUX_RUNTIME_DIR"] = str(runtime)
     env["PATH"] = str(target) + os.pathsep + env.get("PATH", "")
     print(f"Development runtime: {env['BOOMUX_RUNTIME_DIR']}", flush=True)
     cli = target / "boomux"
-    status = subprocess.run([cli, "daemon", "status", "--json"], env=env,
-                            check=True, timeout=30, capture_output=True, text=True)
+    try:
+        status = subprocess.run([cli, "daemon", "status", "--json"], env=env,
+                                check=True, timeout=30, capture_output=True, text=True)
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr or error.stdout or str(error)
+        raise RuntimeError(f"Development daemon status failed: {detail.strip()}") from error
     state = json.loads(status.stdout)["data"]["status"]
     if state not in {"running", "stopped"}:
         raise RuntimeError(f"Unexpected development daemon status: {state}")

--- a/desktop/scripts/test-run-dev.py
+++ b/desktop/scripts/test-run-dev.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 import runpy
 import subprocess
+import stat
+import tempfile
 import unittest
 from unittest.mock import Mock, patch
 
@@ -27,7 +29,7 @@ class DevelopmentLaunchTests(unittest.TestCase):
             "XDG_CACHE_HOME": "/ordinary/cache-home",
             "HOME": "/ordinary/home", "KIRO_HOME": "/explicit/kiro",
             **({"GH_CONFIG_DIR": gh_config} if gh_config else {}),
-        }, clear=True), patch.object(Path, "mkdir"), \
+        }, clear=True), patch.object(Path, "mkdir"), patch.object(Path, "lstat", return_value=Mock(st_mode=stat.S_IFDIR | 0o700, st_uid=os.getuid())), \
                 patch("subprocess.run", side_effect=[Mock(), status, failure or Mock()]) as run, \
                 patch("os.execve") as execute:
             if failure:
@@ -45,7 +47,8 @@ class DevelopmentLaunchTests(unittest.TestCase):
             self.assertEqual(calls[1].args[0], [cli, "daemon", "status", "--json"])
             for call in calls[1:]:
                 env = call.kwargs["env"]
-                for name in ["RUNTIME_DIR", "CONFIG_HOME", "STATE_HOME"]:
+                self.assertEqual(env["BOOMUX_RUNTIME_DIR"], str(DEV["runtime_directory"](ROOT)))
+                for name in ["CONFIG_HOME", "STATE_HOME"]:
                     self.assertEqual(env[f"BOOMUX_{name}"], str(ROOT / "target/desktop-dev" / name.lower()))
                 self.assertEqual(env["XDG_RUNTIME_DIR"], "/ordinary/runtime")
                 for name in ["CONFIG", "STATE", "DATA", "CACHE"]:
@@ -59,6 +62,39 @@ class DevelopmentLaunchTests(unittest.TestCase):
                 self.assertTrue(call.kwargs["check"])
                 self.assertEqual(call.kwargs["timeout"], 30)
             return calls[-1].args[0]
+
+    def test_long_worktrees_get_short_stable_distinct_runtime_paths(self):
+        root = Path("/home/developer/Worktrees/boomux") / ("long-branch-" * 20)
+        path = DEV["runtime_directory"](root)
+        self.assertLess(len(os.fsencode(path / "boomux/daemon.sock")), 108)
+        self.assertEqual(path, DEV["runtime_directory"](root))
+        self.assertNotEqual(path, DEV["runtime_directory"](root / "other"))
+        self.assertEqual(DEV["runtime_directory"](Path("/short")),
+                         Path("/short/target/desktop-dev/runtime_dir"))
+
+    def test_status_failure_exposes_the_underlying_error(self):
+        failure = subprocess.CalledProcessError(1, "status", stderr="socket error details")
+        with patch("sys.argv", ["run-dev.py"]), patch.object(Path, "mkdir"), \
+                patch.object(Path, "lstat", return_value=Mock(st_mode=stat.S_IFDIR | 0o700, st_uid=os.getuid())), \
+                patch("subprocess.run", side_effect=[Mock(), failure]), \
+                patch("os.execve") as execute:
+            with self.assertRaisesRegex(RuntimeError, "socket error details"):
+                DEV["main"]()
+            execute.assert_not_called()
+
+    def test_runtime_rejects_symlinks_and_nonprivate_directories(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            private = root / "private"
+            DEV["prepare_runtime_directory"](private)
+            DEV["prepare_runtime_directory"](private)
+            link = root / "link"
+            link.symlink_to(private, target_is_directory=True)
+            with self.assertRaises(RuntimeError):
+                DEV["prepare_runtime_directory"](link)
+            private.chmod(0o755)
+            with self.assertRaises(RuntimeError):
+                DEV["prepare_runtime_directory"](private)
 
     def test_running_daemon_hands_off_to_the_exact_rebuilt_executable(self):
         self.assertEqual(self.launch("running"), [CLI, "daemon", "restart", "--executable", str(CLI), "--refresh-environment"])

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1480,6 +1480,8 @@ struct Workspace {
     pointer_drag: Option<PointerDrag>,
     terminal_scrollbar_drag: Option<TerminalScrollbarPointerDrag>,
     terminal_selection_release: Option<usize>,
+    copied_pane: Option<usize>,
+    copied_cleanup: Option<gpui::Task<()>>,
     layout_animation: Option<LayoutAnimation>,
     workspace_order_animation: Option<WorkspaceOrderAnimation>,
     floating_animation: Option<FloatingAnimation>,
@@ -1675,6 +1677,8 @@ impl Workspace {
             pointer_drag: None,
             terminal_scrollbar_drag: None,
             terminal_selection_release: None,
+            copied_pane: None,
+            copied_cleanup: None,
             layout_animation: None,
             workspace_order_animation: None,
             floating_animation: None,
@@ -3941,6 +3945,25 @@ impl Workspace {
         cx.notify();
     }
 
+    fn copy_terminal_text(&mut self, pane_id: usize, text: String, cx: &mut Context<Self>) {
+        // Feedback belongs only to Desktop-initiated copies. Do not observe the
+        // clipboard or react to harness output: those applications own their UI.
+        cx.write_to_clipboard(ClipboardItem::new_string(text));
+        self.copied_pane = Some(pane_id);
+        // Replacing the task cancels the old timeout, keeping rapid copies to a
+        // single indicator and one timer, with no clipboard content retained.
+        self.copied_cleanup = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(1500))
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.copied_pane = None;
+                cx.notify();
+            });
+        }));
+        cx.notify();
+    }
+
     fn copy_selection(&mut self, _: &CopySelection, _: &mut Window, cx: &mut Context<Self>) {
         let Some(text) = self.terminals.get(&self.focused).and_then(|pane| {
             Some(terminal_selected_text(
@@ -3951,7 +3974,7 @@ impl Workspace {
             return;
         };
         if !text.is_empty() {
-            cx.write_to_clipboard(ClipboardItem::new_string(text));
+            self.copy_terminal_text(self.focused, text, cx);
             cx.stop_propagation();
         }
     }
@@ -4189,13 +4212,15 @@ impl Workspace {
         cx: &mut Context<Self>,
     ) {
         if event.button == MouseButton::Left {
+            let source_pane = self.terminal_selection_release;
             let enabled = self.copy_on_select && !self.layout_mode && self.pointer_drag.is_none();
             if let Some(text) = take_terminal_selection_copy(
                 &mut self.terminal_selection_release,
                 &self.terminals,
                 enabled,
-            ) {
-                cx.write_to_clipboard(ClipboardItem::new_string(text));
+            ) && let Some(pane_id) = source_pane
+            {
+                self.copy_terminal_text(pane_id, text, cx);
             }
         }
         if self.sidebar_resizing {
@@ -9171,6 +9196,21 @@ impl Workspace {
                     }))
                     .on_mouse_down(MouseButton::Middle, cx.listener(Self::paste_primary))
                     .child(self.boomux_body(id, cx))
+                    .when(self.copied_pane == Some(id), |body| {
+                        body.child(
+                            div()
+                                .absolute()
+                                .bottom(px(12.0))
+                                .right(px(20.0))
+                                .px_3()
+                                .py_1()
+                                .rounded_md()
+                                .bg(rgb(0x313244))
+                                .text_color(rgb(0xa6e3a1))
+                                .text_sm()
+                                .child("Copied"),
+                        )
+                    })
                     .when(
                         self.layout_overlay_visible
                             && (self.layout_mode

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1348,6 +1348,22 @@ fn terminal_selected_text(screen: &TerminalScreen, selection: TerminalSelection)
         .join("\n")
 }
 
+// Consume a completed gesture once, even when automatic copying is disabled.
+// The source pane remains authoritative if focus changed during the drag.
+fn take_terminal_selection_copy(
+    pending: &mut Option<usize>,
+    panes: &HashMap<usize, TerminalPane>,
+    enabled: bool,
+) -> Option<String> {
+    let pane_id = pending.take()?;
+    if !enabled {
+        return None;
+    }
+    let pane = panes.get(&pane_id)?;
+    let text = terminal_selected_text(pane.screen.as_ref()?, pane.selection?);
+    (!text.is_empty()).then_some(text)
+}
+
 fn drop_placement(layout: &Node, point: (f32, f32)) -> Option<(usize, Axis, bool)> {
     let (id, rect) = layout.rects().into_iter().find(|(_, rect)| {
         point.0 >= rect.x
@@ -1463,6 +1479,7 @@ struct Workspace {
     floating: Vec<FloatingPane>,
     pointer_drag: Option<PointerDrag>,
     terminal_scrollbar_drag: Option<TerminalScrollbarPointerDrag>,
+    terminal_selection_release: Option<usize>,
     layout_animation: Option<LayoutAnimation>,
     workspace_order_animation: Option<WorkspaceOrderAnimation>,
     floating_animation: Option<FloatingAnimation>,
@@ -1516,6 +1533,7 @@ struct Workspace {
     focus_highlight_strength: u8,
     motion_speed: MotionSpeed,
     layout_overlay_visible: bool,
+    copy_on_select: bool,
     workspace_pane_mode: WorkspacePaneMode,
     pane_layout_mode: PaneLayoutMode,
     minimized_shells: HashSet<String>,
@@ -1656,6 +1674,7 @@ impl Workspace {
             git_panel: git_panel::Model::default(),
             pointer_drag: None,
             terminal_scrollbar_drag: None,
+            terminal_selection_release: None,
             layout_animation: None,
             workspace_order_animation: None,
             floating_animation: None,
@@ -1713,6 +1732,7 @@ impl Workspace {
             focus_highlight_strength: saved.focus_highlight_strength,
             motion_speed: saved.motion_speed,
             layout_overlay_visible: saved.layout_overlay_visible,
+            copy_on_select: saved.copy_on_select,
             workspace_pane_mode: saved.workspace_pane_mode,
             pane_layout_mode: saved.pane_layout_mode,
             minimized_shells: HashSet::new(),
@@ -1793,6 +1813,7 @@ impl Workspace {
         workspace.watch_updates(cx);
         cx.observe_window_activation(window, |this, window, cx| {
             if !window.is_window_active() {
+                this.terminal_selection_release = None;
                 this.layout_leader_release_task = None;
                 if this.layout_leader_pressed_at.take().is_some() && this.layout_leader_entered {
                     this.leave_layout_mode(cx);
@@ -1823,6 +1844,7 @@ impl Workspace {
                 focus_highlight_strength: self.focus_highlight_strength,
                 motion_speed: self.motion_speed,
                 layout_overlay_visible: self.layout_overlay_visible,
+                copy_on_select: self.copy_on_select,
                 workspace_pane_mode: self.workspace_pane_mode,
                 pane_layout_mode: self.pane_layout_mode,
                 confirm_destructive_actions: self.confirm_destructive_actions,
@@ -3871,6 +3893,7 @@ impl Workspace {
             return;
         }
         if let Some(pane) = self.terminals.get_mut(&pane_id) {
+            self.terminal_selection_release = None;
             pane.selection_anchor_position = Some(event.position);
             pane.selection = None;
             cx.notify();
@@ -3907,6 +3930,7 @@ impl Workspace {
             return;
         };
         pane.selection = Some(selection);
+        self.terminal_selection_release = Some(drag.pane_id);
         let selected = pane
             .selection
             .map(|selection| terminal_selected_text(screen, selection));
@@ -4035,6 +4059,7 @@ impl Workspace {
         if let Some(drag) = self.terminal_scrollbar_drag.clone() {
             if event.pressed_button != Some(MouseButton::Left) {
                 self.terminal_scrollbar_drag = None;
+                self.terminal_selection_release = None;
                 return;
             }
             let offset = scrollbar_offset_from_drag(
@@ -4163,6 +4188,16 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if event.button == MouseButton::Left {
+            let enabled = self.copy_on_select && !self.layout_mode && self.pointer_drag.is_none();
+            if let Some(text) = take_terminal_selection_copy(
+                &mut self.terminal_selection_release,
+                &self.terminals,
+                enabled,
+            ) {
+                cx.write_to_clipboard(ClipboardItem::new_string(text));
+            }
+        }
         if self.sidebar_resizing {
             self.finish_sidebar_resize();
             cx.notify();
@@ -5259,6 +5294,7 @@ impl Workspace {
         self.floating.clear();
         self.pointer_drag = None;
         self.terminal_scrollbar_drag = None;
+        self.terminal_selection_release = None;
         self.layout_animation = None;
         self.floating_animation = None;
         self.minimizing_panes.clear();
@@ -5381,6 +5417,7 @@ impl Workspace {
                 self.floating.clear();
                 self.pointer_drag = None;
                 self.terminal_scrollbar_drag = None;
+                self.terminal_selection_release = None;
                 self.layout_animation = None;
                 self.floating_animation = None;
                 self.minimizing_panes.clear();
@@ -8064,6 +8101,17 @@ impl Workspace {
                 .child(layout)
                 .child(Self::settings_category("Appearance"))
                 .child(appearance)
+                .child(Self::settings_category("Clipboard"))
+                .child(Self::settings_group().child(Self::settings_toggle_row(
+                    "Copy on select",
+                    "Copy selected terminal text to the clipboard when you release the mouse.",
+                    Self::settings_switch("copy-on-select", "Copy on select", self.copy_on_select, true)
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.copy_on_select = !this.copy_on_select;
+                            this.save_settings();
+                            cx.notify();
+                        })),
+                )))
                 .child(Self::settings_category("Notifications & sounds"))
                 .child(Self::settings_group().children(self.shared_settings_rows(&[0, 1, 2, 3, 4, 5], cx)))
                 .child(Self::settings_category("Recovery & history"))
@@ -11049,8 +11097,7 @@ mod pointer_tests {
         );
     }
 
-    #[test]
-    fn terminal_selection_extracts_rows_in_either_drag_direction() {
+    fn selection_test_screen() -> TerminalScreen {
         let cells = "abc efg "
             .chars()
             .map(|character| terminal::TerminalCell {
@@ -11065,7 +11112,7 @@ mod pointer_tests {
                 cursor: false,
             })
             .collect();
-        let screen = TerminalScreen {
+        TerminalScreen {
             rows: 2,
             cols: 4,
             cells,
@@ -11074,12 +11121,71 @@ mod pointer_tests {
             scroll_len: 2,
             images: Vec::new(),
             image_placements: Vec::new(),
-        };
+        }
+    }
+
+    #[test]
+    fn terminal_selection_extracts_rows_in_either_drag_direction() {
+        let screen = selection_test_screen();
         let selection = TerminalSelection {
             anchor: (1, 1),
             head: (0, 1),
         };
         assert_eq!(terminal_selected_text(&screen, selection), "bc\nef");
+    }
+
+    #[test]
+    fn terminal_selection_copy_on_release_is_optional_nonempty_and_once_per_gesture() {
+        let mut panes = HashMap::from([(
+            2,
+            TerminalPane {
+                screen: Some(Arc::new(selection_test_screen())),
+                selection: Some(TerminalSelection {
+                    anchor: (0, 1),
+                    head: (1, 1),
+                }),
+                ..TerminalPane::default()
+            },
+        )]);
+        let mut pending = Some(2);
+        assert_eq!(
+            take_terminal_selection_copy(&mut pending, &panes, true).as_deref(),
+            Some("bc\nef")
+        );
+        assert_eq!(pending, None);
+        assert_eq!(
+            take_terminal_selection_copy(&mut pending, &panes, true),
+            None
+        );
+        pending = Some(2);
+        assert_eq!(
+            take_terminal_selection_copy(&mut pending, &panes, false),
+            None
+        );
+        assert_eq!(pending, None);
+        // Disabling automatic copy preserves the selection for manual copying.
+        assert!(panes[&2].selection.is_some());
+        pending = Some(99);
+        assert_eq!(
+            take_terminal_selection_copy(&mut pending, &panes, true),
+            None
+        );
+        assert_eq!(pending, None);
+        panes.get_mut(&2).unwrap().selection = Some(TerminalSelection {
+            anchor: (0, 3),
+            head: (0, 3),
+        });
+        pending = Some(2);
+        assert_eq!(
+            take_terminal_selection_copy(&mut pending, &panes, true),
+            None
+        );
+        panes.get_mut(&2).unwrap().selection = None;
+        pending = Some(2);
+        assert_eq!(
+            take_terminal_selection_copy(&mut pending, &panes, true),
+            None
+        );
     }
 
     #[test]

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -14,7 +14,6 @@ mod updates;
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use boomux::protocol::AgentState;
@@ -937,7 +936,6 @@ struct TerminalScrollbarPointerDrag {
 #[derive(Clone)]
 struct TerminalSelectionDrag {
     pane_id: usize,
-    started: Arc<AtomicBool>,
 }
 
 #[derive(Clone)]
@@ -968,6 +966,34 @@ impl Render for WorkspaceRowDrag {
                     .text_color(rgb(0xcdd6f4))
                     .child(self.workspace_name.clone()),
             )
+    }
+}
+
+impl TerminalSelectionDrag {
+    fn selection(
+        &self,
+        pane_id: usize,
+        anchor: Option<gpui::Point<gpui::Pixels>>,
+        position: gpui::Point<gpui::Pixels>,
+        bounds: Bounds<gpui::Pixels>,
+        screen: &TerminalScreen,
+    ) -> Option<TerminalSelection> {
+        // GPUI dispatches drag moves to every listener of this type, including
+        // other panes. Only the source pane's bounds describe this selection.
+        if pane_id != self.pane_id {
+            return None;
+        }
+        let cell = |position: gpui::Point<gpui::Pixels>| {
+            terminal_cell_from_offset(
+                f32::from(position.x - bounds.left()),
+                f32::from(position.y - bounds.top()),
+                screen,
+            )
+        };
+        Some(TerminalSelection {
+            anchor: cell(anchor?),
+            head: cell(position),
+        })
     }
 }
 
@@ -1544,6 +1570,7 @@ struct TerminalPane {
     scrollbar_hovered: bool,
     scrollbar_fade_generation: u64,
     selection: Option<TerminalSelection>,
+    selection_anchor_position: Option<gpui::Point<gpui::Pixels>>,
     render_images: HashMap<u64, Arc<RenderImage>>,
     render_image_screen: Option<Arc<TerminalScreen>>,
     paint_cache: Option<Arc<TerminalPaintCache>>,
@@ -3834,8 +3861,25 @@ impl Workspace {
         cx.notify();
     }
 
+    fn begin_terminal_selection(
+        &mut self,
+        pane_id: usize,
+        event: &MouseDownEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if self.layout_mode || self.pointer_drag.is_some() || event.modifiers.control {
+            return;
+        }
+        if let Some(pane) = self.terminals.get_mut(&pane_id) {
+            pane.selection_anchor_position = Some(event.position);
+            pane.selection = None;
+            cx.notify();
+        }
+    }
+
     fn drag_terminal_selection(
         &mut self,
+        pane_id: usize,
         event: &DragMoveEvent<TerminalSelectionDrag>,
         _: &mut Window,
         cx: &mut Context<Self>,
@@ -3843,7 +3887,7 @@ impl Workspace {
         // The terminal surface also owns ordinary left-drag selection. Let a
         // compositor drag bubble to the workspace-level pointer handler instead
         // of consuming its mouse moves as selection updates.
-        if self.pointer_drag.is_some() || event.event.modifiers.control {
+        if self.layout_mode || self.pointer_drag.is_some() || event.event.modifiers.control {
             return;
         }
         let drag = event.drag(cx).clone();
@@ -3853,17 +3897,16 @@ impl Workspace {
         let Some(screen) = pane.screen.as_ref() else {
             return;
         };
-        let offset_x = f32::from(event.event.position.x - event.bounds.left());
-        let offset_y = f32::from(event.event.position.y - event.bounds.top());
-        let cell = terminal_cell_from_offset(offset_x, offset_y, screen);
-        if !drag.started.swap(true, Ordering::AcqRel) {
-            pane.selection = Some(TerminalSelection {
-                anchor: cell,
-                head: cell,
-            });
-        } else if let Some(selection) = &mut pane.selection {
-            selection.head = cell;
-        }
+        let Some(selection) = drag.selection(
+            pane_id,
+            pane.selection_anchor_position,
+            event.event.position,
+            event.bounds,
+            screen,
+        ) else {
+            return;
+        };
+        pane.selection = Some(selection);
         let selected = pane
             .selection
             .map(|selection| terminal_selected_text(screen, selection));
@@ -9066,19 +9109,18 @@ impl Workspace {
                     .overflow_hidden()
                     .flex_1()
                     .min_h_0()
-                    .on_drag(
-                        TerminalSelectionDrag {
-                            pane_id: id,
-                            started: Arc::new(AtomicBool::new(false)),
-                        },
-                        move |_, _, _, cx| {
-                            cx.new(move |_| TerminalSelectionDrag {
-                                pane_id: id,
-                                started: Arc::new(AtomicBool::new(true)),
-                            })
-                        },
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, event, _, cx| {
+                            this.begin_terminal_selection(id, event, cx);
+                        }),
                     )
-                    .on_drag_move(cx.listener(Self::drag_terminal_selection))
+                    .on_drag(TerminalSelectionDrag { pane_id: id }, move |_, _, _, cx| {
+                        cx.new(move |_| TerminalSelectionDrag { pane_id: id })
+                    })
+                    .on_drag_move(cx.listener(move |this, event, window, cx| {
+                        this.drag_terminal_selection(id, event, window, cx);
+                    }))
                     .on_mouse_down(MouseButton::Middle, cx.listener(Self::paste_primary))
                     .child(self.boomux_body(id, cx))
                     .when(
@@ -10938,6 +10980,73 @@ mod pointer_tests {
         assert_eq!(cycled_workspace_id(&order, None, false), Some("alpha"));
         assert_eq!(cycled_workspace_id(&order, None, true), Some("charlie"));
         assert_eq!(cycled_workspace_id(&[], None, false), None);
+    }
+
+    #[test]
+    fn terminal_selection_drag_uses_only_source_pane_bounds_and_mouse_down_anchor() {
+        let screen = TerminalScreen {
+            rows: 24,
+            cols: 80,
+            cells: Vec::new(),
+            scroll_total: 24,
+            scroll_offset: 0,
+            scroll_len: 24,
+            images: Vec::new(),
+            image_placements: Vec::new(),
+        };
+        let bounds = Bounds::new(point(px(600.0), px(100.0)), size(px(700.0), px(430.0)));
+        let position = |row: usize, col: usize| {
+            bounds.origin
+                + point(
+                    px(8.0 + (col as f32 + 0.5) * TERMINAL_CELL_WIDTH),
+                    px(8.0 + (row as f32 + 0.5) * TERMINAL_CELL_HEIGHT),
+                )
+        };
+        let drag = TerminalSelectionDrag { pane_id: 2 };
+        let anchor = Some(position(3, 20));
+        for head in [(3, 30), (3, 10), (2, 40), (5, 10)] {
+            assert_eq!(
+                drag.selection(2, anchor, position(head.0, head.1), bounds, &screen),
+                Some(TerminalSelection {
+                    anchor: (3, 20),
+                    head
+                }),
+            );
+            // A neighboring pane receives the same move with different bounds.
+            // It must neither move the anchor nor consume the source's update.
+            let neighbor = Bounds::new(point(px(0.0), px(0.0)), bounds.size);
+            assert_eq!(
+                drag.selection(1, anchor, position(head.0, head.1), neighbor, &screen),
+                None,
+            );
+        }
+        assert_eq!(
+            drag.selection(2, anchor, point(px(0.0), px(0.0)), bounds, &screen),
+            Some(TerminalSelection {
+                anchor: (3, 20),
+                head: (0, 0)
+            }),
+        );
+        assert_eq!(
+            drag.selection(2, anchor, point(px(2000.0), px(2000.0)), bounds, &screen),
+            Some(TerminalSelection {
+                anchor: (3, 20),
+                head: (23, 79)
+            }),
+        );
+        assert_eq!(
+            drag.selection(2, None, position(3, 30), bounds, &screen),
+            None
+        );
+        // A new gesture uses its own mouse-down position, even before the first
+        // delivered drag move and regardless of the previous selection.
+        assert_eq!(
+            drag.selection(2, Some(position(7, 50)), position(7, 45), bounds, &screen),
+            Some(TerminalSelection {
+                anchor: (7, 50),
+                head: (7, 45)
+            }),
+        );
     }
 
     #[test]

--- a/desktop/src/settings.rs
+++ b/desktop/src/settings.rs
@@ -20,6 +20,7 @@ pub struct Settings {
     pub focus_highlight_strength: u8,
     pub motion_speed: MotionSpeed,
     pub layout_overlay_visible: bool,
+    pub copy_on_select: bool,
     pub workspace_pane_mode: WorkspacePaneMode,
     pub pane_layout_mode: PaneLayoutMode,
     pub confirm_destructive_actions: bool,
@@ -40,6 +41,7 @@ impl Default for Settings {
             focus_highlight_strength: 100,
             motion_speed: MotionSpeed::Smooth,
             layout_overlay_visible: true,
+            copy_on_select: true,
             workspace_pane_mode: WorkspacePaneMode::Workspace,
             pane_layout_mode: PaneLayoutMode::default(),
             confirm_destructive_actions: true,
@@ -146,6 +148,7 @@ impl Settings {
                         _ => return Err(invalid()),
                     }
                 }
+                "copy_on_select" => s.copy_on_select = value.as_bool().ok_or_else(invalid)?,
                 "layout_overlay_visible" => {
                     s.layout_overlay_visible = value.as_bool().ok_or_else(invalid)?
                 }
@@ -216,6 +219,7 @@ impl Settings {
             "layout_overlay_visible = {}\n",
             self.layout_overlay_visible
         ));
+        encoded.push_str(&format!("copy_on_select = {}\n", self.copy_on_select));
         encoded
     }
     fn save(&self, path: &Path) -> Result<(), String> {
@@ -330,11 +334,13 @@ mod tests {
             motion_speed: MotionSpeed::Instant,
             pane_headings_visible: false,
             layout_overlay_visible: false,
+            copy_on_select: false,
             ..Settings::default()
         };
         assert_eq!(Settings::parse(&settings.encode()).unwrap(), settings);
         assert_eq!(Settings::parse("").unwrap(), Settings::default());
         assert!(Settings::parse("").unwrap().layout_overlay_visible);
+        assert!(Settings::parse("").unwrap().copy_on_select);
         assert_eq!(Settings::default().pane_layout_mode, PaneLayoutMode::Tabbed);
         assert_eq!(
             Settings::parse("pane_layout_mode = 'tiled'")
@@ -358,6 +364,7 @@ mod tests {
             "motion_speed = 'slow'",
             "sidebar_visible = 'true'",
             "layout_overlay_visible = 'false'",
+            "copy_on_select = 'true'",
             "unknown = 3",
             "broken[",
         ] {

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -39,6 +39,17 @@ new-Workspace creation retain their existing paths. Reattachment
 to a running Shell retains the exact run already validated by attach, without a
 second owner lookup. Newly started/restarted Shells still resolve their new run.
 
+### Terminal Selection And Clipboard
+
+Selection drag updates use only the source pane's bounds and retain the original
+mouse-down anchor. The primary selection updates during the drag. On left-button
+release, Desktop copies nonempty selected text from that pane to the system
+clipboard once per gesture when `copy_on_select` is enabled (the default).
+The preference applies immediately and is saved in Desktop settings. Disabling
+it preserves manual copying and primary-selection paste. Pending clipboard work
+is a single pane ID, cleared on completion, window deactivation, or Workspace
+replacement; no polling or additional terminal snapshots are retained.
+
 ### Input And Layout Mode
 
 GPUI key contexts separate ordinary terminal input from desktop layout actions.

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -49,6 +49,12 @@ The preference applies immediately and is saved in Desktop settings. Disabling
 it preserves manual copying and primary-selection paste. Pending clipboard work
 is a single pane ID, cleared on completion, window deactivation, or Workspace
 replacement; no polling or additional terminal snapshots are retained.
+Desktop-initiated automatic and manual copies show a source-pane “Copied” badge
+for 1.5 seconds, using one replaceable cleanup task per window. Clipboard changes
+and terminal output never trigger the badge. Left-button selection gestures are
+not forwarded to the harness (current mouse reporting covers wheel events only),
+so a Desktop selection cannot simultaneously invoke a harness copy-on-select
+handler. Future button forwarding must preserve exclusive gesture ownership.
 
 ### Input And Layout Mode
 


### PR DESCRIPTION
Selecting terminal text now copies it to the system clipboard when the left mouse button is released. Settings → Clipboard → Copy on select defaults to on, applies immediately, and persists across launches. Disabling it preserves manual copying and primary-selection paste. Empty selections leave the clipboard untouched, and each completed gesture copies at most once from its source pane.

Automatic and manual Desktop copies show a brief “Copied” badge in the source pane. A single replaceable 1.5-second timer dismisses it. Clipboard changes and harness output do not trigger the badge. Current left-drag gestures stay local to Desktop (only wheel events are forwarded), so the same gesture cannot invoke both Desktop and harness copy-on-select handlers.

Fix multi-pane selection jumping toward the left edge: GPUI delivers drag moves to every listener of the same type, so selection updates now require the source pane's bounds and retain the original mouse-down anchor. Layout gestures do not update text selection.

The development launcher also handles long worktree paths by selecting a short, stable, private per-worktree runtime directory when the default daemon socket path exceeds the Unix socket limit. Config and state keep their existing locations. Status failures expose the underlying error.

Validation:
- `cargo check -p boomux-desktop --locked` passed.
- `cargo test -p boomux-desktop --locked terminal_selection_ -- --test-threads=1` passed (3 tests): pane routing, anchor geometry, text extraction, optional clipboard copying, and one-time gesture consumption.
- `cargo test -p boomux-desktop --locked settings::tests:: -- --test-threads=1` passed (15 tests): includes default-on behavior, disabled preference round-trip, and invalid value rejection.
- All 8 `python3 desktop/scripts/test-run-dev.py` tests passed. The real daemon-status check that previously failed with SUN_LEN now succeeds with the fallback path.
- Formatting and `git diff --check` passed.
- Live GUI, system clipboard behavior, and live harness coexistence remain unverified; comprehensive validation is left to PR CI.
