### PR TITLE
feat(desktop): persist internal pane arrangements across restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,7 @@ dependencies = [
  "libghostty-vt",
  "notify",
  "semver",
+ "serde",
  "serde_json",
  "smallvec",
  "toml 0.9.12+spec-1.1.0",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -20,6 +20,7 @@ notify = { version = "=8.2.0", default-features = false }
 smallvec = "1.15"
 toml = "=0.9.12"
 toml_edit = "=0.25.13"
+serde = { version = "1", features = ["derive"] }
 serde_json = "=1.0.151"
 semver = "=1.0.28"
 uuid = { version = "1", features = ["v4"] }

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -10,8 +10,8 @@ Ghostty’s terminal core, backed by persistent Boomux Shells.
 > [!NOTE]
 > Stable Desktop releases support GNU/Linux x86_64 with glibc 2.39+, X11 or
 > Wayland, and a working Vulkan driver. Ubuntu 24.04+ and current Arch are the
-> runtime baseline. Shells persist when you close Desktop; pane arrangements
-> and window geometry are not yet saved. See [current limitations](#current-limitations).
+> runtime baseline. Shells persist when you close Desktop; internal pane arrangements are saved across restarts. Outer window geometry
+> is not saved. See [current limitations](#current-limitations).
 
 ## Install Release Builds
 
@@ -283,7 +283,24 @@ Desktop preferences live in
 Service configuration is separate; the Advanced config action opens its
 validated editor.
 
-**Pane arrangements and window geometry are not yet saved.**
+**Internal pane arrangements are saved automatically.** Desktop remembers split
+ratios, floating positions/sizes and stacking, focus, expanded panes, minimized
+Shells, Workspace ordering, and separate Workspace/Mixed arrangements. Switching
+Workspaces restores each saved arrangement.
+
+State lives in `~/.local/state/boomux-desktop/layout-state.json`, respecting
+`XDG_STATE_HOME` and the development-only `BOOMUX_STATE_HOME` override. Writes are
+atomic and debounced by 250 ms; normal quit and update restart flush the final
+snapshot. A crash may lose the most recent unsaved adjustment. Corrupt state is
+retained and a notice explains why saving is disabled; close Desktop and move
+that file aside to reset layouts. Concurrent Desktop instances cannot overwrite
+one another's newer saved state; reopen the older instance if a conflict appears.
+
+Restoration reconnects running Shells without taking over another attachment.
+Stopped or unavailable Shells keep a placeholder with an explicit reconnect/start
+button. Restoration does not start or restart processes. Floating panes are fit
+to the available canvas if its dimensions changed. Outer application window
+geometry, terminal selections, and in-progress drag animations are not saved.
 See [preferences](../docs/desktop/releases.md#desktop-integration-and-preferences).
 
 ### Optional Advanced Setup
@@ -328,7 +345,7 @@ See [update ownership and older-install migration](../docs/desktop/releases.md#d
 - IME, hyperlinks, ligatures, and selection across unloaded scrollback remain
   incomplete.
 - Animation curves are not freely configurable.
-- Pane arrangements and window geometry are not persisted.
+- Outer application window geometry is not persisted.
 
 Per-pane scrollback uses a 4 MiB Ghostty page-memory budget, allocated as output
 arrives. Retained line count varies with terminal width and content. This is

--- a/desktop/scripts/smoke-desktop.py
+++ b/desktop/scripts/smoke-desktop.py
@@ -124,6 +124,23 @@ def check_bundle_ownership(bundle, env, root):
     print("PASS: bundle-owned CLI and symlink are ineligible for self-update", flush=True)
 
 
+def restored_layout_matches(document, shell_id, pending_id):
+    """Require the saved live arrangement, independent of remapped pane IDs."""
+    arrangement = document["arrangements"][document["active"]]
+    split = arrangement.get("tree", {}).get("Split", {})
+    if split.get("ratio") != 0.31 or not split.get("horizontal"):
+        return False
+    panes = arrangement["panes"]
+    left, right = split["first"]["Pane"], split["second"]["Pane"]
+    return (panes[str(left)]["shell"] == shell_id
+            and panes[str(right)]["shell"] == pending_id
+            and arrangement["focused"] == left
+            and arrangement["expanded"] == left
+            and len(arrangement["floating"]) == 1
+            and panes[str(arrangement["floating"][0]["pane"])]["shell"] == "remote:offline:missing"
+            and "minimized-missing" in document["minimized"])
+
+
 def smoke(backend, archive, output, software_driver=None, cpu_model=None):
     output.mkdir(parents=True, exist_ok=True)
     expected = Path(str(archive) + ".sha256").read_text().split()[0]
@@ -309,7 +326,32 @@ def smoke(backend, archive, output, software_driver=None, cpu_model=None):
             after = inspect()
             if after["status"] != "running" or after["run"]["id"] != run_id:
                 raise RuntimeError("exiting Desktop did not preserve the exact ShellRun")
+            layout_path = Path(env["XDG_STATE_HOME"]) / "boomux-desktop/layout-state.json"
+            saved_layout = json.loads(layout_path.read_text())
+            pending_id = created_id(cli("shell", "create", workspace_id, "--name", "restore-must-not-start",
+                                        "--cwd", str(root), "--", "/bin/sh", "-c", "exit 99"))
+            key = "workspace:" + workspace_id
+            saved_layout["active"] = key
+            saved_layout["minimized"] = ["minimized-missing"]
+            saved_layout["arrangements"][key] = dict(
+                tree={"Split": {"horizontal": True, "ratio": 0.31, "first": {"Pane": 9}, "second": {"Pane": 13}}},
+                floating=[{"pane": 15, "rect": [80.0, 60.0, 300.0, 200.0]}],
+                panes={"9": {"shell": shell_id, "workspace": workspace_id},
+                       "13": {"shell": pending_id, "workspace": workspace_id},
+                       "15": {"shell": "remote:offline:missing", "workspace": workspace_id}},
+                focused=9, expanded=9, canvas=[1000.0, 700.0])
+            layout_path.write_text(json.dumps(saved_layout))
+            env.pop("BOOMUX_DESKTOP_SHELL_ID", None)
             app = launch("shell-reattach")
+            def layout_restored():
+                document = json.loads(layout_path.read_text())
+                return (document["revision"] != saved_layout["revision"]
+                        and restored_layout_matches(document, shell_id, pending_id))
+            wait_for("internal layout restoration and durable recapture", layout_restored, [*servers, app])
+            (output / "restored-layout.json").write_text(layout_path.read_text())
+            pending_shell = json.loads(cli("--json", "shell", "inspect", pending_id))["data"]["shell"]
+            if pending_shell["status"] != "pending":
+                raise RuntimeError("layout restoration started a pending Shell")
             after = inspect()
             if after["status"] != "running" or after["run"]["id"] != run_id:
                 raise RuntimeError("reopening Desktop changed the ShellRun")
@@ -319,7 +361,7 @@ def smoke(backend, archive, output, software_driver=None, cpu_model=None):
             if json.loads(cli("--json", "daemon", "status"))["data"]["pid"] != daemon_pid:
                 raise RuntimeError("reopening Desktop replaced the daemon")
             (output / "result.json").write_text(json.dumps(
-                dict(backend=backend, cpu_model=cpu_model, emulated_components=["desktop", "daemon", "cli"] if cpu_model else [], shell_id=shell_id, run_id=run_id, status="passed",
+                dict(backend=backend, cpu_model=cpu_model, emulated_components=["desktop", "daemon", "cli"] if cpu_model else [], shell_id=shell_id, run_id=run_id, status="passed", layout_restored=True,
                      archive_sha256=actual, boomux_version=cli("--version").strip()), indent=2))
             print(f"PASS: {backend} bundle startup, attachment, and ShellRun survival", flush=True)
         finally:

--- a/desktop/scripts/smoke-desktop.py
+++ b/desktop/scripts/smoke-desktop.py
@@ -137,6 +137,7 @@ def restored_layout_matches(document, shell_id, pending_id):
             and arrangement["focused"] == left
             and arrangement["expanded"] == left
             and len(arrangement["floating"]) == 1
+            and arrangement["floating"][0]["rect"][2:] == [300.0, 200.0]
             and panes[str(arrangement["floating"][0]["pane"])]["shell"] == "remote:offline:missing"
             and "minimized-missing" in document["minimized"])
 

--- a/desktop/scripts/smoke-desktop.py
+++ b/desktop/scripts/smoke-desktop.py
@@ -346,6 +346,7 @@ def smoke(backend, archive, output, software_driver=None, cpu_model=None):
             app = launch("shell-reattach")
             def layout_restored():
                 document = json.loads(layout_path.read_text())
+                (output / "restored-layout.json").write_text(json.dumps(document, indent=2))
                 return (document["revision"] != saved_layout["revision"]
                         and restored_layout_matches(document, shell_id, pending_id))
             wait_for("internal layout restoration and durable recapture", layout_restored, [*servers, app])

--- a/desktop/scripts/test-smoke.py
+++ b/desktop/scripts/test-smoke.py
@@ -21,7 +21,7 @@ class SmokeEvidenceTests(unittest.TestCase):
         document = {"active": "workspace:w", "minimized": ["minimized-missing"], "arrangements": {
             "workspace:w": {"tree": {"Split": {"ratio": 0.31, "horizontal": True, "first": {"Pane": 101}, "second": {"Pane": 202}}},
                 "panes": {"101": {"shell": "running"}, "202": {"shell": "pending"}, "303": {"shell": "remote:offline:missing"}},
-                "focused": 101, "expanded": 101, "floating": [{"pane": 303}]}}}
+                "focused": 101, "expanded": 101, "floating": [{"pane": 303, "rect": [80.0, 60.0, 300.0, 200.0]}]}}}
         self.assertTrue(SMOKE["restored_layout_matches"](document, "running", "pending"))
         for field, value in [("focused", 202), ("expanded", None), ("floating", [])]:
             broken = copy.deepcopy(document)

--- a/desktop/scripts/test-smoke.py
+++ b/desktop/scripts/test-smoke.py
@@ -1,5 +1,6 @@
 """Checks that smoke-test readiness cannot pass on an idle or failed client."""
 
+import copy
 from pathlib import Path
 import runpy
 import unittest
@@ -16,6 +17,18 @@ wl_callback#23.done(12345)
 
 
 class SmokeEvidenceTests(unittest.TestCase):
+    def test_layout_evidence_requires_restored_geometry_identity_and_state(self):
+        document = {"active": "workspace:w", "minimized": ["minimized-missing"], "arrangements": {
+            "workspace:w": {"tree": {"Split": {"ratio": 0.31, "horizontal": True, "first": {"Pane": 101}, "second": {"Pane": 202}}},
+                "panes": {"101": {"shell": "running"}, "202": {"shell": "pending"}, "303": {"shell": "remote:offline:missing"}},
+                "focused": 101, "expanded": 101, "floating": [{"pane": 303}]}}}
+        self.assertTrue(SMOKE["restored_layout_matches"](document, "running", "pending"))
+        for field, value in [("focused", 202), ("expanded", None), ("floating", [])]:
+            broken = copy.deepcopy(document)
+            broken["arrangements"]["workspace:w"][field] = value
+            self.assertFalse(SMOKE["restored_layout_matches"](broken, "running", "pending"))
+        self.assertFalse(SMOKE["restored_layout_matches"](document, "wrong-runner", "pending"))
+
     def test_accepts_committed_window_frame(self):
         self.assertTrue(SMOKE["wayland_frame_presented"](FRAME))
         self.assertTrue(SMOKE["wayland_frame_presented"](FRAME.replace("#", "@")))

--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -1,0 +1,496 @@
+//! Conversion between live pane entities and durable presentation metadata.
+use crate::{
+    layout_state::{Arrangement, Floating, Pane, Tree},
+    *,
+};
+
+fn encode_tree(node: &Node) -> Tree {
+    match node {
+        Node::Pane(id) => Tree::Pane(*id as u64),
+        Node::Split {
+            axis,
+            ratio,
+            first,
+            second,
+        } => Tree::Split {
+            horizontal: *axis == Axis::Horizontal,
+            ratio: *ratio,
+            first: Box::new(encode_tree(first)),
+            second: Box::new(encode_tree(second)),
+        },
+    }
+}
+fn decode_tree(node: &Tree, ids: &HashMap<u64, usize>) -> Node {
+    match node {
+        Tree::Pane(id) => Node::Pane(ids[id]),
+        Tree::Split {
+            horizontal,
+            ratio,
+            first,
+            second,
+        } => Node::Split {
+            axis: if *horizontal {
+                Axis::Horizontal
+            } else {
+                Axis::Vertical
+            },
+            ratio: *ratio,
+            first: Box::new(decode_tree(first, ids)),
+            second: Box::new(decode_tree(second, ids)),
+        },
+    }
+}
+impl Workspace {
+    pub(super) fn initialize_layout(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.layout_canvas = self.panel_size(window);
+        self.workspace_order = if self.layout_document.workspace_order.is_empty() {
+            self.workspace_order.clone()
+        } else {
+            self.layout_document.workspace_order.clone()
+        };
+        self.minimized_shells = self.layout_document.minimized.iter().cloned().collect();
+        let key = self.layout_document.active.clone();
+        if key == "mixed" {
+            self.workspace_pane_mode = WorkspacePaneMode::Mixed;
+            self.pane_layout_mode = PaneLayoutMode::Tiled;
+        }
+        if let Some(workspace) = key.strip_prefix("workspace:") {
+            self.workspace_pane_mode = WorkspacePaneMode::Workspace;
+            self.expanded_workspaces = HashSet::from([workspace.to_owned()]);
+        }
+        if let Some(arrangement) = self.layout_document.arrangements.get(&key).cloned() {
+            self.restore_arrangement(arrangement, window, cx);
+        } else {
+            self.layout_document.active.clear();
+        }
+        let entity = cx.weak_entity();
+        window.on_window_should_close(cx, move |window, cx| {
+            entity
+                .update(cx, |this, cx| this.close_after_layout_save(window, cx))
+                .unwrap_or(true)
+        });
+        cx.on_app_quit(|this, _| {
+            this.layout_save_task.take();
+            this.capture_arrangement();
+            if this.layout_frozen
+                && !this.layout_closing
+                && let Some(writer) = this.layout_writer.take()
+            {
+                writer.close();
+            }
+            let pending = this.layout_writer.take().map(|writer| {
+                let pending = layout_state::submit(&writer, this.layout_document.clone());
+                writer.close();
+                pending
+            });
+            async move {
+                if let Some(pending) = pending
+                    && let Ok(Err(error)) = pending.recv().await
+                {
+                    eprintln!("Could not save Desktop layout: {error}");
+                }
+            }
+        })
+        .detach();
+    }
+
+    pub(super) fn capture_arrangement(&mut self) {
+        if self.layout_frozen || self.layout_restoring || self.pointer_drag.is_some() {
+            return;
+        }
+        let key = if self.workspace_pane_mode == WorkspacePaneMode::Mixed {
+            "mixed".to_string()
+        } else {
+            self.terminals
+                .get(&self.focused)
+                .and_then(|p| {
+                    p.shell
+                        .as_ref()
+                        .map(|s| s.workspace_id.clone())
+                        .or_else(|| p.restored.as_ref().and_then(|p| p.workspace.clone()))
+                })
+                .map(|w| format!("workspace:{w}"))
+                .unwrap_or_else(|| self.layout_document.active.clone())
+        };
+        if key.is_empty() {
+            return;
+        }
+        let ids = ordered_pane_ids(self.layout.as_ref(), &self.floating);
+        let panes = ids
+            .iter()
+            .filter_map(|id| {
+                self.terminals.get(id).map(|pane| {
+                    let reference = pane
+                        .shell
+                        .as_ref()
+                        .map(|shell| Pane {
+                            shell: Some(shell.id.clone()),
+                            workspace: Some(shell.workspace_id.clone()),
+                        })
+                        .or_else(|| pane.restored.clone())
+                        .unwrap_or(Pane {
+                            shell: None,
+                            workspace: None,
+                        });
+                    (*id as u64, reference)
+                })
+            })
+            .collect();
+        let arrangement = Arrangement {
+            tree: self.layout.as_ref().map(encode_tree),
+            floating: self
+                .floating
+                .iter()
+                .map(|p| Floating {
+                    pane: p.id as u64,
+                    rect: [p.x, p.y, p.width, p.height],
+                })
+                .collect(),
+            panes,
+            focused: ids.contains(&self.focused).then_some(self.focused as u64),
+            expanded: self
+                .fullscreen
+                .filter(|id| ids.contains(id))
+                .map(|id| id as u64),
+            canvas: [self.layout_canvas.0.max(1.0), self.layout_canvas.1.max(1.0)],
+        };
+        let retained_panes: usize = self
+            .layout_document
+            .arrangements
+            .iter()
+            .filter(|(saved_key, _)| **saved_key != key)
+            .map(|(_, saved)| saved.panes.len())
+            .sum();
+        if (self.layout_document.arrangements.len() >= 256
+            && !self.layout_document.arrangements.contains_key(&key))
+            || retained_panes + arrangement.panes.len() > 4096
+        {
+            self.layout_error = Some("Saved layout limit reached".into());
+            return;
+        }
+        self.layout_document.active = key.clone();
+        self.layout_document.arrangements.insert(key, arrangement);
+        self.layout_document.workspace_order = self.workspace_order.clone();
+        self.layout_document
+            .minimized
+            .retain(|id| self.minimized_shells.contains(id));
+        for workspace in &self.boomux_overview.workspaces {
+            for shell in &workspace.shells {
+                if self.minimized_shells.contains(&shell.id)
+                    && !self.layout_document.minimized.contains(&shell.id)
+                {
+                    self.layout_document.minimized.push(shell.id.clone());
+                }
+            }
+        }
+    }
+
+    pub(super) fn layout_changed(&mut self, cx: &mut Context<Self>) {
+        if self.layout_frozen || self.layout_restoring || self.layout_writer.is_none() {
+            return;
+        }
+        self.layout_generation = self.layout_generation.wrapping_add(1);
+        let generation = self.layout_generation;
+        self.layout_save_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(250))
+                .await;
+            let pending = this
+                .update(cx, |this, _| {
+                    if this.layout_generation != generation || this.pointer_drag.is_some() {
+                        return None;
+                    }
+                    this.capture_arrangement();
+                    this.layout_writer
+                        .as_ref()
+                        .map(|writer| layout_state::submit(writer, this.layout_document.clone()))
+                })
+                .ok()
+                .flatten();
+            if let Some(pending) = pending {
+                let result = pending.recv().await;
+                let _ = this.update(cx, |this, cx| {
+                    if let Ok(result) = result {
+                        this.layout_error = result.err();
+                        cx.notify();
+                    }
+                });
+            }
+        }));
+    }
+
+    pub(super) fn restore_arrangement(
+        &mut self,
+        saved: Arrangement,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.layout_restoring = true;
+        self.finish_current_workspace_transition(window);
+        self.detach_all_panes(window);
+        let mut ids = HashMap::new();
+        for (saved_id, reference) in &saved.panes {
+            let id = self.next_id;
+            self.next_id += 1;
+            ids.insert(*saved_id, id);
+            let shell = reference
+                .shell
+                .as_ref()
+                .and_then(|key| self.boomux_shells.iter().find(|s| &s.id == key))
+                .cloned();
+            self.terminals.insert(id, TerminalPane {
+                shell, restored: Some(reference.clone()),
+                error: reference.shell.as_ref().map(|_| "Saved Shell is unavailable or stopped. Select it in the sidebar to reconnect or start it.".into()),
+                ..Default::default()
+            });
+        }
+        self.layout = saved.tree.as_ref().map(|node| decode_tree(node, &ids));
+        let canvas = self.panel_size(window);
+        self.floating = saved
+            .floating
+            .iter()
+            .map(|p| {
+                clamp_floating_to_panel(
+                    FloatingPane {
+                        id: ids[&p.pane],
+                        x: p.rect[0] * canvas.0 / saved.canvas[0],
+                        y: p.rect[1] * canvas.1 / saved.canvas[1],
+                        width: p.rect[2],
+                        height: p.rect[3],
+                    },
+                    canvas,
+                )
+            })
+            .collect();
+        self.focused = saved
+            .focused
+            .and_then(|id| ids.get(&id).copied())
+            .or_else(|| ids.values().copied().min())
+            .unwrap_or(0);
+        self.fullscreen = saved.expanded.and_then(|id| ids.get(&id).copied());
+        self.reconnect_saved_panes(window, cx);
+        self.layout_restoring = false;
+        cx.notify();
+    }
+
+    pub(super) fn restore_workspace_layout(
+        &mut self,
+        workspace: &str,
+        preferred: Option<&str>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let outgoing_mixed = self.layout_document.active == "mixed";
+        if outgoing_mixed == (self.workspace_pane_mode == WorkspacePaneMode::Mixed) {
+            self.capture_arrangement();
+        }
+        if self.workspace_pane_mode == WorkspacePaneMode::Mixed {
+            return false;
+        }
+        let key = format!("workspace:{workspace}");
+        if key == self.layout_document.active {
+            return false;
+        }
+        if let Some(saved) = self.layout_document.arrangements.get(&key).cloned() {
+            self.layout_document.active = key;
+            self.expanded_workspaces = HashSet::from([workspace.to_owned()]);
+            self.restore_arrangement(saved, window, cx);
+            if let Some(preferred) = preferred {
+                self.activate_sidebar_shell(preferred, window, cx);
+            }
+            self.layout_changed(cx);
+            return true;
+        }
+        false
+    }
+
+    pub(super) fn start_restored_attachment(
+        &mut self,
+        id: usize,
+        shell: ShellChoice,
+        size: (u16, u16, u16, u16),
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(pane) = self.terminals.get_mut(&id) {
+            pane.attaching = true;
+            pane.restore_attempt = shell.run_id.clone();
+            pane.error = None;
+        }
+        cx.spawn(async move |this, cx| {
+            let attached = shell.clone();
+            let result = cx
+                .background_spawn(async move {
+                    TerminalSession::restore(shell, size.0, size.1, size.2, size.3)
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                let Some(pane) = this.terminals.get_mut(&id) else {
+                    return;
+                };
+                // The user may have explicitly attached something else while restoring.
+                if pane.session.is_some() || pane.shell.as_ref().is_none_or(|s| s.id != attached.id)
+                {
+                    return;
+                }
+                pane.attaching = false;
+                match result {
+                    Ok(session) => {
+                        pane.screen = Some(session.screen());
+                        pane.session = Some(session);
+                        pane.shell = Some(attached.clone());
+                        this.watch_terminal(id, attached.id, cx);
+                    }
+                    Err(error) => {
+                        pane.error = Some(error);
+                        pane.restore_failures = pane.restore_failures.saturating_add(1);
+                        pane.restore_retry_after = Some(
+                            Instant::now()
+                                + Duration::from_secs(
+                                    (1u64 << pane.restore_failures.min(5)).min(30),
+                                ),
+                        );
+                    }
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+}
+
+impl Workspace {
+    pub(super) fn reconnect_saved_pane(
+        &mut self,
+        id: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let key = self
+            .terminals
+            .get(&id)
+            .and_then(|p| p.restored.as_ref())
+            .and_then(|p| p.shell.as_ref());
+        let shell = key
+            .and_then(|key| self.boomux_shells.iter().find(|s| &s.id == key))
+            .cloned();
+        if let Some(shell) = shell {
+            let size = self.terminal_grid_size(id, window);
+            self.start_terminal_attachment(id, shell, size, cx);
+        } else if let Some(pane) = self.terminals.get_mut(&id) {
+            pane.error =
+                Some("Shell is unavailable. Reconnect its Node or dismiss this pane.".into());
+            cx.notify();
+        }
+    }
+
+    pub(super) fn reconnect_saved_panes(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let mut pending = Vec::new();
+        for (id, pane) in &mut self.terminals {
+            if pane.session.is_some() || pane.attaching {
+                continue;
+            }
+            let Some(key) = pane.restored.as_ref().and_then(|p| p.shell.as_ref()) else {
+                continue;
+            };
+            if let Some(remote) = remote::identity(key)
+                && !self
+                    .node_views
+                    .iter()
+                    .any(|n| n.id == remote.node_id && n.connected())
+            {
+                pane.restore_attempt = None;
+                continue;
+            }
+            let Some(shell) = self.boomux_shells.iter().find(|s| &s.id == key) else {
+                continue;
+            };
+            let Some(run) = &shell.run_id else {
+                continue;
+            };
+            let retry_due = pane
+                .restore_retry_after
+                .is_some_and(|deadline| Instant::now() >= deadline);
+            if pending.len() < 4
+                && matches!(shell.status, boomux::protocol::ShellStatus::Running)
+                && (pane.restore_attempt.as_ref() != Some(run) || retry_due)
+            {
+                pane.restore_attempt = Some(run.clone());
+                pane.restore_retry_after = None;
+                pane.shell = Some(shell.clone());
+                pending.push((*id, shell.clone()));
+            }
+        }
+        for (id, shell) in pending {
+            let size = self.terminal_grid_size(id, window);
+            self.start_restored_attachment(id, shell, size, cx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn layout_tree_remaps_ephemeral_ids_without_changing_split_sizes() {
+        let tree = Node::Split {
+            axis: Axis::Vertical,
+            ratio: 0.37,
+            first: Box::new(Node::Pane(17)),
+            second: Box::new(Node::Pane(42)),
+        };
+        let restored = decode_tree(&encode_tree(&tree), &HashMap::from([(17, 101), (42, 102)]));
+        assert_eq!(restored.pane_ids(), vec![101, 102]);
+        assert_eq!(restored.rects()[0].1.height, 0.37);
+        assert_eq!(restored.rects()[1].1.y, 0.37);
+    }
+}
+
+impl Workspace {
+    fn close_after_layout_save(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        if self.layout_writer.is_none() || self.layout_frozen && !self.layout_closing {
+            return true;
+        }
+        if self.layout_closing {
+            return false;
+        }
+        if self
+            .layout_error
+            .as_ref()
+            .is_some_and(|e| e.ends_with("Close again to exit without saving."))
+        {
+            return true;
+        }
+        self.capture_arrangement();
+        self.layout_save_task.take();
+        self.layout_closing = true;
+        self.layout_frozen = true;
+        let pending = layout_state::submit(
+            self.layout_writer.as_ref().unwrap(),
+            self.layout_document.clone(),
+        );
+        let handle = window.window_handle();
+        cx.spawn(async move |this, cx| {
+            let result = pending
+                .recv()
+                .await
+                .unwrap_or_else(|_| Err("Layout save interrupted".into()));
+            let _ = handle.update(cx, |_, window, cx| {
+                this.update(cx, |this, cx| match result {
+                    Ok(()) => {
+                        this.layout_closing = false;
+                        window.remove_window();
+                    }
+                    Err(error) => {
+                        this.layout_closing = false;
+                        this.layout_frozen = false;
+                        this.layout_error =
+                            Some(format!("{error}. Close again to exit without saving."));
+                        cx.notify();
+                    }
+                })
+            });
+        })
+        .detach();
+        false
+    }
+}

--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -4,6 +4,29 @@ use crate::{
     *,
 };
 
+/// Ignore synthetic/stationary pointer enters while restoring keyboard focus.
+pub(super) enum PointerGuard {
+    Inactive,
+    Waiting,
+    Anchored((f32, f32)),
+}
+impl PointerGuard {
+    pub(super) fn allows_focus(&mut self, position: (f32, f32)) -> bool {
+        match *self {
+            Self::Inactive => true,
+            Self::Waiting => {
+                *self = Self::Anchored(position);
+                false
+            }
+            Self::Anchored(anchor) if !pointer_moved_from(anchor, position) => false,
+            Self::Anchored(_) => {
+                *self = Self::Inactive;
+                true
+            }
+        }
+    }
+}
+
 fn encode_tree(node: &Node) -> Tree {
     match node {
         Node::Pane(id) => Tree::Pane(*id as u64),
@@ -65,6 +88,19 @@ impl Workspace {
         } else {
             self.layout_document.active.clear();
         }
+        cx.observe_window_bounds(window, |this, window, cx| {
+            this.sidebar_viewport_width = f32::from(window.viewport_size().width);
+            let canvas = this.panel_size(window);
+            if canvas.0 > 0.0 && canvas.1 > 0.0 {
+                this.layout_canvas = canvas;
+                for pane in &mut this.floating {
+                    *pane = clamp_floating_to_panel(pane.clone(), canvas);
+                }
+                this.layout_changed(cx);
+                cx.notify();
+            }
+        })
+        .detach();
         let entity = cx.weak_entity();
         window.on_window_should_close(cx, move |window, cx| {
             entity
@@ -235,6 +271,7 @@ impl Workspace {
         cx: &mut Context<Self>,
     ) {
         self.layout_restoring = true;
+        self.restore_pointer_guard = PointerGuard::Waiting;
         self.finish_current_workspace_transition(window);
         self.detach_all_panes(window);
         let mut ids = HashMap::new();
@@ -254,7 +291,12 @@ impl Workspace {
             });
         }
         self.layout = saved.tree.as_ref().map(|node| decode_tree(node, &ids));
-        let canvas = self.panel_size(window);
+        let actual_canvas = self.panel_size(window);
+        let canvas = if actual_canvas.0 > 0.0 && actual_canvas.1 > 0.0 {
+            actual_canvas
+        } else {
+            (saved.canvas[0], saved.canvas[1])
+        };
         self.floating = saved
             .floating
             .iter()
@@ -501,6 +543,15 @@ impl Workspace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn layout_restore_keeps_focus_until_the_pointer_actually_moves() {
+        let mut guard = PointerGuard::Waiting;
+        assert!(!guard.allows_focus((640.0, 400.0)));
+        assert!(!guard.allows_focus((640.0, 400.0)));
+        assert!(guard.allows_focus((650.0, 400.0)));
+        assert!(guard.allows_focus((650.0, 400.0)));
+    }
+
     #[test]
     fn layout_tree_remaps_ephemeral_ids_without_changing_split_sizes() {
         let tree = Node::Split {

--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -42,6 +42,7 @@ fn decode_tree(node: &Tree, ids: &HashMap<u64, usize>) -> Node {
 }
 impl Workspace {
     pub(super) fn initialize_layout(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.sidebar_viewport_width = f32::from(window.viewport_size().width);
         self.layout_canvas = self.panel_size(window);
         self.workspace_order = if self.layout_document.workspace_order.is_empty() {
             self.workspace_order.clone()
@@ -385,6 +386,12 @@ impl Workspace {
     }
 
     pub(super) fn reconnect_saved_panes(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let available = 4usize.saturating_sub(
+            self.terminals
+                .values()
+                .filter(|p| p.restored.is_some() && p.attaching)
+                .count(),
+        );
         let mut pending = Vec::new();
         for (id, pane) in &mut self.terminals {
             if pane.session.is_some() || pane.attaching {
@@ -411,7 +418,7 @@ impl Workspace {
             let retry_due = pane
                 .restore_retry_after
                 .is_some_and(|deadline| Instant::now() >= deadline);
-            if pending.len() < 4
+            if pending.len() < available
                 && matches!(shell.status, boomux::protocol::ShellStatus::Running)
                 && (pane.restore_attempt.as_ref() != Some(run) || retry_due)
             {

--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -60,6 +60,7 @@ impl Workspace {
         }
         if let Some(arrangement) = self.layout_document.arrangements.get(&key).cloned() {
             self.restore_arrangement(arrangement, window, cx);
+            self.layout_changed(cx);
         } else {
             self.layout_document.active.clear();
         }
@@ -427,24 +428,6 @@ impl Workspace {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn layout_tree_remaps_ephemeral_ids_without_changing_split_sizes() {
-        let tree = Node::Split {
-            axis: Axis::Vertical,
-            ratio: 0.37,
-            first: Box::new(Node::Pane(17)),
-            second: Box::new(Node::Pane(42)),
-        };
-        let restored = decode_tree(&encode_tree(&tree), &HashMap::from([(17, 101), (42, 102)]));
-        assert_eq!(restored.pane_ids(), vec![101, 102]);
-        assert_eq!(restored.rects()[0].1.height, 0.37);
-        assert_eq!(restored.rects()[1].1.y, 0.37);
-    }
-}
-
 impl Workspace {
     fn close_after_layout_save(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
         if self.layout_writer.is_none() || self.layout_frozen && !self.layout_closing {
@@ -492,5 +475,23 @@ impl Workspace {
         })
         .detach();
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn layout_tree_remaps_ephemeral_ids_without_changing_split_sizes() {
+        let tree = Node::Split {
+            axis: Axis::Vertical,
+            ratio: 0.37,
+            first: Box::new(Node::Pane(17)),
+            second: Box::new(Node::Pane(42)),
+        };
+        let restored = decode_tree(&encode_tree(&tree), &HashMap::from([(17, 101), (42, 102)]));
+        assert_eq!(restored.pane_ids(), vec![101, 102]);
+        assert_eq!(restored.rects()[0].1.height, 0.37);
+        assert_eq!(restored.rects()[1].1.y, 0.37);
     }
 }

--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -96,9 +96,9 @@ impl Workspace {
         .detach();
     }
 
-    pub(super) fn capture_arrangement(&mut self) {
+    pub(super) fn capture_arrangement(&mut self) -> bool {
         if self.layout_frozen || self.layout_restoring || self.pointer_drag.is_some() {
-            return;
+            return false;
         }
         let key = if self.workspace_pane_mode == WorkspacePaneMode::Mixed {
             "mixed".to_string()
@@ -115,7 +115,7 @@ impl Workspace {
                 .unwrap_or_else(|| self.layout_document.active.clone())
         };
         if key.is_empty() {
-            return;
+            return false;
         }
         let ids = ordered_pane_ids(self.layout.as_ref(), &self.floating);
         let panes = ids
@@ -168,7 +168,10 @@ impl Workspace {
             || retained_panes + arrangement.panes.len() > 4096
         {
             self.layout_error = Some("Saved layout limit reached".into());
-            return;
+            return false;
+        }
+        if self.layout_error.as_deref() == Some("Saved layout limit reached") {
+            self.layout_error = None;
         }
         self.layout_document.active = key.clone();
         self.layout_document.arrangements.insert(key, arrangement);
@@ -185,6 +188,7 @@ impl Workspace {
                 }
             }
         }
+        true
     }
 
     pub(super) fn layout_changed(&mut self, cx: &mut Context<Self>) {
@@ -198,11 +202,14 @@ impl Workspace {
                 .timer(Duration::from_millis(250))
                 .await;
             let pending = this
-                .update(cx, |this, _| {
+                .update(cx, |this, cx| {
                     if this.layout_generation != generation || this.pointer_drag.is_some() {
                         return None;
                     }
-                    this.capture_arrangement();
+                    if !this.capture_arrangement() {
+                        cx.notify();
+                        return None;
+                    }
                     this.layout_writer
                         .as_ref()
                         .map(|writer| layout_state::submit(writer, this.layout_document.clone()))
@@ -451,6 +458,12 @@ impl Workspace {
             return true;
         }
         self.capture_arrangement();
+        if self.layout_error.as_deref() == Some("Saved layout limit reached") {
+            self.layout_error =
+                Some("Saved layout limit reached. Close again to exit without saving.".into());
+            cx.notify();
+            return false;
+        }
         self.layout_save_task.take();
         self.layout_closing = true;
         self.layout_frozen = true;

--- a/desktop/src/layout_state.rs
+++ b/desktop/src/layout_state.rs
@@ -1,0 +1,412 @@
+//! Desktop presentation state only. Never starts Shells or stores terminal data.
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fs,
+    io::{Read, Write as _},
+    os::{fd::AsRawFd, unix::fs::OpenOptionsExt},
+    path::PathBuf,
+};
+
+const MAX_BYTES: usize = 2 * 1024 * 1024;
+const MAX_PANES: usize = 4096;
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Arrangement {
+    pub tree: Option<Tree>,
+    pub floating: Vec<Floating>,
+    pub panes: BTreeMap<u64, Pane>,
+    pub focused: Option<u64>,
+    pub expanded: Option<u64>,
+    pub canvas: [f32; 2],
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Pane {
+    // Remote keys contain both owner and resource. Local keys are scoped by
+    // Document.owner, verified against the connected daemon before restoring.
+    pub shell: Option<String>,
+    pub workspace: Option<String>,
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Tree {
+    Pane(u64),
+    Split {
+        horizontal: bool,
+        ratio: f32,
+        first: Box<Tree>,
+        second: Box<Tree>,
+    },
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Floating {
+    pub pane: u64,
+    pub rect: [f32; 4],
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Document {
+    pub version: u32,
+    pub revision: String,
+    pub owner: String,
+    pub active: String,
+    pub arrangements: BTreeMap<String, Arrangement>,
+    pub minimized: Vec<String>,
+    pub workspace_order: Vec<String>,
+}
+impl Default for Document {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            revision: String::new(),
+            owner: String::new(),
+            active: String::new(),
+            arrangements: BTreeMap::new(),
+            minimized: Vec::new(),
+            workspace_order: Vec::new(),
+        }
+    }
+}
+impl Tree {
+    fn validate(&self, depth: usize, ids: &mut HashSet<u64>) -> Result<(), String> {
+        if depth > 64 || ids.len() >= MAX_PANES {
+            return Err("layout tree exceeds bounds".into());
+        }
+        match self {
+            Self::Pane(id) => {
+                if !ids.insert(*id) {
+                    return Err("duplicate pane".into());
+                }
+            }
+            Self::Split {
+                ratio,
+                first,
+                second,
+                ..
+            } => {
+                if !ratio.is_finite() || !(0.01..=0.99).contains(ratio) {
+                    return Err("invalid split ratio".into());
+                }
+                first.validate(depth + 1, ids)?;
+                second.validate(depth + 1, ids)?;
+            }
+        }
+        Ok(())
+    }
+}
+impl Document {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.version != 1 {
+            return Err("unsupported layout state version; saved file retained".into());
+        }
+        if self.arrangements.len() > 256
+            || self.minimized.len() > MAX_PANES
+            || self.workspace_order.len() > 4096
+        {
+            return Err("layout state exceeds bounds".into());
+        }
+        let mut total = 0;
+        for arrangement in self.arrangements.values() {
+            let mut ids = HashSet::new();
+            if let Some(tree) = &arrangement.tree {
+                tree.validate(0, &mut ids)?;
+            }
+            for floating in &arrangement.floating {
+                if !ids.insert(floating.pane)
+                    || !floating.rect.iter().all(|v| v.is_finite())
+                    || floating.rect[2] <= 0.0
+                    || floating.rect[3] <= 0.0
+                {
+                    return Err("invalid floating pane".into());
+                }
+            }
+            total += ids.len();
+            if total > MAX_PANES
+                || ids.len() != arrangement.panes.len()
+                || !ids.iter().all(|id| arrangement.panes.contains_key(id))
+            {
+                return Err("invalid pane references".into());
+            }
+            for id in [arrangement.focused, arrangement.expanded]
+                .into_iter()
+                .flatten()
+            {
+                if !ids.contains(&id) {
+                    return Err("invalid focused or expanded pane".into());
+                }
+            }
+            if !arrangement.canvas.iter().all(|v| v.is_finite() && *v > 0.0) {
+                return Err("invalid canvas dimensions".into());
+            }
+            let mut shells = HashSet::new();
+            for pane in arrangement.panes.values() {
+                if let Some(shell) = &pane.shell
+                    && (shell.len() > 1024 || !shells.insert(shell))
+                {
+                    return Err("duplicate or oversized Shell identity".into());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+pub fn path() -> Option<PathBuf> {
+    let root = std::env::var_os("BOOMUX_STATE_HOME")
+        .or_else(|| std::env::var_os("XDG_STATE_HOME"))
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/state")))?;
+    root.is_absolute()
+        .then(|| root.join("boomux-desktop/layout-state.json"))
+}
+fn read(path: &PathBuf) -> Result<Document, String> {
+    let file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Document::default()),
+        Err(e) => return Err(e.to_string()),
+    };
+    let mut bytes = Vec::new();
+    file.take((MAX_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|e| e.to_string())?;
+    if bytes.len() > MAX_BYTES {
+        return Err("layout state exceeds 2 MiB".into());
+    }
+    let document: Document = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+    document.validate()?;
+    Ok(document)
+}
+struct Store {
+    path: PathBuf,
+    revision: String,
+}
+impl Store {
+    fn save(&mut self, mut document: Document) -> Result<(), String> {
+        document.validate()?;
+        let parent = self.path.parent().ok_or("invalid layout path")?;
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        let lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(self.path.with_extension("lock"))
+            .map_err(|e| e.to_string())?;
+        if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+            return Err("another Desktop is saving this layout".into());
+        }
+        if read(&self.path)?.revision != self.revision {
+            return Err("another Desktop changed this layout; reopen Desktop before saving".into());
+        }
+        document.revision = uuid::Uuid::new_v4().to_string();
+        let bytes = serde_json::to_vec(&document).map_err(|e| e.to_string())?;
+        if bytes.len() > MAX_BYTES {
+            return Err("layout state exceeds 2 MiB".into());
+        }
+        let temporary = parent.join(format!(".layout-{}", document.revision));
+        let result = (|| -> std::io::Result<()> {
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&temporary)?;
+            file.write_all(&bytes)?;
+            file.sync_all()?;
+            fs::rename(&temporary, &self.path)?;
+            fs::File::open(parent)?.sync_all()
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(temporary);
+        }
+        result.map_err(|e| e.to_string())?;
+        self.revision = document.revision;
+        Ok(())
+    }
+}
+pub struct Write {
+    pub document: Document,
+    pub completion: async_channel::Sender<Result<(), String>>,
+}
+pub struct Session {
+    pub document: Document,
+    pub writer: Option<async_channel::Sender<Write>>,
+    pub error: Option<String>,
+}
+impl Session {
+    pub fn load() -> Self {
+        Self::at(path())
+    }
+    fn at(path: Option<PathBuf>) -> Self {
+        let result = path
+            .ok_or("cannot resolve Desktop state directory".into())
+            .and_then(|path| read(&path).map(|doc| (path, doc)));
+        match result {
+            Err(error) => Self {
+                document: Document::default(),
+                writer: None,
+                error: Some(error),
+            },
+            Ok((path, document)) => {
+                let mut store = Store {
+                    path,
+                    revision: document.revision.clone(),
+                };
+                let (send, receive) = async_channel::bounded::<Write>(1);
+                std::thread::spawn(move || {
+                    while let Ok(request) = receive.recv_blocking() {
+                        let result = store.save(request.document);
+                        let _ = request.completion.send_blocking(result);
+                    }
+                });
+                Self {
+                    document,
+                    writer: Some(send),
+                    error: None,
+                }
+            }
+        }
+    }
+}
+pub fn submit(
+    writer: &async_channel::Sender<Write>,
+    document: Document,
+) -> async_channel::Receiver<Result<(), String>> {
+    let (completion, receive) = async_channel::bounded(1);
+    // Replaced requests lose their sender, so waiters receive cancellation.
+    let _ = writer.force_send(Write {
+        document,
+        completion,
+    });
+    receive
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn fixture() -> Document {
+        let pane = |shell: &str| Pane {
+            shell: Some(shell.into()),
+            workspace: Some("w".into()),
+        };
+        Document {
+            owner: "local-node".into(),
+            active: "workspace:w".into(),
+            arrangements: BTreeMap::from([(
+                "workspace:w".into(),
+                Arrangement {
+                    tree: Some(Tree::Split {
+                        horizontal: true,
+                        ratio: 0.3,
+                        first: Box::new(Tree::Pane(11)),
+                        second: Box::new(Tree::Pane(22)),
+                    }),
+                    floating: vec![Floating {
+                        pane: 33,
+                        rect: [100.0, 80.0, 400.0, 300.0],
+                    }],
+                    panes: BTreeMap::from([
+                        (11, pane("shell-a")),
+                        (22, pane("remote:node-b:shell-a")),
+                        (33, pane("shell-c")),
+                    ]),
+                    focused: Some(33),
+                    expanded: Some(11),
+                    canvas: [1000.0, 700.0],
+                },
+            )]),
+            minimized: vec!["hidden-shell".into()],
+            workspace_order: vec!["w".into()],
+            ..Default::default()
+        }
+    }
+    fn temporary() -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("boomux-layout-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir(&path).unwrap();
+        path
+    }
+    #[test]
+    fn layout_round_trip_preserves_geometry_identity_and_minimized_state() {
+        let doc = fixture();
+        doc.validate().unwrap();
+        let decoded: Document = serde_json::from_slice(&serde_json::to_vec(&doc).unwrap()).unwrap();
+        assert_eq!(doc, decoded);
+    }
+    #[test]
+    fn layout_rejects_invalid_geometry_references_and_versions() {
+        for mutate in [
+            |d: &mut Document| d.version = 99,
+            |d: &mut Document| d.arrangements.get_mut("workspace:w").unwrap().focused = Some(404),
+            |d: &mut Document| {
+                d.arrangements.get_mut("workspace:w").unwrap().floating[0].rect[2] = -1.0
+            },
+            |d: &mut Document| d.arrangements.get_mut("workspace:w").unwrap().floating[0].pane = 11,
+            |d: &mut Document| d.arrangements.get_mut("workspace:w").unwrap().canvas[0] = f32::NAN,
+            |d: &mut Document| {
+                d.arrangements
+                    .get_mut("workspace:w")
+                    .unwrap()
+                    .panes
+                    .remove(&11);
+            },
+        ] {
+            let mut doc = fixture();
+            mutate(&mut doc);
+            assert!(doc.validate().is_err());
+        }
+    }
+    #[test]
+    fn layout_save_is_atomic_and_prevents_stale_desktop_overwrites() {
+        let root = temporary();
+        let path = root.join("layout.json");
+        let mut first = Store {
+            path: path.clone(),
+            revision: String::new(),
+        };
+        let mut stale = Store {
+            path: path.clone(),
+            revision: String::new(),
+        };
+        first.save(fixture()).unwrap();
+        let saved = read(&path).unwrap();
+        assert!(!saved.revision.is_empty());
+        assert!(stale.save(Document::default()).is_err());
+        assert_eq!(read(&path).unwrap(), saved);
+        first.save(fixture()).unwrap();
+        assert_ne!(read(&path).unwrap().revision, saved.revision);
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 2);
+        fs::remove_dir_all(root).unwrap();
+    }
+    #[test]
+    fn layout_corrupt_file_is_preserved_and_disables_writes() {
+        let root = temporary();
+        let path = root.join("layout.json");
+        fs::write(&path, "broken").unwrap();
+        let session = Session::at(Some(path.clone()));
+        assert!(session.writer.is_none() && session.error.is_some());
+        assert_eq!(fs::read_to_string(path).unwrap(), "broken");
+        fs::remove_dir_all(root).unwrap();
+    }
+    #[test]
+    fn layout_writer_acknowledges_durable_final_state_before_replacement_reads() {
+        let root = temporary();
+        let path = root.join("layout.json");
+        let session = Session::at(Some(path.clone()));
+        let writer = session.writer.unwrap();
+        let ack = submit(&writer, fixture());
+        writer.close();
+        ack.recv_blocking().unwrap().unwrap();
+        let restored = Session::at(Some(path));
+        assert_eq!(restored.document.arrangements, fixture().arrangements);
+        drop(restored);
+        fs::remove_dir_all(root).unwrap();
+    }
+    #[test]
+    fn layout_pending_snapshots_are_coalesced_without_unbounded_queue() {
+        let (writer, requests) = async_channel::bounded(1);
+        let old = submit(&writer, Document::default());
+        let latest = submit(&writer, fixture());
+        assert!(old.recv_blocking().is_err());
+        let request = requests.recv_blocking().unwrap();
+        assert_eq!(request.document, fixture());
+        request.completion.send_blocking(Ok(())).unwrap();
+        latest.recv_blocking().unwrap().unwrap();
+    }
+}

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -9581,8 +9581,8 @@ impl Workspace {
 
 impl Render for Workspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        self.layout_canvas = self.panel_size(window);
         self.sidebar_viewport_width = f32::from(window.viewport_size().width);
+        self.layout_canvas = self.panel_size(window);
         let workspace_name = self
             .terminals
             .get(&self.focused)

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1484,6 +1484,7 @@ struct Workspace {
     layout_generation: u64,
     layout_frozen: bool,
     layout_closing: bool,
+    restore_pointer_guard: layout_persistence::PointerGuard,
     layout_restoring: bool,
     git_panel: git_panel::Model,
     layout: Option<Node>,
@@ -1697,6 +1698,7 @@ impl Workspace {
             layout_generation: 0,
             layout_frozen: false,
             layout_closing: false,
+            restore_pointer_guard: layout_persistence::PointerGuard::Inactive,
             layout_restoring: false,
             layout: Some(layout),
             floating: Vec::new(),
@@ -3803,6 +3805,15 @@ impl Workspace {
             return;
         }
         // Keep the dragged pane focused even while it crosses other panes.
+        if self.fullscreen.is_some_and(|expanded| expanded != id) {
+            return;
+        }
+        if !self
+            .restore_pointer_guard
+            .allows_focus((f32::from(event.position.x), f32::from(event.position.y)))
+        {
+            return;
+        }
         if self.pointer_drag.is_some()
             || self.terminal_scrollbar_drag.is_some()
             || self.sidebar_resizing

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1986,6 +1986,12 @@ impl Workspace {
             return;
         };
         self.capture_arrangement();
+        if self.layout_error.as_deref() == Some("Saved layout limit reached") {
+            self.updates_status =
+                Some("Reduce the saved layout before restarting; its limit was reached.".into());
+            cx.notify();
+            return;
+        }
         self.layout_save_task.take();
         self.layout_frozen = true;
         let layout_flush = self

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -4,6 +4,8 @@ use boomux::generated_names;
 mod git_panel;
 mod layout;
 mod layout_badge;
+mod layout_persistence;
+mod layout_state;
 mod nodes;
 mod remote;
 mod runtime;
@@ -1474,6 +1476,15 @@ fn desktop_window_title(workspace_name: Option<&str>) -> String {
 }
 
 struct Workspace {
+    layout_document: layout_state::Document,
+    layout_writer: Option<async_channel::Sender<layout_state::Write>>,
+    layout_save_task: Option<gpui::Task<()>>,
+    layout_error: Option<String>,
+    layout_canvas: (f32, f32),
+    layout_generation: u64,
+    layout_frozen: bool,
+    layout_closing: bool,
+    layout_restoring: bool,
     git_panel: git_panel::Model,
     layout: Option<Node>,
     floating: Vec<FloatingPane>,
@@ -1582,6 +1593,10 @@ struct Workspace {
 #[derive(Default)]
 struct TerminalPane {
     shell: Option<ShellChoice>,
+    restored: Option<layout_state::Pane>,
+    restore_attempt: Option<String>,
+    restore_retry_after: Option<Instant>,
+    restore_failures: u8,
     session: Option<TerminalSession>,
     screen: Option<Arc<TerminalScreen>>,
     attaching: bool,
@@ -1618,6 +1633,7 @@ impl Workspace {
         cx: &mut Context<Self>,
         saved: settings::Settings,
         settings_error: Option<String>,
+        layout_session: layout_state::Session,
     ) -> Self {
         let focus_handle = cx.focus_handle();
         window.focus(&focus_handle, cx);
@@ -1673,6 +1689,15 @@ impl Workspace {
         let minimized_tab_scroll_handle = ScrollHandle::new();
         let help_scroll_handle = ScrollHandle::new();
         let mut workspace = Self {
+            layout_document: layout_session.document,
+            layout_writer: layout_session.writer,
+            layout_save_task: None,
+            layout_error: layout_session.error,
+            layout_canvas: (1.0, 1.0),
+            layout_generation: 0,
+            layout_frozen: false,
+            layout_closing: false,
+            layout_restoring: false,
             layout: Some(layout),
             floating: Vec::new(),
             git_panel: git_panel::Model::default(),
@@ -1781,7 +1806,10 @@ impl Workspace {
             next_id: 2,
             focus_handle,
         };
-        if let Some(shell) = initial_shell {
+        workspace.initialize_layout(window, cx);
+        if workspace.layout_document.active.is_empty()
+            && let Some(shell) = initial_shell
+        {
             let workspace_id = shell.workspace_id.clone();
             let shell_id = shell.id.clone();
             workspace.open_workspace(&workspace_id, Some(&shell_id), window, cx);
@@ -1815,6 +1843,9 @@ impl Workspace {
                 }
             })
             .detach();
+        }
+        if let Some(requested) = requested_shell_id.as_deref() {
+            workspace.activate_sidebar_shell(requested, window, cx);
         }
         workspace.watch_updates(cx);
         cx.observe_window_activation(window, |this, window, cx| {
@@ -1954,15 +1985,33 @@ impl Workspace {
         let Some(prepared) = self.prepared_update.clone() else {
             return;
         };
+        self.capture_arrangement();
+        self.layout_save_task.take();
+        self.layout_frozen = true;
+        let layout_flush = self
+            .layout_writer
+            .as_ref()
+            .map(|writer| layout_state::submit(writer, self.layout_document.clone()));
         self.update_busy = true;
         self.updates_status = Some("Restarting Boomux and reopening Desktop…".into());
         cx.spawn(async move |this, cx| {
-            let result = cx.background_spawn(async move { prepared.restart() }).await;
+            let saved = match layout_flush {
+                Some(flush) => flush
+                    .recv()
+                    .await
+                    .unwrap_or_else(|_| Err("Layout save was interrupted".into())),
+                None => Ok(()),
+            };
+            let result = match saved {
+                Ok(()) => cx.background_spawn(async move { prepared.restart() }).await,
+                Err(error) => Err(format!("Could not save layout before restart: {error}")),
+            };
             this.update(cx, |this, cx| {
                 this.update_busy = false;
                 match result {
                     Ok(()) => cx.quit(),
                     Err(error) => {
+                        this.layout_frozen = false;
                         this.updates_status = Some(error);
                         cx.notify();
                     }
@@ -2185,6 +2234,7 @@ impl Workspace {
             .and_then(|layout| layout.neighbor(self.focused, direction))
         {
             self.focused = id;
+            self.layout_changed(cx);
             cx.notify();
         } else if direction == Direction::Left {
             self.enter_sidebar(window, cx);
@@ -2258,6 +2308,7 @@ impl Workspace {
         {
             terminal.focus();
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -2312,7 +2363,6 @@ impl Workspace {
             .iter()
             .flat_map(|workspace| workspace.shells.iter().cloned())
             .collect();
-        self.retain_known_minimized_shells(&overview);
         self.boomux_overview = overview;
     }
 
@@ -2396,6 +2446,7 @@ impl Workspace {
             } else {
                 self.workspace_order_animation = None;
             }
+            self.layout_changed(cx);
             cx.notify();
         }
     }
@@ -2658,6 +2709,7 @@ impl Workspace {
         if self.pane_layout_mode == mode {
             return;
         }
+        self.capture_arrangement();
         self.pane_layout_mode = mode;
         if mode == PaneLayoutMode::Tabbed {
             self.workspace_pane_mode = WorkspacePaneMode::Workspace;
@@ -2672,6 +2724,7 @@ impl Workspace {
         }
         self.save_settings();
         self.reconcile_sidebar_item();
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -3004,6 +3057,7 @@ impl Workspace {
         {
             self.begin_layout_animation(previous_rects);
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -3037,6 +3091,7 @@ impl Workspace {
                 layout.resize(self.focused, direction, tiled_amount);
             }
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -3054,6 +3109,7 @@ impl Workspace {
         let previous = layout.rects().into_iter().collect::<HashMap<_, _>>();
         if transform(layout, self.focused) {
             self.begin_layout_animation(previous);
+            self.layout_changed(cx);
             cx.notify();
         }
     }
@@ -3088,6 +3144,7 @@ impl Workspace {
                 generation: self.animation_generation,
             });
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -3115,6 +3172,7 @@ impl Workspace {
             self.create_and_attach_terminal(id, anchor, window, cx);
         } else if let Some(pane) = self.terminals.get_mut(&id) {
             pane.error = Some("No Boomux workspace is available for a new terminal".into());
+            self.layout_changed(cx);
             cx.notify();
         }
     }
@@ -3152,6 +3210,14 @@ impl Workspace {
             .any(|animation| animation.pane_id == pane_id)
         {
             return;
+        }
+        if let Some(shell) = self.terminals.get(&pane_id).and_then(|p| {
+            p.shell
+                .as_ref()
+                .map(|s| s.id.clone())
+                .or_else(|| p.restored.as_ref().and_then(|r| r.shell.clone()))
+        }) {
+            self.minimized_shells.insert(shell);
         }
         let from = self.pane_bounds_in_panel(pane_id, window);
         let previous_rects = self
@@ -3213,6 +3279,7 @@ impl Workspace {
                 *pane = clamp_floating_to_panel(pane.clone(), panel_size);
             }
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -3236,6 +3303,7 @@ impl Workspace {
                 *pane = clamp_floating_to_panel(pane.clone(), panel_size);
             }
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -3343,6 +3411,7 @@ impl Workspace {
                 }
             }
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -3383,6 +3452,7 @@ impl Workspace {
                     self.floating_animation = None;
                 }
             }
+            self.layout_changed(cx);
             cx.notify();
             return;
         }
@@ -3407,6 +3477,7 @@ impl Workspace {
                 self.floating_animation = None;
             }
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -3662,6 +3733,8 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.capture_arrangement();
+        self.layout_changed(cx);
         self.git_panel.search_focused = false;
         self.floating_animation = None;
         self.focused = id;
@@ -3756,6 +3829,7 @@ impl Workspace {
         {
             terminal.focus();
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -4252,6 +4326,7 @@ impl Workspace {
         let pointer =
             self.window_position_in_panel(f32::from(event.position.x), f32::from(event.position.y));
         self.finish_pointer_drag(pointer, window);
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -4875,6 +4950,7 @@ impl Workspace {
         pane.shell = Some(shell.clone());
         pane.attaching = true;
         pane.error = None;
+        self.layout_changed(cx);
         cx.notify();
 
         cx.spawn(async move |this, cx| {
@@ -4899,6 +4975,7 @@ impl Workspace {
                     }
                     Err(error) => pane.error = Some(error),
                 }
+                this.layout_changed(cx);
                 cx.notify();
             })
             .ok();
@@ -4918,6 +4995,7 @@ impl Workspace {
             pane.attaching = true;
             pane.error = None;
         }
+        self.layout_changed(cx);
         cx.notify();
         cx.spawn(async move |this, cx| {
             let result = cx
@@ -4956,6 +5034,7 @@ impl Workspace {
                     }
                     Err(error) => pane.error = Some(error),
                 }
+                this.layout_changed(cx);
                 cx.notify();
             })
             .ok();
@@ -5006,6 +5085,7 @@ impl Workspace {
         if let Some(pane) = self.terminals.get_mut(&pane_id) {
             pane.attaching = true;
         }
+        self.layout_changed(cx);
         cx.notify();
         cx.spawn(async move |this, cx| {
             let result = cx
@@ -5044,6 +5124,7 @@ impl Workspace {
                     }
                     Err(error) => pane.error = Some(error),
                 }
+                this.layout_changed(cx);
                 cx.notify();
             })
             .ok();
@@ -5076,6 +5157,7 @@ impl Workspace {
             pane.attaching = true;
             pane.error = None;
         }
+        self.layout_changed(cx);
         cx.notify();
 
         cx.spawn(async move |this, cx| {
@@ -5129,6 +5211,7 @@ impl Workspace {
                     }
                     Err(error) => pane.error = Some(error),
                 }
+                this.layout_changed(cx);
                 cx.notify();
             })
             .ok();
@@ -5216,6 +5299,9 @@ impl Workspace {
                 if !keep_watching {
                     return;
                 }
+                let _ = window_handle.update(cx, |_, window, cx| {
+                    this.update(cx, |this, cx| this.reconnect_saved_panes(window, cx))
+                });
                 if !removed_setup_shells.is_empty() {
                     let _ = window_handle.update(cx, |_, window, cx| {
                         this.update(cx, |this, cx| {
@@ -5256,17 +5342,8 @@ impl Workspace {
         if !self.expanded_workspaces.remove(workspace_id) {
             self.expanded_workspaces.insert(workspace_id.to_string());
         }
+        self.layout_changed(cx);
         cx.notify();
-    }
-
-    fn retain_known_minimized_shells(&mut self, overview: &BoomuxOverview) {
-        let known_shells = overview
-            .workspaces
-            .iter()
-            .flat_map(|workspace| workspace.shells.iter().map(|shell| shell.id.as_str()))
-            .collect::<HashSet<_>>();
-        self.minimized_shells
-            .retain(|shell_id| known_shells.contains(shell_id.as_str()));
     }
 
     fn minimized_tab_shells(&self) -> Vec<ShellChoice> {
@@ -5278,7 +5355,8 @@ impl Workspace {
             .get(&self.focused)
             .and_then(|pane| pane.shell.as_ref())
             .map(|shell| shell.workspace_id.as_str());
-        self.boomux_overview
+        let mut shells = self
+            .boomux_overview
             .workspaces
             .iter()
             .filter(|workspace| {
@@ -5289,7 +5367,15 @@ impl Workspace {
             .flat_map(|workspace| workspace.shells.iter())
             .filter(|shell| self.minimized_shells.contains(&shell.id))
             .cloned()
-            .collect()
+            .collect::<Vec<_>>();
+        shells.sort_by_key(|s| {
+            self.layout_document
+                .minimized
+                .iter()
+                .position(|id| id == &s.id)
+                .unwrap_or(usize::MAX)
+        });
+        shells
     }
 
     fn has_minimized_tabs(&self) -> bool {
@@ -5313,6 +5399,7 @@ impl Workspace {
     }
 
     fn detach_all_panes(&mut self, window: &mut Window) {
+        self.capture_arrangement();
         for (_, pane) in self.terminals.drain() {
             for image in pane.render_images.into_values() {
                 let _ = window.drop_image(image);
@@ -5376,6 +5463,9 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.restore_workspace_layout(workspace_id, preferred_shell_id, window, cx) {
+            return;
+        }
         self.project_menu_open = false;
         let Some(shells) = self
             .boomux_overview
@@ -5546,6 +5636,7 @@ impl Workspace {
             let size = self.terminal_grid_size(pane_id, window);
             self.start_terminal_attachment(pane_id, shell, size, cx);
         }
+        self.layout_changed(cx);
         cx.notify();
     }
 
@@ -5562,6 +5653,15 @@ impl Workspace {
                 .filter(|shell| shell.id == shell_id)
                 .map(|_| *pane_id)
         }) {
+            let retry = self
+                .terminals
+                .get(&pane_id)
+                .filter(|pane| pane.session.is_none() && !pane.attaching)
+                .and_then(|pane| pane.shell.clone());
+            if let Some(shell) = retry {
+                let size = self.terminal_grid_size(pane_id, window);
+                self.start_terminal_attachment(pane_id, shell, size, cx);
+            }
             self.navigation_region = NavigationRegion::Terminal;
             self.focused = pane_id;
             self.raise_floating_pane(pane_id);
@@ -5573,6 +5673,7 @@ impl Workspace {
                 terminal.focus();
             }
             window.focus(&self.focus_handle, cx);
+            self.layout_changed(cx);
             cx.notify();
             return;
         }
@@ -5584,6 +5685,7 @@ impl Workspace {
             .cloned()
         else {
             self.boomux_error = Some("That Boomux shell is no longer available".into());
+            self.layout_changed(cx);
             cx.notify();
             return;
         };
@@ -5598,6 +5700,9 @@ impl Workspace {
             &open_workspace_ids,
             &shell.workspace_id,
         ) {
+            if self.restore_workspace_layout(&shell.workspace_id, Some(&shell.id), window, cx) {
+                return;
+            }
             self.detach_all_panes(window);
         }
         self.navigation_region = NavigationRegion::Terminal;
@@ -7848,6 +7953,7 @@ impl Workspace {
                                     )
                                     .on_click(cx.listener(
                                         |this, _, window, cx| {
+                                            this.capture_arrangement();
                                             this.workspace_pane_mode = WorkspacePaneMode::Workspace;
                                             let workspace_id = this
                                                 .terminals
@@ -7879,12 +7985,23 @@ impl Workspace {
                                         ),
                                     )
                                     .on_click(cx.listener(
-                                        |this, _, _, cx| {
+                                        |this, _, window, cx| {
                                             if pane_layout_supports_scope(
                                                 this.pane_layout_mode,
                                                 WorkspacePaneMode::Mixed,
                                             ) {
+                                                this.capture_arrangement();
                                                 this.workspace_pane_mode = WorkspacePaneMode::Mixed;
+                                                if let Some(saved) = this
+                                                    .layout_document
+                                                    .arrangements
+                                                    .get("mixed")
+                                                    .cloned()
+                                                {
+                                                    this.layout_document.active = "mixed".into();
+                                                    this.restore_arrangement(saved, window, cx);
+                                                }
+                                                this.layout_changed(cx);
                                                 this.save_settings();
                                                 cx.notify();
                                             }
@@ -8774,6 +8891,25 @@ impl Workspace {
                     "No Boomux terminal is available."
                 },
             ))
+            .when(
+                pane.is_some_and(|pane| {
+                    pane.restored.is_some() && !pane.attaching && pane.session.is_none()
+                }),
+                |element| {
+                    element.child(
+                        Self::settings_option(
+                            ("reconnect-saved-pane", pane_id),
+                            "Reconnect / start Shell",
+                            false,
+                        )
+                        .on_click(cx.listener(
+                            move |this, _, window, cx| {
+                                this.reconnect_saved_pane(pane_id, window, cx)
+                            },
+                        )),
+                    )
+                },
+            )
             .when_some(
                 pane.and_then(|pane| pane.error.clone())
                     .or_else(|| self.boomux_error.clone()),
@@ -9445,6 +9581,7 @@ impl Workspace {
 
 impl Render for Workspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.layout_canvas = self.panel_size(window);
         self.sidebar_viewport_width = f32::from(window.viewport_size().width);
         let workspace_name = self
             .terminals
@@ -9797,6 +9934,18 @@ impl Render for Workspace {
 
         div()
             .id("workspace")
+            .when_some(self.layout_error.clone(), |element, error| {
+                element.child(
+                    div()
+                        .absolute()
+                        .top_0()
+                        .left_0()
+                        .text_xs()
+                        .bg(rgb(0x313244))
+                        .text_color(rgb(0xf38ba8))
+                        .child(format!("Layout not saved: {error}")),
+                )
+            })
             .track_focus(&self.focus_handle)
             .key_context(
                 if (self.nodes_open && self.navigation_region == NavigationRegion::Sidebar)
@@ -10291,6 +10440,26 @@ fn main() {
         Ok(saved) => (saved, None),
         Err(error) => (settings::Settings::default(), Some(error)),
     };
+    let mut layout_session = layout_state::Session::load();
+    match boomux::client::connect_if_running()
+        .ok()
+        .flatten()
+        .and_then(|client| client.node_identity().ok())
+    {
+        Some(owner)
+            if layout_session.document.owner.is_empty()
+                || layout_session.document.owner == owner =>
+        {
+            layout_session.document.owner = owner
+        }
+        _ => {
+            layout_session.error = Some(
+                "Saved layout belongs to an unavailable or different Node; it was retained.".into(),
+            );
+            layout_session.writer = None;
+            layout_session.document = layout_state::Document::default();
+        }
+    }
     gpui_platform::application().run(move |cx: &mut App| {
         cx.bind_keys([
             KeyBinding::new("ctrl-shift-v", PasteClipboard, Some("BoomuxSettingsInput")),
@@ -10454,7 +10623,9 @@ fn main() {
                 app_id: Some("org.omarchy.boomux-desktop".into()),
                 ..Default::default()
             },
-            move |window, cx| cx.new(|cx| Workspace::new(window, cx, saved, settings_error)),
+            move |window, cx| {
+                cx.new(|cx| Workspace::new(window, cx, saved, settings_error, layout_session))
+            },
         )
         .unwrap();
         cx.activate(true);

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -396,6 +396,22 @@ impl TerminalSession {
         Self::attach_with_client(client, shell, rows, cols, pixel_width, pixel_height)
     }
 
+    pub fn restore(
+        shell: ShellChoice,
+        rows: u16,
+        cols: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+    ) -> Result<Self, String> {
+        if !matches!(shell.status, ShellStatus::Running) || shell.run_id.is_none() {
+            return Err("Saved Shell is stopped; start it explicitly".into());
+        }
+        let client = client::connect_if_running()
+            .map_err(|e| e.to_string())?
+            .ok_or("Boomux is not running")?;
+        Self::attach_with_policy(client, shell, rows, cols, pixel_width, pixel_height, false)
+    }
+
     fn attach_with_client(
         client: Client,
         shell: ShellChoice,
@@ -404,8 +420,21 @@ impl TerminalSession {
         pixel_width: u16,
         pixel_height: u16,
     ) -> Result<Self, String> {
+        Self::attach_with_policy(client, shell, rows, cols, pixel_width, pixel_height, true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn attach_with_policy(
+        client: Client,
+        shell: ShellChoice,
+        rows: u16,
+        cols: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+        takeover: bool,
+    ) -> Result<Self, String> {
         let profile = terminal_profile(rows, cols, pixel_width, pixel_height);
-        let attachment = attach_shell(&client, &shell, profile.clone(), true)?;
+        let attachment = attach_shell(&client, &shell, profile.clone(), takeover)?;
         let shared = Arc::new(SharedTerminal::new(profile));
         let stream = attachment.stream;
         shared.install_writer(&stream)?;
@@ -2690,6 +2719,89 @@ mod tests {
             boomux::protocol::ShellStatus::Running
         );
         assert!(first.shells[0].cwd.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn layout_restore_requests_exact_run_without_restart_or_takeover() {
+        use boomux::protocol::{self, Envelope, Request, Response, ShellStatus};
+        use std::os::unix::net::UnixListener;
+        let directory =
+            std::env::temp_dir().join(format!("layout-attach-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let envelope: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            let Request::Attach {
+                shell_id,
+                expected_run_id,
+                takeover,
+                restart_exited,
+                ..
+            } = envelope.message
+            else {
+                panic!("expected exact attachment")
+            };
+            assert_eq!(shell_id, "saved-shell");
+            assert_eq!(expected_run_id.as_deref(), Some("saved-run"));
+            assert!(!takeover && !restart_exited);
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    envelope.version,
+                    Response::Error {
+                        code: None,
+                        message: "run exited during restore".into(),
+                    },
+                ),
+            )
+            .unwrap();
+        });
+        let shell = super::ShellChoice {
+            id: "saved-shell".into(),
+            name: "saved".into(),
+            workspace_id: "w".into(),
+            cwd: directory.clone(),
+            status: ShellStatus::Running,
+            run_id: Some("saved-run".into()),
+            desktop_setup: false,
+        };
+        let result = super::TerminalSession::attach_with_policy(
+            boomux::client::Client::from_socket_path(socket),
+            shell,
+            24,
+            80,
+            800,
+            480,
+            false,
+        );
+        assert!(result.is_err());
+        server.join().unwrap();
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn layout_restore_never_starts_pending_or_exited_shells() {
+        use boomux::protocol::ShellStatus;
+        for status in [ShellStatus::Pending, ShellStatus::Exited { code: Some(0) }] {
+            let shell = super::ShellChoice {
+                id: "saved".into(),
+                name: "saved".into(),
+                workspace_id: "workspace".into(),
+                cwd: std::path::PathBuf::new(),
+                status,
+                run_id: None,
+                desktop_setup: false,
+            };
+            let error = super::TerminalSession::restore(shell, 24, 80, 800, 480)
+                .err()
+                .unwrap();
+            assert!(error.contains("start it explicitly"));
+        }
     }
 
     #[test]

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -109,6 +109,12 @@ and history but does not remove project shortcuts or filesystem contents.
   from the daemon's combined snapshot.
 - `src/boomux_settings.rs`: active-layer settings editor and bounded CLI bridge;
   Boomux retains configuration validation and commit authority.
+- `src/layout_state.rs`: versioned, bounded Desktop arrangement storage with atomic
+  background writes and revision checks preventing stale-instance overwrites.
+- `src/layout_persistence.rs`: pane-ID remapping, per-Workspace/Mixed arrangement
+  capture/restore, debounced saves, and deferred exact-run attachments. Local
+  references are scoped to the verified coordinator Node; remote keys retain
+  owner and resource identity. No terminal data or attachment environment is saved.
 - `src/settings.rs`: bounded preference loading, validation, and atomic background
   saves of Desktop-owned settings; shared Boomux configuration remains separate.
 - `src/layout_badge.rs`: shared animated Layout-mode icons and pane overlays.
@@ -444,3 +450,22 @@ Twelve-pixel corner targets paint above side handles and resize both axes with
 diagonal cursors. Tiled corner targets require adjoining dividers on both axes.
 Maximized and transitioning panes omit edge handles. Terminal body selection
 and Ctrl-drag behavior retain their existing input paths.
+
+## Internal layout restoration
+
+Layout mutations retain one 250 ms debounce task and one pending writer request;
+terminal output and rendering do not generate persistence snapshots. Active drag
+state is excluded. Workspace switching captures the outgoing committed tree;
+inactive arrangements retain metadata only, not sessions or emulator state.
+Files cap at 2 MiB, 256 arrangements, 4096 total panes and depth 64. Invalid or
+unsupported files remain untouched and disable writes with a visible notice.
+
+Desktop startup restores the tree and floating geometry before exact-running
+attachments. Stopped Shells require explicit user action. Deferred attachments reuse the
+existing overview refresh, attempt at most four panes per refresh, and back off
+failed attempts up to 30 seconds without per-pane timers. This also allows an
+update replacement to attach after the old window releases its terminals. Restoration never authorizes
+Shell creation, restart, or attachment takeover. Updates freeze saving and await
+the durable snapshot before launching the replacement; failure permits retry.
+A per-file lock plus revision comparison prevents stale windows from replacing
+newer state. Outer OS window placement remains outside this feature.


### PR DESCRIPTION
Desktop currently rebuilds pane arrangements when reopening or switching Workspaces. This change saves the split tree and ratios, floating positions/sizes/stacking, focused and expanded panes, minimized Shells, and Workspace order. Workspace and Mixed arrangements are stored separately, and restored pane IDs are remapped to stable Shell references.

A versioned Desktop-only state file uses bounded loading, atomic background writes, a 250 ms debounce, and revision checks against stale-instance overwrites. Window close and update restart await the final save before closing or launching a replacement. Corrupt or unsupported files remain untouched and produce a visible notice.

Restoration uses exact-running attachments without takeover or process restart. Stopped/unavailable Shells retain placeholders with an explicit reconnect/start action. Deferred attachments reuse the overview refresh with bounded batches and backoff. Outer OS window geometry is outside this change; daemon protocol and state schemas are unchanged.

Validation:
- `cargo check -p boomux-desktop --locked` passed.
- 22 focused layout and attachment tests passed, including corrupt-state preservation, writer acknowledgments, stale-writer rejection, ID remapping, and exact-run/no-restart/no-takeover requests.
- Formatting and whitespace checks passed.
- Complete hosted [CI](https://github.com/gardnmi/boomux/actions/runs/34481354976) passed, including actual cold-start layout restoration on X11 and Wayland. Eight smoke-script fixture tests passed.
- A live Hyprland fixture restored split/floating geometry, focus, expansion, and minimized state while preserving the running ShellRun and leaving a pending Shell stopped.
- Normal GUI close and the complete updater replacement path still need interactive validation; final-write acknowledgment is covered by focused tests.

Persistence is isolated by `BOOMUX_STATE_HOME`/`XDG_STATE_HOME`. Inactive arrangements retain metadata only. No snapshots are taken on terminal output or rendering; no additional per-pane polling timer is added. No performance improvement is claimed or benchmarked.

The feature is also integrated into the experimental macOS branch in #397; [native Mac validation](https://github.com/gardnmi/boomux/actions/runs/34483640079) passed, including all 22 focused tests and packaged app smoke.

Workspace transition correction: saved arrangements now use the same outgoing-pane lifetime and slide animation as newly opened Workspaces, including restored floating/expanded geometry. Rapid sidebar switches ignore outgoing panes. Local debug build and 17 focused Workspace tests passed (one unrelated lifecycle fixture remains ignored). Automated live input was unavailable with the host Hyprland dispatcher interface, so visual confirmation remains needed; CI is rerunning for this correction.

Rapid Workspace reversals now reuse outgoing live panes only for an exact owner-scoped Shell/run match. Pane IDs, screens, sessions, and in-flight attachment callbacks survive the reversal; no inactive Workspace cache is added. In the same two-Workspace Linux debug fixture (180 ms switch interval), seven switches required seven new attachments before this change and one after it. This measures attachment churn, not end-to-end click latency. All 23 focused layout tests passed, including owner/run/stopped-Shell reuse restrictions; the debug app rebuilt successfully. Slower-click latency still needs user confirmation. CI is rerunning.

Captured hang correction: the live Linux stack showed GPUI in TerminalSession::drop waiting for the emulator-sender mutex, held by a reader blocked on the full output queue while Ghostty decoded reconstruction. Blocking sends now release the mutex before waiting. Discarded panes cancel replay between 16 KiB chunks and disconnect instead of enqueueing Stop; normal transport closure still drains and publishes its final screen. Nine focused terminal tests passed. The saturation regression test fails with the original locking code and passes with the fix. The development binary rebuilt; live user confirmation and CI for this correction remain pending. Daemon status and Shell-list requests responded during diagnosis, with no recorded core dump or OOM event.

Pane-focus correction: click and hover handlers now coalesce FocusGained through a pending flag and nonblocking wake marker; the existing terminal worker owns the socket write. A focused regression holds the writer mutex and fills the output queue, verifies 100 focus requests return without waiting, and confirms the worker delivers the retained notification. Locked compile check, focused test, formatting, and development build passed. The specific click-freeze still requires live confirmation; CI is rerunning.
