### PR TITLE
feat(desktop): streamline remote workspace setup and connection management

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -223,15 +223,25 @@ you view Git. See [Git panel behavior](../docs/desktop/git-panel.md).
 
 ### Remotes
 
-Connect another machine using the general connect action above the machine
-cards, or **+ → New remote workspace…**.
+Use **+ → New remote workspace…** to choose a machine. Select a connected
+machine to create and open a Workspace there, or choose **Connect another
+machine…** to set up a new SSH connection. Use Up/Down and Enter to choose;
+Escape closes the picker. You can also connect from the Remotes tab.
+
+Setup asks for an SSH address and a display name, using your existing SSH
+configuration. Authentication and any installation consent happen in the setup
+terminal. After successful setup, press Enter to close setup and open the exact
+remote Shell it created. If opening fails, use the sidebar to reopen that Shell
+rather than repeating setup.
 
 Remote Workspaces use a machine icon and show connection status. Their Shells
-run on that machine. Connecting creates an initial Workspace and Shell;
-open it from the sidebar.
+run on that machine. Connection loss does not mean remote work has stopped.
 
 Machine cards start collapsed. Click a header to expand it, or use Enter/Space
-when the Remotes panel has keyboard focus.
+when the Remotes panel has keyboard focus. Unavailable machines show a recovery
+action even while collapsed: **Sign in…**, **Review update…**, or **Review
+connection…**. Update review retains identity verification and installation
+consent; older incompatible versions may require manual updates on the machine.
 
 | Machine action | Result |
 | --- | --- |

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -232,10 +232,17 @@ Setup asks for an SSH address and a display name, using your existing SSH
 configuration. Authentication and any installation consent happen in the setup
 terminal. After successful setup, press Enter to close setup and open the exact
 remote Shell it created. If opening fails, use the sidebar to reopen that Shell
-rather than repeating setup.
+rather than repeating setup. If the starter Workspace name already exists on
+the machine, connection still succeeds: press Enter, then open an existing
+Workspace from the sidebar or create a new one from the **+** menu. Setup does
+not select or modify an existing Workspace based on its name.
 
 Remote Workspaces use a machine icon and show connection status. Their Shells
 run on that machine. Connection loss does not mean remote work has stopped.
+
+Use **Rename connection…** in an expanded machine card to change its local
+display name, including while disconnected. This leaves its SSH address and
+remote Workspace names unchanged.
 
 Machine cards start collapsed. Click a header to expand it, or use Enter/Space
 when the Remotes panel has keyboard focus. Unavailable machines show a recovery

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1575,6 +1575,8 @@ struct Workspace {
     sidebar_menu: Option<SidebarMenu>,
     sidebar_header_menu_open: bool,
     project_menu_open: bool,
+    remote_picker_open: bool,
+    remote_picker_scroll_handle: ScrollHandle,
     project_search: String,
     projects_loading: bool,
     projects_result: Option<Result<boomux::protocol::HostProjectDiscovery, String>>,
@@ -1797,6 +1799,8 @@ impl Workspace {
             sidebar_menu: None,
             sidebar_header_menu_open: false,
             project_menu_open: false,
+            remote_picker_open: false,
+            remote_picker_scroll_handle: ScrollHandle::new(),
             project_search: String::new(),
             projects_loading: false,
             projects_result: None,
@@ -4272,7 +4276,9 @@ impl Workspace {
     fn paste_clipboard(&mut self, _: &PasteClipboard, _: &mut Window, cx: &mut Context<Self>) {
         if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
             if self.project_menu_open {
-                project_search::append(&mut self.project_search, &text);
+                if !self.remote_picker_open {
+                    project_search::append(&mut self.project_search, &text);
+                }
                 cx.stop_propagation();
                 cx.notify();
                 return;
@@ -4917,6 +4923,51 @@ impl Workspace {
         } else if !event.is_held {
             self.layout_suppressed_keys.remove(&event.keystroke.key);
         }
+        if self.project_menu_open && self.remote_picker_open {
+            let modifiers = event.keystroke.modifiers;
+            if modifiers.control || modifiers.alt || modifiers.platform || modifiers.function {
+                cx.stop_propagation();
+                return;
+            }
+            match event.keystroke.key.as_str() {
+                "escape" => self.project_menu_open = false,
+                "up" | "down" => {
+                    let nodes = self
+                        .node_views
+                        .iter()
+                        .filter(|n| !n.local)
+                        .collect::<Vec<_>>();
+                    // The final keyboard item is “Connect another machine”.
+                    let len = nodes.len() + 1;
+                    let current = nodes
+                        .iter()
+                        .position(|n| Some(&n.id) == self.selected_node.as_ref())
+                        .unwrap_or(nodes.len());
+                    let next = if event.keystroke.key == "up" {
+                        (current + len - 1) % len
+                    } else {
+                        (current + 1) % len
+                    };
+                    self.selected_node = nodes.get(next).map(|node| node.id.clone());
+                    if next < nodes.len() {
+                        let maximum = self.remote_picker_scroll_handle.max_offset();
+                        self.remote_picker_scroll_handle
+                            .set_offset(point(px(0.0), -px(next as f32 * 52.0).min(maximum.y)));
+                    }
+                }
+                "enter" if !event.is_held => {
+                    if let Some(id) = self.selected_node.clone() {
+                        self.activate_remote_machine(&id, window, cx);
+                    } else {
+                        self.launch_node_action(terminal::WorkspaceLaunch::AddNode, window, cx);
+                    }
+                }
+                _ => {}
+            }
+            cx.stop_propagation();
+            cx.notify();
+            return;
+        }
         if self.project_menu_open {
             match event.keystroke.key.as_str() {
                 "escape" => self.project_menu_open = false,
@@ -5417,6 +5468,19 @@ impl Workspace {
         cx.spawn(async move |this, cx| {
             let result = cx
                 .background_spawn(async move {
+                    let connect_result = if matches!(launch, terminal::WorkspaceLaunch::AddNode) {
+                        Some(
+                            boomux::desktop_connect::ConnectResultReceiver::new()
+                                .map_err(|error| error.to_string())?,
+                        )
+                    } else {
+                        None
+                    };
+                    let launch = if let Some(receiver) = &connect_result {
+                        terminal::WorkspaceLaunch::AddNodeResult(receiver.path())
+                    } else {
+                        launch
+                    };
                     let (shell, setup_workspace_cleanup) =
                         terminal::create_workspace_with_shell(launch)?;
                     let mut session = match TerminalSession::attach(
@@ -5436,6 +5500,7 @@ impl Workspace {
                         }
                     };
                     session.setup_workspace_cleanup = setup_workspace_cleanup;
+                    session.connect_result = connect_result;
                     // The existing overview worker refreshes sidebar resources.
                     // Do not hold an attached terminal behind that extra request.
                     Ok::<_, String>((shell, session))
@@ -5483,6 +5548,7 @@ impl Workspace {
                     .await;
                 let mut removed_setup_shells = Vec::new();
                 let mut setup_workspace_cleanups = Vec::new();
+                let mut connect_results = Vec::new();
                 let keep_watching = this
                     .update(cx, |this, cx| {
                         let (result, nodes) = result;
@@ -5498,6 +5564,7 @@ impl Workspace {
                         };
                         if this.node_views != node_views || this.nodes_error != nodes_error {
                             let visible_change = this.nodes_open
+                                || (this.project_menu_open && this.remote_picker_open)
                                 || this.nodes_error != nodes_error
                                 || this.node_views.len() != node_views.len()
                                 || this.node_views.iter().zip(&node_views).any(
@@ -5532,6 +5599,9 @@ impl Workspace {
                                         name: shell.name.clone(),
                                         workspace_id: shell.workspace_id.clone(),
                                     });
+                                    if let Some(receiver) = session.connect_result.take() {
+                                        connect_results.push(receiver);
+                                    }
                                     if let Some(cleanup) = session.setup_workspace_cleanup.take() {
                                         setup_workspace_cleanups.push(cleanup);
                                     }
@@ -5563,6 +5633,24 @@ impl Workspace {
                                 this.remove_resource_panes(&shell, window);
                             }
                             cx.notify();
+                        })
+                    });
+                }
+                for receiver in connect_results {
+                    let result = cx.background_spawn(async move {
+                        receiver.receive().map_err(|e| e.to_string())?
+                            .map(terminal::connected_shell).transpose()
+                    }).await;
+                    let _ = window_handle.update(cx, |_, window, cx| {
+                        this.update(cx, |this, cx| {
+                            match result {
+                                Ok(Some(shell)) => this.open_shell_choice(shell, window, cx),
+                                Ok(None) => {}, // Cancelled or failed setup creates no navigation intent.
+                                Err(error) => {
+                                    this.boomux_error = Some(format!("Could not open the new remote workspace: {error}. Open it from the sidebar; do not repeat setup."));
+                                    cx.notify();
+                                }
+                            }
                         })
                     });
                 }
@@ -5969,6 +6057,16 @@ impl Workspace {
             cx.notify();
             return;
         };
+        self.open_shell_choice(shell, window, cx);
+    }
+
+    fn open_shell_choice(
+        &mut self,
+        shell: ShellChoice,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.project_menu_open = false;
         self.minimized_shells.remove(&shell.id);
         let open_workspace_ids = self
             .terminals
@@ -6228,6 +6326,121 @@ impl Workspace {
         cx.notify();
     }
 
+    fn activate_remote_machine(&mut self, id: &str, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(node) = self.node_views.iter().find(|n| !n.local && n.id == id) else {
+            return;
+        };
+        let node_id = node.id.clone();
+        match node.primary_action() {
+            nodes::PrimaryAction::NewWorkspace => {
+                let name = terminal::project_workspace_name(
+                    &node.label,
+                    self.boomux_overview
+                        .workspaces
+                        .iter()
+                        .filter(|w| remote::identity(&w.id).is_some_and(|id| id.node_id == node_id))
+                        .map(|w| w.name.as_str()),
+                );
+                self.launch_node_action(
+                    terminal::WorkspaceLaunch::RemoteWorkspace { node_id, name },
+                    window,
+                    cx,
+                );
+            }
+            nodes::PrimaryAction::SignIn => self.launch_node_action(
+                terminal::WorkspaceLaunch::ReauthenticateNode(node_id),
+                window,
+                cx,
+            ),
+            nodes::PrimaryAction::Update => {
+                self.launch_node_action(terminal::WorkspaceLaunch::UpgradeNode(node_id), window, cx)
+            }
+            nodes::PrimaryAction::Review => {
+                self.open_nodes(cx);
+                self.selected_node = Some(node_id.clone());
+                self.expanded_node = Some(node_id);
+            }
+        }
+    }
+
+    fn remote_workspace_picker(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let mut list = div()
+            .id("remote-picker-list")
+            .track_scroll(&self.remote_picker_scroll_handle)
+            .max_h(px(320.0))
+            .overflow_y_scroll();
+        for node in self.node_views.iter().filter(|n| !n.local) {
+            let id = node.id.clone();
+            list = list.child(
+                sidebar_menu_row(SharedString::from(format!("remote-picker-{}", node.id)))
+                    .bg(rgb(if self.selected_node.as_ref() == Some(&node.id) {
+                        0x313244
+                    } else {
+                        0x1e1e2e
+                    }))
+                    .h(px(52.0))
+                    .flex_col()
+                    .justify_center()
+                    .items_start()
+                    .child(div().w_full().truncate().child(node.label.clone()))
+                    .child(div().text_xs().text_color(rgb(0xa6adc8)).child(format!(
+                        "{} · {}",
+                        node.status(),
+                        node.primary_action().label()
+                    )))
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        this.activate_remote_machine(&id, window, cx);
+                    })),
+            );
+        }
+        div()
+            .id("remote-workspace-picker")
+            .role(gpui::Role::Menu)
+            .aria_label("Choose remote machine")
+            .absolute()
+            .occlude()
+            .top(px(54.0))
+            .left(px(10.0))
+            .right(px(10.0))
+            .p_1()
+            .rounded_lg()
+            .border_1()
+            .border_color(rgb(0x45475a))
+            .bg(rgb(0x1e1e2e))
+            .shadow_lg()
+            .child(div().p_2().text_sm().child("Choose a machine"))
+            .child(
+                div()
+                    .px_2()
+                    .pb_2()
+                    .text_xs()
+                    .text_color(rgb(0xa6adc8))
+                    .child("Your new workspace and terminal will run there."),
+            )
+            .when_some(self.nodes_error.clone(), |menu, error| {
+                menu.child(div().p_2().text_xs().text_color(rgb(0xf9e2af)).child(error))
+            })
+            .child(list)
+            .when(!self.node_views.iter().any(|n| !n.local), |menu| {
+                menu.child(div().p_2().text_xs().child("No machines connected yet."))
+            })
+            .child(
+                sidebar_menu_row("remote-picker-connect")
+                    .bg(rgb(if self.selected_node.is_none() {
+                        0x313244
+                    } else {
+                        0x1e1e2e
+                    }))
+                    .child("Connect another machine…")
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        cx.stop_propagation();
+                        this.launch_node_action(terminal::WorkspaceLaunch::AddNode, window, cx);
+                    })),
+            )
+            .into_any_element()
+    }
+
     fn launch_node_action(
         &mut self,
         launch: terminal::WorkspaceLaunch,
@@ -6235,6 +6448,8 @@ impl Workspace {
         cx: &mut Context<Self>,
     ) {
         self.nodes_open = false;
+        self.project_menu_open = false;
+        self.remote_picker_open = false;
         if self.layout_mode {
             self.leave_layout_mode(cx);
         }
@@ -6320,6 +6535,14 @@ impl Workspace {
                             .text_color(rgb(if node.connected() { 0xa6e3a1 } else { 0xf9e2af }))
                             .child(node.status()),
                     )
+            .when(!node.connected(), |panel| {
+                let id = node.id.clone();
+                panel.child(Self::settings_option("remote-recovery", node.primary_action().label(), false)
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        this.activate_remote_machine(&id, window, cx);
+                    })))
+            })
             .when(self.expanded_node.as_ref() == Some(&node.id), |panel| {
                 panel.child(div().mt_2().pt_2().border_t_1().border_color(rgb(0x45475a))
                     .id("remote-machine-details")
@@ -6350,15 +6573,6 @@ impl Workspace {
                             .on_click(cx.listener(move |this, _, window, cx| {
                                 cx.stop_propagation();
                                 this.launch_node_action(terminal::WorkspaceLaunch::UpgradeNode(upgrade_id.clone()), window, cx);
-                            })))
-                    })
-                    .when(!node.local && node.health == boomux::protocol::NodeProjectionHealthCode::AuthenticationRequired, |detail| {
-                        let id = node.id.clone();
-                        detail.child(Self::settings_option("reauthenticate-node", "Sign in…", false)
-                            .flex_none()
-                            .on_click(cx.listener(move |this, _, window, cx| {
-                                cx.stop_propagation();
-                                this.launch_node_action(terminal::WorkspaceLaunch::ReauthenticateNode(id.clone()), window, cx);
                             })))
                     })
                     .child(div().mt_2().pt_2().border_t_1().border_color(rgb(0x45475a))
@@ -6459,6 +6673,7 @@ impl Workspace {
 
     fn toggle_project_menu(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.project_menu_open = !self.project_menu_open;
+        self.remote_picker_open = false;
         self.sidebar_header_menu_open = false;
         self.sidebar_menu = None;
         self.project_search.clear();
@@ -6545,6 +6760,9 @@ impl Workspace {
     fn project_menu(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
         if !self.project_menu_open {
             return None;
+        }
+        if self.remote_picker_open {
+            return Some(self.remote_workspace_picker(cx));
         }
         let mut entries = div()
             .id("project-menu-list")
@@ -6688,7 +6906,17 @@ impl Workspace {
                             if this.settings_open {
                                 this.close_settings(cx);
                             }
-                            this.open_nodes(cx);
+                            this.project_menu_open = true;
+                            this.remote_picker_open = true;
+                            this.remote_picker_scroll_handle
+                                .set_offset(point(px(0.0), px(0.0)));
+                            this.nodes_open = false;
+                            this.selected_node = this
+                                .node_views
+                                .iter()
+                                .find(|n| !n.local)
+                                .map(|n| n.id.clone());
+                            cx.notify();
                         })),
                 )
                 .child(div().mx_2().my_1().h(px(1.0)).bg(rgb(0x313244)))

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -223,6 +223,10 @@ enum SidebarItem {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum SidebarResource {
+    Connection {
+        id: String,
+        name: String,
+    },
     Workspace {
         id: String,
         name: String,
@@ -237,12 +241,15 @@ enum SidebarResource {
 impl SidebarResource {
     fn name(&self) -> &str {
         match self {
-            Self::Workspace { name, .. } | Self::Shell { name, .. } => name,
+            Self::Workspace { name, .. }
+            | Self::Shell { name, .. }
+            | Self::Connection { name, .. } => name,
         }
     }
 
     fn kind_label(&self) -> &'static str {
         match self {
+            Self::Connection { .. } => "connection",
             Self::Workspace { .. } => "Workspace",
             Self::Shell { .. } => "Shell",
         }
@@ -2960,6 +2967,7 @@ impl Workspace {
                 let matches = match target {
                     SidebarResource::Workspace { id, .. } => shell.workspace_id == *id,
                     SidebarResource::Shell { id, .. } => shell.id == *id,
+                    SidebarResource::Connection { .. } => false,
                 };
                 matches.then_some(*id)
             })
@@ -3047,6 +3055,12 @@ impl Workspace {
             let result = cx
                 .background_spawn(async move {
                     match (&operation_target, kind) {
+                        (SidebarResource::Connection { id, name }, ResourceDialogKind::Rename) => {
+                            terminal::rename_connection(id, name, &operation_value)?;
+                        }
+                        (SidebarResource::Connection { .. }, ResourceDialogKind::Remove) => {
+                            return Err("Use Forget connection on the machine card".into());
+                        }
                         (SidebarResource::Workspace { id, .. }, ResourceDialogKind::Rename) => {
                             terminal::rename_workspace(id, &operation_value)?;
                         }
@@ -3083,6 +3097,12 @@ impl Workspace {
                                     session.shell_name = value.clone();
                                 }
                             }
+                        }
+                        if let SidebarResource::Connection { id, .. } = &target
+                            && let Some(node) =
+                                this.node_views.iter_mut().find(|node| node.id == *id)
+                        {
+                            node.label = value.clone();
                         }
                         this.set_boomux_overview(overview);
                         this.resource_dialog = None;
@@ -6555,6 +6575,18 @@ impl Workspace {
                         if node.connected() { "" } else { " · cached" }))
                     .when_some(node.version.clone(), |detail, version| detail.child(format!("Boomux {version}")))
                     .when(!node.connected(), |detail| detail.child(node.last_seen(now_ms)).child(node.guidance()))
+                    .child(Self::settings_option("rename-remote-connection", "Rename connection…", false)
+                        .flex_none()
+                        .on_click(cx.listener({
+                            let id = node.id.clone();
+                            let name = node.label.clone();
+                            move |this, _, _, cx| {
+                                cx.stop_propagation();
+                                this.open_resource_dialog(ResourceDialogKind::Rename,
+                                    SidebarResource::Connection { id: id.clone(), name: name.clone() });
+                                cx.notify();
+                            }
+                        })))
                     .when(!node.local && node.connected(), |detail| {
                         let node_id = node.id.clone();
                         let name = node.label.clone();
@@ -7763,11 +7795,11 @@ impl Workspace {
         let target = menu.target.clone();
         let open_workspace_id = match &target {
             SidebarResource::Workspace { id, .. } => Some(id.clone()),
-            SidebarResource::Shell { .. } => None,
+            SidebarResource::Shell { .. } | SidebarResource::Connection { .. } => None,
         };
         let create_workspace_id = match &target {
             SidebarResource::Workspace { id, .. } => Some(id.clone()),
-            SidebarResource::Shell { .. } => None,
+            SidebarResource::Shell { .. } | SidebarResource::Connection { .. } => None,
         };
         let rename_target = target.clone();
         let remove_target = target.clone();
@@ -8921,6 +8953,12 @@ impl Workspace {
             ResourceDialogKind::Remove => format!("Remove {kind_label}?"),
         };
         let detail = match (&dialog.target, dialog.kind) {
+            (SidebarResource::Connection { .. }, ResourceDialogKind::Rename) => {
+                "Change this connection’s display name on this computer. The SSH address and remote Workspace names stay the same.".into()
+            }
+            (SidebarResource::Connection { .. }, ResourceDialogKind::Remove) => {
+                "Use Forget connection on the machine card.".into()
+            }
             (_, ResourceDialogKind::Rename) => {
                 "Type a new name, then press Enter to save it.".to_string()
             }

--- a/desktop/src/nodes.rs
+++ b/desktop/src/nodes.rs
@@ -16,7 +16,37 @@ pub struct NodeView {
     pub shell_count: usize,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrimaryAction {
+    NewWorkspace,
+    SignIn,
+    Update,
+    Review,
+}
+
+impl PrimaryAction {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::NewWorkspace => "New workspace",
+            Self::SignIn => "Sign in…",
+            Self::Update => "Review update…",
+            Self::Review => "Review connection…",
+        }
+    }
+}
+
 impl NodeView {
+    pub fn primary_action(&self) -> PrimaryAction {
+        if self.connected() {
+            return PrimaryAction::NewWorkspace;
+        }
+        match self.health {
+            NodeProjectionHealthCode::AuthenticationRequired => PrimaryAction::SignIn,
+            NodeProjectionHealthCode::Unsupported => PrimaryAction::Update,
+            _ => PrimaryAction::Review,
+        }
+    }
+
     pub fn connected(&self) -> bool {
         self.current && self.health == NodeProjectionHealthCode::Online
     }
@@ -24,47 +54,47 @@ impl NodeView {
     pub fn status(&self) -> &'static str {
         match self.health {
             NodeProjectionHealthCode::Online if self.current => "Connected",
-            NodeProjectionHealthCode::Online | NodeProjectionHealthCode::Stale => "Stale",
+            NodeProjectionHealthCode::Online | NodeProjectionHealthCode::Stale => "Connection lost",
             NodeProjectionHealthCode::Unobserved => "Not yet connected",
             NodeProjectionHealthCode::Reconnecting => "Reconnecting",
-            NodeProjectionHealthCode::Unreachable => "Unreachable",
+            NodeProjectionHealthCode::Unreachable => "Cannot reach machine",
             NodeProjectionHealthCode::AuthenticationRequired => "Sign-in required",
-            NodeProjectionHealthCode::IdentityChanged => "Identity changed",
-            NodeProjectionHealthCode::IdentityConflict => "Identity conflict",
-            NodeProjectionHealthCode::Unsupported => "Incompatible",
+            NodeProjectionHealthCode::IdentityChanged => "Machine identity changed",
+            NodeProjectionHealthCode::IdentityConflict => "Machine identity conflict",
+            NodeProjectionHealthCode::Unsupported => "Version incompatible",
         }
     }
 
     pub fn guidance(&self) -> &'static str {
         match self.health {
             NodeProjectionHealthCode::AuthenticationRequired => {
-                "Sign in through your existing SSH route to reconnect."
+                "Sign in again to reconnect to this machine."
             }
             NodeProjectionHealthCode::IdentityChanged
             | NodeProjectionHealthCode::IdentityConflict => {
-                "This route no longer identifies the expected Node. Inspect it before changing the registration."
+                "This SSH address no longer matches the machine you connected. Verify the machine before changing the saved connection."
             }
             NodeProjectionHealthCode::Unsupported => {
-                "The remote Boomux version is incompatible. Update Boomux on that machine to match this installation."
+                "Review the remote Boomux update. Older incompatible versions may require a manual update on that machine; the guided flow will explain if it cannot proceed."
             }
             _ if !self.connected() => {
-                "Showing the last observation. A lost connection does not establish whether remote work has stopped."
+                "Remote work may still be running. Check the machine and your network; Boomux reconnects automatically when possible."
             }
-            _ => "Closing a terminal pane detaches it; its Shell stays on the owning Node.",
+            _ => "Closing a terminal pane leaves its Shell running on this machine.",
         }
     }
 
     pub fn last_seen(&self, now_ms: u64) -> String {
         if self.observed_at_ms == 0 {
-            return "No observation yet".into();
+            return "Not connected yet".into();
         }
         let seconds = now_ms.saturating_sub(self.observed_at_ms) / 1_000;
         if seconds < 60 {
-            "Last observed less than a minute ago".into()
+            "Last seen less than a minute ago".into()
         } else if seconds < 3_600 {
-            format!("Last observed {} min ago", seconds / 60)
+            format!("Last seen {} min ago", seconds / 60)
         } else {
-            format!("Last observed {} h ago", seconds / 3_600)
+            format!("Last seen {} h ago", seconds / 3_600)
         }
     }
 }
@@ -140,6 +170,41 @@ mod tests {
     }
 
     #[test]
+    fn recovery_actions_remain_available_without_a_healthy_connection() {
+        for (health, action) in [
+            (
+                NodeProjectionHealthCode::AuthenticationRequired,
+                PrimaryAction::SignIn,
+            ),
+            (NodeProjectionHealthCode::Unsupported, PrimaryAction::Update),
+            (
+                NodeProjectionHealthCode::IdentityChanged,
+                PrimaryAction::Review,
+            ),
+            (
+                NodeProjectionHealthCode::IdentityConflict,
+                PrimaryAction::Review,
+            ),
+            (NodeProjectionHealthCode::Unreachable, PrimaryAction::Review),
+            (
+                NodeProjectionHealthCode::Reconnecting,
+                PrimaryAction::Review,
+            ),
+        ] {
+            let mut input = node("remote", false);
+            input.health = health;
+            input.current = false;
+            let nodes = project(&CombinedNodeSnapshot {
+                nodes: vec![input],
+                workspaces: vec![],
+                external_workspaces: vec![],
+                focused_terminal: None,
+            });
+            assert_eq!(nodes[0].primary_action(), action);
+        }
+    }
+
+    #[test]
     fn node_identity_survives_equal_labels_and_routes() {
         let nodes = project(&CombinedNodeSnapshot {
             nodes: vec![node("b", false), node("local", true), node("a", false)],
@@ -168,32 +233,35 @@ mod tests {
             focused_terminal: None,
         });
         assert!(!nodes[0].connected());
-        assert_eq!(nodes[0].status(), "Stale");
-        assert_eq!(nodes[0].last_seen(121_000), "Last observed 2 min ago");
-        assert_eq!(
-            nodes[0].last_seen(0),
-            "Last observed less than a minute ago"
-        );
+        assert_eq!(nodes[0].status(), "Connection lost");
+        assert_eq!(nodes[0].last_seen(121_000), "Last seen 2 min ago");
+        assert_eq!(nodes[0].last_seen(0), "Last seen less than a minute ago");
     }
     #[test]
     fn health_states_keep_distinct_recovery_meanings() {
         let cases = [
             (NodeProjectionHealthCode::Unobserved, "Not yet connected"),
             (NodeProjectionHealthCode::Reconnecting, "Reconnecting"),
-            (NodeProjectionHealthCode::Unreachable, "Unreachable"),
+            (
+                NodeProjectionHealthCode::Unreachable,
+                "Cannot reach machine",
+            ),
             (
                 NodeProjectionHealthCode::AuthenticationRequired,
                 "Sign-in required",
             ),
             (
                 NodeProjectionHealthCode::IdentityChanged,
-                "Identity changed",
+                "Machine identity changed",
             ),
             (
                 NodeProjectionHealthCode::IdentityConflict,
-                "Identity conflict",
+                "Machine identity conflict",
             ),
-            (NodeProjectionHealthCode::Unsupported, "Incompatible"),
+            (
+                NodeProjectionHealthCode::Unsupported,
+                "Version incompatible",
+            ),
         ];
         for (health, label) in cases {
             let mut input = node("remote", false);

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -454,6 +454,7 @@ pub struct TerminalSession {
     pub shell_id: String,
     pub shell_name: String,
     pub setup_workspace_cleanup: Option<SetupWorkspaceCleanup>,
+    pub connect_result: Option<boomux::desktop_connect::ConnectResultReceiver>,
     shared: Arc<SharedTerminal>,
     last_size: Mutex<(u16, u16)>,
 }
@@ -544,6 +545,7 @@ impl TerminalSession {
             shell_id: shell.id,
             shell_name: shell.name,
             setup_workspace_cleanup: None,
+            connect_result: None,
             shared,
             // Attachment already established this geometry. Avoid an unchanged
             // first-render resize canceling the reader's temporary redraw size.
@@ -1112,7 +1114,11 @@ fn shell_choice(shell: ShellSnapshot) -> ShellChoice {
         status: shell.status,
         run_id: shell.run.map(|run| run.id),
         desktop_setup: match shell.command.get(1).map(String::as_str) {
-            Some("__desktop-setup" | "__guided-node-add") => shell.command.len() == 2,
+            Some("__desktop-setup") => shell.command.len() == 2,
+            Some("__guided-node-add") => {
+                shell.command.len() == 2
+                    || (shell.command.len() == 4 && shell.command[2] == "--result-socket")
+            }
             Some(
                 "__guided-node-upgrade"
                 | "__guided-node-reauthenticate"
@@ -1121,6 +1127,16 @@ fn shell_choice(shell: ShellSnapshot) -> ShellChoice {
             _ => false,
         },
     }
+}
+
+pub fn connected_shell(
+    identity: boomux::protocol::QualifiedIdentity,
+) -> Result<ShellChoice, String> {
+    let client = client::connect().map_err(|e| e.to_string())?;
+    let key = crate::remote::key(&identity.node_id, &identity.inner_id);
+    let mut shell = crate::remote::shell(&client, &key).map_err(|e| e.to_string())?;
+    crate::remote::qualify_shell(&identity.node_id, &mut shell);
+    Ok(shell_choice(shell))
 }
 
 /// Create a pending shell next to an existing shell. Boomux remains the owner
@@ -1200,6 +1216,7 @@ pub enum WorkspaceLaunch {
     Setup,
     ConfigEdit,
     AddNode,
+    AddNodeResult(std::path::PathBuf),
     RemoteWorkspace {
         node_id: String,
         name: String,
@@ -1215,6 +1232,7 @@ impl WorkspaceLaunch {
             self,
             Self::Setup
                 | Self::AddNode
+                | Self::AddNodeResult(_)
                 | Self::UpgradeNode(_)
                 | Self::ReauthenticateNode(_)
                 | Self::UninstallNode(_)
@@ -1242,6 +1260,14 @@ impl WorkspaceLaunch {
             Self::Setup => Some(("Set up agents", vec!["__desktop-setup".into()])),
             Self::ConfigEdit => Some(("Edit Boomux config", vec!["config".into(), "edit".into()])),
             Self::AddNode => Some(("Connect remote machine", vec!["__guided-node-add".into()])),
+            Self::AddNodeResult(path) => Some((
+                "Connect remote machine",
+                vec![
+                    "__guided-node-add".into(),
+                    "--result-socket".into(),
+                    path.to_string_lossy().into_owned(),
+                ],
+            )),
             Self::UpgradeNode(id) => Some((
                 "Update remote Boomux",
                 vec!["__guided-node-upgrade".into(), id.clone()],
@@ -2817,6 +2843,7 @@ mod tests {
     fn remote_setup_cleanup_owns_only_the_created_temporary_workspace() {
         for launch in [
             super::WorkspaceLaunch::AddNode,
+            super::WorkspaceLaunch::AddNodeResult("/tmp/setup-result".into()),
             super::WorkspaceLaunch::UpgradeNode("remote".into()),
             super::WorkspaceLaunch::UninstallNode("remote".into()),
             super::WorkspaceLaunch::ReauthenticateNode("remote".into()),
@@ -3300,6 +3327,42 @@ mod tests {
             super::project_workspace_name("api", ["api", "api-2", "api-4"].into_iter()),
             "api-3"
         );
+    }
+
+    #[test]
+    fn remote_result_setup_retains_exact_cleanup_ownership() {
+        let path = std::path::PathBuf::from("/tmp/result with spaces; literal");
+        let launch = super::WorkspaceLaunch::AddNodeResult(path.clone());
+        let command = launch.command().unwrap().1;
+        assert_eq!(
+            command,
+            [
+                "__guided-node-add",
+                "--result-socket",
+                path.to_str().unwrap()
+            ]
+        );
+        let mut shell: boomux::protocol::ShellSnapshot = serde_json::from_value(serde_json::json!({
+            "id": "setup", "workspace_id": "workspace", "name": "connect", "cwd": "/tmp", "status": "pending",
+            "command": ["/bin/boomux", "__guided-node-add", "--result-socket", path]
+        })).unwrap();
+        assert!(super::shell_choice(shell.clone()).desktop_setup);
+        let mut workspace: boomux::protocol::WorkspaceSnapshot =
+            serde_json::from_value(serde_json::json!({
+                "id": "workspace", "name": "temporary", "revision": 1, "shells": [shell]
+            }))
+            .unwrap();
+        assert!(
+            super::SetupWorkspaceCleanup::from_creation(&launch, "owner".into(), &workspace)
+                .is_some()
+        );
+        workspace.shells[0].command[3] = "/tmp/another-launch".into();
+        assert!(
+            super::SetupWorkspaceCleanup::from_creation(&launch, "owner".into(), &workspace)
+                .is_none()
+        );
+        shell.command[2] = "--other".into();
+        assert!(!super::shell_choice(shell).desktop_setup);
     }
 
     #[test]

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -1457,6 +1457,22 @@ pub fn cleanup_setup_workspace(cleanup: SetupWorkspaceCleanup) -> Result<(), Str
     cleanup.cleanup(&client)
 }
 
+pub fn rename_connection(node_id: &str, previous_name: &str, name: &str) -> Result<(), String> {
+    let client = client::connect_if_running()
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "Boomux is not running".to_string())?;
+    let registration = client
+        .node_registration(node_id)
+        .map_err(|error| error.to_string())?;
+    if registration.alias != previous_name {
+        return Err("Connection name changed. Close this dialog and try again.".into());
+    }
+    client
+        .rename_node_registration(node_id, name, registration.revision)
+        .map(|_| ())
+        .map_err(|error| format!("Could not rename connection: {error}"))
+}
+
 pub fn rename_workspace(workspace_id: &str, name: &str) -> Result<(), String> {
     let Some(client) = client::connect_if_running()
         .map_err(|error| format!("could not connect to Boomux: {error}"))?

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -269,8 +269,11 @@ invented from local paths. Remote creation resolves the owner's starting directo
 and creates the owner-local Workspace and first pending Shell with fresh exact IDs;
 ambiguous mutation failures are surfaced without automatic replay.
 The initial connect flow creates this Workspace after successful registration.
-Open its Shell from the sidebar; creating another Workspace from Remotes also
-attaches its first Shell. Multi-placement coordinator metadata is left unchanged.
+Desktop opens its exact Shell after the user acknowledges the setup result.
+The Workspace menu's remote picker uses the existing Node summaries and creates
+and attaches the first Shell on the selected connected machine. Unavailable
+machines offer recovery instead of attempting creation. Multi-placement
+coordinator metadata is left unchanged.
 
 The Remotes tab retains sign-in actions and adds an explicitly confirmed
 remote update action. No background installation or upgrade is performed.
@@ -299,6 +302,24 @@ and protocol compatibility remain owned by that interactive flow. After the
 result acknowledgment, the exact dedicated command Shell/run is removed with a
 revision guard. Desktop removes its temporary Workspace only with ephemeral
 creation proof, the expected post-removal revision, and no remaining resources.
+
+For a Desktop-owned connect launch, a private one-shot Unix datagram socket
+returns only the exact qualified identity of the created Shell. Its random
+short `/tmp` directory is mode 0700; the receiver is owned by that terminal
+session, accepts at most 1 KiB, and removes its socket and directory on drop.
+No terminal output, names, new-row detection, or persisted connection intent is
+used to infer the result. There is no extra worker or polling loop: after the
+existing overview worker confirms setup-Shell removal and output completion,
+it consumes the receipt and resolves the Shell from its registered owner off
+the UI thread before attaching. Failed or cancelled setup without a receipt
+causes no navigation. Closing/detaching the setup pane drops the receiver.
+A failed result delivery or attachment directs the user to the sidebar and never
+replays Workspace creation. This is an ephemeral matching-CLI/Desktop channel,
+not a daemon wire or persistence change.
+
+Collapsed unavailable machine cards expose sign-in, update review, or connection
+details according to the existing typed health. Update review uses the guarded
+CLI flow; it does not bypass incompatible-helper or identity checks.
 
 Ordinary Shells invoking the CLI are not cleanup targets. Remotes does not launch
 the separate terminal dashboard. Healthy cards omit generic lifecycle guidance;

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -268,15 +268,22 @@ use the registered owner's existing guarded APIs. Cached directories are not
 invented from local paths. Remote creation resolves the owner's starting directory
 and creates the owner-local Workspace and first pending Shell with fresh exact IDs;
 ambiguous mutation failures are surfaced without automatic replay.
-The initial connect flow creates this Workspace after successful registration.
-Desktop opens its exact Shell after the user acknowledges the setup result.
+The initial connect flow attempts to create this Workspace after successful
+registration. An owner-confirmed `already_exists` result leaves the connection
+successful and directs the user to existing Workspaces in the sidebar, without
+selecting or modifying one by name. Other failures remain errors and are not
+replayed. When creation succeeds, Desktop opens its exact Shell after the user
+acknowledges the setup result.
 The Workspace menu's remote picker uses the existing Node summaries and creates
 and attaches the first Shell on the selected connected machine. Unavailable
 machines offer recovery instead of attempting creation. Multi-placement
 coordinator metadata is left unchanged.
 
 The Remotes tab retains sign-in actions and adds an explicitly confirmed
-remote update action. No background installation or upgrade is performed.
+remote update action. Expanded machine cards also expose connection renaming,
+including while disconnected. Rename uses the exact registered Node ID and a
+revision guard; it changes only the local alias, preserving the SSH route and
+remote Workspace names. No background installation or upgrade is performed.
 Once remote
 Nodes are registered, the existing sidebar subtitle shows a compact Node count
 and connection summary. Selection uses stable Node IDs, including when aliases

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -303,6 +303,9 @@ discovery, candidate checks, authorization, installation, daemon status and
 restart, final identity-pinned handshake, and live channel creation. Every
 command is a slave of that private owner-only control socket; an observation from
 one endpoint or account can never authorize mutation through another connection.
+When the local runtime path would exceed the SSH control socket limit, its
+configuration and socket use an exclusively created mode-`0700` directory under
+`/tmp`, with the same cleanup lifecycle. The daemon runtime stays unchanged.
 The private configuration terminates any trailing `Match` scope inherited from
 the included user configuration before clearing `SendEnv`, so even an included
 file ending in a nonmatching block cannot retain environment forwarding.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1020,6 +1020,24 @@ impl Client {
         }
     }
 
+    /// Offer a starter Workspace after registering a machine. An owner-confirmed
+    /// collision leaves the connection usable without selecting or changing any
+    /// existing Workspace. Never retry an ambiguous creation.
+    pub fn create_initial_remote_workspace(
+        &self,
+        node_id: &str,
+        name: &str,
+    ) -> Result<Option<ShellSnapshot>> {
+        match self.create_remote_workspace(node_id, name) {
+            Ok(shell) => Ok(Some(shell)),
+            Err(ClientError::Remote(RemoteError {
+                code: Some(ErrorCode::AlreadyExists),
+                ..
+            })) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
     /// Create an owner-local remote Workspace and its first Shell. The owner
     /// resolves the initial directory; this never forwards local environment or paths.
     pub fn create_remote_workspace(&self, node_id: &str, name: &str) -> Result<ShellSnapshot> {
@@ -2645,6 +2663,73 @@ mod tests {
 
         server.join().unwrap();
         fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn initial_remote_workspace_handles_collision_without_replaying_or_hiding_failures() {
+        for outcome in [
+            Some(ErrorCode::AlreadyExists),
+            Some(ErrorCode::OutcomeUnknown),
+            Some(ErrorCode::Timeout),
+            None,
+        ] {
+            let directory =
+                env::temp_dir().join(format!("boomux-client-remote-{}", Uuid::new_v4()));
+            fs::create_dir_all(&directory).unwrap();
+            let socket = directory.join("daemon.sock");
+            let listener = UnixListener::bind(&socket).unwrap();
+            let server = thread::spawn(move || {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                assert!(matches!(request.message, Request::RouteNodeHostService {
+                    node_id, operation: protocol::HostServiceOperation::ResolveDirectory { .. }
+                } if node_id == "remote-owner"));
+                protocol::write_message(
+                    &mut stream,
+                    &Envelope::new(Response::HostService {
+                        result: protocol::HostServiceResult::Directory {
+                            path: "/remote/home".into(),
+                        },
+                    }),
+                )
+                .unwrap();
+                let (mut stream, _) = listener.accept().unwrap();
+                let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+                assert!(matches!(request.message, Request::RouteNodeOperation {
+                    node_id, operation: RoutedOperation::CreateWorkspaceShell {
+                        workspace_name, default_cwd: Some(cwd), ..
+                    }
+                } if node_id == "remote-owner" && workspace_name == "omarchy"
+                    && cwd == Path::new("/remote/home")));
+                // The same text with no typed code must remain an error.
+                protocol::write_message(
+                    &mut stream,
+                    &Envelope::new(Response::Error {
+                        code: outcome,
+                        message: "workspace name already exists: omarchy".into(),
+                    }),
+                )
+                .unwrap();
+                listener.set_nonblocking(true).unwrap();
+                listener
+            });
+            let client = Client::from_socket_path(socket);
+            let result = client.create_initial_remote_workspace("remote-owner", "omarchy");
+            if outcome == Some(ErrorCode::AlreadyExists) {
+                assert!(result.unwrap().is_none());
+            } else {
+                assert!(
+                    matches!(result, Err(ClientError::Remote(RemoteError { code, .. }))
+                    if code == outcome)
+                );
+            }
+            let listener = server.join().unwrap();
+            assert_eq!(
+                listener.accept().unwrap_err().kind(),
+                io::ErrorKind::WouldBlock
+            );
+            fs::remove_dir_all(directory).unwrap();
+        }
     }
 
     #[test]

--- a/src/desktop_connect.rs
+++ b/src/desktop_connect.rs
@@ -1,0 +1,133 @@
+//! One-shot, launch-owned result channel for Desktop's interactive remote setup.
+//! No daemon state or terminal output is used to infer which Shell was created.
+use crate::protocol::QualifiedIdentity;
+use std::fs::{self, DirBuilder};
+use std::io;
+use std::os::unix::fs::DirBuilderExt;
+use std::os::unix::net::UnixDatagram;
+use std::path::{Path, PathBuf};
+
+const MAX_RESULT_BYTES: usize = 1024;
+
+pub struct ConnectResultReceiver {
+    directory: PathBuf,
+    socket: UnixDatagram,
+}
+
+impl ConnectResultReceiver {
+    pub fn new() -> io::Result<Self> {
+        // Keep sockaddr_un short even when the user's runtime/home path is long.
+        let directory =
+            PathBuf::from("/tmp").join(format!("boomux-connect-{}", uuid::Uuid::new_v4()));
+        DirBuilder::new().mode(0o700).create(&directory)?;
+        let socket = match UnixDatagram::bind(directory.join("result")) {
+            Ok(socket) => socket,
+            Err(error) => {
+                let _ = fs::remove_dir(&directory);
+                return Err(error);
+            }
+        };
+        let receiver = Self { directory, socket };
+        receiver.socket.set_nonblocking(true)?;
+        Ok(receiver)
+    }
+
+    pub fn path(&self) -> PathBuf {
+        self.directory.join("result")
+    }
+
+    /// Consume once, after the exact setup Shell has been acknowledged and removed.
+    pub fn receive(self) -> io::Result<Option<QualifiedIdentity>> {
+        let mut bytes = [0; MAX_RESULT_BYTES + 1];
+        match self.socket.recv(&mut bytes) {
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            Err(error) => Err(error),
+            Ok(count) if count > MAX_RESULT_BYTES => {
+                Err(io::Error::other("Remote setup result is too large"))
+            }
+            Ok(count) => {
+                let result: QualifiedIdentity = serde_json::from_slice(&bytes[..count])?;
+                if result.node_id.is_empty() || result.inner_id.is_empty() {
+                    return Err(io::Error::other(
+                        "Remote setup result has no Shell identity",
+                    ));
+                }
+                Ok(Some(result))
+            }
+        }
+    }
+}
+
+impl Drop for ConnectResultReceiver {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(self.path());
+        let _ = fs::remove_dir(&self.directory);
+    }
+}
+
+pub fn send_result(path: &Path, identity: &QualifiedIdentity) -> io::Result<()> {
+    let bytes = serde_json::to_vec(identity)?;
+    if bytes.len() > MAX_RESULT_BYTES {
+        return Err(io::Error::other("Remote setup result is too large"));
+    }
+    let socket = UnixDatagram::unbound()?;
+    socket.set_nonblocking(true)?;
+    socket.send_to(&bytes, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setup_results_are_exact_isolated_and_removed_after_consumption() {
+        let first = ConnectResultReceiver::new().unwrap();
+        let second = ConnectResultReceiver::new().unwrap();
+        let path = first.path();
+        let identity = QualifiedIdentity {
+            node_id: "owner".into(),
+            inner_id: "created-shell".into(),
+        };
+        send_result(&path, &identity).unwrap();
+        assert!(second.receive().unwrap().is_none());
+        assert_eq!(first.receive().unwrap(), Some(identity));
+        assert!(!path.parent().unwrap().exists());
+    }
+
+    #[test]
+    fn invalid_or_oversized_results_are_rejected_and_cleaned_up() {
+        for bytes in [
+            b"not json".to_vec(),
+            vec![b'x'; MAX_RESULT_BYTES + 1],
+            br#"{"node_id":"","inner_id":"s"}"#.to_vec(),
+        ] {
+            let receiver = ConnectResultReceiver::new().unwrap();
+            let path = receiver.path();
+            UnixDatagram::unbound()
+                .unwrap()
+                .send_to(&bytes, &path)
+                .unwrap();
+            assert!(receiver.receive().is_err());
+            assert!(!path.parent().unwrap().exists());
+        }
+    }
+
+    #[test]
+    fn cancelled_setup_releases_its_result_channel() {
+        let receiver = ConnectResultReceiver::new().unwrap();
+        let path = receiver.path();
+        drop(receiver);
+        assert!(!path.parent().unwrap().exists());
+        assert!(
+            send_result(
+                &path,
+                &QualifiedIdentity {
+                    node_id: "n".into(),
+                    inner_id: "s".into()
+                }
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub mod attach;
 pub mod benchmark_support;
 pub mod client;
 pub mod daemon;
+#[doc(hidden)]
+pub mod desktop_connect;
 mod desktop_notifications;
 mod fd_transfer;
 pub mod federation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -473,7 +473,10 @@ enum Commands {
     #[command(name = "__federation-stdio", hide = true)]
     FederationStdio,
     #[command(name = "__guided-node-add", hide = true)]
-    GuidedNodeAdd,
+    GuidedNodeAdd {
+        #[arg(long)]
+        result_socket: Option<PathBuf>,
+    },
     #[command(name = "__guided-node-upgrade", hide = true)]
     GuidedNodeUpgrade { selector: String },
     #[command(name = "__guided-node-uninstall", hide = true)]
@@ -566,6 +569,8 @@ enum NodeCommands {
         target: Option<String>,
         #[arg(long, hide = true)]
         desktop_workspace: bool,
+        #[arg(long, hide = true, requires = "desktop_workspace")]
+        desktop_result_socket: Option<PathBuf>,
     },
     /// List registered remote Nodes
     List,
@@ -1636,7 +1641,7 @@ impl Cli {
             Some(Commands::Attach { .. } | Commands::AwaitAttach { .. }) => CommandKey::Attach,
             Some(Commands::ResumeSession { .. }) => CommandKey::ResumeSessionInternal,
             Some(Commands::FederationStdio) => CommandKey::Attach,
-            Some(Commands::GuidedNodeAdd) => CommandKey::NodeAdd,
+            Some(Commands::GuidedNodeAdd { .. }) => CommandKey::NodeAdd,
             Some(Commands::GuidedNodeUpgrade { .. }) => CommandKey::NodeUpgrade,
             Some(Commands::GuidedNodeUninstall { .. }) => CommandKey::NodeUninstall,
             Some(Commands::GuidedNodeReauthenticate { .. }) => CommandKey::NodeReauthenticate,
@@ -1885,8 +1890,9 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             federation::run_stdio_helper()?;
             return Ok(CliExit::Success);
         }
-        Some(Commands::GuidedNodeAdd) => {
-            return finish_guided_shell(guided_node_add()?).map(CliExit::Child);
+        Some(Commands::GuidedNodeAdd { result_socket }) => {
+            return finish_guided_shell(guided_node_add(result_socket.as_deref())?)
+                .map(CliExit::Child);
         }
         Some(Commands::GuidedNodeUpgrade { selector }) => {
             return finish_guided_shell(guided_node_upgrade(selector)?).map(CliExit::Child);
@@ -2095,7 +2101,7 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
         Some(Commands::Attach { .. } | Commands::AwaitAttach { .. }) => unreachable!(),
         Some(Commands::ResumeSession { .. }) => unreachable!(),
         Some(Commands::FederationStdio) => unreachable!(),
-        Some(Commands::GuidedNodeAdd) => unreachable!(),
+        Some(Commands::GuidedNodeAdd { .. }) => unreachable!(),
         Some(Commands::GuidedNodeUpgrade { .. }) => unreachable!(),
         Some(Commands::GuidedNodeUninstall { .. }) => unreachable!(),
         Some(Commands::GuidedNodeReauthenticate { .. }) => unreachable!(),
@@ -2492,6 +2498,7 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
             alias,
             target,
             desktop_workspace,
+            desktop_result_socket,
         } => {
             if desktop_workspace && json {
                 return Err(
@@ -2509,10 +2516,27 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
             if desktop_workspace {
                 let shell = client::connect_or_start()?
                     .create_remote_workspace(&registration.node_id, &registration.alias)?;
-                println!(
-                    "Remote workspace created with Shell {}. Open it from the Desktop sidebar.",
-                    shell.name
-                );
+                if let Some(path) = desktop_result_socket {
+                    let identity = protocol::QualifiedIdentity {
+                        node_id: registration.node_id.clone(),
+                        inner_id: shell.id.clone(),
+                    };
+                    match boomux::desktop_connect::send_result(&path, &identity) {
+                        Ok(()) => println!(
+                            "Connected to {}. Press Enter at the next prompt to open your remote workspace.",
+                            registration.alias
+                        ),
+                        Err(error) => eprintln!(
+                            "Connected, but Desktop could not receive the new Shell: {error}. Open {} from the sidebar; do not repeat setup.",
+                            shell.name
+                        ),
+                    }
+                } else {
+                    println!(
+                        "Remote workspace created with Shell {}. Open it from the Desktop sidebar.",
+                        shell.name
+                    );
+                }
             }
             Ok(())
         }
@@ -2729,7 +2753,9 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
     }
 }
 
-fn guided_node_add() -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
+fn guided_node_add(
+    result_socket: Option<&Path>,
+) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
     let executable = env::current_exe()?;
     let stdin = io::stdin();
     let interactive = stdin.is_terminal() && io::stdout().is_terminal();
@@ -2741,6 +2767,7 @@ fn guided_node_add() -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
         &mut output,
         interactive,
         interactive.then(|| stdin.as_raw_fd()),
+        result_socket,
     )
 }
 
@@ -2768,7 +2795,10 @@ fn guided_shell_close_request(
     executable: &Path,
 ) -> Option<protocol::Request> {
     let command_matches = match shell.command.get(1).map(String::as_str) {
-        Some("__guided-node-add") => shell.command.len() == 2,
+        Some("__guided-node-add") => {
+            shell.command.len() == 2
+                || (shell.command.len() == 4 && shell.command[2] == "--result-socket")
+        }
         Some(
             "__guided-node-upgrade" | "__guided-node-reauthenticate" | "__guided-node-uninstall",
         ) => shell.command.len() == 3,
@@ -2859,11 +2889,19 @@ fn guided_node_add_with(
     output: &mut impl io::Write,
     wait_for_newline: bool,
     terminal_fd: Option<i32>,
+    result_socket: Option<&Path>,
 ) -> Result<process_adapter::ProcessExit, Box<dyn Error>> {
+    let mut arguments = vec!["node", "add", "--desktop-workspace"];
+    if let Some(path) = result_socket {
+        arguments.extend([
+            "--desktop-result-socket",
+            path.to_str().ok_or("Invalid Desktop result path")?,
+        ]);
+    }
     guided_node_command_with(
         executable,
-        &["node", "add", "--desktop-workspace"],
-        "Node setup",
+        &arguments,
+        "Remote connection",
         input,
         output,
         wait_for_newline,
@@ -3029,11 +3067,13 @@ fn resolve_node_add_inputs(
         .into());
     }
 
-    println!("Add a remote Boomux Node");
-    println!("Boomux uses your normal OpenSSH configuration and keeps remote work on its owner.");
+    println!("Connect a remote machine");
+    println!(
+        "Use an SSH host name or user@hostname. Your terminals and processes will run on that machine."
+    );
     let target = prompt_node_value("SSH target (for example user@workbox): ", None)?;
     let suggested_alias = target.rsplit('@').next().filter(|value| !value.is_empty());
-    let alias = prompt_node_value("Local alias", suggested_alias)?;
+    let alias = prompt_node_value("Display name", suggested_alias)?;
     Ok((alias, target))
 }
 
@@ -12805,6 +12845,7 @@ mod tests {
                     alias: Some(alias),
                     target: Some(target),
                     desktop_workspace: false,
+                    desktop_result_socket: None,
                 }
             }) if alias == "work" && target == "user@host"
         ));
@@ -12816,6 +12857,7 @@ mod tests {
                     alias: None,
                     target: None,
                     desktop_workspace: false,
+                    desktop_result_socket: None,
                 }
             })
         ));
@@ -12827,7 +12869,7 @@ mod tests {
         assert!(resolve_node_add_inputs(None, None, true).is_err());
 
         let held = Cli::try_parse_from(["boomux", "__guided-node-add"]).unwrap();
-        assert!(matches!(held.command, Some(Commands::GuidedNodeAdd)));
+        assert!(matches!(held.command, Some(Commands::GuidedNodeAdd { .. })));
         assert_eq!(held.command_descriptor().key, "node.add");
     }
 
@@ -12862,6 +12904,13 @@ mod tests {
         shell.command[0] = "/other/boomux".into();
         assert!(request(&shell).is_none());
         shell.command[0] = "/bin/boomux".into();
+        shell
+            .command
+            .extend(["--result-socket".into(), "/tmp/setup result".into()]);
+        assert!(request(&shell).is_some());
+        shell.command[2] = "--unexpected".into();
+        assert!(request(&shell).is_none());
+        shell.command.truncate(2);
         shell.command[1] = "__guided-node-uninstall".into();
         assert!(request(&shell).is_none());
         shell.command.push("exact-owner".into());
@@ -12883,11 +12932,12 @@ mod tests {
         fs::create_dir(&directory).unwrap();
         let child = directory.join("child");
         let child_output = directory.join("child-output");
+        let child_arguments = directory.join("child-arguments");
         fs::write(
             &child,
             format!(
-                "#!/bin/sh\nprintf 'child failed\\n'\nprintf 'child failed\\n' > '{}'\nexit 7\n",
-                child_output.display()
+                "#!/bin/sh\nprintf 'child failed\\n'\nprintf 'child failed\\n' > '{}'\nprintf '%s\\n' \"$@\" > '{}'\nexit 7\n",
+                child_output.display(), child_arguments.display()
             ),
         )
         .unwrap();
@@ -12896,19 +12946,31 @@ mod tests {
         let mut newline = io::Cursor::new(b"\n");
         let mut output = Vec::new();
         assert_eq!(
-            guided_node_add_with(&child, &mut newline, &mut output, true, None).unwrap(),
+            guided_node_add_with(
+                &child,
+                &mut newline,
+                &mut output,
+                true,
+                None,
+                Some(Path::new("/tmp/result with spaces; literal"))
+            )
+            .unwrap(),
             process_adapter::ProcessExit::Code(7)
         );
         let output = String::from_utf8(output).unwrap();
         assert_eq!(fs::read_to_string(&child_output).unwrap(), "child failed\n");
-        assert!(output.contains("Node setup failed (exit 7)."));
+        assert_eq!(
+            fs::read_to_string(&child_arguments).unwrap(),
+            "node\nadd\n--desktop-workspace\n--desktop-result-socket\n/tmp/result with spaces; literal\n"
+        );
+        assert!(output.contains("Remote connection failed (exit 7)."));
         assert!(output.contains("Press Enter to close."));
         assert!(!output.contains("Input closed before a newline"));
 
         let mut eof = io::Cursor::new(b"partial");
         let mut output = Vec::new();
         assert_eq!(
-            guided_node_add_with(&child, &mut eof, &mut output, true, None).unwrap(),
+            guided_node_add_with(&child, &mut eof, &mut output, true, None, None).unwrap(),
             process_adapter::ProcessExit::Code(7)
         );
         assert!(
@@ -12925,6 +12987,7 @@ mod tests {
                 &mut eof,
                 &mut output,
                 true,
+                None,
                 None,
             )
             .unwrap(),
@@ -12951,6 +13014,7 @@ mod tests {
             &mut output,
             true,
             Some(stdin.as_raw_fd()),
+            None,
         )
         .unwrap();
         std::process::exit(match outcome {
@@ -13036,7 +13100,7 @@ mod tests {
         let status = wrapper.wait().unwrap();
         assert_eq!(status.code(), Some(130));
         let output = String::from_utf8_lossy(&output);
-        assert!(output.contains("Node setup failed (signal 2)."));
+        assert!(output.contains("Remote connection failed (signal 2)."));
         fs::remove_dir_all(directory).unwrap();
     }
 
@@ -13104,7 +13168,7 @@ mod tests {
         read_pty_until(
             &mut master,
             &mut output,
-            b"Node setup failed to continue",
+            b"Remote connection failed to continue",
             Duration::from_secs(3),
         );
         read_pty_until(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2514,8 +2514,15 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
             )?;
             print_node_registration(CommandKey::NodeAdd, &registration, json)?;
             if desktop_workspace {
-                let shell = client::connect_or_start()?
-                    .create_remote_workspace(&registration.node_id, &registration.alias)?;
+                let Some(shell) = client::connect_or_start()?
+                    .create_initial_remote_workspace(&registration.node_id, &registration.alias)?
+                else {
+                    println!(
+                        "Connected to {}. The starter Workspace name is already in use. Press Enter at the next prompt, then open an existing Workspace from the Desktop sidebar or create a new one from the + menu.",
+                        registration.alias
+                    );
+                    return Ok(());
+                };
                 if let Some(path) = desktop_result_socket {
                     let identity = protocol::QualifiedIdentity {
                         node_id: registration.node_id.clone(),

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -4,7 +4,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs::{self, OpenOptions};
 use std::io::{self, Read, Write};
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -2395,43 +2395,8 @@ impl SshInvocation {
         authentication: SshAuthenticationMode,
         program: &OsStr,
     ) -> io::Result<Self> {
-        secure_runtime_directory(runtime_directory)?;
-        let nonce = Uuid::new_v4().simple().to_string();
-        let directory = runtime_directory.join(format!("ssh-{}", &nonce[..16]));
-        fs::create_dir(&directory)?;
-        fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
-        let config_path = directory.join("config");
-        let control_path = directory.join("c");
-        if control_path.as_os_str().as_bytes().len() > MAX_CONTROL_PATH_BYTES {
-            let _ = fs::remove_dir_all(&directory);
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "SSH control socket path exceeds the safe Unix socket bound",
-            ));
-        }
-        validate_option_path(&control_path, "SSH control socket")?;
-        let result = (|| {
-            let mut config = OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o600)
-                .open(&config_path)?;
-            if let Some(user_config) = user_config {
-                writeln!(config, "Include {}", quote_ssh_config_path(user_config)?)?;
-                writeln!(config, "Match all")?;
-            }
-            // SendEnv is list-valued, so clear user entries after their config.
-            writeln!(config, "SendEnv -*")?;
-            writeln!(config, "Host *")?;
-            writeln!(config, "    ServerAliveInterval 15")?;
-            writeln!(config, "    ServerAliveCountMax 3")?;
-            config.sync_all()?;
-            Ok(())
-        })();
-        if let Err(error) = result {
-            let _ = fs::remove_dir_all(&directory);
-            return Err(error);
-        }
+        let (directory, config_path, control_path) =
+            prepare_ssh_directory(runtime_directory, user_config)?;
         Ok(Self {
             program: program.to_owned(),
             directory,
@@ -2481,19 +2446,16 @@ fn prepare_ssh_directory(
 ) -> io::Result<(PathBuf, PathBuf, PathBuf)> {
     secure_runtime_directory(runtime_directory)?;
     let nonce = Uuid::new_v4().simple().to_string();
-    let directory = runtime_directory.join(format!("ssh-{}", &nonce[..16]));
-    fs::create_dir(&directory)?;
-    fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
+    let mut directory = runtime_directory.join(format!("ssh-{}", &nonce[..16]));
+    if directory.join("c").as_os_str().as_bytes().len() > MAX_CONTROL_PATH_BYTES {
+        // Keep the daemon's runtime unchanged. TMPDIR can itself be too long
+        // (especially on macOS), so use a short, exclusively created directory.
+        directory = Path::new("/tmp").join(format!("boomux-ssh-{nonce}"));
+    }
     let config_path = directory.join("config");
     let control_path = directory.join("c");
-    if control_path.as_os_str().as_bytes().len() > MAX_CONTROL_PATH_BYTES {
-        let _ = fs::remove_dir_all(&directory);
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "SSH control socket path exceeds the safe Unix socket bound",
-        ));
-    }
     validate_option_path(&control_path, "SSH control socket")?;
+    fs::DirBuilder::new().mode(0o700).create(&directory)?;
     let result = (|| {
         let mut config = OpenOptions::new()
             .write(true)
@@ -5298,6 +5260,37 @@ mod tests {
                 io::ErrorKind::InvalidInput
             );
         }
+    }
+
+    #[test]
+    fn long_runtime_uses_private_short_ssh_directory_and_cleans_up() {
+        let runtime = runtime_directory();
+        let long_runtime = runtime.join("long-runtime-".repeat(8));
+        let invocation = SshInvocation::prepare_at(
+            &long_runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            RemoteExecutable::parse("/usr/bin/boomux").unwrap(),
+            SshAuthenticationMode::Interactive,
+        )
+        .unwrap();
+        let directory = invocation.directory.clone();
+        assert!(!directory.starts_with(&long_runtime));
+        assert!(invocation.control_path().as_os_str().as_bytes().len() <= MAX_CONTROL_PATH_BYTES);
+        assert_eq!(fs::metadata(&directory).unwrap().mode() & 0o777, 0o700);
+        assert_eq!(
+            fs::metadata(invocation.config_path()).unwrap().mode() & 0o777,
+            0o600
+        );
+        let listener = std::os::unix::net::UnixListener::bind(invocation.control_path()).unwrap();
+        let second = prepare_ssh_directory(&long_runtime, None).unwrap();
+        assert_ne!(directory, second.0);
+        fs::remove_dir_all(second.0).unwrap();
+        drop(listener);
+        drop(invocation);
+        assert!(!directory.exists());
+        assert!(long_runtime.exists());
+        assert_eq!(fs::read_dir(&long_runtime).unwrap().count(), 0);
     }
 
     #[test]

--- a/tests/native_backend/remote_bootstrap.rs
+++ b/tests/native_backend/remote_bootstrap.rs
@@ -991,7 +991,7 @@ fn guided_node_add_mirrors_master_challenge_and_waits_after_failure() {
     }
     let mut child = command.spawn().unwrap();
     let mut master = fs::File::from(master);
-    master.write_all(b"work\nworkbox\n").unwrap();
+    master.write_all(b"workbox\nwork\n").unwrap();
     let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
     assert_ne!(flags, -1);
     assert_ne!(
@@ -1025,7 +1025,10 @@ fn guided_node_add_mirrors_master_challenge_and_waits_after_failure() {
         output.contains("https://login.tailscale.test/challenge"),
         "{output}"
     );
-    assert!(output.contains("Node setup failed (exit 1)."), "{output}");
+    assert!(
+        output.contains("Remote connection failed (exit 1)."),
+        "{output}"
+    );
     assert!(child.try_wait().unwrap().is_none());
     master.write_all(b"\n").unwrap();
     assert_eq!(child.wait().unwrap().code(), Some(1));
@@ -1055,7 +1058,10 @@ fn guided_node_add_allows_ssh_to_read_authentication_from_the_terminal() {
         fs::read(directory.join("authentication")).unwrap(),
         b"secret"
     );
-    assert!(output.contains("Node setup failed (exit 1)."), "{output}");
+    assert!(
+        output.contains("Remote connection failed (exit 1)."),
+        "{output}"
+    );
     fs::remove_dir_all(directory).unwrap();
 }
 


### PR DESCRIPTION
Remote Workspace setup now offers a machine picker and opens the exact newly created Shell after setup is acknowledged. Unavailable machine cards expose sign-in, update review, or connection review without first expanding the card. Expanded cards add **Rename connection…**, which changes the local display name using the exact Node ID and a revision guard, including while disconnected.

Connecting to a machine with an existing starter Workspace now succeeds instead of reporting a failed connection after successful SSH authentication and registration. An explicit owner `already_exists` response directs users to the sidebar without selecting or modifying an existing Workspace by name. Other failures remain errors and do not trigger another creation attempt. Long local runtime paths now use an exclusively created private SSH directory under `/tmp`, preserving the current daemon runtime and sessions.

New-Shell navigation uses a launch-owned Unix datagram receipt limited to 1 KiB. Cancellation cleans it up; failed delivery or opening never replays Workspace creation. No extra polling worker, daemon protocol change, or persistence schema change is introduced. Update review retains identity verification and installation consent; some older helpers still require manual updates.

Validation:
- Backend and Desktop compile checks, formatting, and `git diff --check` passed.
- New connection regression coverage passed for typed name collisions, unknown outcomes, timeouts, untyped errors, and no mutation replay.
- SSH tests passed for real socket binding under a long runtime path, private permissions, distinct invocation directories, cleanup, exact arguments, and included-config handling.
- Earlier branch validation passed the result-channel tests, eleven guided-setup tests, and focused Desktop recovery, receipt/cleanup, and launch-argument tests.

User testing confirmed SSH authentication and registration reach the remote machine and exposed the existing-Workspace collision. The final fixes and rename UI have not been exercised end to end in a rebuilt Desktop. PR CI owns comprehensive validation.
