### PR TITLE
feat(desktop): add agent details and configuration inventory

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -204,6 +204,11 @@ Drag the divider above **Agents | Git | Remotes** to resize this section.
 
 ### Agents
 
+Select **ⓘ** on an Agent row (or press **i** with the row selected) for
+[Agent details](../docs/desktop/agent-details.md): overview, discovered skills,
+and MCP definitions with source files. Configuration findings are labeled
+separately from live state; MCP connections are not currently reported.
+
 Click an Agent to focus or open its Shell. When an observed working Agent
 becomes idle, its row stays marked **finished** until dismissed.
 

--- a/desktop/src/agent_details.rs
+++ b/desktop/src/agent_details.rs
@@ -1,0 +1,605 @@
+//! On-demand Agent inspection; the owning daemon performs all filesystem reads.
+use super::*;
+use boomux::agent_inspection::{Inspection, Scope};
+
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub enum Tab {
+    #[default]
+    Overview,
+    Skills,
+    Mcp,
+}
+
+pub struct Model {
+    pub agent: AgentChoice,
+    pub machine: String,
+    pub tab: Tab,
+    pub expanded: Option<usize>,
+    pub inspection: Option<Inspection>,
+    pub error: Option<String>,
+    pub busy: bool,
+    pub copied: bool,
+    pub generation: u64,
+    pub task: Option<gpui::Task<()>>,
+    pub scroll: ScrollHandle,
+}
+
+impl Model {
+    fn apply_result(&mut self, generation: u64, result: Result<Inspection, String>) -> bool {
+        if self.generation != generation {
+            return false;
+        }
+        self.busy = false;
+        self.expanded = None;
+        match result {
+            Ok(inspection) => {
+                self.inspection = Some(inspection);
+                self.error = None;
+            }
+            Err(error) => self.error = Some(error),
+        }
+        true
+    }
+}
+
+fn scope(scope: &Scope) -> &'static str {
+    match scope {
+        Scope::User => "User",
+        Scope::Project => "Project",
+        Scope::System => "System",
+    }
+}
+
+fn fetch(agent: &AgentChoice) -> Result<Inspection, String> {
+    let client = boomux::client::Client::from_socket_path(
+        boomux::client::socket_path().map_err(|e| e.to_string())?,
+    );
+    let identity = remote::identity(&agent.id);
+    let result = client.inspect_agent(
+        identity.as_ref().map(|i| i.node_id.as_str()),
+        identity
+            .as_ref()
+            .map_or(agent.id.as_str(), |i| i.inner_id.as_str()),
+        &agent.run_id,
+        Duration::from_secs(5),
+    );
+    result.map_err(|error| format!("Could not inspect this Agent: {error}. Inspection requires Boomux protocol 55 or newer on this computer and the Agent's machine."))
+}
+
+fn field(label: &str, value: impl Into<SharedString>) -> Div {
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .child(
+            div()
+                .text_xs()
+                .text_color(rgb(0xa6adc8))
+                .child(label.to_owned()),
+        )
+        .child(div().text_sm().child(value.into()))
+}
+
+fn note(text: impl Into<SharedString>) -> Div {
+    div().text_xs().text_color(rgb(0xa6adc8)).child(text.into())
+}
+
+impl Workspace {
+    pub(super) fn open_agent_details(
+        &mut self,
+        agent: AgentChoice,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let machine = remote::identity(&agent.id).map_or_else(
+            || "This computer".into(),
+            |id| {
+                self.node_views
+                    .iter()
+                    .find(|n| n.id == id.node_id)
+                    .map_or(id.node_id, |n| n.label.clone())
+            },
+        );
+        self.agent_details_generation = self.agent_details_generation.wrapping_add(1);
+        self.agent_details = Some(Model {
+            agent,
+            machine,
+            tab: Tab::Overview,
+            expanded: None,
+            inspection: None,
+            error: None,
+            busy: false,
+            copied: false,
+            generation: self.agent_details_generation,
+            task: None,
+            scroll: ScrollHandle::new(),
+        });
+        self.project_menu_open = false;
+        self.sidebar_menu = None;
+        window.focus(&self.focus_handle, cx);
+        self.refresh_agent_details(cx);
+    }
+
+    fn refresh_agent_details(&mut self, cx: &mut Context<Self>) {
+        let Some(model) = &mut self.agent_details else {
+            return;
+        };
+        if model.busy {
+            return;
+        }
+        model.busy = true;
+        model.copied = false;
+        let agent = model.agent.clone();
+        let generation = model.generation;
+        model.task = Some(cx.spawn(async move |this, cx| {
+            let result = cx.background_spawn(async move { fetch(&agent) }).await;
+            let _ = this.update(cx, |this, cx| {
+                let Some(model) = &mut this.agent_details else {
+                    return;
+                };
+                if !model.apply_result(generation, result) {
+                    return;
+                }
+                cx.notify();
+            });
+        }));
+        cx.notify();
+    }
+
+    pub(super) fn agent_details_key_down(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+        let Some(model) = &mut self.agent_details else {
+            return;
+        };
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                self.agent_details = None;
+            }
+            "up" | "down" | "pageup" | "pagedown" => {
+                let offset = model.scroll.offset();
+                let delta = if matches!(event.keystroke.key.as_str(), "pageup" | "pagedown") {
+                    320.0
+                } else {
+                    48.0
+                };
+                let delta = if matches!(event.keystroke.key.as_str(), "up" | "pageup") {
+                    delta
+                } else {
+                    -delta
+                };
+                model.scroll.set_offset(point(
+                    offset.x,
+                    (offset.y + px(delta))
+                        .min(px(0.0))
+                        .max(-model.scroll.max_offset().y),
+                ));
+            }
+            "1" => {
+                model.tab = Tab::Overview;
+                model.expanded = None;
+            }
+            "2" => {
+                model.tab = Tab::Skills;
+                model.expanded = None;
+            }
+            "3" => {
+                model.tab = Tab::Mcp;
+                model.expanded = None;
+            }
+            _ => {}
+        }
+        cx.stop_propagation();
+        cx.notify();
+    }
+
+    pub(super) fn agent_details_overlay(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
+        let model = self.agent_details.as_ref()?;
+        let mut content = div().flex().flex_col().gap_4();
+        if let Some(error) = &model.error {
+            content = content.child(
+                div()
+                    .text_sm()
+                    .text_color(rgb(0xf9e2af))
+                    .child(error.clone()),
+            );
+            if model.inspection.is_some() {
+                content = content.child(note(
+                    "Last known details retained. Refresh did not succeed.",
+                ));
+            }
+        }
+        match model.tab {
+            Tab::Overview => {
+                content = content
+                    .child(field("Harness", model.agent.integration.clone()))
+                    .child(field("Machine", model.machine.clone()))
+                    .child(field("Workspace", model.agent.workspace.clone()));
+                if let Some(inspection) = &model.inspection {
+                    let agent = &inspection.agent;
+                    let state = format!("{:?}", agent.observation.state).to_lowercase();
+                    content = content
+                        .child(field("Reported state", state))
+                        .child(field(
+                            "Last Agent report",
+                            relative_time(agent.observation.observed_at_ms),
+                        ))
+                        .child(field(
+                            "Working directory",
+                            agent
+                                .cwd
+                                .as_ref()
+                                .map_or_else(|| "Not reported".into(), |p| p.display().to_string()),
+                        ))
+                        .child(field(
+                            "Needs attention",
+                            agent.attention.as_ref().map_or_else(
+                                || "No attention request in this snapshot".to_string(),
+                                |a| match a.reason {
+                                    boomux::protocol::AgentAttentionReason::Blocked => {
+                                        "Agent is waiting for attention".into()
+                                    }
+                                    boomux::protocol::AgentAttentionReason::Completed => {
+                                        "Agent has reported completion".into()
+                                    }
+                                },
+                            ),
+                        ))
+                        .child(field("Latest evidence", agent.observation.evidence.clone()));
+                    for context in &agent.working_contexts {
+                        content = content.child(field(
+                            "Observed Git context",
+                            format!("{} · {}", context.worktree_root.display(), context.branch),
+                        ));
+                    }
+                    content = content.child(field("Skills found", inspection.skills.len().to_string()))
+                        .child(field("MCP definitions found", inspection.mcp_servers.len().to_string()))
+                        .child(note("Model, context usage, cost and live tool availability are not reported by this integration."));
+                } else {
+                    content = content
+                        .child(field("Last known state", model.agent.state_label()))
+                        .child(field(
+                            "Last Agent report",
+                            relative_time(model.agent.updated_at_ms),
+                        ));
+                }
+                content = content
+                    .child(field("Agent ID", model.agent.id.clone()))
+                    .child(field("Run ID", model.agent.run_id.clone()));
+            }
+            Tab::Skills => {
+                content = content.child(note("Found in skill files on the Agent’s machine. Discovery does not confirm that this run loaded or can use a skill."));
+                if let Some(inspection) = &model.inspection {
+                    if inspection.skills.is_empty() {
+                        content = content.child(note("No skills found in the inspected locations. This is not a complete runtime inventory."));
+                    }
+                    for (index, skill) in inspection.skills.iter().enumerate() {
+                        content = content.child(
+                            div()
+                                .id(SharedString::from(format!("agent-skill-{index}")))
+                                .p_3()
+                                .rounded_md()
+                                .bg(rgb(0x181825))
+                                .cursor_pointer()
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    if let Some(m) = &mut this.agent_details {
+                                        m.expanded = (m.expanded != Some(index)).then_some(index);
+                                    }
+                                    cx.notify();
+                                }))
+                                .child(div().text_sm().child(format!(
+                                    "{} {}",
+                                    if model.expanded == Some(index) {
+                                        "▾"
+                                    } else {
+                                        "▸"
+                                    },
+                                    skill.name
+                                )))
+                                .child(note(format!(
+                                    "{} · Found in configuration",
+                                    scope(&skill.scope)
+                                )))
+                                .when(model.expanded == Some(index), |row| {
+                                    row.child(note(skill.description.clone()))
+                                        .child(note(skill.source.display().to_string()))
+                                }),
+                        );
+                    }
+                }
+            }
+            Tab::Mcp => {
+                content = content.child(note("Connection health, authentication and available tools are not reported. These are file definitions, not confirmed connections."));
+                if let Some(inspection) = &model.inspection {
+                    if inspection.mcp_servers.is_empty() {
+                        content = content.child(note("No MCP definitions found in the inspected locations. Plugin and runtime connections may still exist."));
+                    }
+                    for (index, server) in inspection.mcp_servers.iter().enumerate() {
+                        content = content.child(
+                            div()
+                                .id(SharedString::from(format!("agent-mcp-{index}")))
+                                .p_3()
+                                .rounded_md()
+                                .bg(rgb(0x181825))
+                                .cursor_pointer()
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    cx.stop_propagation();
+                                    if let Some(m) = &mut this.agent_details {
+                                        m.expanded = (m.expanded != Some(index)).then_some(index);
+                                    }
+                                    cx.notify();
+                                }))
+                                .child(div().text_sm().child(format!(
+                                    "{} {}",
+                                    if model.expanded == Some(index) {
+                                        "▾"
+                                    } else {
+                                        "▸"
+                                    },
+                                    server.name
+                                )))
+                                .child(note(format!(
+                                    "{} · {}",
+                                    scope(&server.scope),
+                                    match server.enabled {
+                                        Some(false) => "Disabled in this file",
+                                        Some(true) => "Enabled in this file",
+                                        None => "Found in configuration",
+                                    }
+                                )))
+                                .when(model.expanded == Some(index), |row| {
+                                    row.child(note(format!(
+                                        "Transport: {} · Connection not reported",
+                                        server.transport
+                                    )))
+                                    .child(note(server.source.display().to_string()))
+                                }),
+                        );
+                    }
+                }
+            }
+        }
+        if model.busy {
+            content = content.child(note("Inspecting on the Agent's machine…"));
+        }
+        if let Some(inspection) = &model.inspection {
+            if inspection.truncated {
+                content =
+                    content.child(note("Inspection limits reached; this list is incomplete."));
+            }
+            for warning in &inspection.warnings {
+                content = content.child(note(warning.clone()));
+            }
+        }
+        let mut tabs = div().flex().gap_2();
+        for (tab, label) in [
+            (Tab::Overview, "Overview"),
+            (Tab::Skills, "Skills"),
+            (Tab::Mcp, "MCP"),
+        ] {
+            tabs = tabs.child(
+                Self::settings_option(label, label, model.tab == tab).on_click(cx.listener(
+                    move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        if let Some(m) = &mut this.agent_details {
+                            m.tab = tab;
+                            m.expanded = None;
+                            m.scroll.set_offset(point(px(0.0), px(0.0)));
+                        }
+                        cx.notify();
+                    },
+                )),
+            );
+        }
+        Some(
+            div()
+                .id("agent-details-backdrop")
+                .absolute()
+                .inset_0()
+                .occlude()
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.agent_details = None;
+                    cx.notify();
+                }))
+                .child(
+                    div()
+                        .id("agent-details-drawer")
+                        .absolute()
+                        .right_0()
+                        .top_0()
+                        .bottom_0()
+                        .w(px(460.0))
+                        .max_w_full()
+                        .bg(rgb(0x1e1e2e))
+                        .border_l_1()
+                        .border_color(rgb(0x45475a))
+                        .shadow_lg()
+                        .flex()
+                        .flex_col()
+                        .p_4()
+                        .gap_3()
+                        .on_click(cx.listener(|_, _, _, cx| cx.stop_propagation()))
+                        .child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .justify_between()
+                                .child(div().text_lg().child("Agent details"))
+                                .child(
+                                    Self::settings_option("close-agent-details", "Close", false)
+                                        .on_click(cx.listener(|this, _, _, cx| {
+                                            cx.stop_propagation();
+                                            this.agent_details = None;
+                                            cx.notify();
+                                        })),
+                                ),
+                        )
+                        .child(div().text_sm().child(model.agent.display_name.clone()))
+                        .child(
+                            div()
+                                .flex()
+                                .gap_2()
+                                .child(
+                                    Self::settings_option(
+                                        "agent-details-terminal",
+                                        "Open terminal",
+                                        false,
+                                    )
+                                    .on_click(cx.listener(
+                                        |this, _, window, cx| {
+                                            cx.stop_propagation();
+                                            if let Some(m) = this.agent_details.take() {
+                                                this.activate_sidebar_shell(
+                                                    &m.agent.shell_id,
+                                                    window,
+                                                    cx,
+                                                );
+                                            }
+                                        },
+                                    )),
+                                )
+                                .child(
+                                    Self::settings_control(
+                                        "agent-details-refresh",
+                                        if model.busy {
+                                            "Refreshing…"
+                                        } else {
+                                            "Refresh"
+                                        },
+                                        false,
+                                        !model.busy,
+                                    )
+                                    .on_click(cx.listener(
+                                        |this, _, _, cx| {
+                                            cx.stop_propagation();
+                                            this.refresh_agent_details(cx);
+                                        },
+                                    )),
+                                )
+                                .child(
+                                    Self::settings_option(
+                                        "agent-details-copy",
+                                        if model.copied {
+                                            "Copied"
+                                        } else {
+                                            "Copy details"
+                                        },
+                                        false,
+                                    )
+                                    .on_click(cx.listener(
+                                        |this, _, _, cx| {
+                                            cx.stop_propagation();
+                                            if let Some(m) = &mut this.agent_details {
+                                                let text = export(m);
+                                                cx.write_to_clipboard(ClipboardItem::new_string(
+                                                    text,
+                                                ));
+                                                m.copied = true;
+                                                cx.notify();
+                                            }
+                                        },
+                                    )),
+                                ),
+                        )
+                        .child(tabs)
+                        .child(
+                            div()
+                                .id("agent-details-content")
+                                .flex_1()
+                                .min_h_0()
+                                .overflow_y_scroll()
+                                .track_scroll(&model.scroll)
+                                .child(content),
+                        )
+                        .child(note(model.inspection.as_ref().map_or_else(
+                            || "No inspection snapshot yet".into(),
+                            |i| {
+                                format!(
+                                    "Inspected {} · 1/2/3 tabs · Esc closes",
+                                    relative_time(i.inspected_at_ms)
+                                )
+                            },
+                        ))),
+                )
+                .into_any_element(),
+        )
+    }
+}
+
+fn export(model: &Model) -> String {
+    let mut text = format!(
+        "Agent: {}\nMachine: {}\nHarness: {}\nWorkspace: {}\nAgent ID: {}\nRun ID: {}\n",
+        model.agent.display_name,
+        model.machine,
+        model.agent.integration,
+        model.agent.workspace,
+        model.agent.id,
+        model.agent.run_id
+    );
+    if let Some(inspection) = &model.inspection {
+        text.push_str("\nFile inventory only; not confirmed runtime capabilities.\n");
+        if let Ok(json) = serde_json::to_string_pretty(inspection) {
+            text.push_str(&json);
+        }
+    }
+    if let Some(error) = &model.error {
+        text.push_str(&format!("\nLast refresh failed: {error}\n"));
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_details_rejects_late_results_and_retains_snapshot_on_refresh_failure() {
+        let inspection: Inspection = serde_json::from_value(serde_json::json!({
+            "agent": {
+                "id":"agent", "workspace_id":"workspace", "shell_id":"shell", "run_id":"run",
+                "name":"test", "integration":"codex", "external_session_id":null,
+                "started_at_ms":1, "ended_at_ms":null,
+                "observation":{"revision":1,"state":"idle","authority":"lifecycle_integration","evidence":"fixture","confidence":100,"observed_at_ms":1}
+            },
+            "inspected_at_ms":1, "skills":[], "mcp_servers":[], "warnings":[], "truncated":false
+        })).unwrap();
+        let mut model = Model {
+            agent: AgentChoice {
+                id: "agent".into(),
+                run_id: "run".into(),
+                shell_name: "shell".into(),
+                display_name: "test".into(),
+                workspace: "workspace".into(),
+                shell_id: "shell".into(),
+                integration: "codex".into(),
+                state: boomux::protocol::AgentState::Idle,
+                updated_at_ms: 1,
+                needs_attention: false,
+                completed_attention: false,
+                attention_revision: None,
+            },
+            machine: "This computer".into(),
+            tab: Tab::Overview,
+            expanded: None,
+            inspection: None,
+            error: None,
+            busy: true,
+            copied: false,
+            generation: 2,
+            task: None,
+            scroll: ScrollHandle::new(),
+        };
+        assert!(!model.apply_result(1, Ok(inspection.clone())));
+        assert!(model.busy);
+        assert!(model.inspection.is_none());
+        assert!(model.apply_result(2, Ok(inspection.clone())));
+        assert!(!model.busy);
+        model.busy = true;
+        assert!(model.apply_result(2, Err("Owner unavailable".into())));
+        assert_eq!(model.inspection.as_ref(), Some(&inspection));
+        assert_eq!(model.error.as_deref(), Some("Owner unavailable"));
+        assert!(!model.apply_result(1, Err("Stale error".into())));
+        assert_eq!(model.error.as_deref(), Some("Owner unavailable"));
+        assert!(model.apply_result(2, Ok(inspection)));
+        assert!(model.error.is_none());
+    }
+}

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,3 +1,4 @@
+mod agent_details;
 mod boomux_settings;
 mod bundle_update;
 mod project_search;
@@ -1538,6 +1539,8 @@ struct Workspace {
     restore_pointer_guard: layout_persistence::PointerGuard,
     layout_restoring: bool,
     git_panel: git_panel::Model,
+    agent_details: Option<agent_details::Model>,
+    agent_details_generation: u64,
     layout: Option<Node>,
     floating: Vec<FloatingPane>,
     pointer_drag: Option<PointerDrag>,
@@ -1758,6 +1761,8 @@ impl Workspace {
             layout: Some(layout),
             floating: Vec::new(),
             git_panel: git_panel::Model::default(),
+            agent_details: None,
+            agent_details_generation: 0,
             pointer_drag: None,
             terminal_scrollbar_drag: None,
             terminal_selection_release: None,
@@ -4251,6 +4256,10 @@ impl Workspace {
     }
 
     fn copy_selection(&mut self, _: &CopySelection, _: &mut Window, cx: &mut Context<Self>) {
+        if self.agent_details.is_some() {
+            cx.stop_propagation();
+            return;
+        }
         if self.copy_scrollback_selection(self.focused, true, cx) {
             cx.stop_propagation();
             return;
@@ -4270,6 +4279,10 @@ impl Workspace {
     }
 
     fn paste_clipboard(&mut self, _: &PasteClipboard, _: &mut Window, cx: &mut Context<Self>) {
+        if self.agent_details.is_some() {
+            cx.stop_propagation();
+            return;
+        }
         if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
             if self.project_menu_open {
                 project_search::append(&mut self.project_search, &text);
@@ -4903,6 +4916,32 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.agent_details.is_some() {
+            self.agent_details_key_down(event, cx);
+            return;
+        }
+        if self.navigation_region == NavigationRegion::Sidebar
+            && event.keystroke.key == "i"
+            && !event.keystroke.modifiers.control
+            && !event.keystroke.modifiers.alt
+            && !event.keystroke.modifiers.platform
+            && !event.keystroke.modifiers.function
+            && !event.keystroke.modifiers.shift
+            && !event.is_held
+        {
+            if let Some(SidebarItem::Agent { agent_id, .. }) = &self.sidebar_item
+                && let Some(agent) = self
+                    .boomux_overview
+                    .agents
+                    .iter()
+                    .find(|a| &a.id == agent_id)
+                    .cloned()
+            {
+                self.open_agent_details(agent, window, cx);
+                cx.stop_propagation();
+                return;
+            }
+        }
         if event.keystroke.key == "space" && self.layout_leader_pressed_at.is_some() {
             self.layout_leader_release_task = None;
             cx.stop_propagation();
@@ -9009,6 +9048,7 @@ impl Workspace {
         focused_shell_id: Option<&str>,
         cx: &mut Context<Self>,
     ) -> Stateful<Div> {
+        let details_agent = agent.clone();
         let shell_id = agent.shell_id.clone();
         let agent_item = SidebarItem::Agent {
             agent_id: agent.id.clone(),
@@ -9120,6 +9160,25 @@ impl Workspace {
                                 agent.integration
                             )),
                     ),
+            )
+            .child(
+                div()
+                    .id(SharedString::from(format!(
+                        "agent-details-{}",
+                        details_agent.id
+                    )))
+                    .role(gpui::Role::Button)
+                    .aria_label("Agent details")
+                    .px_2()
+                    .py_1()
+                    .rounded_md()
+                    .text_sm()
+                    .hover(|row| row.bg(rgb(0x313244)))
+                    .child("ⓘ")
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        this.open_agent_details(details_agent.clone(), window, cx);
+                    })),
             )
             .when(dismissible, |row| {
                 row.child(
@@ -10356,6 +10415,7 @@ impl Render for Workspace {
             })
             .into_any_element();
         let sidebar_menu = self.sidebar_menu_overlay(cx);
+        let agent_details = self.agent_details_overlay(cx);
         let resource_dialog = self.resource_dialog_overlay(cx);
         let settings_restart = self.settings_restart_overlay(cx);
         let help = self.help_overlay(cx);
@@ -10381,6 +10441,7 @@ impl Render for Workspace {
                     || self.project_menu_open
                     || self.boomux_setting_input.is_some()
                     || self.settings_restart_confirm
+                    || self.agent_details.is_some()
                 {
                     "BoomuxSettingsInput"
                 } else {
@@ -10466,6 +10527,7 @@ impl Render for Workspace {
             .text_color(rgb(0xcdd6f4))
             .child(content)
             .when_some(sidebar_menu, |element, menu| element.child(menu))
+            .when_some(agent_details, |element, drawer| element.child(drawer))
             .when_some(resource_dialog, |element, dialog| element.child(dialog))
             .when_some(settings_restart, |element, dialog| element.child(dialog))
             .when_some(help, |element, help| element.child(help))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ This is the implementation reference. For product usage, see the
 | `src/main.rs` | CLI schema, process composition, command dispatch, and dashboard backend orchestration |
 | `src/dashboard_projection.rs` | Typed snapshot/session-to-dashboard classification, view construction, and title enrichment |
 | `src/protocol.rs` | Versioned control and attachment wire models, framing, and request version requirements |
+| `src/agent_inspection.rs` | Bounded, read-only skill and MCP file inventory for an exact Agent on its owner |
 | `src/client.rs` | Daemon discovery/startup, protocol negotiation, typed management requests, and attachment setup |
 | `src/platform/` | Linux and Darwin process identity, monitoring, runtime paths, descriptor and filesystem operations |
 | `src/daemon.rs` | `DaemonService` coordination over durable registry, event-stream, shell-runtime, persistence, and handoff owners |
@@ -324,6 +325,15 @@ event readers filter that event while retaining cursor progress. Coordinator
 Workspace schema 8 explicitly migrates schema 7 with empty pending and completed
 default-cwd operation ledgers. Owner state schema 14 and handoff generation 8 are
 unchanged because owner Workspaces already persist `default_cwd`.
+Protocol 55 adds `agent_inspection`: the read-only `InspectAgent` host-service
+operation requires an exact Agent ID and expected ShellRun ID, locally or through
+verified Node routing. The owner snapshots the Agent, releases registry locks,
+and reads bounded configuration metadata. A mismatched run is rejected. Clients
+probe version support before sending the new operation; both local and routed
+requests require 55. Only this new request returns `AgentInspection`, so older
+request response shapes are unchanged. No persistence schema or event changes
+are required. See [Agent details](desktop/agent-details.md) for inventory coverage.
+
 Protocol 54 adds `create_started_shell`: local `CreateStartedShell` creates a
 Shell and its first ShellRun in one durable state replacement. The PTY reader
 stays paused until persistence succeeds; `shell_created` then `run_started` are

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -126,6 +126,12 @@ unsupported owners fail visibly and are never emulated against local PATH,
 configuration, catalogs, or filesystems. Responses are live and transient and do
 not update the cached Node projection.
 
+Protocol 55 advertises `agent_inspection` for the read-only `InspectAgent`
+host-service operation used by Desktop. It requires the exact Agent and expected
+ShellRun IDs and returns bounded owner-side configuration metadata. This adds no
+CLI JSON method. See [Agent details](desktop/agent-details.md) for coverage and
+the distinction between file configuration and runtime capabilities.
+
 `capabilities` advertises only what the installed local CLI can speak and never
 reports negotiated state for a registered Node. `node.list` and `node.inspect`
 return registration data only. `node.snapshot` carries each Node's observed

--- a/docs/desktop/agent-details.md
+++ b/docs/desktop/agent-details.md
@@ -1,0 +1,71 @@
+# Agent details
+
+Select **ⓘ** on an Agent row in the Agents panel to open its details drawer.
+With an Agent selected in sidebar keyboard navigation, press **i**. Clicking the
+row itself still opens its Shell. **Escape** or the backdrop closes the drawer;
+**1**, **2**, and **3** select Overview, Skills, and MCP.
+
+- **Overview** shows the harness, machine, Workspace, reported state, last report,
+  working directory, attention, observed Git contexts, and exact Agent/run IDs.
+- **Skills** lists discovered skill names and descriptions. Expand an entry for
+  its source file and scope.
+- **MCP** lists server definitions, transport, and any explicit enabled/disabled
+  setting. Expand an entry for its source file.
+
+**Open terminal** navigates to the Agent's Shell. **Refresh** reads configuration
+again on the owning machine. **Copy details** copies an Agent summary and the inventory
+as JSON with its inspection caveat for troubleshooting.
+
+## What the inventory means
+
+These are standard configuration locations, not a live capability report.
+Finding a skill does not prove the current run loaded it. Finding an MCP server,
+including one marked enabled, does not prove it is connected or authenticated.
+Model, context usage, cost, connection health, and available tools are currently
+not reported. Names that occur in multiple files retain separate source entries;
+the drawer does not calculate precedence or the effective configuration.
+
+| Harness | Skill directories | MCP files |
+| --- | --- | --- |
+| Codex | User `~/.agents/skills`, `~/.codex/skills`; system `/etc/codex/skills`; project `.agents/skills`, `.codex/skills` | User and project `.codex/config.toml` |
+| Claude Code | User and project `.claude/skills` | `~/.claude.json`, including the repository's project entry; project `.mcp.json` |
+| OpenCode | User `~/.config/opencode/skills`, `~/.claude/skills`, `~/.agents/skills`; project `.opencode/skills`, `.claude/skills`, `.agents/skills` | User `~/.config/opencode/opencode.json` or `.jsonc`; project `opencode.json` or `.jsonc` |
+| Pi | User `~/.pi/agent/skills`, `~/.agents/skills`; project `.pi/skills`, `.agents/skills` | Extension MCP configuration is not inspected |
+| Other harnesses | Overview available; inventory unsupported | Inventory unsupported |
+
+Project locations are searched from the reported working directory upward to
+the nearest `.git` boundary, at most 16 directories. Skills use `SKILL.md`;
+common scalar and folded frontmatter descriptions are supported. Pi standalone
+Markdown skills, custom paths, environment overrides (including `CODEX_HOME`
+and `XDG_CONFIG_HOME`), managed settings, plugins, packages, and runtime
+configuration changes are not resolved. User paths use the owning daemon's home.
+
+Coverage references: [Codex skills](https://developers.openai.com/codex/skills/),
+[Codex MCP](https://developers.openai.com/codex/mcp/),
+[Claude Code MCP](https://code.claude.com/docs/en/mcp),
+[OpenCode skills](https://opencode.ai/docs/skills/),
+[OpenCode MCP](https://opencode.ai/docs/mcp-servers/), and
+[Pi skills](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/skills.md).
+
+## Ownership, refresh, and limits
+
+Inspection requires protocol 55 on both the local daemon and remote owner.
+Remote inspection uses verified Node routing and the exact Agent ID and ShellRun
+ID. Files are read on that owner, never substituted with local files. Unsupported
+or unavailable owners leave the sidebar's basic Agent information usable. A
+failed refresh retains the previous snapshot with a visible stale-data message.
+
+Opening or refreshing performs one background request; there is no polling or
+scan of every Agent. Closing releases the drawer's snapshot; late results cannot
+replace a subsequently opened drawer. The owner releases registry locks before
+reading files and does not persist the inventory or publish lifecycle events.
+
+Each inspection limits Skills and MCP definitions to 128 entries each, directory
+entries to 4,096, skill recursion to eight levels, each file to 256 KiB, total
+read bytes to 4 MiB, and warnings to 16. Reached limits are reported. Symlink cycles
+are deduplicated, and nonregular files are skipped using nonblocking opens.
+
+MCP command lines, URLs, arguments, environment values, headers, and skill
+instruction bodies are excluded from the response and clipboard inventory.
+Parse errors omit file contents. Names, descriptions, paths, and existing Agent
+observation metadata remain visible and are included when copying details.

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -115,6 +115,9 @@ and history but does not remove project shortcuts or filesystem contents.
 - `src/terminal.rs`: Boomux discovery/attachment adapter, per-pane terminal
   worker, Ghostty VT state, scrollback, key/paste encoding, and Kitty graphics
   extraction.
+- `src/agent_details.rs`: on-demand Agent drawer, exact owner/run inspection,
+  generation-guarded background refresh, and one disposable inventory snapshot;
+  see [Agent details](agent-details.md).
 - `src/git_panel.rs`: demand-driven Node Git overview, filtering, lower sidebar tab,
   and exact local Shell navigation; see [Git panel](git-panel.md).
 - `src/nodes.rs`: read-only Node identity, health, and resource-count presentation

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -1076,3 +1076,12 @@ The initial contract excludes:
 - Remote TCP control listeners or forwarding the local daemon socket.
 - Treating a local daemon stop, restart, or Node removal as remote process
   authority.
+
+## Agent configuration inspection
+
+Desktop [Agent details](desktop/agent-details.md) uses protocol-55 `InspectAgent`
+through the existing verified owner host-service route. The exact Agent ID and
+expected ShellRun ID select the snapshot. Skills and MCP configuration are read
+on the owner without changing state. Older or unreachable owners produce an
+inspection error while basic sidebar information remains available; Desktop
+never substitutes local configuration for a remote Agent.

--- a/src/agent_inspection.rs
+++ b/src/agent_inspection.rs
@@ -1,0 +1,638 @@
+//! Bounded, read-only inventory on the Agent's owner. Configuration is not runtime telemetry.
+use crate::protocol::AgentInstanceSnapshot;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs::{self, OpenOptions};
+use std::io::Read;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+
+const MAX_ITEMS: usize = 128;
+const MAX_WARNINGS: usize = 16;
+const MAX_FILE: usize = 256 * 1024;
+const MAX_BYTES: usize = 4 * 1024 * 1024;
+const MAX_ENTRIES: usize = 4096;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Scope {
+    User,
+    Project,
+    System,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Skill {
+    pub name: String,
+    pub description: String,
+    pub source: PathBuf,
+    pub scope: Scope,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpServer {
+    pub name: String,
+    pub source: PathBuf,
+    pub scope: Scope,
+    pub transport: String,
+    pub enabled: Option<bool>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Inspection {
+    pub agent: AgentInstanceSnapshot,
+    pub inspected_at_ms: u64,
+    pub skills: Vec<Skill>,
+    pub mcp_servers: Vec<McpServer>,
+    pub warnings: Vec<String>,
+    pub truncated: bool,
+}
+
+struct Inventory {
+    skills: Vec<Skill>,
+    servers: Vec<McpServer>,
+    warnings: Vec<String>,
+    remaining_bytes: usize,
+    remaining_entries: usize,
+    visited: BTreeSet<PathBuf>,
+    truncated: bool,
+}
+
+impl Inventory {
+    fn warning(&mut self, message: String) {
+        if self.warnings.len() < MAX_WARNINGS && !self.warnings.contains(&message) {
+            self.warnings.push(message);
+        }
+    }
+
+    fn read(&mut self, path: &Path) -> Option<String> {
+        // Nonblocking open rejects device/FIFO inputs without waiting for a writer.
+        let mut file = match OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(path)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(_) => {
+                self.warning(format!("Could not read {}", path.display()));
+                return None;
+            }
+        };
+        let metadata = file.metadata().ok()?;
+        if !metadata.is_file() {
+            self.warning(format!("Skipped non-file {}", path.display()));
+            return None;
+        }
+        let limit = MAX_FILE.min(self.remaining_bytes);
+        if metadata.len() > limit as u64 || limit == 0 {
+            self.truncated = true;
+            self.warning(format!("Inspection limit reached at {}", path.display()));
+            return None;
+        }
+        let mut bytes = Vec::new();
+        if (&mut file)
+            .take(limit as u64 + 1)
+            .read_to_end(&mut bytes)
+            .is_err()
+        {
+            self.warning(format!("Could not read {}", path.display()));
+            return None;
+        }
+        self.remaining_bytes = self.remaining_bytes.saturating_sub(bytes.len());
+        if bytes.len() > limit {
+            self.truncated = true;
+            return None;
+        }
+        match String::from_utf8(bytes) {
+            Ok(text) => Some(text),
+            Err(_) => {
+                self.warning(format!("Invalid text in {}", path.display()));
+                None
+            }
+        }
+    }
+
+    fn skills(&mut self, root: &Path, scope: Scope, depth: usize) {
+        if depth > 8 || self.remaining_entries == 0 || self.skills.len() == MAX_ITEMS {
+            self.truncated = true;
+            return;
+        }
+        let Ok(canonical) = root.canonicalize() else {
+            return;
+        };
+        if !self.visited.insert(canonical) {
+            return;
+        }
+        if root.join("SKILL.md").is_file() {
+            if let Some(text) = self.read(&root.join("SKILL.md")) {
+                let (name, description) = frontmatter(&text);
+                self.skills.push(Skill {
+                    name: name.unwrap_or_else(|| {
+                        clean(&root.file_name().unwrap_or_default().to_string_lossy(), 128)
+                    }),
+                    description: description.unwrap_or_else(|| "Description not available".into()),
+                    source: root.join("SKILL.md"),
+                    scope,
+                });
+            }
+            return;
+        }
+        let entries = match fs::read_dir(root) {
+            Ok(entries) => entries,
+            Err(_) => {
+                self.warning(format!("Could not inspect {}", root.display()));
+                return;
+            }
+        };
+        let mut paths = Vec::new();
+        for entry in entries {
+            if self.remaining_entries == 0 {
+                self.truncated = true;
+                break;
+            }
+            self.remaining_entries -= 1;
+            if let Ok(entry) = entry {
+                paths.push(entry.path());
+            }
+        }
+        paths.sort();
+        for path in paths {
+            if path.is_dir() {
+                self.skills(&path, scope.clone(), depth + 1);
+            }
+            if self.skills.len() == MAX_ITEMS {
+                self.truncated = true;
+                break;
+            }
+        }
+    }
+
+    fn config(&mut self, path: &Path, scope: Scope, toml: bool, key: &str, project: Option<&Path>) {
+        let Some(text) = self.read(path) else {
+            return;
+        };
+        let value = if toml {
+            toml::from_str::<toml::Value>(&text)
+                .ok()
+                .and_then(|v| serde_json::to_value(v).ok())
+        } else {
+            serde_json::from_str::<serde_json::Value>(&json_without_comments(&text)).ok()
+        };
+        let Some(value) = value else {
+            // Parser diagnostics can contain credentials from the offending source line.
+            self.warning(format!(
+                "Could not parse {} (contents omitted)",
+                path.display()
+            ));
+            return;
+        };
+        self.server_map(value.get(key), path, scope.clone());
+        if let Some(project) = project {
+            self.server_map(
+                value
+                    .get("projects")
+                    .and_then(|v| v.get(project.to_string_lossy().as_ref()))
+                    .and_then(|v| v.get(key)),
+                path,
+                Scope::Project,
+            );
+        }
+    }
+
+    fn server_map(&mut self, map: Option<&serde_json::Value>, path: &Path, scope: Scope) {
+        let Some(map) = map.and_then(|v| v.as_object()) else {
+            return;
+        };
+        for (name, server) in map {
+            if self.servers.len() == MAX_ITEMS {
+                self.truncated = true;
+                break;
+            }
+            if !server.is_object() {
+                self.warning(format!("Invalid MCP entry in {}", path.display()));
+                continue;
+            }
+            let transport = match server.get("type").and_then(|v| v.as_str()) {
+                Some("stdio" | "local") => "stdio",
+                Some("http" | "remote") => "http",
+                Some("sse") => "sse",
+                _ if server.get("command").is_some() => "stdio",
+                _ if server.get("url").is_some() => "http",
+                _ => "not specified",
+            };
+            self.servers.push(McpServer {
+                name: clean(name, 128),
+                source: path.into(),
+                scope: scope.clone(),
+                transport: transport.into(),
+                enabled: server
+                    .get("enabled")
+                    .and_then(|v| v.as_bool())
+                    .or_else(|| server.get("disabled").and_then(|v| v.as_bool()).map(|v| !v)),
+            });
+        }
+    }
+}
+
+pub fn inspect(agent: AgentInstanceSnapshot) -> Inspection {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    inspect_at(agent, home.as_deref())
+}
+
+fn inspect_at(agent: AgentInstanceSnapshot, home: Option<&Path>) -> Inspection {
+    let mut inventory = Inventory {
+        skills: vec![],
+        servers: vec![],
+        warnings: vec![],
+        remaining_bytes: MAX_BYTES,
+        remaining_entries: MAX_ENTRIES,
+        visited: BTreeSet::new(),
+        truncated: false,
+    };
+    inventory.warning("Standard configuration locations only: loading, connection health, authentication and tools are not reported by this Agent. Environment and run-specific overrides, managed configuration and plugin/package inventories are not included.".into());
+    let mut ancestors = Vec::new();
+    if let Some(cwd) = agent.cwd.as_ref().filter(|p| p.is_absolute()) {
+        for directory in cwd.ancestors().take(16) {
+            ancestors.push(directory);
+            if directory.join(".git").exists() {
+                break;
+            }
+        }
+    } else {
+        inventory.warning(
+            "Agent working directory is not reported; project configuration was not inspected."
+                .into(),
+        );
+    }
+    let roots: &[&str] = match agent.integration.as_str() {
+        "codex" => &[".agents/skills", ".codex/skills"],
+        "claude" => &[".claude/skills"],
+        "opencode" => &[".opencode/skills", ".claude/skills", ".agents/skills"],
+        "pi" => &[".pi/skills", ".agents/skills"],
+        _ => &[],
+    };
+    if roots.is_empty() {
+        inventory.warning("Skill and MCP inventory is not supported for this harness yet.".into());
+    }
+    if let Some(home) = home.filter(|p| p.is_absolute()) {
+        match agent.integration.as_str() {
+            "codex" => {
+                inventory.skills(&home.join(".agents/skills"), Scope::User, 0);
+                inventory.skills(&home.join(".codex/skills"), Scope::User, 0);
+                inventory.skills(Path::new("/etc/codex/skills"), Scope::System, 0);
+                inventory.config(
+                    &home.join(".codex/config.toml"),
+                    Scope::User,
+                    true,
+                    "mcp_servers",
+                    None,
+                );
+            }
+            "claude" => {
+                inventory.skills(&home.join(".claude/skills"), Scope::User, 0);
+                inventory.config(
+                    &home.join(".claude.json"),
+                    Scope::User,
+                    false,
+                    "mcpServers",
+                    ancestors.last().copied(),
+                );
+            }
+            "opencode" => {
+                for path in [
+                    ".config/opencode/skills",
+                    ".claude/skills",
+                    ".agents/skills",
+                ] {
+                    inventory.skills(&home.join(path), Scope::User, 0);
+                }
+                for path in [
+                    ".config/opencode/opencode.json",
+                    ".config/opencode/opencode.jsonc",
+                ] {
+                    inventory.config(&home.join(path), Scope::User, false, "mcp", None);
+                }
+            }
+            "pi" => {
+                for path in [".pi/agent/skills", ".agents/skills"] {
+                    inventory.skills(&home.join(path), Scope::User, 0);
+                }
+                inventory.warning("Pi MCP extensions are not inspected.".into());
+            }
+            _ => {}
+        }
+    } else {
+        inventory.warning(
+            "Owner home directory is unavailable; user configuration was not inspected.".into(),
+        );
+    }
+    for directory in ancestors {
+        for root in roots {
+            inventory.skills(&directory.join(root), Scope::Project, 0);
+        }
+        match agent.integration.as_str() {
+            "codex" => inventory.config(
+                &directory.join(".codex/config.toml"),
+                Scope::Project,
+                true,
+                "mcp_servers",
+                None,
+            ),
+            "claude" => inventory.config(
+                &directory.join(".mcp.json"),
+                Scope::Project,
+                false,
+                "mcpServers",
+                None,
+            ),
+            "opencode" => {
+                for name in ["opencode.json", "opencode.jsonc"] {
+                    inventory.config(&directory.join(name), Scope::Project, false, "mcp", None);
+                }
+            }
+            _ => {}
+        }
+    }
+    inventory
+        .skills
+        .sort_by(|a, b| (&a.name, &a.source).cmp(&(&b.name, &b.source)));
+    inventory
+        .servers
+        .sort_by(|a, b| (&a.name, &a.source).cmp(&(&b.name, &b.source)));
+    Inspection {
+        agent,
+        inspected_at_ms: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_millis() as u64),
+        skills: inventory.skills,
+        mcp_servers: inventory.servers,
+        warnings: inventory.warnings,
+        truncated: inventory.truncated,
+    }
+}
+
+fn clean(text: &str, limit: usize) -> String {
+    text.chars()
+        .filter(|c| !c.is_control())
+        .take(limit)
+        .collect()
+}
+
+// Read only common scalar/folded metadata. Never return the skill's instruction body.
+fn frontmatter(text: &str) -> (Option<String>, Option<String>) {
+    let mut lines = text.lines();
+    if lines.next().map(str::trim) != Some("---") {
+        return (None, None);
+    }
+    let mut name = None;
+    let mut description = None;
+    let mut folded = false;
+    for line in lines.take(128) {
+        if line.trim() == "---" {
+            break;
+        }
+        if folded && line.starts_with(char::is_whitespace) {
+            if let Some(value) = description.as_mut() {
+                *value = clean(format!("{value} {}", line.trim()).trim(), 512);
+            }
+            continue;
+        }
+        folded = false;
+        if let Some((key, value)) = line.split_once(':') {
+            let value = value.trim();
+            match key {
+                "name" => name = Some(clean(value.trim_matches(['\'', '"']), 128)),
+                "description" => {
+                    folded = matches!(value, ">" | ">-" | "|" | "|-");
+                    description = Some(if folded {
+                        String::new()
+                    } else {
+                        clean(value.trim_matches(['\'', '"']), 512)
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+    (
+        name.filter(|s| !s.is_empty()),
+        description.filter(|s| !s.is_empty()),
+    )
+}
+
+// JSONC comments/trailing commas are removed only outside string literals.
+fn json_without_comments(text: &str) -> String {
+    let mut bytes = text.as_bytes().to_vec();
+    let (mut i, mut quoted) = (0, false);
+    while i < bytes.len() {
+        if quoted {
+            if bytes[i] == b'\\' {
+                i += 2;
+                continue;
+            }
+            if bytes[i] == b'"' {
+                quoted = false;
+            }
+        } else if bytes[i] == b'"' {
+            quoted = true;
+        } else if bytes.get(i..i + 2) == Some(b"//") {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                bytes[i] = b' ';
+                i += 1;
+            }
+            continue;
+        } else if bytes.get(i..i + 2) == Some(b"/*") {
+            bytes[i] = b' ';
+            bytes[i + 1] = b' ';
+            i += 2;
+            while i < bytes.len() && bytes.get(i..i + 2) != Some(b"*/") {
+                bytes[i] = b' ';
+                i += 1;
+            }
+            if i + 1 < bytes.len() {
+                bytes[i] = b' ';
+                bytes[i + 1] = b' ';
+                i += 2;
+            } else {
+                return String::new();
+            }
+            continue;
+        }
+        i += 1;
+    }
+    quoted = false;
+    i = 0;
+    while i < bytes.len() {
+        if quoted {
+            if bytes[i] == b'\\' {
+                i += 2;
+                continue;
+            }
+            if bytes[i] == b'"' {
+                quoted = false;
+            }
+        } else if bytes[i] == b'"' {
+            quoted = true;
+        } else if bytes[i] == b',' {
+            let next = bytes[i + 1..].iter().find(|b| !b.is_ascii_whitespace());
+            if matches!(next, Some(b'}' | b']')) {
+                bytes[i] = b' ';
+            }
+        }
+        i += 1;
+    }
+    String::from_utf8(bytes).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct Fixture(PathBuf);
+    impl Fixture {
+        fn new() -> Self {
+            let root =
+                std::env::temp_dir().join(format!("boomux-inventory-{}", uuid::Uuid::new_v4()));
+            fs::create_dir_all(root.join("project/.git")).unwrap();
+            fs::create_dir_all(root.join("home")).unwrap();
+            Self(root)
+        }
+        fn write(&self, name: &str, text: &str) {
+            let path = self.0.join(name);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, text).unwrap();
+        }
+        fn agent(&self, integration: &str) -> AgentInstanceSnapshot {
+            serde_json::from_value(serde_json::json!({
+                "id":"agent", "workspace_id":"workspace", "shell_id":"shell", "run_id":"run",
+                "name":"test", "integration":integration, "external_session_id":null,
+                "cwd":self.0.join("project"), "started_at_ms":1, "ended_at_ms":null,
+                "observation":{"revision":1,"state":"idle","authority":"lifecycle_integration","evidence":"fixture","confidence":100,"observed_at_ms":1}
+            })).unwrap()
+        }
+        fn inspect(&self, integration: &str) -> Inspection {
+            inspect_at(self.agent(integration), Some(&self.0.join("home")))
+        }
+    }
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn inventory_keeps_sources_and_excludes_mcp_credentials_commands_and_skill_body() {
+        let f = Fixture::new();
+        f.write("home/.codex/config.toml", "[mcp_servers.github]\ncommand='secret-command'\nargs=['SECRET-ARG']\nenabled=false\n[mcp_servers.github.env]\nTOKEN='SECRET-TOKEN'\n");
+        f.write("project/.codex/config.toml", "[mcp_servers.github]\nurl='https://user:SECRET-PASSWORD@example.com/?token=SECRET-QUERY'\nenabled=true\nhttp_headers={Authorization='SECRET-HEADER'}\n");
+        f.write("home/.agents/skills/review/SKILL.md", "---\nname: review\ndescription: >-\n  Review changes\n  carefully.\n---\nSECRET-INSTRUCTION-BODY");
+        let result = f.inspect("codex");
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skills[0].description, "Review changes carefully.");
+        assert_eq!(result.mcp_servers.len(), 2);
+        assert!(
+            result
+                .mcp_servers
+                .iter()
+                .any(|s| s.enabled == Some(false) && s.scope == Scope::User)
+        );
+        assert!(
+            result
+                .mcp_servers
+                .iter()
+                .any(|s| s.enabled == Some(true) && s.scope == Scope::Project)
+        );
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(!json.contains("SECRET"));
+        assert!(!json.contains("secret-command"));
+        assert!(!json.contains("connected"));
+    }
+
+    #[test]
+    fn inventory_jsonc_preserves_string_slashes_and_reports_invalid_files_without_contents() {
+        let f = Fixture::new();
+        f.write("project/opencode.jsonc", r#"{ // note
+            "mcp": { "source": { "url": "https://example.com/a//b", "enabled": false, }, }, /* trailing */
+        }"#);
+        let result = f.inspect("opencode");
+        assert_eq!(result.mcp_servers.len(), 1);
+        assert_eq!(result.mcp_servers[0].transport, "http");
+        assert_eq!(result.mcp_servers[0].enabled, Some(false));
+        f.write(
+            "project/opencode.jsonc",
+            "{ \"token\": SECRET-PARSE-ERROR }",
+        );
+        let result = f.inspect("opencode");
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("Could not parse"))
+        );
+        assert!(
+            !serde_json::to_string(&result)
+                .unwrap()
+                .contains("SECRET-PARSE-ERROR")
+        );
+    }
+
+    #[test]
+    fn inventory_follows_skill_symlinks_without_cycles_or_crossing_repo_boundary() {
+        use std::os::unix::fs::symlink;
+        let f = Fixture::new();
+        f.write(
+            "project/.agents/skills/a/SKILL.md",
+            "---\nname: a\ndescription: test\n---",
+        );
+        f.write(
+            ".agents/skills/outside/SKILL.md",
+            "---\nname: outside\ndescription: wrong scope\n---",
+        );
+        symlink(
+            f.0.join("project/.agents/skills"),
+            f.0.join("project/.agents/skills/loop"),
+        )
+        .unwrap();
+        symlink(
+            f.0.join("project/.agents/skills/a"),
+            f.0.join("project/.agents/skills/alias"),
+        )
+        .unwrap();
+        let result = f.inspect("codex");
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skills[0].name, "a");
+    }
+
+    #[test]
+    fn inventory_limits_files_entries_and_unknown_harnesses_explicitly() {
+        let f = Fixture::new();
+        f.write("home/.codex/config.toml", &"x".repeat(MAX_FILE + 1));
+        for i in 0..MAX_ITEMS + 2 {
+            f.write(
+                &format!("project/.agents/skills/s{i}/SKILL.md"),
+                "---\nname: test\ndescription: test\n---",
+            );
+        }
+        let result = f.inspect("codex");
+        assert!(result.truncated);
+        assert_eq!(result.skills.len(), MAX_ITEMS);
+        assert!(result.mcp_servers.is_empty());
+        assert!(
+            f.inspect("unknown")
+                .warnings
+                .iter()
+                .any(|w| w.contains("not supported"))
+        );
+    }
+
+    #[test]
+    fn inventory_never_opens_fifo_as_a_blocking_file() {
+        let f = Fixture::new();
+        fs::create_dir_all(f.0.join("home/.codex")).unwrap();
+        let path =
+            std::ffi::CString::new(f.0.join("home/.codex/config.toml").to_str().unwrap()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
+        let result = f.inspect("codex");
+        assert!(result.warnings.iter().any(|w| w.contains("non-file")));
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1142,6 +1142,42 @@ impl Client {
         }
     }
 
+    /// Read a bounded configuration inventory from the exact Agent owner/run.
+    pub fn inspect_agent(
+        &self,
+        node_id: Option<&str>,
+        agent_id: &str,
+        expected_run_id: &str,
+        timeout: Duration,
+    ) -> Result<crate::agent_inspection::Inspection> {
+        // Probe at the required version before serializing a new operation to an old peer.
+        self.send_with_version_timeout(
+            Request::Ping,
+            protocol::ProtocolFeature::AgentInspection.minimum_version(),
+            Some(timeout),
+        )?;
+        let operation = protocol::HostServiceOperation::InspectAgent {
+            agent_id: agent_id.into(),
+            expected_run_id: expected_run_id.into(),
+        };
+        let request = match node_id {
+            Some(node_id) => Request::RouteNodeHostService {
+                node_id: node_id.into(),
+                operation,
+            },
+            None => Request::HostService { operation },
+        };
+        match self
+            .send_with_version_timeout(request, protocol::PROTOCOL_VERSION, Some(timeout))?
+            .1
+        {
+            Response::HostService {
+                result: protocol::HostServiceResult::AgentInspection { inspection },
+            } => Ok(inspection),
+            response => unexpected(response),
+        }
+    }
+
     pub fn host_service(
         &self,
         operation: crate::protocol::HostServiceOperation,
@@ -2643,6 +2679,43 @@ mod tests {
             })
         ));
 
+        server.join().unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn agent_inspection_probes_old_peer_without_sending_new_operation() {
+        let directory = env::temp_dir().join(format!("boomux-inspect-client-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let socket = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request: Envelope<Request> = protocol::read_message(&mut stream).unwrap();
+            assert_eq!(request.version, 55);
+            assert_eq!(request.message, Request::Ping);
+            protocol::write_message(
+                &mut stream,
+                &Envelope::with_version(
+                    54,
+                    Response::Error {
+                        code: Some(ErrorCode::UnsupportedVersion),
+                        message: "old peer".into(),
+                    },
+                ),
+            )
+            .unwrap();
+            listener.set_nonblocking(true).unwrap();
+            assert!(listener.accept().is_err());
+        });
+        let client = Client::from_socket_path(socket);
+        assert!(matches!(
+            client.inspect_agent(None, "a", "r", Duration::from_secs(1)),
+            Err(ClientError::Remote(RemoteError {
+                code: Some(ErrorCode::UnsupportedVersion),
+                ..
+            }))
+        ));
         server.join().unwrap();
         fs::remove_dir_all(directory).unwrap();
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9764,6 +9764,21 @@ impl DaemonService {
         _requester_version: u32,
     ) -> DaemonResult<HostServiceResult> {
         match operation {
+            HostServiceOperation::InspectAgent {
+                agent_id,
+                expected_run_id,
+            } => {
+                let agent = self.agent(&agent_id)?.snapshot()?;
+                if agent.run_id != expected_run_id {
+                    return Err(DaemonError::lifecycle(
+                        ErrorCode::RevisionChanged,
+                        "Agent run changed; reopen its details",
+                    ));
+                }
+                Ok(HostServiceResult::AgentInspection {
+                    inspection: crate::agent_inspection::inspect(agent),
+                })
+            }
             HostServiceOperation::GitOverview { refresh } => {
                 if let Some(overview) = self.git_work.cached_if_fresh(refresh) {
                     return Ok(HostServiceResult::GitOverview { overview });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate self as boomux;
 
+pub mod agent_inspection;
 pub mod attach;
 #[cfg(feature = "benchmark-internals")]
 #[doc(hidden)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 54;
+pub const PROTOCOL_VERSION: u32 = 55;
 pub const MIN_PROTOCOL_VERSION: u32 = 47;
 pub const MAX_CONTROL_FRAME: usize = 8 * 1024 * 1024;
 pub const MAX_ATTACH_FRAME: usize = 1024 * 1024;
@@ -201,6 +201,7 @@ define_protocol_features! {
         "workspace_session_hiding",
     ]),
     GitWorkOverview => (53, "Git work overview", ["protocol_53", "git_work_overview"]),
+    AgentInspection => (55, "Agent details inventory", ["protocol_55", "agent_inspection"]),
     CreateStartedShell => (54, "atomic Shell creation and start", ["protocol_54", "create_started_shell"]),
     RestartExecutable => (52, "restart executable", ["protocol_52", "restart_executable"]),
 }
@@ -228,6 +229,10 @@ pub enum HostServiceIntegrationAction {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
 pub enum HostServiceOperation {
+    InspectAgent {
+        agent_id: String,
+        expected_run_id: String,
+    },
     DiscoverProjects,
     GitOverview {
         #[serde(default)]
@@ -454,6 +459,9 @@ pub struct HostAgentSessionResumePlan {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "result", rename_all = "snake_case", deny_unknown_fields)]
 pub enum HostServiceResult {
+    AgentInspection {
+        inspection: crate::agent_inspection::Inspection,
+    },
     GitOverview {
         overview: crate::git_work::Overview,
     },
@@ -2206,6 +2214,13 @@ impl Request {
             | Self::GuardedRestartShell { .. }
             | Self::GuardedRemoveLauncher { .. } => Some(ProtocolFeature::GuardedNodeRouting),
             Self::HostService {
+                operation: HostServiceOperation::InspectAgent { .. },
+            }
+            | Self::RouteNodeHostService {
+                operation: HostServiceOperation::InspectAgent { .. },
+                ..
+            } => Some(ProtocolFeature::AgentInspection),
+            Self::HostService {
                 operation: HostServiceOperation::GitOverview { .. },
             }
             | Self::RouteNodeHostService {
@@ -2857,8 +2872,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_fifty_four_with_forty_seven_floor() {
-        assert_eq!(PROTOCOL_VERSION, 54);
+    fn protocol_version_is_fifty_five_with_forty_seven_floor() {
+        assert_eq!(PROTOCOL_VERSION, 55);
         assert_eq!(MIN_PROTOCOL_VERSION, 47);
     }
 
@@ -2884,6 +2899,32 @@ mod tests {
         assert!(encoded.get("environment").is_none());
         assert_eq!(serde_json::from_value::<Request>(encoded).unwrap(), request);
         assert!(!ProtocolFeature::CreateStartedShell.is_supported_by(53));
+    }
+
+    #[test]
+    fn agent_inspection_requires_fifty_five_locally_and_when_routed() {
+        for request in [
+            Request::HostService {
+                operation: HostServiceOperation::InspectAgent {
+                    agent_id: "a".into(),
+                    expected_run_id: "r".into(),
+                },
+            },
+            Request::RouteNodeHostService {
+                node_id: "owner".into(),
+                operation: HostServiceOperation::InspectAgent {
+                    agent_id: "a".into(),
+                    expected_run_id: "r".into(),
+                },
+            },
+        ] {
+            assert_eq!(request.minimum_protocol_version(), 55);
+            assert!(!request.required_feature().unwrap().is_supported_by(54));
+            assert_eq!(
+                serde_json::from_value::<Request>(serde_json::to_value(&request).unwrap()).unwrap(),
+                request
+            );
+        }
     }
 
     #[test]
@@ -4529,6 +4570,7 @@ mod tests {
             ),
             (51, &["workspace_session_hiding"][..]),
             (53, &["protocol_53", "git_work_overview"][..]),
+            (55, &["protocol_55", "agent_inspection"][..]),
             (54, &["protocol_54", "create_started_shell"][..]),
             (52, &["protocol_52", "restart_executable"][..]),
         ];

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -35,3 +35,6 @@ mod workspace_creation;
 
 #[path = "native_backend/git_work.rs"]
 mod git_work;
+
+#[path = "native_backend/agent_inspection.rs"]
+mod agent_inspection;

--- a/tests/native_backend/agent_inspection.rs
+++ b/tests/native_backend/agent_inspection.rs
@@ -1,0 +1,102 @@
+use crate::support::{TestDaemon, profile};
+use boomux::protocol::{
+    self, AgentAuthority, AgentRegistrationSpec, AgentReport, AgentState, Envelope, ErrorCode,
+    HostServiceOperation, Request, Response, ShellSpec,
+};
+use std::{fs, os::unix::net::UnixStream, time::Duration};
+
+#[test]
+fn agent_inspection_is_read_only_exact_run_and_rejects_old_wire_requests() {
+    let mut daemon = TestDaemon::start();
+    let project = daemon.runtime_dir.join("repo");
+    fs::create_dir_all(project.join(".git")).unwrap();
+    fs::create_dir_all(project.join(".codex")).unwrap();
+    fs::write(
+        project.join(".codex/config.toml"),
+        "[mcp_servers.fixture]\ncommand='unused'\nargs=['SECRET-ARGV']\n",
+    )
+    .unwrap();
+    let workspace = daemon
+        .client
+        .create_workspace(
+            "inspection",
+            vec![ShellSpec {
+                name: "shell".into(),
+                cwd: project,
+                command: vec!["/bin/sleep".into(), "60".into()],
+            }],
+        )
+        .unwrap();
+    let shell = &workspace.shells[0];
+    let attachment = daemon.client.attach(&shell.id, false, profile()).unwrap();
+    let run = daemon.client.get_shell(&shell.id).unwrap().run.unwrap();
+    let agent = daemon
+        .client
+        .register_agent(
+            &shell.id,
+            &run.id,
+            AgentRegistrationSpec {
+                name: "fixture".into(),
+                integration: "codex".into(),
+                external_session_id: None,
+                report: AgentReport {
+                    state: AgentState::Idle,
+                    authority: AgentAuthority::LifecycleIntegration,
+                    evidence: "fixture".into(),
+                    confidence: 100,
+                },
+            },
+        )
+        .unwrap();
+    let state = fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap();
+    let inspection = daemon
+        .client
+        .inspect_agent(None, &agent.id, &run.id, Duration::from_secs(5))
+        .unwrap();
+    assert_eq!(inspection.agent.run_id, run.id);
+    assert!(inspection.mcp_servers.iter().any(|s| s.name == "fixture"));
+    let response = Response::HostService {
+        result: protocol::HostServiceResult::AgentInspection { inspection },
+    };
+    let json = serde_json::to_string(&response).unwrap();
+    assert!(!json.contains("SECRET-ARGV"));
+    assert_eq!(serde_json::from_str::<Response>(&json).unwrap(), response);
+    assert_eq!(
+        state,
+        fs::read(daemon.runtime_dir.join("state/boomux/state.json")).unwrap()
+    );
+    for request in [
+        Request::HostService {
+            operation: HostServiceOperation::InspectAgent {
+                agent_id: agent.id.clone(),
+                expected_run_id: run.id.clone(),
+            },
+        },
+        Request::RouteNodeHostService {
+            node_id: "missing-owner".into(),
+            operation: HostServiceOperation::InspectAgent {
+                agent_id: agent.id.clone(),
+                expected_run_id: run.id.clone(),
+            },
+        },
+    ] {
+        let mut stream = UnixStream::connect(daemon.client.socket_path()).unwrap();
+        protocol::write_message(&mut stream, &Envelope::with_version(54, request)).unwrap();
+        let response: Envelope<Response> = protocol::read_message(&mut stream).unwrap();
+        assert!(matches!(
+            response.message,
+            Response::Error {
+                code: Some(ErrorCode::UnsupportedVersion),
+                ..
+            }
+        ));
+    }
+    assert!(
+        daemon
+            .client
+            .inspect_agent(None, &agent.id, "wrong-run", Duration::from_secs(5))
+            .is_err()
+    );
+    drop(attachment);
+    daemon.stop_with_cli();
+}

--- a/tests/native_backend/remote_host_services.rs
+++ b/tests/native_backend/remote_host_services.rs
@@ -194,6 +194,40 @@ fn registered_node_host_services_use_only_owner_path_config_cwd_and_stored_argv(
             },
         )
         .unwrap();
+    for (home, name) in [
+        ("owner-home", "owner-skill"),
+        ("local-home", "wrong-local-skill"),
+    ] {
+        let directory = root.join(home).join(".pi/agent/skills").join(name);
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(
+            directory.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: fixture\n---\n"),
+        )
+        .unwrap();
+    }
+    let inspection = local
+        .client
+        .inspect_agent(Some(&owner_id), &agent.id, &run_id, Duration::from_secs(5))
+        .unwrap();
+    assert_eq!(inspection.agent.id, agent.id);
+    assert!(inspection.skills.iter().any(|s| s.name == "owner-skill"));
+    assert!(
+        !inspection
+            .skills
+            .iter()
+            .any(|s| s.name == "wrong-local-skill")
+    );
+    let error = local
+        .client
+        .inspect_agent(
+            Some(&owner_id),
+            &agent.id,
+            "wrong-run",
+            Duration::from_secs(5),
+        )
+        .unwrap_err();
+    assert_remote_code(&error, ErrorCode::RevisionChanged);
     for operation in [
         HostServiceOperation::ListAgentSessions {
             workspace_id: Some(session_workspace.id.clone()),


### PR DESCRIPTION
Add an Agent Details drawer from the Agents panel so users can inspect an Agent without leaving its terminal. Each row has an info button; sidebar keyboard navigation also supports `i`.

The drawer provides Overview, Skills, and MCP tabs, expandable descriptions/source files, Refresh, Copy details, and Open terminal. Reported lifecycle information is distinguished from file configuration: discovered skills are not claimed to be loaded, and MCP definitions are not claimed to be connected.

Inspection runs on demand on the exact Agent owner and ShellRun through a new protocol-55 host-service operation. Standard configuration locations are supported for Codex, Claude Code, OpenCode, and Pi skills. Reads and result collections are bounded; MCP commands, arguments, URLs, credentials, and skill instruction bodies are excluded. No inventory is persisted or polled. Older/offline owners retain basic Agent details, and failed refreshes visibly retain the previous snapshot.

Documentation describes coverage and limitations, including unsupported custom environment paths, plugin/package inventories, live connection health, model/context/cost reporting, and Pi MCP extensions.

Validation:
- `cargo check --locked` and `cargo check -p boomux-desktop --locked` passed during development.
- Focused inventory, old-peer negotiation, protocol round-trip/version/capability tests passed.
- Native exact-run/read-only/old-wire and remote-owner filesystem isolation tests passed.
- Desktop late-result rejection and failed-refresh snapshot retention test passed.
- Formatting and `git diff --check` passed.

No hands-on GUI or macOS validation was performed. Full selected CI remains required before merge.
