### PR TITLE
fix(desktop): preserve terminal background and faint colors

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -10927,7 +10927,7 @@ fn prepare_terminal_paint(
                     color: terminal_theme.cursor,
                 });
             }
-            if background != terminal_theme.background {
+            if background != screen.background {
                 backgrounds.push(TerminalBackground {
                     row,
                     col,
@@ -10950,15 +10950,21 @@ fn prepare_terminal_paint(
             if cell.italic {
                 cell_font = cell_font.italic();
             }
+            let mut text_color = rgb_to_hsla(gpui::rgb(foreground));
+            // Match Ghostty's default faint opacity without changing the cell
+            // background or its palette/truecolor value.
+            if cell.faint {
+                text_color.alpha = 0.5;
+            }
             push_text_run(
                 &mut runs,
                 TextRun {
                     len: text.len() - start,
                     font: cell_font,
-                    color: rgb_to_hsla(gpui::rgb(foreground)),
+                    color: text_color,
                     underline: cell.underline.then_some(UnderlineStyle {
                         thickness: px(1.0),
-                        color: Some(rgb_to_hsla(gpui::rgb(foreground))),
+                        color: Some(text_color),
                         wavy: false,
                     }),
                     ..Default::default()
@@ -10985,7 +10991,8 @@ fn prepare_terminal_paint(
 
 fn terminal_view(paint_cache: Arc<TerminalPaintCache>, images: Vec<RenderedTerminalImage>) -> Div {
     let cached_paint = Arc::clone(&paint_cache);
-    div().size_full().overflow_hidden().bg(rgb(0x11111b)).child(
+    let background = gpui::rgb(paint_cache.screen.background);
+    div().size_full().overflow_hidden().bg(background).child(
         canvas(
             move |_, _, _| images,
             move |bounds, images, window, cx| {
@@ -12015,6 +12022,7 @@ mod pointer_tests {
     #[test]
     fn terminal_selection_drag_uses_only_source_pane_bounds_and_mouse_down_anchor() {
         let screen = TerminalScreen {
+            background: 0,
             rows: 24,
             cols: 80,
             cells: Vec::new(),
@@ -12087,6 +12095,7 @@ mod pointer_tests {
                 foreground: 0xffffff,
                 background: 0,
                 bold: false,
+                faint: false,
                 italic: false,
                 underline: false,
                 wide: false,
@@ -12095,6 +12104,7 @@ mod pointer_tests {
             })
             .collect();
         TerminalScreen {
+            background: 0,
             rows: 2,
             cols: 4,
             cells,

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -113,6 +113,7 @@ pub struct TerminalCell {
     pub foreground: u32,
     pub background: u32,
     pub bold: bool,
+    pub faint: bool,
     pub italic: bool,
     pub underline: bool,
     pub wide: bool,
@@ -122,6 +123,7 @@ pub struct TerminalCell {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TerminalScreen {
+    pub background: u32,
     pub rows: u16,
     pub cols: u16,
     pub cells: Vec<TerminalCell>,
@@ -1814,6 +1816,7 @@ impl EmulatorCore {
                     foreground: rgb_value(foreground),
                     background: rgb_value(background),
                     bold: style.bold,
+                    faint: style.faint,
                     italic: style.italic,
                     underline: style.underline != Underline::None,
                     wide: wide == CellWide::Wide,
@@ -1826,6 +1829,7 @@ impl EmulatorCore {
         }
 
         Ok(TerminalScreen {
+            background: rgb_value(colors.background),
             rows,
             cols,
             cells: output,
@@ -2258,6 +2262,7 @@ fn configure_terminal(
 fn blank_screen(rows: u16, cols: u16) -> TerminalScreen {
     let theme = crate::theme::current_terminal();
     TerminalScreen {
+        background: theme.background,
         rows,
         cols,
         cells: vec![
@@ -2266,6 +2271,7 @@ fn blank_screen(rows: u16, cols: u16) -> TerminalScreen {
                 foreground: theme.foreground,
                 background: theme.background,
                 bold: false,
+                faint: false,
                 italic: false,
                 underline: false,
                 wide: false,
@@ -3888,6 +3894,46 @@ mod tests {
         assert_eq!(indexed_color(231), 0xffffff);
         assert_eq!(indexed_color(232), 0x080808);
         assert_eq!(indexed_color(255), 0xeeeeee);
+    }
+
+    #[test]
+    fn terminal_colors_preserve_faint_and_resolved_background() {
+        let shared = Arc::new(SharedTerminal::new(terminal_profile(2, 10, 100, 40)));
+        let mut core = EmulatorCore::new(&shared, 2, 10, 100, 40).unwrap();
+        let theme = TerminalTheme {
+            foreground: 0xdcd7ba,
+            background: 0x1f1f28,
+            cursor: 0xdcd7ba,
+            ansi: [0x7e9cd8; 16],
+        };
+        configure_terminal(&mut core.terminal, theme).unwrap();
+        core.apply(EmulatorCommand::Output(
+            b"\x1b[34mA\x1b[2mB\x1b[22mC\x1b[0mD".to_vec(),
+        ))
+        .unwrap();
+        let screen = core.screen().unwrap();
+        assert_eq!(screen.background, theme.background);
+        assert_eq!(screen.cells[0].foreground, theme.ansi[4]);
+        assert_eq!(screen.cells[1].foreground, theme.ansi[4]);
+        assert!(!screen.cells[0].faint);
+        assert!(screen.cells[1].faint);
+        assert!(!screen.cells[2].faint);
+        assert_eq!(screen.cells[3].foreground, theme.foreground);
+        assert!(
+            screen
+                .cells
+                .iter()
+                .all(|cell| cell.background == screen.background)
+        );
+
+        core.apply(EmulatorCommand::Output(b"\x1b]11;#123456\x07".to_vec()))
+            .unwrap();
+        let screen = core.screen().unwrap();
+        assert_eq!(screen.background, 0x123456);
+        assert_eq!(screen.cells[0].background, screen.background);
+        core.apply(EmulatorCommand::Output(b"\x1b]111\x07".to_vec()))
+            .unwrap();
+        assert_eq!(core.screen().unwrap().background, theme.background);
     }
 
     #[test]

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -187,6 +187,10 @@ command path and republishes a screen without reconnecting the Boomux Shell.
 ## Rendering
 
 Text cells and Kitty image placements come from the same Ghostty terminal state.
+Each screen carries its resolved terminal background, including application OSC
+changes; the terminal canvas and padding use that color rather than the app
+canvas color. SGR faint text retains its palette/truecolor value and renders at
+50% foreground opacity, including underlines.
 The GPUI layer draws background images, cells, and foreground images in z-order,
 clips every placement to its pane, and caches GPU images by terminal generation.
 Images are explicitly dropped when their generation disappears or their pane


### PR DESCRIPTION
Desktop painted the terminal’s default-background cells and padding with the app canvas color. With the current Omarchy theme, this showed `#111116` instead of the terminal’s `#1f1f28`. Desktop also discarded SGR faint, making secondary text too bright.

Carry the resolved Ghostty background in each screen and use it for the terminal canvas and background-cell batching, including application OSC background changes. Preserve faint styling and render foreground text and underlines at 50% opacity without changing their palette or truecolor values.

Validation:
- `cargo check -p boomux-desktop --locked` passed.
- Focused emulator regression passed for ANSI colors, faint/reset sequences, default background, and OSC background set/reset.
- Formatting and `git diff --check` passed.

A rebuilt visual comparison has not been performed. PR CI owns comprehensive validation.
