### PR TITLE
feat(desktop): filter projects in the workspace menu

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -55,7 +55,7 @@ Workspaces remain visible until their owning machine can confirm they are empty.
 | To… | Use… |
 | --- | --- |
 | Create a Workspace | **+ → New workspace** |
-| Open a project | Choose a configured project from **+** |
+| Open a project | Open **+**, type to filter projects by name or path, then choose a project |
 | Add project folders | **Settings → Projects → Browse for folders** |
 | Create a Shell | **Ctrl + Enter** |
 | Rename a Workspace or Shell | Select it, then **F2** |

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,5 +1,6 @@
 mod boomux_settings;
 mod bundle_update;
+mod project_search;
 use boomux::generated_names;
 mod git_panel;
 mod layout;
@@ -1546,6 +1547,7 @@ struct Workspace {
     sidebar_menu: Option<SidebarMenu>,
     sidebar_header_menu_open: bool,
     project_menu_open: bool,
+    project_search: String,
     projects_loading: bool,
     projects_result: Option<Result<boomux::protocol::HostProjectDiscovery, String>>,
     project_folder_picker_pending: bool,
@@ -1764,6 +1766,7 @@ impl Workspace {
             sidebar_menu: None,
             sidebar_header_menu_open: false,
             project_menu_open: false,
+            project_search: String::new(),
             projects_loading: false,
             projects_result: None,
             project_folder_picker_pending: false,
@@ -4103,6 +4106,12 @@ impl Workspace {
 
     fn paste_clipboard(&mut self, _: &PasteClipboard, _: &mut Window, cx: &mut Context<Self>) {
         if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+            if self.project_menu_open {
+                project_search::append(&mut self.project_search, &text);
+                cx.stop_propagation();
+                cx.notify();
+                return;
+            }
             if let Some((_, value)) = &mut self.boomux_setting_input {
                 append_boomux_setting_text(value, &text);
                 cx.stop_propagation();
@@ -4737,6 +4746,32 @@ impl Workspace {
             return;
         } else if !event.is_held {
             self.layout_suppressed_keys.remove(&event.keystroke.key);
+        }
+        if self.project_menu_open {
+            match event.keystroke.key.as_str() {
+                "escape" => self.project_menu_open = false,
+                "backspace" => {
+                    self.project_search.pop();
+                }
+                "u" if event.keystroke.modifiers.control => self.project_search.clear(),
+                "v" if event.keystroke.modifiers.control && !cfg!(target_os = "macos") => {
+                    if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+                        project_search::append(&mut self.project_search, &text);
+                    }
+                }
+                _ if !event.keystroke.modifiers.control
+                    && !event.keystroke.modifiers.platform
+                    && !event.keystroke.modifiers.alt =>
+                {
+                    if let Some(text) = &event.keystroke.key_char {
+                        project_search::append(&mut self.project_search, text);
+                    }
+                }
+                _ => (),
+            }
+            cx.stop_propagation();
+            cx.notify();
+            return;
         }
         if self.git_panel.search_focused {
             match event.keystroke.key.as_str() {
@@ -6243,6 +6278,8 @@ impl Workspace {
         self.project_menu_open = !self.project_menu_open;
         self.sidebar_header_menu_open = false;
         self.sidebar_menu = None;
+        self.project_search.clear();
+        self.git_panel.search_focused = false;
         window.focus(&self.focus_handle, cx);
         if self.project_menu_open && !self.projects_loading {
             self.projects_loading = true;
@@ -6330,6 +6367,7 @@ impl Workspace {
             .id("project-menu-list")
             .max_h(px(320.0))
             .overflow_y_scroll();
+        let query = self.project_search.trim().to_lowercase();
         let mut configured = false;
         if self.projects_loading {
             entries = entries.child(
@@ -6353,7 +6391,24 @@ impl Workspace {
                                 },
                             ));
                     }
-                    for (index, project) in discovery.projects.iter().enumerate() {
+                    let mut matches = discovery
+                        .projects
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, project)| {
+                            project_search::matches(&project.name, &project.path, &query)
+                        })
+                        .peekable();
+                    if !discovery.projects.is_empty() && matches.peek().is_none() {
+                        entries = entries.child(
+                            div()
+                                .p_3()
+                                .text_sm()
+                                .text_color(rgb(0x9399b2))
+                                .child("No projects match your search."),
+                        );
+                    }
+                    for (index, project) in matches {
                         let project = project.clone();
                         entries = entries.child(
                             sidebar_menu_row(("project-choice", index))
@@ -6461,6 +6516,59 @@ impl Workspace {
                         .text_xs()
                         .text_color(rgb(0x9399b2))
                         .child("LOCAL PROJECTS"),
+                )
+                .child(
+                    div()
+                        .id("project-search")
+                        .role(gpui::Role::SearchInput)
+                        .aria_label("Filter projects by name or path")
+                        .mx_2()
+                        .my_1()
+                        .p_2()
+                        .rounded_md()
+                        .border_1()
+                        .border_color(rgb(0x89b4fa))
+                        .flex()
+                        .items_center()
+                        .gap_2()
+                        .text_sm()
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            cx.stop_propagation();
+                            window.focus(&this.focus_handle, cx);
+                        }))
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .truncate()
+                                .text_color(rgb(if self.project_search.is_empty() {
+                                    0x9399b2
+                                } else {
+                                    0xcdd6f4
+                                }))
+                                .child(if self.project_search.is_empty() {
+                                    "Search projects…".to_string()
+                                } else {
+                                    self.project_search.clone()
+                                }),
+                        )
+                        .when(!self.project_search.is_empty(), |field| {
+                            field.child(
+                                div()
+                                    .id("project-search-clear")
+                                    .role(gpui::Role::Button)
+                                    .aria_label("Clear project search")
+                                    .cursor_pointer()
+                                    .px_1()
+                                    .child("×")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        cx.stop_propagation();
+                                        this.project_search.clear();
+                                        window.focus(&this.focus_handle, cx);
+                                        cx.notify();
+                                    })),
+                            )
+                        }),
                 )
                 .child(entries)
                 .child(div().mx_2().my_1().h(px(1.0)).bg(rgb(0x313244)))
@@ -10087,6 +10195,7 @@ impl Render for Workspace {
             .key_context(
                 if (self.nodes_open && self.navigation_region == NavigationRegion::Sidebar)
                     || self.git_panel.search_focused
+                    || self.project_menu_open
                     || self.boomux_setting_input.is_some()
                     || self.settings_restart_confirm
                 {

--- a/desktop/src/project_search.rs
+++ b/desktop/src/project_search.rs
@@ -1,0 +1,46 @@
+//! Bounded, in-memory filtering for the local project picker.
+use std::path::Path;
+
+pub fn matches(name: &str, path: &Path, normalized_query: &str) -> bool {
+    normalized_query.is_empty()
+        || name.to_lowercase().contains(normalized_query)
+        || path
+            .to_string_lossy()
+            .to_lowercase()
+            .contains(normalized_query)
+}
+
+pub fn append(query: &mut String, text: &str) {
+    for ch in text.chars().filter(|ch| !ch.is_control()) {
+        if query.len() + ch.len_utf8() > 256 {
+            break;
+        }
+        query.push(ch);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filters_names_and_parent_paths_without_case_sensitivity() {
+        let path = Path::new("/home/user/Projects/Tools/Boomux");
+        for query in ["", "boom", "projects/tools", "tools/boom"] {
+            assert!(matches("Boomux", path, query));
+        }
+        assert!(!matches("Boomux", path, "other-project"));
+    }
+
+    #[test]
+    fn pasted_text_is_bounded_without_splitting_unicode_or_inserting_controls() {
+        let mut query = String::new();
+        append(&mut query, "boom\nux\r\t");
+        assert_eq!(query, "boomux");
+        query = "a".repeat(255);
+        append(&mut query, "é");
+        assert_eq!(query.len(), 255);
+        append(&mut query, "bextra");
+        assert_eq!(query.len(), 256);
+    }
+}


### PR DESCRIPTION
The + menu previously required scrolling through every discovered project. Add a search field under Local Projects that filters the cached list by name or full folder path, ignoring case and surrounding whitespace.

Opening the menu starts with an empty search and accepts typing immediately. Backspace, clipboard paste, a clear button, and Escape are supported. Empty matches have a distinct message while Workspace creation and project-folder management remain available. Search input is capped at 256 UTF-8 bytes and never sent to the terminal; filtering does not trigger filesystem discovery.

Validation: `cargo check -p boomux-desktop --locked`, formatting, whitespace checks, and both focused filter/input tests passed. The helper tests were run directly with rustc to avoid compiling the complete Desktop test binary locally. Manual GUI validation has not been performed; selected PR CI remains required.
