### PR TITLE
fix(desktop): discard unbound saved pane placeholders

### DIFF
--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -188,7 +188,7 @@ impl Workspace {
                 })
             })
             .collect();
-        let arrangement = Arrangement {
+        let mut arrangement = Arrangement {
             tree: self.layout.as_ref().map(encode_tree),
             floating: self
                 .floating
@@ -206,6 +206,7 @@ impl Workspace {
                 .map(|id| id as u64),
             canvas: [self.layout_canvas.0.max(1.0), self.layout_canvas.1.max(1.0)],
         };
+        arrangement.discard_unbound_panes();
         let retained_panes: usize = self
             .layout_document
             .arrangements
@@ -294,6 +295,8 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let mut saved = saved;
+        saved.discard_unbound_panes();
         self.layout_restoring = true;
         self.restore_pointer_guard = PointerGuard::Waiting;
         // A quick return can find this Workspace still sliding out. Preserve

--- a/desktop/src/layout_state.rs
+++ b/desktop/src/layout_state.rs
@@ -64,6 +64,41 @@ impl Default for Document {
         }
     }
 }
+impl Arrangement {
+    /// Unbound UI placeholders have no terminal identity to restore. Retain
+    /// references to unavailable Shells, which can still be reconnected later.
+    pub fn discard_unbound_panes(&mut self) {
+        self.panes.retain(|_, pane| pane.shell.is_some());
+        fn prune(tree: Tree, panes: &BTreeMap<u64, Pane>) -> Option<Tree> {
+            match tree {
+                Tree::Pane(id) => panes.contains_key(&id).then_some(Tree::Pane(id)),
+                Tree::Split {
+                    horizontal,
+                    ratio,
+                    first,
+                    second,
+                } => match (prune(*first, panes), prune(*second, panes)) {
+                    (Some(first), Some(second)) => Some(Tree::Split {
+                        horizontal,
+                        ratio,
+                        first: Box::new(first),
+                        second: Box::new(second),
+                    }),
+                    (first, second) => first.or(second),
+                },
+            }
+        }
+        self.tree = self.tree.take().and_then(|tree| prune(tree, &self.panes));
+        self.floating
+            .retain(|pane| self.panes.contains_key(&pane.pane));
+        self.focused = self
+            .focused
+            .filter(|id| self.panes.contains_key(id))
+            .or_else(|| self.panes.keys().next().copied());
+        self.expanded = self.expanded.filter(|id| self.panes.contains_key(id));
+    }
+}
+
 impl Tree {
     fn validate(&self, depth: usize, ids: &mut HashSet<u64>) -> Result<(), String> {
         if depth > 64 || ids.len() >= MAX_PANES {
@@ -408,5 +443,79 @@ mod tests {
         assert_eq!(request.document, fixture());
         request.completion.send_blocking(Ok(())).unwrap();
         latest.recv_blocking().unwrap().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod unbound_tests {
+    use super::*;
+    #[test]
+    fn empty_placeholders_collapse_without_losing_saved_shells() {
+        let branch = Tree::Split {
+            horizontal: true,
+            ratio: 0.3,
+            first: Box::new(Tree::Pane(7)),
+            second: Box::new(Tree::Pane(8)),
+        };
+        let mut saved = Arrangement {
+            tree: Some(Tree::Split {
+                horizontal: false,
+                ratio: 0.5,
+                first: Box::new(Tree::Pane(6)),
+                second: Box::new(branch.clone()),
+            }),
+            panes: BTreeMap::from([
+                (
+                    6,
+                    Pane {
+                        shell: None,
+                        workspace: None,
+                    },
+                ),
+                (
+                    7,
+                    Pane {
+                        shell: Some("running".into()),
+                        workspace: Some("workspace".into()),
+                    },
+                ),
+                (
+                    8,
+                    Pane {
+                        shell: Some("unavailable-but-reconnectable".into()),
+                        workspace: None,
+                    },
+                ),
+                (
+                    9,
+                    Pane {
+                        shell: None,
+                        workspace: None,
+                    },
+                ),
+            ]),
+            floating: vec![Floating {
+                pane: 9,
+                rect: [0., 0., 100., 100.],
+            }],
+            focused: Some(6),
+            expanded: Some(9),
+            canvas: [1000., 800.],
+        };
+        saved.discard_unbound_panes();
+        assert_eq!(saved.tree, Some(branch));
+        assert_eq!(saved.panes.len(), 2);
+        assert!(saved.floating.is_empty());
+        assert_eq!(saved.focused, Some(7));
+        assert_eq!(saved.expanded, None);
+        let cleaned = saved.clone();
+        saved.discard_unbound_panes();
+        assert_eq!(saved, cleaned);
+        for pane in saved.panes.values_mut() {
+            pane.shell = None;
+        }
+        saved.discard_unbound_panes();
+        assert!(saved.tree.is_none() && saved.panes.is_empty());
+        assert_eq!(saved.focused, None);
     }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -8944,7 +8944,11 @@ impl Workspace {
             ))
             .when(
                 pane.is_some_and(|pane| {
-                    pane.restored.is_some() && !pane.attaching && pane.session.is_none()
+                    pane.restored
+                        .as_ref()
+                        .is_some_and(|saved| saved.shell.is_some())
+                        && !pane.attaching
+                        && pane.session.is_none()
                 }),
                 |element| {
                     element.child(

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -29,6 +29,8 @@ where Ghostty's reusable key encoder reads the current terminal modes before
 encoding and forwarding them; this keeps Kitty keyboard, modifyOtherKeys,
 cursor, keypad, and backarrow negotiation ordered with terminal output.
 Detaching a pane never implies closing its Boomux Shell.
+Layout capture and restore discard unbound placeholders that have no Shell identity,
+collapsing their splits. Saved references to unavailable Shells remain reconnectable.
 
 New terminal creation publishes the attachment before any sidebar overview refresh;
 the existing overview worker refreshes resource rows independently. New local


### PR DESCRIPTION
Desktop could save a pane with no Shell identity and later restore it as an extra empty tile above working terminals. The tile also offered “Reconnect / start Shell” even though it had nothing to reconnect to.

Discard unbound placeholders during layout capture and restore, collapsing their splits and removing stale floating, focus, and expansion references. Preserve saved references to real but unavailable Shells. Only show reconnect when a saved Shell identity exists. The persisted format is unchanged.

Validation:
- `cargo check -p boomux-desktop --locked` passed.
- `cargo test -p boomux-desktop empty_placeholders_collapse_without_losing_saved_shells --locked -- --test-threads=1` passed; covers split preservation, unavailable Shell references, floating placeholders, focus/expansion cleanup, idempotence, and an entirely empty layout.
- `git diff --check` passed.

The installed Desktop has not been replaced; live GUI behavior with a rebuilt application remains unverified. Complete validation is left to PR CI.
