### PR TITLE
fix(desktop): guide new users to create a workspace

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -9676,6 +9676,29 @@ impl Render for Workspace {
         self.refresh_terminal_paint_caches(window);
         let tiled = if let Some(layout) = &self.layout {
             self.render_layout(layout, cx)
+        } else if self.boomux_overview.workspaces.is_empty() && self.terminals.is_empty() {
+            div()
+                .size_full()
+                .flex()
+                .flex_col()
+                .items_center()
+                .justify_center()
+                .gap_3()
+                .p_6()
+                .text_center()
+                .text_sm()
+                .text_color(rgb(0xa6adc8))
+                .child(
+                    div()
+                        .text_xl()
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .text_color(rgb(0xcdd6f4))
+                        .child("Create your first Workspace"),
+                )
+                .child("Click + in the sidebar, then choose New Workspace to get started.")
+                .child("Once created, press Ctrl + Enter to add a Shell.")
+                .child("Press F1 for keyboard shortcuts.")
+                .into_any_element()
         } else {
             div().size_full().into_any_element()
         };


### PR DESCRIPTION
When Desktop has no Workspaces or terminal panes, the main pane now explains how to create the first Workspace using **+ → New Workspace**. It also points to **Ctrl + Enter** for adding Shells afterward and **F1** for keyboard shortcuts.

Validation: `cargo fmt --all -- --check`, `cargo check -p boomux-desktop --locked`, and `git diff --check` passed. Live visual appearance has not been checked.
