### PR TITLE
test(integrations): tolerate maintenance lock contention

### DIFF
--- a/tests/native_backend/launchers_integrations.rs
+++ b/tests/native_backend/launchers_integrations.rs
@@ -51,28 +51,37 @@ fn managed_integrations_install_at_startup_refresh_on_handoff_and_respect_uninst
         },
         "refresh receipt was not saved",
     );
-    let output = daemon
-        .command()
-        .args(["integration", "uninstall", "pi"])
-        .output()
-        .unwrap();
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    // Receipt publication precedes releasing the integration lock. A restart
+    // also begins asynchronous maintenance, so both explicit commands can
+    // legitimately encounter a busy lock. Retry only that documented outcome;
+    // ownership, filesystem, and other command failures must still fail here.
+    let run_after_maintenance = |arguments: &[&str]| {
+        let busy = std::io::Error::from_raw_os_error(libc::EWOULDBLOCK).to_string();
+        wait_until(
+            || {
+                let output = daemon
+                    .command()
+                    .args(arguments)
+                    .env("PATH", daemon.runtime_dir.join("bin"))
+                    .output()
+                    .unwrap();
+                if output.status.success() {
+                    return true;
+                }
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                // Sync prefixes each integration's error with its name.
+                assert!(
+                    !stderr.trim().is_empty() && stderr.lines().all(|line| line.ends_with(&busy)),
+                    "{arguments:?}: {stderr}"
+                );
+                false
+            },
+            &format!("integration maintenance did not release its lock for {arguments:?}"),
+        );
+    };
+    run_after_maintenance(&["integration", "uninstall", "pi"]);
     daemon.client.restart().unwrap();
-    let output = daemon
-        .command()
-        .args(["integration", "sync"])
-        .env("PATH", daemon.runtime_dir.join("bin"))
-        .output()
-        .unwrap();
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    run_after_maintenance(&["integration", "sync"]);
     assert!(!asset.exists());
 }
 


### PR DESCRIPTION
The post-merge main CI run failed when the managed-integration lifecycle test uninstalled Pi immediately after observing its refreshed receipt. Receipt publication happens before the background maintenance worker releases its nonblocking integration lock, so the command can legitimately return EWOULDBLOCK. The explicit sync after the next restart has the same race.

Retry only that expected busy-lock result within the test's existing bounded wait. Fail immediately for other command errors and retain the final assertion that an opted-out integration stays uninstalled. Production locking and startup behavior are unchanged.

Validation: the focused native lifecycle test passed locally, with formatting and whitespace checks. The failed main jobs have also been rerun; full selected validation remains in PR CI.

Failure: https://github.com/gardnmi/boomux/actions/runs/34557056900/job/103131895287
