### PR TITLE
fix(desktop): scroll while extending terminal selections

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -996,6 +996,24 @@ impl Render for WorkspaceRowDrag {
     }
 }
 
+#[derive(Clone, Copy)]
+struct SelectionAutoscroll {
+    pane_id: usize,
+    position: gpui::Point<gpui::Pixels>,
+    bounds: Bounds<gpui::Pixels>,
+}
+
+fn selection_scroll_delta(y: f32, top: f32, bottom: f32) -> isize {
+    let distance = if y < top {
+        y - top
+    } else if y >= bottom {
+        y - bottom + 1.0
+    } else {
+        return 0;
+    };
+    (distance.signum() * (1.0 + distance.abs() / TERMINAL_CELL_HEIGHT).min(6.0)) as isize
+}
+
 impl TerminalSelectionDrag {
     fn selection(
         &self,
@@ -1018,8 +1036,14 @@ impl TerminalSelectionDrag {
             )
         };
         Some(TerminalSelection {
-            anchor: cell(anchor?),
-            head: cell(position),
+            anchor: {
+                let (row, col) = cell(anchor?);
+                (row + screen.scroll_offset as usize, col)
+            },
+            head: {
+                let (row, col) = cell(position);
+                (row + screen.scroll_offset as usize, col)
+            },
         })
     }
 }
@@ -1352,19 +1376,20 @@ fn selection_indices(selection: TerminalSelection, cols: usize) -> (usize, usize
 fn terminal_selected_text(screen: &TerminalScreen, selection: TerminalSelection) -> String {
     let cols = usize::from(screen.cols);
     let (start, end) = selection_indices(selection, cols);
-    let first_row = start / cols;
-    let last_row = end / cols;
+    let offset = screen.scroll_offset as usize;
+    let first_row = (start / cols).max(offset);
+    let last_row = (end / cols).min(offset + usize::from(screen.rows).saturating_sub(1));
     (first_row..=last_row)
         .map(|row| {
-            let start_col = if row == first_row { start % cols } else { 0 };
-            let end_col = if row == last_row {
+            let start_col = if row == start / cols { start % cols } else { 0 };
+            let end_col = if row == end / cols {
                 end % cols
             } else {
                 cols.saturating_sub(1)
             };
             let mut line = String::new();
             for col in start_col..=end_col {
-                let cell = &screen.cells[row * cols + col];
+                let cell = &screen.cells[(row - offset) * cols + col];
                 if !cell.continuation {
                     line.push_str(&cell.text);
                 }
@@ -1517,6 +1542,9 @@ struct Workspace {
     pointer_drag: Option<PointerDrag>,
     terminal_scrollbar_drag: Option<TerminalScrollbarPointerDrag>,
     terminal_selection_release: Option<usize>,
+    selection_autoscroll: Option<SelectionAutoscroll>,
+    selection_autoscroll_task: Option<gpui::Task<()>>,
+    selection_copy_task: Option<gpui::Task<()>>,
     copied_pane: Option<usize>,
     copied_cleanup: Option<gpui::Task<()>>,
     layout_animation: Option<LayoutAnimation>,
@@ -1731,6 +1759,9 @@ impl Workspace {
             pointer_drag: None,
             terminal_scrollbar_drag: None,
             terminal_selection_release: None,
+            selection_autoscroll: None,
+            selection_autoscroll_task: None,
+            selection_copy_task: None,
             copied_pane: None,
             copied_cleanup: None,
             layout_animation: None,
@@ -1878,6 +1909,8 @@ impl Workspace {
         cx.observe_window_activation(window, |this, window, cx| {
             if !window.is_window_active() {
                 this.terminal_selection_release = None;
+                this.selection_autoscroll = None;
+                this.selection_autoscroll_task = None;
                 this.layout_leader_release_task = None;
                 if this.layout_leader_pressed_at.take().is_some() && this.layout_leader_entered {
                     this.leave_layout_mode(cx);
@@ -4017,6 +4050,9 @@ impl Workspace {
         }
         if let Some(pane) = self.terminals.get_mut(&pane_id) {
             self.terminal_selection_release = None;
+            self.selection_autoscroll = None;
+            self.selection_autoscroll_task = None;
+            self.selection_copy_task = None;
             pane.selection_anchor_position = Some(event.position);
             pane.selection = None;
             cx.notify();
@@ -4052,6 +4088,13 @@ impl Workspace {
         ) else {
             return;
         };
+        // Keep the original cell anchored in scrollback, not in viewport pixels.
+        let selection = TerminalSelection {
+            anchor: pane
+                .selection
+                .map_or(selection.anchor, |previous| previous.anchor),
+            head: selection.head,
+        };
         pane.selection = Some(selection);
         self.terminal_selection_release = Some(drag.pane_id);
         #[cfg(target_os = "linux")]
@@ -4063,8 +4106,126 @@ impl Workspace {
                 cx.write_to_primary(ClipboardItem::new_string(text));
             }
         }
+        let scrolling = selection_scroll_delta(
+            f32::from(event.event.position.y),
+            f32::from(event.bounds.top()),
+            f32::from(event.bounds.bottom()),
+        ) != 0;
+        self.selection_autoscroll = scrolling.then_some(SelectionAutoscroll {
+            pane_id,
+            position: event.event.position,
+            bounds: event.bounds,
+        });
+        if scrolling && self.selection_autoscroll_task.is_none() {
+            self.selection_autoscroll_task = Some(cx.spawn(async move |this, cx| {
+                loop {
+                    cx.background_executor()
+                        .timer(Duration::from_millis(50))
+                        .await;
+                    if !this
+                        .update(cx, |this, cx| this.tick_selection_autoscroll(cx))
+                        .unwrap_or(false)
+                    {
+                        break;
+                    }
+                }
+            }));
+        } else if !scrolling {
+            self.selection_autoscroll_task = None;
+        }
         cx.stop_propagation();
         cx.notify();
+    }
+
+    fn tick_selection_autoscroll(&mut self, cx: &mut Context<Self>) -> bool {
+        let keep_scrolling = (|| {
+            let drag = self.selection_autoscroll?;
+            if self.terminal_selection_release != Some(drag.pane_id)
+                || self.layout_mode
+                || self.pointer_drag.is_some()
+            {
+                return None;
+            }
+            let pane = self.terminals.get_mut(&drag.pane_id)?;
+            let screen = pane.screen.as_ref()?;
+            let delta = selection_scroll_delta(
+                f32::from(drag.position.y),
+                f32::from(drag.bounds.top()),
+                f32::from(drag.bounds.bottom()),
+            );
+            let offset = screen.scroll_offset as usize;
+            let target = offset
+                .saturating_add_signed(delta)
+                .min(screen.scroll_total.saturating_sub(screen.scroll_len) as usize);
+            if target == offset {
+                return None;
+            }
+            pane.session.as_ref()?.scroll_to(target);
+            Some(())
+        })()
+        .is_some();
+        if !keep_scrolling {
+            self.selection_autoscroll_task = None;
+            self.selection_autoscroll = None;
+        }
+        cx.notify();
+        keep_scrolling
+    }
+
+    fn copy_scrollback_selection(
+        &mut self,
+        pane_id: usize,
+        clipboard: bool,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(pane) = self.terminals.get(&pane_id) else {
+            return false;
+        };
+        let (Some(selection), Some(screen), Some(session)) =
+            (pane.selection, pane.screen.as_ref(), pane.session.as_ref())
+        else {
+            return false;
+        };
+        let visible =
+            screen.scroll_offset as usize..screen.scroll_offset as usize + usize::from(screen.rows);
+        if visible.contains(&selection.anchor.0) && visible.contains(&selection.head.0) {
+            return false;
+        }
+        let receiver = match session.selected_text(selection.anchor, selection.head) {
+            Ok(receiver) => receiver,
+            Err(error) => {
+                self.terminals.get_mut(&pane_id).unwrap().error = Some(error);
+                cx.notify();
+                return true;
+            }
+        };
+        self.selection_copy_task = Some(cx.spawn(async move |this, cx| {
+            if let Ok(result) = receiver.recv().await {
+                let _ = this.update(cx, |this, cx| {
+                    // A later gesture or closed pane must not receive this copy.
+                    if this.terminals.get(&pane_id).and_then(|pane| pane.selection)
+                        != Some(selection)
+                    {
+                        return;
+                    }
+                    match result {
+                        Ok(text) if !text.is_empty() => {
+                            #[cfg(target_os = "linux")]
+                            cx.write_to_primary(ClipboardItem::new_string(text.clone()));
+                            if clipboard {
+                                this.copy_terminal_text(pane_id, text, cx);
+                            }
+                        }
+                        Err(error) => {
+                            this.terminals.get_mut(&pane_id).unwrap().error = Some(error);
+                            cx.notify();
+                        }
+                        _ => (),
+                    }
+                });
+            }
+        }));
+        true
     }
 
     fn copy_terminal_text(&mut self, pane_id: usize, text: String, cx: &mut Context<Self>) {
@@ -4087,6 +4248,10 @@ impl Workspace {
     }
 
     fn copy_selection(&mut self, _: &CopySelection, _: &mut Window, cx: &mut Context<Self>) {
+        if self.copy_scrollback_selection(self.focused, true, cx) {
+            cx.stop_propagation();
+            return;
+        }
         let Some(text) = self.terminals.get(&self.focused).and_then(|pane| {
             Some(terminal_selected_text(
                 pane.screen.as_ref()?,
@@ -4338,8 +4503,13 @@ impl Workspace {
         cx: &mut Context<Self>,
     ) {
         if event.button == MouseButton::Left {
+            self.selection_autoscroll = None;
+            self.selection_autoscroll_task = None;
             let source_pane = self.terminal_selection_release;
             let enabled = self.copy_on_select && !self.layout_mode && self.pointer_drag.is_none();
+            if source_pane.is_some_and(|id| self.copy_scrollback_selection(id, enabled, cx)) {
+                self.terminal_selection_release = None;
+            }
             if let Some(text) = take_terminal_selection_copy(
                 &mut self.terminal_selection_release,
                 &self.terminals,
@@ -5848,6 +6018,19 @@ impl Workspace {
                         let next_revision = terminal.revision();
                         if next_revision != revision {
                             pane.screen = Some(terminal.screen());
+                            if let Some(drag) = this
+                                .selection_autoscroll
+                                .filter(|drag| drag.pane_id == pane_id)
+                                && let (Some(selection), Some(screen)) =
+                                    (pane.selection.as_mut(), pane.screen.as_ref())
+                            {
+                                let (row, col) = terminal_cell_from_offset(
+                                    f32::from(drag.position.x - drag.bounds.left()),
+                                    f32::from(drag.position.y - drag.bounds.top()),
+                                    screen,
+                                );
+                                selection.head = (row + screen.scroll_offset as usize, col);
+                            }
                             revision = next_revision;
                             cx.notify();
                         }
@@ -10349,7 +10532,7 @@ fn prepare_terminal_paint(
         let mut runs = Vec::with_capacity(cells.len());
         for (col, cell) in cells.iter().enumerate() {
             let selected = selection_range.is_some_and(|(start, end)| {
-                let index = row * cols + col;
+                let index = (row + screen.scroll_offset as usize) * cols + col;
                 (start..=end).contains(&index)
             });
             let (foreground, background) = if selected {
@@ -11546,6 +11729,48 @@ mod pointer_tests {
             images: Vec::new(),
             image_placements: Vec::new(),
         }
+    }
+
+    #[test]
+    fn terminal_selection_autoscroll_is_directional_bounded_and_stops_inside() {
+        assert_eq!(selection_scroll_delta(100.0, 100.0, 500.0), 0);
+        assert_eq!(selection_scroll_delta(499.0, 100.0, 500.0), 0);
+        assert_eq!(selection_scroll_delta(99.0, 100.0, 500.0), -1);
+        assert_eq!(selection_scroll_delta(500.0, 100.0, 500.0), 1);
+        assert_eq!(selection_scroll_delta(-1000.0, 100.0, 500.0), -6);
+        assert_eq!(selection_scroll_delta(2000.0, 100.0, 500.0), 6);
+    }
+
+    #[test]
+    fn terminal_selection_clips_visible_text_using_scrollback_coordinates() {
+        let mut screen = selection_test_screen();
+        screen.scroll_offset = 10;
+        screen.scroll_total = 20;
+        let selection = TerminalSelection {
+            anchor: (9, 2),
+            head: (11, 1),
+        };
+        assert_eq!(terminal_selected_text(&screen, selection), "abc\nef");
+        assert_eq!(
+            terminal_selected_text(
+                &screen,
+                TerminalSelection {
+                    anchor: selection.head,
+                    head: selection.anchor
+                }
+            ),
+            "abc\nef"
+        );
+        assert_eq!(
+            terminal_selected_text(
+                &screen,
+                TerminalSelection {
+                    anchor: (0, 0),
+                    head: (1, 2)
+                }
+            ),
+            ""
+        );
     }
 
     #[test]

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -430,6 +430,11 @@ enum EmulatorCommand {
         cell_width: u32,
         cell_height: u32,
     },
+    CopySelection {
+        anchor: (usize, usize),
+        head: (usize, usize),
+        reply: async_channel::Sender<Result<String, String>>,
+    },
     Scroll(ScrollViewport),
     ScrollLatest,
     ThemeLatest,
@@ -594,6 +599,21 @@ impl TerminalSession {
             self.shared.set_status(error);
         }
         true
+    }
+
+    pub fn selected_text(
+        &self,
+        anchor: (usize, usize),
+        head: (usize, usize),
+    ) -> Result<async_channel::Receiver<Result<String, String>>, String> {
+        let (reply, receiver) = async_channel::bounded(1);
+        self.shared
+            .emulator_command(EmulatorCommand::CopySelection {
+                anchor,
+                head,
+                reply,
+            })?;
+        Ok(receiver)
     }
 
     pub fn scroll(&self, lines: isize) -> bool {
@@ -1606,6 +1626,13 @@ impl EmulatorCore {
                 self.cell_width = cell_width;
                 self.cell_height = cell_height;
             }
+            EmulatorCommand::CopySelection {
+                anchor,
+                head,
+                reply,
+            } => {
+                let _ = reply.try_send(self.selected_text(anchor, head));
+            }
             EmulatorCommand::Scroll(viewport) => self.terminal.scroll_viewport(viewport),
             EmulatorCommand::ScrollLatest => {
                 unreachable!("latest scroll requests are resolved by the emulator worker")
@@ -1624,6 +1651,45 @@ impl EmulatorCore {
             }
         }
         Ok(true)
+    }
+
+    fn selected_text(
+        &self,
+        anchor: (usize, usize),
+        head: (usize, usize),
+    ) -> Result<String, String> {
+        use libghostty_vt::selection::{FormatOptions, Selection};
+        use libghostty_vt::terminal::{Point, PointCoordinate};
+        let endpoint = |(row, col): (usize, usize)| {
+            let point = PointCoordinate {
+                x: u16::try_from(col)
+                    .map_err(|_| "selection column is out of range".to_string())?,
+                y: u32::try_from(row).map_err(|_| "selection row is out of range".to_string())?,
+            };
+            self.terminal
+                .grid_ref(Point::Screen(point))
+                .map_err(|error| error.to_string())
+        };
+        let selection = Selection::new(endpoint(anchor)?, endpoint(head)?, false);
+        let options = || {
+            FormatOptions::new()
+                .with_selection(&selection)
+                .with_trim(true)
+        };
+        // Clipboard extraction stays on the worker and allocates only on copy.
+        // Refuse oversized copies instead of truncating or duplicating scrollback.
+        let mut bytes = vec![0; 8192];
+        let length = match self.terminal.format_selection_buf(options(), &mut bytes) {
+            Err(libghostty_vt::Error::OutOfSpace { required }) if required <= 4 * 1024 * 1024 => {
+                bytes.resize(required, 0);
+                self.terminal.format_selection_buf(options(), &mut bytes)
+            }
+            result => result,
+        }
+        .map_err(|error| format!("could not copy selection (4 MiB maximum): {error}"))?
+        .unwrap_or(0);
+        bytes.truncate(length);
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
     }
 
     fn screen(&mut self) -> Result<TerminalScreen, String> {
@@ -3915,6 +3981,30 @@ mod tests {
             text.contains("history-19999"),
             "newest output must remain available"
         );
+    }
+
+    #[test]
+    fn terminal_selection_copy_includes_offscreen_history_in_both_directions() {
+        let shared = Arc::new(SharedTerminal::new(terminal_profile(3, 10, 100, 60)));
+        let mut core = EmulatorCore::new(&shared, 3, 10, 100, 60).unwrap();
+        core.apply(EmulatorCommand::Output(
+            b"one\r\ntwo\r\nthree\r\nfour\r\nfive".to_vec(),
+        ))
+        .unwrap();
+        assert!(core.screen().unwrap().scroll_offset > 0);
+        assert_eq!(
+            core.selected_text((0, 1), (4, 2)).unwrap(),
+            "ne\ntwo\nthree\nfour\nfiv"
+        );
+        core.apply(EmulatorCommand::Scroll(
+            libghostty_vt::terminal::ScrollViewport::Top,
+        ))
+        .unwrap();
+        assert_eq!(
+            core.selected_text((4, 2), (0, 1)).unwrap(),
+            "ne\ntwo\nthree\nfour\nfiv"
+        );
+        assert!(core.selected_text((99999, 0), (0, 0)).is_err());
     }
 
     #[test]

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -44,7 +44,17 @@ second owner lookup. Newly started/restarted Shells still resolve their new run.
 ### Terminal Selection And Clipboard
 
 Selection drag updates use only the source pane's bounds and retain the original
-mouse-down anchor. The primary selection updates during the drag. On left-button
+mouse-down anchor in scrollback coordinates. Dragging above or below the source
+pane runs one gesture-scoped 50 ms timer, scrolling one to six rows per tick.
+Viewport requests coalesce through the existing emulator worker queue. Returning
+inside, releasing the button, losing window activation, removing the pane, or
+reaching a history boundary ends the timer; there is no idle per-pane polling.
+
+Visible highlighting projects the anchored selection into each new viewport.
+Copies spanning off-screen history are formatted by Ghostty on its existing
+worker, with a 4 MiB output limit and an explicit error on overflow. Only one
+pending asynchronous copy is retained per Desktop; a new gesture cancels it.
+No second scrollback buffer is created. The primary selection updates during the drag. On left-button
 release, Desktop copies nonempty selected text from that pane to the system
 clipboard once per gesture when `copy_on_select` is enabled (the default).
 The preference applies immediately and is saved in Desktop settings. Disabling


### PR DESCRIPTION
Dragging a terminal text selection above or below its pane previously clamped the endpoint to the visible screen. Add scrolling while the pointer remains beyond either edge, and anchor selection endpoints in scrollback coordinates so highlighting survives viewport movement.

A single gesture-scoped timer scrolls at 20 Hz with a maximum of six rows per tick, using the existing coalesced viewport requests. It stops on returning inside, mouse release, focus loss, pane removal, compositor gestures, or reaching a history boundary. Idle panes gain no polling or duplicate scrollback storage.

Off-screen copies are extracted from Ghostty on the existing emulator worker. Only one asynchronous copy is retained per Desktop; new gestures cancel stale work. Clipboard output is bounded to 4 MiB and oversized requests report an error instead of truncating. Existing copy-on-select preferences and source-pane ownership remain intact.

Validation: the locked Desktop compile check, formatting, whitespace checks, and all six focused terminal-selection tests passed. Coverage includes source-pane isolation, edge direction/rate, visible clipping with scrollback coordinates, release-copy behavior, and actual Ghostty extraction across off-screen history in both directions. Manual GUI validation has not been performed; full selected coverage remains in PR CI.
