### PR TITLE
ci(release): reuse validation and enable development preview publishing

### DIFF
--- a/.github/scripts/classify-ci.py
+++ b/.github/scripts/classify-ci.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import tomllib
+from urllib.parse import quote
 
 DOCS = {"AGENTS.md", "CONTEXT.md", "DEVELOPMENT.md", "BENCHMARKING.md",
         "CHANGELOG.md", "SECURITY.md"}
@@ -64,47 +65,96 @@ def release_only(base, head, paths):
     return manifests[0] == manifests[1]
 
 
-def validated_base(sha):
+COMPONENT_STEPS = {
+    "backend": ("Rust", {"Run Clippy", "Run Rust unit tests", "Run configuration CLI tests", "Run native backend tests"}),
+    "desktop": ("Desktop Rust", {"Run Desktop Clippy", "Run Desktop tests"}),
+    "integrations": ("Integrations", {"Verify embedded web terminal assets", "Run integration tests"}),
+    "dependencies": ("Dependency policy", {"Audit advisories, licenses, and dependency sources"}),
+}
+
+
+def changed_paths(base, head):
+    return set(git("diff", "--name-only", "--no-renames", "-z", base, head).decode().rstrip("\0").split("\0")) - {""}
+
+
+def reusable_components(source, base):
+    """Only proven input-preserving changes can inherit an ancestor's checks."""
+    if source == base:
+        return set(COMPONENT_STEPS)
+    if not re.fullmatch(r"[0-9a-f]{40}", source):
+        return set()
+    ancestor = subprocess.run(["git", "merge-base", "--is-ancestor", source, base],
+                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30)
+    if ancestor.returncode != 0:
+        return set()
+    paths = changed_paths(source, base)
+    desktop = {path for path in paths if path.startswith("desktop/src/") and path.endswith(".rs")}
+    # Versions may have changed alongside Desktop source since the last full
+    # backend run. Validate the exact metadata transformation before ignoring it.
+    metadata = paths - desktop - {path for path in paths if documentation(path) or website(path)}
+    if metadata and release_only(source, base, metadata):
+        paths -= RELEASE_FILES
+    paths = {path for path in paths if not documentation(path) and not website(path)}
+    if not paths:
+        return set(COMPONENT_STEPS)
+    if paths <= desktop:
+        return set(COMPONENT_STEPS) - {"desktop"}
+    # Shared manifests, dependencies, CI definitions, renames, or unknown inputs
+    # invalidate inherited evidence. A green run or a cache hit alone is no proof.
+    return set()
+
+
+def validated_base(sha, evidence=None):
     repo = os.environ["GITHUB_REPOSITORY"]
     branch = os.environ["DEFAULT_BRANCH"]
-    # Bounded run/job queries. A green docs-only run is not test evidence.
     response = subprocess.check_output([
-        "gh", "api", f"repos/{repo}/actions/workflows/ci.yml/runs?event=push&head_sha={sha}&status=success&per_page=100"
+        "gh", "api", f"repos/{repo}/actions/workflows/ci.yml/runs?event=push&branch={quote(branch, safe='')}&status=success&per_page=20"
     ], timeout=30)
-    runs = [run for run in json.loads(response)["workflow_runs"]
-            if run["head_sha"] == sha and run["event"] == "push"
-            and run["conclusion"] == "success" and run["head_branch"] == branch
-            and run["head_repository"]["full_name"] == repo]
-    if not runs:
-        return False
-    run_id = int(runs[0]["id"])
-    jobs = json.loads(subprocess.check_output([
-        "gh", "api", f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"
-    ], timeout=30))["jobs"]
-    required = {
-        "Rust": {"Run Clippy", "Run Rust unit tests", "Run configuration CLI tests", "Run native backend tests"},
-        "Desktop Rust": {"Run Desktop Clippy", "Run Desktop tests"},
-        "Integrations": {"Verify embedded web terminal assets", "Run integration tests"},
-        "Dependency policy": {"Audit advisories, licenses, and dependency sources"},
-    }
-    return all(any(job["name"] == name and job["conclusion"] == "success"
+    missing = set(COMPONENT_STEPS)
+    records = []
+    lookups = 0
+    for run in json.loads(response)["workflow_runs"][:20]:
+        if not (run["event"] == "push" and run["conclusion"] == "success"
+                and run["head_branch"] == branch and run["head_repository"]["full_name"] == repo):
+            continue
+        eligible = reusable_components(run["head_sha"], sha) & missing
+        if not eligible:
+            continue
+        if lookups >= 6:
+            break
+        lookups += 1
+        jobs = json.loads(subprocess.check_output([
+            "gh", "api", f"repos/{repo}/actions/runs/{int(run['id'])}/jobs?per_page=100"
+        ], timeout=30))["jobs"]
+        for component in eligible:
+            name, steps = COMPONENT_STEPS[component]
+            if any(job["name"] == name and job["conclusion"] == "success"
                    and steps <= {step["name"] for step in job["steps"] if step["conclusion"] == "success"}
-                   for job in jobs) for name, steps in required.items())
+                   for job in jobs):
+                missing.remove(component)
+                records.append((component, run["id"], run["head_sha"]))
+        if not missing:
+            if evidence is not None:
+                evidence.extend(records)
+            return True
+    return False
 
 
 
-def classify(base, head, proof=validated_base):
+def classify(base, head, proof=validated_base, event="push"):
     try:
         if not re.fullmatch(r"[0-9a-f]{40}", base) or base == "0" * 40:
             return FULL.copy(), "No usable comparison base; full validation."
-        paths = set(git("diff", "--name-only", "--no-renames", "-z", base, head).decode().rstrip("\0").split("\0")) - {""}
+        paths = changed_paths(base, head)
         if all(documentation(path) for path in paths):
             return dict.fromkeys(FULL, False), "Documentation-only change; no executable or packaged inputs changed."
         if all(documentation(path) or website(path) for path in paths):
             return dict.fromkeys(FULL, False), "Website-only change; the Website workflow owns validation."
         if release_only(base, head, paths):
             if proof(base):
-                return {"run_code": False, "run_desktop": False, "run_package": True, "run_benchmarks": False}, f"Version-only release; reuse successful push CI for {base}. Build and smoke test the new version."
+                package = event not in {"pull_request", "merge_group"}
+                action = "Build and smoke test the merged release version." if package else "Metadata-only PR validation; final artifacts are built after merge."
+                return {"run_code": False, "run_desktop": False, "run_package": package, "run_benchmarks": False}, f"Version-only release; reuse proven component checks for {base}. {action}"
             return FULL.copy(), "Version-only change has no successful base push CI; full validation."
         executable_paths = {path for path in paths if not documentation(path) and not website(path)}
         if executable_paths and all(path.startswith("desktop/src/") and path.endswith(".rs")
@@ -121,9 +171,14 @@ def classify(base, head, proof=validated_base):
 
 
 if __name__ == "__main__":
-    selection, reason = classify(os.environ.get("BASE_SHA", ""), os.environ["HEAD_SHA"])
+    evidence = []
+    selection, reason = classify(os.environ.get("BASE_SHA", ""), os.environ["HEAD_SHA"],
+                                 proof=lambda sha: validated_base(sha, evidence),
+                                 event=os.environ.get("GITHUB_EVENT_NAME", ""))
     with open(os.environ["GITHUB_OUTPUT"], "a") as output:
         for key, value in selection.items():
             print(f"{key}={str(value).lower()}", file=output)
     with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
         print(reason, file=summary)
+        for component, run_id, sha in sorted(evidence):
+            print(f"\n- {component}: main CI run `{run_id}`, source `{sha}`", file=summary)

--- a/.github/scripts/development-release.py
+++ b/.github/scripts/development-release.py
@@ -1,0 +1,243 @@
+"""Promote a validated macOS preview artifact; never execute or rebuild its code."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import zipfile
+
+MAX_ARCHIVE = 128 * 1024 * 1024
+MAX_CONTENT = 512 * 1024 * 1024
+REQUIRED_JOBS = {
+    "macos": {"Check backend", "Test descriptor transfer", "Test native process identity",
+              "Test native lifecycle and recovery"},
+    "package": {"Build preview executables", "Package preview", "Exercise packaged application"},
+}
+
+
+def api(repo, path, *, method=None, data=None, missing=False):
+    command = ["gh", "api", f"repos/{repo}/{path}"]
+    if method:
+        command += ["--method", method]
+    if data is not None:
+        command += ["--input", "-"]
+    result = subprocess.run(command, input=json.dumps(data) if data is not None else None,
+                            text=True, capture_output=True, timeout=60)
+    if result.returncode:
+        if missing and "HTTP 404" in result.stderr:
+            return None
+        raise RuntimeError(f"GitHub request failed: {result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+def digest(path):
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def validate_general_ci(repo, sha):
+    runs = api(repo, f"actions/workflows/ci.yml/runs?head_sha={sha}&per_page=20")["workflow_runs"]
+    matching = [run for run in runs if run["head_sha"] == sha
+                and run["event"] in {"push", "pull_request", "workflow_dispatch"}
+                and run["head_repository"]["full_name"] == repo
+                and run["repository"]["full_name"] == repo]
+    if not matching or matching[0]["status"] != "completed" or matching[0]["conclusion"] != "success":
+        raise ValueError("The source revision also needs successful general CI (open a PR or run CI manually)")
+    run = matching[0]
+    jobs = api(repo, f"actions/runs/{int(run['id'])}/attempts/{int(run['run_attempt'])}/jobs?per_page=100")["jobs"]
+    if not any(job["name"] == "CI result" and job["conclusion"] == "success" for job in jobs):
+        raise ValueError("General CI did not pass its aggregate required-check gate")
+    return run["id"]
+
+
+def validate_run(run, jobs, repo, run_id):
+    if not (run["id"] == int(run_id) and run["status"] == "completed"
+            and run["conclusion"] == "success" and run["event"] in {"push", "workflow_dispatch"}
+            and run["head_repository"]["full_name"] == repo
+            and run["repository"]["full_name"] == repo
+            and run["path"] == ".github/workflows/macos-preview.yml"
+            and re.fullmatch(r"[0-9a-f]{40}", run["head_sha"])):
+        raise ValueError("Expected a successful macOS preview run from this repository")
+    for name, steps in REQUIRED_JOBS.items():
+        if not any(job["name"] == name and job["conclusion"] == "success"
+                   and steps <= {step["name"] for step in job["steps"] if step["conclusion"] == "success"}
+                   for job in jobs):
+            raise ValueError(f"Missing successful native validation: {name}")
+    if not re.match(r"\d{4}-\d{2}-\d{2}T", run["created_at"]):
+        raise ValueError("Invalid build date")
+    return run["head_sha"]
+
+
+def source_run(repo, run_id):
+    if not re.fullmatch(r"[1-9][0-9]*", str(run_id)):
+        raise ValueError("Run ID must be a positive integer")
+    run = api(repo, f"actions/runs/{run_id}")
+    # Pin job evidence to this completed attempt, including when a run was rerun.
+    attempt = int(run["run_attempt"])
+    jobs = api(repo, f"actions/runs/{run_id}/attempts/{attempt}/jobs?per_page=100")["jobs"]
+    validate_run(run, jobs, repo, run_id)
+    run["general_ci_run"] = validate_general_ci(repo, run["head_sha"])
+    return run
+
+
+def validate_package(directory, sha):
+    name = f"boomux-macos-preview-aarch64-{sha[:8]}.zip"
+    archive = directory / name
+    checksum = directory / (name + ".sha256")
+    if archive.is_symlink() or checksum.is_symlink() or not 0 < archive.stat().st_size <= MAX_ARCHIVE:
+        raise ValueError("Invalid preview archive")
+    archive_digest = digest(archive)
+    if checksum.stat().st_size > 256 or checksum.read_text().strip() != f"{archive_digest}  {name}":
+        raise ValueError("Preview checksum mismatch")
+    with zipfile.ZipFile(archive) as bundle:
+        members = bundle.infolist()
+        names = [item.filename for item in members]
+        if len(names) > 1024 or len(set(names)) != len(names) or sum(item.file_size for item in members) > MAX_CONTENT:
+            raise ValueError("Invalid preview archive contents")
+        prefix = "Boomux macOS Preview/"
+        metadata_name = prefix + "build.json"
+        if bundle.getinfo(metadata_name).file_size > 16384:
+            raise ValueError("Oversized build metadata")
+        metadata = json.loads(bundle.read(metadata_name))
+        if not (metadata["source"] == sha and metadata["target"] == "aarch64-apple-darwin"
+                and metadata["distribution"] == "testing-preview" and metadata["notarized"] is False
+                and re.fullmatch(r"\d+\.\d+\.\d+", metadata["version"])):
+            raise ValueError("Preview metadata does not match the successful build")
+        for executable in ["boomux", "boomux-desktop"]:
+            member = bundle.getinfo(prefix + "Boomux.app/Contents/MacOS/" + executable)
+            with bundle.open(member) as binary:
+                header = binary.read(8)
+            if header != bytes.fromhex("cffaedfe0c000001") or not (member.external_attr >> 16) & 0o111:
+                raise ValueError("Expected executable ARM64 Mach-O binaries")
+        guide = prefix + "READ ME FIRST.md"
+        if bundle.getinfo(guide).file_size > 65536:
+            raise ValueError("Oversized testing guide")
+        testing = bundle.read(guide).decode()
+    return {"archive": name, "sha256": archive_digest, "version": metadata["version"], "guide": testing}
+
+
+def publication(run, package, repo):
+    sha = run["head_sha"]
+    date = run["created_at"][:10]
+    # A separate namespace avoids suggesting these tags are stable SemVer releases.
+    tag = f"preview-macos-{date.replace('-', '')}.{run['id']}"
+    title = f"macOS Development Preview — {date} ({sha[:8]})"
+    notes = f"""Development preview for testing. Not a stable release.
+
+- Apple Silicon (M1 or newer), macOS 15+.
+- Matching Desktop and CLI, version {package['version']}.
+- Source: `{sha}`.
+- Validated Mac build: https://github.com/{repo}/actions/runs/{run['id']}
+- General CI: https://github.com/{repo}/actions/runs/{run['general_ci_run']}
+- SHA-256: `{package['sha256']}`.
+- Ad-hoc signed, not notarized; see the installation steps below.
+- Known preview issue: the initial window can extend off-screen on small displays.
+
+Please report reproducible problems at https://github.com/{repo}/issues, including
+this preview tag, macOS version, chip, steps, and error text. Do not include secrets.
+
+{package['guide']}
+"""
+    return {"repo": repo, "run_id": run["id"], "source": sha, "tag": tag,
+            "title": title, "archive": package["archive"], "sha256": package["sha256"], "notes": notes}
+
+
+def prepare(repo, run_id, directory):
+    run = source_run(repo, run_id)
+    artifacts = api(repo, f"actions/runs/{run_id}/artifacts?per_page=100")["artifacts"]
+    matches = [a for a in artifacts if a["name"] == "boomux-macos-preview" and not a["expired"]]
+    if len(matches) != 1 or not 0 < matches[0]["size_in_bytes"] <= MAX_ARCHIVE:
+        raise ValueError("Missing, expired, ambiguous, or oversized preview artifact; rebuild explicitly")
+    directory.mkdir(parents=True, exist_ok=True)
+    if any(directory.iterdir()):
+        raise ValueError("Preparation directory must be empty")
+    subprocess.run(["gh", "run", "download", str(run_id), "--repo", repo,
+                    "--name", "boomux-macos-preview", "--dir", str(directory)], check=True, timeout=180)
+    package = validate_package(directory, run["head_sha"])
+    if {p.name for p in directory.iterdir()} != {package["archive"], package["archive"] + ".sha256"}:
+        raise ValueError("Unexpected files in preview artifact")
+    request = publication(run, package, repo)
+    (directory / "publication.json").write_text(json.dumps(request, indent=2) + "\n")
+    (directory / "release-notes.md").write_text(request["notes"])
+    return request
+
+
+def ensure_tag(repo, tag, sha):
+    reference = api(repo, f"git/ref/tags/{tag}", missing=True)
+    if reference is None:
+        api(repo, "git/refs", method="POST", data={"ref": f"refs/tags/{tag}", "sha": sha})
+    elif reference["object"]["type"] != "commit" or reference["object"]["sha"] != sha:
+        raise ValueError("Existing preview tag has a different source; tags are never moved")
+
+
+def verify_assets(assets, expected):
+    if len({a["name"] for a in assets}) != len(assets):
+        raise ValueError("Duplicate release assets")
+    for asset in assets:
+        if asset["name"] not in expected or asset.get("digest") != "sha256:" + expected[asset["name"]]:
+            raise ValueError("Existing release asset conflicts with validated bytes; refusing replacement")
+
+
+def publish(repo, run_id, directory):
+    run = source_run(repo, run_id)
+    package = validate_package(directory, run["head_sha"])
+    request = publication(run, package, repo)
+    if json.loads((directory / "publication.json").read_text()) != request:
+        raise ValueError("Prepared publication no longer matches its validated source")
+    tag, sha = request["tag"], request["source"]
+    ensure_tag(repo, tag, sha)
+    release = api(repo, f"releases/tags/{tag}", missing=True)
+    if release is None:
+        # GitHub can omit drafts from the tag endpoint. Resume an interrupted
+        # upload without creating another draft or overwriting existing bytes.
+        drafts = [r for r in api(repo, "releases?per_page=100") if r["tag_name"] == tag]
+        if len(drafts) > 1:
+            raise ValueError("Ambiguous preview drafts")
+        release = drafts[0] if drafts else None
+    if release is None:
+        release = api(repo, "releases", method="POST", data={
+            "tag_name": tag, "target_commitish": sha, "name": request["title"], "body": request["notes"],
+            "draft": True, "prerelease": True, "make_latest": "false"})
+    if release["tag_name"] != tag or release["prerelease"] is not True:
+        raise ValueError("Existing release is not this development prerelease")
+    release_id = int(release["id"])
+    names = [package["archive"], package["archive"] + ".sha256"]
+    expected = {name: digest(directory / name) for name in names}
+    assets = api(repo, f"releases/{release_id}/assets?per_page=100")
+    verify_assets(assets, expected)
+    missing = set(names) - {asset["name"] for asset in assets}
+    if missing and not release["draft"]:
+        raise ValueError("Published preview is incomplete; publish a new preview instead of changing it")
+    for name in sorted(missing):
+        subprocess.run(["gh", "release", "upload", tag, str(directory / name), "--repo", repo],
+                       check=True, timeout=180)
+    assets = api(repo, f"releases/{release_id}/assets?per_page=100")
+    verify_assets(assets, expected)
+    if {asset["name"] for asset in assets} != set(names):
+        raise ValueError("Upload verification failed")
+    ensure_tag(repo, tag, sha)
+    if release["draft"]:
+        api(repo, f"releases/{release_id}", method="PATCH",
+            data={"draft": False, "prerelease": True, "make_latest": "false"})
+    published = api(repo, f"releases/{release_id}")
+    if published["draft"] or not published["prerelease"] or published["tag_name"] != tag:
+        raise ValueError("Prerelease publication verification failed")
+    return f"https://github.com/{repo}/releases/tag/{tag}"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=["prepare", "publish"])
+    parser.add_argument("run_id")
+    parser.add_argument("directory", type=Path)
+    args = parser.parse_args()
+    repo = os.environ["GITHUB_REPOSITORY"]
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
+        raise SystemExit("Invalid repository")
+    if args.mode == "prepare":
+        result = prepare(repo, args.run_id, args.directory)
+        print(json.dumps({key: value for key, value in result.items() if key != "notes"}, indent=2))
+    else:
+        print(publish(repo, args.run_id, args.directory))

--- a/.github/scripts/install-macos-preview.sh
+++ b/.github/scripts/install-macos-preview.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Installer for one immutable, CI-validated preview. No GitHub login required.
+set -euo pipefail
+
+fail() { printf '%s\n' "$*" >&2; exit 1; }
+[ "$(uname -s)" = Darwin ] || fail 'This preview requires macOS.'
+[ "$(uname -m)" = arm64 ] || fail 'This preview requires an Apple Silicon Mac. Run Terminal without Rosetta.'
+version=$(sw_vers -productVersion)
+[ "${version%%.*}" -ge 15 ] || fail 'This preview requires macOS 15 or newer.'
+
+readonly tag=preview-macos-20260910.34427759652
+readonly archive=boomux-macos-preview-aarch64-66bca02a.zip
+readonly sha256=65088ef421eb25bd35576d059bc37e0f318aa8cefdf12d29f23049da8bd174a4
+readonly destination="$HOME/Applications/Boomux Preview-66bca02a.app"
+[ ! -e "$destination" ] && [ ! -L "$destination" ] || fail "Already installed: $destination. Open it from Finder."
+
+staging=$(mktemp -d "${TMPDIR:-/tmp}/boomux-preview.XXXXXX")
+trap 'rm -rf "$staging"' EXIT
+printf 'Downloading Boomux development preview (ad-hoc signed, not notarized)...\n'
+curl --fail --location --silent --show-error --proto '=https' --proto-redir '=https' \
+  --connect-timeout 20 --max-time 300 --max-filesize 134217728 \
+  "https://github.com/gardnmi/boomux/releases/download/$tag/$archive" -o "$staging/$archive"
+actual=$(shasum -a 256 "$staging/$archive")
+[ "${actual%% *}" = "$sha256" ] || fail 'Download checksum mismatch; nothing was installed.'
+ditto -x -k "$staging/$archive" "$staging/unpacked"
+app="$staging/unpacked/Boomux macOS Preview/Boomux.app"
+[ -d "$app" ] && [ ! -L "$app" ] || fail 'The download does not contain the expected application.'
+codesign --verify --deep --strict "$app"
+for executable in boomux boomux-desktop; do
+  [ "$(lipo -archs "$app/Contents/MacOS/$executable")" = arm64 ] || fail 'Unexpected executable architecture.'
+done
+mkdir -p "$HOME/Applications"
+# -n prevents replacement if another installer created the destination meanwhile.
+mv -n "$app" "$destination"
+[ ! -e "$app" ] || fail 'Another installation already exists; it was not replaced.'
+printf '\nInstalled: %s\nOpen this app in Finder to start Boomux.\n' "$destination"
+printf 'If macOS blocks it, use System Settings > Privacy & Security > Open Anyway.\n'
+printf 'This is a testing preview; it does not install a login service or a global CLI.\n'

--- a/.github/scripts/test_ci_development_release.py
+++ b/.github/scripts/test_ci_development_release.py
@@ -1,0 +1,247 @@
+"""Development promotion verifies CI and bytes; retries never replace assets."""
+import copy
+import hashlib
+import importlib.util
+import json
+import re
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+import zipfile
+
+spec = importlib.util.spec_from_file_location("development", Path(__file__).with_name("development-release.py"))
+development = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(development)
+REPO = "owner/boomux"
+SHA = "a" * 40
+
+
+class PreviewTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.run = {"id": 123, "run_attempt": 1, "general_ci_run": 789, "head_sha": SHA, "status": "completed",
+                    "conclusion": "success", "event": "push", "head_repository": {"full_name": REPO},
+                    "repository": {"full_name": REPO}, "path": ".github/workflows/macos-preview.yml",
+                    "created_at": "2026-09-10T00:00:00Z"}
+        self.jobs = [{"name": name, "conclusion": "success", "steps": [
+            {"name": step, "conclusion": "success"} for step in steps]}
+            for name, steps in development.REQUIRED_JOBS.items()]
+        self.archive = self.directory / f"boomux-macos-preview-aarch64-{SHA[:8]}.zip"
+        self.metadata = {"source": SHA, "target": "aarch64-apple-darwin", "version": "1.14.1",
+                         "distribution": "testing-preview", "notarized": False}
+        self.bundle()
+        self.tag = None
+        self.release = None
+        self.assets = []
+        self.mutations = []
+        self.uploads = []
+        self.fail_upload = False
+
+    def bundle(self, header=bytes.fromhex("cffaedfe0c000001")):
+        prefix = "Boomux macOS Preview/"
+        with zipfile.ZipFile(self.archive, "w") as bundle:
+            bundle.writestr(prefix + "build.json", json.dumps(self.metadata))
+            bundle.writestr(prefix + "READ ME FIRST.md", "Testing instructions\n")
+            for name in ["boomux", "boomux-desktop"]:
+                info = zipfile.ZipInfo(prefix + "Boomux.app/Contents/MacOS/" + name)
+                info.external_attr = 0o100755 << 16
+                bundle.writestr(info, header)
+        self.checksum()
+
+    def checksum(self):
+        digest = hashlib.sha256(self.archive.read_bytes()).hexdigest()
+        Path(str(self.archive) + ".sha256").write_text(f"{digest}  {self.archive.name}\n")
+
+    def prepared(self):
+        package = development.validate_package(self.directory, SHA)
+        request = development.publication(self.run, package, REPO)
+        (self.directory / "publication.json").write_text(json.dumps(request))
+        return request
+
+    def api(self, repo, path, *, method=None, data=None, missing=False):
+        self.assertEqual(repo, REPO)
+        if method:
+            self.mutations.append((path, method, data))
+        if path.startswith("git/ref/tags/"):
+            return {"object": {"type": "commit", "sha": self.tag}} if self.tag else None
+        if path == "git/refs":
+            self.tag = data["sha"]
+            return {}
+        if path.startswith("releases/tags/"):
+            # Drafts deliberately only appear in the list endpoint.
+            return copy.deepcopy(self.release) if self.release and not self.release["draft"] else None
+        if path == "releases?per_page=100":
+            return [copy.deepcopy(self.release)] if self.release else []
+        if path == "releases" and method == "POST":
+            self.release = {"id": 456, **data}
+            return copy.deepcopy(self.release)
+        if path == "releases/456/assets?per_page=100":
+            return copy.deepcopy(self.assets)
+        if path == "releases/456":
+            if method:
+                self.release.update(data)
+            return copy.deepcopy(self.release)
+        raise AssertionError(path)
+
+    def upload(self, command, **kwargs):
+        self.assertEqual(command[:3], ["gh", "release", "upload"])
+        self.assertNotIn("--clobber", command)
+        if self.fail_upload:
+            raise subprocess.CalledProcessError(1, command)
+        path = Path(command[4])
+        self.uploads.append(path.name)
+        self.assets.append({"name": path.name, "digest": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()})
+
+    def publish(self):
+        with patch.object(development, "source_run", return_value=self.run), patch.object(
+                development, "api", side_effect=self.api), patch.object(
+                development.subprocess, "run", side_effect=self.upload):
+            return development.publish(REPO, "123", self.directory)
+
+    def test_run_requires_successful_same_repository_native_validation(self):
+        self.assertEqual(development.validate_run(self.run, self.jobs, REPO, "123"), SHA)
+        for field, value in [("status", "in_progress"), ("conclusion", "failure"), ("event", "pull_request"),
+                             ("head_sha", "bad"), ("head_repository", {"full_name": "fork/boomux"}),
+                             ("path", ".github/workflows/ci.yml"), ("id", 124)]:
+            with self.subTest(field=field):
+                run = {**self.run, field: value}
+                with self.assertRaises(ValueError):
+                    development.validate_run(run, self.jobs, REPO, "123")
+        self.jobs[0]["steps"][0]["conclusion"] = "skipped"
+        with self.assertRaises(ValueError):
+            development.validate_run(self.run, self.jobs, REPO, "123")
+
+    def test_general_ci_requires_matching_success_and_aggregate_gate(self):
+        run = {**self.run, "id": 789, "event": "pull_request"}
+        jobs = {"jobs": [{"name": "CI result", "conclusion": "success"}]}
+        with patch.object(development, "api", side_effect=[{"workflow_runs": [run]}, jobs]):
+            self.assertEqual(development.validate_general_ci(REPO, SHA), 789)
+        for change in [{"head_sha": "b" * 40}, {"conclusion": "failure"}, {"status": "in_progress"},
+                       {"head_repository": {"full_name": "fork/boomux"}}]:
+            with self.subTest(change=change), patch.object(development, "api", return_value={"workflow_runs": [{**run, **change}]}):
+                with self.assertRaises(ValueError):
+                    development.validate_general_ci(REPO, SHA)
+        with patch.object(development, "api", side_effect=[{"workflow_runs": [run]}, {"jobs": []}]):
+            with self.assertRaisesRegex(ValueError, "aggregate"):
+                development.validate_general_ci(REPO, SHA)
+
+    def test_checksum_and_source_must_match(self):
+        self.archive.write_bytes(self.archive.read_bytes() + b"changed")
+        with self.assertRaisesRegex(ValueError, "checksum"):
+            development.validate_package(self.directory, SHA)
+        self.metadata["source"] = "b" * 40
+        self.bundle()
+        with self.assertRaisesRegex(ValueError, "metadata"):
+            development.validate_package(self.directory, SHA)
+
+    def test_wrong_architecture_is_rejected(self):
+        self.bundle(header=b"not MachO")
+        with self.assertRaisesRegex(ValueError, "Mach-O"):
+            development.validate_package(self.directory, SHA)
+
+    def test_duplicate_metadata_is_rejected(self):
+        with self.assertWarns(UserWarning), zipfile.ZipFile(self.archive, "a") as bundle:
+            bundle.writestr("Boomux macOS Preview/build.json", json.dumps(self.metadata))
+        self.checksum()
+        with self.assertRaisesRegex(ValueError, "contents"):
+            development.validate_package(self.directory, SHA)
+
+    def test_publishes_prerelease_once_without_rebuild_or_latest(self):
+        request = self.prepared()
+        url = self.publish()
+        self.assertEqual(url, f"https://github.com/{REPO}/releases/tag/preview-macos-20260910.123")
+        self.assertEqual(self.tag, SHA)
+        self.assertFalse(self.release["draft"])
+        self.assertTrue(self.release["prerelease"])
+        self.assertEqual(self.release["make_latest"], "false")
+        self.assertEqual(self.release["target_commitish"], SHA)
+        self.assertEqual(len(self.uploads), 2)
+        self.assertEqual(self.publish(), url)
+        self.assertEqual(len(self.uploads), 2)
+        self.assertEqual(sum(path == "releases" for path, _, _ in self.mutations), 1)
+        self.assertIn(request["sha256"], self.release["body"])
+
+    def test_interrupted_draft_upload_resumes(self):
+        self.prepared()
+        self.fail_upload = True
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.publish()
+        self.assertTrue(self.release["draft"])
+        self.fail_upload = False
+        self.publish()
+        self.assertFalse(self.release["draft"])
+        self.assertEqual(sum(path == "releases" for path, _, _ in self.mutations), 1)
+
+    def test_conflicting_tag_is_never_moved(self):
+        self.prepared()
+        self.tag = "b" * 40
+        with self.assertRaisesRegex(ValueError, "different source"):
+            self.publish()
+        self.assertEqual(self.mutations, [])
+
+    def test_conflicting_asset_is_never_replaced(self):
+        request = self.prepared()
+        self.tag = SHA
+        self.release = {"id": 456, "tag_name": request["tag"], "draft": True, "prerelease": True}
+        self.assets = [{"name": request["archive"], "digest": "sha256:" + "0" * 64}]
+        with self.assertRaisesRegex(ValueError, "conflicts"):
+            self.publish()
+        self.assertEqual(self.uploads, [])
+        self.assertTrue(self.release["draft"])
+
+    def test_published_incomplete_preview_is_not_modified(self):
+        request = self.prepared()
+        self.tag = SHA
+        self.release = {"id": 456, "tag_name": request["tag"], "draft": False, "prerelease": True}
+        with self.assertRaisesRegex(ValueError, "incomplete"):
+            self.publish()
+        self.assertEqual(self.uploads, [])
+
+    def test_preparation_is_read_only_and_rejects_expired_artifact(self):
+        output = self.directory / "prepared"
+        artifact = {"name": "boomux-macos-preview", "size_in_bytes": 4096, "expired": True}
+        with patch.object(development, "source_run", return_value=self.run), patch.object(
+                development, "api", return_value={"artifacts": [artifact]}), patch.object(
+                development.subprocess, "run") as download:
+            with self.assertRaisesRegex(ValueError, "expired"):
+                development.prepare(REPO, "123", output)
+            download.assert_not_called()
+            artifact["expired"] = False
+            def copy(command, **kwargs):
+                self.assertEqual(command[:3], ["gh", "run", "download"])
+                for name in [self.archive.name, self.archive.name + ".sha256"]:
+                    shutil.copy2(self.directory / name, output / name)
+            download.side_effect = copy
+            request = development.prepare(REPO, "123", output)
+            self.assertEqual(request["source"], SHA)
+            self.assertTrue((output / "publication.json").exists())
+
+    def test_only_namespaced_preview_drafts_are_excluded_from_stable_gate(self):
+        workflow = Path(__file__).parents[1] / "workflows/release-please.yml"
+        query = re.search(r"--jq '(\.\[\] \| select\(\.draft == true\).*?)'", workflow.read_text()).group(1)
+        releases = [
+            {"id": 1, "tag_name": "v1.2.3", "draft": True, "prerelease": False},
+            {"id": 2, "tag_name": "preview-macos-20260910.123", "draft": True, "prerelease": True},
+            {"id": 3, "tag_name": "preview-macos-20260910.124", "draft": True, "prerelease": False},
+            {"id": 4, "tag_name": "v1.3.0-rc.1", "draft": True, "prerelease": True},
+            {"id": 5, "tag_name": "v1.2.2", "draft": False, "prerelease": False},
+        ]
+        result = subprocess.check_output(["jq", "-r", query], input=json.dumps(releases), text=True, timeout=5)
+        self.assertEqual(result.splitlines(), ["1", "3", "4"])
+
+    def test_changed_prepared_request_cannot_publish(self):
+        request = self.prepared()
+        request["source"] = "b" * 40
+        (self.directory / "publication.json").write_text(json.dumps(request))
+        with self.assertRaisesRegex(ValueError, "Prepared publication"):
+            self.publish()
+        self.assertEqual(self.mutations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_ci_macos_preview_installer.py
+++ b/.github/scripts/test_ci_macos_preview_installer.py
@@ -1,0 +1,80 @@
+"""Exercise installer decisions with isolated command fixtures, without a Mac."""
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name('install-macos-preview.sh')
+
+
+class InstallerTests(unittest.TestCase):
+    def run_installer(self, *, system='Darwin', arch='arm64', version='15.7',
+                      corrupt=False, signature_failure=False, existing=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / 'home with spaces'
+            home.mkdir()
+            binaries = root / 'bin'
+            binaries.mkdir()
+            payload = b'fixture download'
+            script = root / 'install.sh'
+            script.write_text(SCRIPT.read_text().replace(
+                '65088ef421eb25bd35576d059bc37e0f318aa8cefdf12d29f23049da8bd174a4',
+                hashlib.sha256(payload).hexdigest()))
+            commands = {
+                'uname': f'if [ "$1" = -s ]; then echo {system}; else echo {arch}; fi',
+                'sw_vers': f'echo {version}',
+                'curl': 'while [ "$1" != -o ]; do shift; done\nshift\nprintf "%s" "' + ('bad' if corrupt else payload.decode()) + '" > "$1"',
+                'ditto': 'mkdir -p "$4/Boomux macOS Preview/Boomux.app/Contents/MacOS"',
+                'codesign': 'exit ' + ('1' if signature_failure else '0'),
+                'lipo': 'echo arm64',
+            }
+            for name, body in commands.items():
+                command = binaries / name
+                command.write_text('#!/bin/bash\nset -eu\n' + body + '\n')
+                command.chmod(0o755)
+            destination = home / 'Applications/Boomux Preview-66bca02a.app'
+            if existing:
+                destination.mkdir(parents=True)
+                (destination / 'preserve').write_text('existing app')
+            env = {**os.environ, 'HOME': str(home), 'TMPDIR': str(root),
+                   'PATH': str(binaries) + os.pathsep + os.environ['PATH']}
+            result = subprocess.run(['bash', str(script)], env=env, capture_output=True, text=True)
+            installed = destination.exists()
+            preserved = (destination / 'preserve').exists()
+            self.assertEqual(list(root.glob('boomux-preview.*')), [])
+            return result, installed, preserved
+
+    def test_supported_mac_installs_with_spaces_in_home(self):
+        result, installed, _ = self.run_installer()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(installed)
+
+    def test_unsupported_hosts_install_nothing(self):
+        for kwargs in [{'system': 'Linux'}, {'arch': 'x86_64'}, {'version': '14.7'}]:
+            with self.subTest(**kwargs):
+                result, installed, _ = self.run_installer(**kwargs)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(installed)
+
+    def test_corrupt_download_installs_nothing(self):
+        result, installed, _ = self.run_installer(corrupt=True)
+        self.assertIn('checksum mismatch', result.stderr)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(installed)
+
+    def test_invalid_signature_installs_nothing(self):
+        result, installed, _ = self.run_installer(signature_failure=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(installed)
+
+    def test_existing_installation_is_preserved(self):
+        result, installed, preserved = self.run_installer(existing=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(installed and preserved)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/scripts/test_ci_selection.py
+++ b/.github/scripts/test_ci_selection.py
@@ -249,6 +249,90 @@ class SelectionTests(unittest.TestCase):
             with patch.object(selection.subprocess, "check_output", side_effect=responses):
                 self.assertFalse(selection.validated_base(self.base))
 
+    def test_release_pr_defers_artifacts_until_merge(self):
+        self.write_version("1.2.4")
+        head = self.commit()
+        for event in ["pull_request", "merge_group"]:
+            with self.subTest(event=event):
+                result, _ = selection.classify(self.base, head, lambda sha: True, event=event)
+                self.assertEqual(result, dict.fromkeys(selection.FULL, False))
+                result, _ = selection.classify(self.base, head, lambda sha: False, event=event)
+                self.assertEqual(result, selection.FULL)
+        for event in ["push", "workflow_dispatch", ""]:
+            self.assertTrue(selection.classify(self.base, head, lambda sha: True, event=event)[0]["run_package"])
+
+    def jobs(self, components):
+        return {"jobs": [{"name": selection.COMPONENT_STEPS[c][0], "conclusion": "success", "steps": [
+            {"name": step, "conclusion": "success"} for step in selection.COMPONENT_STEPS[c][1]]}
+            for c in components]}
+
+    def evidence(self, target, candidates):
+        runs = [{"id": i + 1, "head_sha": sha, "event": "push", "conclusion": "success",
+                 "head_branch": "main", "head_repository": {"full_name": "owner/repo"}}
+                for i, (sha, _) in enumerate(candidates)]
+        original = subprocess.check_output
+        calls = []
+        def request(command, **kwargs):
+            if command[0] != "gh":
+                return original(command, **kwargs)
+            calls.append(command[-1])
+            if "/workflows/" in command[-1]:
+                return json.dumps({"workflow_runs": runs}).encode()
+            run_id = int(command[-1].split("/runs/")[1].split("/")[0])
+            return json.dumps(self.jobs(candidates[run_id - 1][1])).encode()
+        with patch.dict(os.environ, GITHUB_REPOSITORY="owner/repo", DEFAULT_BRANCH="main"), patch.object(
+                selection.subprocess, "check_output", side_effect=request):
+            result = selection.validated_base(target)
+        return result, calls
+
+    def test_desktop_run_inherits_unchanged_backend_components(self):
+        self.write("desktop/src/main.rs", "new Desktop")
+        desktop = self.commit()
+        result, _ = self.evidence(desktop, [(desktop, {"desktop"}), (self.base, set(selection.COMPONENT_STEPS))])
+        self.assertTrue(result)
+
+    def test_docs_runs_can_inherit_actual_ancestor_checks(self):
+        self.write("docs/ci.md", "new guidance")
+        docs = self.commit()
+        self.assertTrue(self.evidence(docs, [(docs, set()), (self.base, set(selection.COMPONENT_STEPS))])[0])
+
+    def test_combined_version_and_desktop_changes_preserve_backend_evidence(self):
+        self.write_version("1.2.4")
+        self.write("desktop/src/main.rs", "new Desktop")
+        self.write("docs/ci.md", "guidance")
+        head = self.commit()
+        self.assertTrue(self.evidence(head, [(head, {"desktop"}), (self.base, set(selection.COMPONENT_STEPS))])[0])
+
+    def test_shared_changes_and_missing_components_cannot_inherit(self):
+        self.write("src/lib.rs", "backend change")
+        head = self.commit()
+        self.assertFalse(self.evidence(head, [(head, {"desktop"}), (self.base, set(selection.COMPONENT_STEPS))])[0])
+        self.assertFalse(self.evidence(self.base, [(self.base, {"desktop", "backend"})])[0])
+
+    def test_dependency_change_cannot_hide_behind_version_bump(self):
+        self.write_version("1.2.4")
+        lock = Path("Cargo.lock")
+        lock.write_text(lock.read_text().replace('"2.0.0"', '"2.0.1"'))
+        head = self.commit()
+        self.assertEqual(selection.reusable_components(self.base, head), set())
+
+    def test_renamed_core_file_invalidates_inheritance(self):
+        Path("desktop/src").mkdir(parents=True)
+        self.git("mv", "src/lib.rs", "desktop/src/lib.rs")
+        head = self.commit()
+        self.assertEqual(selection.reusable_components(self.base, head), set())
+
+    def test_unrelated_successful_commit_is_not_evidence(self):
+        self.git("checkout", "--orphan", "other")
+        self.write("unrelated", "other root")
+        other = self.commit()
+        self.assertEqual(selection.reusable_components(other, self.base), set())
+
+    def test_evidence_queries_are_bounded(self):
+        result, calls = self.evidence(self.base, [(self.base, set())] * 20)
+        self.assertFalse(result)
+        self.assertEqual(len(calls), 7)  # one run list, at most six job lists
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -1,0 +1,64 @@
+name: Publish development preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Successful macOS preview run ID to publish (no rebuild)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: development-preview-${{ inputs.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Verify development candidate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify source run and downloaded bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_RUN_ID: ${{ inputs.run_id }}
+        run: python3 .github/scripts/development-release.py prepare "$PREVIEW_RUN_ID" prepared
+      - name: Show publication details
+        run: cat prepared/release-notes.md >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: verified-development-preview
+          path: prepared/
+          retention-days: 7
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub prerelease
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: verified-development-preview
+          path: prepared
+      - name: Revalidate and publish exact candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_RUN_ID: ${{ inputs.run_id }}
+        run: |
+          python3 .github/scripts/development-release.py publish "$PREVIEW_RUN_ID" prepared > preview-url.txt
+          cat preview-url.txt >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,6 +54,8 @@ jobs:
             exit 1
           fi
 
+      # Development preview drafts belong to their own publisher and must not
+      # block stable proposals while their artifacts are being uploaded.
       - name: Check for pending draft release
         if: ${{ github.event_name == 'workflow_run' }}
         id: pending-draft
@@ -62,11 +64,11 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           draft_ids=$(gh api --paginate "repos/$GH_REPO/releases?per_page=100" \
-            --jq '.[] | select(.draft == true) | .id' \
+            --jq '.[] | select(.draft == true) | select(.prerelease != true or (.tag_name | startswith("preview-macos-") | not)) | .id' \
             | sed -n '/^[0-9][0-9]*$/p')
           if [[ -n "$draft_ids" ]]; then
             printf 'exists=true\n' >> "$GITHUB_OUTPUT"
-            printf 'An unpublished draft release exists; deferring the next release proposal.\n' >> "$GITHUB_STEP_SUMMARY"
+            printf 'An unpublished stable draft release exists; deferring the next release proposal.\n' >> "$GITHUB_STEP_SUMMARY"
           else
             printf 'exists=false\n' >> "$GITHUB_OUTPUT"
           fi

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -335,15 +335,34 @@ title becomes the squash commit consumed by Release Please.
 ## Release Lifecycle
 
 After CI succeeds for the exact current `main` commit, Release Please creates or
-updates the release pull request. Merging that pull request updates the package
-version and changelog. CI builds and smoke tests x86_64 and aarch64 artifacts
-for that exact commit. When only release metadata changed and the base has
-successful push CI, it reuses that validation instead of rerunning the test
-suites. The release workflow downloads the exact CI artifacts, checks their
-source metadata and checksums, validates consumer compatibility, renders the
-installer, and publishes the completed release. Manual tag dispatch is reserved
-for explicit recovery, including rebuilding when the CI artifacts have expired.
-See [`docs/ci.md`](docs/ci.md) for the stage-by-stage contract.
+updates the release pull request. For strict version-only PRs, CI checks shared
+version metadata and verifies reusable component evidence from successful main
+runs; it defers artifact builds until merge. Missing evidence or mixed source
+changes select full validation. A Desktop-only main run can inherit unchanged
+backend evidence from an earlier main run.
+
+Merging the release PR updates the version and changelog. CI builds and smoke
+tests x86_64 and aarch64 artifacts and the Desktop bundle for that exact commit.
+It reuses proven correctness checks. The release workflow downloads those exact
+artifacts, verifies source metadata and checksums, checks consumer compatibility,
+renders installers, and publishes. Packaging failures after merge block
+publication. Manual tag dispatch remains reserved for explicit recovery.
+See [`docs/ci.md`](docs/ci.md) for the full selection and evidence contract.
+
+### Development previews
+
+Use a GitHub prerelease to distribute a tested development build before the
+feature joins the stable release. Previews are manually published, not nightly.
+The initial publisher supports the macOS Apple Silicon ZIP.
+
+After both general CI for the source revision and the `macOS preview` workflow
+pass, run **Actions → Publish development preview → Run workflow**, supplying the
+Mac build run ID. This entry becomes available after the workflow is merged to
+the default branch. It promotes the exact tested bytes without rebuilding, uses
+a unique `preview-macos-YYYYMMDD.<run-id>` tag, and keeps stable updates unchanged.
+The release contains requirements, testing instructions, checksums, and source
+information. New previews use new tags; retries cannot replace published bytes.
+
 
 ## Clean Up
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -353,7 +353,9 @@ See [`docs/ci.md`](docs/ci.md) for the full selection and evidence contract.
 
 Use a GitHub prerelease to distribute a tested development build before the
 feature joins the stable release. Previews are manually published, not nightly.
-The initial publisher supports the macOS Apple Silicon ZIP.
+The initial publisher supports the macOS Apple Silicon ZIP. The publishing
+workflow can live on `main` while the Mac build workflow and application port
+remain on `feature/macos`; publishing does not require merging that port.
 
 After both general CI for the source revision and the `macOS preview` workflow
 pass, run **Actions → Publish development preview → Run workflow**, supplying the

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -10,16 +10,17 @@ release stage.
 | Desktop-only Rust PR | Formatting, Desktop Clippy/tests, and optimized Desktop build; omit unchanged backend tests, integrations, dependency audit, CLI packaging, and backend benchmarks |
 | Code merge to main | Same component selection on the actual merged commit; main also saves dependency caches |
 | Release Please proposal generation | No builds or test suites; runs after successful main push CI |
-| Version-only release PR | Reuse successful base main CI; build and smoke test both release architectures, validate packaging scripts, and check Arch compatibility |
-| Version-only release merge | Same selection, with artifacts built for the exact new main commit |
+| Version-only release PR / merge group | Verify strict metadata-only changes and reusable component evidence; defer release builds until merge. Missing evidence selects full validation. |
+| Version-only release merge | Reuse proven correctness checks; build and smoke test both release architectures and the Desktop bundle for the exact new main commit, validate packaging, and check Arch compatibility |
 | Automatic publication | Download that main CI run's artifacts; verify source SHA, version, architecture, and checksums; validate pinned omarchy-boomux compatibility; upload and publish |
 | Manual release recovery | Rebuild and smoke test the requested draft source, then run consumer compatibility and publication checks; an already published tag retains its compatibility-only path |
 
 PR and main correctness checks cover different integration commits. They remain
 separate. Automatic publication does not rebuild or rerun the unit, native,
-integration, or benchmark suites. The new version is still compiled and smoke
-tested on the release PR and its merge because the version is embedded in the
-binary and used by update/packaging behavior.
+integration, or benchmark suites. The new version is compiled and smoke tested after the release PR merges,
+because the version is embedded in the binary and used by update/packaging
+behavior. A packaging failure then blocks publication and requires a fix or
+explicit recovery; lightweight release PR checks cannot prove the final binary.
 
 ## Conservative Selection
 
@@ -50,15 +51,18 @@ A version-only release must satisfy all of these conditions:
 - Parsed lockfiles differ only in the source-less Boomux package version;
   dependencies and checksums remain identical.
 - The Release Please manifest matches the new version and has no other changes.
-- GitHub reports successful `CI` push validation for the exact base SHA on this
-  repository's default branch, with the Rust lint/unit/CLI/native steps actually
-  executed successfully. A green documentation-only run is not sufficient.
-  PR names, labels, and authors are not proof.
+- Successful default-branch `CI` push runs provide actual executed steps for
+  backend, Desktop, integrations, and dependency policy. Evidence may come from
+  different ancestor commits only when their relevant inputs remain unchanged.
+  A green documentation-only run contributes no new component evidence.
+  PR names, labels, authors, and dependency caches are not proof.
 
-Each CI lookup has a 30-second timeout: at most one page of 100 runs and one
-page of 100 jobs from the selected successful run. Missing
-or inaccessible evidence causes validation to run. Source or dependency changes
-mixed into a release PR always receive full checks.
+Each CI lookup has a 30-second timeout. Evidence lookup considers one page of
+20 recent successful main push runs and at most six job lists of 100 jobs each.
+Candidates must belong to this repository and be ancestors of the base commit.
+Missing, inaccessible, malformed, or out-of-window evidence selects full
+validation. Source or dependency changes mixed into a release PR still receive
+full checks. The selection summary records each reused component's run and SHA.
 
 After excluding guidance, a change consisting entirely of `.rs` files under
 `desktop/src/` selects Desktop validation only. Deletions still select Desktop;
@@ -74,11 +78,17 @@ installer/assets still require packaging coverage. A source-only change does not
 rebuild the unchanged packaging machinery or CLI architectures; release version
 changes always build both CLI architectures and the complete bundle.
 
-A partial Desktop-only success is not complete release-validation evidence.
-Version-only releases following such a base conservatively run the full suites;
-component evidence inheritance is not implemented. This preserves the existing
-rule that release reuse requires real, successful steps for every required
-component, rather than a green job that only reports a skip.
+A Desktop-only main success supplies Desktop evidence. Backend, integration,
+and dependency-policy evidence may be inherited from an earlier successful main
+run when the intervening diff contains only Desktop Rust, guidance, website, and
+strictly validated project-version changes. Guidance-only runs can inherit all
+components. Shared manifests, dependencies, workflow changes, renames out of
+core, and unknown inputs invalidate inheritance. This deliberately conservative
+input policy does not infer equivalence across arbitrary backend changes.
+
+Component evidence currently controls release correctness reuse as a group:
+all required components must be proven, or the release receives full validation.
+Packaging is always fresh after a release-version merge; it is not inherited.
 
 Backend Rust source, test, benchmark, Cargo/toolchain/build, and `.github/` changes retain
 optimized benchmark smoke. Packaging and JavaScript-only changes still receive
@@ -139,3 +149,50 @@ job durations are not additive. These are observations from one run, not an
 estimated or measured improvement. Hosted cache behavior, release metadata
 selection, artifact download permissions, and elapsed savings need verification
 after deployment.
+
+## Development previews
+
+Development previews are published GitHub prereleases, not scheduled nightlies.
+The stable release path remains Linux-only; the initial development publisher
+promotes the Apple Silicon macOS preview artifact.
+
+1. Push the development branch and open/update its PR. General CI runs its
+   selected checks; the `macOS preview` workflow separately runs native backend
+   checks and builds, ad-hoc signs, checks glyph rasterization, and smoke-tests
+   the app. Both native and package jobs must pass.
+2. Manually run `Publish development preview` with that Mac workflow run ID.
+   The workflow becomes available for manual dispatch once its definition lands
+   on the default branch. No schedule or automatic publication is enabled.
+3. The read-only prepare job requires a completed successful Mac run and
+   successful general CI for the same source revision, including `CI result`.
+   It rejects fork/PR-triggered Mac builds, expired/missing artifacts, wrong
+   architecture/source metadata, and mismatched checksums. It prepares reviewable
+   release metadata without executing the downloaded app or rebuilding it.
+4. The publication job revalidates the candidate, creates a fixed-source tag
+   `preview-macos-YYYYMMDD.<build-run-id>`, uploads the exact ZIP and checksum,
+   verifies uploaded digests, then publishes with `prerelease=true` and
+   `make_latest=false`. GitHub's stable latest release and Desktop stable update
+   checks continue to exclude previews.
+5. Testers report the tag, chip, macOS version, and reproduction steps. A new
+   build gets a new preview tag; published bytes and source tags are never
+   silently replaced. An interrupted draft can be resumed if its existing assets
+   match. Missing/expired artifacts require a new build, not a silent fallback.
+
+General PR CI validates the proposed integration commit; the native Mac workflow
+builds the branch revision itself. Promotion requires both corresponding checks,
+not just a successful packaging job. If general CI is pending or failed,
+publication stops before creating a tag or release.
+
+The stable draft-release blocker ignores only prerelease drafts in the
+`preview-macos-` namespace, so interrupted preview uploads do not stall stable
+release proposals. Other drafts retain the existing blocking behavior.
+
+The same helper can prepare a candidate locally for review without publishing:
+
+```sh
+GITHUB_REPOSITORY=gardnmi/boomux python3 .github/scripts/development-release.py prepare "<run-id>" /tmp/boomux-preview-review
+```
+
+Use a fresh output directory. The explicit `publish` subcommand performs the
+remote mutations and repeats validation. Routine publication should use Actions
+so its result and permissions are recorded with the workflow run.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -162,7 +162,9 @@ promotes the Apple Silicon macOS preview artifact.
    the app. Both native and package jobs must pass.
 2. Manually run `Publish development preview` with that Mac workflow run ID.
    The workflow becomes available for manual dispatch once its definition lands
-   on the default branch. No schedule or automatic publication is enabled.
+   on the default branch. Before then, use the local commands below from the
+   experimental worktree; no merge into `main` is required. No schedule or
+   automatic publication is enabled.
 3. The read-only prepare job requires a completed successful Mac run and
    successful general CI for the same source revision, including `CI result`.
    It rejects fork/PR-triggered Mac builds, expired/missing artifacts, wrong
@@ -194,5 +196,21 @@ GITHUB_REPOSITORY=gardnmi/boomux python3 .github/scripts/development-release.py 
 ```
 
 Use a fresh output directory. The explicit `publish` subcommand performs the
-remote mutations and repeats validation. Routine publication should use Actions
-so its result and permissions are recorded with the workflow run.
+remote mutations and repeats validation. To publish from an experimental branch
+without adding a workflow to `main`, authenticate `gh` with release-write access
+and run both steps against the same fresh directory:
+
+```sh
+GITHUB_REPOSITORY=gardnmi/boomux python3 .github/scripts/development-release.py prepare "<run-id>" /tmp/boomux-preview-publication
+GITHUB_REPOSITORY=gardnmi/boomux python3 .github/scripts/development-release.py publish "<run-id>" /tmp/boomux-preview-publication
+```
+
+The resulting prerelease and its assets are publicly downloadable. The first
+preview also has `.github/scripts/install-macos-preview.sh`: it pins the release,
+archive checksum, and installation directory to build `66bca02a`. Share its raw
+URL pinned to the installer commit, never a moving branch URL. It installs into
+`~/Applications`, verifies the archive and ad-hoc signature, and refuses to
+replace an existing app. A newer preview needs an explicitly updated installer.
+It does not alter Gatekeeper settings; testers may need to approve the app in
+Privacy & Security. Once the dispatcher reaches the default branch, routine
+publication can use Actions to record its result and permissions with the run.


### PR DESCRIPTION
Version-only release PRs currently repeat packaging work, and unchanged component evidence can be lost across selective main-branch CI runs. This change reuses verified ancestor evidence and defers final release builds to the merged release commit. Missing evidence or changed shared inputs select full validation.

It also enables **Publish development preview** from Actions on the default branch. The publisher requires successful general CI and native Mac validation for the source revision, verifies the downloaded ZIP, and publishes the exact bytes as an immutable GitHub prerelease without marking it Latest. The Mac build workflow and application port remain experimental in #397; neither is included here. The checksum-pinned installer for the existing public preview is included with failure-path fixtures.

Validation:
- 72 CI/publisher/installer Python tests passed.
- Actionlint, installer shell syntax, and whitespace checks passed.
- The publisher already promoted run 34427759652 successfully; anonymous downloads matched the validated checksum, and the stable Latest release remained v1.14.1.
- Hosted CI will validate this extraction independently. No Rust code, dependencies, or application packaging changes are included.

This PR can merge independently of the macOS port. Stable product versions should not advance solely for these development/release tooling changes.

BEGIN_COMMIT_OVERRIDE
ci(release): reuse validation and enable development preview publishing
END_COMMIT_OVERRIDE
