### PR TITLE
fix(desktop): restore workspace animations and prevent UI stalls

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Keep Rust debug builds debuggable without Ghostty's expensive debug page scans.
+# Set LIBGHOSTTY_VT_SYS_OPTIMIZE=Debug explicitly to debug the native terminal core.
+[env]
+LIBGHOSTTY_VT_SYS_OPTIMIZE = { value = "ReleaseFast", force = false }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,6 +95,12 @@ cargo check -p boomux-desktop --locked
 cargo test -p boomux-desktop <test-name> --locked -- --test-threads=1
 ```
 
+Cargo development builds keep Rust debug information but compile the native
+Ghostty terminal core with `ReleaseFast`, avoiding expensive debug integrity
+scans during transcript replay. To debug the native core itself, explicitly set
+`LIBGHOSTTY_VT_SYS_OPTIMIZE=Debug` when building or running. Changing this setting
+rebuilds the native library.
+
 For a performance comparison, run `python3 desktop/scripts/run-dev.py --release`.
 This builds and launches optimized Desktop and daemon binaries against the same
 isolated development runtime. The first optimized build takes longer; keep the

--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -270,10 +270,24 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.restore_arrangement_with_transition(saved, None, window, cx);
+    }
+
+    fn restore_arrangement_with_transition(
+        &mut self,
+        saved: Arrangement,
+        direction: Option<f32>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.layout_restoring = true;
         self.restore_pointer_guard = PointerGuard::Waiting;
-        self.finish_current_workspace_transition(window);
-        self.detach_all_panes(window);
+        if let Some(direction) = direction {
+            self.begin_workspace_transition(direction, window, cx);
+        } else {
+            self.finish_current_workspace_transition(window);
+            self.detach_all_panes(window);
+        }
         let mut ids = HashMap::new();
         for (saved_id, reference) in &saved.panes {
             let id = self.next_id;
@@ -319,6 +333,7 @@ impl Workspace {
             .or_else(|| ids.values().copied().min())
             .unwrap_or(0);
         self.fullscreen = saved.expanded.and_then(|id| ids.get(&id).copied());
+        self.animate_workspace_arrival();
         self.reconnect_saved_panes(window, cx);
         self.layout_restoring = false;
         cx.notify();
@@ -343,9 +358,13 @@ impl Workspace {
             return false;
         }
         if let Some(saved) = self.layout_document.arrangements.get(&key).cloned() {
+            let current = self.layout_document.active.strip_prefix("workspace:");
+            let direction = workspace_slide_direction(&self.workspace_order, current, workspace);
             self.layout_document.active = key;
+            self.project_menu_open = false;
+            self.sidebar_menu = None;
             self.expanded_workspaces = HashSet::from([workspace.to_owned()]);
-            self.restore_arrangement(saved, window, cx);
+            self.restore_arrangement_with_transition(saved, Some(direction), window, cx);
             if let Some(preferred) = preferred {
                 self.activate_sidebar_shell(preferred, window, cx);
             }

--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -27,6 +27,20 @@ impl PointerGuard {
     }
 }
 
+// Reuse is restricted to the same owner-scoped Shell and exact running instance.
+fn same_running_shell(current: Option<&ShellChoice>, target: Option<&ShellChoice>) -> bool {
+    match (current, target) {
+        (Some(current), Some(target)) => {
+            matches!(current.status, boomux::protocol::ShellStatus::Running)
+                && matches!(target.status, boomux::protocol::ShellStatus::Running)
+                && current.id == target.id
+                && current.run_id.is_some()
+                && current.run_id == target.run_id
+        }
+        _ => false,
+    }
+}
+
 fn encode_tree(node: &Node) -> Tree {
     match node {
         Node::Pane(id) => Tree::Pane(*id as u64),
@@ -282,6 +296,52 @@ impl Workspace {
     ) {
         self.layout_restoring = true;
         self.restore_pointer_guard = PointerGuard::Waiting;
+        // A quick return can find this Workspace still sliding out. Preserve
+        // those sessions, screens, and pane IDs before finishing the old slide;
+        // detaching and immediately reattaching races the owner's controller.
+        let mut reusable = HashMap::new();
+        if direction.is_some() {
+            let outgoing = self
+                .workspace_transition
+                .as_ref()
+                .map(|transition| {
+                    transition
+                        .outgoing
+                        .iter()
+                        .filter_map(|outgoing| {
+                            self.terminals
+                                .get(&outgoing.id)
+                                .and_then(|pane| pane.shell.as_ref())
+                                .map(|shell| (shell.id.clone(), outgoing.id))
+                        })
+                        .collect::<HashMap<_, _>>()
+                })
+                .unwrap_or_default();
+            for (saved_id, reference) in &saved.panes {
+                let target = reference
+                    .shell
+                    .as_ref()
+                    .and_then(|key| self.boomux_shells.iter().find(|shell| &shell.id == key));
+                let candidate = reference
+                    .shell
+                    .as_ref()
+                    .and_then(|key| outgoing.get(key))
+                    .copied()
+                    .filter(|id| {
+                        self.terminals.get(id).is_some_and(|pane| {
+                            (pane.attaching
+                                || pane
+                                    .session
+                                    .as_ref()
+                                    .is_some_and(|session| session.status_message().is_none()))
+                                && same_running_shell(pane.shell.as_ref(), target)
+                        })
+                    });
+                if let Some(id) = candidate {
+                    reusable.insert(*saved_id, (id, self.terminals.remove(&id).unwrap()));
+                }
+            }
+        }
         if let Some(direction) = direction {
             self.begin_workspace_transition(direction, window, cx);
         } else {
@@ -290,6 +350,12 @@ impl Workspace {
         }
         let mut ids = HashMap::new();
         for (saved_id, reference) in &saved.panes {
+            if let Some((id, mut pane)) = reusable.remove(saved_id) {
+                pane.restored = Some(reference.clone());
+                ids.insert(*saved_id, id);
+                self.terminals.insert(id, pane);
+                continue;
+            }
             let id = self.next_id;
             self.next_id += 1;
             ids.insert(*saved_id, id);
@@ -562,6 +628,32 @@ impl Workspace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn layout_reuse_requires_the_same_owner_shell_and_running_instance() {
+        let current = ShellChoice {
+            id: "remote:owner-a:shell".into(),
+            name: "same label".into(),
+            workspace_id: "workspace".into(),
+            cwd: Default::default(),
+            status: boomux::protocol::ShellStatus::Running,
+            run_id: Some("run-a".into()),
+            desktop_setup: false,
+        };
+        assert!(same_running_shell(Some(&current), Some(&current)));
+        let mut changed = current.clone();
+        changed.id = "remote:owner-b:shell".into();
+        assert!(!same_running_shell(Some(&current), Some(&changed)));
+        changed = current.clone();
+        changed.run_id = Some("run-b".into());
+        assert!(!same_running_shell(Some(&current), Some(&changed)));
+        changed.run_id = None;
+        assert!(!same_running_shell(Some(&changed), Some(&changed)));
+        changed = current.clone();
+        changed.status = boomux::protocol::ShellStatus::Pending;
+        assert!(!same_running_shell(Some(&current), Some(&changed)));
+        assert!(!same_running_shell(None, Some(&current)));
+    }
+
     #[test]
     fn layout_restore_keeps_focus_until_the_pointer_actually_moves() {
         let mut guard = PointerGuard::Waiting;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -5473,6 +5473,84 @@ impl Workspace {
         cx.notify();
     }
 
+    // Retain outgoing terminals and their paint state until the slide completes.
+    // Both newly opened and persisted arrangements use this lifecycle.
+    fn begin_workspace_transition(
+        &mut self,
+        slide_direction: f32,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.finish_current_workspace_transition(window);
+        let mut outgoing = self
+            .layout
+            .as_ref()
+            .map(Node::pane_ids)
+            .unwrap_or_default()
+            .into_iter()
+            .chain(self.floating.iter().map(|pane| pane.id))
+            .filter_map(|pane_id| self.pane_bounds_in_panel(pane_id, window))
+            .collect::<Vec<_>>();
+        for animation in &self.minimizing_panes {
+            if !outgoing.iter().any(|pane| pane.id == animation.pane_id) {
+                outgoing.push(animation.from.clone());
+            }
+        }
+        let outgoing_ids = outgoing.iter().map(|pane| pane.id).collect::<Vec<_>>();
+        let should_animate = !outgoing.is_empty();
+
+        self.layout = None;
+        self.floating.clear();
+        self.pointer_drag = None;
+        self.terminal_scrollbar_drag = None;
+        self.terminal_selection_release = None;
+        self.layout_animation = None;
+        self.floating_animation = None;
+        self.minimizing_panes.clear();
+        self.fullscreen = None;
+
+        if let Some(duration) = self.motion_speed.duration().filter(|_| should_animate) {
+            self.animation_generation = self.animation_generation.wrapping_add(1);
+            let generation = self.animation_generation;
+            self.workspace_transition = Some(WorkspaceTransition {
+                outgoing,
+                direction: slide_direction,
+                generation,
+                duration,
+            });
+            let window_handle = window.window_handle();
+            cx.spawn(async move |this, cx| {
+                cx.background_executor().timer(duration).await;
+                let _ = window_handle.update(cx, |_, window, cx| {
+                    this.update(cx, |this, cx| {
+                        this.finish_workspace_transition(generation, window, cx);
+                    })
+                });
+            })
+            .detach();
+        } else {
+            self.detach_terminal_ids(&outgoing_ids, window);
+        }
+    }
+
+    fn animate_workspace_arrival(&mut self) {
+        let Some(transition) = &self.workspace_transition else {
+            return;
+        };
+        let direction = transition.direction;
+        let incoming = self
+            .layout
+            .as_ref()
+            .map(|layout| {
+                workspace_layout_rects(layout, self.fullscreen)
+                    .into_iter()
+                    .map(|(id, rect)| (id, shifted_workspace_rect(rect, direction)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        self.begin_layout_animation(incoming);
+    }
+
     fn open_workspace(
         &mut self,
         workspace_id: &str,
@@ -5530,56 +5608,7 @@ impl Workspace {
                 .filter_map(|pane| pane.shell.as_ref().map(|shell| shell.id.clone()))
                 .collect::<HashSet<_>>();
             if workspace_open_replaces_panes(self.workspace_pane_mode, &current, &desired) {
-                self.finish_current_workspace_transition(window);
-                let mut outgoing = self
-                    .layout
-                    .as_ref()
-                    .map(Node::pane_ids)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .chain(self.floating.iter().map(|pane| pane.id))
-                    .filter_map(|pane_id| self.pane_bounds_in_panel(pane_id, window))
-                    .collect::<Vec<_>>();
-                for animation in &self.minimizing_panes {
-                    if !outgoing.iter().any(|pane| pane.id == animation.pane_id) {
-                        outgoing.push(animation.from.clone());
-                    }
-                }
-                let outgoing_ids = outgoing.iter().map(|pane| pane.id).collect::<Vec<_>>();
-                let should_animate = !current.is_empty() && !outgoing.is_empty();
-
-                self.layout = None;
-                self.floating.clear();
-                self.pointer_drag = None;
-                self.terminal_scrollbar_drag = None;
-                self.terminal_selection_release = None;
-                self.layout_animation = None;
-                self.floating_animation = None;
-                self.minimizing_panes.clear();
-                self.fullscreen = None;
-
-                if let Some(duration) = self.motion_speed.duration().filter(|_| should_animate) {
-                    self.animation_generation = self.animation_generation.wrapping_add(1);
-                    let generation = self.animation_generation;
-                    self.workspace_transition = Some(WorkspaceTransition {
-                        outgoing,
-                        direction: slide_direction,
-                        generation,
-                        duration,
-                    });
-                    let window_handle = window.window_handle();
-                    cx.spawn(async move |this, cx| {
-                        cx.background_executor().timer(duration).await;
-                        let _ = window_handle.update(cx, |_, window, cx| {
-                            this.update(cx, |this, cx| {
-                                this.finish_workspace_transition(generation, window, cx);
-                            })
-                        });
-                    })
-                    .detach();
-                } else {
-                    self.detach_terminal_ids(&outgoing_ids, window);
-                }
+                self.begin_workspace_transition(slide_direction, window, cx);
             }
         }
 
@@ -5615,22 +5644,7 @@ impl Workspace {
             pending.push((pane_id, shell));
         }
 
-        if self.workspace_transition.is_some() {
-            let incoming = self
-                .layout
-                .as_ref()
-                .map(|layout| {
-                    layout
-                        .rects()
-                        .into_iter()
-                        .map(|(pane_id, rect)| {
-                            (pane_id, shifted_workspace_rect(rect, slide_direction))
-                        })
-                        .collect::<HashMap<_, _>>()
-                })
-                .unwrap_or_default();
-            self.begin_layout_animation(incoming);
-        }
+        self.animate_workspace_arrival();
 
         let preferred_pane = preferred_shell_id
             .and_then(|shell_id| pane_ids.get(shell_id).copied())
@@ -5665,6 +5679,18 @@ impl Workspace {
     ) {
         self.project_menu_open = false;
         if let Some(pane_id) = self.terminals.iter().find_map(|(pane_id, pane)| {
+            if self
+                .workspace_transition
+                .as_ref()
+                .is_some_and(|transition| {
+                    transition
+                        .outgoing
+                        .iter()
+                        .any(|outgoing| outgoing.id == *pane_id)
+                })
+            {
+                return None;
+            }
             pane.shell
                 .as_ref()
                 .filter(|shell| shell.id == shell_id)
@@ -5709,8 +5735,16 @@ impl Workspace {
         self.minimized_shells.remove(&shell.id);
         let open_workspace_ids = self
             .terminals
-            .values()
-            .filter_map(|pane| pane.shell.as_ref().map(|shell| shell.workspace_id.clone()))
+            .iter()
+            .filter(|(id, _)| {
+                self.workspace_transition.as_ref().is_none_or(|transition| {
+                    !transition
+                        .outgoing
+                        .iter()
+                        .any(|outgoing| outgoing.id == **id)
+                })
+            })
+            .filter_map(|(_, pane)| pane.shell.as_ref().map(|shell| shell.workspace_id.clone()))
             .collect::<HashSet<_>>();
         if shell_open_replaces_panes(
             self.workspace_pane_mode,
@@ -9694,7 +9728,30 @@ impl Render for Workspace {
                     )
                     .when(lifted_id == Some(pane.id), |element| element.opacity(0.92))
                     .child(self.pane(pane.id, cx));
-                if let (Some(animation), Some(duration)) = (
+                if let Some(transition) = &self.workspace_transition {
+                    let target = pane.clone();
+                    let from = FloatingPane {
+                        x: target.x + transition.direction * self.panel_size(window).0,
+                        ..target.clone()
+                    };
+                    let animation_id = SharedString::from(format!(
+                        "workspace-enter-{}-{}",
+                        transition.generation, pane.id
+                    ));
+                    base.with_animation(
+                        animation_id,
+                        Animation::new(transition.duration).with_easing(ease_out_quint()),
+                        move |element, progress| {
+                            let bounds = interpolate_floating_pane(&from, &target, progress);
+                            element
+                                .left(px(bounds.x))
+                                .top(px(bounds.y))
+                                .w(px(bounds.width))
+                                .h(px(bounds.height))
+                        },
+                    )
+                    .into_any_element()
+                } else if let (Some(animation), Some(duration)) = (
                     floating_animation
                         .as_ref()
                         .filter(|animation| animation.pane_id == pane.id),

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -170,6 +170,7 @@ struct SharedTerminal {
     revision: AtomicU64,
     bracketed_paste: AtomicBool,
     mouse_tracking: AtomicBool,
+    pending_resize: Mutex<Option<(u16, u16, u16, u16)>>,
     pending_focus: AtomicBool,
     pending_scroll_row: AtomicU64,
     pending_scroll_wakeup: AtomicBool,
@@ -193,6 +194,7 @@ impl SharedTerminal {
             revision: AtomicU64::new(1),
             bracketed_paste: AtomicBool::new(false),
             mouse_tracking: AtomicBool::new(false),
+            pending_resize: Mutex::new(None),
             pending_focus: AtomicBool::new(false),
             pending_scroll_row: AtomicU64::new(0),
             pending_scroll_wakeup: AtomicBool::new(false),
@@ -238,6 +240,41 @@ impl SharedTerminal {
             Ok(()) | Err(mpsc::TrySendError::Full(_)) => Ok(()),
             Err(mpsc::TrySendError::Disconnected(_)) => Err("Ghostty terminal core stopped".into()),
         }
+    }
+
+    fn request_resize(&self, size: (u16, u16, u16, u16)) -> Result<(), String> {
+        let wake = self.pending_resize.lock().unwrap().replace(size).is_none();
+        if wake {
+            self.try_emulator_command(EmulatorCommand::ResizeLatest)?;
+        }
+        Ok(())
+    }
+
+    fn flush_pending_resize(&self, core: &mut EmulatorCore) -> Result<(), String> {
+        let pending = self.pending_resize.lock().unwrap().take();
+        if let Some((rows, cols, pixel_width, pixel_height)) = pending {
+            {
+                let mut profile = self.profile.lock().unwrap();
+                profile.rows = rows;
+                profile.cols = cols;
+                profile.pixel_width = pixel_width;
+                profile.pixel_height = pixel_height;
+            }
+            core.apply(EmulatorCommand::Resize {
+                rows,
+                cols,
+                cell_width: cell_dimension(pixel_width, cols),
+                cell_height: cell_dimension(pixel_height, rows),
+            })?;
+            self.send(AttachFrame::Resize {
+                rows,
+                cols,
+                pixel_width,
+                pixel_height,
+            })?;
+            self.bump_revision();
+        }
+        Ok(())
     }
 
     fn request_focus(&self) -> Result<(), String> {
@@ -397,6 +434,7 @@ enum EmulatorCommand {
     ScrollLatest,
     ThemeLatest,
     FocusLatest,
+    ResizeLatest,
     MouseWheel {
         lines: isize,
         x: f32,
@@ -627,24 +665,11 @@ impl TerminalSession {
             return false;
         }
         *last_size = (rows, cols);
+        if let Err(error) = self
+            .shared
+            .request_resize((rows, cols, pixel_width, pixel_height))
         {
-            let mut profile = self.shared.profile.lock().unwrap();
-            profile.rows = rows;
-            profile.cols = cols;
-            profile.pixel_width = pixel_width;
-            profile.pixel_height = pixel_height;
-        }
-        self.shared
-            .resize_emulator(rows, cols, pixel_width, pixel_height);
-        if let Err(error) = self.shared.send(AttachFrame::Resize {
-            rows,
-            cols,
-            pixel_width,
-            pixel_height,
-        }) {
             self.shared.set_status(error);
-        } else {
-            self.shared.bump_revision();
         }
         true
     }
@@ -1591,6 +1616,9 @@ impl EmulatorCore {
             EmulatorCommand::FocusLatest => {
                 unreachable!("focus notifications are resolved by the emulator worker")
             }
+            EmulatorCommand::ResizeLatest => {
+                unreachable!("UI resize requests are resolved by the emulator worker")
+            }
             EmulatorCommand::MouseWheel { .. } => {
                 unreachable!("mouse events are resolved by the emulator worker")
             }
@@ -1710,9 +1738,10 @@ fn apply_emulator_command(
     if shared.cancelled.load(Ordering::Acquire) {
         return Ok(false);
     }
+    shared.flush_pending_resize(core)?;
     shared.flush_pending_focus()?;
     match command {
-        EmulatorCommand::FocusLatest => Ok(true),
+        EmulatorCommand::FocusLatest | EmulatorCommand::ResizeLatest => Ok(true),
         EmulatorCommand::Output(bytes) => {
             // A reconstruction can contain a large transcript. Yield to pane
             // cancellation between chunks without changing byte ordering.
@@ -1720,6 +1749,7 @@ fn apply_emulator_command(
                 if shared.cancelled.load(Ordering::Acquire) {
                     return Ok(false);
                 }
+                shared.flush_pending_resize(core)?;
                 shared.flush_pending_focus()?;
                 core.terminal.vt_write(chunk);
             }
@@ -3983,6 +4013,93 @@ mod tests {
             panic!("expected a keyboard enhancement response");
         };
         assert_eq!(bytes, b"\x1b[?0u");
+    }
+
+    #[test]
+    fn terminal_resize_coalesces_without_waiting_for_output_or_socket_capacity() {
+        let (client, mut daemon) = UnixStream::pair().unwrap();
+        daemon
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let shared = Arc::new(SharedTerminal::new(terminal_profile(3, 10, 100, 60)));
+        shared.install_writer(&client).unwrap();
+        let (sender, receiver) = mpsc::sync_channel(1);
+        shared.install_emulator(sender);
+        shared
+            .emulator_command(EmulatorCommand::Output(vec![b'a']))
+            .unwrap();
+        let writer = shared.writer.lock().unwrap();
+        let profile = shared.profile.lock().unwrap();
+        let (done, completed) = mpsc::channel();
+        let pending = shared.clone();
+        let requester = std::thread::spawn(move || {
+            for cols in 10..=109 {
+                pending.request_resize((6, cols, cols * 10, 120)).unwrap();
+            }
+            let _ = done.send(());
+        });
+        let result = completed.recv_timeout(Duration::from_millis(250));
+        drop(profile);
+        drop(writer);
+        requester.join().unwrap();
+        assert!(
+            result.is_ok(),
+            "resize waited on a worker lock or full queue"
+        );
+        assert_eq!(
+            *shared.pending_resize.lock().unwrap(),
+            Some((6, 109, 1090, 120))
+        );
+        let mut core = EmulatorCore::new(&shared, 3, 10, 100, 60).unwrap();
+        assert!(apply_emulator_command(&mut core, &shared, receiver.recv().unwrap()).unwrap());
+        assert!(matches!(
+            AttachFrame::read_from(&mut daemon).unwrap(),
+            AttachFrame::Resize {
+                rows: 6,
+                cols: 109,
+                pixel_width: 1090,
+                pixel_height: 120
+            }
+        ));
+        assert_eq!(
+            (core.screen().unwrap().rows, core.screen().unwrap().cols),
+            (6, 109)
+        );
+        assert!(shared.pending_resize.lock().unwrap().is_none());
+        assert!(receiver.try_recv().is_err(), "resize flood grew the queue");
+        shared.request_resize((3, 10, 100, 60)).unwrap();
+        assert!(matches!(
+            receiver.recv().unwrap(),
+            EmulatorCommand::ResizeLatest
+        ));
+    }
+
+    #[test]
+    #[ignore = "manual native terminal replay and fullscreen resize measurement"]
+    fn terminal_replay_resize_measurement() {
+        let shared = Arc::new(SharedTerminal::new(terminal_profile(40, 120, 1200, 800)));
+        let mut core = EmulatorCore::new(&shared, 40, 120, 1200, 800).unwrap();
+        let bytes = b"\x1b[32mterminal replay fixture with colored output and normal line wrapping\x1b[0m\r\n".repeat(2048);
+        let replay = std::time::Instant::now();
+        core.apply(EmulatorCommand::Output(bytes.clone())).unwrap();
+        let replay_elapsed = replay.elapsed();
+        let resize = std::time::Instant::now();
+        for (rows, cols) in [(80, 200), (40, 120), (80, 200), (40, 120)] {
+            core.apply(EmulatorCommand::Resize {
+                rows,
+                cols,
+                cell_width: 10,
+                cell_height: 20,
+            })
+            .unwrap();
+            let _ = core.screen().unwrap();
+        }
+        eprintln!(
+            "native replay/resize: bytes={} replay_ms={:.3} resize_ms={:.3}",
+            bytes.len(),
+            replay_elapsed.as_secs_f64() * 1000.0,
+            resize.elapsed().as_secs_f64() * 1000.0
+        );
     }
 
     #[test]

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -170,6 +170,7 @@ struct SharedTerminal {
     revision: AtomicU64,
     bracketed_paste: AtomicBool,
     mouse_tracking: AtomicBool,
+    pending_focus: AtomicBool,
     pending_scroll_row: AtomicU64,
     pending_scroll_wakeup: AtomicBool,
     pending_theme: Mutex<Option<TerminalTheme>>,
@@ -192,6 +193,7 @@ impl SharedTerminal {
             revision: AtomicU64::new(1),
             bracketed_paste: AtomicBool::new(false),
             mouse_tracking: AtomicBool::new(false),
+            pending_focus: AtomicBool::new(false),
             pending_scroll_row: AtomicU64::new(0),
             pending_scroll_wakeup: AtomicBool::new(false),
             pending_theme: Mutex::new(Some(theme)),
@@ -236,6 +238,22 @@ impl SharedTerminal {
             Ok(()) | Err(mpsc::TrySendError::Full(_)) => Ok(()),
             Err(mpsc::TrySendError::Disconnected(_)) => Err("Ghostty terminal core stopped".into()),
         }
+    }
+
+    fn request_focus(&self) -> Result<(), String> {
+        if self.pending_focus.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+        // A full queue already wakes the worker. The pending flag retains the
+        // notification until that worker can write it, without blocking GPUI.
+        self.try_emulator_command(EmulatorCommand::FocusLatest)
+    }
+
+    fn flush_pending_focus(&self) -> Result<(), String> {
+        if self.pending_focus.swap(false, Ordering::AcqRel) {
+            self.send(AttachFrame::FocusGained)?;
+        }
+        Ok(())
     }
 
     fn try_key_command(&self, keystroke: Keystroke, action: KeyAction) -> Result<(), String> {
@@ -378,6 +396,7 @@ enum EmulatorCommand {
     Scroll(ScrollViewport),
     ScrollLatest,
     ThemeLatest,
+    FocusLatest,
     MouseWheel {
         lines: isize,
         x: f32,
@@ -631,7 +650,7 @@ impl TerminalSession {
     }
 
     pub fn focus(&self) {
-        if let Err(error) = self.shared.send(AttachFrame::FocusGained) {
+        if let Err(error) = self.shared.request_focus() {
             self.shared.set_status(error);
         }
     }
@@ -1569,6 +1588,9 @@ impl EmulatorCore {
             EmulatorCommand::ThemeLatest => {
                 unreachable!("latest theme requests are resolved by the emulator worker")
             }
+            EmulatorCommand::FocusLatest => {
+                unreachable!("focus notifications are resolved by the emulator worker")
+            }
             EmulatorCommand::MouseWheel { .. } => {
                 unreachable!("mouse events are resolved by the emulator worker")
             }
@@ -1688,7 +1710,9 @@ fn apply_emulator_command(
     if shared.cancelled.load(Ordering::Acquire) {
         return Ok(false);
     }
+    shared.flush_pending_focus()?;
     match command {
+        EmulatorCommand::FocusLatest => Ok(true),
         EmulatorCommand::Output(bytes) => {
             // A reconstruction can contain a large transcript. Yield to pane
             // cancellation between chunks without changing byte ordering.
@@ -1696,6 +1720,7 @@ fn apply_emulator_command(
                 if shared.cancelled.load(Ordering::Acquire) {
                     return Ok(false);
                 }
+                shared.flush_pending_focus()?;
                 core.terminal.vt_write(chunk);
             }
             Ok(true)
@@ -3958,6 +3983,57 @@ mod tests {
             panic!("expected a keyboard enhancement response");
         };
         assert_eq!(bytes, b"\x1b[?0u");
+    }
+
+    #[test]
+    fn terminal_focus_does_not_wait_for_the_socket_writer_or_queue_capacity() {
+        let (client, mut daemon) = UnixStream::pair().unwrap();
+        daemon
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let shared = Arc::new(SharedTerminal::new(terminal_profile(3, 10, 100, 60)));
+        shared.install_writer(&client).unwrap();
+        let (sender, receiver) = mpsc::sync_channel(1);
+        shared.install_emulator(sender);
+        shared
+            .emulator_command(EmulatorCommand::Output(vec![b'a']))
+            .unwrap();
+        let writer = shared.writer.lock().unwrap();
+        let (done, completed) = mpsc::channel();
+        let pending = shared.clone();
+        let requester = std::thread::spawn(move || {
+            for _ in 0..100 {
+                pending.request_focus().unwrap();
+            }
+            let _ = done.send(());
+        });
+        let result = completed.recv_timeout(Duration::from_millis(250));
+        drop(writer);
+        requester.join().unwrap();
+        assert!(
+            result.is_ok(),
+            "focus blocked the UI on the socket or full queue"
+        );
+        assert!(shared.pending_focus.load(Ordering::Acquire));
+        let mut core = EmulatorCore::new(&shared, 3, 10, 100, 60).unwrap();
+        assert!(apply_emulator_command(&mut core, &shared, receiver.recv().unwrap()).unwrap());
+        assert!(matches!(
+            AttachFrame::read_from(&mut daemon).unwrap(),
+            AttachFrame::FocusGained
+        ));
+        assert!(!shared.pending_focus.load(Ordering::Acquire));
+        assert!(
+            receiver.try_recv().is_err(),
+            "focus requests grew the full queue"
+        );
+        // On an idle queue, one marker wakes the worker and duplicate requests coalesce.
+        shared.request_focus().unwrap();
+        shared.request_focus().unwrap();
+        assert!(matches!(
+            receiver.recv().unwrap(),
+            EmulatorCommand::FocusLatest
+        ));
+        assert!(receiver.try_recv().is_err());
     }
 
     #[test]

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -174,6 +174,7 @@ struct SharedTerminal {
     pending_scroll_wakeup: AtomicBool,
     pending_theme: Mutex<Option<TerminalTheme>>,
     closed: AtomicBool,
+    cancelled: AtomicBool,
 }
 
 impl SharedTerminal {
@@ -195,6 +196,7 @@ impl SharedTerminal {
             pending_scroll_wakeup: AtomicBool::new(false),
             pending_theme: Mutex::new(Some(theme)),
             closed: AtomicBool::new(false),
+            cancelled: AtomicBool::new(false),
         }
     }
 
@@ -203,13 +205,26 @@ impl SharedTerminal {
     }
 
     fn emulator_command(&self, command: EmulatorCommand) -> Result<(), String> {
-        self.emulator
+        // Output producers may wait for queue capacity, but must never keep
+        // the sender mutex locked while waiting: UI input and teardown use it.
+        let sender = self
+            .emulator
             .lock()
             .unwrap()
             .as_ref()
-            .ok_or_else(|| "Ghostty terminal core is not running".to_string())?
+            .cloned()
+            .ok_or_else(|| "Ghostty terminal core is not running".to_string())?;
+        sender
             .send(command)
             .map_err(|_| "Ghostty terminal core stopped".to_string())
+    }
+
+    fn cancel_emulator(&self) {
+        self.cancelled.store(true, Ordering::Release);
+        // Disconnect instead of enqueueing Stop into a potentially full queue.
+        // The worker sees cancellation between replay chunks and drops its
+        // receiver, releasing any blocked output producer.
+        self.emulator.lock().unwrap().take();
     }
 
     fn try_emulator_command(&self, command: EmulatorCommand) -> Result<(), String> {
@@ -341,9 +356,9 @@ impl SharedTerminal {
             return;
         }
         *self.writer.lock().unwrap() = None;
-        if let Some(emulator) = self.emulator.lock().unwrap().take() {
-            let _ = emulator.send(EmulatorCommand::Stop);
-        }
+        // Transport closure still drains queued output and publishes the final
+        // screen. Disconnecting the sender does not require queue capacity.
+        self.emulator.lock().unwrap().take();
         self.replace_status(status);
     }
 }
@@ -371,7 +386,6 @@ enum EmulatorCommand {
         screen_height: u32,
         modifiers: Modifiers,
     },
-    Stop,
 }
 
 pub struct TerminalSession {
@@ -639,9 +653,7 @@ impl Drop for TerminalSession {
     fn drop(&mut self) {
         let _ = self.shared.send(AttachFrame::Detached);
         self.shared.closed.store(true, Ordering::Release);
-        if let Some(emulator) = self.shared.emulator.lock().unwrap().take() {
-            let _ = emulator.send(EmulatorCommand::Stop);
-        }
+        self.shared.cancel_emulator();
     }
 }
 
@@ -1560,7 +1572,6 @@ impl EmulatorCore {
             EmulatorCommand::MouseWheel { .. } => {
                 unreachable!("mouse events are resolved by the emulator worker")
             }
-            EmulatorCommand::Stop => return Ok(false),
         }
         Ok(true)
     }
@@ -1674,7 +1685,21 @@ fn apply_emulator_command(
     shared: &SharedTerminal,
     command: EmulatorCommand,
 ) -> Result<bool, String> {
+    if shared.cancelled.load(Ordering::Acquire) {
+        return Ok(false);
+    }
     match command {
+        EmulatorCommand::Output(bytes) => {
+            // A reconstruction can contain a large transcript. Yield to pane
+            // cancellation between chunks without changing byte ordering.
+            for chunk in bytes.chunks(16 * 1024) {
+                if shared.cancelled.load(Ordering::Acquire) {
+                    return Ok(false);
+                }
+                core.terminal.vt_write(chunk);
+            }
+            Ok(true)
+        }
         EmulatorCommand::Key { keystroke, action } => {
             // Typing follows conventional terminal behavior and returns the
             // viewport to the live prompt before the PTY produces more output.
@@ -2017,9 +2042,11 @@ fn run_emulator(
             return;
         }
     }
-    // Stop may share a batch with final output, or end synchronized output.
-    // Preserve those bytes in the detached pane before releasing the core.
-    if let Err(error) = publish_screen(core, worker_shared) {
+    // Transport closure may end synchronized output. Preserve the final screen
+    // unless the pane itself was discarded and cancelled its replay.
+    if !worker_shared.cancelled.load(Ordering::Acquire)
+        && let Err(error) = publish_screen(core, worker_shared)
+    {
         worker_shared.close(error);
     }
 }
@@ -3200,9 +3227,10 @@ mod tests {
 
     use super::{
         AgentChoice, EMULATOR_QUEUE_CAPACITY, EmulatorCommand, EmulatorCore, SharedTerminal,
-        agent_is_visible, blank_screen, configure_terminal, distinguish_agent_rows, encode_key,
-        encode_mouse_wheel, encode_paste, image_bgra, indexed_color, resynchronize_terminal_size,
-        run_emulator, spawn_reader, start_emulator, terminal_profile,
+        agent_is_visible, apply_emulator_command, blank_screen, configure_terminal,
+        distinguish_agent_rows, encode_key, encode_mouse_wheel, encode_paste, image_bgra,
+        indexed_color, resynchronize_terminal_size, run_emulator, spawn_reader, start_emulator,
+        terminal_profile,
     };
     use crate::theme::TerminalTheme;
     use std::sync::{Arc, mpsc};
@@ -3930,6 +3958,70 @@ mod tests {
             panic!("expected a keyboard enhancement response");
         };
         assert_eq!(bytes, b"\x1b[?0u");
+    }
+
+    #[test]
+    fn terminal_full_output_queue_does_not_block_pane_cancellation_or_transport_close() {
+        for cancel in [true, false] {
+            let shared = Arc::new(SharedTerminal::new(terminal_profile(3, 10, 100, 60)));
+            let (sender, receiver) = mpsc::sync_channel(1);
+            shared.install_emulator(sender);
+            shared
+                .emulator_command(EmulatorCommand::Output(vec![b'a']))
+                .unwrap();
+            let (started, ready) = mpsc::channel();
+            let producer_shared = shared.clone();
+            let producer = std::thread::spawn(move || {
+                started.send(()).unwrap();
+                producer_shared.emulator_command(EmulatorCommand::Output(vec![b'b']))
+            });
+            ready.recv().unwrap();
+            // Let the producer block behind the deliberately full queue.
+            std::thread::sleep(Duration::from_millis(20));
+            let (done, completed) = mpsc::channel();
+            let cleanup_shared = shared.clone();
+            let cleanup = std::thread::spawn(move || {
+                if cancel {
+                    cleanup_shared.cancel_emulator();
+                } else {
+                    cleanup_shared.close("detached");
+                }
+                let _ = done.send(());
+            });
+            let result = completed.recv_timeout(Duration::from_millis(250));
+            // Always release the blocked producer, including on regression.
+            drop(receiver);
+            assert!(producer.join().unwrap().is_err());
+            cleanup.join().unwrap();
+            assert!(result.is_ok(), "cleanup waited for output queue capacity");
+            assert!(shared.emulator.lock().unwrap().is_none());
+        }
+    }
+
+    #[test]
+    fn terminal_replay_chunking_preserves_escape_sequences_and_honors_cancellation() {
+        let shared = Arc::new(SharedTerminal::new(terminal_profile(3, 80, 800, 60)));
+        let mut chunked = EmulatorCore::new(&shared, 3, 80, 800, 60).unwrap();
+        let whole_shared = Arc::new(SharedTerminal::new(terminal_profile(3, 80, 800, 60)));
+        let mut whole = EmulatorCore::new(&whole_shared, 3, 80, 800, 60).unwrap();
+        let mut bytes = vec![b'\r'; 16 * 1024 - 1];
+        bytes.extend_from_slice("\x1b[31mhello 世界".as_bytes());
+        whole.apply(EmulatorCommand::Output(bytes.clone())).unwrap();
+        assert!(
+            apply_emulator_command(&mut chunked, &shared, EmulatorCommand::Output(bytes)).unwrap()
+        );
+        assert_eq!(whole.screen().unwrap(), chunked.screen().unwrap());
+        let before = chunked.screen().unwrap();
+        shared.cancel_emulator();
+        assert!(
+            !apply_emulator_command(
+                &mut chunked,
+                &shared,
+                EmulatorCommand::Output(b"discarded".to_vec())
+            )
+            .unwrap()
+        );
+        assert_eq!(before, chunked.screen().unwrap());
     }
 
     #[test]

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -136,6 +136,12 @@ The terminal worker sends the notification, including between replay chunks;
 click and hover handlers never acquire the attachment writer or write a focus
 frame themselves. Repeated focus requests coalesce while the queue is full.
 
+Pane resize requests likewise retain only one latest set of dimensions per pane
+and use a nonblocking wake marker. The worker updates the terminal profile,
+resizes the emulator, and sends the daemon resize frame between replay chunks.
+Fullscreen and window resize handlers do not wait for queue capacity or socket
+writes.
+
 Discarding a pane cancels its local replay and disconnects the queue sender;
 it does not enqueue a blocking stop command. The worker checks cancellation
 between 16 KiB decode chunks and releases pending replay data when it exits.

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -128,7 +128,15 @@ terminal parser. Each attached pane has a socket reader and one terminal worker.
 The reader sends byte chunks through a bounded queue. When decoding falls behind,
 pressure propagates back through the Boomux socket to the PTY producer; arbitrary
 terminal bytes are never discarded because doing so could corrupt escape or
-Kitty graphics sequences.
+Kitty graphics sequences. A producer clones the queue sender under its mutex,
+then releases the mutex before waiting for capacity. Queue saturation must not
+prevent GPUI from accessing the sender or cancelling a discarded pane.
+
+Discarding a pane cancels its local replay and disconnects the queue sender;
+it does not enqueue a blocking stop command. The worker checks cancellation
+between 16 KiB decode chunks and releases pending replay data when it exits.
+This discards only presentation work for a closed pane, not daemon-owned Shell
+output or processes.
 
 After initial attachment and daemon reconnect, the reader requests one redraw
 by briefly changing the PTY width and restoring the latest pane dimensions after
@@ -142,7 +150,7 @@ new snapshot or terminal status exists; bursts collapse into one wakeup because
 the consumer always reads the newest snapshot. Synchronized-output mode delays
 publication until the terminal frame is complete.
 When an attachment ends, the worker publishes its final decoded screen before
-stopping, including output batched with the stop command. Detachment itself does
+stopping, including output queued before transport closure. Detachment itself does
 not establish command success. The UI watches until the worker closes its update
 stream after final publication, rather than stopping at transport closure.
 

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -131,6 +131,10 @@ terminal bytes are never discarded because doing so could corrupt escape or
 Kitty graphics sequences. A producer clones the queue sender under its mutex,
 then releases the mutex before waiting for capacity. Queue saturation must not
 prevent GPUI from accessing the sender or cancelling a discarded pane.
+Pane focus notifications use a single pending flag and a nonblocking wake marker.
+The terminal worker sends the notification, including between replay chunks;
+click and hover handlers never acquire the attachment writer or write a focus
+frame themselves. Repeated focus requests coalesce while the queue is full.
 
 Discarding a pane cancels its local replay and disconnects the queue sender;
 it does not enqueue a blocking stop command. The worker checks cancellation


### PR DESCRIPTION
Restored Workspace layouts now slide correctly, including floating and expanded panes. Rapid reversals reuse outgoing panes for the exact Shell/run instead of reconnecting them. This fixes regressions following the layout persistence feature in #399.

Terminal queue backpressure could block pane cleanup on the UI thread; the captured Linux hang stack confirmed this path. Queue sends now release the sender mutex before waiting, and discarded panes cancel replay between bounded chunks. Focus and fullscreen resize requests coalesce and run on the terminal worker so their UI handlers do not wait for socket writes or queue capacity.

Development builds retain Rust debug information while optimizing the native Ghostty core. An explicit `LIBGHOSTTY_VT_SYS_OPTIMIZE=Debug` override remains available.

Validation:
- Locked Desktop compile check and development build passed; 23 focused layout tests and 11 focused terminal tests passed on the source branch. One manual measurement test is ignored by default.
- The cleanup saturation regression fails with the original locking code and passes with the fix. Focus/resize regressions exercise a full output queue and locked socket writer.
- Same-host native terminal fixture, Rust debug profile, 161,792 bytes: replay took 9,363 ms with native Debug and 1.601 ms with native ReleaseFast; four resizes/snapshots took 195.533 ms and 23.646 ms. These are native fixture timings, not end-to-end UI latency.
- User reports improved responsiveness with some remaining sluggishness. Release-mode interactive comparison remains unconfirmed.
- Changes applied cleanly to current main; affected source matches the locally validated branch. Whitespace checks passed. Complete validation is left to PR CI.

These corrections are already included in experimental macOS draft #397. This PR changes neither daemon protocol nor persisted state schemas.
